### PR TITLE
fix: tags search & "Pages List" menu item site rendering

### DIFF
--- a/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
+++ b/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
@@ -1,0 +1,76 @@
+import uniqid from "uniqid";
+
+context("Menus Module", () => {
+    beforeEach(() => cy.login());
+
+    it(`"pages List" menu item type should work as expected`, () => {
+        const id = uniqid();
+        cy.visit("/page-builder/menus");
+
+        cy.wait(500)
+            .findByTestId("default-data-list")
+            .within(() => {
+                cy.get("div")
+                    .first()
+                    .within(() => {
+                        cy.findByText(/Main Menu/i).click();
+                    });
+            });
+
+        // Test "Page List".
+        cy.findByText(/\+ Add Menu Item/i)
+            .click()
+            .findByText("Page list")
+            .click()
+            .findByLabelText("Title")
+            .type(`Page List ${id}`)
+            .findByText(/Save Menu Item/i)
+            .click()
+            .wait(200)
+            .findByText("Value is required.")
+            .should("exist")
+            .findByLabelText("Category")
+            .type(`Static`)
+            .findByText("Static")
+            .click()
+            .findByText("Sort by...")
+            .prev()
+            .select("Title")
+            .findByText("Sort direction...")
+            .prev()
+            .select("Descending")
+            .findByLabelText("Tags")
+            .type(`err`)
+            .findByText("error")
+            .click()
+            .findByLabelText("Tags")
+            .type(`no`)
+            .findByText("not-found")
+            .click()
+
+            .findByLabelText("Tags")
+            .type(`some-custom-tag`)
+            .findByText(`some-custom-tag`)
+            .click();
+
+        cy.findByText(/Save Menu Item/i)
+            .click()
+            .findByText("Save menu")
+            .click()
+            .visit(Cypress.env("SITE_URL"))
+            .wait(30000);
+
+        cy.visit(Cypress.env("SITE_URL"))
+            .findByTestId("pb-desktop-header")
+            .within(() => {
+                cy.findByText(`Page List ${id}`)
+                    .should("exist")
+                    .findByText(/404/i)
+                    .should("exist")
+                    .findByText(/error page/i)
+                    .should("exist");
+            });
+
+        cy.visit("/page-builder/menus");
+    });
+});

--- a/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
+++ b/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
@@ -23,7 +23,7 @@ context("Menus Module", () => {
             .findByText("Page list")
             .click()
             .findByLabelText("Title")
-            .type(`Page List ${id}`)
+            .type(id)
             .findByText(/Save Menu Item/i)
             .click()
             .wait(200)
@@ -57,20 +57,57 @@ context("Menus Module", () => {
             .click()
             .findByText("Save menu")
             .click()
+            .wait(2000)
             .visit(Cypress.env("SITE_URL"))
             .wait(30000);
 
         cy.visit(Cypress.env("SITE_URL"))
             .findByTestId("pb-desktop-header")
             .within(() => {
-                cy.findByText(`Page List ${id}`)
-                    .should("exist")
-                    .findByText(/404/i)
-                    .should("exist")
-                    .findByText(/error page/i)
-                    .should("exist");
+                // Let's check the links and the order.
+                cy.findByText(id).within(() => {
+                    cy.get("ul li:nth-child(1)").contains(/error page/i);
+                    cy.get("ul li:nth-child(2)").contains(/404/i);
+                });
             });
 
         cy.visit("/page-builder/menus");
+
+        // Let's return to the admin and change the ordering of links.
+        cy.wait(500)
+            .findByTestId("default-data-list")
+            .within(() => {
+                cy.get("div")
+                    .first()
+                    .within(() => {
+                        cy.findByText(/Main Menu/i).click();
+                    });
+            });
+
+        cy.findByTestId(`pb-menu-item-render-${id}`).within(() => {
+            cy.findByTestId("pb-edit-icon-button").click();
+        });
+
+        cy.findByText("Sort direction...")
+            .prev()
+            .select("Ascending");
+
+        cy.findByText(/Save Menu Item/i)
+            .click()
+            .findByText("Save menu")
+            .click()
+            .wait(2000)
+            .visit(Cypress.env("SITE_URL"))
+            .wait(30000);
+
+        cy.visit(Cypress.env("SITE_URL"))
+            .findByTestId("pb-desktop-header")
+            .within(() => {
+                // Let's check the links and the order.
+                cy.findByText(id).within(() => {
+                    cy.get("ul li:nth-child(1)").contains(/404/i);
+                    cy.get("ul li:nth-child(2)").contains(/error page/i);
+                });
+            });
     });
 });

