### PR TITLE
fix: add "MongoNetworkError" to the list of connection errors

### DIFF
--- a/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
+++ b/packages/commodo-fields-storage-db-proxy/src/DbProxyDriver.ts
@@ -5,7 +5,7 @@ import { getName } from "@commodo/name";
 import LambdaClient from "aws-sdk/clients/lambda";
 import { EJSON } from "bson";
 
-const MONGO_CONNECTION_ERRORS = ['MongoServerSelectionError'];
+const MONGO_CONNECTION_ERRORS = ["MongoServerSelectionError", "MongoNetworkError"];
 
 class DbProxyClient {
     dbProxyFunctionName: string;


### PR DESCRIPTION
## Related Issue
When trying to establish a MongoDB connection with incorrect connection params, a few times, I've also received `MongoNetworkError` as the connection error type. In that case, we also want a nice error message (with the link to the docs) to be shown. Currently, we were only doing that when the error was type of `MongoServerSelectionError`.

## Your solution
Added `MongoNetworkError` to the array of all connection-related errors.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A