### PR TITLE
PageBuilder settings sliders

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/PMSettings.js
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/PMSettings.js
@@ -1,5 +1,5 @@
 //@flow
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { connect } from "@webiny/app-page-builder/editor/redux";
 import { useHandler } from "@webiny/app/hooks/useHandler";
 import { Tabs, Tab } from "@webiny/ui/Tabs";
@@ -26,6 +26,8 @@ type Props = Object & {
 
 const PMSettings = (props: Props) => {
     const { advanced, valueKey } = props;
+
+    const [tabIndex, setTabIndex] = useState(0);
 
     const updateSettings = useHandler(props, ({ element, updateElement }) => {
         return (name: string, newValue: mixed, history = false) => {
@@ -79,84 +81,92 @@ const PMSettings = (props: Props) => {
     }, [updateSettings]);
 
     return (
-        <Tabs>
+        <Tabs onActivate={setTabIndex}>
             <Tab label={"Desktop"}>
-                {!advanced ? (
-                    <SliderWithInput
-                        className={"no-bottom-padding"}
-                        icon={<BorderOuterIcon />}
-                        valueKey={valueKey + ".desktop.all"}
-                        updateValue={getUpdateValue("desktop.all")}
-                        updatePreview={getUpdatePreview("desktop.all")}
-                    />
-                ) : (
-                    <React.Fragment>
-                        <SliderWithInput
-                            icon={<BorderTopIcon />}
-                            valueKey={valueKey + ".desktop.top"}
-                            updateValue={getUpdateValue("desktop.top")}
-                            updatePreview={getUpdatePreview("desktop.top")}
-                        />
-                        <SliderWithInput
-                            icon={<BorderRightIcon />}
-                            valueKey={valueKey + ".desktop.right"}
-                            updateValue={getUpdateValue("desktop.right")}
-                            updatePreview={getUpdatePreview("desktop.right")}
-                        />
-                        <SliderWithInput
-                            icon={<BorderBottomIcon />}
-                            valueKey={valueKey + ".desktop.bottom"}
-                            updateValue={getUpdateValue("desktop.bottom")}
-                            updatePreview={getUpdatePreview("desktop.bottom")}
-                        />
-                        <SliderWithInput
-                            className={"no-bottom-padding"}
-                            icon={<BorderLeftIcon />}
-                            valueKey={valueKey + ".desktop.left"}
-                            updateValue={getUpdateValue("desktop.left")}
-                            updatePreview={getUpdatePreview("desktop.left")}
-                        />
-                    </React.Fragment>
+                {tabIndex === 0 && (
+                    <>
+                        {!advanced ? (
+                            <SliderWithInput
+                                className={"no-bottom-padding"}
+                                icon={<BorderOuterIcon />}
+                                valueKey={valueKey + ".desktop.all"}
+                                updateValue={getUpdateValue("desktop.all")}
+                                updatePreview={getUpdatePreview("desktop.all")}
+                            />
+                        ) : (
+                            <React.Fragment>
+                                <SliderWithInput
+                                    icon={<BorderTopIcon />}
+                                    valueKey={valueKey + ".desktop.top"}
+                                    updateValue={getUpdateValue("desktop.top")}
+                                    updatePreview={getUpdatePreview("desktop.top")}
+                                />
+                                <SliderWithInput
+                                    icon={<BorderRightIcon />}
+                                    valueKey={valueKey + ".desktop.right"}
+                                    updateValue={getUpdateValue("desktop.right")}
+                                    updatePreview={getUpdatePreview("desktop.right")}
+                                />
+                                <SliderWithInput
+                                    icon={<BorderBottomIcon />}
+                                    valueKey={valueKey + ".desktop.bottom"}
+                                    updateValue={getUpdateValue("desktop.bottom")}
+                                    updatePreview={getUpdatePreview("desktop.bottom")}
+                                />
+                                <SliderWithInput
+                                    className={"no-bottom-padding"}
+                                    icon={<BorderLeftIcon />}
+                                    valueKey={valueKey + ".desktop.left"}
+                                    updateValue={getUpdateValue("desktop.left")}
+                                    updatePreview={getUpdatePreview("desktop.left")}
+                                />
+                            </React.Fragment>
+                        )}
+                    </>
                 )}
                 <Footer advanced={Boolean(advanced)} toggleAdvanced={getUpdateValue("advanced")} />
             </Tab>
             <Tab label={"Mobile"}>
-                {!advanced ? (
-                    <SliderWithInput
-                        className={"no-bottom-padding"}
-                        icon={<BorderOuterIcon />}
-                        valueKey={valueKey + ".mobile.all"}
-                        updateValue={getUpdateValue("mobile.all")}
-                        updatePreview={getUpdatePreview("mobile.all")}
-                    />
-                ) : (
-                    <React.Fragment>
-                        <SliderWithInput
-                            icon={<BorderTopIcon />}
-                            valueKey={valueKey + ".mobile.top"}
-                            updateValue={getUpdateValue("mobile.top")}
-                            updatePreview={getUpdatePreview("mobile.top")}
-                        />
-                        <SliderWithInput
-                            icon={<BorderRightIcon />}
-                            valueKey={valueKey + ".mobile.right"}
-                            updateValue={getUpdateValue("mobile.right")}
-                            updatePreview={getUpdatePreview("mobile.right")}
-                        />
-                        <SliderWithInput
-                            icon={<BorderBottomIcon />}
-                            valueKey={valueKey + ".mobile.bottom"}
-                            updateValue={getUpdateValue("mobile.bottom")}
-                            updatePreview={getUpdatePreview("mobile.bottom")}
-                        />
-                        <SliderWithInput
-                            className={"no-bottom-padding"}
-                            icon={<BorderLeftIcon />}
-                            valueKey={valueKey + ".mobile.left"}
-                            updateValue={getUpdateValue("mobile.left")}
-                            updatePreview={getUpdatePreview("mobile.left")}
-                        />
-                    </React.Fragment>
+                {tabIndex === 1 && (
+                    <>
+                        {!advanced ? (
+                            <SliderWithInput
+                                className={"no-bottom-padding"}
+                                icon={<BorderOuterIcon />}
+                                valueKey={valueKey + ".mobile.all"}
+                                updateValue={getUpdateValue("mobile.all")}
+                                updatePreview={getUpdatePreview("mobile.all")}
+                            />
+                        ) : (
+                            <React.Fragment>
+                                <SliderWithInput
+                                    icon={<BorderTopIcon />}
+                                    valueKey={valueKey + ".mobile.top"}
+                                    updateValue={getUpdateValue("mobile.top")}
+                                    updatePreview={getUpdatePreview("mobile.top")}
+                                />
+                                <SliderWithInput
+                                    icon={<BorderRightIcon />}
+                                    valueKey={valueKey + ".mobile.right"}
+                                    updateValue={getUpdateValue("mobile.right")}
+                                    updatePreview={getUpdatePreview("mobile.right")}
+                                />
+                                <SliderWithInput
+                                    icon={<BorderBottomIcon />}
+                                    valueKey={valueKey + ".mobile.bottom"}
+                                    updateValue={getUpdateValue("mobile.bottom")}
+                                    updatePreview={getUpdatePreview("mobile.bottom")}
+                                />
+                                <SliderWithInput
+                                    className={"no-bottom-padding"}
+                                    icon={<BorderLeftIcon />}
+                                    valueKey={valueKey + ".mobile.left"}
+                                    updateValue={getUpdateValue("mobile.left")}
+                                    updatePreview={getUpdatePreview("mobile.left")}
+                                />
+                            </React.Fragment>
+                        )}
+                    </>
                 )}
                 <Footer advanced={Boolean(advanced)} toggleAdvanced={getUpdateValue("advanced")} />
             </Tab>

--- a/packages/ui/src/Tabs/Tabs.js
+++ b/packages/ui/src/Tabs/Tabs.js
@@ -9,7 +9,10 @@ type Props = {
     children?: React.Node,
 
     // Append a class name
-    className?: string
+    className?: string,
+
+    // Callback to execute when a tab is changed
+    onActivate?: (index: number) => void
 };
 
 type State = {
@@ -52,7 +55,10 @@ class Tabs extends React.Component<Props, State> {
             <TabBar
                 className="webiny-ui-tabs__tab-bar"
                 activeTabIndex={this.state.activeTabIndex}
-                onActivate={evt => this.setState({ activeTabIndex: evt.detail.index })}
+                onActivate={evt => {
+                    this.setState({ activeTabIndex: evt.detail.index });
+                    this.props.onActivate && this.props.onActivate(evt.detail.index);
+                }}
             >
                 {tabs.map(item => {
                     const style = item.style || {};


### PR DESCRIPTION
## Related Issue
Fixes #621 

## Your solution
After searching RMWC for issues, I found this one [#524](https://github.com/jamesmfriedman/rmwc/issues/524).

Looks like this is a [bug in material-components-web](https://github.com/material-components/material-components-web/issues/5296) (not 100% sure), but to get around this issue I forced re-render of Tab contents when tabs are being switched. It's not optimal, but it works. When the Material team releases an official fix, we'll test and see if this hack of mine will be necessary.

## How Has This Been Tested?
Manually.