### PR TITLE
Form component - passed "onSubmit" data is now properly populated with default values

### DIFF
--- a/packages/webiny-form/src/Form.js
+++ b/packages/webiny-form/src/Form.js
@@ -116,8 +116,9 @@ class Form extends React.Component<Props, State> {
                 // Make sure all current inputs have a value in the model (defaultValues do not exist in form data)
                 const inputNames = Object.keys(this.inputs);
                 inputNames.forEach(name => {
-                    if (!_.get(data, name)) {
-                        data = set(name, this.inputs[name].defaultValue, data);
+                    const defaultValue = this.inputs[name].defaultValue;
+                    if (!_.has(data, name) && typeof defaultValue !== 'undefined') {
+                        data = set(name, defaultValue, data);
                     }
                 });
 
@@ -237,10 +238,10 @@ class Form extends React.Component<Props, State> {
     };
 
     getOnChangeFn = ({
-        name,
-        beforeChange,
-        afterChange
-    }: {
+                         name,
+                         beforeChange,
+                         afterChange
+                     }: {
         name: string,
         beforeChange: any,
         afterChange: any


### PR DESCRIPTION
Upon form submission, if a value of a form field was falsy, it would get changed to its default value, which in most cases is just `undefined` (no default value set). 

This has been fixed.