### PR TITLE
fix: 🐛  Commitizen error

### DIFF
--- a/scripts/cz-adapter/index.js
+++ b/scripts/cz-adapter/index.js
@@ -75,7 +75,7 @@ module.exports = {
             answers.subject = commitTypes[answers.type].emoji + "  " + answers.subject;
 
             // Build commit message
-            const message = buildCommit(answers);
+            const message = buildCommit(answers, { breaklineChar: "\n" });
             console.log("\n\nCommit message:");
             console.log(chalk.blue(`\n\n${message}\n`));
             commitCb(message);


### PR DESCRIPTION
Add config with breaklineChar for buildCommit function

## Related Issue
https://github.com/webiny/webiny-js/issues/751

## Your solution
Add `breaklineChar` option in config. However we might want to use https://github.com/ds300/patch-package to fix this in library

## How Has This Been Tested?
I've been able to commit with the help of `yarn commit`

## Screenshots (if relevant):