### PR TITLE
Improve CLI usage tracking

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -133,26 +133,20 @@ yargs.command(
 );
 
 yargs.command(
-    "disable-tracking",
-    "Disable tracking of Webiny stats.",
+    "enable-tracking",
+    "Enable tracking of Webiny stats.",
     () => {},
-    () => {
-        const { setTracking } = require("./config");
-        setTracking(false);
-        console.log("INFO: tracking of Webiny stats is now DISABLED!");
+    async () => {
+        await require("./sls/enableTracking")();
     }
 );
 
 yargs.command(
-    "enable-tracking",
-    "Enable tracking of Webiny stats.",
+    "disable-tracking",
+    "Disable tracking of Webiny stats.",
     () => {},
-    () => {
-        const { setTracking } = require("./config");
-        setTracking(true);
-        console.log(
-            "INFO: tracking of Webiny stats is now ENABLED! Thank you for helping us with anonymous data 🎉"
-        );
+    async () => {
+        await require("./sls/disableTracking")();
     }
 );
 

--- a/packages/cli/create/index.js
+++ b/packages/cli/create/index.js
@@ -132,7 +132,7 @@ module.exports = async ({ name, tag }) => {
     spinner.succeed(`All dependencies installed successfully!`);
 
     await trackProject({ cliVersion: version });
-    await trackActivity({ activityId, ype: "create_project_end", cliVersion: version });
+    await trackActivity({ activityId, type: "create_project_end", cliVersion: version });
 
     console.log(await getSuccessBanner());
 };

--- a/packages/cli/create/index.js
+++ b/packages/cli/create/index.js
@@ -9,7 +9,7 @@ const uuid = require("uuid/v4");
 const loadJsonFile = require("load-json-file");
 const ora = require("ora");
 const writeJsonFile = require("write-json-file");
-const { trackProject, trackActivity } = require("@webiny/tracking");
+const { trackActivity } = require("@webiny/tracking");
 const { version } = require(require.resolve("@webiny/cli/package.json"));
 const { getSuccessBanner } = require("./messages");
 const { getPackageVersion } = require("./utils");
@@ -131,7 +131,6 @@ module.exports = async ({ name, tag }) => {
     await execa("yarn", [], { cwd: root });
     spinner.succeed(`All dependencies installed successfully!`);
 
-    await trackProject({ cliVersion: version });
     await trackActivity({ activityId, type: "create_project_end", cliVersion: version });
 
     console.log(await getSuccessBanner());

--- a/packages/cli/create/index.js
+++ b/packages/cli/create/index.js
@@ -9,10 +9,11 @@ const uuid = require("uuid/v4");
 const loadJsonFile = require("load-json-file");
 const ora = require("ora");
 const writeJsonFile = require("write-json-file");
-const { trackProject } = require("@webiny/tracking");
+const { trackProject, trackActivity } = require("@webiny/tracking");
 const { version } = require(require.resolve("@webiny/cli/package.json"));
 const { getSuccessBanner } = require("./messages");
 const { getPackageVersion } = require("./utils");
+const uniqueId = require('uniqid');
 
 const globFiles = util.promisify(glob);
 
@@ -33,6 +34,10 @@ module.exports = async ({ name, tag }) => {
     }
 
     console.log(`📦 Creating a new Webiny project in ${green(root)}...`);
+
+    const activityId = uniqueId();
+    await trackActivity({ activityId, type: "create_project_start", cliVersion: version });
+
     fs.ensureDirSync(root);
     process.chdir(root);
 
@@ -127,6 +132,7 @@ module.exports = async ({ name, tag }) => {
     spinner.succeed(`All dependencies installed successfully!`);
 
     await trackProject({ cliVersion: version });
+    await trackActivity({ activityId, ype: "create_project_end", cliVersion: version });
 
     console.log(await getSuccessBanner());
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "semver": "^7.1.2",
     "traverse": "^0.6.6",
     "update-notifier": "^3.0.1",
+    "uniqid": "^5.0.3",
     "uuid": "^3.3.3",
     "write-json-file": "^4.2.0",
     "yargs": "^14.0.0"

--- a/packages/cli/sls/deploy.js
+++ b/packages/cli/sls/deploy.js
@@ -4,9 +4,6 @@ const { green, red } = require("chalk");
 const notifier = require("node-notifier");
 const execute = require("./execute");
 const { isApiEnvDeployed, isAppsEnvDeployed } = require("./utils");
-const { trackActivity } = require("@webiny/tracking");
-const { version } = require(require.resolve("@webiny/cli/package.json"));
-const uniqueId = require("uniqid");
 
 const perks = ["🍪", "☕️", "🍎", "🍺", "🥤"];
 
@@ -25,8 +22,6 @@ module.exports = async inputs => {
 
     const webinyJs = resolve("webiny.js");
     const config = require(webinyJs);
-
-    const activityId = uniqueId();
 
     if (what === "apps") {
         if (typeof env === "undefined") {
@@ -62,11 +57,7 @@ module.exports = async inputs => {
 
         const isFirstDeploy = !(await isAppsEnvDeployed(env));
 
-        await trackActivity({ activityId, type: "apps_deploy_start", cliVersion: version });
-
         const { output, duration } = await execute(inputs);
-
-        await trackActivity({ activityId, type: "apps_deploy_end", cliVersion: version });
 
         console.log(`\n🎉 Done! Deploy finished in ${green(duration + "s")}.`);
 
@@ -95,11 +86,7 @@ module.exports = async inputs => {
             );
         }
 
-        await trackActivity({ activityId, type: "api_deploy_start", cliVersion: version });
-
         const { output, duration } = await execute(inputs);
-
-        await trackActivity({ activityId, type: "api_deploy_end", cliVersion: version });
 
         // Run app state hooks
         if (!fs.existsSync(webinyJs)) {

--- a/packages/cli/sls/disableTracking.js
+++ b/packages/cli/sls/disableTracking.js
@@ -1,9 +1,10 @@
 const { setTracking } = require("./../config");
 const { version } = require(require.resolve("@webiny/cli/package.json"));
 const { trackActivity } = require("@webiny/tracking");
+const uniqueId = require('uniqid');
 
 module.exports = async () => {
     setTracking(false);
-    await trackActivity({ type: 'tracking-disabled', cliVersion: version });
+    await trackActivity({ type: 'tracking-disabled', cliVersion: version, activityId: uniqueId() });
     console.log("INFO: tracking of Webiny stats is now DISABLED!");
 };

--- a/packages/cli/sls/disableTracking.js
+++ b/packages/cli/sls/disableTracking.js
@@ -1,0 +1,6 @@
+const { setTracking } = require("./../config");
+
+module.exports = async () => {
+    setTracking(false);
+    console.log("INFO: tracking of Webiny stats is now DISABLED!");
+};

--- a/packages/cli/sls/disableTracking.js
+++ b/packages/cli/sls/disableTracking.js
@@ -4,7 +4,7 @@ const { trackActivity } = require("@webiny/tracking");
 const uniqueId = require('uniqid');
 
 module.exports = async () => {
-    setTracking(false);
     await trackActivity({ type: 'tracking-disabled', cliVersion: version, activityId: uniqueId() });
+    setTracking(false);
     console.log("INFO: tracking of Webiny stats is now DISABLED!");
 };

--- a/packages/cli/sls/disableTracking.js
+++ b/packages/cli/sls/disableTracking.js
@@ -1,6 +1,9 @@
 const { setTracking } = require("./../config");
+const { version } = require(require.resolve("@webiny/cli/package.json"));
+const { trackActivity } = require("@webiny/tracking");
 
 module.exports = async () => {
     setTracking(false);
+    await trackActivity({ type: 'tracking-disabled', cliVersion: version });
     console.log("INFO: tracking of Webiny stats is now DISABLED!");
 };

--- a/packages/cli/sls/enableTracking.js
+++ b/packages/cli/sls/enableTracking.js
@@ -1,0 +1,8 @@
+const { setTracking } = require("./../config");
+
+module.exports = async () => {
+    setTracking(true);
+    console.log(
+        "INFO: tracking of Webiny stats is now ENABLED! Thank you for helping us with anonymous data 🎉"
+    );
+};

--- a/packages/cli/sls/execute.js
+++ b/packages/cli/sls/execute.js
@@ -30,7 +30,7 @@ module.exports = async (inputs, method = "default") => {
     const component = new Template(`Webiny.${env}`, context);
     await component.init();
 
-    const output = await component[method]({ env, debug, alias });
+    const output = await component[method]({ env, debug, alias, what });
     if (debug) {
         // Add an empty line after debug output for nicer output
         console.log();

--- a/packages/cli/sls/template/serverless.js
+++ b/packages/cli/sls/template/serverless.js
@@ -65,25 +65,25 @@ class Template extends Component {
             context: this.context
         });
 
-        this.context.status("Deploying");
-
-        const template = await getTemplate(inputs);
-
-        const resolvedTemplate = resolveTemplate(inputs, template);
-
-        this.context.debug("Collecting components from the template.");
-
-        const allComponents = getAllComponents(resolvedTemplate);
-
-        const allComponentsWithDependencies = setDependencies(allComponents);
-
-        const graph = createGraph(allComponentsWithDependencies);
-
-        await syncState(allComponentsWithDependencies, this);
-
-        this.context.debug(`Executing the template's components graph.`);
-
         try {
+            this.context.status("Deploying");
+
+            const template = await getTemplate(inputs);
+
+            const resolvedTemplate = resolveTemplate(inputs, template);
+
+            this.context.debug("Collecting components from the template.");
+
+            const allComponents = getAllComponents(resolvedTemplate);
+
+            const allComponentsWithDependencies = setDependencies(allComponents);
+
+            const graph = createGraph(allComponentsWithDependencies);
+
+            await syncState(allComponentsWithDependencies, this);
+
+            this.context.debug(`Executing the template's components graph.`);
+
             const allComponentsWithOutputs = await executeGraph(
                 allComponentsWithDependencies,
                 graph,
@@ -113,6 +113,7 @@ class Template extends Component {
                 errorMessage: e.message,
                 errorStack: e.stack
             });
+
             throw e;
         }
     }

--- a/packages/cli/sls/template/serverless.js
+++ b/packages/cli/sls/template/serverless.js
@@ -106,7 +106,7 @@ class Template extends Component {
             return outputs;
         } catch (e) {
             await trackError({
-                instance: this.context.instance.id,
+                context: this.context,
                 activityId,
                 type: `${what}_deploy`,
                 cliVersion: version,

--- a/packages/cli/sls/template/serverless.js
+++ b/packages/cli/sls/template/serverless.js
@@ -62,7 +62,7 @@ class Template extends Component {
             activityId,
             type: `${what}_deploy_start`,
             cliVersion: version,
-            instance: this.context.instance.id
+            context: this.context
         });
 
         this.context.status("Deploying");
@@ -100,7 +100,7 @@ class Template extends Component {
                 activityId,
                 type: `${what}_deploy_end`,
                 cliVersion: version,
-                instance: this.context.instance.id
+                context: this.context
             });
 
             return outputs;

--- a/packages/cli/sls/template/utils.js
+++ b/packages/cli/sls/template/utils.js
@@ -249,10 +249,7 @@ const executeGraph = async (allComponents, graph, instance, inputs) => {
             await trackComponent({ context: instance.context, component: componentData.path });
         } catch (err) {
             instance.context.log(`An error occurred during deployment of ${red(alias)}`);
-            console.log();
-            console.log(err);
-            console.log();
-            process.exit(1);
+            throw err;
         }
 
         graph.removeNode(alias);

--- a/packages/http-handler-ssr/src/index.ts
+++ b/packages/http-handler-ssr/src/index.ts
@@ -3,17 +3,33 @@ import ssrServe from "./ssrServe";
 import models from "./models";
 import { withFields, boolean, number, string, fields } from "@webiny/commodo/fields";
 
-const OptionsModel = withFields({
-    ssrFunction: string({ value: process.env.SSR_FUNCTION }),
-    cache: fields({
+const Animal = withFields({
+    name: string({
+        validate: value => {
+            if (!value) {
+                throw Error("A pet must have a name!");
+            }
+        }
+    }),
+    age: number(),
+    isAwesome: boolean(),
+    about: fields({
         value: {},
         instanceOf: withFields({
-            enabled: boolean({ value: false }),
-            ttl: number({ value: 80 }),
-            staleTtl: number({ value: 20 })
+            type: string({ value: "cat" }),
+            dangerous: boolean({ value: true })
         })()
     })
 })();
+
+const animal = new Animal();
+animal.populate({ age: "7" }); // Throws data type error, cannot populate a string with number.
+
+animal.populate({ age: 7 });
+await animal.validate(); // Throws a validation error - name must be defined.
+
+animal.name = "Garfield";
+await animal.validate(); // All good.
 
 export default rawOptions => {
     const options = new OptionsModel().populate(rawOptions);

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -18,7 +18,7 @@ const sendStats = (action, data) => {
     });
 };
 
-const loadConfig = async ({ logger = defaultLogger }) => {
+const loadConfig = async ({ logger = defaultLogger } = {}) => {
     if (!config) {
         const dataPath = path.join(os.homedir(), ".webiny", "config");
         try {

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -2,6 +2,7 @@ const os = require("os");
 const path = require("path");
 const readJson = require("load-json-file");
 const request = require("request");
+const get = require("lodash.get");
 
 let config;
 const defaultLogger = () => {};
@@ -48,7 +49,7 @@ const trackComponent = async ({ context, component, method = "deploy" }) => {
         await sendStats("telemetry", {
             type: "component",
             user: config.id,
-            instance: context.instance.id,
+            instance: get(context, "instance.id") || "",
             component: name,
             version,
             method
@@ -76,7 +77,7 @@ const trackProject = async ({ cliVersion }) => {
     }
 };
 
-const trackActivity = async ({ cliVersion, type, activityId, instance = "" }) => {
+const trackActivity = async ({ cliVersion, type, activityId, context }) => {
     if (!cliVersion) {
         throw new Error(`Cannot track activity - "cliVersion" not specified.`);
     }
@@ -100,7 +101,7 @@ const trackActivity = async ({ cliVersion, type, activityId, instance = "" }) =>
             version: cliVersion,
             type,
             activityId,
-            instance,
+            instance: get(context, "instance.id") || "",
             user: config.id
         });
     } catch (e) {
@@ -108,7 +109,7 @@ const trackActivity = async ({ cliVersion, type, activityId, instance = "" }) =>
     }
 };
 
-const trackError = async ({ cliVersion, type, errorMessage, errorStack, activityId, instance = "" }) => {
+const trackError = async ({ cliVersion, type, errorMessage, errorStack, activityId }) => {
     if (!cliVersion) {
         throw new Error("Cannot track activity - CLI version not specified.");
     }
@@ -134,7 +135,7 @@ const trackError = async ({ cliVersion, type, errorMessage, errorStack, activity
             errorMessage,
             errorStack,
             activityId,
-            instance,
+            instance: get(context, "instance.id") || "",
             user: config.id
         });
     } catch (e) {

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -76,7 +76,27 @@ const trackProject = async ({ cliVersion }) => {
     }
 };
 
+const trackActivity = async ({ cliVersion, type, activityId }) => {
+    try {
+        await loadConfig();
+
+        if (config.tracking !== true) {
+            return;
+        }
+
+        await sendStats("activity", {
+            type,
+            activityId,
+            user: config.id,
+            version: cliVersion
+        });
+    } catch (e) {
+        // Ignore errors
+    }
+};
+
 module.exports = {
     trackProject,
-    trackComponent
+    trackComponent,
+    trackActivity
 };

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -77,6 +77,14 @@ const trackProject = async ({ cliVersion }) => {
 };
 
 const trackActivity = async ({ cliVersion, type, activityId }) => {
+    if (!type) {
+        throw new Error("Cannot track activity - type not specified.");
+    }
+
+    if (!cliVersion) {
+        throw new Error("Cannot track activity - CLI version not specified.");
+    }
+
     try {
         await loadConfig();
 

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -77,7 +77,7 @@ const trackProject = async ({ cliVersion }) => {
     }
 };
 
-const trackActivity = async ({ cliVersion, type, activityId, context }) => {
+const trackActivity = async ({ cliVersion, type, activityId, context = {} }) => {
     if (!cliVersion) {
         throw new Error(`Cannot track activity - "cliVersion" not specified.`);
     }
@@ -91,7 +91,7 @@ const trackActivity = async ({ cliVersion, type, activityId, context }) => {
     }
 
     try {
-        await loadConfig();
+        await loadConfig({ logger: context.debug });
 
         if (config.tracking !== true) {
             return;
@@ -109,7 +109,7 @@ const trackActivity = async ({ cliVersion, type, activityId, context }) => {
     }
 };
 
-const trackError = async ({ cliVersion, type, errorMessage, errorStack, activityId }) => {
+const trackError = async ({ cliVersion, type, errorMessage, errorStack, activityId, context = {} }) => {
     if (!cliVersion) {
         throw new Error("Cannot track activity - CLI version not specified.");
     }
@@ -123,7 +123,7 @@ const trackError = async ({ cliVersion, type, errorMessage, errorStack, activity
     }
 
     try {
-        await loadConfig();
+        await loadConfig({ logger: context.debug });
 
         if (config.tracking !== true) {
             return;

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -6,12 +6,12 @@ const request = require("request");
 let config;
 const defaultLogger = () => {};
 
-const sendStats = data => {
+const sendStats = (action, data) => {
     return new Promise(resolve => {
         request.post(
             {
                 url: "https://stats.webiny.com/track",
-                json: data
+                json: { action, data }
             },
             resolve
         );
@@ -45,7 +45,7 @@ const trackComponent = async ({ context, component, method = "deploy" }) => {
 
         const { name, version } = readJson.sync(path.join(path.dirname(component), "package.json"));
         context.debug(`Tracking component: ${name} (${method})`);
-        await sendStats({
+        await sendStats("telemetry", {
             type: "component",
             user: config.id,
             instance: context.instance.id,
@@ -66,7 +66,7 @@ const trackProject = async ({ cliVersion }) => {
             return;
         }
 
-        await sendStats({
+        await sendStats("telemetry", {
             type: "project",
             user: config.id,
             version: cliVersion

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -96,7 +96,7 @@ const trackActivity = async ({ cliVersion, type, activityId, instance = "" }) =>
             return;
         }
 
-        await sendStats("activity", {
+        await sendStats("activities", {
             version: cliVersion,
             type,
             activityId,
@@ -128,7 +128,7 @@ const trackError = async ({ cliVersion, type, errorMessage, errorStack, activity
             return;
         }
 
-        await sendStats("error", {
+        await sendStats("errors", {
             version: cliVersion,
             type,
             errorMessage,

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -76,13 +76,17 @@ const trackProject = async ({ cliVersion }) => {
     }
 };
 
-const trackActivity = async ({ cliVersion, type, activityId }) => {
-    if (!type) {
-        throw new Error("Cannot track activity - type not specified.");
+const trackActivity = async ({ cliVersion, type, activityId, instance = "" }) => {
+    if (!cliVersion) {
+        throw new Error(`Cannot track activity - "cliVersion" not specified.`);
     }
 
-    if (!cliVersion) {
-        throw new Error("Cannot track activity - CLI version not specified.");
+    if (!type) {
+        throw new Error(`Cannot track activity - "type" not specified.`);
+    }
+
+    if (!activityId) {
+        throw new Error(`Cannot track activity - "activityId" not specified.`);
     }
 
     try {
@@ -93,10 +97,45 @@ const trackActivity = async ({ cliVersion, type, activityId }) => {
         }
 
         await sendStats("activity", {
+            version: cliVersion,
             type,
             activityId,
-            user: config.id,
-            version: cliVersion
+            instance,
+            user: config.id
+        });
+    } catch (e) {
+        // Ignore errors
+    }
+};
+
+const trackError = async ({ cliVersion, type, errorMessage, errorStack, activityId, instance = "" }) => {
+    if (!cliVersion) {
+        throw new Error("Cannot track activity - CLI version not specified.");
+    }
+
+    if (!type) {
+        throw new Error("Cannot track activity - type not specified.");
+    }
+
+    if (!errorMessage) {
+        throw new Error("Cannot track activity - CLI version not specified.");
+    }
+
+    try {
+        await loadConfig();
+
+        if (config.tracking !== true) {
+            return;
+        }
+
+        await sendStats("error", {
+            version: cliVersion,
+            type,
+            errorMessage,
+            errorStack,
+            activityId,
+            instance,
+            user: config.id
         });
     } catch (e) {
         // Ignore errors
@@ -106,5 +145,6 @@ const trackActivity = async ({ cliVersion, type, activityId }) => {
 module.exports = {
     trackProject,
     trackComponent,
-    trackActivity
+    trackActivity,
+    trackError
 };

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -59,24 +59,6 @@ const trackComponent = async ({ context, component, method = "deploy" }) => {
     }
 };
 
-const trackProject = async ({ cliVersion }) => {
-    try {
-        await loadConfig();
-
-        if (config.tracking !== true) {
-            return;
-        }
-
-        await sendStats("telemetry", {
-            type: "project",
-            user: config.id,
-            version: cliVersion
-        });
-    } catch (e) {
-        // Ignore errors
-    }
-};
-
 const trackActivity = async ({ cliVersion, type, activityId, context = {} }) => {
     if (!cliVersion) {
         throw new Error(`Cannot track activity - "cliVersion" not specified.`);
@@ -144,7 +126,6 @@ const trackError = async ({ cliVersion, type, errorMessage, errorStack, activity
 };
 
 module.exports = {
-    trackProject,
     trackComponent,
     trackActivity,
     trackError

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "load-json-file": "^6.2.0",
+    "lodash.get": "^4.4.0",
     "request": "^2.88.0"
   },
   "publishConfig": {


### PR DESCRIPTION
The Webiny CLI internally tracks the user's usage. This exists because we want to have information about potential problems that the users might experience, and to make the DX as great as possible.

Note: this is clearly explained while the CLI is being used, and users can also completely disable tracking if they want, by running the `webiny disable-tracking`.

With this PR, we added tracking of the following CLI events:

- create_project_start
- create_project_end
- apps_deploy_start
- apps_deploy_end
- api_deploy_start
- api_deploy_end
- tracking-disabled

These events will give us an even better understanding of the experience our users are having.