### PR TITLE
GraphQL Playground now works in development as expected

### DIFF
--- a/packages/webiny-api/src/lambda/lambda.js
+++ b/packages/webiny-api/src/lambda/lambda.js
@@ -108,7 +108,10 @@ export const createHandler = (configFactory: (context: Object) => Promise<Object
                     return reject(error);
                 }
 
-                if (process.env.NODE_ENV === "development") {
+                if (
+                    process.env.NODE_ENV === "development" &&
+                    data.headers["Content-Type"] === "application/json"
+                ) {
                     data.body = JSON.stringify(JSON.parse(data.body), null, 2);
                 }
 


### PR DESCRIPTION
Fixes #490.

Sending a `GET` request to `/function/api` will open GraphQL Playground as expected. This is a built-in feature of Apollo so there is no reason to not support it.

Additionally, for some developers, this might also be the preferred way to inspect the GraphQL schema.