### PR TITLE
Fixed Storybook local deployment & Added 'Section' component

### DIFF
--- a/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsOverview.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsOverview.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Block from "./Block";
+import Section from "@webiny/ui/Section";
 import { Typography } from "@webiny/ui/Typography";
 import styled from "@emotion/styled";
 import { FbFormModel } from "@webiny/app-form-builder/types";
@@ -26,7 +26,7 @@ const ContentWrapper = styled("div")({
 
 const FormSubmissionsOverview = ({ form }: Props) => {
     return (
-        <Block title="Overview">
+        <Section title="Overview">
             <ContentWrapper>
                 <StatBox>
                     <Typography use="headline2">{form.overallStats.submissions}</Typography>
@@ -41,7 +41,7 @@ const FormSubmissionsOverview = ({ form }: Props) => {
                     <Typography use="overline">Conversion Rate</Typography>
                 </StatBox>
             </ContentWrapper>
-        </Block>
+        </Section>
     );
 };
 

--- a/packages/ui/.storybook/webpack.config.js
+++ b/packages/ui/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const aliases = require("@webiny/project-utils/aliases/webpack");
 
 const includePaths = [
     path.join(__dirname, "../node_modules"),
@@ -8,6 +9,7 @@ const includePaths = [
 
 module.exports = ({ config }) => {
     config.resolve.extensions.push(".ts", ".tsx");
+    config.resolve.alias = aliases;
 
     config.module.rules.push({
         test: /\.tsx?$/,

--- a/packages/ui/src/Section/README.md
+++ b/packages/ui/src/Section/README.md
@@ -1,0 +1,9 @@
+# Section
+
+### Description
+Use `Section` to nicely separate components vertically in the UI.
+
+### Import
+```js
+import Section from "@webiny/ui/Section";
+```

--- a/packages/ui/src/Section/Section.stories.tsx
+++ b/packages/ui/src/Section/Section.stories.tsx
@@ -11,25 +11,8 @@ import readme from "./README.md";
 
 import Section from "./index";
 import styled from "@emotion/styled";
-import { Typography } from "@webiny/ui/Typography";
 
 const story = storiesOf("Components/Section", module);
-
-const StatBox = styled("div")({
-    width: "33.33%",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    flexDirection: "column",
-    color: "var(--mdc-theme-on-surface)"
-});
-
-const ContentWrapper = styled("div")({
-    flexDirection: "row",
-    display: "flex",
-    width: "100%",
-    boxSizing: "border-box"
-});
 
 const RenderSection = styled("div")({
     backgroundColor: "var(--mdc-theme-background)",

--- a/packages/ui/src/Section/Section.stories.tsx
+++ b/packages/ui/src/Section/Section.stories.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import {
+    Story,
+    StoryReadme,
+    StorySandboxCode,
+    StorySandbox,
+    StorySandboxExample
+} from "@webiny/storybook-utils/Story";
+import readme from "./README.md";
+
+import Section from "./index";
+import styled from "@emotion/styled";
+import { Typography } from "@webiny/ui/Typography";
+
+const story = storiesOf("Components/Section", module);
+
+const StatBox = styled("div")({
+    width: "33.33%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "column",
+    color: "var(--mdc-theme-on-surface)"
+});
+
+const ContentWrapper = styled("div")({
+    flexDirection: "row",
+    display: "flex",
+    width: "100%",
+    boxSizing: "border-box"
+});
+
+const RenderSection = styled("div")({
+    backgroundColor: "var(--mdc-theme-background)",
+    padding: "1px 25px 0 25px"
+});
+
+story.add(
+    "usage",
+    () => {
+        return (
+            <Story>
+                <StoryReadme>{readme}</StoryReadme>
+                <StorySandbox>
+                    <StorySandboxExample>
+                        <RenderSection>
+                            <Section title="Section 1">Here goes the first section</Section>
+                            <Section title="Section 2">And this is the second section 🦄</Section>
+                        </RenderSection>
+                    </StorySandboxExample>
+                    <StorySandboxCode>
+                        {`
+                        import styled from "@emotion/styled";
+                        
+                        const RenderSection = styled("div")({
+                            backgroundColor: "var(--mdc-theme-background)",
+                            padding: "1px 25px 0 25px"
+                        });
+
+                         <RenderSection>
+                            <Section title="Section 1">Here goes the first section</Section>
+                            <Section title="Section 2">And this is the second section 🦄</Section>
+                        </RenderSection>
+                    `}
+                    </StorySandboxCode>
+                </StorySandbox>
+            </Story>
+        );
+    },
+    { info: { propTables: [Section] } }
+);

--- a/packages/ui/src/Section/index.tsx
+++ b/packages/ui/src/Section/index.tsx
@@ -27,7 +27,12 @@ const ElevationContent = styled("div")({
     backgroundColor: "#fff"
 });
 
-const Section = ({ children, title, ...props }) => {
+type SectionProps = {
+    children?: React.ReactNode;
+    title?: String;
+};
+
+const Section = ({ children, title, ...props }: SectionProps) => {
     return (
         <SectionWrapper {...props}>
             <h4>

--- a/packages/ui/src/Section/index.tsx
+++ b/packages/ui/src/Section/index.tsx
@@ -4,7 +4,7 @@ import { css } from "emotion";
 import { Typography } from "@webiny/ui/Typography";
 import { Elevation } from "@webiny/ui/Elevation";
 
-const BlockWrapper = styled("div")({
+const SectionWrapper = styled("div")({
     backgroundColor: "var(--mdc-theme-background)",
     padding: "0 0 25px 0"
 });
@@ -23,12 +23,13 @@ const titleStyle = css({
 });
 
 const ElevationContent = styled("div")({
-    padding: 20
+    padding: 20,
+    backgroundColor: "#fff"
 });
 
-const Block = ({ children, title, ...props }) => {
+const Section = ({ children, title, ...props }) => {
     return (
-        <BlockWrapper {...props}>
+        <SectionWrapper {...props}>
             <h4>
                 <Typography className={titleStyle} use={"overline"}>
                     {title}
@@ -38,8 +39,8 @@ const Block = ({ children, title, ...props }) => {
             <Elevation z={2}>
                 <ElevationContent>{children}</ElevationContent>
             </Elevation>
-        </BlockWrapper>
+        </SectionWrapper>
     );
 };
 
-export default Block;
+export default Section;


### PR DESCRIPTION
## Related Issue
None, but it helps #762 and #695.

I had to employ a "Section" component in order to display the Personal Access Tokens.

## Your solution
I've moved the former `Block` component used in `packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsOverview.tsx` into the new `webiny/ui/Section` component.

## How Has This Been Tested?
I've run `admin` app locally and Form Builder looks the same when selecting a Form & displaying the "Overview" section.