### PR TITLE
fix: Database is now replaced in /.env.json instead of /api/.env.json

### DIFF
--- a/packages/cli/create/index.js
+++ b/packages/cli/create/index.js
@@ -77,12 +77,16 @@ module.exports = async ({ name, tag }) => {
     writeFileContents("api/serverless.yml", apiYaml);
     writeJsonFile.sync(resolve("api/.serverless/_.json"), { id: apiId });
 
+    // Update api/.env.json
+    let apiEnvFile = getFileContents("api/.env.json");
+    apiEnvFile = apiEnvFile.replace("[JWT_SECRET]", jwtSecret);
+    apiEnvFile = apiEnvFile.replace("[BUCKET]", `webiny-files-${apiId}`);
+    writeFileContents("api/.env.json", apiEnvFile);
+
     // Update .env.json
-    let envFile = getFileContents("api/.env.json");
-    envFile = envFile.replace("[JWT_SECRET]", jwtSecret);
-    envFile = envFile.replace("[BUCKET]", `webiny-files-${apiId}`);
+    let envFile = getFileContents(".env.json");
     envFile = envFile.replace("[DATABASE]", `webiny-${apiId}`);
-    writeFileContents("api/.env.json", envFile);
+    writeFileContents(".env.json", envFile);
 
     // Update apps serverless.yml
     let appsYaml = getFileContents("apps/serverless.yml");

--- a/packages/cli/create/template/example.env.json
+++ b/packages/cli/create/template/example.env.json
@@ -3,7 +3,7 @@
     "AWS_PROFILE": "default",
     "AWS_REGION": "us-east-1",
     "MONGODB_SERVER": "[MONGODB_SERVER]",
-    "MONGODB_NAME": "webiny",
+    "MONGODB_NAME": "[DATABASE]",
     "DEBUG": true
   }
 }


### PR DESCRIPTION
## Related Issue
#679 

## Your solution
I split the updating of `/api/.env.json` and `/.env.json`. The [DATABASE] will now be replaced in `/.env.json`

## How Has This Been Tested?
By placing a `[DATABASE]` string in `packages\cli\create\template\example.env.json` and running `webiny create test-project`. This produced an `.env.json` file with a correct value (ie: webiny-123456789) `[DATABASE]` value.