### PR TITLE
Site settings can now be queried by non-logged-in users too (for site)

### DIFF
--- a/independent/webiny-integration-google-tag-manager/src/plugins/api/index.js
+++ b/independent/webiny-integration-google-tag-manager/src/plugins/api/index.js
@@ -19,9 +19,6 @@ export default [
         resolvers: {},
         security: {
             shield: {
-                SettingsQuery: {
-                    googleTagManager: hasScope("cms:settings")
-                },
                 SettingsMutation: {
                     googleTagManager: hasScope("cms:settings")
                 }

--- a/independent/webiny-integration-mailchimp/src/plugins/api/index.js
+++ b/independent/webiny-integration-mailchimp/src/plugins/api/index.js
@@ -102,9 +102,6 @@ export default [
                 },
                 MailchimpQuery: {
                     listLists: hasScope("cms:editor")
-                },
-                MailchimpMutation: {
-                    addToList: hasScope("cms:editor")
                 }
             }
         },

--- a/packages/demo-api/src/configs/development.js
+++ b/packages/demo-api/src/configs/development.js
@@ -39,7 +39,7 @@ export default async () => {
             }
         },
         security: {
-            enabled: false,
+            enabled: true,
             token: {
                 secret: process.env.WEBINY_JWT_SECRET,
                 expiresOn: () => addDays(new Date(), 30)

--- a/packages/demo-api/src/configs/production.js
+++ b/packages/demo-api/src/configs/production.js
@@ -21,7 +21,7 @@ export default async (context: Object) => {
             }
         },
         security: {
-            enabled: false,
+            enabled: true,
             token: {
                 secret: context.jwtSecret,
                 expiresOn: () => addDays(new Date(), 30)

--- a/packages/webiny-api-cms/src/plugins/graphql.js
+++ b/packages/webiny-api-cms/src/plugins/graphql.js
@@ -79,9 +79,6 @@ export default {
                 updateElement: hasScope("cms:element:crud"),
                 deleteElement: hasScope("cms:element:crud")
             },
-            SettingsQuery: {
-                cms: hasScope("cms:settings")
-            },
             SettingsMutation: {
                 cms: hasScope("cms:settings")
             }


### PR DESCRIPTION
"scope" restrictions were applied to the whole settings, which means non-logged-in users wouldn't be able to load data like site name, social settings etc., even on the public site.

In the future, if there's a field that must not be exposed publicly, put a shield rule only for that specific field.