### PR TITLE
Support functions in schema security key.

### DIFF
--- a/packages/webiny-api-security/src/plugins/security.js
+++ b/packages/webiny-api-security/src/plugins/security.js
@@ -17,9 +17,13 @@ export default ([
 
             const middleware = [];
             getPlugins("graphql").forEach(plugin => {
-                const { security } = plugin;
+                let { security } = plugin;
                 if (!security) {
                     return true;
+                }
+
+                if (typeof security === "function") {
+                    security = security();
                 }
 
                 security.shield &&
@@ -36,12 +40,12 @@ export default ([
     {
         type: "graphql-context",
         name: "graphql-context-security",
-        apply: async (...args) => {
+        apply: async (context) => {
             const securityPlugins: Array<PluginType> = getPlugins("graphql-security");
             for (let i = 0; i < securityPlugins.length; i++) {
-                await securityPlugins[i].authenticate(...args);
+                await securityPlugins[i].authenticate(context);
             }
         }
     },
-    { type: "graphql-security", name: "graphql-security", authenticate },
+    { type: "graphql-security", name: "graphql-security", authenticate }
 ]: Array<PluginType>);


### PR DESCRIPTION
## Related Issue
CMS schema supports addition of `typeDefs` and `resolvers` via plugins. However, we must also be able to add security rules via plugins. At this point `security` only supported an `object` as its value, and as such it was interpreted too early for other plugins to be registered.

## Your solution
This PR adds the ability to assign a function to schema plugin `security` key, and it will be executed at runtime, when all plugins have already been registered, and so we'll be able to use our plugin system to add `graphql-shield` rules.

```js
{
  // ... other schema keys
  security: () =>
    merge(
      {
        shield: {
          CmsQuery: {
            getMenu: hasScope("cms:menu:crud")
          },
          CmsMutation: {
            createMenu: hasScope("cms:menu:crud")
          }
        }
      },
      // Fetch plugins and merge with current security value
      ...getPlugins("cms-schema").map(pl => pl.security)
    );
}
```

## How Has This Been Tested?
Manual testing.
