### PR TITLE
In Social Media page settings, once an image is selected, og:image:width and og:image:height meta tags will automatically be set 

### DIFF
--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
@@ -9,6 +9,7 @@ import { Input } from "webiny-ui/Input";
 import { Select } from "webiny-ui/Select";
 import PageImage from "./PageImage";
 import { set, get } from "lodash";
+import appendOgImageDimensions from "./appendOgImageDimensions";
 
 const toSlug = (value, cb) => {
     cb(slugify(value, { replacement: "-", lower: true, remove: /[*#\?<>_\{\}\[\]+~.()'"!:;@]/g })); // eslint-disable-line
@@ -78,6 +79,7 @@ export default compose(
                     set(state, "data.settings.social.image", selectedImage);
                     return state;
                 });
+                appendOgImageDimensions({ form, value: selectedImage });
             }
         }
     })

--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/GeneralSettings.js
@@ -66,9 +66,11 @@ const GeneralSettings = ({ Bind, onAfterChangeImage, cms: { theme } }: Object) =
 export default compose(
     withCms(),
     withHandlers({
-        hasOgImage: ({ data }) => () => {
-            const src = get(data, "settings.social.image.src");
-            return typeof src === "string" && !src.startsWith("data:");
+        hasOgImage: ({ form }) => () => {
+            // const src = get(data, "settings.social.image.src"); // Doesn't work.
+            const src = get(form.state, "data.settings.social.image.src"); // Works.
+
+            return typeof src === "string" && src && !src.startsWith("data:");
         }
     }),
     withHandlers({

--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/SocialSettings.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/SocialSettings.js
@@ -5,8 +5,9 @@ import { Grid, Cell } from "webiny-ui/Grid";
 import { Input } from "webiny-ui/Input";
 import OpenGraphTags from "./OpenGraphTags";
 import PageImage from "./PageImage";
+import appendOgImageDimensions from "./appendOgImageDimensions";
 
-const SocialSettings = ({ Bind }: Object) => {
+const SocialSettings = ({ Bind, form }: Object) => {
     return (
         <React.Fragment>
             <Grid>
@@ -36,7 +37,10 @@ const SocialSettings = ({ Bind }: Object) => {
 
             <Grid>
                 <Cell span={12}>
-                    <Bind name={"settings.social.image"}>
+                    <Bind
+                        name={"settings.social.image"}
+                        afterChange={value => appendOgImageDimensions({ value, form })}
+                    >
                         <PageImage
                             label="Social Image"
                             imageEditor={{

--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/appendOgImageDimensions.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/appendOgImageDimensions.js
@@ -6,7 +6,7 @@ export default async ({ form, value }) => {
             const next = { ...state };
             // Remove previously set og:image:width / og:image:height.
             next.data.settings.social.meta = next.data.settings.social.meta.filter(item => {
-                return !OG_IMAGE_DIMENSIONS_PROPERTIES.includes(item.property);
+                return item.property && !OG_IMAGE_DIMENSIONS_PROPERTIES.includes(item.property);
             });
             return next;
         });
@@ -32,11 +32,11 @@ export default async ({ form, value }) => {
         next.data.settings.social.meta.push(
             {
                 property: "og:image:width",
-                content: image.width
+                content: String(image.width)
             },
             {
                 property: "og:image:height",
-                content: image.height
+                content: String(image.height)
             }
         );
 

--- a/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/appendOgImageDimensions.js
+++ b/packages/webiny-app-cms/src/editor/plugins/pageSettings/components/appendOgImageDimensions.js
@@ -1,0 +1,45 @@
+const OG_IMAGE_DIMENSIONS_PROPERTIES = ["og:image:width", "og:image:height"];
+
+export default async ({ form, value }) => {
+    if (!value || value.src.startsWith("data:")) {
+        form.setState(state => {
+            const next = { ...state };
+            // Remove previously set og:image:width / og:image:height.
+            next.data.settings.social.meta = next.data.settings.social.meta.filter(item => {
+                return !OG_IMAGE_DIMENSIONS_PROPERTIES.includes(item.property);
+            });
+            return next;
+        });
+        return;
+    }
+
+    const image = await new Promise(function(resolve, reject) {
+        let image = new window.Image();
+        image.onload = function() {
+            resolve(image);
+        };
+        image.onerror = reject;
+        image.src = value.src + "?width=1596";
+    });
+
+    form.setState(state => {
+        const next = { ...state };
+        // Remove previously set og:image:width / og:image:height.
+        next.data.settings.social.meta = next.data.settings.social.meta.filter(item => {
+            return !OG_IMAGE_DIMENSIONS_PROPERTIES.includes(item.property);
+        });
+
+        next.data.settings.social.meta.push(
+            {
+                property: "og:image:width",
+                content: image.width
+            },
+            {
+                property: "og:image:height",
+                content: image.height
+            }
+        );
+
+        return next;
+    });
+};


### PR DESCRIPTION
Since Facebook debugger shows warnings if `og:image:width` and `og:image:height` meta tags are not set, we decided to set them automatically, once an image was selected.

![image](https://user-images.githubusercontent.com/5121148/54999599-dd884d00-4fd0-11e9-993f-f5d91c9bdd76.png)
