### PR TITLE
Improved File Manager UI

### DIFF
--- a/packages/app-admin/src/components/FileManager/FileDetails.js
+++ b/packages/app-admin/src/components/FileManager/FileDetails.js
@@ -18,7 +18,7 @@ import { useFileManager } from "./FileManagerContext";
 import { useMutation } from "react-apollo";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
-import gql from "graphql-tag";
+import { DELETE_FILE } from "./graphql";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-admin/file-manager/file-details");
 
@@ -79,16 +79,6 @@ const style = {
     })
 };
 
-const DELETE_FILE = gql`
-    mutation deleteFile($id: ID!) {
-        files {
-            deleteFile(id: $id) {
-                data
-            }
-        }
-    }
-`;
-
 export default function FileDetails(props: *) {
     const { file, uploadFile, validateFiles } = props;
     const filePlugin = getFileTypePlugin(file);
@@ -104,7 +94,7 @@ export default function FileDetails(props: *) {
         }
     });
 
-    const [deleteFile] = useMutation(DELETE_FILE);
+    const [deleteFile] = useMutation(DELETE_FILE, { refetchQueries: ["ListFiles"] });
     const { showSnackbar } = useSnackbar();
 
     const { showConfirmation: showDeleteConfirmation } = useConfirmationDialog({

--- a/packages/app-admin/src/components/FileManager/FileManagerView.js
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.js
@@ -241,10 +241,15 @@ function FileManagerView(props: Props) {
         setUploading(true);
         const list = Array.isArray(files) ? files : [files];
 
+        const errors = [];
         await Promise.all(
             list.map(async file => {
-                const response = await getFileUploader()(file, { apolloClient });
-                await createFile({ variables: { data: response } });
+                try {
+                    const response = await getFileUploader()(file, { apolloClient });
+                    await createFile({ variables: { data: response } });
+                } catch (e) {
+                    errors.push(e);
+                }
             })
         );
 
@@ -253,6 +258,15 @@ function FileManagerView(props: Props) {
         }
 
         setUploading(false);
+
+        if (errors.length > 0) {
+            // We wait 750ms, just for everything to settle down a bit.
+            setTimeout(
+                () => showSnackbar("One or more files were not uploaded successfully."),
+                750
+            );
+            return;
+        }
 
         // We wait 750ms, just for everything to settle down a bit.
         setTimeout(() => showSnackbar("File upload complete."), 750);

--- a/packages/app-admin/src/components/FileManager/FileManagerView.js
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.js
@@ -173,23 +173,23 @@ function FileManagerView(props: Props) {
                 const { data } = gqlQuery.current.getQueryResult();
                 const nextPage = get(data, "files.listFiles.meta.nextPage");
                 nextPage &&
-                fetchMore({
-                    variables: { page: nextPage },
-                    updateQuery: (prev, { fetchMoreResult }) => {
-                        if (!fetchMoreResult) {
-                            return prev;
+                    fetchMore({
+                        variables: { page: nextPage },
+                        updateQuery: (prev, { fetchMoreResult }) => {
+                            if (!fetchMoreResult) {
+                                return prev;
+                            }
+
+                            const next = { ...fetchMoreResult };
+
+                            next.files.listFiles.data = [
+                                ...prev.files.listFiles.data,
+                                ...fetchMoreResult.files.listFiles.data
+                            ];
+
+                            return next;
                         }
-
-                        const next = { ...fetchMoreResult };
-
-                        next.files.listFiles.data = [
-                            ...prev.files.listFiles.data,
-                            ...fetchMoreResult.files.listFiles.data
-                        ];
-
-                        return next;
-                    }
-                });
+                    });
             }
         }, 500),
         []
@@ -257,7 +257,6 @@ function FileManagerView(props: Props) {
         // We wait 750ms, just for everything to settle down a bit.
         setTimeout(() => showSnackbar("File upload complete."), 750);
     };
-
 
     return (
         <Files
@@ -342,28 +341,28 @@ function FileManagerView(props: Props) {
                                 <FileList>
                                     {list.length
                                         ? list.map(file =>
-                                            renderFile({
-                                                uploadFile,
-                                                file,
-                                                showFileDetails: () => showFileDetails(file.src),
-                                                selected: selected.find(
-                                                    current => current.src === file.src
-                                                ),
-                                                onSelect: async () => {
-                                                    if (multiple) {
-                                                        toggleSelected(file);
-                                                        return;
-                                                    }
+                                              renderFile({
+                                                  uploadFile,
+                                                  file,
+                                                  showFileDetails: () => showFileDetails(file.src),
+                                                  selected: selected.find(
+                                                      current => current.src === file.src
+                                                  ),
+                                                  onSelect: async () => {
+                                                      if (multiple) {
+                                                          toggleSelected(file);
+                                                          return;
+                                                      }
 
-                                                    await onChange(file);
-                                                    onClose();
-                                                }
-                                            })
-                                        )
+                                                      await onChange(file);
+                                                      onClose();
+                                                  }
+                                              })
+                                          )
                                         : renderEmpty({
-                                            hasPreviouslyUploadedFiles,
-                                            browseFiles
-                                        })}
+                                              hasPreviouslyUploadedFiles,
+                                              browseFiles
+                                          })}
                                 </FileList>
                             </Scrollbar>
                             <BottomInfoBar accept={accept} uploading={uploading} />

