### PR TITLE
When creating a new revision, page URL will be preserved.

### DIFF
--- a/packages/webiny-api-cms/src/entities/Page.entity.js
+++ b/packages/webiny-api-cms/src/entities/Page.entity.js
@@ -132,8 +132,15 @@ export const pageFactory = (context: Object): Class<IPage> => {
                 }
 
                 this.createdBy = user.id;
-                this.title = this.title || "Untitled";
-                this.url = (await this.category).url + "untitled-" + this.id;
+
+                if (!this.title) {
+                    this.title = "Untitled";
+                }
+
+                if (!this.url) {
+                    this.url = (await this.category).url + "untitled-" + this.id;
+                }
+
                 this.version = await this.getNextVersion();
 
                 this.settings = {

--- a/packages/webiny-app-cms/src/admin/plugins/pageDetails/header/editRevision/EditRevision.js
+++ b/packages/webiny-app-cms/src/admin/plugins/pageDetails/header/editRevision/EditRevision.js
@@ -16,7 +16,7 @@ import { ReactComponent as CreateRevision } from "./icons/round-add-24px.svg";
 type Props = WithPageDetailsProps & WithRouterProps & { gqlCreate: Function } & WithSnackbarProps;
 
 const EditRevision = ({ pageDetails: { page }, router, gqlCreate, showSnackbar }: Props) => {
-    const unpublishedRevision = page.revisions.find(item => !item.published);
+    const unpublishedRevision = page.revisions.find(item => !item.published && !item.locked);
     if (unpublishedRevision) {
         return (
             <Tooltip content={"Edit"} placement={"top"}>

--- a/packages/webiny-app-cms/src/admin/plugins/pageDetails/pageRevisions/Revision.js
+++ b/packages/webiny-app-cms/src/admin/plugins/pageDetails/pageRevisions/Revision.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-import { compose, withProps, withState, withHandlers } from "recompose";
+import { compose } from "recompose";
 import { css } from "emotion";
 import TimeAgo from "timeago-react";
 import {
@@ -58,7 +58,6 @@ const getIcon = (rev: Object) => {
 
 const Revision = ({
     rev,
-    pageDetails: { page },
     createRevision,
     editRevision,
     deleteRevision,
@@ -88,7 +87,8 @@ const Revision = ({
                     <ListItemMeta>
                         <Menu handle={<IconButton icon={<MoreVerticalIcon />} />}>
                             <MenuItem onClick={createRevision}>New</MenuItem>
-                            <MenuItem onClick={editRevision}>Edit</MenuItem>
+                            {!rev.locked && <MenuItem onClick={editRevision}>Edit</MenuItem>}
+
                             {!rev.published && (
                                 <MenuItem onClick={() => publishRevision(rev)}>Publish</MenuItem>
                             )}


### PR DESCRIPTION
Before this fix, each revision would get a new URL, eg: `/untitled-5c20ef0946e6daf6d952c53c`, which is not what we want.

Fixes #338.