### PR TITLE
Site will only show cookie policy banner if enabled via admin settings

### DIFF
--- a/independent/webiny-integration-cookie-policy/src/plugins/render/index.js
+++ b/independent/webiny-integration-cookie-policy/src/plugins/render/index.js
@@ -7,11 +7,10 @@ import showCookiePolicy from "./../utils/showCookiePolicy";
 class CookiePolicy extends React.Component<*> {
     componentDidMount() {
         const { settings } = this.props;
-        if (settings && settings.enabled !== true) {
-            return;
+        if (settings && settings.enabled === true) {
+            showCookiePolicy(settings);
         }
 
-        showCookiePolicy(settings);
     }
 
     render() {

--- a/independent/webiny-integration-cookie-policy/src/plugins/utils/showCookiePolicy.js
+++ b/independent/webiny-integration-cookie-policy/src/plugins/utils/showCookiePolicy.js
@@ -8,6 +8,14 @@ const prepareParams = (params: Object) => {
         prepared.showLink = false;
     }
 
+    if (!prepared.content.dismiss) {
+        delete prepared.content.dismiss;
+    }
+
+    if (!prepared.content.message) {
+        delete prepared.content.message;
+    }
+
     return prepared;
 };
 


### PR DESCRIPTION
## Related Issue
Even if you would disable the cookie policy banner, it would still get shown on the actual site.

## Your solution
Fixed the `if` statement that determines whether the banner should be shown or not.

## How Has This Been Tested?
Manual testing.