### PR TITLE
Notify users a new CLI version is available.

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -149,3 +149,10 @@ yargs.command(
 
 // Run
 yargs.argv;
+
+// Checks for updates
+if (!process.env.CI) {
+    const updateNotifier = require("update-notifier");
+    const pkg = require("./package.json");
+    updateNotifier({ pkg }).notify();
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "node-notifier": "^6.0.0",
     "ramda": "^0.26.1",
     "traverse": "^0.6.6",
+    "update-notifier": "^3.0.1",
     "uuid": "^3.3.3",
     "write-json-file": "^4.2.0",
     "yargs": "^14.0.0"


### PR DESCRIPTION
This PR adds the `update-notifier` package which will notify users when a new CLI version is available.