### PR TITLE
feat: improved scopes selection auto-complete component

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,11 +4,12 @@
   "baseUrl": "http://localhost:3001",
   "defaultCommandTimeout": 10000,
   "env": {
-    "AWS_COGNITO_USER_POOL_ID": "eu-central-1_LGh6br2ix",
-    "AWS_COGNITO_CLIENT_ID": "561rp7m88m81t4jgdvq1j5eobf",
-    "API_URL": "https://d1cfsi9llzrdlf.cloudfront.net",
-    "DEFAULT_ADMIN_USER_USERNAME": "asd@net.hr",
+    "SITE_URL": "http://localhost:3000",
+    "AWS_COGNITO_USER_POOL_ID": "eu-central-1_4rzqiPNHm",
+    "AWS_COGNITO_CLIENT_ID": "1agul1e3ge3afpb4a0vsrqtuhb",
+    "API_URL": "https://d2sj4ukj5xxt5i.cloudfront.net",
+    "DEFAULT_ADMIN_USER_USERNAME": "admin@webiny.com",
     "DEFAULT_ADMIN_USER_PASSWORD": "12345678",
-    "GRAPHQL_API_URL": "https://d1cfsi9llzrdlf.cloudfront.net/graphql"
+    "GRAPHQL_API_URL": "https://d2sj4ukj5xxt5i.cloudfront.net/graphql"
   }
 }

