### PR TITLE
Cookie policy banner doesn't reinitialize itself on every URL change

### DIFF
--- a/packages/webiny-app-cookie-policy/src/admin/components/CookiePolicySettings.js
+++ b/packages/webiny-app-cookie-policy/src/admin/components/CookiePolicySettings.js
@@ -217,7 +217,7 @@ const CookiePolicySettings = ({ showSnackbar }) => {
                                                                 cookie: {
                                                                     expiryDays: 0.00000001
                                                                 }
-                                                            });
+                                                            }, true);
                                                         }}
                                                     >
                                                         Preview

--- a/packages/webiny-app-cookie-policy/src/utils/showCookiePolicy.js
+++ b/packages/webiny-app-cookie-policy/src/utils/showCookiePolicy.js
@@ -19,7 +19,14 @@ const prepareParams = (params: Object) => {
     return prepared;
 };
 
+let initialized = false;
 const showCookiePolicy = async (params: Object) => {
+    if (initialized) {
+        return;
+    }
+
+    initialized = true;
+
     await load(
         "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css",
         "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"

--- a/packages/webiny-app-cookie-policy/src/utils/showCookiePolicy.js
+++ b/packages/webiny-app-cookie-policy/src/utils/showCookiePolicy.js
@@ -20,12 +20,14 @@ const prepareParams = (params: Object) => {
 };
 
 let initialized = false;
-const showCookiePolicy = async (params: Object) => {
-    if (initialized) {
-        return;
-    }
+const showCookiePolicy = async (params: Object, previewMode: boolean = false) => {
+    if (!previewMode) {
+        if (initialized) {
+            return;
+        }
 
-    initialized = true;
+        initialized = true;
+    }
 
     await load(
         "//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css",


### PR DESCRIPTION
## Related Issue
While navigating on the site, cookie policy would reinitialize itself, rendering multiple banners.

## Your solution
Only initialize if not already initialized before.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A