### PR TITLE
Page Builder - Fix page publishing

### DIFF
--- a/packages/api-page-builder/src/plugins/models/pbPage.model.js
+++ b/packages/api-page-builder/src/plugins/models/pbPage.model.js
@@ -50,7 +50,6 @@ export default ({ createBase, context, PbCategory, PbSettings }) => {
             version: number(),
             parent: id(),
             published: flow(
-                skipOnPopulate(),
                 onSet(value => {
                     // Deactivate previously published revision
                     if (value && value !== instance.published && instance.isExisting()) {


### PR DESCRIPTION
## Related Issue
The publishing of pages did not work. This is because the `published` field in the `PbPage` model had `skipOnPopulate`, and `publishRevision` GQL field resolver just populates the page instance with `{ published: true}`. I checked the old `Page` entity, and the attribute did not have `skipOnPopulate` set, so this was a mistake in the refactoring process.

## Your solution
Removed the `skipOnPopulate` on the `published` field. Additionally, I removed 'published' key in the pages data in the PB installation ZIP file, since it's manually set after initial save (`packages/api-page-builder/src/plugins/graphql/installResolver/utils/savePages.js:47`).

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A