### PR TITLE
Added "allowRelative" option for the `url` validator

### DIFF
--- a/packages/validation/__tests__/url.test.js
+++ b/packages/validation/__tests__/url.test.js
@@ -45,4 +45,9 @@ describe("url test", () => {
         await validation.validate("https://localhost:3000", "url").should.become(true);
         await validation.validate("https://localhost:3000/graphql", "url").should.become(true);
     });
+
+    it("should pass - allow relative URL", async () => {
+        await validation.validate("/relative/url?this=is", "url").should.be.rejected;
+        await validation.validate("/relative/url?this=is", "url:allowRelative").should.become(true);
+    });
 });

--- a/packages/validation/src/validators/url.js
+++ b/packages/validation/src/validators/url.js
@@ -1,6 +1,21 @@
 // @flow
 import ValidationError from "./../validationError";
 
+const regex = {
+    base: new RegExp(
+        // eslint-disable-next-line
+        /^(https?:\/\/)((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/i
+    ),
+    ip: new RegExp(
+        // eslint-disable-next-line
+        /^(https?:\/\/)(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+    ),
+    relative: new RegExp(
+        // eslint-disable-next-line
+        /^\/.*$/
+    )
+};
+
 export default (value: any, params: Array<string>) => {
     if (!value) return;
     value = value + "";
@@ -9,22 +24,18 @@ export default (value: any, params: Array<string>) => {
         value = value.replace("//localhost", "//localhost.com");
     }
 
-    const regex = new RegExp(
-        // eslint-disable-next-line
-        /^(https?:\/\/)((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/i
-    );
-
-    const ipRegex = new RegExp(
-        // eslint-disable-next-line
-        /^(https?:\/\/)(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-    );
-
-    if (regex.test(value)) {
+    if (regex.base.test(value)) {
         if (!params.includes("noIp")) {
             return;
         }
 
-        if (!ipRegex.test(value)) {
+        if (!regex.ip.test(value)) {
+            return;
+        }
+    }
+
+    if (params.includes("allowRelative")) {
+        if (regex.relative.test(value)) {
             return;
         }
     }


### PR DESCRIPTION
## Related Issue
We want to be able to validate relative URLs, like eg. `"/relative/url?this=is"`.

## Your solution
Added `allowRelative` option to the `url` validator. You can use it like so:
```
await validation.validate("/relative/url?this=is", "url:allowRelative");
```

## How Has This Been Tested?
Unit test.

## Screenshots (if relevant):
N/A