### PR TITLE
Entity / entities attributes - fixed save / delete behavior when set as dynamic

### DIFF
--- a/packages/webiny-entity/__tests__/entities/abcDynamicAttribute.js
+++ b/packages/webiny-entity/__tests__/entities/abcDynamicAttribute.js
@@ -1,0 +1,38 @@
+import { Entity } from "webiny-entity";
+
+class ClassADynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("name").char();
+        this.attr("classBDynamic").entity(ClassBDynamic);
+        this.attr("classBDynamic")
+            .entity(ClassBDynamic)
+            .setDynamic(() => null);
+    }
+}
+
+ClassADynamic.classId = "ClassADynamic";
+
+class ClassBDynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("name").char();
+        this.attr("classCDynamic").entity(ClassCDynamic);
+        this.attr("classCDynamic")
+            .entity(ClassCDynamic)
+            .setDynamic(() => null);
+    }
+}
+
+ClassBDynamic.classId = "ClassBDynamic";
+
+class ClassCDynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("name").char();
+    }
+}
+
+ClassCDynamic.classId = "ClassCDynamic";
+
+export { ClassADynamic, ClassBDynamic, ClassCDynamic };

--- a/packages/webiny-entity/__tests__/entities/abcDynamicAttribute.js
+++ b/packages/webiny-entity/__tests__/entities/abcDynamicAttribute.js
@@ -5,9 +5,6 @@ class ClassADynamic extends Entity {
         super();
         this.attr("name").char();
         this.attr("classBDynamic").entity(ClassBDynamic);
-        this.attr("classBDynamic")
-            .entity(ClassBDynamic)
-            .setDynamic(() => null);
     }
 }
 
@@ -18,9 +15,6 @@ class ClassBDynamic extends Entity {
         super();
         this.attr("name").char();
         this.attr("classCDynamic").entity(ClassCDynamic);
-        this.attr("classCDynamic")
-            .entity(ClassCDynamic)
-            .setDynamic(() => null);
     }
 }
 

--- a/packages/webiny-entity/__tests__/entities/entitiesUsingDynamic.js
+++ b/packages/webiny-entity/__tests__/entities/entitiesUsingDynamic.js
@@ -1,0 +1,34 @@
+import { Entity } from "webiny-entity";
+
+class UserDynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("name").char();
+        this.attr("groupsDynamic")
+            .entities(GroupDynamic)
+            .setUsing(UserDynamicGroupsDynamic)
+            .setDynamic(() => [new GroupDynamic(), new GroupDynamic()]);
+    }
+}
+
+UserDynamic.classId = "UserDynamic";
+
+class GroupDynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("name").char();
+    }
+}
+
+GroupDynamic.classId = "GroupDynamic";
+
+class UserDynamicGroupsDynamic extends Entity {
+    constructor() {
+        super();
+        this.attr("userDynamic").entity(UserDynamic);
+        this.attr("groupDynamic").entity(GroupDynamic);
+    }
+}
+UserDynamicGroupsDynamic.classId = "UserDynamicGroupsDynamic";
+
+export { UserDynamic, GroupDynamic, UserDynamicGroupsDynamic };

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
@@ -50,6 +50,10 @@ class EntitiesAttribute extends Attribute {
         this.auto = { save: true, delete: true };
 
         this.parentEntity.on("__save", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             const value: EntitiesAttributeValue = (this.value: any);
 
             // If loading is in progress, wait until loaded.
@@ -79,6 +83,10 @@ class EntitiesAttribute extends Attribute {
          * At this point, entities are ready to be saved (only loaded entities).
          */
         this.parentEntity.on("__afterSave", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             // We don't have to do the following check here:
             // this.value.isLoading() && (await this.value.load());
 
@@ -121,6 +129,10 @@ class EntitiesAttribute extends Attribute {
         });
 
         this.parentEntity.on("delete", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             const value: EntitiesAttributeValue = (this.value: any);
 
             if (this.getAutoDelete()) {
@@ -138,6 +150,10 @@ class EntitiesAttribute extends Attribute {
         });
 
         this.parentEntity.on("beforeDelete", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             const value: EntitiesAttributeValue = (this.value: any);
 
             if (this.getAutoDelete()) {

--- a/packages/webiny-entity/src/entityAttributes/entityAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entityAttribute.js
@@ -53,6 +53,10 @@ class EntityAttribute extends Attribute {
          * nested entities, ending with the main parent entity.
          */
         this.parentEntity.on("__beforeSave", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             const value = ((this.value: any): EntityAttributeValue);
 
             // At this point current value is an instance or is not instance. It cannot be in the 'loading' state, because that was
@@ -82,6 +86,10 @@ class EntityAttribute extends Attribute {
          * The deletes are done on initial storage entities, not on entities stored as current value.
          */
         this.parentEntity.on("delete", async () => {
+            if (this.getDynamic()) {
+                return;
+            }
+
             if (this.getAutoDelete()) {
                 const value = ((this.value: any): EntityAttributeValue);
                 await value.load();


### PR DESCRIPTION
Normally in entity / entities attributes, certain save / delete processes must occur once the main entity is being saved / deleted. This is because links need to be validated and properly managed.

But, if entity / entities attributes are marked as dynamic, value is always returned by provided callback, eg.:

```
this.attr("revisions")
                .entities(Page)
                .setDynamic(() => {
                    return Page.find({ query: { parent: this.parent }, sort: { version: -1 } });
                });
```
Also, these cannot have value assigned.

So in these cases, when entity / entities attributes are dynamic, mentioned save / deleted processes must not occur at all.