### PR TITLE
Handle undefined value in SlateEditor component.

### DIFF
--- a/packages/app-page-builder/src/render/components/Slate.js
+++ b/packages/app-page-builder/src/render/components/Slate.js
@@ -8,7 +8,7 @@ import { usePageBuilder } from "@webiny/app-page-builder/hooks/usePageBuilder";
 const SlateEditor = props => {
     const { theme } = usePageBuilder();
     const plugins = useRef(getPlugins("pb-render-slate-editor").map(pl => pl.slate));
-    const [value] = useState(Value.fromJSON(props.value));
+    const [value] = useState(Value.fromJSON(props.value || {}));
 
     return (
         <Editor


### PR DESCRIPTION
## Related Issue
In PageBuilder, SlateEditor component throws an error if `props.value` is `undefined`. 

## Your solution
Pass a default `{}` to `Value.fromJSON` which would throw otherwise.

## How Has This Been Tested?
Manually.

