### PR TITLE
Created "webiny-load-assets" package for easier inclusion of additional scripts and links (eg. stylesheets)

### DIFF
--- a/packages/webiny-install/README.md
+++ b/packages/webiny-install/README.md
@@ -1,0 +1,3 @@
+# webiny-install
+
+A small package for easy installation of Webiny apps and integrations.

--- a/packages/webiny-load-assets/.babelrc
+++ b/packages/webiny-load-assets/.babelrc
@@ -1,0 +1,15 @@
+{
+    "presets": [
+        ["@babel/preset-env", {
+            "targets": {
+                "node": "8.10"
+            }
+        }],
+        "@babel/preset-flow"
+    ],
+    "plugins": [
+        ["babel-plugin-lodash"],
+        ["@babel/plugin-proposal-object-rest-spread", {"useBuiltIns": true}],
+        ["@babel/plugin-transform-runtime"]
+    ]
+}

--- a/packages/webiny-load-assets/README.md
+++ b/packages/webiny-load-assets/README.md
@@ -1,0 +1,23 @@
+# webiny-load-assets
+
+A small library for easy loading additional scripts and links (eg. stylesheets).
+
+Example:
+
+```
+load(
+    "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css",
+    "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"
+).then(() => {
+    window.cookieconsent.initialise({
+        palette: {
+            popup: {
+                background: "#000"
+            },
+            button: {
+                background: "#f1d600"
+            }
+        }
+    });
+});
+        ```

--- a/packages/webiny-load-assets/index.js
+++ b/packages/webiny-load-assets/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from "./src";

--- a/packages/webiny-load-assets/package.json
+++ b/packages/webiny-load-assets/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "webiny-load-assets",
+  "version": "0.0.0-semantically-released",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "contributors": [
+    "Pavel Denisjuk <pavel@webiny.com>",
+    "Adrian Smijulj <adrian@webiny.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.0.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0"
+  },
+  "scripts": {
+    "build": "babel src types.js -d ${DEST:-build} --source-maps --copy-files --ignore types.js",
+    "flow-copy-source": "flow-copy-source src ${DEST:-build}",
+    "postbuild": "yarn flow-copy-source"
+  }
+}

--- a/packages/webiny-load-assets/src/argumentProcessors/index.js
+++ b/packages/webiny-load-assets/src/argumentProcessors/index.js
@@ -1,0 +1,4 @@
+// @flow
+import { default as stringArgumentProcessor } from "./stringArgumentProcessor";
+
+export default [stringArgumentProcessor];

--- a/packages/webiny-load-assets/src/argumentProcessors/stringArgumentProcessor.js
+++ b/packages/webiny-load-assets/src/argumentProcessors/stringArgumentProcessor.js
@@ -1,0 +1,18 @@
+// @flow
+import { type ArgumentProcessorType } from "webiny-load-assets/types";
+
+export default ({
+    canProcess(argument) {
+        if (typeof argument !== "string") {
+            return false;
+        }
+
+        return argument.startsWith("//") || argument.startsWith("http");
+    },
+    process(argument: any) {
+        if (argument.endsWith(".js")) {
+            return { type: "script", src: argument };
+        }
+        return { type: "link", src: argument };
+    }
+}: ArgumentProcessorType);

--- a/packages/webiny-load-assets/src/assetLoaders/index.js
+++ b/packages/webiny-load-assets/src/assetLoaders/index.js
@@ -1,0 +1,5 @@
+// @flow
+import { default as linkLoader } from "./linkLoader";
+import { default as scriptLoader } from "./scriptLoader";
+
+export default [linkLoader, scriptLoader];

--- a/packages/webiny-load-assets/src/assetLoaders/linkLoader.js
+++ b/packages/webiny-load-assets/src/assetLoaders/linkLoader.js
@@ -1,0 +1,24 @@
+// @flow
+
+/* global document */
+
+import { type AssetLoaderType } from "webiny-load-assets/types";
+
+export default ({
+    canProcess: processedArgument => processedArgument.type === "link",
+    mustProcess: processedArgument => {
+        const { src } = processedArgument;
+        return document.querySelectorAll(`link[rel="stylesheet"][href="${src}"]`).length === 0;
+    },
+    process: processedArgument => {
+        const { src } = processedArgument;
+
+        return new Promise(resolve => {
+            const s = document.createElement("link");
+            s.rel = "stylesheet";
+            s.href = src;
+            s.onload = resolve;
+            document.head && document.head.appendChild(s);
+        });
+    }
+}: AssetLoaderType);

--- a/packages/webiny-load-assets/src/assetLoaders/scriptLoader.js
+++ b/packages/webiny-load-assets/src/assetLoaders/scriptLoader.js
@@ -1,0 +1,25 @@
+// @flow
+
+/* global document */
+
+import { type AssetLoaderType } from "webiny-load-assets/types";
+
+export default ({
+    canProcess: processedArgument => processedArgument.type === "script",
+    mustProcess: processedArgument => {
+        const { src } = processedArgument;
+        return document.querySelectorAll(`script[src="${src}"]`).length === 0;
+    },
+    process: processedArgument => {
+        const { src } = processedArgument;
+
+        return new Promise(resolve => {
+            const s = document.createElement("script");
+            s.type = "text/javascript";
+            s.src = src;
+            s.async = true;
+            s.onload = resolve;
+            document.body && document.body.appendChild(s);
+        });
+    }
+}: AssetLoaderType);

--- a/packages/webiny-load-assets/src/index.js
+++ b/packages/webiny-load-assets/src/index.js
@@ -1,0 +1,36 @@
+// @flow
+import argumentProcessors from "./argumentProcessors";
+import assetLoaders from "./assetLoaders";
+
+export default async (...args: Array<any>) => {
+    return new Promise(async resolve => {
+        outerLoop: for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            let eligibleProcessor = null;
+            argumentProcessors.forEach(processor => {
+                if (processor.canProcess(arg)) {
+                    eligibleProcessor = processor;
+                    return false;
+                }
+            });
+
+            if (!eligibleProcessor) {
+                throw Error("Cannot process load argument: " + arg);
+            }
+
+            const processedArgument = eligibleProcessor.process(arg);
+
+            for (let j = 0; j < assetLoaders.length; j++) {
+                let assetLoader = assetLoaders[j];
+                if (assetLoader.canProcess(processedArgument)) {
+                    await assetLoader.process(processedArgument);
+                    continue outerLoop;
+                }
+            }
+
+            throw Error("Cannot load given argument " + JSON.stringify(processedArgument));
+        }
+
+        resolve();
+    });
+};

--- a/packages/webiny-load-assets/types.js
+++ b/packages/webiny-load-assets/types.js
@@ -1,0 +1,16 @@
+// @flow
+export type ArgumentProcessorType = {
+    canProcess: any => boolean,
+    process: any => ProcessedArgumentType
+};
+
+export type ProcessedArgumentType = Object & {
+    type: "script" | "link",
+    src: string
+};
+
+export type AssetLoaderType = {
+    canProcess: ProcessedArgumentType => boolean,
+    mustProcess: ProcessedArgumentType => boolean,
+    process: ProcessedArgumentType => any
+};


### PR DESCRIPTION
# webiny-load-assets

A small library for easy loading additional scripts and links (eg. stylesheets).

Example:

```javascript
load(
    "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css",
    "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"
).then(() => {
    window.cookieconsent.initialise({
        palette: {
            popup: {
                background: "#000"
            },
            button: {
                background: "#f1d600"
            }
        }
    });
});
```