### PR TITLE
CDN cache is now invalidated properly upon updating Page Builder settings

### DIFF
--- a/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
+++ b/cypress/integration/admin/pageBuilder/menus/pagesListMenuItemType.spec.js
@@ -58,8 +58,7 @@ context("Menus Module", () => {
             .findByText("Save menu")
             .click()
             .wait(2000)
-            .visit(Cypress.env("SITE_URL"))
-            .wait(30000);
+            .visitAndReloadOnceInvalidated(Cypress.env("SITE_URL"));
 
         cy.visit(Cypress.env("SITE_URL"))
             .findByTestId("pb-desktop-header")
@@ -97,8 +96,7 @@ context("Menus Module", () => {
             .findByText("Save menu")
             .click()
             .wait(2000)
-            .visit(Cypress.env("SITE_URL"))
-            .wait(30000);
+            .visitAndReloadOnceInvalidated(Cypress.env("SITE_URL"));
 
         cy.visit(Cypress.env("SITE_URL"))
             .findByTestId("pb-desktop-header")

--- a/cypress/integration/admin/settings/siteRefresh.spec.js
+++ b/cypress/integration/admin/settings/siteRefresh.spec.js
@@ -1,0 +1,49 @@
+import uniqid from "uniqid";
+
+context("Page Builder Settings", () => {
+    beforeEach(() => cy.login());
+
+    it("should invalidate CDN cache once the settings have changed", () => {
+        const id = uniqid();
+
+        cy.visit("/settings/general")
+            .findByLabelText(/website name/i)
+            .clear()
+            .type(`New-site-name-${id}`)
+            .findByText(/save/i)
+            .click()
+            .wait(2000);
+
+        cy.visitAndReloadOnceInvalidated(Cypress.env("SITE_URL"))
+            .findByTestId("pb-desktop-header")
+            .within(() => {
+                cy.findByText(`New-site-name-${id}`).should("exist");
+            });
+
+        const facebook = `https://facebook.com/${id}`;
+        const twitter = `https://twitter.com/${id}`;
+        const instagram = `https://instagram.com/${id}`;
+
+        cy.visit("/settings/general")
+            .findByLabelText(/facebook/i)
+            .clear()
+            .type(facebook)
+            .findByLabelText(/twitter/i)
+            .clear()
+            .type(twitter)
+            .findByLabelText(/instagram/i)
+            .clear()
+            .type(instagram)
+            .findByText(/save/i)
+            .click()
+            .wait(2000);
+
+        cy.visitAndReloadOnceInvalidated(Cypress.env("SITE_URL"))
+            .findByTestId("pb-footer")
+            .within(() => {
+                cy.get(`a[href="${facebook}"]`).should("exist");
+                cy.get(`a[href="${twitter}"]`).should("exist");
+                cy.get(`a[href="${instagram}"]`).should("exist");
+            });
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,2 @@
-import "@testing-library/cypress/add-commands";
-
 import "./login";
+import "./visitAndReloadOnceInvalidated";

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,2 @@
+import "@testing-library/cypress/add-commands";
 import "./commands";

--- a/cypress/support/visitAndReloadOnceInvalidated/index.js
+++ b/cypress/support/visitAndReloadOnceInvalidated/index.js
@@ -1,0 +1,39 @@
+Cypress.Commands.add("visitAndReloadOnceInvalidated", url => {
+    return cy
+        .log(`Visiting ${url} and waiting for the CDN cache to be invalidated...`)
+        .visit(url)
+        .then(() => {
+            let retries = -1;
+
+            function doIt() {
+                retries++;
+                return cy
+                    .log(`Invalidation check (attempt #${retries + 1})`)
+                    .request(url)
+                    .then(async response => {
+                        try {
+                            if (response.headers.age) {
+                                throw Error("Still not invalidated...");
+                            }
+                            return cy
+                                .log("Cache invalidated, moving on.")
+                                .wait(500)
+                                .reload();
+                        } catch (err) {
+                            if (retries > 10) {
+                                throw new Error(`retried too many times (${--retries})`);
+                            }
+
+                            return new Promise(resolve => {
+                                setTimeout(() => {
+                                    resolve();
+                                }, 3333);
+                            }).then(() => doIt());
+                        }
+                        return response;
+                    });
+            }
+
+            return doIt();
+        });
+});

--- a/cypress/support/visitAndReloadOnceInvalidated/index.js
+++ b/cypress/support/visitAndReloadOnceInvalidated/index.js
@@ -17,7 +17,7 @@ Cypress.Commands.add("visitAndReloadOnceInvalidated", url => {
                             }
                             return cy
                                 .log("Cache invalidated, moving on.")
-                                .wait(500)
+                                .wait(1000)
                                 .reload();
                         } catch (err) {
                             if (retries > 10) {

--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -16,18 +16,25 @@ export default () => [
                 );
             }
 
-            const settings = await PbSettings.load();
-            context.ssrApiClient = new SsrApiClient({ url: settings.data.domain });
+            context.__ssrApiClient = null;
+            context.getSsrApiClient = async () => {
+                if (!context.__ssrApiClient) {
+                    const settings = await PbSettings.load();
+                    context.__ssrApiClient = new SsrApiClient({ url: settings.data.domain });
+                }
+                return context.__ssrApiClient;
+            };
         }
     },
     {
         // After a page was published, we want to invalidate the SSR cache.
         type: "graphql-context",
         name: "graphql-context-extend-pb-page-invalidate-ssr-cache-on-publish-gt-1",
-        apply({ ssrApiClient, models: { PbPage } }) {
+        apply({ getSsrApiClient, models: { PbPage } }) {
             withHooks({
                 async afterPublish() {
                     if (this.version > 1) {
+                        const ssrApiClient = await getSsrApiClient();
                         await ssrApiClient.invalidateSsrCacheByPath({
                             path: this.url,
                             refresh: true
@@ -41,9 +48,10 @@ export default () => [
         // After a page was published, we want to invalidate caches that contain pages list element.
         type: "graphql-context",
         name: "graphql-context-extend-pb-page-invalidate-ssr-cache-after-publish-pages-list",
-        apply({ ssrApiClient, models: { PbPage } }) {
+        apply({ getSsrApiClient, models: { PbPage } }) {
             withHooks({
                 async afterPublish() {
+                    const ssrApiClient = await getSsrApiClient();
                     await ssrApiClient.invalidateSsrCacheByTags({
                         tags: [{ class: "pb-pages-list" }]
                     });
@@ -52,20 +60,26 @@ export default () => [
         }
     },
     {
-        // After settings were changed, invalidate all pages that contain pb-settings tag.
+        // After settings were changed, invalidate all pages that contain pb-page tag.
         type: "graphql-context",
         name: "graphql-context-extend-pb-page-invalidate-ssr-cache-settings",
-        apply({ ssrApiClient, models: { PbSettings } }) {
+        apply({ getSsrApiClient, models: { PbSettings } }) {
             withHooks({
                 beforeSave() {
+                    // Avoid calling this callback while the Page Builder is installing and multiple save commands are issued.
+                    if (!this.data.installation.completed) {
+                        return;
+                    }
+
                     if (!this.isDirty()) {
                         return;
                     }
 
                     const removeCallback = this.hook("afterSave", async () => {
                         try {
+                            const ssrApiClient = await getSsrApiClient();
                             await ssrApiClient.invalidateSsrCacheByTags({
-                                tags: [{ class: "pb-settings" }]
+                                tags: [{ class: "pb-page" }]
                             });
                         } catch {
                             // Do nothing.
@@ -80,7 +94,7 @@ export default () => [
         // After settings were changed, invalidate all pages that contain pb-menu tag.
         type: "graphql-context",
         name: "graphql-context-extend-pb-page-pb-menu-invalidate-ssr-cache-cache-menu",
-        apply({ ssrApiClient, models: { PbMenu } }) {
+        apply({ getSsrApiClient, models: { PbMenu } }) {
             // If the menu has changed, we need to delete page caches.
             withHooks({
                 async beforeSave() {
@@ -88,6 +102,7 @@ export default () => [
                     if (this.isDirty()) {
                         const removeCallback = this.hook("afterSave", async () => {
                             try {
+                                const ssrApiClient = await getSsrApiClient();
                                 await ssrApiClient.invalidateSsrCacheByTags({
                                     tags: [{ class: "pb-menu", id: this.slug }]
                                 });
@@ -130,7 +145,7 @@ export default () => [
             `,
             resolvers: {
                 PbMutation: {
-                    invalidateSsrCache: async (_, args, { models, ssrApiClient }) => {
+                    invalidateSsrCache: async (_, args, { models, getSsrApiClient }) => {
                         const { PbPage } = models;
                         const page = await PbPage.findById(args.revision);
                         if (!page) {
@@ -144,6 +159,7 @@ export default () => [
                             });
                         }
 
+                        const ssrApiClient = await getSsrApiClient();
                         await ssrApiClient.invalidateSsrCacheByPath({
                             path: page.url,
                             refresh: args.refresh

--- a/packages/app-page-builder-theme/src/components/Footer.tsx
+++ b/packages/app-page-builder-theme/src/components/Footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
                 const { name, logo, social } = get(response, "pageBuilder.getSettings.data") || {};
 
                 return (
-                    <div className={"webiny-pb-section-footer"}>
+                    <div className={"webiny-pb-section-footer"} data-testid={"pb-footer"}>
                         <div className="webiny-pb-section-footer__wrapper">
                             <div className={"webiny-pb-section-footer__logo"}>
                                 <Link to="/">

--- a/packages/app-page-builder/src/site/components/Page/Page.tsx
+++ b/packages/app-page-builder/src/site/components/Page/Page.tsx
@@ -12,7 +12,7 @@ type PageProps = {
     content?: any;
 };
 
-const Page = (props: PageProps) => {
+const getPageRender = props => {
     if (props.content) {
         return <PageContent data={props.content} />;
     }
@@ -26,6 +26,15 @@ const Page = (props: PageProps) => {
     }
 
     return null;
+};
+
+const Page = (props: PageProps) => {
+    return (
+        <>
+            {getPageRender(props)}
+            <ssr-cache data-class="pb-page" />
+        </>
+    );
 };
 
 export default Page;


### PR DESCRIPTION
## Related Issue
#727 

## Your solution
In a nutshell, the solution was simple. Every time changes to the page builder settings are made, we invalidate SSR cache (`packages/api-page-builder/src/plugins/useSsrCacheTags.ts:81`). 

The thing that was tricky was finding a way to invalidate all Page Builder pages. We don't want to necessarily invalidate ALL SSR HTML cache entries (this was the initial idea, discussed with @Fsalker). We just want to invalidate SSR HTML entries for URLs on which Page Builder pages are being rendered.

To solve this, I added a simple `pb-page` `ssr-cache` tag (`packages/app-page-builder/src/site/components/Page/Page.tsx:35`).

## Additional notes
I'm closing @Fsalker's PR because this one also includes a couple of other features/fixes, and because it'll be faster this way.

We had a bug in the `packages/api-page-builder/src/plugins/useSsrCacheTags.ts` file, which caused the `withHooks` HOF, applied to the `PbSettings` model, not to work as expected.

Additionally, I added some tests here, and what's super important is the new `visitAndReloadOnceInvalidated` Cypress command. What does it do?

Well, when making changes in the Admin UI, we have to wait for 5-10secs in order to get the new content from the CDN. If we were to immediately visit the page in question, we would always get the old SSR HTML.

To fix that, previously, we basically added `.wait(30000)` commands whenever we wanted to make sure the assertions are going to be done on a fresh SSR HTML. But this is slow of course because cache might have been invalidated in the first 5 seconds, which basically wastes 25seconds.

With this command, this goes away, because it will ping the page periodically, and once it detects updated page is available, it will continue with the assertions.

## How Has This Been Tested?
Added Cypress testing. Used mentioned `visitAndReloadOnceInvalidated` command.

## Screenshots (if relevant):
N/A