### PR TITLE
Fix: Headless CMS - User menu not opening anymore

### DIFF
--- a/packages/app-admin/src/plugins/UserMenu/UserMenu.tsx
+++ b/packages/app-admin/src/plugins/UserMenu/UserMenu.tsx
@@ -18,7 +18,7 @@ const UserMenu = () => {
                 <Menu
                     className={menuDialog}
                     anchor={"topEnd"}
-                    handle={<React.Fragment>{renderPlugin("user-menu-handle")}</React.Fragment>}
+                    handle={<div>{renderPlugin("user-menu-handle")}</div>}
                 >
                     <List data-testid="logged-in-user-menu-list">
                         {renderPlugin("header-user-menu-user-info")}


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #810 
Headless CMS - User menu not opening anymore
## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Use an `HTML` element instead of `React.Fragment`
We can also revert the change and use `menu-handle`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by following these steps:
1. Visit the admin app
2. Click on user avatar present at top RHS corner
3. User is able to see the user menu 

## Screenshots (if relevant):
https://www.loom.com/share/61b351260bbc4bc8865ec8bffaaef824