### PR TITLE
Move production dependency to "dependencies".

### DIFF
--- a/addons/webiny-integration-cookie-policy/package.json
+++ b/addons/webiny-integration-cookie-policy/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react-dom": "^16.4.0",
+    "webiny-load-assets": "0.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -24,8 +25,7 @@
     "@babel/preset-react": "^7.0.0",
     "@svgr/webpack": "^2.1.1",
     "babel-plugin-module-resolver": "^3.1.1",
-    "babel-plugin-named-asset-import": "^1.0.0-next.3e165448",
-    "webiny-load-assets": "0.0.0"
+    "babel-plugin-named-asset-import": "^1.0.0-next.3e165448"
   },
   "scripts": {
     "build": "babel src -d ${DEST:-build} --source-maps --copy-files",


### PR DESCRIPTION
A production dependency was listed in `devDependencies` thus breaking the npm package on release.