### PR TITLE
Page Builder: Saved page elements are now correctly shown in the page elements menu.

### DIFF
--- a/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
+++ b/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
@@ -5,7 +5,7 @@ import { PbElement, PbEditorPageElementPlugin } from "@webiny/app-page-builder/t
 import Title from "./components/Title";
 
 export default (el: PbElement) => {
-    const plugins = getPlugins("pb-page-element") as PbEditorPageElementPlugin[];
+    const plugins = getPlugins("pb-editor-page-element") as PbEditorPageElementPlugin[];
     const rootPlugin: PbEditorPageElementPlugin = plugins.find(pl => pl.elementType === el.content.type);
 
     if (!rootPlugin) {


### PR DESCRIPTION
## Related Issue
[#787](https://github.com/webiny/webiny-js/issues/787) 

## Your solution
I changed the type of getplugin as Adrian says in his issue

## How Has This Been Tested?
I tested in my deployed apps

## Screenshots (if relevant):
The result
<img width="1437" alt="Capture d’écran 2020-04-11 à 18 19 46" src="https://user-images.githubusercontent.com/40340340/79048986-21bcae80-7c21-11ea-8b26-cbf932ade33f.png">
