### PR TITLE
fix: Allow null value to be sent into Avatar component (#172)

### DIFF
--- a/packages/webiny-ui/src/Avatar/Avatar.js
+++ b/packages/webiny-ui/src/Avatar/Avatar.js
@@ -21,7 +21,7 @@ type Props = {
     src: string,
 
     // "alt" text.
-    alt: string,
+    alt: ?string,
 
     // Width.
     width?: number,


### PR DESCRIPTION
affects: webiny-ui