### PR TITLE
When creating storage value, do not modify current attribute value.

### DIFF
--- a/packages/api-page-builder/package.json
+++ b/packages/api-page-builder/package.json
@@ -31,6 +31,7 @@
         "load-json-file": "^6.2.0",
         "lodash": "^4.17.11",
         "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
         "lodash.get": "^4.4.0",
         "lodash.pick": "^4.4.0",
         "mdbid": "^1.0.0",

--- a/packages/api-page-builder/src/plugins/models/pbPage/contentField.js
+++ b/packages/api-page-builder/src/plugins/models/pbPage/contentField.js
@@ -1,5 +1,6 @@
 // @flow
 import { object } from "@webiny/commodo";
+import cloneDeep from "lodash.clonedeep";
 
 const isValidElement = element => {
     return element && element.type;
@@ -38,7 +39,7 @@ export default ({ context, ...rest }) => {
         ...rest,
         async getStorageValue() {
             // Not using getValue method because it would load the model without need.
-            let element = this.current;
+            let element = cloneDeep(this.current);
             await asyncModifiers({
                 context,
                 element,


### PR DESCRIPTION
## Related Issue
When Page Editor saves page content, it returns images with IDs instead of data objects.

## Your solution
Make a deep clone of the current attribute values before applying modifiers that create the storage value, as we don't want to modify the attribute value itself.

## How Has This Been Tested?
Manually.