### PR TITLE
Fixed page title font style

### DIFF
--- a/packages/demo-theme/src/style/elements/header-nav.scss
+++ b/packages/demo-theme/src/style/elements/header-nav.scss
@@ -46,6 +46,10 @@
       }
     }
 
+    &__site-name{
+      font-size: 1.1rem;
+    }
+
     &__navigation {
       color: $webiny-cms-theme-primary;
       font-family: unquote($webiny-cms-theme-typography-primary-font-family);

--- a/packages/demo-theme/src/style/elements/typography.scss
+++ b/packages/demo-theme/src/style/elements/typography.scss
@@ -9,7 +9,7 @@ $leading:$baseLineHeight * 1rem !default;
 $scale:1.414 !default;
 
 
-.webiny-cms-page-document{
+body, .webiny-cms-page-document{
   /* Change default typefaces here */
   font-family: unquote($webiny-cms-theme-typography-secondary-font-family);
   font-size: $baseFontSize / 16 * 100%;


### PR DESCRIPTION
## Related Issue
Closes #505 

## Your solution
Adjusted the default theme in a way that the body takes the definition of the base font-face, which then corrects the header font.

## How Has This Been Tested?
Browser, manual visual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/3808420/55292003-53c7ed80-53dd-11e9-9eb3-4381c04e0805.png)
