### PR TITLE
fix: set minimum password length to the same as defined in cognito

### DIFF
--- a/packages/validation/__tests__/password.test.js
+++ b/packages/validation/__tests__/password.test.js
@@ -8,14 +8,14 @@ describe("password test", () => {
 
     it("should fail - values are too short", () => {
         return Promise.all([
-            validation.validate("12312", "password").should.be.rejected,
+            validation.validate("1231231", "password").should.be.rejected,
             validation.validate("123123", "password:10").should.be.rejected
         ]);
     });
 
     it("should pass - value is long enough", () => {
         return Promise.all([
-            validation.validate("123123", "password").should.become(true),
+            validation.validate("12312312", "password").should.become(true),
             validation.validate("123", "password:3").should.become(true)
         ]);
     });

--- a/packages/validation/src/validators/password.js
+++ b/packages/validation/src/validators/password.js
@@ -5,7 +5,7 @@ export default (value: any, params: Array<string> = []) => {
     if (!value) return;
     value = value + "";
 
-    const length = params[0] || 6;
+    const length = params[0] || 8;
     const test = value.match(new RegExp(`^.{${length},}$`));
     if (test === null) {
         throw new ValidationError(`Password must contain at least ${length} characters`);


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/webiny/webiny-js/issues/657

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->
Set minimum length on validation module to 8 characters same as cognito

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual and Unit test

