### PR TITLE
Fix: Page Builder - "Icon" page element not working

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/button/ButtonSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/ButtonSettings.tsx
@@ -115,7 +115,7 @@ const getIcons = (): PbIcon[] => {
     return icons;
 };
 
-const getSvg = (id: string[], props) => {
+const getSvg = (id: string[], props: any = {}) => {
     if (!props.width) {
         props.width = 50;
     }

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
@@ -44,7 +44,7 @@ const IconSettings = ({ element, updateElement }) => {
             <Tabs>
                 <Tab label={"Icon"}>
                     <IconPicker label={"Icon"} value={icon.id} updateValue={updateIcon} />
-                    <Input label={"Width"} value={icon.width || 50} updateValue={updateWidth} />
+                    <Input label={"Width"} value={icon.width} updateValue={updateWidth} placeholder={"50"}/>
                     <ColorPicker
                         label={"Color"}
                         value={icon.color}

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
@@ -44,7 +44,12 @@ const IconSettings = ({ element, updateElement }) => {
             <Tabs>
                 <Tab label={"Icon"}>
                     <IconPicker label={"Icon"} value={icon.id} updateValue={updateIcon} />
-                    <Input label={"Width"} value={icon.width} updateValue={updateWidth} placeholder={"50"}/>
+                    <Input
+                        label={"Width"}
+                        value={icon.width}
+                        updateValue={updateWidth}
+                        placeholder="50"
+                    />
                     <ColorPicker
                         label={"Color"}
                         value={icon.color}

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/index.tsx
@@ -56,7 +56,7 @@ export default () => {
                     data: {
                         icon: {
                             id: ["far", "star"],
-                            svg: getSvg(["far", "star"]),
+                            svg: getSvg(["far", "star"], { width: 50 }),
                             width: 50
                         },
                         settings: {

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/utils.ts
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/utils.ts
@@ -15,7 +15,7 @@ export const getIcons = () => {
     return icons;
 };
 
-export const getSvg = (id: Array<string>, props?: any) => {
+export const getSvg = (id: Array<string>, props: any = {}) => {
     if (!props.width) {
         props.width = 50;
     }


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #761 
Page Builder - "Icon" page element not working
## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
My solution has two parts:
1. Fix `getSvg` function by add missing width prop to `getSvg` function and add default value for `props` arg
2. Improve the functionality of changing width prop in Icon Picker by removing 50 passed to value and adding 50 as placeholder text to input

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually tested my solution using the following steps:
1. Login into the Admin app and select any page to edit.
2. Inside page editor, use the LHS menu to insert an icon element into the page.
3. The icon is visible in preview and also applied changes to Icon properties like `color` and `width` 
are reflected in the preview

## Screenshots (if relevant):
Here is the result after applying the above-mentioned solution

https://www.loom.com/share/153230b1245546b8b638e57e2e4433b8