### PR TITLE
fix: All external links now work. Two broken links have been replaced

### DIFF
--- a/packages/app-page-builder/src/render/plugins/slate/link/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/slate/link/index.tsx
@@ -18,16 +18,16 @@ export default (): PbRenderSlateEditorPlugin => {
                     const noFollow = data.get("noFollow");
                     const newTab = data.get("newTab");
 
-                    return (
-                        <a
-                            href={href}
-                            {...attributes}
-                            rel={noFollow ? "nofollow" : null}
-                            target={newTab ? "_blank" : "_self"}
-                        >
-                            {children}
-                        </a>
-                    );
+                    const isInternal = href.startsWith("/")
+                    const LinkComponent = isInternal ? Link : "a"
+                    const linkProps = {
+                        ...attributes,
+                        rel: noFollow ? "nofollow" : null,
+                        target: newTab ? "_blank" : "_self",
+                        [isInternal ? "to" : "href"]: href
+                    }
+
+                    return <LinkComponent {...linkProps}>{children}</LinkComponent>
                 }
 
                 return next();

--- a/packages/app-page-builder/src/render/plugins/slate/link/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/slate/link/index.tsx
@@ -19,14 +19,14 @@ export default (): PbRenderSlateEditorPlugin => {
                     const newTab = data.get("newTab");
 
                     return (
-                        <Link
-                            to={href}
+                        <a
+                            href={href}
                             {...attributes}
                             rel={noFollow ? "nofollow" : null}
                             target={newTab ? "_blank" : "_self"}
                         >
                             {children}
-                        </Link>
+                        </a>
                     );
                 }
 


### PR DESCRIPTION
## Related Issue
#683 

## Your solution
The external links have been fixed by using `<a>` instead of `<Link>` elements. It seems like Link elements haven't been designed to allow "routing" to external URLs (https://github.com/ReactTraining/react-router/issues/1147), so I've just scrapped them. They still look the same to me now on the site.

I've unzipped `webiny\components\serverless-page-builder\installation\page_builder_installation_files.zip` and replaced 

`https://docs.webiny.com/docs/developer-tutorials/local-setup`
`https://docs.webiny.com/docs/cms-guides/get-started-webiny-administration` 

with  

`https://docs.webiny.com/docs/webiny/introduction/`
`https://docs.webiny.com/docs/get-started/quick-start`.

## How Has This Been Tested?
By running `site` app locally and clicking the new `<a>` elements.