--- a/packages/app-admin/src/components/FileManager/FileManagerView.js
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.js
@@ -23,6 +23,8 @@ import { css } from "emotion";
 import styled from "@emotion/styled";
 import { useHotkeys } from "react-hotkeyz";
 import { useFileManager } from "./FileManagerContext";
+import { i18n } from "@webiny/app/i18n";
+const t = i18n.ns("app-admin/file-manager/file-manager-view");
 
 import { ReactComponent as SearchIcon } from "./icons/round-search-24px.svg";
 import { ReactComponent as UploadIcon } from "./icons/round-cloud_upload-24px.svg";
@@ -262,14 +264,14 @@ function FileManagerView(props: Props) {
         if (errors.length > 0) {
             // We wait 750ms, just for everything to settle down a bit.
             setTimeout(
-                () => showSnackbar("One or more files were not uploaded successfully."),
+                () => showSnackbar(t`One or more files were not uploaded successfully.`),
                 750
             );
             return;
         }
 
         // We wait 750ms, just for everything to settle down a bit.
-        setTimeout(() => showSnackbar("File upload complete."), 750);
+        setTimeout(() => showSnackbar(t`File upload complete.`), 750);
     };
 
     return (
@@ -297,7 +299,7 @@ function FileManagerView(props: Props) {
                             <input
                                 ref={searchInput}
                                 onChange={e => searchOnChange(e.target.value)}
-                                placeholder={"Search by filename or tags"}
+                                placeholder={t`Search by filename or tags`}
                             />
                         </InputSearch>
                     }
@@ -311,12 +313,12 @@ function FileManagerView(props: Props) {
                                     onClose();
                                 }}
                             >
-                                Select {multiple && `(${selected.length})`}
+                                {t`Select`} {multiple && `(${selected.length})`}
                             </ButtonPrimary>
                         ) : (
                             <ButtonPrimary onClick={browseFiles} disabled={uploading}>
                                 <ButtonIcon icon={<UploadIcon />} />
-                                Upload...
+                                {t`Upload...`}
                             </ButtonPrimary>
                         )
                     }

--- a/packages/app-admin/src/components/FileManager/FileManagerView.js
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.js
@@ -290,6 +290,7 @@ function FileManagerView(props: Props) {
                     barRight={
                         selected.length > 0 ? (
                             <ButtonPrimary
+                                disabled={uploading}
                                 onClick={async () => {
                                     await onChange(multiple ? selected : selected[0]);
 
@@ -299,7 +300,7 @@ function FileManagerView(props: Props) {
                                 Select {multiple && `(${selected.length})`}
                             </ButtonPrimary>
                         ) : (
-                            <ButtonPrimary onClick={browseFiles}>
+                            <ButtonPrimary onClick={browseFiles} disabled={uploading}>
                                 <ButtonIcon icon={<UploadIcon />} />
                                 Upload...
                             </ButtonPrimary>

--- a/packages/app-admin/src/components/FileManager/graphql.js
+++ b/packages/app-admin/src/components/FileManager/graphql.js
@@ -71,3 +71,13 @@ export const UPDATE_FILE = gql`
         }
     }
 `;
+
+export const DELETE_FILE = gql`
+    mutation deleteFile($id: ID!) {
+        files {
+            deleteFile(id: $id) {
+                data
+            }
+        }
+    }
+`;


### PR DESCRIPTION
## Related Issue
There were a few places in the File Manager UI that could use some improvements:
1. disable top right UPLOAD button while there is an active upload (screenshot below)
2. show file upload related error messages in snackbars (screenshot below)
3. refresh list of files after a file was deleted

## Your solution
All of the listed improvements are resolved.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
1. disable top right UPLOAD button while there is an active upload

![Snip20191105_10](https://user-images.githubusercontent.com/5121148/68209869-9c2f3580-ffd4-11e9-8876-1490f62f513d.png)

2. show file upload related error messages in snackbars

![Snip20191105_11](https://user-images.githubusercontent.com/5121148/68209868-9c2f3580-ffd4-11e9-9834-50384663f772.png)
