### PR TITLE
Added "NotFoundResponse" class

### DIFF
--- a/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/getMenuBySlug.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/getMenuBySlug.js
@@ -1,6 +1,6 @@
 // @flow
 import { Entity } from "webiny-entity";
-import { Response, ErrorResponse } from "webiny-api/graphql/responses";
+import { Response, NotFoundResponse } from "webiny-api/graphql/responses";
 import prepareMenuItems from "./prepareMenuItems";
 
 type EntityFetcher = (context: Object) => Class<Entity>;
@@ -15,10 +15,7 @@ export default (entityFetcher: EntityFetcher) => async (
 
     const entity = await entityClass.findOne({ query: { slug } });
     if (!entity) {
-        return new ErrorResponse({
-            code: "NOT_FOUND",
-            message: "Menu not found."
-        });
+        return new NotFoundResponse("Menu not found.");
     }
 
     return new Response({

--- a/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/createRevisionFrom.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/createRevisionFrom.js
@@ -1,15 +1,9 @@
 // @flow
 import type { Entity } from "webiny-entity";
 import type { IPage } from "../../../entities/Page.entity";
-import { ErrorResponse, Response } from "webiny-api/graphql";
+import { ErrorResponse, NotFoundResponse, Response } from "webiny-api/graphql";
 
 type EntityFetcher = (context: Object) => Class<Entity>;
-
-const notFound = (id: string) =>
-    new ErrorResponse({
-        code: "NOT_FOUND",
-        message: `Revision with id "${id}" was not found!`
-    });
 
 export default (entityFetcher: EntityFetcher) => async (
     root: any,
@@ -20,7 +14,7 @@ export default (entityFetcher: EntityFetcher) => async (
 
     const sourceRev: IPage = (await pageClass.findById(args.revision): any);
     if (!sourceRev) {
-        return notFound(args.revision);
+        return new NotFoundResponse(`Revision with id "${args.revision}" was not found!`);
     }
 
     const newRevision: IPage = (new pageClass(): any);

--- a/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/getPublishedPage.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/getPublishedPage.js
@@ -1,13 +1,10 @@
 // @flow
-import { Response, ErrorResponse } from "webiny-api/graphql/responses";
+import { Response, NotFoundResponse } from "webiny-api/graphql/responses";
 import { listPublishedPages } from "./listPublishedPages";
 
 export default async (root: any, args: Object, context: Object) => {
     if (!args.parent && !args.url) {
-        return new ErrorResponse({
-            code: "NOT_FOUND",
-            message: "Page parent or URL missing."
-        });
+        return new NotFoundResponse("Page parent or URL missing.");
     }
 
     // We utilize the same query used for listing published pages (single source of truth = less maintenance).
@@ -15,10 +12,7 @@ export default async (root: any, args: Object, context: Object) => {
     const [page] = await listPublishedPages({ Page, Category, args: { ...args, perPage: 1 } });
 
     if (!page) {
-        return new ErrorResponse({
-            code: "NOT_FOUND",
-            message: "The requested page was not found!"
-        });
+        return new NotFoundResponse("The requested page was not found.");
     }
 
     return new Response(page);

--- a/packages/webiny-api-security/src/plugins/graphql/userResolvers/getCurrentUser.js
+++ b/packages/webiny-api-security/src/plugins/graphql/userResolvers/getCurrentUser.js
@@ -1,5 +1,5 @@
 // @flow
-import { Response, ErrorResponse } from "webiny-api/graphql";
+import { Response, NotFoundResponse } from "webiny-api/graphql";
 import type { Entity } from "webiny-entity";
 type EntityFetcher = (context: Object) => Class<Entity>;
 
@@ -15,10 +15,7 @@ export default (entityFetcher: EntityFetcher) => async (
     if (user) {
         const instance = await User.findById(user.id);
         if (!instance) {
-            return new ErrorResponse({
-                code: "NOT_FOUND",
-                message: `User with ID ${user.id} was not found!`
-            });
+            return new NotFoundResponse(`User with ID ${user.id} was not found!`);
         }
 
         return new Response(instance);

--- a/packages/webiny-api-security/src/plugins/graphql/userResolvers/updateCurrentUser.js
+++ b/packages/webiny-api-security/src/plugins/graphql/userResolvers/updateCurrentUser.js
@@ -1,5 +1,5 @@
 // @flow
-import { Response, ErrorResponse } from "webiny-api/graphql";
+import { Response, NotFoundResponse, ErrorResponse } from "webiny-api/graphql";
 import type { Entity } from "webiny-entity";
 type EntityFetcher = (context: Object) => Class<Entity>;
 
@@ -27,8 +27,5 @@ export default (entityFetcher: EntityFetcher) => async (
         }
     }
 
-    return new ErrorResponse({
-        code: "NOT_FOUND",
-        message: "User not found!"
-    });
+    return new NotFoundResponse("User not found!");
 };

--- a/packages/webiny-api/src/graphql/crudResolvers.js
+++ b/packages/webiny-api/src/graphql/crudResolvers.js
@@ -3,15 +3,13 @@ import { ModelError } from "webiny-model";
 import type { Entity, EntityCollection } from "webiny-entity";
 import parseBoolean from "./parseBoolean";
 import InvalidAttributesError from "./InvalidAttributesError";
-import { ListResponse, ErrorResponse, Response } from "./responses";
+import { ListResponse, ErrorResponse, NotFoundResponse, Response } from "./responses";
 
 type EntityFetcher = (context: Object) => Class<Entity>;
 
-const notFound = (id?: string) =>
-    new ErrorResponse({
-        code: "NOT_FOUND",
-        message: id ? `Record "${id}" not found!` : "Record not found!"
-    });
+const notFound = (id?: string) => {
+    return new NotFoundResponse(id ? `Record "${id}" not found!` : "Record not found!");
+};
 
 export const resolveGet = (entityFetcher: EntityFetcher) => async (
     root: any,

--- a/packages/webiny-api/src/graphql/index.js
+++ b/packages/webiny-api/src/graphql/index.js
@@ -1,4 +1,16 @@
-export { resolveGet, resolveList, resolveCreate, resolveUpdate, resolveDelete } from "./crudResolvers";
+export {
+    resolveGet,
+    resolveList,
+    resolveCreate,
+    resolveUpdate,
+    resolveDelete
+} from "./crudResolvers";
 export const dummyResolver = () => ({});
-export { Response, ListResponse, ErrorResponse, ListErrorResponse } from "./responses";
+export {
+    Response,
+    ListResponse,
+    ErrorResponse,
+    NotFoundResponse,
+    ListErrorResponse
+} from "./responses";
 export { default as InvalidAttributesError } from "./InvalidAttributesError";

--- a/packages/webiny-api/src/graphql/responses.js
+++ b/packages/webiny-api/src/graphql/responses.js
@@ -30,6 +30,15 @@ export class ErrorResponse {
     }
 }
 
+export class NotFoundResponse extends ErrorResponse {
+    constructor(message) {
+        super({
+            code: "NOT_FOUND",
+            message
+        });
+    }
+}
+
 export class ListErrorResponse {
     data: null;
     meta: null;


### PR DESCRIPTION
When creating custom GraphQL field resolvers, often times developers need to return a simple "record not found" error. To avoid manually creating the same error every time, a `NotFoundResponse` class was introduced. Consider the following example:

```javascript
import { Response, NotFoundResponse } from "webiny-api/graphql/responses";

(...)

const entity = await entityClass.findOne({ query: { slug } });
if (!entity) {
   return new NotFoundResponse("Menu not found.");
}
```

Current `ErrorResponse` is still available.