### PR TITLE
Page Builder - fixed saving of links (Slate editor)

### DIFF
--- a/cypress/integration/admin/pageBuilder/elements/pagesList.spec.js
+++ b/cypress/integration/admin/pageBuilder/elements/pagesList.spec.js
@@ -1,0 +1,87 @@
+import uniqid from "uniqid";
+
+context("Page Elements - Pages List", () => {
+    beforeEach(() => cy.login());
+
+    const pageTitle = `Test page ${uniqid()}`;
+
+    it("should be able to create Pages List element", () => {
+        cy.visit("/page-builder/pages")
+            .findByTestId("new-record-button")
+            .click()
+            .findByTestId("pb-new-page-category-modal")
+            .within(() => {
+                cy.findByText("Static").click();
+            })
+            .findByTestId("pb-editor-page-title")
+            .click()
+            .get(`input[value="Untitled"]`)
+            .clear()
+            .type(`${pageTitle} {enter}`)
+            .findByTestId("pb-content-add-block-button")
+            .click()
+            .findByTestId("pb-editor-page-blocks-list-item-empty-block")
+            .within(() => {
+                cy.findByText(/click to add/i).click({ force: true });
+            })
+            .findByTestId("pb-editor-column-add-button")
+            .click()
+            .findByTestId("pb-editor-add-element-button-pages-list")
+            .within(() => {
+                cy.findByText(/click to add/i).click({ force: true });
+            })
+            .wait(500)
+            .findByTestId("pb-editor-advanced-element-settings-dialog")
+            .within(() => {
+                cy.findByLabelText("Category")
+                    .type("Static")
+                    .findByText("Static")
+                    .click()
+                    .findByLabelText("Tags")
+                    .type(`pag`)
+                    .findByText("page")
+                    .click()
+                    .findByText("Sort direction")
+                    .prev()
+                    .select("Ascending")
+                    .findByText("Sort by")
+                    .prev()
+                    .select("Title")
+                    .findByText("Save")
+                    .click();
+            })
+            .findByTestId("pb-editor-page-canvas-section")
+            .within(() => {
+                cy.get(".webiny-pb-page-element-page-list__item")
+                    .should("have.length", 3)
+                    .findByText("404")
+                    .should("exist")
+                    .findByText("Error Page")
+                    .should("exist")
+                    .findByText("Welcome to Webiny")
+                    .should("exist");
+            })
+            .findByTestId("pb-editor-advanced-settings-button")
+            .click()
+            .findByTestId("pb-editor-advanced-element-settings-dialog")
+            .within(() => {
+                cy.findByLabelText("Tags")
+                    .type(`err`)
+                    .findByText("error")
+                    .click()
+                    .findByText("Save")
+                    .click();
+            });
+
+        cy.findByTestId("pb-editor-page-canvas-section").within(() => {
+            cy.get(".webiny-pb-page-element-page-list__item")
+                .should("have.length", 1)
+                .findByText("404")
+                .should("not.exist")
+                .findByText("Error Page")
+                .should("exist")
+                .findByText("Welcome to Webiny")
+                .should("not.exist");
+        });
+    });
+});

--- a/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
+++ b/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
@@ -248,7 +248,14 @@ class SlateEditor extends React.Component<SlateEditorProps, SlateEditorState> {
                     .filter(pl => typeof pl.renderDialog === "function")
                     .map(pl => {
                         const props = {
-                            onChange: this.onChange,
+                            onChange: change => {
+                                // For dialogs, we send a complete callback, which will not only update the state of
+                                // the Slate editor, but will also save the changes via GraphQL mutation.
+                                this.onChange(change, () =>
+                                    this.props.onChange(this.state.value.toJSON())
+                                );
+                                this.setState({ modified: false });
+                            },
                             editor: this.editor.current,
                             open: activePlugin ? activePlugin.plugin === pl.name : false,
                             closeDialog: this.deactivatePlugin,

--- a/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
+++ b/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
@@ -131,6 +131,12 @@ class SlateEditor extends React.Component<SlateEditorProps, SlateEditorState> {
     };
 
     onBlur = () => {
+        // Do not save changes if there is a plugin that's still active. This can happen, for example, when
+        // you click on the "Link" tool, which opens a dialog, which then triggers the blur event and this callback.
+        if (this.state.activePlugin) {
+            return;
+        }
+
         if (!this.nextElement) {
             this.setState({ modified: false });
             this.props.onChange(this.state.value.toJSON());

--- a/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
+++ b/packages/app-page-builder/src/editor/components/Slate/Slate.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject } from "react";
 import ReactDOM from "react-dom";
-import { get, isEqual } from "lodash";
+import { get, isEqual, noop } from "lodash";
 import shortid from "shortid";
 import { Editor } from "slate-react";
 import { Value } from "slate";
@@ -110,7 +110,7 @@ class SlateEditor extends React.Component<SlateEditorProps, SlateEditorState> {
         return null;
     }
 
-    onChange = change => {
+    onChange = (change, callback = noop) => {
         if (this.state.readOnly) {
             return;
         }
@@ -123,11 +123,14 @@ class SlateEditor extends React.Component<SlateEditorProps, SlateEditorState> {
         }
 
         // Only update local state.
-        this.setState(state => ({
-            ...state,
-            value: change.value,
-            modified: true
-        }));
+        this.setState(
+            state => ({
+                ...state,
+                value: change.value,
+                modified: true
+            }),
+            callback
+        );
     };
 
     onBlur = () => {


### PR DESCRIPTION
## Related Issue
Clicking on the "link" icon in the Page Builder editor would bring up the link dialog, which would cause a "blur" event on the text, and a GraphQL update mutation to be sent. Then, when you would press the Save button in the dialog, the change would not save, because blur event already happened upon showing the dialog.

## Your solution
Both Irregularities mentioned above were taken care of.

## How Has This Been Tested?
I really wanted to test this, but it's gonna have to wait.

## Screenshots (if relevant):
N/A