### PR TITLE
In page preview section (list of pages view), pen icon is always shown for editing (better UX)

### DIFF
--- a/packages/webiny-app-cms/src/admin/plugins/pageDetails/header/editRevision/EditRevision.js
+++ b/packages/webiny-app-cms/src/admin/plugins/pageDetails/header/editRevision/EditRevision.js
@@ -4,14 +4,12 @@ import { withRouter, type WithRouterProps } from "webiny-app/components";
 import { type WithPageDetailsProps } from "webiny-app-cms/admin/components";
 import { IconButton } from "webiny-ui/Button";
 import { Tooltip } from "webiny-ui/Tooltip";
-import { ConfirmationDialog } from "webiny-ui/ConfirmationDialog";
 import { ReactComponent as EditIcon } from "webiny-app-cms/admin/assets/edit.svg";
 import withRevisionHandlers from "../../pageRevisions/withRevisionHandlers";
 import { compose } from "recompose";
 import { createRevisionFrom } from "webiny-app-cms/admin/graphql/pages";
 import { graphql } from "react-apollo";
 import { withSnackbar, type WithSnackbarProps } from "webiny-admin/components";
-import { ReactComponent as CreateRevision } from "./icons/round-add-24px.svg";
 import { get } from "lodash";
 type Props = WithPageDetailsProps & WithRouterProps & { gqlCreate: Function } & WithSnackbarProps;
 
@@ -37,36 +35,26 @@ const EditRevision = ({ pageDetails: { page }, router, gqlCreate, showSnackbar }
     }
 
     return (
-        <Tooltip content={"New draft"} placement={"top"}>
-            <ConfirmationDialog
-                title="Create new draft"
-                message="You are about to create a new draft, do you want to continue?"
-            >
-                {({ showConfirmation }) => (
-                    <IconButton
-                        icon={<CreateRevision />}
-                        onClick={() => {
-                            const [latestRevision] = page.revisions;
+        <Tooltip content={"Edit"} placement={"top"}>
+            <IconButton
+                icon={<EditIcon />}
+                onClick={async () => {
+                    const [latestRevision] = page.revisions;
+                    const { data: res } = await gqlCreate({
+                        variables: { revision: latestRevision.id }
+                    });
+                    const { data, error } = res.cms.revision;
 
-                            showConfirmation(async () => {
-                                const { data: res } = await gqlCreate({
-                                    variables: { revision: latestRevision.id }
-                                });
-                                const { data, error } = res.cms.revision;
+                    if (error) {
+                        return showSnackbar(error.message);
+                    }
 
-                                if (error) {
-                                    return showSnackbar(error.message);
-                                }
-
-                                router.goToRoute({
-                                    name: "Cms.Editor",
-                                    params: { id: data.id }
-                                });
-                            });
-                        }}
-                    />
-                )}
-            </ConfirmationDialog>
+                    router.goToRoute({
+                        name: "Cms.Editor",
+                        params: { id: data.id }
+                    });
+                }}
+            />
         </Tooltip>
     );
 };


### PR DESCRIPTION
We would switch between "pen" and "plus" icon, depending if the page is draft or not. By always showing the pen icon, we make it less confusing for the user. Pen icon is also more intuitive.

![image](https://user-images.githubusercontent.com/5121148/54864942-80856080-4d5e-11e9-9f2f-0dc8f2818b77.png)
