### PR TITLE
Handle PB Element plugin errors during render

### DIFF
--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -36,41 +36,6 @@ export type ElementProps = {
     dragging: boolean;
 };
 
-// Using a class element for a change because `componentDidCatch` only works with class elements ;/
-class ErrorBoundary extends React.Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            error: null,
-            errorInfo: null
-        }
-    }
-
-    componentDidCatch(error, errorInfo) {
-        this.setState({
-            error,
-            errorInfo
-        })
-    }
-
-    render() {
-        if(this.state.error) {
-            return (
-                <div>
-                    <h3>An unexpected error has occurred</h3>
-                    <details>
-                        <div>{this.state.error.toString()}</div>
-                        <div>{this.state.errorInfo.componentStack}</div>
-                    </details>
-                </div>
-            )
-        }
-
-        return this.props.children
-    }
-}
-
-
 const getElementPlugin = (element): PbEditorPageElementPlugin => {
     if (!element) {
         return null;
@@ -135,32 +100,44 @@ const Element = (props: ElementProps) => {
         return null;
     }
 
+    let renderedPlugin = null
+    try {
+        throw new Error("bahaha!!")
+        renderedPlugin = plugin.render({ theme, element })
+    } catch(err) {
+        renderedPlugin = (
+            <div>
+                <div>{err.message}</div>
+                <div>{err.stack}</div>
+            </div>
+        )
+        console.log(err)
+    }
+
     return (
-        <ErrorBoundary>
-            <Transition in={true} timeout={250} appear={true}>
-                {state => (
-                    <ElementContainer
-                        id={element.id}
-                        onMouseOver={onMouseOver}
-                        highlight={highlight}
-                        active={active}
-                        style={{ ...defaultStyle, ...transitionStyles[state] }}
-                        className={"webiny-pb-page-element-container"}
-                    >
-                        <div className={["innerWrapper", className].filter(c => c).join(" ")}>
-                            <Draggable target={plugin.target} beginDrag={beginDrag} endDrag={endDrag}>
-                                {renderDraggable}
-                            </Draggable>
-                            {plugin.render({ element })}
-                        </div>
-                        {/*
-                            <div className="add-element add-element--above">+</div>
-                            <div className="add-element add-element--below">+</div>
-                            */}
-                    </ElementContainer>
-                )}
-            </Transition>
-        </ErrorBoundary>
+        <Transition in={true} timeout={250} appear={true}>
+            {state => (
+                <ElementContainer
+                    id={element.id}
+                    onMouseOver={onMouseOver}
+                    highlight={highlight}
+                    active={active}
+                    style={{ ...defaultStyle, ...transitionStyles[state] }}
+                    className={"webiny-pb-page-element-container"}
+                >
+                    <div className={["innerWrapper", className].filter(c => c).join(" ")}>
+                        <Draggable target={plugin.target} beginDrag={beginDrag} endDrag={endDrag}>
+                            {renderDraggable}
+                        </Draggable>
+                        {renderedPlugin}
+                    </div>
+                    {/*
+                        <div className="add-element add-element--above">+</div>
+                        <div className="add-element add-element--below">+</div>
+                        */}
+                </ElementContainer>
+            )}
+        </Transition>
     );
 };
 

--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -20,6 +20,7 @@ import {
     transitionStyles,
     typeStyle
 } from "./Element/ElementStyled";
+import tryRenderingPlugin from "./../../utils/tryRenderingPlugin";
 
 export type ElementProps = {
     className?: string;
@@ -100,18 +101,7 @@ const Element = (props: ElementProps) => {
         return null;
     }
 
-    let renderedPlugin = null
-    try {
-        renderedPlugin = plugin.render({ element })
-    } catch(err) {
-        renderedPlugin = (
-            <div>
-                <div>{err.message}</div>
-                <div>{err.stack}</div>
-            </div>
-        )
-        console.log(err)
-    }
+    const renderedPlugin = tryRenderingPlugin(() => plugin.render({ element }));
 
     return (
         <Transition in={true} timeout={250} appear={true}>

--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -36,6 +36,41 @@ export type ElementProps = {
     dragging: boolean;
 };
 
+// Using a class element for a change because `componentDidCatch` only works with class elements ;/
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            error: null,
+            errorInfo: null
+        }
+    }
+
+    componentDidCatch(error, errorInfo) {
+        this.setState({
+            error,
+            errorInfo
+        })
+    }
+
+    render() {
+        if(this.state.error) {
+            return (
+                <div>
+                    <h3>An unexpected error has occurred</h3>
+                    <details>
+                        <div>{this.state.error.toString()}</div>
+                        <div>{this.state.errorInfo.componentStack}</div>
+                    </details>
+                </div>
+            )
+        }
+
+        return this.props.children
+    }
+}
+
+
 const getElementPlugin = (element): PbEditorPageElementPlugin => {
     if (!element) {
         return null;
@@ -101,29 +136,31 @@ const Element = (props: ElementProps) => {
     }
 
     return (
-        <Transition in={true} timeout={250} appear={true}>
-            {state => (
-                <ElementContainer
-                    id={element.id}
-                    onMouseOver={onMouseOver}
-                    highlight={highlight}
-                    active={active}
-                    style={{ ...defaultStyle, ...transitionStyles[state] }}
-                    className={"webiny-pb-page-element-container"}
-                >
-                    <div className={["innerWrapper", className].filter(c => c).join(" ")}>
-                        <Draggable target={plugin.target} beginDrag={beginDrag} endDrag={endDrag}>
-                            {renderDraggable}
-                        </Draggable>
-                        {plugin.render({ element })}
-                    </div>
-                    {/*
-                        <div className="add-element add-element--above">+</div>
-                        <div className="add-element add-element--below">+</div>
-                        */}
-                </ElementContainer>
-            )}
-        </Transition>
+        <ErrorBoundary>
+            <Transition in={true} timeout={250} appear={true}>
+                {state => (
+                    <ElementContainer
+                        id={element.id}
+                        onMouseOver={onMouseOver}
+                        highlight={highlight}
+                        active={active}
+                        style={{ ...defaultStyle, ...transitionStyles[state] }}
+                        className={"webiny-pb-page-element-container"}
+                    >
+                        <div className={["innerWrapper", className].filter(c => c).join(" ")}>
+                            <Draggable target={plugin.target} beginDrag={beginDrag} endDrag={endDrag}>
+                                {renderDraggable}
+                            </Draggable>
+                            {plugin.render({ element })}
+                        </div>
+                        {/*
+                            <div className="add-element add-element--above">+</div>
+                            <div className="add-element add-element--below">+</div>
+                            */}
+                    </ElementContainer>
+                )}
+            </Transition>
+        </ErrorBoundary>
     );
 };
 

--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -102,8 +102,7 @@ const Element = (props: ElementProps) => {
 
     let renderedPlugin = null
     try {
-        throw new Error("bahaha!!")
-        renderedPlugin = plugin.render({ theme, element })
+        renderedPlugin = plugin.render({ element })
     } catch(err) {
         renderedPlugin = (
             <div>

--- a/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
@@ -3,14 +3,20 @@ import ConnectedElement from "@webiny/app-page-builder/editor/components/Connect
 import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
 import RowContainer from "./RowContainer";
 import ElementAnimation from "@webiny/app-page-builder/render/components/ElementAnimation";
+// import tryRenderingPlugin from "./../../../../utils/tryRenderingPlugin";
 
 /**
  * TODO: this entire component can be further optimized (see the Chrome Profiler) to avoid unnecessary elements re-renders.
  */
 
 const Row = ({ element }) => {
+    // const x = tryRenderingPlugin(function asd() {
+    //     return <h3>Helloooooooooo there!!</h3>;
+    // });
     return (
         <ElementAnimation>
+            {/*Hello woooorld!*/}
+            {/*{x}*/}
             <ElementRoot
                 element={element}
                 className={"webiny-pb-base-page-element-style webiny-pb-layout-row"}

--- a/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
@@ -3,20 +3,13 @@ import ConnectedElement from "@webiny/app-page-builder/editor/components/Connect
 import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
 import RowContainer from "./RowContainer";
 import ElementAnimation from "@webiny/app-page-builder/render/components/ElementAnimation";
-import tryRenderingPlugin from "./../../../../utils/tryRenderingPlugin";
-
 /**
  * TODO: this entire component can be further optimized (see the Chrome Profiler) to avoid unnecessary elements re-renders.
  */
 
 const Row = ({ element }) => {
-    const x = tryRenderingPlugin(function asd() {
-        return <h3>Helloooooooooo there!!</h3>;
-    });
     return (
         <ElementAnimation>
-            Hello woooorld!
-            {x}
             <ElementRoot
                 element={element}
                 className={"webiny-pb-base-page-element-style webiny-pb-layout-row"}

--- a/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/row/Row.tsx
@@ -3,20 +3,20 @@ import ConnectedElement from "@webiny/app-page-builder/editor/components/Connect
 import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
 import RowContainer from "./RowContainer";
 import ElementAnimation from "@webiny/app-page-builder/render/components/ElementAnimation";
-// import tryRenderingPlugin from "./../../../../utils/tryRenderingPlugin";
+import tryRenderingPlugin from "./../../../../utils/tryRenderingPlugin";
 
 /**
  * TODO: this entire component can be further optimized (see the Chrome Profiler) to avoid unnecessary elements re-renders.
  */
 
 const Row = ({ element }) => {
-    // const x = tryRenderingPlugin(function asd() {
-    //     return <h3>Helloooooooooo there!!</h3>;
-    // });
+    const x = tryRenderingPlugin(function asd() {
+        return <h3>Helloooooooooo there!!</h3>;
+    });
     return (
         <ElementAnimation>
-            {/*Hello woooorld!*/}
-            {/*{x}*/}
+            Hello woooorld!
+            {x}
             <ElementRoot
                 element={element}
                 className={"webiny-pb-base-page-element-style webiny-pb-layout-row"}

--- a/packages/app-page-builder/src/render/components/Element.tsx
+++ b/packages/app-page-builder/src/render/components/Element.tsx
@@ -7,6 +7,40 @@ export type ElementProps = {
     element: PbElement;
 };
 
+// Using a class element for a change because `componentDidCatch` only works with class elements ;/
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            error: null,
+            errorInfo: null
+        }
+    }
+
+    componentDidCatch(error, errorInfo) {
+        this.setState({
+            error,
+            errorInfo
+        })
+    }
+
+    render() {
+        if(this.state.error) {
+            return (
+                <div>
+                    <h3>An unexpected error has occurred</h3>
+                    <details>
+                        <div>{this.state.error.toString()}</div>
+                        <div>{this.state.errorInfo.componentStack}</div>
+                    </details>
+                </div>
+            )
+        }
+
+        return this.props.children
+    }
+}
+
 const Element = (props: ElementProps) => {
     const { element } = props;
 
@@ -27,7 +61,7 @@ const Element = (props: ElementProps) => {
         return null;
     }
 
-    return <>{plugin.render({ theme, element })}</>;
+    return <ErrorBoundary>{plugin.render({ theme, element })}</ErrorBoundary>;
 };
 
 export default Element;

--- a/packages/app-page-builder/src/render/components/Element.tsx
+++ b/packages/app-page-builder/src/render/components/Element.tsx
@@ -7,40 +7,6 @@ export type ElementProps = {
     element: PbElement;
 };
 
-// Using a class element for a change because `componentDidCatch` only works with class elements ;/
-class ErrorBoundary extends React.Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            error: null,
-            errorInfo: null
-        }
-    }
-
-    componentDidCatch(error, errorInfo) {
-        this.setState({
-            error,
-            errorInfo
-        })
-    }
-
-    render() {
-        if(this.state.error) {
-            return (
-                <div>
-                    <h3>An unexpected error has occurred</h3>
-                    <details>
-                        <div>{this.state.error.toString()}</div>
-                        <div>{this.state.errorInfo.componentStack}</div>
-                    </details>
-                </div>
-            )
-        }
-
-        return this.props.children
-    }
-}
-
 const Element = (props: ElementProps) => {
     const { element } = props;
 
@@ -61,7 +27,21 @@ const Element = (props: ElementProps) => {
         return null;
     }
 
-    return <ErrorBoundary>{plugin.render({ theme, element })}</ErrorBoundary>;
+    let renderedPlugin = null
+    try {
+        throw new Error("bahaha!!")
+        renderedPlugin = plugin.render({ theme, element })
+    } catch(err) {
+        renderedPlugin = (
+            <div>
+                <div>{err.message}</div>
+                <div>{err.stack}</div>
+            </div>
+        )
+        console.log(err)
+    }
+
+    return <>{renderedPlugin}</>;
 };
 
 export default Element;

--- a/packages/app-page-builder/src/render/components/Element.tsx
+++ b/packages/app-page-builder/src/render/components/Element.tsx
@@ -3,6 +3,8 @@ import React, { useMemo } from "react";
 import { getPlugins } from "@webiny/plugins";
 import { PbElement, PbRenderElementPlugin, PbThemePlugin } from "@webiny/app-page-builder/types";
 
+import tryRenderingPlugin from "./../../utils/tryRenderingPlugin";
+
 export type ElementProps = {
     element: PbElement;
 };
@@ -27,18 +29,7 @@ const Element = (props: ElementProps) => {
         return null;
     }
 
-    let renderedPlugin = null
-    try {
-        renderedPlugin = plugin.render({ theme, element })
-    } catch(err) {
-        renderedPlugin = (
-            <div>
-                <div>{err.message}</div>
-                <div>{err.stack}</div>
-            </div>
-        )
-        console.log(err)
-    }
+    const renderedPlugin = tryRenderingPlugin(() => plugin.render({ theme, element }));
 
     return <>{renderedPlugin}</>;
 };

--- a/packages/app-page-builder/src/render/components/Element.tsx
+++ b/packages/app-page-builder/src/render/components/Element.tsx
@@ -29,7 +29,6 @@ const Element = (props: ElementProps) => {
 
     let renderedPlugin = null
     try {
-        throw new Error("bahaha!!")
         renderedPlugin = plugin.render({ theme, element })
     } catch(err) {
         renderedPlugin = (

--- a/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
+++ b/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const tryRenderingPlugin = fn => {
+    // console.log(fn.name);
+    try {
+        // if (fn.name === "asd") throw new Error("error1238523");
+        return fn();
+    } catch (err) {
+        console.log(err);
+        return (
+            <div style={{ padding: "15px", color: "rgb(206, 17, 38)" }}>
+                <div style={{ fontSize: "2.0em", paddingBottom: "5px" }}>
+                    An error has occurred: {err.message}
+                </div>
+                <div style={{ fontSize: "1.3em", color: "rgb(206, 17, 38)", padding: "10px" }}>
+                    Check the console for more information regarding the error.
+                </div>
+            </div>
+        );
+    }
+};
+
+export default tryRenderingPlugin;

--- a/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
+++ b/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
@@ -2,15 +2,12 @@ import React from "react";
 
 const tryRenderingPlugin = fn => {
     try {
-        // if (fn.name === "asd") throw new Error("error1238523");
         return fn();
     } catch (err) {
         console.log(err);
         return (
             <div style={{ paddingTop: "15px", paddingBottom: "15px", color: "rgb(206, 17, 38)" }}>
-                <div style={{ fontSize: "1.5em", paddingBottom: "5px" }}>
-                    An error has occurred: {err.message}
-                </div>
+                <div style={{ fontSize: "1.5em", paddingBottom: "5px" }}>Error: {err.message}</div>
                 <div style={{ fontSize: "1.1em", color: "rgb(206, 17, 38)" }}>
                     Check the console for more information regarding the error.
                 </div>

--- a/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
+++ b/packages/app-page-builder/src/utils/tryRenderingPlugin.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 
 const tryRenderingPlugin = fn => {
-    // console.log(fn.name);
     try {
         // if (fn.name === "asd") throw new Error("error1238523");
         return fn();
     } catch (err) {
         console.log(err);
         return (
-            <div style={{ padding: "15px", color: "rgb(206, 17, 38)" }}>
-                <div style={{ fontSize: "2.0em", paddingBottom: "5px" }}>
+            <div style={{ paddingTop: "15px", paddingBottom: "15px", color: "rgb(206, 17, 38)" }}>
+                <div style={{ fontSize: "1.5em", paddingBottom: "5px" }}>
                     An error has occurred: {err.message}
                 </div>
-                <div style={{ fontSize: "1.3em", color: "rgb(206, 17, 38)", padding: "10px" }}>
+                <div style={{ fontSize: "1.1em", color: "rgb(206, 17, 38)" }}>
                     Check the console for more information regarding the error.
                 </div>
             </div>


### PR DESCRIPTION
## Related Issue
#686 

## Your solution
Wrapped the two `Element.tsx` components inside Error Boundaries.

## How Has This Been Tested?
The `Render` `Element ` was tested by opening up the Pages. Here we clearly see an `Element` component which I've tested by intentionally throwing an error inside the Error Boundary.

![image](https://user-images.githubusercontent.com/16700631/75166560-b3816280-572c-11ea-8670-ea1345049dc7.png)
