### PR TITLE
Page Builder - fixes UI bugs in revisions list

### DIFF
--- a/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/PagePreview.js
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/PagePreview.js
@@ -60,7 +60,7 @@ const PagePreview = ({ pageDetails }: Props) => {
                     className={pageInnerWrapper}
                     style={{ "--webiny-pb-page-preview-scale": zoom }}
                 >
-                    <RenderElement element={pageDetails.page.content} />
+                    <RenderElement key={pageDetails.page.id} element={pageDetails.page.content} />
                     <PagePreviewToolbar>
                         <span>
                             <Typography use={"overline"}>Zoom:&nbsp;</Typography>

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/PublishPageButton/graphql.js
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/PublishPageButton/graphql.js
@@ -5,6 +5,10 @@ export const publishRevision = gql`
     mutation PbPublishRevision($id: ID!) {
         pageBuilder {
             publishRevision(id: $id) {
+                data {
+                    id
+                    published
+                }
                 error {
                     code
                     message


### PR DESCRIPTION
## Related Issue
This PR fixes issues with updating the revisions list and revision content when selecting different revisions from the dropdown menu (see screenshot).

When doing a `publishRevision` mutation, we must require `id` and `published` in the response `data` fields so Apollo client can update its cache. That's, in general, a needed practice, we should avoid not-listing any `data` fields when doing updates (unless there is a good reason not to list any of course).

## Your solution
Added `id` and `published` fields in response data, so Apollo can update its cache. I also added the `key` prop to the `RenderElement` component, with the value of currently selected revision `id`, so the revision content gets re-rendered when selecting different revisions (`packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/PagePreview.js:63`).

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/68014037-c7411e80-fc8e-11e9-852f-78e7bd2ac06c.png)
List will now update correctly when doing changes in page builder. The content of active revision will also change when selecting different revisions.