### PR TITLE
Fix I18N broken tests

### DIFF
--- a/packages/i18n/__tests__/modifiers.test.js
+++ b/packages/i18n/__tests__/modifiers.test.js
@@ -1,7 +1,7 @@
-import i18n from "@webiny/i18n";
-import defaultProcessor from "@webiny/i18n/processors/default";
+import i18n, { defaultProcessor, defaultModifiers } from "@webiny/i18n";
 
 i18n.registerProcessor(defaultProcessor);
+i18n.registerModifiers(defaultModifiers);
 
 const t = i18n.namespace("Random.Namespace");
 


### PR DESCRIPTION
## Related Issue
Running `yarn test` fails because of a set of bad `i18n` lib's tests.

## Your solution
Fix relevant `i18n` lib's tests.

## How Has This Been Tested?
Unit tests.

## Screenshots (if relevant):
N/A