### PR TITLE
When creating a new revision, all data is now copied correctly.

### DIFF
--- a/packages/webiny-api-cms/src/entities/Page.entity.js
+++ b/packages/webiny-api-cms/src/entities/Page.entity.js
@@ -142,11 +142,13 @@ export const pageFactory = (context: Object): Class<IPage> => {
 
                 this.version = await this.getNextVersion();
 
-                this.settings = {
-                    general: {
-                        layout: (await this.category).layout
-                    }
-                };
+                if (!this.settings) {
+                    this.settings = {
+                        general: {
+                            layout: (await this.category).layout
+                        }
+                    };
+                }
             });
 
             this.on("beforeUpdate", () => {

--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
@@ -11,7 +11,7 @@ import PageImage from "./PageImage";
 import { set, get } from "lodash";
 
 const toSlug = (value, cb) => {
-    cb(slugify(value, { replacement: "-", lower: true, remove: /[*#\?<>_\{\}\[\]+~.()'"!:;@]/g }));
+    cb(slugify(value, { replacement: "-", lower: true, remove: /[*#\?<>_\{\}\[\]+~.()'"!:;@]/g })); // eslint-disable-line
 };
 
 const GeneralSettings = ({ Bind, onAfterChangeImage, cms: { theme } }: Object) => {
@@ -65,7 +65,10 @@ const GeneralSettings = ({ Bind, onAfterChangeImage, cms: { theme } }: Object) =
 export default compose(
     withCms(),
     withHandlers({
-        hasOgImage: ({ data }) => () => !!get(data, "settings.social.image.src")
+        hasOgImage: ({ data }) => () => {
+            const src = get(data, "settings.social.image.src");
+            return typeof src === "string" && !src.startsWith("data:");
+        }
     }),
     withHandlers({
         onAfterChangeImage: ({ hasOgImage, form }) => selectedImage => {

--- a/packages/webiny-model/__tests__/attributes/model.test.js
+++ b/packages/webiny-model/__tests__/attributes/model.test.js
@@ -25,8 +25,10 @@ describe("attribute model test", () => {
 
     describe("accepting correct Model classes test", () => {
         class Model1 extends Model {}
+        Model1.classId = "Model1";
 
         class Model2 extends Model {}
+        Model2.classId = "Model2";
 
         const model = new Model(function() {
             this.attr("attribute1").model(Model1);

--- a/packages/webiny-model/src/attributes/modelAttribute.js
+++ b/packages/webiny-model/src/attributes/modelAttribute.js
@@ -88,7 +88,7 @@ class ModelAttribute extends Attribute {
      * If value is assigned (checked in the parent validate call), it must by an instance of Model.
      */
     async validateType(value: mixed) {
-        if (value instanceof this.getModelClass()) {
+        if (Model.isInstanceOf(value, this.getModelClass())) {
             return;
         }
         this.expected("instance of Model class", typeof value);

--- a/packages/webiny-model/src/attributes/modelsAttribute.js
+++ b/packages/webiny-model/src/attributes/modelsAttribute.js
@@ -200,7 +200,7 @@ class ModelsAttribute extends Attribute {
 
             for (let key in objectValue) {
                 const current = objectValue[key];
-                if (!(current instanceof this.getModelClass())) {
+                if (!Model.isInstanceOf(current, this.getModelClass())) {
                     errors.push({
                         code: ModelError.INVALID_ATTRIBUTE,
                         data: {
@@ -231,7 +231,7 @@ class ModelsAttribute extends Attribute {
 
             for (let i = 0; i < arrayValue.length; i++) {
                 const current = arrayValue[i];
-                if (!(current instanceof this.getModelClass())) {
+                if (!Model.isInstanceOf(current, this.getModelClass())) {
                     errors.push({
                         code: ModelError.INVALID_ATTRIBUTE,
                         data: {

--- a/packages/webiny-model/src/model.js
+++ b/packages/webiny-model/src/model.js
@@ -285,6 +285,18 @@ class Model {
 
         return this;
     }
+
+    static isModelInstance(value: any): boolean {
+        return !!_.get(value, "constructor.classId");
+    }
+
+    static isModelClass(value: any): boolean {
+        return !!_.get(value, "classId");
+    }
+
+    static isInstanceOf(instance: ?any, instanceClass: ?Class<Model>) {
+        return _.get(instance, "constructor.classId") === _.get(instanceClass, "classId");
+    }
 }
 
 Model.classId = "";


### PR DESCRIPTION
Upon creating a new page revision, data in both `snippet` and `settings` attributes in source page would not be copied to the new revision. This PR fixes this.