### PR TITLE
fix: change the name of the before/after `http-handler` plugins

### DIFF
--- a/packages/http-handler/src/create.ts
+++ b/packages/http-handler/src/create.ts
@@ -1,8 +1,8 @@
 import { PluginsContainer } from "@webiny/plugins";
 import createResponse from "./createResponse";
 import {
-    HttpAfterHandlePlugin,
-    HttpBeforeHandlePlugin,
+    HttpAfterHandlerPlugin,
+    HttpBeforeHandlerPlugin,
     HttpContextPlugin,
     HttpHandlerPlugin
 } from "./types";
@@ -18,7 +18,7 @@ export default (...plugins) => async (...args) => {
             contextPlugins[i].apply({ context, args });
         }
 
-        const beforeHandle = context.plugins.byType<HttpBeforeHandlePlugin>("before-handle");
+        const beforeHandle = context.plugins.byType<HttpBeforeHandlerPlugin>("before-handler");
         for (let i = 0; i < beforeHandle.length; i++) {
             await beforeHandle[i].handle({ context, args });
         }
@@ -32,7 +32,7 @@ export default (...plugins) => async (...args) => {
             }
         }
 
-        const afterHandle = context.plugins.byType<HttpAfterHandlePlugin>("after-handle");
+        const afterHandle = context.plugins.byType<HttpAfterHandlerPlugin>("after-handler");
         for (let i = 0; i < afterHandle.length; i++) {
             await afterHandle[i].handle({ context, args, result });
         }

--- a/packages/http-handler/src/create.ts
+++ b/packages/http-handler/src/create.ts
@@ -18,9 +18,9 @@ export default (...plugins) => async (...args) => {
             contextPlugins[i].apply({ context, args });
         }
 
-        const beforeHandle = context.plugins.byType<HttpBeforeHandlerPlugin>("before-handler");
-        for (let i = 0; i < beforeHandle.length; i++) {
-            await beforeHandle[i].handle({ context, args });
+        const beforeHandlers = context.plugins.byType<HttpBeforeHandlerPlugin>("before-handler");
+        for (let i = 0; i < beforeHandlers.length; i++) {
+            await beforeHandlers[i].handle({ context, args });
         }
 
         let result;
@@ -32,9 +32,9 @@ export default (...plugins) => async (...args) => {
             }
         }
 
-        const afterHandle = context.plugins.byType<HttpAfterHandlerPlugin>("after-handler");
-        for (let i = 0; i < afterHandle.length; i++) {
-            await afterHandle[i].handle({ context, args, result });
+        const afterHandlers = context.plugins.byType<HttpAfterHandlerPlugin>("after-handler");
+        for (let i = 0; i < afterHandlers.length; i++) {
+            await afterHandlers[i].handle({ context, args, result });
         }
 
         if (!result) {

--- a/packages/http-handler/src/types.ts
+++ b/packages/http-handler/src/types.ts
@@ -12,8 +12,8 @@ export type HttpContextPlugin = Plugin & {
     apply(params: { context: HttpContext; args: HttpArgs }): void;
 };
 
-export type HttpBeforeHandlePlugin = Plugin & {
-    type: "before-handle";
+export type HttpBeforeHandlerPlugin = Plugin & {
+    type: "before-handler";
     handle(params: { context: HttpContext; args: HttpArgs }): Promise<void>;
 };
 
@@ -23,7 +23,7 @@ export type HttpHandlerPlugin = Plugin & {
     handle(params: { context: HttpContext; args: HttpArgs }): Promise<any>;
 };
 
-export type HttpAfterHandlePlugin = Plugin & {
-    type: "after-handle";
+export type HttpAfterHandlerPlugin = Plugin & {
+    type: "after-handler";
     handle(params: { context: HttpContext; args: HttpArgs; result: any }): Promise<void>;
 };


### PR DESCRIPTION
## Related Issue
I changed the type of the before/after handler plugins in the `http-handler` function:
- ~before-handle~ `before-handler`
- ~after-handle~ `after-handler`

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A