### PR TITLE
Instead of checking instance types via `instanceof`, `classId` is now used (more reliable)

### DIFF
--- a/packages/webiny-api/src/lambda/lambda.js
+++ b/packages/webiny-api/src/lambda/lambda.js
@@ -68,17 +68,19 @@ function getErrorResponse(error: Error & Object) {
             errors: [{ code: error.code, message: error.message }]
         }),
         statusCode: 200,
-        headers: { "Content-Type": "application/json" }
+        headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Credentials": true
+        }
     };
 }
 
 let handler = null;
 
-export const createHandler = (config: () => Promise<Object>) => {
+export const createHandler = (configObject: () => Promise<Object>) => {
     return async (event: Object, context: Object) => {
-        if (typeof config === "function") {
-            config = await config();
-        }
+        const config = await configObject();
 
         return await new Promise(async (resolve, reject) => {
             if (!handler) {

--- a/packages/webiny-entity/__tests__/attributes/entityAttribute/general.test.js
+++ b/packages/webiny-entity/__tests__/attributes/entityAttribute/general.test.js
@@ -80,6 +80,8 @@ describe("entity attribute test", () => {
             }
         }
 
+        Primary.classId = "Primary";
+
         class Secondary extends Entity {
             constructor() {
                 super();
@@ -88,6 +90,8 @@ describe("entity attribute test", () => {
                     .setValidators("required");
             }
         }
+
+        Secondary.classId = "Secondary";
 
         const secondary1 = new Secondary();
         secondary1.name = "secondary1";
@@ -144,6 +148,8 @@ describe("entity attribute test", () => {
             }
         }
 
+        Primary.classId = "Primary";
+
         class Secondary extends Entity {
             constructor() {
                 super();
@@ -152,6 +158,8 @@ describe("entity attribute test", () => {
                     .setValidators("required");
             }
         }
+
+        Secondary.classId = "secondary";
 
         const secondary1 = new Secondary();
         secondary1.name = "secondary1";

--- a/packages/webiny-entity/src/entity.js
+++ b/packages/webiny-entity/src/entity.js
@@ -149,6 +149,18 @@ class Entity {
         return this.constructor.pool;
     }
 
+    static isEntityInstance(value: any): boolean {
+        return !!_.get(value, "constructor.classId");
+    }
+
+    static isEntityClass(value: any): boolean {
+        return !!_.get(value, "classId");
+    }
+
+    static isInstanceOf(instance: ?any, instanceClass: ?Class<Entity>) {
+        return _.get(instance, "constructor.classId") === _.get(instanceClass, "classId");
+    }
+
     /**
      * Sets whether entity is existing or not.
      */

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttribute.js
@@ -142,7 +142,7 @@ class EntitiesAttribute extends Attribute {
                     class: this.getUsingClass() || this.getEntitiesClass()
                 };
                 for (let i = 0; i < entities.current.length; i++) {
-                    if (entities.current[i] instanceof entities.class) {
+                    if (Entity.isInstanceOf(entities.current[i], entities.class)) {
                         await entities.current[i].emit("delete");
                     }
                 }
@@ -164,7 +164,7 @@ class EntitiesAttribute extends Attribute {
                 };
 
                 for (let i = 0; i < entities.current.length; i++) {
-                    if (entities.current[i] instanceof entities.class) {
+                    if (Entity.isInstanceOf(entities.current[i], entities.class)) {
                         await entities.current[i].delete({ events: { delete: false } });
                     }
                 }
@@ -320,7 +320,7 @@ class EntitiesAttribute extends Attribute {
 
         for (let i = 0; i < value.length; i++) {
             const currentEntity = value[i];
-            if (!(currentEntity instanceof correctClass)) {
+            if (!(Entity.isInstanceOf(currentEntity, correctClass))) {
                 errors.push({
                     code: ModelError.INVALID_ATTRIBUTE,
                     data: {
@@ -393,7 +393,7 @@ class EntitiesAttribute extends Attribute {
             let current = entities[i];
 
             // "Instance of Entity" check is enough at this point.
-            if (current instanceof Entity) {
+            if (Entity.isEntityInstance(current)) {
                 continue;
             }
 

--- a/packages/webiny-entity/src/entityAttributes/entitiesAttributeValue.js
+++ b/packages/webiny-entity/src/entityAttributes/entitiesAttributeValue.js
@@ -124,7 +124,7 @@ class EntitiesAttributeValue extends AttributeValue {
 
         for (let i = 0; i < initial.length; i++) {
             const currentInitial: mixed = initial[i];
-            if (currentInitial instanceof Entity) {
+            if (Entity.isEntityInstance(currentInitial)) {
                 if (!currentEntitiesIds.includes(currentInitial.id)) {
                     await currentInitial.delete();
                 }
@@ -144,7 +144,7 @@ class EntitiesAttributeValue extends AttributeValue {
 
         for (let i = 0; i < current.length; i++) {
             const entity = current[i];
-            if (entity instanceof Entity) {
+            if (Entity.isEntityInstance(entity)) {
                 const attribute: EntitiesAttribute = (this.attribute: any);
                 const classes = attribute.classes;
 
@@ -206,7 +206,7 @@ class EntitiesAttributeValue extends AttributeValue {
             const initial = initialLinks[i];
             // $FlowFixMe
             if (!currentLinksIds.includes(initial.id)) {
-                initial instanceof Entity && (await initial.delete());
+                Entity.isEntityInstance(initial) && (await initial.delete());
             }
         }
     }
@@ -300,7 +300,7 @@ class EntitiesAttributeValue extends AttributeValue {
     clean(): EntitiesAttributeValue {
         const current = this.getCurrent();
         for (let i = 0; i < current.length; i++) {
-            if (current[i] instanceof Entity) {
+            if (Entity.isEntityInstance(current[i])) {
                 if (!current[i].id) {
                     return this;
                 }
@@ -317,7 +317,7 @@ class EntitiesAttributeValue extends AttributeValue {
         }
         if (Array.isArray(this.current)) {
             for (let i = 0; i < this.current.length; i++) {
-                if (this.current[i] instanceof Entity && this.current[i].isDirty()) {
+                if (Entity.isEntityInstance(this.current[i]) && this.current[i].isDirty()) {
                     return true;
                 }
             }

--- a/packages/webiny-entity/src/entityAttributes/entityAttribute.js
+++ b/packages/webiny-entity/src/entityAttributes/entityAttribute.js
@@ -65,7 +65,7 @@ class EntityAttribute extends Attribute {
                 // We don't need to validate here because validate method was called on the parent entity, which caused
                 // the validation of data to be executed recursively on all attribute values.
                 const current = this.value.getCurrent();
-                if (current instanceof Entity) {
+                if (Entity.isEntityInstance(current)) {
                     await current.save({ validation: false });
                 }
 
@@ -94,7 +94,7 @@ class EntityAttribute extends Attribute {
                 const value = ((this.value: any): EntityAttributeValue);
                 await value.load();
                 const entity = value.getInitial();
-                if (entity instanceof this.getEntityClass()) {
+                if (Entity.isInstanceOf(entity, this.getEntityClass())) {
                     await entity.emit("delete");
                 }
             }
@@ -105,7 +105,7 @@ class EntityAttribute extends Attribute {
                 const value = ((this.value: any): EntityAttributeValue);
                 await value.load();
                 const entity = value.getInitial();
-                if (entity instanceof this.getEntityClass()) {
+                if (Entity.isInstanceOf(entity, this.getEntityClass())) {
                     // We don't want to fire the "delete" event because its handlers were already executed by upper 'delete' listener.
                     // That listener ensured that all callbacks that might've had blocked the deleted process were executed.
                     await entity.delete({ validation: false, events: { delete: false } });
@@ -216,7 +216,7 @@ class EntityAttribute extends Attribute {
         // attribute specified by the "classIdAttribute" option (passed on attribute construction).
         const classIdAttribute = this.getClassIdAttribute();
         if (classIdAttribute && this.hasMultipleEntityClasses()) {
-            if (finalValue instanceof Entity) {
+            if (Entity.isEntityInstance(finalValue)) {
                 return classIdAttribute.setValue(finalValue.classId);
             }
             if (!finalValue) {
@@ -240,7 +240,7 @@ class EntityAttribute extends Attribute {
         }
 
         // "Instance of Entity" check is enough at this point.
-        if (this.value.getCurrent() instanceof Entity) {
+        if (Entity.isEntityInstance(this.value.getCurrent())) {
             return this.value.getCurrent();
         }
 
@@ -310,7 +310,7 @@ class EntityAttribute extends Attribute {
 
     async getJSONValue() {
         const value = await this.getValue();
-        if (value instanceof Entity) {
+        if (Entity.isEntityInstance(value)) {
             return await value.toJSON();
         }
         return value;
@@ -401,14 +401,15 @@ class EntityAttribute extends Attribute {
 
     async validateValue(value: mixed) {
         // This validates on the entity level.
-        value instanceof Entity && (await value.validate());
+        Entity.isEntityInstance(value) && (await value.validate());
     }
 
     isValidInstance(instance: ?Entity) {
         if (this.hasMultipleEntityClasses()) {
-            return instance instanceof Entity;
+            return Entity.isEntityInstance(instance);
         }
-        return instance instanceof this.getEntityClass();
+
+        return Entity.isInstanceOf(instance, this.getEntityClass());
     }
 }
 

--- a/packages/webiny-entity/src/entityAttributes/entityAttributeValue.js
+++ b/packages/webiny-entity/src/entityAttributes/entityAttributeValue.js
@@ -68,7 +68,10 @@ class EntityAttributeValue extends AttributeValue {
 
         // Initial value will always be an existing (already saved) Entity instance.
         const initial = this.getInitial();
-        if (initial instanceof Entity && _.get(initial, "id") !== _.get(this.getCurrent(), "id")) {
+        if (
+            Entity.isEntityInstance(initial) &&
+            _.get(initial, "id") !== _.get(this.getCurrent(), "id")
+        ) {
             await initial.delete(options);
         }
     }
@@ -88,14 +91,14 @@ class EntityAttributeValue extends AttributeValue {
 
     hasInitial() {
         const attribute: EntityAttribute = (this.attribute: any);
-        return this.initial instanceof attribute.getEntityClass();
+        return Entity.isInstanceOf(this.initial, attribute.getEntityClass());
     }
 
     isDirty(): boolean {
         if (super.isDirty()) {
             return true;
         }
-        return this.current instanceof Entity && this.current.isDirty();
+        return Entity.isEntityInstance(this.current) && this.current.isDirty();
     }
 
     isClean(): boolean {
@@ -117,7 +120,7 @@ class EntityAttributeValue extends AttributeValue {
     isDifferentFrom(value: mixed): boolean {
         const currentId = _.get(this.current, "id", this.current);
 
-        if (value instanceof Entity) {
+        if (Entity.isEntityInstance(value)) {
             return !value.id || value.id !== currentId;
         }
 

--- a/packages/webiny-entity/src/entityCollection.js
+++ b/packages/webiny-entity/src/entityCollection.js
@@ -32,7 +32,7 @@ class EntityCollection<T: $Subtype<Entity>> extends Array<T> {
 
     async toJSON(fields: ?string): Promise<Array<mixed>> {
         const collection = this.map(async (entity: mixed) => {
-            if (entity instanceof Entity) {
+            if (Entity.isEntityInstance(entity)) {
                 return await entity.toJSON(fields);
             }
             return entity;

--- a/packages/webiny-entity/src/entityPool.js
+++ b/packages/webiny-entity/src/entityPool.js
@@ -27,7 +27,7 @@ class EntityPool {
             return false;
         }
 
-        const entityId = entity instanceof Entity ? entity.id : id;
+        const entityId = Entity.isEntityInstance(entity) ? entity.id : id;
         return typeof this.getPool()[entityClass][entityId] !== "undefined";
     }
 
@@ -46,7 +46,7 @@ class EntityPool {
             return undefined;
         }
 
-        const entityId = entity instanceof Entity ? entity.id : id;
+        const entityId = Entity.isEntityInstance(entity) ? entity.id : id;
         const poolEntry: EntityPoolEntry = this.getPool()[entityClass][entityId];
         if (poolEntry) {
             return poolEntry.getEntity();


### PR DESCRIPTION
Problems occurred after the code was built. This was the safer approach since strings are not touched in the process.