### PR TITLE
Image components will show "Uploading..." snackbar and show circular spinner once the upload has started

### DIFF
--- a/packages/webiny-app/src/components/withFileUpload.js
+++ b/packages/webiny-app/src/components/withFileUpload.js
@@ -96,6 +96,7 @@ export const withFileUpload = (options: WithFileUploadOptions = {}): Function =>
 
                     if (mustUpload(file)) {
                         // Send file to server and get its path.
+                        props.showSnackbar("Uploading...");
                         try {
                             return upload(file)
                                 .then(async uploadedFile => {

--- a/packages/webiny-ui/src/ImageUpload/Image.js
+++ b/packages/webiny-ui/src/ImageUpload/Image.js
@@ -6,6 +6,7 @@ import { ReactComponent as AddImageIcon } from "./icons/round-add_photo_alternat
 import { ReactComponent as RemoveImageIcon } from "./icons/round-close-24px.svg";
 import { ReactComponent as EditImageIcon } from "./icons/round-edit-24px.svg";
 import { Typography } from "webiny-ui/Typography";
+import { CircularProgress } from "webiny-ui/Progress";
 
 const AddImageIconWrapper = styled("div")({
     color: "var(--mdc-theme-text-secondary-on-background)",
@@ -201,17 +202,12 @@ class Image extends React.Component<Props> {
 
     render() {
         const { value, disabled } = this.props;
-
-        const image = (
+        return (
             <div className={classNames({ disabled })} style={{ height: "100%" }}>
+                {this.props.loading && <CircularProgress />}
                 {value && value.src ? this.renderImg() : this.renderBlank()}
             </div>
         );
-
-        if (this.props.loading) {
-            return <div style={{ opacity: 0.75, pointerEvents: "none" }}>{image}</div>;
-        }
-        return image;
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16610,7 +16610,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17287,6 +17287,13 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-loadable@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"
+  integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
+  dependencies:
+    prop-types "^15.5.0"
 
 react-loading-skeleton@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Previously, both `SingleImageUpload` and `MultiImageUpload` would just get disabled (transparent, no pointer events). Circular spinner looks better and it's easier to notice.

A snackbar message was also added.

![image](https://user-images.githubusercontent.com/5121148/55081936-11cb3e80-50a1-11e9-8509-0bc705fff3e2.png)
