### PR TITLE
On creation of new revisions, version numbers are now properly incremented 

### DIFF
--- a/packages/webiny-api-cms/src/entities/Page.entity.js
+++ b/packages/webiny-api-cms/src/entities/Page.entity.js
@@ -169,7 +169,7 @@ export const pageFactory = (context: Object): Class<IPage> => {
 
         async getNextVersion() {
             const revision: null | Page = await Page.findOne({
-                query: { parent: this.parent },
+                query: { parent: this.parent, deleted: [true, false] },
                 sort: { version: -1 }
             });
 


### PR DESCRIPTION
The problem occurred when a revision was deleted, and then a new one was created. 

The number that would be used on the deleted revision would again be picked for the new one. This is not only an incorrect number, but more importantly, it would cause a MySQL unique keys error.

Fixes #342.