### PR TITLE
fix: 🐛  Fix incorrect pagination info in DataList component.

### DIFF
--- a/packages/webiny-ui/src/List/DataList/DataList.js
+++ b/packages/webiny-ui/src/List/DataList/DataList.js
@@ -246,7 +246,7 @@ const Pagination = (props: Props) => {
 
     return (
         <React.Fragment>
-            {meta.totalCount &&
+            {typeof meta.totalCount !== "undefined" &&
                 meta.totalCount > 0 &&
                 meta.from &&
                 meta.to && (


### PR DESCRIPTION
A "0" would be outputted in the pagination section if there were no records to show.