### PR TITLE
WIP - Cache invalidation when updating PB settings

### DIFF
--- a/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
@@ -3,7 +3,6 @@ import {
     withStaticProps,
     withProps,
     withName,
-    withHooks,
     string,
     date,
     fields,
@@ -119,17 +118,6 @@ export default ({ createBase, context }) => {
                     })
                 })()
             })
-        }),
-        withHooks({
-            async afterSave() {
-                const getPluginByName = () => () =>
-                    "gimme le plugin (i actually haven't imported the proper function here bc idk if this really is a good implementation. Saving time ftw!)";
-                const invalidateCachePlugin = getPluginByName(
-                    "pb-install-invalidate-previous-homepage-cache"
-                );
-
-                invalidateCachePlugin();
-            }
         })
     )(createBase());
 };

--- a/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
@@ -3,6 +3,7 @@ import {
     withStaticProps,
     withProps,
     withName,
+    withHooks,
     string,
     date,
     fields,
@@ -118,6 +119,17 @@ export default ({ createBase, context }) => {
                     })
                 })()
             })
+        }),
+        withHooks({
+            async afterSave() {
+                const getPluginByName = () => () =>
+                    "gimme le plugin (i actually haven't imported the proper function here bc idk if this really is a good implementation. Saving time ftw!)";
+                const invalidateCachePlugin = getPluginByName(
+                    "pb-install-invalidate-previous-homepage-cache"
+                );
+
+                invalidateCachePlugin();
+            }
         })
     )(createBase());
 };

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -102,6 +102,20 @@ export default () => [
         }
     },
     {
+        type: "graphql-context",
+        name: "graphql-context-invalidate-cache-on-pb-settings-save",
+        apply({ ssrApiClient, models: { PbSettings } }) {
+            withHooks({
+                async afterSave() {
+                    await ssrApiClient.invalidateSsrCacheByTags({
+                        tags: [{ class: "pb-menu" }],
+                        refresh: true
+                    });
+                }
+            })(PbSettings);
+        }
+    },
+    {
         // After successful installation, GET requests will be issued to initially installed pages.
         // This is fine, but if a user visited the homepage first (without going straight to "/admin", which is
         // a frequent case), that page will get cached unfortunately, and we need to invalidate it. There could be

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -70,7 +70,6 @@ export default () => [
                         } catch {
                             // Do nothing.
                         }
-                        removeCallback();
                     });
                 }
             })(PbSettings);
