### PR TITLE
Page Builder - fixed link preloading error

### DIFF
--- a/packages/app-page-builder/src/site/plugins/linkPreload.ts
+++ b/packages/app-page-builder/src/site/plugins/linkPreload.ts
@@ -9,7 +9,10 @@ export default (): ReactRouterOnLinkPlugin => {
         type: "react-router-on-link",
         onLink({ link, apolloClient }) {
             if (process.env.REACT_APP_ENV === "browser") {
-                if (!link.startsWith("/") || preloadedLinks.includes(link)) {
+                if (
+                    typeof link !== "string" ||
+                    !link.startsWith("/") || preloadedLinks.includes(link)
+                ) {
                     return;
                 }
 


### PR DESCRIPTION
## Related Issue
One of our users had a page that had an empty link in it (`href` attribute wasn't defined). 

Because of this, the `react-router-on-link-pb` plugin (`packages/app-page-builder/src/site/plugins/linkPreload.ts`) would throw an error, because it was using the `startsWith` function on a value that wasn't a string.

## Your solution
We now check if the passed `link` argument is actually a string.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![Snipaste_2020-03-05_12-19-48](https://user-images.githubusercontent.com/5121148/75986576-9ef05780-5eee-11ea-9c23-e448c4bf4db1.png)
