### PR TITLE
Add support for selective component deploy and improve debug output

### DIFF
--- a/components/serverless-apollo-gateway/package.json
+++ b/components/serverless-apollo-gateway/package.json
@@ -15,6 +15,7 @@
     "fs-extra": "^8.1.0",
     "load-json-file": "^6.2.0",
     "lodash.camelcase": "^4.3.0",
+    "lodash.isequal": "^4.5.0",
     "prettier": "^1.18.2",
     "webpack": "^4.39.2",
     "write-json-file": "^4.2.0"

--- a/components/serverless-aws-api-gateway/package.json
+++ b/components/serverless-aws-api-gateway/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@serverless/core": "^1.0.0",
     "aws-sdk": "^2.0.0",
+    "lodash.isequal": "^4.5.0",
     "p-retry": "^4.1.0"
   },
   "gitHead": "71cab7d5607b2e32a63034e324a663770507b32b"

--- a/components/serverless-aws-api-gateway/serverless.js
+++ b/components/serverless-aws-api-gateway/serverless.js
@@ -1,4 +1,5 @@
 const AWS = require("aws-sdk");
+const isEqual = require("lodash.isequal");
 const { Component, utils } = require("@serverless/core");
 
 const {
@@ -29,6 +30,13 @@ const defaults = {
 class AwsApiGateway extends Component {
     async default(inputs = {}) {
         try {
+            if (isEqual(this.state.inputs, inputs)) {
+                this.context.instance.debug("Input was not changed, no action required.");
+                return this.state;
+            } else {
+                this.state.inputs = inputs;
+            }
+
             this.context.status("Deploying");
 
             const config = { ...defaults, ...inputs };
@@ -43,8 +51,10 @@ class AwsApiGateway extends Component {
 
             const { name, description, region, stage, endpointTypes, binaryMediaTypes } = config;
 
-            this.context.debug(
-                `Starting API Gateway deployment with name ${name} in the ${region} region`
+            this.context.instance.debug(
+                `Starting API Gateway deployment with name %o in the %o region`,
+                name,
+                region
             );
 
             // quick fix for array of objects in yaml issue
@@ -63,18 +73,18 @@ class AwsApiGateway extends Component {
             let apiId = this.state.id || config.id;
 
             if (!apiId) {
-                this.context.debug(`API ID not found in state. Creating a new API.`);
+                this.context.instance.debug(`API ID not found in state. Creating a new API.`);
                 apiId = await retry(() =>
                     createApi({ apig, name, description, endpointTypes, binaryMediaTypes })
                 );
-                this.context.debug(`API with ID ${apiId} created.`);
+                this.context.instance.debug(`API with ID %o created.`, apiId);
                 this.state.id = apiId;
                 await this.save();
             } else if (!(await apiExists({ apig, apiId }))) {
                 throw Error(`the specified api id "${apiId}" does not exist`);
             }
 
-            this.context.debug(
+            this.context.instance.debug(
                 `Validating ownership for the provided endpoints for API ID ${apiId}.`
             );
 
@@ -87,32 +97,33 @@ class AwsApiGateway extends Component {
                 region
             });
 
-            this.context.debug(`Deploying authorizers if any for API ID ${apiId}.`);
+            this.context.instance.debug(`Deploying authorizers if any for API ID %o.`, apiId);
 
             endpoints = await createAuthorizers({ apig, lambda, apiId, endpoints });
 
-            this.context.debug(`Deploying paths/resources for API ID ${apiId}.`);
+            this.context.instance.debug(`Deploying paths/resources for API ID %o.`, apiId);
 
             endpoints = await createPaths({ apig, apiId, endpoints });
 
-            this.context.debug(`Deploying methods for API ID ${apiId}.`);
+            this.context.instance.debug(`Deploying methods for API ID %o.`, apiId);
 
             endpoints = await createMethods({ apig, apiId, endpoints });
 
-            this.context.debug(
+            this.context.instance.debug(
                 `Sleeping for couple of seconds before creating method integration.`
             );
 
             // need to sleep for a bit between method and integration creation
             await utils.sleep(2000);
 
-            this.context.debug(
-                `Creating integrations for the provided methods for API ID ${apiId}.`
+            this.context.instance.debug(
+                `Creating integrations for the provided methods for API ID %o.`,
+                apiId
             );
 
             endpoints = await createIntegrations({ apig, lambda, apiId, endpoints });
 
-            this.context.debug(`Removing any old endpoints for API ID ${apiId}.`);
+            this.context.instance.debug(`Removing any old endpoints for API ID ${apiId}.`);
 
             // keep endpoints in sync with provider
             await removeOutdatedEndpoints({
@@ -122,8 +133,11 @@ class AwsApiGateway extends Component {
                 stateEndpoints: this.state.endpoints || []
             });
 
-            this.context.debug(
-                `Creating deployment for API ID ${apiId} in the ${stage} stage and the ${region} region.`
+            this.context.instance.debug(
+                `Creating deployment for API ID %o in the %o stage and the %o region.`,
+                apiId,
+                stage,
+                region
             );
 
             await retry(() => createDeployment({ apig, apiId, stage }));
@@ -137,10 +151,12 @@ class AwsApiGateway extends Component {
             this.state.url = config.url;
             await this.save();
 
-            this.context.debug(
-                `Deployment successful for the API named ${name} in the ${region} region.`
+            this.context.instance.debug(
+                `Deployment successful for the API named %o in the %o region.`,
+                name,
+                region
             );
-            this.context.debug(`API URL is ${config.url}.`);
+            this.context.instance.debug(`API URL is %o.`, config.url);
 
             const outputs = {
                 name: config.name,
@@ -166,25 +182,29 @@ class AwsApiGateway extends Component {
         });
 
         if (this.state.id) {
-            this.context.debug(
-                `API ID ${this.state.id} found in state. Removing from the ${this.state.region}.`
+            this.context.instance.debug(
+                `API ID %o found in state. Removing from the %o.`,
+                this.state.id,
+                this.state.region
             );
             await retry(() => removeApi({ apig, apiId: this.state.id }));
 
-            this.context.debug(
-                `API with ID ${this.state.id} was successfully removed from the ${this.state.region} region.`
+            this.context.instance.debug(
+                `API with ID %o was successfully removed from the %o region.`,
+                this.state.id,
+                this.state.region
             );
         } else if (inputs.id && this.state.endpoints && this.state.endpoints.length !== undefined) {
-            this.context.debug(`No API ID found in state.`);
-            this.context.debug(`Removing any previously deployed authorizers.`);
+            this.context.instance.debug(`No API ID found in state.`);
+            this.context.instance.debug(`Removing any previously deployed authorizers.`);
 
             await removeAuthorizers({ apig, apiId: inputs.id, endpoints: this.state.endpoints });
 
-            this.context.debug(`Removing any previously deployed methods.`);
+            this.context.instance.debug(`Removing any previously deployed methods.`);
 
             await removeMethods({ apig, apiId: inputs.id, endpoints: this.state.endpoints });
 
-            this.context.debug(`Removing any previously deployed resources.`);
+            this.context.instance.debug(`Removing any previously deployed resources.`);
 
             await removeResources({ apig, apiId: inputs.id, endpoints: this.state.endpoints });
         }
@@ -196,7 +216,7 @@ class AwsApiGateway extends Component {
             url: this.state.url
         };
 
-        this.context.debug(`Flushing state for the API Gateway component.`);
+        this.context.instance.debug(`Flushing state for the API Gateway component.`);
 
         this.state = {};
         await this.save();

--- a/components/serverless-aws-cognito-user-pool/serverless.js
+++ b/components/serverless-aws-cognito-user-pool/serverless.js
@@ -14,7 +14,7 @@ const defaultPasswordPolicy = {
 class ServerlessAwsCognito extends Component {
     async default(inputs = {}) {
         if (isEqual(this.state.inputs, inputs)) {
-            this.context.debug("Input was not changed, no action required.");
+            this.context.instance.debug("Input was not changed, no action required.");
             return this.state.output;
         }
 
@@ -44,8 +44,10 @@ class ServerlessAwsCognito extends Component {
                 const clientInInput = appClients[i];
 
                 if (clientInState && clientInInput) {
-                    this.context.debug(
-                        `Updating client ${clientInState.ClientName} (${clientInState.ClientId}).`
+                    this.context.instance.debug(
+                        `Updating client %o (%o).`,
+                        clientInState.ClientName,
+                        clientInState.ClientId
                     );
 
                     const clientParams = {
@@ -63,8 +65,10 @@ class ServerlessAwsCognito extends Component {
 
                 if (clientInState && !clientInInput) {
                     // Delete existing client
-                    this.context.debug(
-                        `Deleting client ${clientInState.ClientName} (${clientInState.ClientId}).`
+                    this.context.instance.debug(
+                        `Deleting client %o (%o).`,
+                        clientInState.ClientName,
+                        clientInState.ClientId
                     );
                     const clientParams = {
                         UserPoolId: this.state.output.userPool.Id,
@@ -76,7 +80,7 @@ class ServerlessAwsCognito extends Component {
                 }
 
                 // Create new client
-                this.context.debug(`Creating new user pool client ${name}.`);
+                this.context.instance.debug(`Creating new user pool client %o.`, name);
                 const clientParams = {
                     UserPoolId: this.state.output.userPool.Id,
                     ClientName: name,
@@ -92,7 +96,7 @@ class ServerlessAwsCognito extends Component {
             // Filter null values
             this.state.output.appClients = this.state.output.appClients.filter(Boolean);
         } else {
-            this.context.debug(`Creating new user pool.`);
+            this.context.instance.debug(`Creating new user pool.`);
 
             const params = {
                 PoolName: name,
@@ -152,11 +156,11 @@ class ServerlessAwsCognito extends Component {
             this.state.output.userPool.Region = region;
             await this.save();
 
-            this.context.debug(`Created user pool ${UserPool.Id}.`);
+            this.context.instance.debug(`Created user pool %o.`, UserPool.Id);
 
             // Create app clients
             for (let i = 0; i < appClients.length; i++) {
-                this.context.debug(`Creating new user pool client.`);
+                this.context.instance.debug(`Creating new user pool client.`);
                 const { name, refreshTokenValidity = 30, generateSecret = false } = appClients[i];
                 const clientParams = {
                     UserPoolId: this.state.output.userPool.Id,
@@ -186,7 +190,7 @@ class ServerlessAwsCognito extends Component {
         const cognito = new Cognito({ region });
         const UserPoolId = this.state.output.userPool.Id;
 
-        this.context.debug(`Removing Cognito User Pool ${UserPoolId}.`);
+        this.context.instance.debug(`Removing Cognito User Pool %o.`, UserPoolId);
 
         await cognito
             .deleteUserPool({

--- a/components/serverless-files/utils/configureS3Bucket.js
+++ b/components/serverless-files/utils/configureS3Bucket.js
@@ -33,9 +33,7 @@ module.exports = async ({ bucket, region, component, s3Output, manageFilesLambda
         );
 
         await component.save();
-        component.context.debug(
-            `Saved state for serverless-files component: applied CORS configuration to the "${bucket}" S3 bucket.`
-        );
+        component.context.instance.debug(`Applied CORS configuration to the %o S3 bucket.`, bucket);
     }
 
     path = "state.lambda.manageS3Objects.permissions";
@@ -52,8 +50,10 @@ module.exports = async ({ bucket, region, component, s3Output, manageFilesLambda
         await pRetry(() => lambda.addPermission(get(component, path)).promise(), PRETRY_ARGS);
 
         await component.save();
-        component.context.debug(
-            `Saved state for serverless-files component: added "lambda:InvokeFunction" permission to the "manageS3Objects" Lambda.`
+        component.context.instance.debug(
+            `Added %o permission to the %o Lambda.`,
+            "lambda:InvokeFunction",
+            "manageS3Objects"
         );
     }
 
@@ -80,8 +80,9 @@ module.exports = async ({ bucket, region, component, s3Output, manageFilesLambda
         );
 
         await component.save();
-        component.context.debug(
-            `Saved state for serverless-files component: applied bucket notification configuration to the "${bucket}" S3 bucket.`
+        component.context.instance.debug(
+            `Applied bucket notification configuration to the %o S3 bucket.`,
+            bucket
         );
     }
 };

--- a/components/serverless-page-builder/serverless.js
+++ b/components/serverless-page-builder/serverless.js
@@ -38,8 +38,9 @@ class ServerlessPageBuilder extends Component {
                 .getObject({ Bucket: s3Output.name, Key: PAGE_BUILDER_INSTALLATION_FILES_ZIP_KEY })
                 .promise();
         } catch (e) {
-            this.context.debug(
-                `Uploading Page Builder installation files to bucket ${s3Output.name}.`
+            this.context.instance.debug(
+                `Uploading Page Builder installation files to bucket %o`,
+                s3Output.name
             );
             await s3
                 .putObject({

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -49,6 +49,9 @@ yargs.command(
             describe: "Environment to deploy. Must match your environments in .env.json.",
             default: "local"
         });
+        yargs.option("alias", {
+            describe: "Alias to deploy."
+        });
         yargs.option("debug", {
             describe: "Show debug messages.",
             default: false,

--- a/packages/cli/sls/execute.js
+++ b/packages/cli/sls/execute.js
@@ -2,8 +2,9 @@ const { join, resolve } = require("path");
 const ansiEscapes = require("ansi-escapes");
 const Context = require("@serverless/cli/src/Context");
 const { loadEnv } = require("./utils");
+
 module.exports = async (inputs, method = "default") => {
-    const { what, env, debug = false } = inputs;
+    const { what, env, debug = false, alias = null } = inputs;
     const cwd = process.cwd();
     // Load .env.json from project root
     await loadEnv(resolve(".env.json"), env, { debug });
@@ -19,11 +20,15 @@ module.exports = async (inputs, method = "default") => {
     };
 
     const context = new Context(config);
+    if (debug) {
+        process.env.DEBUG = "webiny*";
+        context.debug = require("debug")("webiny");
+    }
     const Template = require("./template/serverless.js");
     const component = new Template(`Webiny.${env}`, context);
     await component.init();
 
-    const output = await component[method]({ env, debug });
+    const output = await component[method]({ env, debug, alias });
     if (debug) {
         // Add an empty line after debug output for nicer output
         console.log();


### PR DESCRIPTION
This PR closes #608, closes #607. 

You can now run deploy of only the selected aliases:
`webiny deploy-api --alias i18n --alias security --debug`

Watching is not yet implemented.