### PR TITLE
fix: restore slate v0.42 onKeyDown plugin signature

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/slate/italic/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/slate/italic/index.tsx
@@ -43,11 +43,14 @@ export default () => {
                 name: "pb-editor-slate-editor-italic",
                 type: "pb-editor-slate-editor",
                 slate: {
-                    onKeyDown(event, change) {
+                    onKeyDown(event, change, next) {
                         if (isItalicHotkey(event)) {
                             event.preventDefault();
                             change.toggleMark(mark);
+                            return true;
                         }
+
+                        return next();
                     },
                     renderMark(props, next) {
                         if (props.mark.type === mark) {

--- a/packages/app-page-builder/src/editor/plugins/slate/scroll/index.ts
+++ b/packages/app-page-builder/src/editor/plugins/slate/scroll/index.ts
@@ -5,7 +5,7 @@ export default () => {
                 name: "pb-editor-slate-editor-scroll",
                 type: "pb-editor-slate-editor",
                 slate: {
-                    onKeyDown() {
+                    onKeyDown(event, change, next) {
                         const native = window.getSelection();
                         if (native.type === "None") {
                             return { top: 0, left: 0, width: 0, height: 0 };
@@ -22,6 +22,8 @@ export default () => {
                             const scrollDiff = cursorY - height;
                             window.scrollTo(0, window.scrollY + scrollDiff + 20);
                         }
+
+                        return next();
                     }
                 }
             }

--- a/packages/app-page-builder/src/editor/plugins/slate/underline/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/slate/underline/index.tsx
@@ -43,12 +43,15 @@ export default () => {
                 name: "pb-editor-slate-editor-underline",
                 type: "pb-editor-slate-editor",
                 slate: {
-                    onKeyDown(event, change) {
+                    onKeyDown(event, change, next) {
                         // Decide what to do based on the key code...
                         if (isUnderlineHotkey(event)) {
                             event.preventDefault();
                             change.toggleMark(mark);
+                            return true;
                         }
+
+                        return next();
                     },
                     renderMark(props, next) {
                         if (props.mark.type === mark) {


### PR DESCRIPTION
## Related Issue
Fixes #716 

## Your solution
During migration to TS, I accidentally messed up Slate plugin signature on `onKeyDown` plugins. The solution was to restore the plugin signature for the corresponding `v0.42` version of `slate`.

## How Has This Been Tested?
Manually.