### PR TITLE
fix: show a more friendly database connection error message

### DIFF
--- a/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
+++ b/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
@@ -5,6 +5,8 @@ import { getName } from "@commodo/name";
 import LambdaClient from "aws-sdk/clients/lambda";
 import { EJSON } from "bson";
 
+const MONGO_CONNECTION_ERRORS = ['MongoServerSelectionError'];
+
 class DbProxyClient {
     dbProxyFunctionName: string;
 
@@ -28,6 +30,11 @@ class DbProxyClient {
         }
 
         if (parsedPayload.error) {
+            if (MONGO_CONNECTION_ERRORS.includes('MongoServerSelectionError')) {
+                throw new Error(
+                    `Could not connect to MongoDB server, make sure the connection string is correct and that the database server allows outside connections. Check https://docs.webiny.com/docs/get-started/quick-start#3-setup-database-connection for more information.`
+                );
+            }
             throw new Error(`${parsedPayload.error.name}: ${parsedPayload.error.message}`);
         }
 

--- a/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
+++ b/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
@@ -30,7 +30,7 @@ class DbProxyClient {
         }
 
         if (parsedPayload.error) {
-            if (MONGO_CONNECTION_ERRORS.includes('MongoServerSelectionError')) {
+            if (MONGO_CONNECTION_ERRORS.includes(parsedPayload.error.name)) {
                 throw new Error(
                     `Could not connect to MongoDB server, make sure the connection string is correct and that the database server allows outside connections. Check https://docs.webiny.com/docs/get-started/quick-start#3-setup-database-connection for more information.`
                 );


### PR DESCRIPTION
## Related Issue
#682 

## Your solution
The following message will be returned from the API, if the database connection wasn't successfully established:
> Could not connect to MongoDB server, make sure the connection string is correct and that the database server allows outside connections. Check https://docs.webiny.com/docs/get-started/quick-start#3-setup-database-connection for more information.

This will make debugging connection-related issues easier for new developers.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
<img width="1239" alt="Snipaste_2020-02-05_14-29-47" src="https://user-images.githubusercontent.com/5121148/73847662-09967080-4827-11ea-8bc8-82bb9acec2d6.png">
<img width="1354" alt="Snipaste_2020-02-05_14-20-57" src="https://user-images.githubusercontent.com/5121148/73847677-0c916100-4827-11ea-80b2-cfaf7c0d373b.png">
