### PR TITLE
fix: synchronize pageList component name with element plugin

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/index.tsx
@@ -46,7 +46,7 @@ export default () => {
                     type: "pages-list",
                     data: {
                         resultsPerPage: 10,
-                        component: "pb-editor-page-element-pages-list-component-default",
+                        component: "default",
                         settings: {
                             margin: {
                                 desktop: { all: 0 },


### PR DESCRIPTION
## Related Issue
Fixes #715 

## Your solution
There was a mismatch in component naming between `pb-editor-page-element-pages-list` and the actual component plugin. Now we use the `componentName` property of the plugin instead of its name.

## How Has This Been Tested?
Manual testing