--- a/packages/api-page-builder/src/plugins/graphql/Page.ts
+++ b/packages/api-page-builder/src/plugins/graphql/Page.ts
@@ -284,7 +284,7 @@ export default {
             ) => {
                 const resolver = context.plugins.byName("pb-resolver-search-tags");
 
-                return await resolver.resolve({ root, args, context, info });
+                return { data: await resolver.resolve({ root, args, context, info }) };
             },
             oembedData: oembed
         },

--- a/packages/app-admin/src/components/SimpleForm/SimpleForm.tsx
+++ b/packages/app-admin/src/components/SimpleForm/SimpleForm.tsx
@@ -41,9 +41,13 @@ const footer = css({
     }
 });
 
-export const SimpleForm = (props: { children: React.ReactNode; noElevation?: boolean }) => {
+export const SimpleForm = (props: {
+    "data-testid"?: string;
+    children: React.ReactNode;
+    noElevation?: boolean;
+}) => {
     return (
-        <SimpleFormContainer className={"webiny-data-list"}>
+        <SimpleFormContainer className={"webiny-data-list"} data-testid={props["data-testid"]}>
             {props.noElevation ? props.children : <Elevation z={1}>{props.children}</Elevation>}
         </SimpleFormContainer>
     );

--- a/packages/app-page-builder-theme/src/components/DesktopHeader.tsx
+++ b/packages/app-page-builder-theme/src/components/DesktopHeader.tsx
@@ -15,7 +15,10 @@ const DesktopHeader = ({
     name: string;
 }) => {
     return (
-        <div className="webiny-pb-section-header__wrapper hide-on-mobile">
+        <div
+            className="webiny-pb-section-header__wrapper hide-on-mobile"
+            data-testid={"pb-desktop-header"}
+        >
             <div className={"webiny-pb-section-header__logo"}>
                 <Link to="/">
                     {logo && logo.src && <img src={logo.src} alt={name} />}{" "}

--- a/packages/app-page-builder-theme/src/components/Header.tsx
+++ b/packages/app-page-builder-theme/src/components/Header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
 
                 return (
                     <React.Fragment>
-                        <div className={"webiny-pb-section-header"}>
+                        <div className={"webiny-pb-section-header"} data-testid={"pb-desktop-mobile-headers"}>
                             <DesktopHeader menuName={menuName} name={name} logo={logo} />
                             <MobileHeader
                                 menuName={menuName}

--- a/packages/app-page-builder-theme/src/components/MobileHeader.tsx
+++ b/packages/app-page-builder-theme/src/components/MobileHeader.tsx
@@ -7,7 +7,7 @@ import Navigation from "./Navigation";
 
 const MobileHeader = ({ menuName, logo, name, active, toggleMenu }) => {
     return (
-        <div className="webiny-pb-section-header__wrapper hide-on-desktop-and-tablet">
+        <div className="webiny-pb-section-header__wrapper hide-on-desktop-and-tablet" data-testid={"pb-mobile-header"}>
             <div className={"webiny-pb-section-header__logo"}>
                 <Link to="/">
                     {logo && logo.src && <img src={logo.src} alt={name} />}{" "}

--- a/packages/app-page-builder/src/admin/views/Menus/MenusForm.tsx
+++ b/packages/app-page-builder/src/admin/views/Menus/MenusForm.tsx
@@ -22,7 +22,7 @@ function MenusForm() {
     return (
         <Form {...crudForm} data={crudForm.id ? crudForm.data : { items: [] }}>
             {({ data, form, Bind }) => (
-                <SimpleForm>
+                <SimpleForm data-testid={"pb-menus-form"}>
                     {crudForm.loading && <CircularProgress />}
                     <SimpleFormContent>
                         <Grid>

--- a/packages/app-page-builder/src/admin/views/Menus/MenusForm/MenuItems/MenuItemRenderer.tsx
+++ b/packages/app-page-builder/src/admin/views/Menus/MenusForm/MenuItems/MenuItemRenderer.tsx
@@ -71,7 +71,7 @@ class NodeRendererDefault extends React.Component<any> {
         const buttonStyle = { left: -0.5 * scaffoldBlockPxWidth };
 
         return (
-            <div style={{ height: "100%" }} data-testid={`pb-menu-item-render-${node.id}`}>
+            <div style={{ height: "100%" }} data-testid={`pb-menu-item-render-${nodeTitle}`}>
                 {toggleChildrenVisibility &&
                     node.children &&
                     (node.children.length > 0 || typeof node.children === "function") && (

--- a/packages/app-page-builder/src/admin/views/Menus/MenusForm/MenuItems/MenuItemRenderer.tsx
+++ b/packages/app-page-builder/src/admin/views/Menus/MenusForm/MenuItems/MenuItemRenderer.tsx
@@ -47,6 +47,7 @@ class NodeRendererDefault extends React.Component<any> {
             style,
             didDrop
         } = this.props;
+
         const nodeTitle = title || node.title;
 
         const plugins = getPlugins("pb-menu-item") as PbMenuItemPlugin[];
@@ -70,7 +71,7 @@ class NodeRendererDefault extends React.Component<any> {
         const buttonStyle = { left: -0.5 * scaffoldBlockPxWidth };
 
         return (
-            <div style={{ height: "100%" }}>
+            <div style={{ height: "100%" }} data-testid={`pb-menu-item-render-${node.id}`}>
                 {toggleChildrenVisibility &&
                     node.children &&
                     (node.children.length > 0 || typeof node.children === "function") && (
@@ -136,10 +137,12 @@ class NodeRendererDefault extends React.Component<any> {
 
                                     <div className="rst__rowToolbar">
                                         <IconButton
+                                            data-testid={"pb-edit-icon-button"}
                                             icon={<EditIcon />}
                                             onClick={() => editItem(node)}
                                         />
                                         <IconButton
+                                            data-testid={"pb-delete-icon-button"}
                                             icon={<DeleteIcon />}
                                             onClick={() => deleteItem(node)}
                                         />


### PR DESCRIPTION
## Related Issue
#731 

## Your solution
A couple of issues here.

First, the GraphQL query would not return the pages that need to be shown in the drop-down menu. This is because the modifier name was incorrect (`packages/api-page-builder/src/plugins/graphql/menuResolvers/prepareMenuItems.ts:112`). But even if it was correct, the code in there would still not work, had some refactor leftovers there as well.

Secondly, @Pavel910 also noticed the tags search input didn't work. I inspected that and found an error in the GraphQL resolver (`packages/api-page-builder/src/plugins/graphql/Page.ts`), so that was taken care of too.

## How Has This Been Tested?
Added Cypress tests that check if the "pages list" menu item type is working on the public-facing site. And to make sure the tags search is working as expected, I've used `error` and `not-found` tags when defining which pages need to be shown in the drop-down menu. 

![image](https://user-images.githubusercontent.com/5121148/75624943-a1cf0d80-5bb9-11ea-9e14-95da8697fbf1.png)

Finally, just while I was at it, I also tested that the ordering of pages is working as expected (Ascending/Descending).

![image](https://user-images.githubusercontent.com/5121148/75624947-a98eb200-5bb9-11ea-97c9-cada48cacf11.png)

All tests are passing 😀 
![image](https://user-images.githubusercontent.com/5121148/75624822-39cbf780-5bb8-11ea-99f6-36d33546cd48.png)

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/75624841-844d7400-5bb8-11ea-9517-3f45a8d1a570.png)
