### PR TITLE
Add control flags to installation process of Security and CMS.

### DIFF
--- a/packages/webiny-api-cms/.babelrc
+++ b/packages/webiny-api-cms/.babelrc
@@ -10,8 +10,6 @@
     "plugins": [
         ["@babel/plugin-proposal-class-properties"],
         ["@babel/plugin-proposal-object-rest-spread", {"useBuiltIns": true}],
-        ["@babel/plugin-transform-runtime"],
-        ["@babel/plugin-syntax-dynamic-import"],
-        ["babel-plugin-dynamic-import-node"]
+        ["@babel/plugin-transform-runtime"]
     ]
 }

--- a/packages/webiny-api-cms/package.json
+++ b/packages/webiny-api-cms/package.json
@@ -10,8 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "graphql-iso-date": "^3.5.0",
     "lodash": "^4.17.11",
+    "fs-extra": "^7.0.1",
     "mdbid": "^1.0.0",
     "request": "^2.88.0",
     "webiny-api": "0.0.0",
@@ -25,8 +25,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",
     "babel-plugin-dynamic-import-node": "^2.0.0",
-    "flow-copy-source": "^2.0.2",
-    "fs-extra": "^7.0.1"
+    "flow-copy-source": "^2.0.2"
   },
   "scripts": {
     "build": "babel src -d ${DEST:-build} --source-maps --copy-files",

--- a/packages/webiny-api-cms/src/install/plugins/importData/createDefaultBlocks.js
+++ b/packages/webiny-api-cms/src/install/plugins/importData/createDefaultBlocks.js
@@ -1,6 +1,7 @@
 // @flow
-import blocks from "./blocks";
+import get from "lodash/get";
 import fs from "fs-extra";
+import blocks from "./blocks";
 
 const createDefaultBlocks = async (context: Object) => {
     const { Element } = context.cms.entities;
@@ -13,8 +14,10 @@ const createDefaultBlocks = async (context: Object) => {
     }
 
     // Copy images.
-    const pwd: string = (process.cwd(): any);
-    await fs.copy(`${__dirname}/blocks/images`, pwd + "/static");
+    if (get(context, "cms.copyFiles", true) !== false) {
+        const pwd: string = (process.cwd(): any);
+        await fs.copy(`${__dirname}/blocks/images`, pwd + "/static");
+    }
 };
 
 export default createDefaultBlocks;

--- a/packages/webiny-api-cms/src/install/plugins/setupEntities.js
+++ b/packages/webiny-api-cms/src/install/plugins/setupEntities.js
@@ -6,7 +6,7 @@ import { elementFactory } from "./../../entities/Element.entity";
 import { cmsSettingsFactory } from "./../../entities/CmsSettings.entity";
 
 export default (context: Object) => {
-    context.cms = { entities: {} };
+    context.cms = { ...context.cms, entities: {} };
 
     context.cms.entities.Category = categoryFactory();
     context.cms.entities.Page = pageFactory(context);

--- a/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
@@ -1,6 +1,6 @@
 // @flow
 import { Entity } from "webiny-entity";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 import { listPublishedPages } from "webiny-api-cms/plugins/graphql/pageResolvers/listPublishedPages";
 

--- a/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/listPublishedPages.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/listPublishedPages.js
@@ -1,7 +1,7 @@
 // @flow
 import { createPaginationMeta } from "webiny-entity";
 import { ListResponse } from "webiny-api/graphql/responses";
-import { get } from "lodash";
+import get from "lodash/get";
 export const listPublishedPages = async ({ args, Page, Category }: Object) => {
     const {
         page = 1,

--- a/packages/webiny-api-security/src/entities/User.entity.js
+++ b/packages/webiny-api-security/src/entities/User.entity.js
@@ -1,7 +1,7 @@
 // @flow
 import md5 from "md5";
 import bcrypt from "bcryptjs";
-import { get } from "lodash";
+import get from "lodash/get";
 import { Entity } from "webiny-entity";
 import type { Group } from "./Group.entity";
 import type { Role } from "./Role.entity";

--- a/packages/webiny-api-security/src/install/plugins/importData.js
+++ b/packages/webiny-api-security/src/install/plugins/importData.js
@@ -1,4 +1,5 @@
 // @flow
+import get from "lodash/get";
 import setupEntities from "./setupEntities";
 import * as data from "./data";
 
@@ -11,7 +12,9 @@ export default async (context: Object) => {
     const fullAccess = new Role();
     await fullAccess.populate(data.fullAccessRole).save();
 
-    await user.populate({ ...data.superAdminUser, roles: [fullAccess] }).save();
+    const userData = get(context, "security.admin", data.superAdminUser);
+
+    await user.populate({ ...userData, roles: [fullAccess] }).save();
 
     context.user = user;
 

--- a/packages/webiny-api-security/src/install/plugins/setupEntities.js
+++ b/packages/webiny-api-security/src/install/plugins/setupEntities.js
@@ -7,7 +7,7 @@ import { roles2entitiesFactory } from "./../../entities/Roles2Entities.entity";
 import { userSettingsFactory } from "./../../entities/UserSettings.entity";
 
 export default (context: Object) => {
-    context.security = { entities: {} };
+    context.security = { ...context.security, entities: {} };
     context.security.entities.User = userFactory(context);
     context.security.entities.Group = groupFactory(context);
     context.security.entities.Role = roleFactory(context);

--- a/packages/webiny-api-security/src/plugins/graphql/userResolvers/loginUser.js
+++ b/packages/webiny-api-security/src/plugins/graphql/userResolvers/loginUser.js
@@ -40,6 +40,7 @@ export default (entityFetcher: EntityFetcher) => async (
     }
 
     const jwt = new JwtToken({ secret: context.config.security.token.secret });
+    // $FlowFixMe
     const access = await user.access;
     const token = await jwt.encode(
         // $FlowFixMe - instance that will be validated will have "password" attribute.

--- a/packages/webiny-api-security/src/plugins/security.js
+++ b/packages/webiny-api-security/src/plugins/security.js
@@ -3,7 +3,7 @@ import type { PluginType } from "webiny-plugins/types";
 import authenticate from "./authentication/authenticate";
 import { getPlugins } from "webiny-plugins";
 import { shield } from "graphql-shield";
-import { get } from "lodash";
+import get from "lodash/get";
 
 export default ([
     {

--- a/packages/webiny-api/package.json
+++ b/packages/webiny-api/package.json
@@ -15,22 +15,14 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "apollo-server-lambda": "^2.1.0",
-    "bcryptjs": "^2.4.3",
-    "chalk": "^2.4.1",
-    "debug": "^3.1.0",
-    "file-type": "^7.6.0",
     "graphql": "^0.13.2",
     "graphql-iso-date": "^3.5.0",
     "graphql-middleware": "^1.7.6",
     "graphql-tools": "^4.0.0",
     "graphql-type-json": "^0.2.0",
-    "invariant": "^2.2.4",
-    "jsonwebtoken": "^8.2.2",
     "lodash": "^4.17.4",
-    "md5": "^2.2.1",
-    "webiny-compose": "0.0.0",
     "webiny-entity": "0.0.0",
-    "webiny-service-manager": "0.0.0",
+    "webiny-model": "0.0.0",
     "webiny-plugins": "0.0.0"
   },
   "devDependencies": {

--- a/packages/webiny-api/src/graphql/InvalidAttributesError.js
+++ b/packages/webiny-api/src/graphql/InvalidAttributesError.js
@@ -1,10 +1,11 @@
 // @flow
-import _ from "lodash";
+import each from "lodash/each";
+import get from "lodash/get";
 import { ModelError } from "webiny-model";
 
 function formatInvalidAttributes(invalidAttributes, prefix = "") {
     const formatted = {};
-    _.each(invalidAttributes, ({ code, data, message }, name) => {
+    each(invalidAttributes, ({ code, data, message }, name) => {
         if (code !== "INVALID_ATTRIBUTE") {
             return;
         }
@@ -12,7 +13,7 @@ function formatInvalidAttributes(invalidAttributes, prefix = "") {
         const path = prefix ? `${prefix}.${name}` : name;
 
         if (Array.isArray(data)) {
-            return _.each(data, (err, index) => {
+            return each(data, (err, index) => {
                 const {
                     data: { invalidAttributes },
                     message
@@ -29,7 +30,7 @@ function formatInvalidAttributes(invalidAttributes, prefix = "") {
             });
         }
 
-        formatted[path] = _.get(data, "message", message);
+        formatted[path] = get(data, "message", message);
     });
 
     return formatted;
@@ -41,7 +42,7 @@ class InvalidAttributesError extends ModelError {
 
         let data: Object = (error.data: any);
         data.invalidAttributes = formatInvalidAttributes(
-            _.get(error, "data.invalidAttributes", {})
+            get(error, "data.invalidAttributes", {})
         );
 
         return new InvalidAttributesError(message, code, data);

--- a/packages/webiny-api/src/graphql/parseBoolean.js
+++ b/packages/webiny-api/src/graphql/parseBoolean.js
@@ -1,13 +1,14 @@
 // @flow
-import _ from "lodash";
+import forOwn from "lodash/forOwn";
+import isObject from "lodash/isObject";
 
 const traverse = (obj: Object) => {
-    _.forOwn(obj, (val, key) => {
-        if (_.isArray(val)) {
+    forOwn(obj, (val, key) => {
+        if (Array.isArray(val)) {
             val.forEach(el => {
                 traverse(el);
             });
-        } else if (_.isObject(val)) {
+        } else if (isObject(val)) {
             traverse(val);
         } else {
             if (val === "true") {


### PR DESCRIPTION
It is now possible to pass `security.admin` object through the installation context to create a root user with specified email and password. Also, we can now turn off file copying of CMS, via `cms.copyFiles` context key.