### PR TITLE
Added default theme for cookie-policy-integration.

### DIFF
--- a/independent/webiny-integration-cookie-policy/src/plugins/admin/components/CookiePolicySettings.js
+++ b/independent/webiny-integration-cookie-policy/src/plugins/admin/components/CookiePolicySettings.js
@@ -11,6 +11,7 @@ import { withSnackbar } from "webiny-admin/components";
 import { RadioGroup, Radio } from "webiny-ui/Radio";
 import graphql from "./graphql";
 import showCookiePolicy from "./../../utils/showCookiePolicy";
+import getDefaultCookiePolicySettings from "./getDefaultCookiePolicySettings";
 import { CircularProgress } from "webiny-ui/Progress";
 
 import {
@@ -27,222 +28,251 @@ const positionOptions = [
     { id: "bottom-right", name: "Floating right" }
 ];
 
+const getFormData = settings => {
+    const defaults = getDefaultCookiePolicySettings();
+    if (!settings || !settings.cookiePolicy) {
+        return { cookiePolicy: defaults };
+    }
+
+    const cookiePolicy = { ...settings.cookiePolicy };
+
+    if (!cookiePolicy.palette) {
+        cookiePolicy.palette = defaults.palette;
+    }
+
+    if (!cookiePolicy.content) {
+        cookiePolicy.content = defaults.content;
+    }
+
+    if (!cookiePolicy.position) {
+        cookiePolicy.position = defaults.position;
+    }
+
+    return { cookiePolicy };
+};
+
 const CookiePolicySettings = ({ showSnackbar }) => {
     return (
         <Query query={graphql.query}>
             {({ data, loading: queryInProgress }) => (
                 <Mutation mutation={graphql.mutation}>
-                    {(update, { loading: mutationInProgress }) => (
-                        <Form
-                            data={data.settings}
-                            onSubmit={async data => {
-                                await update({
-                                    variables: {
-                                        data: data.cookiePolicy
-                                    }
-                                });
-                                showSnackbar("Settings updated successfully.");
-                            }}
-                        >
-                            {({ Bind, form, data }) => (
-                                <SimpleForm>
-                                    {(queryInProgress || mutationInProgress) && (
-                                        <CircularProgress />
-                                    )}
-                                    <SimpleFormHeader title="Cookie Policy Settings">
-                                        <Bind
-                                            name={"cookiePolicy.enabled"}
-                                            afterChange={aaa => {
-                                                if (!aaa) {
-                                                    form.submit();
-                                                }
-                                            }}
-                                        >
-                                            <Switch label="Enabled" />
-                                        </Bind>
-                                    </SimpleFormHeader>
-                                    {data.cookiePolicy && data.cookiePolicy.enabled ? (
-                                        <>
-                                            <SimpleFormContent>
-                                                <Grid>
-                                                    <Cell span={12}>
-                                                        <Grid>
-                                                            <Cell span={3}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.palette.popup.background"
-                                                                    }
-                                                                >
-                                                                    <ColorPicker label="Banner background color" />
-                                                                </Bind>
-                                                            </Cell>
-                                                            <Cell span={3}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.palette.popup.text"
-                                                                    }
-                                                                >
-                                                                    <ColorPicker label="Banner text color" />
-                                                                </Bind>
-                                                            </Cell>
-                                                            <Cell span={3}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.palette.button.background"
-                                                                    }
-                                                                >
-                                                                    <ColorPicker label="Button background color" />
-                                                                </Bind>
-                                                            </Cell>
-                                                            <Cell span={3}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.palette.button.text"
-                                                                    }
-                                                                >
-                                                                    <ColorPicker label="Button text color" />
-                                                                </Bind>
-                                                            </Cell>
-                                                        </Grid>
-                                                    </Cell>
-                                                </Grid>
-                                                <Grid>
-                                                    <Cell span={12}>
-                                                        <Grid>
-                                                            <Cell span={12}>
-                                                                <Bind
-                                                                    name={"cookiePolicy.position"}
-                                                                >
-                                                                    <RadioGroup label="Position">
-                                                                        {({
-                                                                            onChange,
-                                                                            getValue
-                                                                        }) => (
-                                                                            <React.Fragment>
-                                                                                {positionOptions.map(
-                                                                                    ({
-                                                                                        id,
-                                                                                        name
-                                                                                    }) => (
-                                                                                        <Radio
-                                                                                            key={id}
-                                                                                            label={
-                                                                                                name
-                                                                                            }
-                                                                                            value={getValue(
-                                                                                                id
-                                                                                            )}
-                                                                                            onChange={onChange(
-                                                                                                id
-                                                                                            )}
-                                                                                        />
-                                                                                    )
-                                                                                )}
-                                                                            </React.Fragment>
-                                                                        )}
-                                                                    </RadioGroup>
-                                                                </Bind>
-                                                            </Cell>
-
-                                                            <Cell span={12}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.content.message"
-                                                                    }
-                                                                >
-                                                                    <Input
-                                                                        label="Message"
-                                                                        desciption={
-                                                                            "Link to your own policy\n"
+                    {(update, { loading: mutationInProgress }) => {
+                        return (
+                            <Form
+                                data={getFormData(data.settings)}
+                                onSubmit={async data => {
+                                    await update({
+                                        variables: {
+                                            data: data.cookiePolicy
+                                        }
+                                    });
+                                    showSnackbar("Settings updated successfully.");
+                                }}
+                            >
+                                {({ Bind, form, data }) => (
+                                    <SimpleForm>
+                                        {(queryInProgress || mutationInProgress) && (
+                                            <CircularProgress />
+                                        )}
+                                        <SimpleFormHeader title="Cookie Policy Settings">
+                                            <Bind
+                                                name={"cookiePolicy.enabled"}
+                                                afterChange={aaa => {
+                                                    if (!aaa) {
+                                                        form.submit();
+                                                    }
+                                                }}
+                                            >
+                                                <Switch label="Enabled" />
+                                            </Bind>
+                                        </SimpleFormHeader>
+                                        {data.cookiePolicy && data.cookiePolicy.enabled ? (
+                                            <>
+                                                <SimpleFormContent>
+                                                    <Grid>
+                                                        <Cell span={12}>
+                                                            <Grid>
+                                                                <Cell span={3}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.palette.popup.background"
                                                                         }
-                                                                    />
-                                                                </Bind>
-                                                            </Cell>
-
-                                                            <Cell span={12}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.content.dismiss"
-                                                                    }
-                                                                >
-                                                                    <Input
-                                                                        label="Dismiss button text"
-                                                                        desciption={
-                                                                            "Link to your own policy\n"
+                                                                    >
+                                                                        <ColorPicker label="Banner background color" />
+                                                                    </Bind>
+                                                                </Cell>
+                                                                <Cell span={3}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.palette.popup.text"
                                                                         }
-                                                                    />
-                                                                </Bind>
-                                                            </Cell>
-
-                                                            <Cell span={12}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.content.href"
-                                                                    }
-                                                                >
-                                                                    <Input
-                                                                        validators={["url"]}
-                                                                        label="Policy link"
-                                                                        desciption={
-                                                                            "Link to your own policy\n"
+                                                                    >
+                                                                        <ColorPicker label="Banner text color" />
+                                                                    </Bind>
+                                                                </Cell>
+                                                                <Cell span={3}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.palette.button.background"
                                                                         }
-                                                                    />
-                                                                </Bind>
-                                                            </Cell>
-
-                                                            <Cell span={12}>
-                                                                <Bind
-                                                                    name={
-                                                                        "cookiePolicy.content.link"
-                                                                    }
-                                                                >
-                                                                    <Input
-                                                                        validators={["url"]}
-                                                                        label="Policy link"
-                                                                        desciption={
-                                                                            "Link to your own policy\n"
+                                                                    >
+                                                                        <ColorPicker label="Button background color" />
+                                                                    </Bind>
+                                                                </Cell>
+                                                                <Cell span={3}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.palette.button.text"
                                                                         }
-                                                                    />
-                                                                </Bind>
-                                                            </Cell>
-                                                        </Grid>
-                                                    </Cell>
-                                                </Grid>
-                                            </SimpleFormContent>
-                                            <SimpleFormFooter>
-                                                <ButtonSecondary
-                                                    type="primary"
-                                                    align="right"
-                                                    onClick={() => {
-                                                        showCookiePolicy({
-                                                            ...data.cookiePolicy,
-                                                            // Official bug fix.
-                                                            messagelink:
-                                                                '<span id="cookieconsent:desc" class="cc-message">{{message}} <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="{{href}}" target="_blank">{{link}}</a></span>',
-                                                            dismissOnTimeout: 5000,
-                                                            cookie: {
-                                                                expiryDays: 0.00000001
-                                                            }
-                                                        });
-                                                    }}
-                                                >
-                                                    Preview
-                                                </ButtonSecondary>
-                                                &nbsp;
-                                                <ButtonPrimary
-                                                    type="primary"
-                                                    onClick={form.submit}
-                                                    align="right"
-                                                >
-                                                    Save
-                                                </ButtonPrimary>
-                                            </SimpleFormFooter>
-                                        </>
-                                    ) : null}
-                                </SimpleForm>
-                            )}
-                        </Form>
-                    )}
+                                                                    >
+                                                                        <ColorPicker label="Button text color" />
+                                                                    </Bind>
+                                                                </Cell>
+                                                            </Grid>
+                                                        </Cell>
+                                                    </Grid>
+                                                    <Grid>
+                                                        <Cell span={12}>
+                                                            <Grid>
+                                                                <Cell span={12}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.position"
+                                                                        }
+                                                                    >
+                                                                        <RadioGroup label="Position">
+                                                                            {({
+                                                                                onChange,
+                                                                                getValue
+                                                                            }) => (
+                                                                                <React.Fragment>
+                                                                                    {positionOptions.map(
+                                                                                        ({
+                                                                                            id,
+                                                                                            name
+                                                                                        }) => (
+                                                                                            <Radio
+                                                                                                key={
+                                                                                                    id
+                                                                                                }
+                                                                                                label={
+                                                                                                    name
+                                                                                                }
+                                                                                                value={getValue(
+                                                                                                    id
+                                                                                                )}
+                                                                                                onChange={onChange(
+                                                                                                    id
+                                                                                                )}
+                                                                                            />
+                                                                                        )
+                                                                                    )}
+                                                                                </React.Fragment>
+                                                                            )}
+                                                                        </RadioGroup>
+                                                                    </Bind>
+                                                                </Cell>
+
+                                                                <Cell span={12}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.content.message"
+                                                                        }
+                                                                    >
+                                                                        <Input
+                                                                            label="Message"
+                                                                            desciption={
+                                                                                "Link to your own policy\n"
+                                                                            }
+                                                                        />
+                                                                    </Bind>
+                                                                </Cell>
+
+                                                                <Cell span={12}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.content.dismiss"
+                                                                        }
+                                                                    >
+                                                                        <Input
+                                                                            label="Dismiss button text"
+                                                                            desciption={
+                                                                                "Link to your own policy\n"
+                                                                            }
+                                                                        />
+                                                                    </Bind>
+                                                                </Cell>
+
+                                                                <Cell span={12}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.content.href"
+                                                                        }
+                                                                    >
+                                                                        <Input
+                                                                            validators={["url"]}
+                                                                            label="Policy link"
+                                                                            desciption={
+                                                                                "Link to your own policy\n"
+                                                                            }
+                                                                        />
+                                                                    </Bind>
+                                                                </Cell>
+
+                                                                <Cell span={12}>
+                                                                    <Bind
+                                                                        name={
+                                                                            "cookiePolicy.content.link"
+                                                                        }
+                                                                    >
+                                                                        <Input
+                                                                            validators={["url"]}
+                                                                            label="Policy link"
+                                                                            desciption={
+                                                                                "Link to your own policy\n"
+                                                                            }
+                                                                        />
+                                                                    </Bind>
+                                                                </Cell>
+                                                            </Grid>
+                                                        </Cell>
+                                                    </Grid>
+                                                </SimpleFormContent>
+                                                <SimpleFormFooter>
+                                                    <ButtonSecondary
+                                                        type="primary"
+                                                        align="right"
+                                                        onClick={() => {
+                                                            showCookiePolicy({
+                                                                ...data.cookiePolicy,
+                                                                // Official bug fix.
+                                                                messagelink:
+                                                                    '<span id="cookieconsent:desc" class="cc-message">{{message}} <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="{{href}}" target="_blank">{{link}}</a></span>',
+                                                                dismissOnTimeout: 5000,
+                                                                cookie: {
+                                                                    expiryDays: 0.00000001
+                                                                }
+                                                            });
+                                                        }}
+                                                    >
+                                                        Preview
+                                                    </ButtonSecondary>
+                                                    &nbsp;
+                                                    <ButtonPrimary
+                                                        type="primary"
+                                                        onClick={form.submit}
+                                                        align="right"
+                                                    >
+                                                        Save
+                                                    </ButtonPrimary>
+                                                </SimpleFormFooter>
+                                            </>
+                                        ) : null}
+                                    </SimpleForm>
+                                )}
+                            </Form>
+                        );
+                    }}
                 </Mutation>
             )}
         </Query>

--- a/independent/webiny-integration-cookie-policy/src/plugins/admin/components/getDefaultCookiePolicySettings.js
+++ b/independent/webiny-integration-cookie-policy/src/plugins/admin/components/getDefaultCookiePolicySettings.js
@@ -1,0 +1,21 @@
+export default () => {
+    return {
+        position: "bottom",
+        palette: {
+            popup: {
+                background: "#ffffff",
+                text: "#0c0c0c"
+            },
+            button: {
+                background: "#fa5723",
+                text: "#ffffff"
+            }
+        },
+        content: {
+            href: "",
+            message: "",
+            dismiss: "",
+            link: ""
+        }
+    };
+};


### PR DESCRIPTION
## Related Issue
When enabling cookie policy integration, hitting preview without any initial values would show a transparent banner, which might confuse users.

## Your solution
We prepended default theme, from which users can do further alterations.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
Following screenshot shows initial state of cookie policy settings, and previewed banner on bottom.

![image](https://user-images.githubusercontent.com/5121148/55163605-61297180-516a-11e9-9fec-8f8e4b1f4841.png)
