### PR TITLE
Renamed "Modules" component to "Addons"

### DIFF
--- a/packages/demo-theme/src/layouts/static.js
+++ b/packages/demo-theme/src/layouts/static.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import styled from "react-emotion";
 import { Menu } from "webiny-app-cms/render/components";
-import { Modules } from "webiny-app/components";
+import { Addons } from "webiny-app/components";
 
 const Banner = styled("div")({
     backgroundColor: "#666",
@@ -17,7 +17,7 @@ type Props = {
 const Static = ({ children }: Props) => {
     return (
         <div className={"static-page-container"}>
-            <Modules />
+            <Addons />
             <Menu slug={"demo-menu"}>
                 {({ data }) => (
                     <ul>

--- a/packages/webiny-app/src/components/Addons.js
+++ b/packages/webiny-app/src/components/Addons.js
@@ -7,7 +7,7 @@ type State = {
     ready: boolean
 };
 
-export default class Modules extends React.Component<Props, State> {
+export default class Addons extends React.Component<Props, State> {
     settings = {};
     state = {
         ready: false

--- a/packages/webiny-app/src/components/index.js
+++ b/packages/webiny-app/src/components/index.js
@@ -9,4 +9,4 @@ export { withKeyHandler } from "./withKeyHandler";
 export { withUi } from "./withUi";
 export type { WithDataListProps, SearchParams, WithDataListParams } from "./withDataList";
 export { Image } from "./Image";
-export { default as Modules } from "./Modules";
+export { default as Addons } from "./Addons";


### PR DESCRIPTION
Integrations and apps are types of "addons". That's why this component was renamed.