### PR TITLE
feat: enable registration of error-handler plugin

### DIFF
--- a/packages/http-handler/src/types.ts
+++ b/packages/http-handler/src/types.ts
@@ -23,6 +23,12 @@ export type HttpHandlerPlugin = Plugin & {
     handle(params: { context: HttpContext; args: HttpArgs }): Promise<any>;
 };
 
+export type HttpErrorHandlerPlugin = Plugin & {
+    type: "error-handler";
+    canHandle(params: { context: HttpContext; args: HttpArgs; error: any }): boolean;
+    handle(params: { context: HttpContext; args: HttpArgs; error: any }): Promise<any>;
+};
+
 export type HttpAfterHandlerPlugin = Plugin & {
     type: "after-handler";
     handle(params: { context: HttpContext; args: HttpArgs; result: any }): Promise<void>;


### PR DESCRIPTION
## Related Issue
By default, if an error was thrown in the `Site` Lambda function (by one of the registered handlers - `examples/apps/site/handler/handler.js`), we would show the default error page, which wasn't customizable.

Ideally, users might want to customize this page or completely hide everything.

## Your solution
If an `error-handler` plugin was registered, it will be used to handle the thrown error. Otherwise, a generic error page will be shown.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A