@@ -82,21 +81,25 @@ export default () => [
         name: "graphql-context-extend-pb-page-pb-menu-invalidate-ssr-cache-cache-menu",
         apply({ ssrApiClient, models: { PbMenu } }) {
             // If the menu has changed, we need to delete page caches.
+            console.log("[Andrei] Outside the hook");
             withHooks({
                 async beforeSave() {
+                    console.log("[Andrei] Inside the hook");
+                    await ssrApiClient.invalidateAllSsrCache();
+
                     // If menus structure has changed, we need to invalidate SSR caches that contain this menu.
-                    if (this.isDirty()) {
-                        const removeCallback = this.hook("afterSave", async () => {
-                            try {
-                                await ssrApiClient.invalidateSsrCacheByTags({
-                                    tags: [{ class: "pb-menu", id: this.slug }]
-                                });
-                            } catch {
-                                // Do nothing.
-                            }
-                            removeCallback();
-                        });
-                    }
+                    // if (this.isDirty()) {
+                    //     const removeCallback = this.hook("afterSave", async () => {
+                    //         try {
+                    //             await ssrApiClient.invalidateSsrCacheByTags({
+                    //                 tags: [{ class: "pb-menu", id: this.slug }]
+                    //             });
+                    //         } catch {
+                    //             // Do nothing.
+                    //         }
+                    //         removeCallback();
+                    //     });
+                    // }
                 }
             })(PbMenu);
         }
@@ -107,10 +110,7 @@ export default () => [
         apply({ ssrApiClient, models: { PbSettings } }) {
             withHooks({
                 async afterSave() {
-                    await ssrApiClient.invalidateSsrCacheByTags({
-                        tags: [{ class: "pb-menu" }],
-                        refresh: true
-                    });
+                    await ssrApiClient.invalidateAllSsrCache();
                 }
             })(PbSettings);
         }

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -70,6 +70,7 @@ export default () => [
                         } catch {
                             // Do nothing.
                         }
+                        removeCallback();
                     });
                 }
             })(PbSettings);

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -81,25 +81,21 @@ export default () => [
         name: "graphql-context-extend-pb-page-pb-menu-invalidate-ssr-cache-cache-menu",
         apply({ ssrApiClient, models: { PbMenu } }) {
             // If the menu has changed, we need to delete page caches.
-            console.log("[Andrei] Outside the hook");
             withHooks({
                 async beforeSave() {
-                    console.log("[Andrei] Inside the hook");
-                    await ssrApiClient.invalidateAllSsrCache();
-
                     // If menus structure has changed, we need to invalidate SSR caches that contain this menu.
-                    // if (this.isDirty()) {
-                    //     const removeCallback = this.hook("afterSave", async () => {
-                    //         try {
-                    //             await ssrApiClient.invalidateSsrCacheByTags({
-                    //                 tags: [{ class: "pb-menu", id: this.slug }]
-                    //             });
-                    //         } catch {
-                    //             // Do nothing.
-                    //         }
-                    //         removeCallback();
-                    //     });
-                    // }
+                    if (this.isDirty()) {
+                        const removeCallback = this.hook("afterSave", async () => {
+                            try {
+                                await ssrApiClient.invalidateSsrCacheByTags({
+                                    tags: [{ class: "pb-menu", id: this.slug }]
+                                });
+                            } catch {
+                                // Do nothing.
+                            }
+                            removeCallback();
+                        });
+                    }
                 }
             })(PbMenu);
         }

--- a/packages/http-handler-ssr/src/Client.ts
+++ b/packages/http-handler-ssr/src/Client.ts
@@ -1,11 +1,7 @@
 import got from "got";
+import { API_ACTION } from "./common";
 
-const API_ACTION = {
-    INVALIDATE_SSR_CACHE_BY_PATH: "invalidateSsrCacheByPath",
-    INVALIDATE_SSR_CACHE_BY_TAGS: "invalidateSsrCacheByTags"
-};
-
-const ssrApiCall = async ({ url, action, actionPayload, async }) => {
+const ssrApiCall = async ({ url, action, actionPayload = {}, async }) => {
     const args = {
         method: "POST",
         body: JSON.stringify({ ssr: [action, actionPayload] })
@@ -69,6 +65,14 @@ export default class Client {
             url: this.url,
             action: API_ACTION.INVALIDATE_SSR_CACHE_BY_TAGS,
             actionPayload: { tags },
+            async
+        });
+    }
+
+    async invalidateAllSsrCache({ async = true } = {}) {
+        await ssrApiCall({
+            url: this.url,
+            action: API_ACTION.INVALIDATE_SSR_CACHE_ALL,
             async
         });
     }

--- a/packages/http-handler-ssr/src/common.ts
+++ b/packages/http-handler-ssr/src/common.ts
@@ -1,0 +1,5 @@
+export const API_ACTION = {
+    INVALIDATE_SSR_CACHE_BY_PATH: "invalidateSsrCacheByPath",
+    INVALIDATE_SSR_CACHE_BY_TAGS: "invalidateSsrCacheByTags",
+    INVALIDATE_SSR_CACHE_ALL: "invalidateAllSsrCache"
+};

--- a/packages/http-handler-ssr/src/ssrServe.ts
+++ b/packages/http-handler-ssr/src/ssrServe.ts
@@ -46,10 +46,13 @@ export default (options): HttpHandlerPlugin => {
                                 ...event,
                                 httpMethod: "POST",
                                 body: {
-                                    ssr: ["invalidateSsrCacheByPath", {
-                                        path: ssrCache.path,
-                                        refresh: true,
-                                    }]
+                                    ssr: [
+                                        "invalidateSsrCacheByPath",
+                                        {
+                                            path: ssrCache.path,
+                                            refresh: true
+                                        }
+                                    ]
                                 }
                             })
                         }).promise();


### PR DESCRIPTION
## Related Issue
#727 

## Your solution
I've written an `afterSave` hook in `withHook` (as advised: thanks, Adrian!). It doesn't correctly get the plugin at the moment, but perhaps this is a good stab at solving the issue. I'll need a few opinions here.

## How Has This Been Tested?
It will be tested by deploying the app, changing a few settings and seeing if the cache is cleared (ie: changing the site's name) since cache clearing can't be tested locally yet.