### PR TITLE
Fixed sorting of pages in CMS / List of pages

### DIFF
--- a/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/listPages.js
+++ b/packages/webiny-api-cms/src/plugins/graphql/pageResolvers/listPages.js
@@ -27,6 +27,9 @@ export default (entityFetcher: EntityFetcher) => async (
                 parent: {
                     $first: "$parent"
                 },
+                createdOn: {
+                    $first: "$createdOn"
+                },
                 id: {
                     $first: "$id"
                 },
@@ -52,6 +55,7 @@ export default (entityFetcher: EntityFetcher) => async (
     }
 
     const collection = entityClass.getDriver().getCollectionName(entityClass);
+
     const ids = await entityClass
         .getDriver()
         .aggregate(collection, [
@@ -69,7 +73,7 @@ export default (entityFetcher: EntityFetcher) => async (
     ]);
 
     return new ListResponse(
-        await entityClass.find({ query: { id: { $in: ids.map(item => item.id) } } }),
+        await entityClass.find({ sort, query: { id: { $in: ids.map(item => item.id) } } }),
         createPaginationMeta({
             page,
             perPage,


### PR DESCRIPTION
## Related Issue
Sorting pages doesn't work.

## Your solution
Fixed the MongoDB aggregation pipeline construction logic.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/57133310-aad92d80-6da2-11e9-9fdc-de07ce74447b.png)
