### PR TITLE
Enable configuring min / max size for file uploads

### DIFF
--- a/components/serverless-files/serverless.js
+++ b/components/serverless-files/serverless.js
@@ -16,7 +16,14 @@ const prefix = "serverless-files";
 
 class FilesComponent extends Component {
     async default(inputs = {}) {
-        const { region = "us-east-1", bucket = "webiny-files", env, ...rest } = inputs;
+        const {
+            region = "us-east-1",
+            bucket = "webiny-files",
+            env,
+            uploadMinFileSize,
+            uploadMaxFileSize,
+            ...rest
+        } = inputs;
 
         const manageFilesLambda = await this.load("@webiny/serverless-function", "manage-files");
         const manageFilesLambdaOutput = await manageFilesLambda({
@@ -82,7 +89,12 @@ class FilesComponent extends Component {
             endpoints: [
                 { path: "/files/{path}", method: "ANY", function: downloadLambdaOutput.arn }
             ],
-            env: { ...env, S3_BUCKET: bucket },
+            env: {
+                ...env,
+                S3_BUCKET: bucket,
+                UPLOAD_MIN_FILE_SIZE: String(uploadMinFileSize),
+                UPLOAD_MAX_FILE_SIZE: String(uploadMaxFileSize)
+            },
             ...rest
         });
 

--- a/examples/api/serverless.yml
+++ b/examples/api/serverless.yml
@@ -61,6 +61,8 @@ files:
     bucket: ${vars.bucket}
     memory: 512
     database: ${vars.database}
+    uploadMinFileSize: 0 # 0 MB
+    uploadMaxFileSize: 26214400 # 25 MB
     env: ${vars.env}
     webpackConfig: ./webpack.config.js
 

--- a/packages/api-files/src/plugins/resolvers/utils/getPresignedPostPayload.js
+++ b/packages/api-files/src/plugins/resolvers/utils/getPresignedPostPayload.js
@@ -3,10 +3,23 @@ import uniqueId from "uniqid";
 import sanitizeFilename from "sanitize-filename";
 import S3 from "aws-sdk/clients/s3";
 import mime from "mime";
+import { validation } from "@webiny/validation";
 
 const S3_BUCKET = process.env.S3_BUCKET;
+const UPLOAD_MAX_FILE_SIZE = process.env.UPLOAD_MAX_FILE_SIZE;
+const UPLOAD_MAX_FILE_SIZE_DEFAULT = 26214400; // 25MB
+const UPLOAD_MIN_FILE_SIZE = process.env.UPLOAD_MIN_FILE_SIZE;
 
-export default data => {
+const sanitizeFileSizeValue = (value, defaultValue) => {
+    try {
+        validation.validateSync(value, "numeric,gte:0");
+        return value;
+    } catch (e) {
+        return defaultValue;
+    }
+};
+
+export default async data => {
     const contentType = mime.getType(data.name);
     if (!contentType) {
         throw Error(`File's content type could not be resolved.`);
@@ -20,10 +33,16 @@ export default data => {
     // Replace all whitespace.
     key = key.replace(/\s/g, "");
 
+    let uploadMinFileSize = sanitizeFileSizeValue(UPLOAD_MIN_FILE_SIZE, 0);
+    let uploadMaxFileSize = sanitizeFileSizeValue(
+        UPLOAD_MAX_FILE_SIZE,
+        UPLOAD_MAX_FILE_SIZE_DEFAULT
+    );
+
     const params = {
         Expires: 60,
         Bucket: S3_BUCKET,
-        Conditions: [["content-length-range", 100, 26214400]], // 100Byte - 25MB
+        Conditions: [["content-length-range", uploadMinFileSize, uploadMaxFileSize]], // 0 Bytes - 25MB
         Fields: {
             "Content-Type": contentType,
             key
@@ -43,7 +62,7 @@ export default data => {
             name: key,
             key,
             type: contentType,
-            size: data.size,
+            size: data.size
         }
     };
 };

--- a/packages/cli/create/template/api/serverless.yml
+++ b/packages/cli/create/template/api/serverless.yml
@@ -60,8 +60,9 @@ files:
     bucket: ${vars.bucket}
     memory: 512
     database: ${vars.database}
+    uploadMinFileSize: 0 # 0 MB
+    uploadMaxFileSize: 26214400 # 25 MB
     env: ${vars.env}
-
 
 i18n:
   component: "@webiny/serverless-apollo-service"


### PR DESCRIPTION
## Related Issue
Developers currently cannot adjust the minimum or maximum size of the uploaded file, it was hardcoded to 100B / 25MB

## Your solution
Developers can adjust this in the `serverless-files` component's `inputs` section, by providing `uploadMinFileSize` and `uploadMaxFileSize` values.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A