### PR TITLE
Make sure new forms are visible in page builder (without refreshing the page)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,14 +1,14 @@
 {
   "viewportWidth": 1600,
   "viewportHeight": 1200,
-  "baseUrl": "https://dx7ymomoh1jp3.cloudfront.net/admin",
+  "baseUrl": "http://localhost:3001",
   "defaultCommandTimeout": 10000,
   "env": {
-    "AWS_COGNITO_USER_POOL_ID": "eu-central-1_42ThoxnJI",
-    "AWS_COGNITO_CLIENT_ID": "2u43k5t0a2d2tpnh6drfeofvq4",
-    "API_URL": "https://diux8va81evaz.cloudfront.net",
+    "AWS_COGNITO_USER_POOL_ID": "eu-central-1_LGh6br2ix",
+    "AWS_COGNITO_CLIENT_ID": "561rp7m88m81t4jgdvq1j5eobf",
+    "API_URL": "https://d1cfsi9llzrdlf.cloudfront.net",
     "DEFAULT_ADMIN_USER_USERNAME": "admin@webiny.com",
     "DEFAULT_ADMIN_USER_PASSWORD": "12345678",
-    "GRAPHQL_API_URL": "https://diux8va81evaz.cloudfront.net/graphql"
+    "GRAPHQL_API_URL": "https://d1cfsi9llzrdlf.cloudfront.net/graphql"
   }
 }

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/admin/formBuilder/forms/createForm.spec.js
+++ b/cypress/integration/admin/formBuilder/forms/createForm.spec.js
@@ -1,0 +1,44 @@
+import uniqid from "uniqid";
+
+context("Forms Creation", () => {
+    beforeEach(() => cy.login());
+
+    it("should be able to create, publish, create new revision, and immediately delete everything", () => {
+        const newFormTitle = `Test form ${uniqid()}`;
+        const newFormTitle2 = `Test form ${uniqid()}`;
+
+        cy.visit("/forms")
+            .findByTestId("new-record-button")
+            .click()
+            .findByTestId("fb-new-form-modal")
+            .within(() => {
+                cy.findByPlaceholderText("Enter a name for your new form")
+                    .type(newFormTitle)
+                    .findByText("+ Create");
+            })
+            .click()
+            .wait(1000)
+            .findByTestId("fb-editor-form-title")
+            .click()
+            .get(`input[value="${newFormTitle}"]`)
+            .clear()
+            .type(`${newFormTitle2} {enter}`)
+            .wait(333)
+            .findByTestId("fb-editor-back-button")
+            .click()
+            .wait(1000);
+
+        cy.findByTestId("default-data-list").within(() => {
+            cy.get("div")
+                .first()
+                .within(() => {
+                    cy.findByText(newFormTitle2)
+                        .should("exist")
+                        .findByText(/Draft/i)
+                        .should("exist")
+                        .findByText(/(v1)/i)
+                        .should("exist");
+                });
+        });
+    });
+});

--- a/cypress/integration/admin/formBuilder/forms/pageBuilderElement.spec.js
+++ b/cypress/integration/admin/formBuilder/forms/pageBuilderElement.spec.js
@@ -1,0 +1,56 @@
+import uniqid from "uniqid";
+
+context("Forms Creation", () => {
+    beforeEach(() => cy.login());
+
+    it("should be able to create, publish, create new revision, and immediately delete everything", () => {
+        const pageTitle = `Test page ${uniqid()}`;
+
+        cy.visit("/page-builder/pages")
+            .findByTestId("new-record-button")
+            .click()
+            .findByTestId("pb-new-page-category-modal")
+            .within(() => {
+                cy.findByText("Static").click();
+            })
+            .findByTestId("pb-editor-page-title")
+            .click()
+            .get(`input[value="Untitled"]`)
+            .clear()
+            .type(`${pageTitle} {enter}`)
+            .findByTestId("pb-content-add-block-button")
+            .click();
+
+
+            /*
+            .findByTestId("pb-editor-back-button")
+            .click()
+            .wait(1000);
+
+        const newFormTitle = `Test form ${uniqid()}`;
+
+        cy.visit("/forms")
+            .findByTestId("new-record-button")
+            .click()
+            .findByTestId("fb-new-form-modal")
+            .within(() => {
+                cy.findByPlaceholderText("Enter a name for your new form")
+                    .type(newFormTitle)
+                    .findByText("+ Create")
+                    .click();
+            })
+            .wait(1000);
+
+        cy.visit("/page-builder/pages");
+        cy.findByTestId("default-data-list").within(() => {
+            cy.get("div")
+                .first()
+                .click();
+        });
+
+        cy.findByTestId("pb-page-details")
+            .within(() => {
+                cy.findByTestId("pb-page-details-header-edit-revision").click();
+            })*/
+    });
+});

