### PR TITLE
fix: invalidate site cache on successful installation

### DIFF
--- a/examples/apps/serverless.yml
+++ b/examples/apps/serverless.yml
@@ -9,7 +9,9 @@ vars:
 dbProxy:
   component: "@webiny/serverless-db-proxy/dist"
   inputs:
+    region: ${vars.region}
     concurrencyLimit: 15
+    timeout: 30
     env:
       MONGODB_SERVER: ${vars.mongodb.server}
       MONGODB_NAME: ${vars.mongodb.name}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "build:apps": "lerna run build --scope=@webiny/app* --stream",
     "build:api": "lerna run build --scope=@webiny/api* --stream",
     "build:packages": "lerna run build --scope=@webiny/* --ignore=@webiny/serv* --stream",
-    "build:@webiny": "lerna run build --scope=@webiny/* --stream",
+    "watch:packages": "lerna run watch --scope=@webiny/* --ignore=@webiny/serv* --stream --parallel",
     "clear-dist": "yarn rimraf components/*/dist packages/*/dist",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",

--- a/packages/api-page-builder/src/plugins/graphql/installResolver/install.ts
+++ b/packages/api-page-builder/src/plugins/graphql/installResolver/install.ts
@@ -4,7 +4,6 @@ import saveElements from "./utils/saveElements";
 import savePages from "./utils/savePages";
 import path from "path";
 import loadJson from "load-json-file";
-import got from "got";
 
 export const install = async (
     root: any,
@@ -27,6 +26,8 @@ export const install = async (
             message: "Page builder is already installed."
         });
     }
+
+    await settings.hook('beforeInstallation');
 
     const { step } = args;
 
@@ -116,20 +117,7 @@ export const install = async (
             installation.getStep(5).markAsCompleted();
             await settings.save();
 
-            // Asynchronously send a GET request to each page so that the SSR cache gets populated.
-            const initialPages = await PbPage.find();
-            for (let i = 0; i < initialPages.length; i++) {
-                const url = await initialPages[i].fullUrl;
-                try {
-                    await got(url, {
-                        ...args,
-                        timeout: 200,
-                        retry: 0
-                    });
-                } catch {
-                    // Do nothing.
-                }
-            }
+            await settings.hook('afterInstallation');
 
             return new Response(true);
         }

--- a/packages/api-page-builder/src/plugins/models.ts
+++ b/packages/api-page-builder/src/plugins/models.ts
@@ -80,30 +80,26 @@ export default (): GraphQLContextPlugin[] => [
         // After successful installation, GET requests will be issued to all of the initially installed pages.
         // This way, once user visits one of the initially installed pages, he won't have to wait for the background
         // SSR render to finish.
-        type: "graphql-context",
-        name: "graphql-context-after-pb-installation-generate-ssr-via-get-requests",
-        apply(context) {
+        type: "pb-install",
+        name: "pb-install-generate-ssr-via-get-requests",
+        async after({ context }) {
             const {
-                models: { PbPage, PbSettings }
+                models: { PbPage }
             } = context;
 
-            withHooks({
-                async afterInstallation() {
-                    // Asynchronously send a GET request to each page so that the SSR cache gets populated.
-                    const initialPages = await PbPage.find();
-                    for (let i = 0; i < initialPages.length; i++) {
-                        const url = await initialPages[i].fullUrl;
-                        try {
-                            await got(url, {
-                                timeout: 200,
-                                retry: 0
-                            });
-                        } catch {
-                            // Do nothing.
-                        }
-                    }
+            // Asynchronously send a GET request to each page so that the SSR cache gets populated.
+            const initialPages = await PbPage.find();
+            for (let i = 0; i < initialPages.length; i++) {
+                const url = await initialPages[i].fullUrl;
+                try {
+                    await got(url, {
+                        timeout: 200,
+                        retry: 0
+                    });
+                } catch {
+                    // Do nothing.
                 }
-            })(PbSettings);
+            }
         }
     }
 ];

--- a/packages/api-page-builder/src/plugins/models.ts
+++ b/packages/api-page-builder/src/plugins/models.ts
@@ -75,5 +75,35 @@ export default (): GraphQLContextPlugin[] => [
                 }
             })(PbPage);
         }
