### PR TITLE
Implemented "groupBy" option

### DIFF
--- a/packages/webiny-entity-mysql/__tests__/count.test.js
+++ b/packages/webiny-entity-mysql/__tests__/count.test.js
@@ -22,6 +22,22 @@ describe("count test", () => {
         queryStub.restore();
     });
 
+    test("must generate correct query - must have GROUP BY included", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        await SimpleEntity.count({ groupBy: ["something"] });
+
+        expect(queryStub.getCall(0).args[0]).toEqual(
+            "SELECT COUNT(*) AS count FROM `SimpleEntity` GROUP BY something"
+        );
+
+        queryStub.restore();
+    });
+
     test("should count entities", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => {
             return [{ count: 1 }];

--- a/packages/webiny-entity-mysql/__tests__/find.test.js
+++ b/packages/webiny-entity-mysql/__tests__/find.test.js
@@ -24,6 +24,23 @@ describe("find test", () => {
         queryStub.restore();
     });
 
+    test("find - must generate correct query - must have GROUP BY included", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        await SimpleEntity.find({ groupBy: ["something"] });
+
+        expect(queryStub.getCall(0).args[0]).toEqual([
+            "SELECT SQL_CALC_FOUND_ROWS * FROM `SimpleEntity` GROUP BY something LIMIT 10",
+            "SELECT FOUND_ROWS() as count"
+        ]);
+
+        queryStub.restore();
+    });
+
     test("should find entities and total count", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => [
             [

--- a/packages/webiny-entity-mysql/__tests__/findOne.test.js
+++ b/packages/webiny-entity-mysql/__tests__/findOne.test.js
@@ -20,6 +20,22 @@ describe("findOne test", () => {
         queryStub.restore();
     });
 
+    test("findOne must generate correct query - must have GROUP BY included", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        await SimpleEntity.findOne({ groupBy: ["something"] });
+
+        expect(queryStub.getCall(0).args[0]).toEqual(
+            "SELECT * FROM `SimpleEntity` GROUP BY something LIMIT 1"
+        );
+
+        queryStub.restore();
+    });
+
     test("findOne - should find previously inserted entity", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => {
             return [

--- a/packages/webiny-entity-mysql/__tests__/statements/select.test.js
+++ b/packages/webiny-entity-mysql/__tests__/statements/select.test.js
@@ -26,4 +26,29 @@ describe("SELECT statement test", () => {
             "SELECT name, enabled FROM `TestTable` WHERE (`name` = 'Test' AND `enabled` = true AND `deletedOn` IS NULL) ORDER BY name DESC, createdOn ASC LIMIT 10"
         );
     });
+
+    test("should generate a SELECT statement with GROUP BY", async () => {
+        const params = {
+            operation: "select",
+            operators,
+            table: "TestTable",
+            where: { name: "Test", enabled: true, deletedOn: null },
+            limit: 10,
+            offset: 0,
+            sort: { name: -1, createdOn: 1 },
+            groupBy: ["parent"]
+        };
+
+        let sql = new Select(params, Entity).generate();
+        expect(sql).toEqual(
+            "SELECT * FROM `TestTable` WHERE (`name` = 'Test' AND `enabled` = true AND `deletedOn` IS NULL) GROUP BY parent ORDER BY name DESC, createdOn ASC LIMIT 10"
+        );
+
+        params.columns = ["name", "enabled"];
+        sql = new Select(params, Entity).generate();
+
+        expect(sql).toEqual(
+            "SELECT name, enabled FROM `TestTable` WHERE (`name` = 'Test' AND `enabled` = true AND `deletedOn` IS NULL) GROUP BY parent ORDER BY name DESC, createdOn ASC LIMIT 10"
+        );
+    });
 });

--- a/packages/webiny-entity-mysql/src/mysqlDriver.js
+++ b/packages/webiny-entity-mysql/src/mysqlDriver.js
@@ -178,6 +178,7 @@ class MySQLDriver extends Driver {
             table: this.getTableName(entity),
             where: options.query,
             search: options.search,
+            groupBy: options.groupBy,
             sort: options.sort,
             page: options.page,
             limit: 1

--- a/packages/webiny-entity-mysql/src/statements/select.js
+++ b/packages/webiny-entity-mysql/src/statements/select.js
@@ -12,6 +12,7 @@ class Select extends Statement {
         output += this.getColumns(options);
         output += ` FROM \`${options.table}\``;
         output += this.getWhere(options);
+        output += this.getGroup(options);
         output += this.getOrder(options);
         output += this.getLimit(options);
         output += this.getOffset(options);

--- a/packages/webiny-entity-mysql/src/statements/statement.js
+++ b/packages/webiny-entity-mysql/src/statements/statement.js
@@ -11,6 +11,7 @@ declare type StatementOptions = {
     data: Object,
     limit?: number,
     offset?: number,
+    groupBy?: Array<string>,
     sort?: string,
     where?: Object,
     columns?: Array<string>,
@@ -45,6 +46,14 @@ class Statement {
         }
 
         return " WHERE " + this.process({ $and: options.where });
+    }
+
+    getGroup(options: StatementOptions): string {
+        if (!(Array.isArray(options.groupBy) && options.groupBy.length > 0)) {
+            return "";
+        }
+
+        return " GROUP BY " + options.groupBy.join(", ");
     }
 
     getOrder(options: StatementOptions): string {


### PR DESCRIPTION
Now you can use `groupBy` parameter, in order to group queried data. Eg. 

```
await SimpleEntity.findOne({ groupBy: ["something"] });
```

You can use this in `find`, `findOne` and `count` methods.