--- a/cypress/integration/admin/security/roles/createGroup.spec.js
+++ b/cypress/integration/admin/security/roles/createGroup.spec.js
@@ -1,0 +1,91 @@
+import uniqid from "uniqid";
+
+context("Groups Module", () => {
+    beforeEach(() => cy.login());
+
+    it("should be able to create, edit, and immediately delete a group", () => {
+        const id = uniqid();
+        cy.visit("/groups")
+            .findByLabelText("Name")
+            .type(`Test Group ${id}`)
+            .findByText("Save group")
+            .click()
+            .findByText("Value is required.")
+            .should("exist")
+            .findByLabelText("Slug")
+            .type(`test-group-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save group")
+            .click();
+
+        cy.wait(500)
+            .findByText("Record saved successfully.")
+            .should("exist");
+
+        cy.findByLabelText("Slug")
+            .type("-edited")
+            .findByLabelText("Description")
+            .type(" Test test.")
+            .findByText("Save group")
+            .click();
+
+        cy.wait(500)
+            .findByTestId("default-data-list")
+            .within(() => {
+                cy.get("div")
+                    .first()
+                    .within(() => {
+                        cy.findByText(`Test Group ${id}`)
+                            .should("exist")
+                            .findByText("This is a test test. Test test.")
+                            .should("exist");
+                        cy.get("button").click({ force: true });
+                    });
+            });
+
+        cy.get('[role="alertdialog"] :visible').within(() => {
+            cy.contains("Are you sure you want to continue?")
+                .next()
+                .within(() => cy.findByText("Confirm").click());
+        });
+
+        cy.findByText("Record deleted successfully.").should("exist");
+        cy.findByTestId("default-data-list").within(() => {
+            cy.findByText(`Test Group ${id}`).should("not.exist");
+        });
+    });
+
+    it("groups with the same slug should not be allowed - an error message must be shown", () => {
+        const id = uniqid();
+        cy.visit("/groups")
+            .findByLabelText("Name")
+            .type(`Test Group ${id}`)
+            .findByText("Save group")
+            .findByLabelText("Slug")
+            .type(`test-group-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save group")
+            .click()
+            .wait(1500);
+
+        cy.findByTestId("new-record-button")
+            .click()
+            .findByLabelText("Name")
+            .type(`Test Group ${id}`)
+            .findByText("Save group")
+            .findByLabelText("Slug")
+            .type(`test-group-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save group")
+            .click();
+
+        cy.wait(500)
+            .get('[role="alertdialog"] :visible')
+            .within(() => {
+                cy.findByText(`Group with slug "test-group-${id}" already exists.`).should("exist");
+            });
+    });
+});

--- a/cypress/integration/admin/security/roles/createRole.spec.js
+++ b/cypress/integration/admin/security/roles/createRole.spec.js
@@ -99,7 +99,7 @@ context("Roles Module", () => {
             });
     });
 
-    it.only("should save scopes correctly", () => {
+    it("should save scopes correctly", () => {
         const id = uniqid();
         cy.visit("/roles")
             .findByLabelText("Name")

--- a/cypress/integration/admin/security/roles/createRole.spec.js
+++ b/cypress/integration/admin/security/roles/createRole.spec.js
@@ -1,0 +1,132 @@
+import uniqid from "uniqid";
+
+context("Roles Module", () => {
+    beforeEach(() => cy.login());
+
+    it("should be able to create, edit, and immediately delete a role", () => {
+        const id = uniqid();
+        cy.visit("/roles")
+            .findByLabelText("Name")
+            .type(`Test Role ${id}`)
+            .findByText("Save role")
+            .click()
+            .findByText("Value is required.")
+            .should("exist")
+            .findByLabelText("Slug")
+            .type(`test-role-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save role")
+            .click();
+
+        cy.wait(500)
+            .findByText("Record saved successfully.")
+            .should("exist");
+
+        cy.findByLabelText("Slug")
+            .type("-edited")
+            .findByLabelText("Description")
+            .type(" Test test.");
+
+        // Check if the scopes auto-complete is working.
+        cy.findByLabelText("Scopes")
+            .type(`revi`)
+            .findByText("Publish form revisions")
+            .click()
+            .findByLabelText("Scopes")
+            .type(`revi`)
+            .findByText("Unpublish form revisions")
+            .click();
+
+        cy.findByText("Save role").click();
+
+        cy.wait(500)
+            .findByTestId("default-data-list")
+            .within(() => {
+                cy.get("div")
+                    .first()
+                    .within(() => {
+                        cy.findByText(`Test Role ${id}`)
+                            .should("exist")
+                            .findByText("This is a test test. Test test.")
+                            .should("exist");
+                        cy.get("button").click({ force: true });
+                    });
+            });
+
+        cy.get('[role="alertdialog"] :visible').within(() => {
+            cy.contains("Are you sure you want to continue?")
+                .next()
+                .within(() => cy.findByText("Confirm").click());
+        });
+
+        cy.findByText("Record deleted successfully.").should("exist");
+        cy.findByTestId("default-data-list").within(() => {
+            cy.findByText(`Test Role ${id}`).should("not.exist");
+        });
+    });
+
+    it("roles with the same slug should not be allowed - an error message must be shown", () => {
+        const id = uniqid();
+        cy.visit("/roles")
+            .findByLabelText("Name")
+            .type(`Test Role ${id}`)
+            .findByText("Save role")
+            .findByLabelText("Slug")
+            .type(`test-role-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save role")
+            .click()
+            .wait(1500);
+
+        cy.findByTestId("new-record-button")
+            .click()
+            .findByLabelText("Name")
+            .type(`Test Role ${id}`)
+            .findByText("Save role")
+            .findByLabelText("Slug")
+            .type(`test-role-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByText("Save role")
+            .click();
+
+        cy.wait(500)
+            .get('[role="alertdialog"] :visible')
+            .within(() => {
+                cy.findByText(`Role with slug "test-role-${id}" already exists.`).should("exist");
+            });
+    });
+
+    it.only("should save scopes correctly", () => {
+        const id = uniqid();
+        cy.visit("/roles")
+            .findByLabelText("Name")
+            .type(`Test Role ${id}`)
+            .findByLabelText("Slug")
+            .type(`test-role-${id}`)
+            .findByLabelText("Description")
+            .type("This is a test test.")
+            .findByLabelText("Scopes")
+            .type(`revi`)
+            .findByText("Publish form revisions")
+            .click()
+            .findByLabelText("Scopes")
+            .type(`revi`)
+            .findByText("Unpublish form revisions")
+            .click()
+            .findByText("Save role")
+            .click();
+
+        cy.wait(2500)
+            .reload()
+            .findByTestId("default-form")
+            .within(() => {
+                cy.findByText("forms:form:revision:publish")
+                    .should("exist")
+                    .findByText("forms:form:revision:unpublish")
+                    .should("exist");
+            });
+    });
+});

--- a/packages/api-form-builder/src/plugins/graphql.ts
+++ b/packages/api-form-builder/src/plugins/graphql.ts
@@ -104,12 +104,12 @@ const plugin: GraphQLSchemaPlugin = {
                 updateSettings: hasScope("forms:settings"),
                 createForm: hasScope("forms:form:crud"),
                 deleteForm: hasScope("forms:form:crud"),
-                createRevisionFrom: hasScope("forms:form:revision:create"),
-                updateRevision: hasScope("forms:form:revision:update"),
+                createRevisionFrom: hasScope("forms:form:crud"),
+                updateRevision: hasScope("forms:form:crud"),
                 publishRevision: hasScope("forms:form:revision:publish"),
                 unpublishRevision: hasScope("forms:form:revision:unpublish"),
-                deleteRevision: hasScope("forms:form:revision:delete"),
-                exportFormSubmissions: hasScope("forms:form:submission:export")
+                deleteRevision: hasScope("forms:form:crud"),
+                exportFormSubmissions: hasScope("forms:form:submissions:export")
                 // saveFormView: hasScope("forms:form:revision:delete") // Expose publicly.
                 // createFormSubmission: hasScope("forms:form:revision:delete") // Expose publicly.
             }

--- a/packages/api-form-builder/src/plugins/graphql.ts
+++ b/packages/api-form-builder/src/plugins/graphql.ts
@@ -93,7 +93,7 @@ const plugin: GraphQLSchemaPlugin = {
     security: {
         shield: {
             FormsQuery: {
-                getSettings: hasScope("cms:settings"),
+                getSettings: hasScope("forms:settings"),
                 getForm: hasScope("forms:form:crud"),
                 listForms: hasScope("forms:form:crud"),
                 listFormSubmissions: hasScope("forms:form:crud")
@@ -101,7 +101,7 @@ const plugin: GraphQLSchemaPlugin = {
                 // getPublishedForms: hasScope("forms:form:crud") // Expose publicly.
             },
             FormsMutation: {
-                updateSettings: hasScope("cms:settings"),
+                updateSettings: hasScope("forms:settings"),
                 createForm: hasScope("forms:form:crud"),
                 deleteForm: hasScope("forms:form:crud"),
                 createRevisionFrom: hasScope("forms:form:revision:create"),

--- a/packages/api-page-builder/src/plugins/graphql.ts
+++ b/packages/api-page-builder/src/plugins/graphql.ts
@@ -110,10 +110,10 @@ export default {
                 createPage: hasScope("pb:page:crud"),
                 deletePage: hasScope("pb:page:crud"),
 
-                createRevisionFrom: hasScope("pb:page:revision:create"),
-                updateRevision: hasScope("pb:page:revision:update"),
-                publishRevision: hasScope("pb:page:revision:publish"),
-                deleteRevision: hasScope("pb:page:revision:delete"),
+                createRevisionFrom: hasScope("pb:page:crud"),
+                updateRevision: hasScope("pb:page:crud"),
+                publishRevision: hasScope("pb:page:crud"),
+                deleteRevision: hasScope("pb:page:crud"),
 
                 createElement: hasScope("pb:element:crud"),
                 updateElement: hasScope("pb:element:crud"),

--- a/packages/api-security/src/plugins/graphql.ts
+++ b/packages/api-security/src/plugins/graphql.ts
@@ -2,7 +2,7 @@ import { merge } from "lodash";
 import gql from "graphql-tag";
 import { emptyResolver } from "@webiny/commodo-graphql";
 import { GraphQLSchemaPlugin } from "@webiny/api/types";
-import { getRegisteredScopes, hasScope } from "@webiny/api-security";
+import { hasScope } from "@webiny/api-security";
 
 import role from "./graphql/Role";
 import group from "./graphql/Group";
@@ -19,8 +19,7 @@ const plugin: GraphQLSchemaPlugin = {
             }
 
             type SecurityQuery {
-                # Returns all scopes that were registered throughout the schema.
-                scopes: [String]
+                _empty: String
             }
 
             type SecurityMutation {
@@ -59,9 +58,6 @@ const plugin: GraphQLSchemaPlugin = {
                 Mutation: {
                     security: emptyResolver
                 },
-                SecurityQuery: {
-                    scopes: getRegisteredScopes
-                }
             },
             install.resolvers,
             role.resolvers,

--- a/packages/api-security/src/scopes.ts
+++ b/packages/api-security/src/scopes.ts
@@ -1,24 +1,6 @@
 import { rule } from "graphql-shield";
-/**
- * Contains a list of all registered scopes throughout GraphQL Schema.
- * @type {Array}
- */
-export const __scopes = {
-    registered: []
-};
-
-export const registerScopes = (...scopes: Array<string>) => {
-    scopes.forEach(scope => {
-        __scopes.registered.includes(scope) === false && __scopes.registered.push(scope);
-    });
-};
-
-export const getRegisteredScopes = () => {
-    return __scopes.registered;
-};
 
 export const hasScope = (scope: string) => {
-    registerScopes(scope);
     return rule()(async (parent, args, ctx) => {
         if (!ctx.user) {
             return false;

--- a/packages/app-form-builder/src/admin/plugins/index.ts
+++ b/packages/app-form-builder/src/admin/plugins/index.ts
@@ -12,6 +12,7 @@ import previewContent from "./formDetails/previewContent";
 import formRevisions from "./formDetails/formRevisions";
 import formSubmissions from "./formDetails/formSubmissions";
 import install from "./install";
+import scopesList from "./scopesList";
 
 export default [
     install,
@@ -21,6 +22,7 @@ export default [
     formSubmissions,
     previewContent,
     formRevisions,
+    scopesList,
 
     // Editor
     fields,

--- a/packages/app-form-builder/src/admin/plugins/scopesList.ts
+++ b/packages/app-form-builder/src/admin/plugins/scopesList.ts
@@ -1,0 +1,38 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-form-builder/admin/scopesList");
+
+export default [
+    {
+        name: "security-scopes-list-form-builder",
+        type: "security-scopes-list",
+        scopes: [
+            {
+                scope: "forms:form:crud",
+                title: t`Forms CRUD`,
+                description: t`Allows basic CRUD operations on all forms.`
+            },
+            {
+                scope: "forms:settings",
+                title: t`Form Builder Settings`,
+                description: t`Allows updating Form Builder's settings.`
+            },
+            {
+                scope: "forms:form:revision:publish",
+                title: t`Publish form revisions`,
+                description: t`Allows publishing form revision.`
+            },
+            {
+                scope: "forms:form:revision:unpublish",
+                title: t`Unpublish form revisions`,
+                description: t`Allows unpublishing form revisions.`
+            },
+            {
+                scope: "forms:form:submissions:export",
+                title: t`Export form submissions`,
+                description: t`Allows creating form submission exports.`
+            }
+        ]
+    } as SecurityScopesListPlugin
+];

--- a/packages/app-i18n/src/admin/plugins/index.ts
+++ b/packages/app-i18n/src/admin/plugins/index.ts
@@ -4,6 +4,7 @@ import routes from "./routes";
 import menus from "./menus";
 import richTextEditor from "./richTextEditor";
 import install from "./install";
+import scopesList from "./scopesList";
 
 /**
  * Prevents opening global search menu when pressing "/" inside of I18N Rich Text Editor.
@@ -19,4 +20,4 @@ const globalSearchHotkey: GlobalSearchPreventHotkeyPlugin = {
     }
 };
 
-export default [routes, menus, richTextEditor, i18nSitePlugins, globalSearchHotkey, install];
+export default [routes, menus, scopesList, richTextEditor, i18nSitePlugins, globalSearchHotkey, install];

--- a/packages/app-i18n/src/admin/plugins/scopesList.ts
+++ b/packages/app-i18n/src/admin/plugins/scopesList.ts
@@ -1,0 +1,18 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-i18n/admin/scopesList");
+
+export default [
+    {
+        name: "security-scopes-list-i18n",
+        type: "security-scopes-list",
+        scopes: [
+            {
+                scope: "i18n:locale:crud",
+                title: t`I18N locales CRUD`,
+                description: t`Allows CRUD operations on all locales.`
+            },
+        ]
+    } as SecurityScopesListPlugin
+];

--- a/packages/app-page-builder/src/admin/plugins/index.ts
+++ b/packages/app-page-builder/src/admin/plugins/index.ts
@@ -8,6 +8,7 @@ import settings from "./settings";
 import routes from "./routes";
 import menus from "./menus";
 import install from "./install";
+import scopesList from "./scopesList";
 
 export default [
     header,
@@ -19,5 +20,6 @@ export default [
     settings,
     routes,
     menus,
+    scopesList,
     install
 ];

--- a/packages/app-page-builder/src/admin/plugins/scopesList.ts
+++ b/packages/app-page-builder/src/admin/plugins/scopesList.ts
@@ -1,0 +1,38 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-page-builder/admin/scopesList");
+
+export default [
+    {
+        name: "security-scopes-list-page-builder",
+        type: "security-scopes-list",
+        scopes: [
+            {
+                scope: "pb:page:crud",
+                title: t`Pages CRUD`,
+                description: t`Allows CRUD operations on all pages.`
+            },
+            {
+                scope: "pb:menu:crud",
+                title: t`Menus CRUD`,
+                description: t`Allows CRUD operations on all menus.`
+            },
+            {
+                scope: "pb:category:crud",
+                title: t`Categories CRUD`,
+                description: t`Allows CRUD operations on all categories.`
+            },
+            {
+                scope: "pb:element:crud",
+                title: t`Elements CRUD`,
+                description: t`Allows CRUD operations on all elements.`
+            },
+            {
+                scope: "pb:oembed:read",
+                title: t`Read oEmbed data`,
+                description: t`Allows reading oEmbed data in the Page Builder editor.`
+            }
+        ]
+    } as SecurityScopesListPlugin
+];

--- a/packages/app-security/src/admin/components/ScopesMultiAutoComplete.tsx
+++ b/packages/app-security/src/admin/components/ScopesMultiAutoComplete.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { i18n } from "@webiny/app/i18n";
+import { MultiAutoComplete } from "@webiny/ui/AutoComplete";
+import { getPlugins } from "@webiny/plugins";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+import { Typography } from "@webiny/ui/Typography";
+import { css } from "emotion";
+
+const t = i18n.ns("app-security/admin/roles/form");
+
+const styles = {
+    wrapper: css({
+        ".mdc-elevation--z1": {
+            maxHeight: 275
+        }
+    })
+};
+
+const ScopesMultiAutoComplete = props => {
+    const [scopesList, setScopesList] = useState([]);
+
+    useEffect(() => {
+        const getScopesList = async () => {
+            const plugins = getPlugins<SecurityScopesListPlugin>("security-scopes-list");
+            const scopes = [];
+            for (let i = 0; i < plugins.length; i++) {
+                const plugin = plugins[i];
+                if (!plugin.scopes) {
+                    throw new Error(
+                        `Missing "scopes" key in registered "security-scopes-list" plugin. The name of the plugin is "${plugin.name ||
+                            "undefined"}"`
+                    );
+                }
+
+                let pluginScopes = plugin.scopes;
+
+                if (typeof pluginScopes === "function") {
+                    pluginScopes = await pluginScopes();
+                }
+
+                scopes.push(...pluginScopes);
+            }
+
+            setScopesList(scopes);
+        };
+
+        getScopesList();
+    }, []);
+
+    return (
+        <span className={styles.wrapper}>
+            <MultiAutoComplete
+                useSimpleValues
+                options={scopesList.map(({ scope }) => scope)}
+                label={t`Scopes`}
+                description={t`Choose one or more scopes.`}
+                unique
+                renderItem={item => {
+                    const scope = scopesList.find(current => current.scope === item);
+
+                    return (
+                        <>
+                            <div>
+                                <strong>
+                                    <Typography use={"subtitle1"}>
+                                        <strong>{scope.title}</strong>
+                                    </Typography>
+                                </strong>
+                            </div>
+                            <div>
+                                <Typography use={"subtitle2"}>{scope.description}</Typography>
+                            </div>
+                            <div>
+                                <Typography use={"caption"}>{scope.scope}</Typography>
+                            </div>
+                        </>
+                    );
+                }}
+                {...props}
+            />
+        </span>
+    );
+};
+
+export default ScopesMultiAutoComplete;

--- a/packages/app-security/src/admin/components/index.ts
+++ b/packages/app-security/src/admin/components/index.ts
@@ -1,0 +1,1 @@
+export { default as ScopesMultiAutoComplete } from "./ScopesMultiAutoComplete";

--- a/packages/app-security/src/admin/plugins/index.ts
+++ b/packages/app-security/src/admin/plugins/index.ts
@@ -4,6 +4,7 @@ import routes from "./routes";
 import menus from "./menus";
 import secureRouteError from "./secureRouteError";
 import installation from "./installation";
+import scopesList from "./scopesList";
 
 export default [
     // Layout plugins
@@ -11,6 +12,7 @@ export default [
     globalSearchUsers,
     routes,
     menus,
+    scopesList,
     secureRouteError,
     installation
 ];

--- a/packages/app-security/src/admin/plugins/scopesList.ts
+++ b/packages/app-security/src/admin/plugins/scopesList.ts
@@ -1,0 +1,28 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-security/admin/scopesList");
+
+export default [
+    {
+        name: "security-scopes-list-security",
+        type: "security-scopes-list",
+        scopes: [
+            {
+                scope: "security:group:crud",
+                title: t`Security groups CRUD`,
+                description: t`Allows CRUD operations on all groups.`
+            },
+            {
+                scope: "security:role:crud",
+                title: t`Security roles CRUD`,
+                description: t`Allows CRUD operations on all roles.`
+            },
+            {
+                scope: "security:user:crud",
+                title: t`Security users CRUD`,
+                description: t`Allows CRUD operations on all users.`
+            }
+        ]
+    } as SecurityScopesListPlugin
+];

--- a/packages/app-security/src/admin/views/Groups/Groups.tsx
+++ b/packages/app-security/src/admin/views/Groups/Groups.tsx
@@ -43,7 +43,10 @@ const Groups = ({ scopes, formProps, listProps }: any) => {
                                 <GroupsForm scopes={scopes} {...formProps} />
                             </RightPanel>
                         </SplitView>
-                        <FloatingActionButton onClick={actions.resetForm} />
+                        <FloatingActionButton
+                            data-testid="new-record-button"
+                            onClick={actions.resetForm}
+                        />
                     </>
                 )}
             </CrudProvider>

--- a/packages/app-security/src/admin/views/Groups/GroupsDataList.tsx
+++ b/packages/app-security/src/admin/views/Groups/GroupsDataList.tsx
@@ -42,7 +42,7 @@ const GroupsDataList = () => {
             ]}
         >
             {({ data, select, isSelected }) => (
-                <ScrollList>
+                <ScrollList data-testid="default-data-list">
                     {data.map(item => (
                         <ListItem key={item.id} selected={isSelected(item)}>
                             <ListItemText onClick={() => select(item)}>

--- a/packages/app-security/src/admin/views/Groups/GroupsDataList.tsx
+++ b/packages/app-security/src/admin/views/Groups/GroupsDataList.tsx
@@ -56,9 +56,7 @@ const GroupsDataList = () => {
                                         {({ showConfirmation }) => (
                                             <DeleteIcon
                                                 onClick={() =>
-                                                    showConfirmation(() =>
-                                                        actions.deleteRecord(item)
-                                                    )
+                                                    showConfirmation(() => actions.delete(item))
                                                 }
                                             />
                                         )}

--- a/packages/app-security/src/admin/views/Roles/Roles.tsx
+++ b/packages/app-security/src/admin/views/Roles/Roles.tsx
@@ -28,7 +28,10 @@ function Roles() {
                             <RolesForm />
                         </RightPanel>
                     </SplitView>
-                    <FloatingActionButton onClick={actions.resetForm} />
+                    <FloatingActionButton
+                        data-testid="new-record-button"
+                        onClick={actions.resetForm}
+                    />
                 </>
             )}
         </CrudProvider>

--- a/packages/app-security/src/admin/views/Roles/RolesDataList.tsx
+++ b/packages/app-security/src/admin/views/Roles/RolesDataList.tsx
@@ -42,7 +42,7 @@ const RolesDataList = () => {
             ]}
         >
             {({ data, isSelected, select }) => (
-                <ScrollList>
+                <ScrollList data-testid="default-data-list">
                     {data.map(item => (
                         <ListItem key={item.id} selected={isSelected(item)}>
                             <ListItemText onClick={() => select(item)}>

--- a/packages/app-security/src/admin/views/Roles/RolesForm.tsx
+++ b/packages/app-security/src/admin/views/Roles/RolesForm.tsx
@@ -1,16 +1,13 @@
-import * as React from "react";
+import React from "react";
 import { i18n } from "@webiny/app/i18n";
 import { Form } from "@webiny/form";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { Input } from "@webiny/ui/Input";
 import { ButtonPrimary } from "@webiny/ui/Button";
-import { MultiAutoComplete } from "@webiny/ui/AutoComplete";
+import { ScopesMultiAutoComplete } from "@webiny/app-security/admin/components";
 import { CircularProgress } from "@webiny/ui/Progress";
-import { useQuery } from "react-apollo";
 import { useCrud } from "@webiny/app-admin/hooks/useCrud";
 import { validation } from "@webiny/validation";
-import { get } from "lodash";
-import { LIST_SCOPES } from "./graphql";
 import {
     SimpleForm,
     SimpleFormFooter,
@@ -21,8 +18,6 @@ import {
 const t = i18n.ns("app-security/admin/roles/form");
 
 const RoleForm = () => {
-    const scopesQuery = useQuery(LIST_SCOPES);
-    const scopes = get(scopesQuery, "data.security.scopes") || [];
     const { form: crudForm } = useCrud();
 
     return (
@@ -54,14 +49,7 @@ const RoleForm = () => {
                         <Grid>
                             <Cell span={12}>
                                 <Bind name="scopes">
-                                    <MultiAutoComplete
-                                        useSimpleValues
-                                        options={scopes}
-                                        label={t`Scopes`}
-                                        description={t`Choose one or more scopes.`}
-                                        /* TODO: @adrian what's this "multiple" prop ? // multiple */
-                                        unique
-                                    />
+                                    <ScopesMultiAutoComplete />
                                 </Bind>
                             </Cell>
                         </Grid>

--- a/packages/app-security/src/admin/views/Roles/RolesForm.tsx
+++ b/packages/app-security/src/admin/views/Roles/RolesForm.tsx
@@ -23,7 +23,7 @@ const RoleForm = () => {
     return (
         <Form {...crudForm}>
             {({ data, form, Bind }) => (
-                <SimpleForm>
+                <SimpleForm data-testid={"default-form"}>
                     {crudForm.loading && <CircularProgress />}
                     <SimpleFormHeader title={data.name ? data.name : t`Untitled`} />
                     <SimpleFormContent>

--- a/packages/app-security/src/admin/views/Roles/graphql.ts
+++ b/packages/app-security/src/admin/views/Roles/graphql.ts
@@ -8,14 +8,6 @@ const fields = `
     scopes
 `;
 
-export const LIST_SCOPES = gql`
-    query loadScopes {
-        security {
-            scopes
-        }
-    }
-`;
-
 export const LIST_ROLES = gql`
     query listRoles(
         $where: JSON

--- a/packages/app-security/src/types.ts
+++ b/packages/app-security/src/types.ts
@@ -34,3 +34,17 @@ export type SecurityViewUserFormPlugin = Plugin & {
 export type SecurityViewUserAccountFormPlugin = Plugin & {
     view: React.ComponentType<SecurityViewProps>;
 };
+
+type SecurityScopesListPluginScope = {
+    title: any;
+    description: any;
+    scope: string;
+};
+
+export type SecurityScopesListPlugin = Plugin & {
+    type: "security-scopes-list";
+    scopes:
+        | SecurityScopesListPluginScope[]
+        | (() => SecurityScopesListPluginScope[])
+        | (() => Promise<SecurityScopesListPluginScope[]>);
+};

--- a/packages/app-security/src/types.ts
+++ b/packages/app-security/src/types.ts
@@ -41,6 +41,10 @@ type SecurityScopesListPluginScope = {
     scope: string;
 };
 
+/**
+ * Enables adding custom security scopes to the multi-select autocomplete component in the Roles form.
+ * @see https://docs.webiny.com/docs/webiny-apps/security/development/plugin-reference/app/#security-scopes-list
+ */
 export type SecurityScopesListPlugin = Plugin & {
     type: "security-scopes-list";
     scopes:

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -62,17 +62,16 @@ export class MultiAutoComplete extends React.Component<MultiAutoCompleteProps, S
             // 1) If "unique" prop was passed, we don't want to show already picked options again.
             if (unique) {
                 const values = value;
-                if (!Array.isArray(values)) {
-                    return true;
-                }
-
-                if (
-                    values.find(
-                        value =>
-                            getOptionValue(value, this.props) === getOptionValue(item, this.props)
-                    )
-                ) {
-                    return false;
+                if (Array.isArray(values)) {
+                    if (
+                        values.find(
+                            value =>
+                                getOptionValue(value, this.props) ===
+                                getOptionValue(item, this.props)
+                        )
+                    ) {
+                        return false;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Related Issue
#729 

## Your solution
There are a couple of things this PR introduces.

1. First and foremost, users can finally get a list of all available security scopes in the system, in the Roles form. Users just have to register the app plugin with the type `security-scopes-list`, and their custom scope will be shown in the list. Default apps already are doing this out-of-the-box. For custom development, users will have to register this on their own (obviously).

2. Secondly, the scopes selection multi autocomplete was visually improved. Users can now see not only the meaningless scope (e.g. `fb:forms:crud`), but also its title and description. It will be more informative for the user. Check the sshot at the bottom.

3. I also removed some of the scopes-related functionality on the API side, since it's not needed anymore. For example, we don't need the `scopes` GraphQL field anymore, which was here to return the list of all registered scopes in the system.

## Additional bug fixes
While I was testing this, I managed to stumble upon some really significant bugs. 

#### Multi-autocomplete search bug
While the user was typing his own search string into the input, on order to do options filtering, the options wouldn't be filtered at all. This is now fixed.

#### Groups form - delete not working
The delete icon in the `packages/app-security/src/admin/views/Groups/GroupsDataList.tsx` was calling the old method, which caused the interface to blow up once the user clicked on it.

## Additional cool stuff

#### Plugins reference
I created docs page for the `security-scopes-list` plugin - https://docs.webiny.com/docs/webiny-apps/security/development/plugin-reference/app.

And that's not all, I also made use of `@see` tag in the code, to directly link this page with the actual TS type. Awesome DX if you ask me! 😊
 
![image](https://user-images.githubusercontent.com/5121148/75972178-41024680-5ed3-11ea-9bb1-ff1384b755e3.png)

<img width="892" alt="Snipaste_2020-03-05_06-52-56" src="https://user-images.githubusercontent.com/5121148/75972084-12846b80-5ed3-11ea-84a8-368e95544528.png">

I believe we should try to make documentation for plugins as we're creating them. I tried it here, and it was super easy and satisfying.

## How Has This Been Tested?
Added Cypress test not only for the scopes selection component but also for the whole Roles form. And while I was at it, I also added the tests for Groups form. It was fast since basically I just copied the Roles form test, and made few minor alterations.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/75970652-f8e22480-5ed0-11ea-98a6-ccb5981f5377.png)