### PR TITLE
Added ability to pass custom SQL queries into find methods.

### DIFF
--- a/packages/webiny-entity-mysql/__tests__/count.test.js
+++ b/packages/webiny-entity-mysql/__tests__/count.test.js
@@ -38,6 +38,28 @@ describe("count test", () => {
         queryStub.restore();
     });
 
+    test("must generate correct query - custom query and values must be accepted", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        await SimpleEntity.count({
+            sql: {
+                query: "SELECT COUNT(*) FROM `SimpleEntity` WHERE age > ? OR type = ?",
+                values: [20, "developer"]
+            },
+            groupBy: ["something"]
+        });
+
+        expect(queryStub.getCall(0).args[0]).toEqual(
+            "SELECT COUNT(*) FROM `SimpleEntity` WHERE age > 20 OR type = 'developer'"
+        );
+
+        queryStub.restore();
+    });
+
     test("should count entities", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => {
             return [{ count: 1 }];

--- a/packages/webiny-entity-mysql/__tests__/find.test.js
+++ b/packages/webiny-entity-mysql/__tests__/find.test.js
@@ -41,6 +41,30 @@ describe("find test", () => {
         queryStub.restore();
     });
 
+    test("find - must accept given passed custom query and variables", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        // Left "groupBy", just to make sure it's totally ignored.
+        await SimpleEntity.find({
+            sql: {
+                query: "SELECT SQL_CALC_FOUND_ROWS * FROM `SimpleEntity` WHERE age > ? OR type = ?",
+                values: [20, "developer"]
+            },
+            groupBy: ["something"]
+        });
+
+        expect(queryStub.getCall(0).args[0]).toEqual([
+            "SELECT SQL_CALC_FOUND_ROWS * FROM `SimpleEntity` WHERE age > 20 OR type = 'developer'",
+            "SELECT FOUND_ROWS() as count"
+        ]);
+
+        queryStub.restore();
+    });
+
     test("should find entities and total count", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => [
             [

--- a/packages/webiny-entity-mysql/__tests__/findOne.test.js
+++ b/packages/webiny-entity-mysql/__tests__/findOne.test.js
@@ -36,6 +36,28 @@ describe("findOne test", () => {
         queryStub.restore();
     });
 
+    test("findOne - must accept custom query and values", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        await SimpleEntity.findOne({
+            groupBy: ["something"],
+            sql: {
+                query: "SELECT * FROM `SimpleEntity` WHERE age > ? OR type = ? LIMIT 1",
+                values: [20, "developer"]
+            }
+        });
+
+        expect(queryStub.getCall(0).args[0]).toEqual(
+            "SELECT * FROM `SimpleEntity` WHERE age > 20 OR type = 'developer' LIMIT 1"
+        );
+
+        queryStub.restore();
+    });
+
     test("findOne - should find previously inserted entity", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query").callsFake(() => {
             return [

--- a/packages/webiny-entity-mysql/src/mysqlDriver.js
+++ b/packages/webiny-entity-mysql/src/mysqlDriver.js
@@ -180,6 +180,7 @@ class MySQLDriver extends Driver {
             search: options.search,
             groupBy: options.groupBy,
             sort: options.sort,
+            sql: options.sql,
             page: options.page,
             limit: 1
         };

--- a/packages/webiny-entity-mysql/src/statements/select.js
+++ b/packages/webiny-entity-mysql/src/statements/select.js
@@ -1,9 +1,17 @@
 // @flow
 import Statement from "./statement";
+import SqlString from "sqlstring";
 
 class Select extends Statement {
     generate() {
         const options = this.options;
+        if (options.sql) {
+            const { query, values } = options.sql;
+            if (typeof query === "string") {
+                return SqlString.format(query, values);
+            }
+        }
+
         let output = `SELECT`;
         if (options.calculateFoundRows) {
             output += ` SQL_CALC_FOUND_ROWS`;

--- a/packages/webiny-entity-mysql/src/statements/statement.js
+++ b/packages/webiny-entity-mysql/src/statements/statement.js
@@ -15,7 +15,8 @@ declare type StatementOptions = {
     sort?: string,
     where?: Object,
     columns?: Array<string>,
-    onDuplicateKeyUpdate?: boolean
+    onDuplicateKeyUpdate?: boolean,
+    sql: { query: string, values: any }
 };
 
 class Statement {


### PR DESCRIPTION
Example:

```
await SimpleEntity.count({
            sql: {
                query: "SELECT COUNT(*) FROM `SimpleEntity` WHERE age > ? OR type = ?",
                values: [20, "developer"]
            },
            groupBy: ["something"]
        });
```

Note that in this example `groupBy` will totally be ignored, because the custom `sql` was passed.

This behavior is supported by `find`, `findOne` and `count` methods.