+    },
+    {
+        // After successful installation, GET requests will be issued to all of the initially installed pages.
+        // This way, once user visits one of the initially installed pages, he won't have to wait for the background
+        // SSR render to finish.
+        type: "graphql-context",
+        name: "graphql-context-after-pb-installation-generate-ssr-via-get-requests",
+        apply(context) {
+            const {
+                models: { PbPage, PbSettings }
+            } = context;
+
+            withHooks({
+                async afterInstallation() {
+                    // Asynchronously send a GET request to each page so that the SSR cache gets populated.
+                    const initialPages = await PbPage.find();
+                    for (let i = 0; i < initialPages.length; i++) {
+                        const url = await initialPages[i].fullUrl;
+                        try {
+                            await got(url, {
+                                timeout: 200,
+                                retry: 0
+                            });
+                        } catch {
+                            // Do nothing.
+                        }
+                    }
+                }
+            })(PbSettings);
+        }
     }
 ];

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -106,17 +106,16 @@ export default () => [
         // This is fine, but if a user visited the homepage first (without going straight to "/admin", which is
         // a frequent case), that page will get cached unfortunately, and we need to invalidate it. There could be
         // of course more pages that the user visited before entering admin, for now we'll just focus on the homepage.
-        type: "graphql-context",
-        name: "graphql-context-after-pb-installation-invalidate-cache",
-        apply({ ssrApiClient, models: { PbSettings } }) {
-            withHooks({
-                async afterInstallation() {
-                    await ssrApiClient.invalidateSsrCacheByPath({
-                        path: "/",
-                        refresh: true
-                    });
-                }
-            })(PbSettings);
+        type: "pb-install",
+        name: "pb-install-invalidate-previous-homepage-cache",
+        async after({ data }) {
+            // Although we had client registered above, it's not ready yet because domain wasn't
+            // set in PbSettings instance. That's why we just take the domain from the received args.
+            const ssrApiClient = new SsrApiClient({ url: data.domain });
+            await ssrApiClient.invalidateSsrCacheByPath({
+                path: "/",
+                refresh: true
+            });
         }
     },
     {

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -102,6 +102,24 @@ export default () => [
         }
     },
     {
+        // After successful installation, GET requests will be issued to initially installed pages.
+        // This is fine, but if a user visited the homepage first (without going straight to "/admin", which is
+        // a frequent case), that page will get cached unfortunately, and we need to invalidate it. There could be
+        // of course more pages that the user visited before entering admin, for now we'll just focus on the homepage.
+        type: "graphql-context",
+        name: "graphql-context-after-pb-installation-invalidate-cache",
+        apply({ ssrApiClient, models: { PbSettings } }) {
+            withHooks({
+                async afterInstallation() {
+                    await ssrApiClient.invalidateSsrCacheByPath({
+                        path: "/",
+                        refresh: true
+                    });
+                }
+            })(PbSettings);
+        }
+    },
+    {
         name: "graphql-schema-page-builder-use-ssr-cache-tags",
         type: "graphql-schema",
         schema: {

--- a/packages/api-page-builder/src/types.ts
+++ b/packages/api-page-builder/src/types.ts
@@ -7,3 +7,9 @@ export type PbResolverListPagesPlugin = Plugin & {
         context: GraphQLContext;
     }): Promise<{ pages: any[]; totalCount: number }>;
 };
+
+export type PbInstallPlugin = Plugin & {
+    name: "pb-install";
+    before: ({ context: GraphQLContext, data: any }) => void;
+    after: ({ context: GraphQLContext, data: any }) => void;
+};

--- a/packages/http-handler-ssr/src/Client.ts
+++ b/packages/http-handler-ssr/src/Client.ts
@@ -27,20 +27,20 @@ const ssrApiCall = async ({ url, action, actionPayload, async }) => {
 };
 
 interface InvalidateSsrCacheByPathParams {
-    path: null;
-    refresh: boolean;
-    expired: boolean;
-    async: boolean;
+    path: string;
+    refresh?: boolean;
+    expired?: boolean;
+    async?: boolean;
 }
 
 type Tag = {
-    id: string;
-    class: string;
+    id?: string;
+    class?: string;
 };
 
 interface InvalidateSsrCacheByTagsParams {
     tags: Tag[];
-    async: boolean;
+    async?: boolean;
 }
 
 export default class Client {


### PR DESCRIPTION
If a user visits his site without installing everything from the Admin, he will receive the "Installation Incomplete" error (with the link to the Admin of course).

The problem is, this generic page gets cached on the CDN, and after the installation has finished, this page would still be shown to the user.

### Solution
Once the PB installation has finished successfully, we trigger a cache invalidation request. This way, users will see the correct page, once the CDN cache has been cleared.