### PR TITLE
Ensure before / after events are executed independently

### DIFF
--- a/packages/webiny-entity/__tests__/events.test.js
+++ b/packages/webiny-entity/__tests__/events.test.js
@@ -5,15 +5,15 @@ class Invoice extends Entity {
         super();
         this.attr("company").entity(Company);
         this.attr("isPaid").boolean();
-        this.attr("beforeSaveCalled").integer();
-        this.attr("afterSaveCalled").integer();
+        this.attr("__beforeSaveCalled").integer();
+        this.attr("__afterSaveCalled").integer();
 
-        this.on("beforeSave", () => {
-            this.beforeSaveCalled++;
+        this.on("__beforeSave", () => {
+            this.__beforeSaveCalled++;
         }).setOnce();
 
-        this.on("afterSave", () => {
-            this.afterSaveCalled++;
+        this.on("__afterSave", () => {
+            this.__afterSaveCalled++;
         });
     }
 
@@ -60,8 +60,8 @@ describe("events test", () => {
 
         expect(company1.invoicesPaidCount).toEqual(1);
         expect(company1.invoicesPaidAmount).toEqual(100);
-        expect(invoice1.afterSaveCalled).toEqual(1);
-        expect(invoice1.beforeSaveCalled).toEqual(1);
+        expect(invoice1.__afterSaveCalled).toEqual(1);
+        expect(invoice1.__beforeSaveCalled).toEqual(1);
 
         const company2 = new Company();
         company2.name = "Company";
@@ -75,8 +75,8 @@ describe("events test", () => {
         expect(company2.invoicesPaidCount).toEqual(1);
         expect(company2.invoicesPaidAmount).toEqual(200);
 
-        expect(invoice2.afterSaveCalled).toEqual(1);
-        expect(invoice2.beforeSaveCalled).toEqual(1);
+        expect(invoice2.__afterSaveCalled).toEqual(1);
+        expect(invoice2.__beforeSaveCalled).toEqual(1);
 
         const company3 = new Company();
         company3.name = "Company";
@@ -91,8 +91,8 @@ describe("events test", () => {
         expect(company2.invoicesPaidAmount).toEqual(200);
         expect(company3.invoicesPaidCount).toEqual(1);
         expect(company3.invoicesPaidAmount).toEqual(300);
-        expect(invoice3.afterSaveCalled).toEqual(1);
-        expect(invoice3.beforeSaveCalled).toEqual(1);
+        expect(invoice3.__afterSaveCalled).toEqual(1);
+        expect(invoice3.__beforeSaveCalled).toEqual(1);
 
         const invoice4 = new Invoice();
         invoice4.company = company1;
@@ -105,8 +105,8 @@ describe("events test", () => {
         expect(company2.invoicesPaidAmount).toEqual(200);
         expect(company3.invoicesPaidCount).toEqual(1);
         expect(company3.invoicesPaidAmount).toEqual(300);
-        expect(invoice4.afterSaveCalled).toEqual(1);
-        expect(invoice4.beforeSaveCalled).toEqual(1);
+        expect(invoice4.__afterSaveCalled).toEqual(1);
+        expect(invoice4.__beforeSaveCalled).toEqual(1);
 
         const invoice5 = new Invoice();
         invoice5.company = company2;
@@ -119,8 +119,8 @@ describe("events test", () => {
         expect(company2.invoicesPaidAmount).toEqual(300);
         expect(company3.invoicesPaidCount).toEqual(1);
         expect(company3.invoicesPaidAmount).toEqual(300);
-        expect(invoice5.afterSaveCalled).toEqual(1);
-        expect(invoice5.beforeSaveCalled).toEqual(1);
+        expect(invoice5.__afterSaveCalled).toEqual(1);
+        expect(invoice5.__beforeSaveCalled).toEqual(1);
 
         const invoice6 = new Invoice();
         invoice6.company = company3;
@@ -133,26 +133,26 @@ describe("events test", () => {
         expect(company2.invoicesPaidAmount).toEqual(300);
         expect(company3.invoicesPaidCount).toEqual(2);
         expect(company3.invoicesPaidAmount).toEqual(1000);
-        expect(invoice6.afterSaveCalled).toEqual(1);
-        expect(invoice6.beforeSaveCalled).toEqual(1);
+        expect(invoice6.__afterSaveCalled).toEqual(1);
+        expect(invoice6.__beforeSaveCalled).toEqual(1);
     });
 
     test("event handler should be triggered only once", async () => {
         const invoice1 = new Invoice();
         await invoice1.save();
-        expect(invoice1.beforeSaveCalled).toEqual(1);
-        expect(invoice1.afterSaveCalled).toEqual(1);
+        expect(invoice1.__beforeSaveCalled).toEqual(1);
+        expect(invoice1.__afterSaveCalled).toEqual(1);
 
         await invoice1.save();
 
-        expect(invoice1.beforeSaveCalled).toEqual(1);
-        expect(invoice1.afterSaveCalled).toEqual(2);
+        expect(invoice1.__beforeSaveCalled).toEqual(1);
+        expect(invoice1.__afterSaveCalled).toEqual(2);
 
         await invoice1.save();
         await invoice1.save();
 
-        expect(invoice1.beforeSaveCalled).toEqual(1);
-        expect(invoice1.afterSaveCalled).toEqual(4);
+        expect(invoice1.__beforeSaveCalled).toEqual(1);
+        expect(invoice1.__afterSaveCalled).toEqual(4);
     });
 
     test("should inherit static events from extended class", async () => {

--- a/packages/webiny-entity/src/entity.js
+++ b/packages/webiny-entity/src/entity.js
@@ -271,20 +271,28 @@ class Entity {
      * @param params
      */
     async save(params: ?Object): Promise<void> {
+        if (!params) {
+            params = {};
+        }
+        const events = params.events || {};
+        const existing = this.isExisting();
+
+        events.beforeSave !== false && (await this.emit("beforeSave", { params }));
+
+        if (existing) {
+            events.beforeUpdate !== false && (await this.emit("beforeUpdate", { params }));
+        } else {
+            events.beforeCreate !== false && (await this.emit("beforeCreate", { params }));
+        }
+
         if (this.processing) {
             return;
         }
 
         this.processing = "save";
-        const existing = this.isExisting();
         const logs = _.get(this, "constructor.crud.logs");
 
-        if (!params) {
-            params = {};
-        }
-
         try {
-            const events = params.events || {};
             events.save !== false && (await this.emit("save", { params }));
             if (existing) {
                 events.update !== false && (await this.emit("update", { params }));
@@ -294,16 +302,16 @@ class Entity {
 
             params.validation !== false && (await this.validate());
 
-            events.beforeSave !== false && (await this.emit("beforeSave", { params }));
+            events.__beforeSave !== false && (await this.emit("__beforeSave", { params }));
 
             if (existing) {
-                events.beforeUpdate !== false && (await this.emit("beforeUpdate", { params }));
+                events.__beforeUpdate !== false && (await this.emit("__beforeUpdate", { params }));
                 if (logs && this.isDirty()) {
                     this.savedOn = new Date();
                     this.updatedOn = new Date();
                 }
             } else {
-                events.beforeCreate !== false && (await this.emit("beforeCreate", { params }));
+                events.__beforeCreate !== false && (await this.emit("__beforeCreate", { params }));
                 if (logs && this.isDirty()) {
                     this.savedOn = new Date();
                     this.createdOn = new Date();
@@ -314,11 +322,11 @@ class Entity {
                 await this.getDriver().save(this, params);
             }
 
-            events.afterSave !== false && (await this.emit("afterSave", { params }));
+            events.__afterSave !== false && (await this.emit("__afterSave", { params }));
             if (existing) {
-                events.afterUpdate !== false && (await this.emit("afterUpdate", { params }));
+                events.__afterUpdate !== false && (await this.emit("__afterUpdate", { params }));
             } else {
-                events.afterCreate !== false && (await this.emit("afterCreate", { params }));
+                events.__afterCreate !== false && (await this.emit("__afterCreate", { params }));
             }
 
             this.setExisting();
@@ -329,6 +337,13 @@ class Entity {
             throw e;
         } finally {
             this.processing = null;
+        }
+
+        events.afterSave !== false && (await this.emit("afterSave", { params }));
+        if (existing) {
+            events.afterUpdate !== false && (await this.emit("afterUpdate", { params }));
+        } else {
+            events.afterCreate !== false && (await this.emit("afterCreate", { params }));
         }
     }
 

--- a/packages/webiny-entity/src/entity.js
+++ b/packages/webiny-entity/src/entity.js
@@ -293,11 +293,11 @@ class Entity {
         const logs = _.get(this, "constructor.crud.logs");
 
         try {
-            events.save !== false && (await this.emit("save", { params }));
+            events.save !== false && (await this.emit("__save", { params }));
             if (existing) {
-                events.update !== false && (await this.emit("update", { params }));
+                events.update !== false && (await this.emit("__update", { params }));
             } else {
-                events.create !== false && (await this.emit("create", { params }));
+                events.create !== false && (await this.emit("__create", { params }));
             }
 
             params.validation !== false && (await this.validate());

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
@@ -49,7 +49,7 @@ class EntitiesAttribute extends Attribute {
          */
         this.auto = { save: true, delete: true };
 
-        this.parentEntity.on("save", async () => {
+        this.parentEntity.on("__save", async () => {
             const value: EntitiesAttributeValue = (this.value: any);
 
             // If loading is in progress, wait until loaded.

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
@@ -78,7 +78,7 @@ class EntitiesAttribute extends Attribute {
          * Same as in EntityAttribute, entities present here were already validated when parent entity called the validate method.
          * At this point, entities are ready to be saved (only loaded entities).
          */
-        this.parentEntity.on("afterSave", async () => {
+        this.parentEntity.on("__afterSave", async () => {
             // We don't have to do the following check here:
             // this.value.isLoading() && (await this.value.load());
 

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttributeValue.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttributeValue.js
@@ -220,7 +220,7 @@ class EntitiesAttributeValue extends AttributeValue {
      * Sets current links, based on initial and currently set entities.
      *
      * How links-management works?
-     * When entities are set, on "save" event, attribute will be first loaded - meaning all initial (from storage)
+     * When entities are set, on "__save" event, attribute will be first loaded - meaning all initial (from storage)
      * linked entities and its links will be loaded ("this.initial" / "this.links.initial"). After that, this method
      * will iterate over all newly set entities, and check if for each a link is already existing. If so, it will
      * use it, otherwise a new instance is created, linking parent and set entity together.

--- a/packages/webiny-entity/src/entityAttributes/entityAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entityAttribute.js
@@ -52,7 +52,7 @@ class EntityAttribute extends Attribute {
          * validation will be called internally in the save method. Save operations will be executed starting from bottom
          * nested entities, ending with the main parent entity.
          */
-        this.parentEntity.on("beforeSave", async () => {
+        this.parentEntity.on("__beforeSave", async () => {
             const value = ((this.value: any): EntityAttributeValue);
 
             // At this point current value is an instance or is not instance. It cannot be in the 'loading' state, because that was


### PR DESCRIPTION
These events must be executed outside save process. 

This means that once the save starts, immediately execute `beforeSave`, `beforeUpdate`, `beforeCreate` events, and only then start the actual processing of entity. The same goes for "after" events, execute them once processing has been completely done.

This was done simply by renaming current `before` and `after` events to `__before` and `__after`, making them internal events, and inserting new ones that follow the explained behavior.

Motivation:
Eg. `onAfterCreate` developer again calls `this.save()`, this save call would not work. Entity was still in "processing" state, and method would immediately return.