--- a/packages/app-form-builder/src/admin/views/Forms/Forms.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/Forms.tsx
@@ -33,7 +33,10 @@ function Forms() {
                     <FormDetails refreshForms={dataList.refresh} />
                 </RightPanel>
             </SplitView>
-            <FloatingActionButton onClick={() => openNewFormDialog(true)} />
+            <FloatingActionButton
+                data-testid="new-record-button"
+                onClick={() => openNewFormDialog(true)}
+            />
         </>
     );
 }

--- a/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
@@ -114,7 +114,7 @@ const FormsDataList = (props: FormsDataListProps) => {
             ]}
         >
             {({ data = [] }) => (
-                <List>
+                <List data-testid="default-data-list">
                     {data.map(form => (
                         <ListItem key={form.id}>
                             <ListItemText
@@ -124,7 +124,6 @@ const FormsDataList = (props: FormsDataListProps) => {
                                 }}
                             >
                                 {form.name}
-                                <ListTextOverline>{form.name}</ListTextOverline>
                                 {form.createdBy && (
                                     <ListItemTextSecondary>
                                         {form.createdBy.firstName && (

--- a/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
@@ -17,7 +17,6 @@ import {
     ListItem,
     ListItemText,
     ListItemTextSecondary,
-    ListTextOverline,
     ListItemMeta,
     ListActions
 } from "@webiny/ui/List";

--- a/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
@@ -53,7 +53,9 @@ const NewFormDialog: React.FC<NewFormDialogProps> = ({ open, onClose, formsDataL
                             setLoading(true);
                             const response = get(
                                 await update({
-                                    variables: data
+                                    variables: data,
+                                    refetchQueries: ["FormsListForms"],
+                                    awaitRefetchQueries: true
                                 }),
                                 "data.forms.form"
                             );

--- a/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
@@ -34,17 +34,18 @@ export type NewFormDialogProps = {
     formsDataList: any;
 };
 
-const NewFormDialog: React.FC<NewFormDialogProps> = ({
-    open,
-    onClose,
-    formsDataList
-}) => {
+const NewFormDialog: React.FC<NewFormDialogProps> = ({ open, onClose, formsDataList }) => {
     const [loading, setLoading] = React.useState(false);
     const { showSnackbar } = useSnackbar();
     const { history } = useReactRouter();
 
     return (
-        <Dialog open={open} onClose={onClose} className={narrowDialog}>
+        <Dialog
+            open={open}
+            onClose={onClose}
+            className={narrowDialog}
+            data-testid="fb-new-form-modal"
+        >
             <Mutation mutation={CREATE_FORM}>
                 {update => (
                     <Form

--- a/packages/app-form-builder/src/editor/plugins/defaultBar/BackButton.tsx
+++ b/packages/app-form-builder/src/editor/plugins/defaultBar/BackButton.tsx
@@ -20,6 +20,7 @@ const BackButton = React.memo(() => {
 
     return (
         <IconButton
+            data-testid="fb-editor-back-button"
             className={backStyles}
             onClick={() => router.history.push(`/forms?id=${id}`)}
             icon={<BackIcon />}

--- a/packages/app-form-builder/src/editor/plugins/defaultBar/Name/Name.tsx
+++ b/packages/app-form-builder/src/editor/plugins/defaultBar/Name/Name.tsx
@@ -56,10 +56,14 @@ export const Name = () => {
         }
     });
 
+    // Disable autoFocus because for some reason, blur event would automatically be triggered when clicking
+    // on the page title when doing Cypress testing. Not sure if this is RMWC or Cypress related issue.
+    const autoFocus = !window.Cypress;
+
     return editingEnabled ? (
         <NameInputWrapper>
             <Input
-                autoFocus
+                autoFocus={autoFocus}
                 fullwidth
                 value={localName}
                 onChange={setLocalName}
@@ -79,7 +83,9 @@ export const Name = () => {
                     placement={"bottom"}
                     content={<span>{t`rename`}</span>}
                 >
-                    <FormName onClick={startEditing}>{state.data.name}</FormName>
+                    <FormName data-testid="fb-editor-form-title" onClick={startEditing}>
+                        {state.data.name}
+                    </FormName>
                 </Tooltip>
                 <FormVersion>{`(v${state.data.version})`}</FormVersion>
             </div>

--- a/packages/app-form-builder/src/page-builder/admin/plugins/components/FormElementAdvancedSettings.tsx
+++ b/packages/app-form-builder/src/page-builder/admin/plugins/components/FormElementAdvancedSettings.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { Query } from "react-apollo";
-import gql from "graphql-tag";
 import { get } from "lodash";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { Alert } from "@webiny/ui/Alert";
 import { AutoComplete } from "@webiny/ui/AutoComplete";
 import styled from "@emotion/styled";
 import { validation } from "@webiny/validation";
+import { LIST_FORMS } from "./graphql";
 
 const FormOptionsWrapper = styled("div")({
     minHeight: 250
@@ -57,26 +57,7 @@ const getOptions = ({ gqlResponse, data }) => {
 const FormElementAdvancedSettings = ({ Bind, data }) => {
     return (
         <FormOptionsWrapper>
-            <Query
-                query={gql`
-                    {
-                        forms {
-                            listForms {
-                                data {
-                                    parent
-                                    name
-                                    publishedRevisions {
-                                        id
-                                        name
-                                        version
-                                        published
-                                    }
-                                }
-                            }
-                        }
-                    }
-                `}
-            >
+            <Query query={LIST_FORMS} fetchPolicy="network-only">
                 {gqlResponse => {
                     const options = getOptions({ gqlResponse, data });
                     return (
@@ -86,16 +67,14 @@ const FormElementAdvancedSettings = ({ Bind, data }) => {
                                     name={"settings.form.parent"}
                                     validators={validation.create("required")}
                                 >
-                                    {({ onChange }) => {
-                                        return (
-                                            <AutoComplete
-                                                options={options.parents.options}
-                                                value={options.parents.value}
-                                                onChange={onChange}
-                                                label={"Form"}
-                                            />
-                                        );
-                                    }}
+                                    {({ onChange }) => (
+                                        <AutoComplete
+                                            options={options.parents.options}
+                                            value={options.parents.value}
+                                            onChange={onChange}
+                                            label={"Form"}
+                                        />
+                                    )}
                                 </Bind>
                             </Cell>
                             <Cell span={12}>

--- a/packages/app-form-builder/src/page-builder/admin/plugins/components/graphql.js
+++ b/packages/app-form-builder/src/page-builder/admin/plugins/components/graphql.js
@@ -1,0 +1,20 @@
+import gql from "graphql-tag";
+
+export const LIST_FORMS = gql`
+    query FormsListForms {
+        forms {
+            listForms(perPage: 50) {
+                data {
+                    parent
+                    name
+                    publishedRevisions {
+                        id
+                        name
+                        version
+                        published
+                    }
+                }
+            }
+        }
+    }
+`;

--- a/packages/app-page-builder/src/editor/plugins/blockEditing/AddContent.tsx
+++ b/packages/app-page-builder/src/editor/plugins/blockEditing/AddContent.tsx
@@ -64,6 +64,7 @@ const AddContent = ({ count, togglePlugin }) => {
                 <AddBlockContent>
                     Click the
                     <ButtonFloating
+                        data-testid={"pb-content-add-block-button"}
                         style={{ animation: pulse + " 3s ease infinite", margin: "0 10px" }}
                         small
                         icon={<AddIcon />}
@@ -76,7 +77,6 @@ const AddContent = ({ count, togglePlugin }) => {
     );
 };
 
-export default connect<any, any, any>(
-    state => ({ count: getContent(state).elements.length }),
-    { togglePlugin }
-)(React.memo(AddContent));
+export default connect<any, any, any>(state => ({ count: getContent(state).elements.length }), {
+    togglePlugin
+})(React.memo(AddContent));

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -121,6 +121,9 @@ type ButtonFloatingProps = Props &
         icon?: React.ReactNode;
         onMouseDown?: (e: SyntheticEvent) => void;
         onMouseUp?: (e: SyntheticEvent) => void;
+
+        // For testing purposes.
+        "data-testid"?: string;
     };
 
 /**
@@ -142,6 +145,7 @@ export const ButtonFloating = (props: ButtonFloatingProps) => {
     } = props;
     return (
         <Fab
+            data-testid={props["data-testid"]}
             disabled={disabled}
             mini={small}
             onClick={onClick}


### PR DESCRIPTION
## Related Issue
#678

## Your solution
First, I fixed another bug here - if a user created a new form (which redirects him to the form editor) and then returned back to the forms view, the new form would not be visible in the list of forms. That's why we added the following  at `packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx:58`:

```
   refetchQueries: ["FormsListForms"],
   awaitRefetchQueries: true
```

Regarding the initial issue...

I added `fetchPolicy="network-only"` in the `packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx:57`, because the just added `refetchQueries: ["FormsListForms"]` in the `packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx:57` had no effect, or in other words, when re-opening the page builder and then form element's settings, the list of forms would still be old. I believe this solution would suffice for now.


## How Has This Been Tested?
Added 2 Cypress tests that test:
- basic form creation flow and if the forms list was updated correctly
- if the forms list in the page builder's form element contains the new form after it was created

Note: the 2nd one is work in progress, but will finish it soon.

## Screenshots (if relevant):
N/A