### PR TITLE
Add support for schema factory

### DIFF
--- a/packages/webiny-api-cms/src/plugins/graphql.js
+++ b/packages/webiny-api-cms/src/plugins/graphql.js
@@ -9,13 +9,14 @@ import category from "./graphql/Category";
 import menu from "./graphql/Menu";
 
 export default {
-    type: "graphql",
-    name: "graphql-cms",
-    namespace: "cms",
-    typeDefs: () => [
-        FileType,
-        FileInputType,
-        `
+    type: "graphql-schema",
+    name: "graphql-schema-cms",
+    schema: {
+        namespace: "cms",
+        typeDefs: () => [
+            FileType,
+            FileInputType,
+            `
             type CmsQuery {
                 _empty: String
             }   
@@ -32,25 +33,26 @@ export default {
                 cms: CmsMutation
             }
         `,
-        page.typeDefs,
-        category.typeDefs,
-        menu.typeDefs,
-        ...getPlugins("cms-schema").map(pl => pl.typeDefs)
-    ],
-    resolvers: () => [
-        {
-            Query: {
-                cms: dummyResolver
+            page.typeDefs,
+            category.typeDefs,
+            menu.typeDefs,
+            ...getPlugins("cms-schema").map(pl => pl.typeDefs)
+        ],
+        resolvers: () => [
+            {
+                Query: {
+                    cms: dummyResolver
+                },
+                Mutation: {
+                    cms: dummyResolver
+                }
             },
-            Mutation: {
-                cms: dummyResolver
-            }
-        },
-        page.resolvers,
-        category.resolvers,
-        menu.resolvers,
-        ...getPlugins("cms-schema").map(pl => pl.resolvers)
-    ],
+            page.resolvers,
+            category.resolvers,
+            menu.resolvers,
+            ...getPlugins("cms-schema").map(pl => pl.resolvers)
+        ]
+    },
     security: {
         shield: {
             CmsQuery: {

--- a/packages/webiny-api-cookie-policy/src/index.js
+++ b/packages/webiny-api-cookie-policy/src/index.js
@@ -44,9 +44,7 @@ class CookiePolicySettingsModel extends Model {
 export default [
     {
         name: "graphql-schema-settings-cookie-policy",
-        type: "graphql",
-        typeDefs: ``,
-        resolvers: {},
+        type: "graphql-schema",
         security: {
             shield: {
                 SettingsMutation: {

--- a/packages/webiny-api-files/src/plugins/graphql.js
+++ b/packages/webiny-api-files/src/plugins/graphql.js
@@ -3,54 +3,47 @@ import { dummyResolver } from "webiny-api/graphql";
 import file from "./graphql/file";
 import { type PluginType } from "webiny-api/types";
 import { hasScope } from "webiny-api-security";
-import {
-    FileType,
-    FileInputType,
-    FileResponseType,
-    FileListResponseType
-} from "webiny-api-files/graphql";
 
 export default ([
     {
-        type: "graphql",
-        name: "graphql-files-schema",
-        namespace: "files",
-        typeDefs: [
-            FileType,
-            FileInputType,
-            FileResponseType,
-            FileListResponseType,
-            file.typeExtensions,
-            /* GraphQL */ `
-                type FilesQuery {
-                    _empty: String
-                }
+        type: "graphql-schema",
+        name: "graphql-schema-files",
+        schema: {
+            namespace: "files",
+            typeDefs: () => [
+                file.typeDefs,
+                /* GraphQL */ `
+                    type FilesQuery {
+                        _empty: String
+                    }
 
-                type FilesMutation {
-                    _empty: String
-                }
+                    type FilesMutation {
+                        _empty: String
+                    }
 
-                type Query {
-                    files: FilesQuery
-                }
+                    type Query {
+                        files: FilesQuery
+                    }
 
-                type Mutation {
-                    files: FilesMutation
-                }
-            `
-        ],
-        resolvers: () => [
-            {
-                Query: {
-                    files: dummyResolver
+                    type Mutation {
+                        files: FilesMutation
+                    }
+                `,
+                file.typeExtensions
+            ],
+            resolvers: () => [
+                {
+                    Query: {
+                        files: dummyResolver
+                    },
+                    Mutation: {
+                        files: dummyResolver
+                    }
                 },
-                Mutation: {
-                    files: dummyResolver
-                }
-            },
-            file.resolvers
-        ],
-        files: {
+                file.resolvers
+            ]
+        },
+        security: {
             shield: {
                 FilesQuery: {
                     getFile: hasScope("files:file:crud"),
@@ -58,7 +51,7 @@ export default ([
                 },
                 FilesMutation: {
                     createFile: hasScope("files:file:crud"),
-                    updateFile: hasScope("files:file:crud"),
+                    updateFileBySrc: hasScope("files:file:crud"),
                     deleteFile: hasScope("files:file:crud")
                 }
             }

--- a/packages/webiny-api-google-tag-manager/src/index.js
+++ b/packages/webiny-api-google-tag-manager/src/index.js
@@ -14,9 +14,7 @@ class GoogleTagManagerSettingsModel extends Model {
 export default [
     {
         name: "graphql-schema-settings-google-tag-manager",
-        type: "graphql",
-        typeDefs: ``,
-        resolvers: {},
+        type: "graphql-schema",
         security: {
             shield: {
                 SettingsMutation: {

--- a/packages/webiny-api-security/src/plugins/graphql.js
+++ b/packages/webiny-api-security/src/plugins/graphql.js
@@ -9,19 +9,20 @@ import { FileType, FileInputType } from "webiny-api-files/graphql";
 
 export default ([
     {
-        type: "graphql",
-        name: "graphql-security-schema",
-        namespace: "security",
-        typeDefs: () => [
-            FileType,
-            FileInputType,
-            user.typeDefs,
-            user.typeExtensions,
-            role.typeDefs,
-            role.typeExtensions,
-            group.typeDefs,
-            group.typeExtensions,
-            /* GraphQL */ `
+        type: "graphql-schema",
+        name: "graphql-schema-security",
+        schema: {
+            namespace: "security",
+            typeDefs: () => [
+                FileType,
+                FileInputType,
+                user.typeDefs,
+                user.typeExtensions,
+                role.typeDefs,
+                role.typeExtensions,
+                group.typeDefs,
+                group.typeExtensions,
+                /* GraphQL */ `
                 type SecurityQuery {
                     # Returns all scopes that were registered throughout the schema.
                     scopes: [String]
@@ -39,23 +40,24 @@ export default ([
                     security: SecurityMutation
                 }
             `
-        ],
-        resolvers: () => [
-            {
-                Query: {
-                    security: dummyResolver
+            ],
+            resolvers: () => [
+                {
+                    Query: {
+                        security: dummyResolver
+                    },
+                    Mutation: {
+                        security: dummyResolver
+                    },
+                    SecurityQuery: {
+                        scopes: getRegisteredScopes
+                    }
                 },
-                Mutation: {
-                    security: dummyResolver
-                },
-                SecurityQuery: {
-                    scopes: getRegisteredScopes
-                }
-            },
-            group.resolvers,
-            role.resolvers,
-            user.resolvers
-        ],
+                group.resolvers,
+                role.resolvers,
+                user.resolvers
+            ]
+        },
         security: {
             shield: {
                 SecurityQuery: {

--- a/packages/webiny-api-security/src/plugins/security.js
+++ b/packages/webiny-api-security/src/plugins/security.js
@@ -16,7 +16,7 @@ export default ([
             }
 
             const middleware = [];
-            getPlugins("graphql").forEach(plugin => {
+            getPlugins("graphql-schema").forEach(plugin => {
                 let { security } = plugin;
                 if (!security) {
                     return true;

--- a/packages/webiny-api/src/lambda/lambda.js
+++ b/packages/webiny-api/src/lambda/lambda.js
@@ -8,7 +8,9 @@ import { prepareSchema, createGraphqlRunner } from "../graphql/schema";
 import { getPlugins } from "webiny-plugins";
 
 export const createHandler = async (config: Object) => {
-    let schema = prepareSchema();
+    await requestSetup(config);
+
+    let schema = await prepareSchema();
 
     const registeredMiddleware: Array<GraphQLMiddlewarePluginType> = [];
 

--- a/packages/webiny-api/src/plugins/graphql.js
+++ b/packages/webiny-api/src/plugins/graphql.js
@@ -5,12 +5,13 @@ import { type GraphQLSchemaPluginType } from "webiny-api/types";
 import { ErrorResponse } from "webiny-api/graphql";
 
 export default ({
-    type: "graphql",
-    name: "graphql-api",
-    namespace: "api",
-    typeDefs: () => {
-        return [
-            /* GraphQL */ `
+    type: "graphql-schema",
+    name: "graphql-schema-api",
+    schema: {
+        namespace: "api",
+        typeDefs: () => {
+            return [
+                /* GraphQL */ `
                 type SettingsQuery {
                     _empty: String
                 }
@@ -27,55 +28,56 @@ export default ({
                     settings: SettingsMutation
                 }
             `,
-            ...getPlugins("schema-settings").map(pl => pl.typeDefs)
-        ];
-    },
-    resolvers: () => [
-        {
-            Query: {
-                settings: dummyResolver
-            },
-            Mutation: {
-                settings: dummyResolver
-            }
+                ...getPlugins("schema-settings").map(pl => pl.typeDefs)
+            ];
         },
-        ...getPlugins("schema-settings").map(plugin => {
-            return {
-                SettingsQuery: {
-                    [plugin.namespace]: async (_: any, args: Object, ctx: Object) => {
-                        const entityClass = plugin.entity(ctx);
-                        let settings = await entityClass.load();
-                        if (!settings) {
-                            settings = new entityClass();
-                            await settings.save();
-                        }
-
-                        return settings;
-                    }
+        resolvers: () => [
+            {
+                Query: {
+                    settings: dummyResolver
                 },
-                SettingsMutation: {
-                    [plugin.namespace]: async (_: any, args: Object, ctx: Object) => {
-                        const { data } = args;
-                        const entityClass = plugin.entity(ctx);
-                        let settings = await entityClass.load();
-                        if (!settings) {
-                            settings = new entityClass();
-                        }
+                Mutation: {
+                    settings: dummyResolver
+                }
+            },
+            ...getPlugins("schema-settings").map(plugin => {
+                return {
+                    SettingsQuery: {
+                        [plugin.namespace]: async (_: any, args: Object, ctx: Object) => {
+                            const entityClass = plugin.entity(ctx);
+                            let settings = await entityClass.load();
+                            if (!settings) {
+                                settings = new entityClass();
+                                await settings.save();
+                            }
 
-                        if (!settings.data) {
-                            settings.data = {};
-                        }
-
-                        try {
-                            settings.data.populate(data);
-                            await settings.save();
                             return settings;
-                        } catch (e) {
-                            return new ErrorResponse(e);
+                        }
+                    },
+                    SettingsMutation: {
+                        [plugin.namespace]: async (_: any, args: Object, ctx: Object) => {
+                            const { data } = args;
+                            const entityClass = plugin.entity(ctx);
+                            let settings = await entityClass.load();
+                            if (!settings) {
+                                settings = new entityClass();
+                            }
+
+                            if (!settings.data) {
+                                settings.data = {};
+                            }
+
+                            try {
+                                settings.data.populate(data);
+                                await settings.save();
+                                return settings;
+                            } catch (e) {
+                                return new ErrorResponse(e);
+                            }
                         }
                     }
-                }
-            };
-        })
-    ]
+                };
+            })
+        ]
+    }
 }: GraphQLSchemaPluginType);

--- a/packages/webiny-api/src/types.js
+++ b/packages/webiny-api/src/types.js
@@ -12,15 +12,15 @@ export type EntityPluginType = PluginType & {
     }
 };
 
-export type ModelPluginType = PluginType & {
-    namespace: string,
-    model: Function
-};
-
-export type GraphQLSchemaPluginType = PluginType & {
+export type GraphQLSchemaType = {
     namespace: string,
     typeDefs: *,
     resolvers: Object | (() => Object)
+};
+
+export type GraphQLSchemaPluginType = PluginType & {
+    schema?: GraphQLSchemaType | () => GraphQLSchemaType,
+    security?: Object | (() => Object)
 };
 
 export type GraphQLMiddlewarePluginType = PluginType & {


### PR DESCRIPTION
## Related Issue
Currently, schema plugins only support static definitions of schemas. There is a need for dynamic schema creation, so we can dynamically build schemas (typeDefs and resolvers).

## Your solution
`graphql-schema` plugin now supports `schema` value as plain object but also as an async function which must return the schema definition. 