### PR TITLE
Fixed the styles for the "i" icon in the File Manager.

### DIFF
--- a/packages/app-admin/src/components/FileManager/File.tsx
+++ b/packages/app-admin/src/components/FileManager/File.tsx
@@ -32,14 +32,13 @@ const styles = css({
             zIndex: 11
         },
         ".infoIcon": {
+            opacity: 0,
             color: "var(--icon-color)",
             position: "absolute",
             top: 4,
             right: 4,
             zIndex: 10,
-            "&:hover": {
-                "--icon-color": "var(--mdc-theme-secondary)"
-            }
+            transition: 'all 150ms ease-in',
         },
         ".filePreview": {
             textAlign: "center",
@@ -55,6 +54,10 @@ const styles = css({
                 height: 170,
                 zIndex: 2
             }
+        },
+        "&:hover .infoIcon": {
+            opacity: 1,
+            "--icon-color": "var(--mdc-theme-secondary)",
         }
     },
     "> .label": {


### PR DESCRIPTION
Show `infoIcon` on image hover

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[UI improvement] The "i" icon that opens picture properties in File Manager is not obvious
https://github.com/webiny/webiny-js/issues/756

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Instead of changing `infoIcon` color to theme-secondary on hovering over the icon itself,
now the `infoIcon` will be visible when hovering over the image
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Visit the admin app and navigate to the pages section
2. Edit a page and select an image block
3. In the File Manager, hover over an image and `InfoIcon` i.e "i" icon that shows picture properties in File Manager will appear

## Screenshots (if relevant):
https://www.loom.com/share/fe2471e87ce54bdfa5d11f545ea044ef