### PR TITLE
feat: Clicking outside the 'Get Started Guide' modal now exits the guide

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/toolbar/onboarding/Onboarding.tsx
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/onboarding/Onboarding.tsx
@@ -38,6 +38,12 @@ const Overlay = styled("div")({
     }
 });
 
+const OutsideContainer = styled("div")({
+    width: "100%",
+    height: "100%",
+    position: "absolute"
+})
+
 const Container = styled("div")({
     width: 800,
     height: 600,
@@ -91,6 +97,7 @@ const Onboarding = ({ deactivatePlugin, showOnboarding }) => {
 
     return (
         <Overlay>
+            <OutsideContainer onClick={closeDialog} />
             <Container>
                 <Carousel
                     speed={slideIndex < 1 || slideIndex > 4 ? 500 : 0}


### PR DESCRIPTION
## Related Issue
Closes #667

## Your solution
I've created a background div that's clickable and closes the Guide.

## How Has This Been Tested?
Locally by running the `admin` app, reproducing the issue and fixing it.