### PR TITLE
Log out users on invalid signature security error

### DIFF
--- a/packages/api-security/src/plugins/security.js
+++ b/packages/api-security/src/plugins/security.js
@@ -3,47 +3,50 @@ import type { PluginType } from "@webiny/api/types";
 import { shield } from "graphql-shield";
 import authenticate from "./authentication/authenticate";
 
-export default options => ([
-    {
-        type: "graphql-middleware",
-        name: "graphql-middleware-shield",
-        middleware: ({ plugins }) => {
-            const middleware = [];
-            plugins.byType("graphql-schema").forEach(plugin => {
-                let { security } = plugin;
-                if (!security) {
-                    return true;
-                }
+export default options =>
+    ([
+        {
+            type: "graphql-middleware",
+            name: "graphql-middleware-shield",
+            middleware: ({ plugins }) => {
+                const middleware = [];
+                plugins.byType("graphql-schema").forEach(plugin => {
+                    let { security } = plugin;
+                    if (!security) {
+                        return true;
+                    }
 
-                if (typeof security === "function") {
-                    security = security();
-                }
+                    if (typeof security === "function") {
+                        security = security();
+                    }
 
-                security.shield &&
-                    middleware.push(
-                        shield(security.shield, {
-                            allowExternalErrors: true
-                        })
-                    );
-            });
+                    security.shield &&
+                        middleware.push(
+                            shield(security.shield, {
+                                allowExternalErrors: true
+                            })
+                        );
+                });
 
-            return middleware;
-        }
-    },
-    {
-        type: "graphql-context",
-        name: "graphql-context-security",
-        preApply: async context => {
-            context.security = options;
-            context.token = null;
-            context.user = null;
-            context.getUser = () => context.user;
-
-            const securityPlugins: Array<PluginType> = context.plugins.byType("graphql-security");
-            for (let i = 0; i < securityPlugins.length; i++) {
-                await securityPlugins[i].authenticate(context);
+                return middleware;
             }
-        }
-    },
-    { type: "graphql-security", name: "graphql-security", authenticate }
-]: Array<PluginType>);
+        },
+        {
+            type: "graphql-context",
+            name: "graphql-context-security",
+            preApply: async context => {
+                context.security = options;
+                context.token = null;
+                context.user = null;
+                context.getUser = () => context.user;
+
+                const securityPlugins: Array<PluginType> = context.plugins.byType(
+                    "graphql-security"
+                );
+                for (let i = 0; i < securityPlugins.length; i++) {
+                    await securityPlugins[i].authenticate(context);
+                }
+            }
+        },
+        { type: "graphql-security", name: "graphql-security", authenticate }
+    ]: Array<PluginType>);

--- a/packages/app-i18n/.babelrc
+++ b/packages/app-i18n/.babelrc
@@ -10,7 +10,6 @@
     ],
     "plugins": [
         ["babel-plugin-emotion", { "autoLabel": true }],
-        ["babel-plugin-lodash", { "id": ["lodash"] }],
         ["babel-plugin-named-asset-import", {
             "loaderMap": {
                 "svg": {

--- a/packages/app-i18n/package.json
+++ b/packages/app-i18n/package.json
@@ -26,7 +26,8 @@
     "emotion": "10.0.17",
     "graphql-tag": "^2.10.1",
     "is-hotkey": "^0.1.3",
-    "lodash": "^4.17.11",
+    "lodash.get": "^4.4.2",
+    "lodash.clonedeep": "^4.5.0",
     "react-apollo": "^3.1.0-beta.0",
     "react-helmet": "^5.2.0",
     "react-router-dom": "^5.0.0",
@@ -40,7 +41,6 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-emotion": "^9.2.8",
-    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-named-asset-import": "^1.0.0-next.3e165448"
   },
   "peerDependencies": {

--- a/packages/app-i18n/src/admin/components/I18NInput.js
+++ b/packages/app-i18n/src/admin/components/I18NInput.js
@@ -7,7 +7,7 @@ import { css } from "emotion";
 import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { Tooltip } from "@webiny/ui/Tooltip";
 import classNames from "classnames";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash.clonedeep";
 import I18NRichTextEditor from "./I18NRichTextEditor";
 
 const style = {
@@ -52,13 +52,13 @@ type Props = {
 } & Object;
 
 const I18NInput = ({
-                       richText,
-                       value,
-                       onChange,
-                       children,
-                       showTranslateIcon,
-                       ...inputProps
-                   }: Props) => {
+    richText,
+    value,
+    onChange,
+    children,
+    showTranslateIcon,
+    ...inputProps
+}: Props) => {
     const [values, setValues] = useState(null);
     const { getLocale, getLocales } = useI18N();
 

--- a/packages/app-i18n/src/contexts/I18N/I18NContext.js
+++ b/packages/app-i18n/src/contexts/I18N/I18NContext.js
@@ -4,7 +4,7 @@ import React from "react";
 import { useQuery } from "react-apollo";
 import gql from "graphql-tag";
 import { CircularProgress } from "@webiny/ui/Progress";
-import { get } from "lodash";
+import get from "lodash.get";
 
 export const getI18NInformation = gql`
     query GetI18NInformation {

--- a/packages/app-i18n/src/contexts/I18N/I18NContext.js
+++ b/packages/app-i18n/src/contexts/I18N/I18NContext.js
@@ -4,6 +4,7 @@ import React from "react";
 import { useQuery } from "react-apollo";
 import gql from "graphql-tag";
 import { CircularProgress } from "@webiny/ui/Progress";
+import { get } from "lodash";
 
 export const getI18NInformation = gql`
     query GetI18NInformation {
@@ -33,7 +34,7 @@ const I18NProvider = ({ children }: Object) => {
         return <CircularProgress label={"Loading locales..."} />;
     }
 
-    const { currentLocale, locales } = data.i18n.getI18NInformation;
+    const { currentLocale, locales } = get(data, "i18n.getI18NInformation", {});
 
     const value = {
         refetchLocales: refetch,

--- a/packages/app-security/src/components/createAuthLink.js
+++ b/packages/app-security/src/components/createAuthLink.js
@@ -1,6 +1,7 @@
 // @flow
 import { ApolloLink, Observable } from "apollo-link";
 import localStorage from "store";
+import get from "lodash.get";
 
 export default ({ token = "webiny-token" }: { token: string } = {}) => {
     return new ApolloLink((operation, forward) => {
@@ -22,7 +23,8 @@ export default ({ token = "webiny-token" }: { token: string } = {}) => {
                 next: data => {
                     if (data.errors) {
                         data.errors.forEach(error => {
-                            if (unsetTokenCodes.includes(error.code)) {
+                            let code = get(error, "extensions.exception.code", error.code);
+                            if (unsetTokenCodes.includes(code)) {
                                 localStorage.remove(token);
                             }
                         });

--- a/packages/app-security/src/components/createAuthLink.js
+++ b/packages/app-security/src/components/createAuthLink.js
@@ -1,7 +1,7 @@
 // @flow
 import { ApolloLink, Observable } from "apollo-link";
 import localStorage from "store";
-import get from "lodash.get";
+import { get } from "lodash";
 
 export default ({ token = "webiny-token" }: { token: string } = {}) => {
     return new ApolloLink((operation, forward) => {


### PR DESCRIPTION
## Related Issue
`invalid signature` can happen when user switches to another Webiny project, because the other project contains a different JWT Token secret. The main problem is that the admin UI just crashes, with a not very informative error message.

## Your solution
Updated the `createAuthLink` handler - now it read errors not only from the `code`, but also from the `extensions.exception.code` key. 

I also updated the `I18NContext.js` - we're now getting the `getI18NInformation` data using `lodash.get`, and not directly. This was needed because this part of code would cause errors, when an error is present on the backend.

Fixes #584 
## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A