### PR TITLE
Fixed incorrect import and added eslint rule to prevent future errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     parser: "babel-eslint",
     extends: ["eslint:recommended", "plugin:jest/recommended", "plugin:react/recommended"],
-    plugins: ["flowtype", "jest"],
+    plugins: ["flowtype", "jest", "import"],
     env: {
         jest: true,
         commonjs: true,
@@ -15,7 +15,8 @@ module.exports = {
     rules: {
         "flowtype/define-flow-type": 1,
         "flowtype/use-flow-type": 1,
-        "react/prop-types": 0
+        "react/prop-types": 0,
+        "import/no-unresolved": [2, { commonjs: true, amd: true }]
     },
     settings: {
         flowtype: {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^4.16.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-flowtype": "^2.41.0",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",

--- a/packages/api-files/src/plugins/resolvers/uploadFiles.js
+++ b/packages/api-files/src/plugins/resolvers/uploadFiles.js
@@ -1,6 +1,6 @@
 // @flow
 import { Response, ErrorResponse } from "@webiny/api";
-import getPreSignedPostPayload from "./utils/getPreSignedPostPayload";
+import getPreSignedPostPayload from "./utils/getPresignedPostPayload";
 import { BATCH_UPLOAD_MAX_FILES } from "./utils/constants";
 
 export default async (root: any, args: Object) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,7 +8893,7 @@ eslint-plugin-flowtype@^2.41.0:
   dependencies:
     lodash "^4.17.10"
 
-eslint-plugin-import@2.18.2:
+eslint-plugin-import@2.18.2, eslint-plugin-import@^2.18.2:
   version "2.18.2"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6"
   integrity sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==


### PR DESCRIPTION
Fixes #579.

## Related Issue
In `packages/api-files/src/plugins/resolvers/uploadFiles.js`, we had the following import:
`import getPreSignedPostPayload from "./utils/getPresignedPostPayload";`

The actual file is not `getPresignedPostPayload`, but `getPreSignedPostPayload`.

## Your solution
I fixed the import and additionally added the [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import), to prevent these kind of errors in the future.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A