### PR TITLE
fix: on new deployments, consider existing SSR HTML as stale

### DIFF
--- a/components/serverless-aws-cloudfront/serverless.js
+++ b/components/serverless-aws-cloudfront/serverless.js
@@ -64,8 +64,6 @@ class ServerlessAwsCloudfront extends Component {
                     }
                 })
                 .promise();
-        } else {
-            this.context.instance.debug(`Skipping creation of CDN cache invalidation request.`);
         }
 
         this.state.output = output;

--- a/components/serverless-aws-cloudfront/serverless.js
+++ b/components/serverless-aws-cloudfront/serverless.js
@@ -1,6 +1,8 @@
 const { Component } = require("@serverless/core");
 const CloudFront = require("aws-sdk/clients/cloudfront");
 const get = require("lodash.get");
+const setCdnDistributionForwardedHeader = require("./utils/setCdnDistributionForwardedHeader");
+const unsetCdnDistributionForwardedHeader = require("./utils/unsetCdnDistributionForwardedHeader");
 
 class ServerlessAwsCloudfront extends Component {
     async default(inputs = {}) {
@@ -9,65 +11,44 @@ class ServerlessAwsCloudfront extends Component {
 
         const cloudfrontClient = new CloudFront();
 
+        // Get CDN Distribution's config and the ETag.
+        const { DistributionConfig, ETag } = await cloudfrontClient
+            .getDistributionConfig({ Id: output.id })
+            .promise();
+
+        // Append deployment ID (a simple timestamp) into the forwarded headers list.
+        this.context.instance.debug(`Adding "X-Cdn-Deployment-Id" forwarded header...`);
+
+        setCdnDistributionForwardedHeader({
+            DistributionConfig,
+            key: "X-Cdn-Deployment-Id",
+            value: new Date().getTime()
+        });
+
+        // If enabled, append CDN ID into the forwarded headers list.
         const forwardIdViaHeadersChanged =
             get(this.state, "output.forwardIdViaHeaders") !== inputs.forwardIdViaHeaders;
 
         if (forwardIdViaHeadersChanged) {
             output.forwardIdViaHeaders = inputs.forwardIdViaHeaders;
-            const { DistributionConfig, ETag } = await cloudfrontClient
-                .getDistributionConfig({ Id: output.id })
-                .promise();
 
             if (inputs.forwardIdViaHeaders) {
-                DistributionConfig.Origins.Items.forEach(origin => {
-                    let hasHeader = false;
-                    for (let i = 0; i < origin.CustomHeaders.Items.length; i++) {
-                        const item = origin.CustomHeaders.Items[i];
-                        if (item.HeaderName === "X-Cdn-Id") {
-                            item.HeaderValue = output.id;
-                            hasHeader = true;
-                            break;
-                        }
-                    }
-
-                    if (!hasHeader) {
-                        origin.CustomHeaders.Quantity++;
-                        origin.CustomHeaders.Items.push({
-                            HeaderName: "X-Cdn-Id",
-                            HeaderValue: output.id
-                        });
-                    }
+                this.context.instance.debug(`Adding "X-Cdn-Id" forwarded header...`);
+                setCdnDistributionForwardedHeader({
+                    DistributionConfig,
+                    key: "X-Cdn-Id",
+                    value: output.id
                 });
-
-                this.context.instance.debug(
-                    `Adding custom header forwarding - Cloudfront Distribution ID.`
-                );
             } else {
-                DistributionConfig.Origins.Items.forEach(origin => {
-                    let headerItemIndex = null;
-                    for (let i = 0; i < origin.CustomHeaders.Items.length; i++) {
-                        const item = origin.CustomHeaders.Items[i];
-                        if (item.HeaderName === "X-Cdn-Id") {
-                            headerItemIndex = i;
-                            break;
-                        }
-                    }
-
-                    if (headerItemIndex !== null) {
-                        origin.CustomHeaders.Items.splice(headerItemIndex, 1);
-                        origin.CustomHeaders.Quantity--;
-                    }
-                });
-
-                this.context.instance.debug(
-                    `Removing custom header forwarding - Cloudfront Distribution ID.`
-                );
+                this.context.instance.debug(`Removing "X-Cdn-Deployment-Id" forwarded header...`);
+                unsetCdnDistributionForwardedHeader({ DistributionConfig, key: "X-Cdn-Id" });
             }
-
-            await cloudfrontClient
-                .updateDistribution({ DistributionConfig, Id: output.id, IfMatch: ETag })
-                .promise();
         }
+
+        this.context.instance.debug(`Updating CDN with forwarded headers...`);
+        await cloudfrontClient
+            .updateDistribution({ DistributionConfig, Id: output.id, IfMatch: ETag })
+            .promise();
 
         if (inputs.invalidateOnDeploy === true) {
             this.context.instance.debug(`Creating a CDN cache invalidation request.`);

--- a/components/serverless-aws-cloudfront/serverless.js
+++ b/components/serverless-aws-cloudfront/serverless.js
@@ -22,7 +22,7 @@ class ServerlessAwsCloudfront extends Component {
         setCdnDistributionForwardedHeader({
             DistributionConfig,
             key: "X-Cdn-Deployment-Id",
-            value: new Date().getTime()
+            value: String(new Date().getTime())
         });
 
         // If enabled, append CDN ID into the forwarded headers list.

--- a/components/serverless-aws-cloudfront/utils/setCdnDistributionForwardedHeader.js
+++ b/components/serverless-aws-cloudfront/utils/setCdnDistributionForwardedHeader.js
@@ -1,0 +1,22 @@
+module.exports = function setCdnDistributionForwardedHeader({ DistributionConfig, key, value }) {
+    DistributionConfig.Origins.Items.forEach(origin => {
+        let hasHeader = false;
+        for (let i = 0; i < origin.CustomHeaders.Items.length; i++) {
+            const item = origin.CustomHeaders.Items[i];
+            if (item.HeaderName === key) {
+                item.HeaderValue = value;
+                hasHeader = true;
+                break;
+            }
+        }
+
+        if (!hasHeader) {
+            origin.CustomHeaders.Quantity++;
+            origin.CustomHeaders.Items.push({
+                HeaderName: key,
+                HeaderValue: value
+            });
+        }
+    });
+}
+

--- a/components/serverless-aws-cloudfront/utils/unsetCdnDistributionForwardedHeader.js
+++ b/components/serverless-aws-cloudfront/utils/unsetCdnDistributionForwardedHeader.js
@@ -1,0 +1,19 @@
+module.exports = function unsetCdnDistributionForwardedHeader({ DistributionConfig, key }) {
+    DistributionConfig.Origins.Items.forEach(origin => {
+        let headerItemIndex = null;
+        for (let i = 0; i < origin.CustomHeaders.Items.length; i++) {
+            const item = origin.CustomHeaders.Items[i];
+            if (item.HeaderName === key) {
+                headerItemIndex = i;
+                break;
+            }
+        }
+
+        if (headerItemIndex !== null) {
+            origin.CustomHeaders.Items.splice(headerItemIndex, 1);
+            origin.CustomHeaders.Quantity--;
+        }
+    });
+
+}
+

--- a/examples/apps/serverless.yml
+++ b/examples/apps/serverless.yml
@@ -72,7 +72,6 @@ api:
 cdn:
   component: "@webiny/serverless-aws-cloudfront"
   inputs:
-    invalidateOnDeploy: true
     forwardIdViaHeaders: true
     defaults: # optional
       ttl: 300

--- a/packages/cli/create/template/apps/serverless.yml
+++ b/packages/cli/create/template/apps/serverless.yml
@@ -71,7 +71,6 @@ api:
 cdn:
   component: "@webiny/serverless-aws-cloudfront"
   inputs:
-    invalidateOnDeploy: true
     forwardIdViaHeaders: true
     defaults: # optional
       ttl: 300

--- a/packages/http-handler-ssr/src/models/ssrCache.model.ts
+++ b/packages/http-handler-ssr/src/models/ssrCache.model.ts
@@ -26,6 +26,14 @@ export default ({ createBase, options = {} }: any = {}) =>
                 }
             }),
             content: string({ value: null }),
+            key: string({
+                value: null,
+                validate(value) {
+                    if (value && value.length > 100) {
+                        throw Error(`Field "key" cannot have more than 100 characters.`);
+                    }
+                }
+            }),
             refreshedOn: skipOnPopulate()(date()),
             expiresOn: skipOnPopulate()(date()),
             cacheTags: skipOnPopulate()(object({ list: true })),
@@ -76,21 +84,32 @@ export default ({ createBase, options = {} }: any = {}) =>
                 const expiresIn = this.expiresOn - new Date();
                 return expiresIn > 0 ? expiresIn : 0;
             },
+            get isRefreshing() {
+                return this.lastRefresh.startedOn && !this.lastRefresh.endedOn;
+            },
+            isStale(key) {
+                if (this.hasExpired) {
+                    return true;
+                }
 
+                return key && key !== this.key;
+            },
             incrementExpiresOn(seconds = options.cache.staleTtl) {
                 this.expiresOn = new Date();
                 this.expiresOn.setSeconds(this.expiresOn.getSeconds() + seconds);
                 return this;
             },
-            async refresh() {
+            async refresh(key = null) {
+                this.key = key;
                 this.lastRefresh.startedOn = new Date();
+                this.lastRefresh.endedOn = null;
+                this.lastRefresh.duration = null;
                 await this.save();
 
                 this.content = await getSsrHtml(options.ssrFunction, { path: this.path });
-
-                this.lastRefresh.endedOn = new Date();
-                this.lastRefresh.duration = this.lastRefresh.endedOn - this.lastRefresh.startedOn;
                 this.refreshedOn = new Date();
+                this.lastRefresh.endedOn = this.refreshedOn;
+                this.lastRefresh.duration = this.lastRefresh.endedOn - this.lastRefresh.startedOn;
                 this.incrementExpiresOn(options.cache.ttl);
 
                 await this.save();
@@ -99,6 +118,7 @@ export default ({ createBase, options = {} }: any = {}) =>
                 await this.hook("beforeInvalidate");
                 this.expiresOn = null;
                 this.content = null;
+                this.key = null;
                 await this.save();
                 await this.hook("afterInvalidate");
             }

--- a/packages/http-handler-ssr/src/models/ssrCache.model.ts
+++ b/packages/http-handler-ssr/src/models/ssrCache.model.ts
@@ -87,20 +87,20 @@ export default ({ createBase, options = {} }: any = {}) =>
             get isRefreshing() {
                 return this.lastRefresh.startedOn && !this.lastRefresh.endedOn;
             },
-            isStale(version) {
+            isStale(currentVersion) {
                 if (this.hasExpired) {
                     return true;
                 }
 
-                return version && version !== this.version;
+                return currentVersion && currentVersion !== this.version;
             },
             incrementExpiresOn(seconds = options.cache.staleTtl) {
                 this.expiresOn = new Date();
                 this.expiresOn.setSeconds(this.expiresOn.getSeconds() + seconds);
                 return this;
             },
-            async refresh(version = null) {
-                this.version = version;
+            async refresh(currentVersion = null) {
+                this.version = currentVersion;
                 this.lastRefresh.startedOn = new Date();
                 this.lastRefresh.endedOn = null;
                 this.lastRefresh.duration = null;

--- a/packages/http-handler-ssr/src/models/ssrCache.model.ts
+++ b/packages/http-handler-ssr/src/models/ssrCache.model.ts
@@ -26,11 +26,11 @@ export default ({ createBase, options = {} }: any = {}) =>
                 }
             }),
             content: string({ value: null }),
-            key: string({
+            version: string({
                 value: null,
                 validate(value) {
                     if (value && value.length > 100) {
-                        throw Error(`Field "key" cannot have more than 100 characters.`);
+                        throw Error(`Field "version" cannot have more than 100 characters.`);
                     }
                 }
             }),
@@ -87,20 +87,20 @@ export default ({ createBase, options = {} }: any = {}) =>
             get isRefreshing() {
                 return this.lastRefresh.startedOn && !this.lastRefresh.endedOn;
             },
-            isStale(key) {
+            isStale(version) {
                 if (this.hasExpired) {
                     return true;
                 }
 
-                return key && key !== this.key;
+                return version && version !== this.version;
             },
             incrementExpiresOn(seconds = options.cache.staleTtl) {
                 this.expiresOn = new Date();
                 this.expiresOn.setSeconds(this.expiresOn.getSeconds() + seconds);
                 return this;
             },
-            async refresh(key = null) {
-                this.key = key;
+            async refresh(version = null) {
+                this.version = version;
                 this.lastRefresh.startedOn = new Date();
                 this.lastRefresh.endedOn = null;
                 this.lastRefresh.duration = null;
@@ -118,7 +118,7 @@ export default ({ createBase, options = {} }: any = {}) =>
                 await this.hook("beforeInvalidate");
                 this.expiresOn = null;
                 this.content = null;
-                this.key = null;
+                this.version = null;
                 await this.save();
                 await this.hook("afterInvalidate");
             }

--- a/packages/http-handler-ssr/src/ssrCacheApi.ts
+++ b/packages/http-handler-ssr/src/ssrCacheApi.ts
@@ -18,7 +18,7 @@ export default (): HttpHandlerPlugin => ({
             return false;
         }
 
-        if (event.path !== "/" || event.httpMethod !== "POST") {
+        if (event.httpMethod !== "POST") {
             return false;
         }
 

--- a/packages/http-handler-ssr/src/ssrCacheApi.ts
+++ b/packages/http-handler-ssr/src/ssrCacheApi.ts
@@ -115,17 +115,17 @@ export default (): HttpHandlerPlugin => ({
                     });
                 }
 
-                const key = event.headers["X-Cdn-Deployment-Id"];
+                const version = event.headers["X-Cdn-Deployment-Id"];
 
                 // "expired" flag tells us to invalidate only if the cache is considered as expired.
                 if (actionArgs.expired === true) {
-                    // Only check "key" if it was actually received in the headers.
-                    let keysDifferent = false;
-                    if (key) {
-                        keysDifferent = ssrCache.key !== key;
+                    // Only check "version" if it was actually received in the headers.
+                    let versionsDifferent = false;
+                    if (version) {
+                        versionsDifferent = ssrCache.version !== version;
                     }
 
-                    if (!keysDifferent && !ssrCache.hasExpired) {
+                    if (!versionsDifferent && !ssrCache.hasExpired) {
                         return createResponse({
                             type: "text/json",
                             body: JSON.stringify({
@@ -139,7 +139,7 @@ export default (): HttpHandlerPlugin => ({
                 await ssrCache.invalidate();
                 data.invalidated = true;
                 if (actionArgs.refresh) {
-                    await ssrCache.refresh(key);
+                    await ssrCache.refresh(version);
                     data.refreshed = true;
                 }
 

--- a/packages/http-handler-ssr/src/ssrServe.ts
+++ b/packages/http-handler-ssr/src/ssrServe.ts
@@ -27,12 +27,12 @@ export default (options): HttpHandlerPlugin => {
                     await ssrCache.save();
                 }
 
-                const key = event.headers["X-Cdn-Deployment-Id"];
+                const version = event.headers["X-Cdn-Deployment-Id"];
 
                 if (ssrCache.isEmpty) {
-                    await ssrCache.refresh(key);
+                    await ssrCache.refresh(version);
                 } else {
-                    if (ssrCache.isStale(key)) {
+                    if (ssrCache.isStale(version)) {
                         // On expiration, asynchronously trigger SSR cache refreshing.
                         // This will only increment expiresOn for the "options.cache.staleTtl" seconds, which
                         // is a short duration, enough for the actual refresh to complete, which will again update the

--- a/packages/http-handler-ssr/src/ssrServe.ts
+++ b/packages/http-handler-ssr/src/ssrServe.ts
@@ -27,24 +27,28 @@ export default (options): HttpHandlerPlugin => {
                     await ssrCache.save();
                 }
 
+                const key = event.headers["X-Cdn-Deployment-Id"];
+
                 if (ssrCache.isEmpty) {
-                    await ssrCache.refresh();
-                } else if (ssrCache.hasExpired) {
-                    // On expiration, asynchronously trigger SSR cache refreshing.
-                    // This will only increment expiresOn for the "options.cache.staleTtl" seconds, which
-                    // is a short duration, enough for the actual refresh to complete, which will again update the
-                    // expiration. Default value of "options.cache.staleTtl" is 20 seconds.
-                    await ssrCache.incrementExpiresOn().save();
-                    const Lambda = new LambdaClient({ region: process.env.AWS_REGION });
-                    await Lambda.invoke({
-                        FunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
-                        InvocationType: "Event",
-                        Payload: JSON.stringify({
-                            ...event,
-                            httpMethod: "POST",
-                            body: ["refreshSsrCache", { path: ssrCache.path }]
-                        })
-                    }).promise();
+                    await ssrCache.refresh(key);
+                } else {
+                    if (ssrCache.isStale(key)) {
+                        // On expiration, asynchronously trigger SSR cache refreshing.
+                        // This will only increment expiresOn for the "options.cache.staleTtl" seconds, which
+                        // is a short duration, enough for the actual refresh to complete, which will again update the
+                        // expiration. Default value of "options.cache.staleTtl" is 20 seconds.
+                        await ssrCache.incrementExpiresOn().save();
+                        const Lambda = new LambdaClient({ region: process.env.AWS_REGION });
+                        await Lambda.invoke({
+                            FunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+                            InvocationType: "Event",
+                            Payload: JSON.stringify({
+                                ...event,
+                                httpMethod: "POST",
+                                body: { ssr: ["invalidateSsrCacheByPath", { path: ssrCache.path }] }
+                            })
+                        }).promise();
+                    }
                 }
 
                 let buffer = Buffer.from(ssrCache.content);


### PR DESCRIPTION
## Related Issue
#708 

## The Problem
The problem that the user experienced here was related to the inproper cache invalidation. Initially, we would flush the CDN cache on every successful deployment, but not the SSR HTML in the database. 

So, after the deploy has finished, user would visit the site, his request would reach the `Site` Lambda function (because CDN has been flushed), and there, we would just return the same old SSR HTML back to the CDN / to the user.

## The Solution
From now on, on each deploy of CDN, we will generate a unique `deploymendId` and make the CDN send it via custom headers (`X-Cdn-Deployment-Id`). 

So, every time a request from the CDN arrives to the `Site` Lambda function, this deployment ID will be present in the invocation payload (in the `headers` key).

With this, we can detect a new deployment, or in other words, consider every SSR HTML in the database as stale, even if the `expiresOn` of the SSR HTML entry is far in the future.

## Additional fixes
There were some other issues that I detected while resolving the initial issue. The most significant fix is the one located in the `packages/http-handler-ssr/src/ssrServe.ts` file (was sending incorrect payload), and in `serverless.yml` files, where I removed CDN flushing on deploy.


## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A