### PR TITLE
SSR is now invalidated correctly when publishing site's homepage.

### DIFF
--- a/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
+++ b/packages/api-page-builder/src/plugins/useSsrCacheTags.ts
@@ -39,6 +39,14 @@ export default () => [
                             path: this.url,
                             refresh: true
                         });
+
+                        // If the page is set as site's homepage, we need to invalidate the "/" path too.
+                        if (await this.isHomePage) {
+                            await ssrApiClient.invalidateSsrCacheByPath({
+                                path: "/",
+                                refresh: true
+                            });
+                        }
                     }
                 }
             })(PbPage);


### PR DESCRIPTION
## Related Issue
#757 

## Your solution
If the page that was published is marked as site's homepage, then we also invalidate the root path ("/") of the site.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A