### PR TITLE
Tabs component - inactive tabs are now hidden instead of completely unmounted

### DIFF
--- a/packages/webiny-app-cms/src/admin/plugins/pageDetails/pageRevisions/RevisionsList.js
+++ b/packages/webiny-app-cms/src/admin/plugins/pageDetails/pageRevisions/RevisionsList.js
@@ -29,9 +29,8 @@ const RevisionsList = ({ pageDetails: { page }, loading }: RevisionsProps) => {
             <div style={{ position: "relative" }}>
                 {loading && <CircularProgress />}
                 <List nonInteractive twoLine>
-                    {page.revisions.map(rev => (
-                        <Revision rev={rev} key={rev.id} />
-                    ))}
+                    {Array.isArray(page.revisions) &&
+                        page.revisions.map(rev => <Revision rev={rev} key={rev.id} />)}
                 </List>
             </div>
         </Elevation>

--- a/packages/webiny-ui/src/Tabs/Tabs.js
+++ b/packages/webiny-ui/src/Tabs/Tabs.js
@@ -40,7 +40,7 @@ class Tabs extends React.Component<Props, State> {
                 };
             });
 
-        const content = (
+        const tabBar = (
             <TabBar
                 activeTabIndex={this.state.activeTabIndex}
                 onActivate={evt => this.setState({ activeTabIndex: evt.detail.index })}
@@ -64,15 +64,24 @@ class Tabs extends React.Component<Props, State> {
             </TabBar>
         );
 
-        let children = null;
-        if (tabs[this.state.activeTabIndex]) {
-            children = tabs[this.state.activeTabIndex].children;
+        const content = [];
+        for (let i = 0; i < tabs.length; i++) {
+            let current = tabs[i];
+            if (this.state.activeTabIndex === i) {
+                content.push(<div key={i}>{current.children}</div>);
+            } else {
+                content.push(
+                    <div key={i} style={{ display: "none" }}>
+                        {current.children}
+                    </div>
+                );
+            }
         }
 
         return (
             <React.Fragment>
-                {content}
-                <div className={"mdc-tab-content"}>{children}</div>
+                {tabBar}
+                <div className={"mdc-tab-content"}>{content}</div>
             </React.Fragment>
         );
     }


### PR DESCRIPTION
## Related Issue
Inactive tabs would unmount, which can cause issues. For example, when validating forms, we want to validate elements on all tabs, not just on the current one.

## Your solution
Instead of unmounting inactive tabs, we hide them with `display: none`. Please check the screenshot for the new functionality.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/56414254-47bba700-628a-11e9-9782-2db771030292.png)
