### PR TITLE
change hint to examples/.env.json when running setup-repo

### DIFF
--- a/scripts/setupRepo.js
+++ b/scripts/setupRepo.js
@@ -80,9 +80,7 @@ const execa = require("execa");
         });
         console.log(`✅️ Packages were built successfully!`);
     } catch (err) {
-        console.log(
-            `🚨 Failed to build packages: ${err.message}`
-        );
+        console.log(`🚨 Failed to build packages: ${err.message}`);
     }
 
     // Link `@webiny/cli`
@@ -108,7 +106,7 @@ const execa = require("execa");
     console.log(`\n🏁 Your repo is almost ready!`);
     console.log(
         `Update ${green(
-            "examples/api/.env.json"
+            "examples/.env.json"
         )} with your MongoDB connection string and you're ready to develop!\n`
     );
 })();


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The hint when you run `yarn setup-repo` is wrong because the mongoDB connection string is in examples/.env.json, not examples/api/.env.json

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->
I changed the hint about path to .env.json that point to mongoDB connection

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run `yarn setup-repo`

## Screenshots (if relevant):