### PR TITLE
Added ability to manually assign an ID before saving a new entity

### DIFF
--- a/packages/webiny-entity-mysql/__tests__/save.test.js
+++ b/packages/webiny-entity-mysql/__tests__/save.test.js
@@ -47,6 +47,18 @@ describe("save test", () => {
             });
 
         const simpleEntity = new SimpleEntity();
+
+        simpleEntity.id = "123";
+        let error = null;
+        try {
+            await simpleEntity.save();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error !== null).toBeTrue();
+        expect(error.message).toBe("You have assigned an invalid id (123)");
+
         simpleEntity.id = "aaaaaaaaaabbbbbbbbbbcccc";
         await simpleEntity.save();
 

--- a/packages/webiny-entity-mysql/__tests__/save.test.js
+++ b/packages/webiny-entity-mysql/__tests__/save.test.js
@@ -39,6 +39,37 @@ describe("save test", () => {
         queryStub.restore();
     });
 
+    test("must generate correct query - use manually assigned ID (works only when not in autoIncrement mode)", async () => {
+        const queryStub = sandbox
+            .stub(SimpleEntity.getDriver().getConnection(), "query")
+            .callsFake(() => {
+                return [[], [{ count: null }]];
+            });
+
+        const simpleEntity = new SimpleEntity();
+        simpleEntity.id = "aaaaaaaaaabbbbbbbbbbcccc";
+        await simpleEntity.save();
+
+        // 'slug' and 'enabled' have default value set, that's why they are present in following statement.
+        expect(queryStub.getCall(0).args[0]).toEqual(
+            "INSERT INTO `SimpleEntity` (`id`, `slug`, `enabled`) VALUES ('aaaaaaaaaabbbbbbbbbbcccc', '', 1)"
+        );
+
+        simpleEntity.name = "test case";
+        simpleEntity.slug = "testCase";
+        simpleEntity.enabled = false;
+        simpleEntity.tags = ["test1", "test2"];
+
+        await simpleEntity.save();
+        expect(queryStub.getCall(1).args[0]).toEqual(
+            "UPDATE `SimpleEntity` SET `name` = 'test case', `slug` = 'testCase', `enabled` = 0, `tags` = '[\\\"test1\\\",\\\"test2\\\"]' WHERE (`id` = '" +
+                simpleEntity.id +
+                "') LIMIT 1"
+        );
+
+        queryStub.restore();
+    });
+
     test("should save new entity into database and entity should receive an integer ID", async () => {
         sandbox.stub(SimpleEntity.getDriver().getConnection(), "query");
 

--- a/packages/webiny-entity-mysql/src/mysqlDriver.js
+++ b/packages/webiny-entity-mysql/src/mysqlDriver.js
@@ -100,7 +100,7 @@ class MySQLDriver extends Driver {
             return new QueryResult(true);
         }
 
-        if (!this.autoIncrementIds) {
+        if (!this.autoIncrementIds && !entity.id) {
             entity.id = MySQLDriver.__generateID();
         }
 

--- a/packages/webiny-entity-mysql/src/mysqlDriver.js
+++ b/packages/webiny-entity-mysql/src/mysqlDriver.js
@@ -100,8 +100,15 @@ class MySQLDriver extends Driver {
             return new QueryResult(true);
         }
 
-        if (!this.autoIncrementIds && !entity.id) {
-            entity.id = MySQLDriver.__generateID();
+        if (!this.autoIncrementIds) {
+            // If ID was assigned manually, just check if it's valid.
+            if (entity.id) {
+                if (!this.isId(entity, entity.id)) {
+                    throw Error(`You have assigned an invalid id (${entity.id})`);
+                }
+            } else {
+                entity.id = MySQLDriver.__generateID();
+            }
         }
 
         const data = await entity.toStorage();


### PR DESCRIPTION
If for some reason you would like to manually assign an ID (instead of receiving an automatic and randomly generated one), you can now assign it by yourself, before you call `save` and it will be used.

Just make sure it's a valid ID (MongoDB format) - `^[0-9a-fA-F]{24}$`. Otherwise an error will be thrown.