### PR TITLE
Image resizing not working for larger images (timeout)

### DIFF
--- a/examples/api/serverless.yml
+++ b/examples/api/serverless.yml
@@ -92,8 +92,8 @@ files:
         memory: 512
         timeout: 10
       imageTransformer:
-        memory: 1024
-        timeout: 10
+        memory: 1600
+        timeout: 30
 
 i18n:
   component: "@webiny/serverless-apollo-service"


### PR DESCRIPTION
## Related Issue
Resizing images to 2500px (which is the maximum value) can last more than 10 seconds, causing the image transformer Lambda to time out, and the resized image never to be created.

## Your solution
I changed the timeout to 30seconds, and also increased the amount of memory, from 1024 to 1600.

## How Has This Been Tested?
Manual testing, with the image that caused the issue, it works now.

## Screenshots (if relevant):