### PR TITLE
"Page list" menu item type now works correctly on site

### DIFF
--- a/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
@@ -119,6 +119,12 @@ export default async ({ entity: menu, context: graphqlContext }: Object) => {
                             Category
                         });
 
+                        item.children = item.children.map(entity => ({
+                            id: entity.id,
+                            title: entity.title,
+                            url: entity.url
+                        }));
+
                         break;
                     }
                 }

--- a/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
@@ -119,11 +119,7 @@ export default async ({ entity: menu, context: graphqlContext }: Object) => {
                             Category
                         });
 
-                        item.children = item.children.map(entity => ({
-                            id: entity.id,
-                            title: entity.title,
-                            url: entity.url
-                        }));
+                        item.children = await item.children.toJSON("id,title,url");
 
                         break;
                     }

--- a/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/menuResolvers/prepareMenuItems.js
@@ -114,7 +114,7 @@ export default async ({ entity: menu, context: graphqlContext }: Object) => {
 
                         const { Page, Category } = graphqlContext.cms.entities;
                         item.children = await listPublishedPages({
-                            args: { category, sort: { [sortBy]: sortDir } },
+                            args: { category, sort: { [sortBy]: parseInt(sortDir) } },
                             Page,
                             Category
                         });


### PR DESCRIPTION
## Related Issue
When creating menus, if you were to select the "Page list" menu item type and then open the site, it would crash because of an API error (related to sorting of pages).

## Your solution
The issue was related to sorting, and it is now fixed.

## How Has This Been Tested?
Manual testing.
