### PR TITLE
fix: prevent crash & run prettier

### DIFF
--- a/packages/app-page-builder/src/editor/components/OEmbed.tsx
+++ b/packages/app-page-builder/src/editor/components/OEmbed.tsx
@@ -85,6 +85,9 @@ const OEmbed = React.memo((props: OEmbedProps) => {
         skip,
         variables: source,
         onCompleted: data => {
+            if (skip) {
+                return;
+            }
             const { data: oembed, error } = get(data, "pageBuilder.oembedData");
             if (oembed) {
                 // Store loaded oembed data
@@ -128,7 +131,4 @@ const OEmbed = React.memo((props: OEmbedProps) => {
     return url ? renderEmbed() : renderEmpty();
 });
 
-export default connect<any, any, any>(
-    null,
-    { updateElement }
-)(OEmbed);
+export default connect<any, any, any>(null, { updateElement })(OEmbed);


### PR DESCRIPTION
## Related Issue
We've encountered an issue where opening the "Get Started" page generated by default, when initially creating the app, was crashing because of an Oembed bug.

This issue was fixed so quickly that I skipped writing a separate issue for it 😎

## Your solution
For some reason, when `skip` is set to `true`, `onComplete` function will still be executed. This caused the app to break.

So, I've added a return statement to prevent this.

## How Has This Been Tested?
Ran admin app locally.
