### PR TITLE
Auto-scroll document when Slate cursor is outside the viewport.

### DIFF
--- a/packages/webiny-app-cms/src/editor/plugins/slate/index.js
+++ b/packages/webiny-app-cms/src/editor/plugins/slate/index.js
@@ -7,6 +7,7 @@ import codeFactory from "./code";
 import breakFactory from "./break";
 import blockFactory from "./block";
 import linkFactory from "./link";
+import scrollFactory from "./scroll";
 
 const blockPlugins = blockFactory();
 const boldPlugins = boldFactory();
@@ -16,23 +17,25 @@ const codePlugins = codeFactory();
 const linkPlugins = linkFactory();
 const listsPlugins = listsFactory();
 const breakPlugins = breakFactory();
+const scrollPlugins = scrollFactory();
 
 export default [
     // Menu plugins
-    ...blockPlugins.menu,
-    ...boldPlugins.menu,
-    ...italicPlugins.menu,
-    ...underlinePlugins.menu,
-    ...codePlugins.menu,
-    ...linkPlugins.menu,
-    ...listsPlugins.menu,
+    blockPlugins.menu,
+    boldPlugins.menu,
+    italicPlugins.menu,
+    underlinePlugins.menu,
+    codePlugins.menu,
+    linkPlugins.menu,
+    listsPlugins.menu,
     // Editor plugins
-    ...boldPlugins.editor,
-    ...italicPlugins.editor,
-    ...underlinePlugins.editor,
-    ...codePlugins.editor,
-    ...listsPlugins.editor,
-    ...linkPlugins.editor,
-    ...breakPlugins.editor,
-    ...blockPlugins.editor
+    boldPlugins.editor,
+    italicPlugins.editor,
+    underlinePlugins.editor,
+    codePlugins.editor,
+    listsPlugins.editor,
+    linkPlugins.editor,
+    breakPlugins.editor,
+    blockPlugins.editor,
+    scrollPlugins.editor
 ];

--- a/packages/webiny-app-cms/src/editor/plugins/slate/scroll/index.js
+++ b/packages/webiny-app-cms/src/editor/plugins/slate/scroll/index.js
@@ -1,0 +1,36 @@
+// @flow
+import type { Change } from "slate";
+
+export default () => {
+    return {
+        editor: [
+            {
+                name: "cms-slate-editor-scroll",
+                type: "cms-slate-editor",
+                slate: {
+                    onKeyDown(event: SyntheticKeyboardEvent<*>, change: Change, next: Function) {
+                        const native = window.getSelection();
+                        if (native.type === "None") {
+                            return { top: 0, left: 0, width: 0, height: 0 };
+                        }
+
+                        const range = native.getRangeAt(0);
+                        const pos = range.getBoundingClientRect();
+
+                        const cursorY = pos.top;
+                        // $FlowFixMe
+                        const { clientHeight } = document.documentElement;
+                        const height = clientHeight - 50;
+
+                        if (cursorY > height) {
+                            const scrollDiff = cursorY - height;
+                            window.scrollTo(0, window.scrollY + scrollDiff + 20);
+                        }
+
+                        return next();
+                    }
+                }
+            }
+        ]
+    };
+};


### PR DESCRIPTION
This PR fixes a problem with Slate editor regarding cursor position and autoscroll.
Slate does have the auto-scroll feature but our editor UI is slightly different and requires custom handling so a new `scroll` plugin is introduced to handle keystrokes and calculate position of the cursor and scroll the document if necessary.