### PR TITLE
Adjusted the maximum file size that can be directly returned from the file download Lambda

### DIFF
--- a/components/serverless-files/functions/downloadFile/handler.js
+++ b/components/serverless-files/functions/downloadFile/handler.js
@@ -5,7 +5,7 @@ const pathLib = require("path");
 const { createHandler, getEnvironment, getObjectParams } = require("../utils");
 const loaders = require("./../loaders");
 
-const MAX_RETURN_CONTENT_LENGTH = 6000000; // almost 6MB
+const MAX_RETURN_CONTENT_LENGTH = 5000000; // ~4.77MB
 
 /**
  * Based on given path, extracts file key and additional options sent via query params.


### PR DESCRIPTION
## Related Issue
It seems that the current `MAX_RETURN_CONTENT_LENGTH` value, located in `downloadFile` function, is too small. 

This is used upon serving files, to determine whether the file content should be directly returned to the API Gateway, or we should issue a 301 redirect. The previous value was `6000000`, which is equal to `5.72MB`, and in one particular case, although the max size of returned content by a Lambda function must be smaller than 6MB, returning an image of `5.13MB` caused issues for some reason.

`LAMBDA_RUNTIME Failed to post handler success response. Http response code: 413.`

## Your solution
I set a new value, `5000000`, which is equal to `4.77MB`. Tested the case explained above, it works.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/69324920-9d559900-0c49-11ea-8ae4-7574cf304337.png)
