### PR TITLE
fix: remove "serverless" dependency from new project template.

### DIFF
--- a/packages/cli/create/template/package.json
+++ b/packages/cli/create/template/package.json
@@ -27,7 +27,6 @@
     "devDependencies": {
         "prettier": "^1.18.2",
         "flow-bin": "^0.110.0",
-        "serverless": "^1.55.0",
         "webpack-cli": "^3.3.9"
     }
 }


### PR DESCRIPTION
Since we do not use `serverless` CLI directly, we don't need it as a dependency for the new project.