### PR TITLE
Remove "NumpadDivide" shortcut - doesn't work

### DIFF
--- a/packages/app-admin/src/plugins/GlobalSearch/SearchBar.js
+++ b/packages/app-admin/src/plugins/GlobalSearch/SearchBar.js
@@ -156,8 +156,7 @@ class SearchBar extends React.Component<*, State> {
                                 zIndex={10}
                                 keys={{
                                     esc: () => document.activeElement.blur(),
-                                    "/": this.handleOpenHotkey,
-                                    NumpadDivide: this.handleOpenHotkey
+                                    "/": this.handleOpenHotkey
                                 }}
                             />
 


### PR DESCRIPTION
Fixes #646.

## Your solution
It seems there's a bug in the `is-hotkey` lib - when I press the letter "n" on my keyboard, it also assumes that the `NumpadDivide` key was pressed. Not sure why (checked in few places in code). For now, I just removed this shortcut, we'll see in the future if we'll need to bring this hotkey back.