### PR TITLE
Previewing pages is now working as expected

### DIFF
--- a/cypress/integration/admin/pageBuilder/pages/previewPage.spec.js
+++ b/cypress/integration/admin/pageBuilder/pages/previewPage.spec.js
@@ -1,0 +1,42 @@
+import uniqid from "uniqid";
+
+context("Pages Previewing", () => {
+    beforeEach(() => cy.login());
+
+    it(`should be able to preview a page with the "ssr-no-cache" query param`, () => {
+        const pageTitle1 = `Test page ${uniqid()}`;
+        const pageTitle2 = `Test page ${uniqid()}`;
+
+        cy.visit("/page-builder/pages")
+            .findByTestId("new-record-button")
+            .click()
+            .findByTestId("pb-new-page-category-modal")
+            .within(() => {
+                cy.findByText("Static").click();
+            })
+            .findByTestId("pb-editor-page-title")
+            .click()
+            .get(`input[value="Untitled"]`)
+            .clear()
+            .type(pageTitle1)
+            .findByTestId("pb-editor-page-options-menu")
+            .click()
+            .wait(1000)
+            .findByTestId("pb-editor-page-options-menu-preview")
+            .click();
+        cy.title().should("contain", pageTitle1);
+
+        cy.go("back")
+            .findByTestId("pb-editor-page-title")
+            .click()
+            .get(`input[value="${pageTitle1}"]`)
+            .clear()
+            .type(pageTitle2)
+            .findByTestId("pb-editor-page-options-menu")
+            .click()
+            .wait(1000)
+            .findByTestId("pb-editor-page-options-menu-preview")
+            .click();
+        cy.title().should("contain", pageTitle2);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chalk": "^2.4.1",
     "commitizen": "^2.10.1",
     "cross-env": "^5.2.0",
-    "cypress": "^3.8.0",
+    "cypress": "^4.4.0",
     "cz-customizable": "^5.2.0",
     "dotenv": "^5.0.1",
     "empty": "^0.10.1",

--- a/packages/app-page-builder/__tests__/getPagePreviewUrl.test.js
+++ b/packages/app-page-builder/__tests__/getPagePreviewUrl.test.js
@@ -1,13 +1,13 @@
-import formatPreviewUrl from "@webiny/app-page-builder/src/admin/hooks/usePageBuilderSettings/formatPreviewUrl";
+import getPagePreviewUrl from "@webiny/app-page-builder/src/admin/hooks/usePageBuilderSettings/getPagePreviewUrl";
 
-describe("formatPreviewUrl test", () => {
+describe("getPagePreviewUrl test", () => {
     test(`if no domain, just return path ("id" query param must be present)`, async () => {
-        const url = formatPreviewUrl({ page: { id: "xyz", url: "/testers" } });
+        const url = getPagePreviewUrl({ page: { id: "xyz", url: "/testers" } });
         expect(url).toBe("/testers?preview=xyz");
     });
 
     test(`if domain, path must be prefixed with id ("id" query param must be present)`, async () => {
-        const url = formatPreviewUrl({
+        const url = getPagePreviewUrl({
             domain: "http://localhost:3002",
             page: { id: "xyz", url: "/testers" }
         });

--- a/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/getPagePreviewUrl.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/getPagePreviewUrl.ts
@@ -1,6 +1,6 @@
 import { trimEnd } from "lodash";
 
-export default ({ page: { url, id }, domain, addTimestamp = false }) => {
+export default ({ page: { url, id }, domain }) => {
     let previewUrl = "";
 
     if (!domain) {
@@ -16,11 +16,7 @@ export default ({ page: { url, id }, domain, addTimestamp = false }) => {
 
     previewUrl = trimEnd(previewUrl, "/");
     previewUrl += url;
-    previewUrl += "?preview=" + id;
-
-    if (addTimestamp !== false) {
-        previewUrl += "&ts=" + new Date().getTime();
-    }
+    previewUrl += "?preview=" + id + '&ssr-no-cache';
 
     return previewUrl;
 };

--- a/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useQuery } from "react-apollo";
 import gql from "graphql-tag";
 import { get } from "lodash";
-import formatPreviewUrl from "./formatPreviewUrl";
+import getPagePreviewUrlFunction from "./getPagePreviewUrl";
 
 const DOMAIN_QUERY = gql`
     query PbGetDomain {
@@ -39,7 +39,7 @@ export function usePageBuilderSettings() {
             if (loading) {
                 return null;
             }
-            return formatPreviewUrl({ page, domain: getDomain(), addTimestamp: true });
+            return getPagePreviewUrlFunction({ page, domain: getDomain() });
         },
         [data, loading]
     );

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/PageOptionsMenu.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/PageOptionsMenu.tsx
@@ -21,7 +21,7 @@ export default function PageOptionsMenu() {
         "pb-editor-default-bar-right-page-options"
     ) as PbEditorDefaultBarRightPageOptionsPlugin[];
     return (
-        <Menu className={menuStyles} handle={<IconButton icon={<MoreVerticalIcon />} />}>
+        <Menu data-testid="pb-editor-page-options-menu" className={menuStyles} handle={<IconButton icon={<MoreVerticalIcon />} />}>
             {plugins.map(pl => React.cloneElement(pl.render(), { key: pl.name }))}
         </Menu>
     );

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/PreviewPageButton.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/PreviewPageButton.tsx
@@ -9,10 +9,15 @@ import { ListItemGraphic } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
 import { ReactComponent as PreviewIcon } from "@webiny/app-page-builder/admin/assets/visibility.svg";
 
+const openTarget = window.Cypress ? "_self" : "_blank";
+
 const PreviewPageButton = ({ page }) => {
     const { getPagePreviewUrl } = usePageBuilderSettings();
     return (
-        <MenuItem onClick={() => window.open(getPagePreviewUrl(page), "_blank")}>
+        <MenuItem
+            onClick={() => window.open(getPagePreviewUrl(page), openTarget)}
+            data-testid={"pb-editor-page-options-menu-preview"}
+        >
             <ListItemGraphic>
                 <Icon icon={<PreviewIcon />} />
             </ListItemGraphic>

--- a/packages/ui/src/Menu/Menu.tsx
+++ b/packages/ui/src/Menu/Menu.tsx
@@ -39,6 +39,9 @@ type MenuProps = RmwcMenuProps & {
 
     // Class that will be added to the Menu element.
     className?: string;
+
+    // For testing purposes.
+    "data-testid"?: string;
 };
 
 type State = {
@@ -130,7 +133,7 @@ class Menu extends React.Component<MenuProps, State> {
 
     render() {
         return (
-            <MenuSurfaceAnchor ref={this.anchorRef}>
+            <MenuSurfaceAnchor ref={this.anchorRef} data-testid={this.props["data-testid"]}>
                 {this.renderMenuContent()}
                 {this.props.handle &&
                     React.cloneElement(this.props.handle, { onClick: this.openMenu })}
@@ -147,6 +150,7 @@ interface MenuItemProps extends BaseMenuItemProps {
     children: React.ReactNode;
     className?: string;
     onClick?: (event: React.MouseEvent) => void;
+    "data-testid"?: string;
 }
 
 const MenuItem = ({ disabled, className, ...rest }: MenuItemProps) => {


### PR DESCRIPTION
## Related Issue
Using `ts` as a way to ensure pages are not returned from the CDN cache was a bad idea. 

![image](https://user-images.githubusercontent.com/5121148/79485579-beae8b80-8015-11ea-8ab8-02561c6f8760.png)

Yeah, it would work if the user would click on the `Preview` link all the time, but he's not. He would click on it just once, and after that, he would continue by refreshing the page, which would return the same cached page, and never the new one.

## Your solution
Ditched the idea, and added support for `?ssr-no-cache` query param. Every time this is present in the requested URL, SSR will be generated from scratch, and no cache will be involved.

## How Has This Been Tested?
Cypress test.

## Screenshots (if relevant):
N/A