### PR TITLE
Feat/headless cms installation

### DIFF
--- a/packages/api-headless-cms/src/plugins/graphql.ts
+++ b/packages/api-headless-cms/src/plugins/graphql.ts
@@ -3,6 +3,7 @@ import merge from "lodash.merge";
 import gql from "graphql-tag";
 import cmsEnvironment from "./graphql/environment";
 import cmsEnvironmentAlias from "./graphql/environmentAlias";
+import cmsInstall from "./graphql/install";
 
 import { emptyResolver } from "@webiny/commodo-graphql";
 
@@ -61,6 +62,7 @@ export default () => [
                     _empty: String
                 }
 
+                ${cmsInstall.typeDefs}
                 ${cmsEnvironment.typeDefs}
                 ${cmsEnvironmentAlias.typeDefs}
             `,
@@ -73,6 +75,7 @@ export default () => [
                         cms: emptyResolver
                     }
                 },
+                cmsInstall.resolvers,
                 cmsEnvironment.resolvers,
                 cmsEnvironmentAlias.resolvers
             )

--- a/packages/api-headless-cms/src/plugins/graphql.ts
+++ b/packages/api-headless-cms/src/plugins/graphql.ts
@@ -46,6 +46,11 @@ export default () => [
                     error: CmsError
                 }
 
+                type CmsBooleanResponse {
+                    data: Boolean
+                    error: CmsError
+                }
+
                 extend type Query {
                     cms: CmsQuery
                 }

--- a/packages/api-headless-cms/src/plugins/graphql/install.ts
+++ b/packages/api-headless-cms/src/plugins/graphql/install.ts
@@ -2,11 +2,6 @@ import { install, isInstalled } from "./installResolver/install";
 
 export default {
     typeDefs: /* GraphQL */ `
-        type CmsBooleanResponse {
-            data: Boolean
-            error: CmsError
-        }
-
         extend type CmsQuery {
             # Is CMS installed?
             isInstalled: CmsBooleanResponse

--- a/packages/api-headless-cms/src/plugins/graphql/install.ts
+++ b/packages/api-headless-cms/src/plugins/graphql/install.ts
@@ -1,0 +1,24 @@
+import { install, isInstalled } from "./installResolver/install";
+
+export default {
+    typeDefs: /* GraphQL */ `
+        type CmsBooleanResponse {
+            data: Boolean
+            error: CmsError
+        }
+
+        extend type CmsQuery {
+            # Is CMS installed?
+            isInstalled: CmsBooleanResponse
+        }
+
+        extend type CmsMutation {
+            # Install CMS
+            install: CmsBooleanResponse
+        }
+    `,
+    resolvers: {
+        CmsQuery: { isInstalled },
+        CmsMutation: { install }
+    }
+};

--- a/packages/api-headless-cms/src/plugins/graphql/installResolver/install.ts
+++ b/packages/api-headless-cms/src/plugins/graphql/installResolver/install.ts
@@ -1,0 +1,92 @@
+import mdbid from "mdbid";
+import { ErrorResponse, Response } from "@webiny/graphql";
+import { GraphQLFieldResolver } from "@webiny/graphql/types";
+
+const initialEnvironment = {
+    id: mdbid(),
+    name: "Production",
+    description: "Ready to go live",
+    createdFrom: null
+};
+
+const initialEnvironmentAlias = {
+    slug: "production",
+    name: "Production",
+    description: "Ready to go live"
+};
+
+const initialContentModelGroup = {
+    name: "E-commerce",
+    slug: "e-commerce",
+    description: "A generic group for e-commerce",
+    icon: "fas/star"
+};
+
+export const install: GraphQLFieldResolver = async (root, args, context) => {
+    const {
+        CmsSettings,
+        CmsEnvironment,
+        CmsEnvironmentAlias,
+        CmsContentModelGroup
+    } = context.models;
+
+    const cmsEnvironment = new CmsEnvironment();
+    const cmsEnvironmentAlias = new CmsEnvironmentAlias();
+    const cmsContentModelGroup = new CmsContentModelGroup();
+
+    try {
+        const settings = await CmsSettings.load();
+        if (await settings.data.installed) {
+            return new ErrorResponse({
+                code: "CMS_INSTALL_ABORTED",
+                message: "Cms is already installed."
+            });
+        }
+        // Create a production environment
+        const cmsEnvironmentProduction = await cmsEnvironment.populate({
+            id: initialEnvironment.id,
+            name: initialEnvironment.name,
+            description: initialEnvironment.description,
+            createdFrom: initialEnvironment.createdFrom
+        });
+        cmsEnvironmentProduction.initial = true;
+        await cmsEnvironmentProduction.save();
+
+        // Create the "Production" environment alias and link it to the "Production" environment
+        await cmsEnvironmentAlias
+            .populate({
+                name: initialEnvironmentAlias.name,
+                slug: initialEnvironmentAlias.slug,
+                description: initialEnvironmentAlias.description,
+                environment: cmsEnvironmentProduction.id
+            })
+            .save();
+
+        // Create a default Content Model group
+        await cmsContentModelGroup
+            .populate({
+                name: initialContentModelGroup.name,
+                slug: initialContentModelGroup.slug,
+                description: initialContentModelGroup.description,
+                icon: initialContentModelGroup.icon,
+                environment: cmsEnvironmentProduction.id
+            })
+            .save();
+
+        // All done here
+        settings.data.installed = true;
+        await settings.save();
+        return new Response(true);
+    } catch (e) {
+        return new ErrorResponse({
+            code: "CMS_INSTALLATION_ERROR",
+            message: e.message
+        });
+    }
+};
+
+export const isInstalled: GraphQLFieldResolver = async (root, args, context) => {
+    const { CmsSettings } = context.models;
+    const settings = await CmsSettings.load();
+    return new Response(settings.data.installed);
+};

--- a/packages/api-headless-cms/src/plugins/graphql/installResolver/install.ts
+++ b/packages/api-headless-cms/src/plugins/graphql/installResolver/install.ts
@@ -1,24 +1,21 @@
-import mdbid from "mdbid";
 import { ErrorResponse, Response } from "@webiny/graphql";
 import { GraphQLFieldResolver } from "@webiny/graphql/types";
 
 const initialEnvironment = {
-    id: mdbid(),
     name: "Production",
-    description: "Ready to go live",
-    createdFrom: null
+    description: "This is the production environment"
 };
 
 const initialEnvironmentAlias = {
     slug: "production",
     name: "Production",
-    description: "Ready to go live"
+    description: `This is the "production" environment alias`
 };
 
 const initialContentModelGroup = {
-    name: "E-commerce",
-    slug: "e-commerce",
-    description: "A generic group for e-commerce",
+    name: "Ungrouped",
+    slug: "ungrouped",
+    description: "A generic content model group",
     icon: "fas/star"
 };
 
@@ -39,15 +36,13 @@ export const install: GraphQLFieldResolver = async (root, args, context) => {
         if (await settings.data.installed) {
             return new ErrorResponse({
                 code: "CMS_INSTALL_ABORTED",
-                message: "Cms is already installed."
+                message: "Cms -> The app is already installed."
             });
         }
         // Create a production environment
         const cmsEnvironmentProduction = await cmsEnvironment.populate({
-            id: initialEnvironment.id,
             name: initialEnvironment.name,
-            description: initialEnvironment.description,
-            createdFrom: initialEnvironment.createdFrom
+            description: initialEnvironment.description
         });
         cmsEnvironmentProduction.initial = true;
         await cmsEnvironmentProduction.save();

--- a/packages/api-headless-cms/src/plugins/models.ts
+++ b/packages/api-headless-cms/src/plugins/models.ts
@@ -2,6 +2,8 @@ import { pipe, withStorage, withCrudLogs, withSoftDelete, withFields } from "@we
 import { withUser } from "@webiny/api-security";
 import cmsEnvironment from "./models/environment.model";
 import cmsEnvironmentAlias from "./models/environmentAlias.model";
+import cmsSettings from "./models/cmsSettings.model";
+import cmsContentModelGroup from "./models/contentModelGroup.model";
 
 export default () => ({
     name: "context-models",
@@ -29,5 +31,7 @@ export default () => ({
         context.models = { createBase };
         context.models.CmsEnvironment = cmsEnvironment({ createBase, context });
         context.models.CmsEnvironmentAlias = cmsEnvironmentAlias({ createBase, context });
+        context.models.CmsSettings = cmsSettings({ createBase });
+        context.models.CmsContentModelGroup = cmsContentModelGroup({ createBase, context });
     }
 });

--- a/packages/api-headless-cms/src/plugins/models/cmsSettings.model.ts
+++ b/packages/api-headless-cms/src/plugins/models/cmsSettings.model.ts
@@ -1,0 +1,37 @@
+import { flow } from "lodash";
+import {
+    withFields,
+    setOnce,
+    string,
+    fields,
+    boolean,
+    withName,
+    withStaticProps
+} from "@webiny/commodo";
+
+const SETTINGS_KEY = "cms";
+
+export default ({ createBase }) => {
+    return flow(
+        withName("Settings"),
+        withStaticProps({
+            async load() {
+                let settings = await this.findOne({ query: { key: SETTINGS_KEY } });
+                if (!settings) {
+                    settings = new this();
+                    await settings.save();
+                }
+                return settings;
+            }
+        }),
+        withFields({
+            key: setOnce()(string({ value: SETTINGS_KEY })),
+            data: fields({
+                value: {},
+                instanceOf: withFields({
+                    installed: boolean()
+                })()
+            })
+        })
+    )(createBase());
+};

--- a/packages/api-headless-cms/src/plugins/models/contentModelGroup.model.ts
+++ b/packages/api-headless-cms/src/plugins/models/contentModelGroup.model.ts
@@ -1,0 +1,17 @@
+import { validation } from "@webiny/validation";
+import { compose, withFields, setOnce, string, withName } from "@webiny/commodo";
+
+export default ({ createBase, context }) => {
+    const CmsGroup: any = compose(
+        withName(`CmsContentModelGroup`),
+        withFields({
+            name: string({ validation: validation.create("required") }),
+            slug: setOnce()(string({ validation: validation.create("required") })),
+            description: string({ validation: validation.create("maxLength:200") }),
+            icon: string({ validation: validation.create("required") }),
+            environment: setOnce()(context.commodo.fields.id())
+        })
+    )(createBase());
+
+    return CmsGroup;
+};

--- a/packages/app-headless-cms/src/admin/plugins/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/index.ts
@@ -8,7 +8,6 @@ import install from "./install";
 import revisionContent from "./contentDetails/revisionContent";
 import previewContent from "./contentDetails/contentForm";
 import header from "./contentDetails/header";
-// import pageRevisions from "./contentDetails/pageRevisions";
 
 import contentModelEditorPlugins from "./../editor/plugins";
 

--- a/packages/app-headless-cms/src/admin/plugins/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/index.ts
@@ -3,16 +3,17 @@ import menus from "./menus";
 import fields from "./fields";
 import validators from "./validators";
 import icons from "./icons";
-
+import install from "./install";
 // import header from "./contentDetails/header";
 import revisionContent from "./contentDetails/revisionContent";
 import previewContent from "./contentDetails/contentForm";
 import header from "./contentDetails/header";
-import pageRevisions from "./contentDetails/pageRevisions";
+// import pageRevisions from "./contentDetails/pageRevisions";
 
 import contentModelEditorPlugins from "./../editor/plugins";
 
 export default [
+    install,
     routes,
     menus,
     icons,

--- a/packages/app-headless-cms/src/admin/plugins/install.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/install.tsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from "react";
+import gql from "graphql-tag";
+import { useApolloClient } from "react-apollo";
+import { i18n } from "@webiny/app/i18n";
+import { Alert } from "@webiny/ui/Alert";
+import { CircularProgress } from "@webiny/ui/Progress";
+import { SimpleForm, SimpleFormContent } from "@webiny/app-admin/components/SimpleForm";
+import styled from "@emotion/styled";
+import { InstallationPlugin } from "@webiny/app-admin/types";
+
+const SimpleFormPlaceholder = styled.div({
+  minHeight: 300,
+  minWidth: 400
+});
+
+const t = i18n.ns("app-headless-cms/admin/installation");
+
+const IS_INSTALLED = gql`
+    {
+        cms {
+            isInstalled {
+                data
+                error {
+                    code
+                    message
+                }
+            }
+        }
+    }
+`;
+
+const INSTALL = gql`
+    mutation InstallCms {
+        cms {
+            install {
+                data
+                error {
+                    code
+                    message
+                }
+            }
+        }
+    }
+`;
+
+const CMSInstaller = ({ onInstalled }) => {
+  const client = useApolloClient();
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    client
+      .mutate({
+        mutation: INSTALL
+      })
+      .then(({ data }) => {
+        const { error } = data.cms.install;
+        if (error) {
+          setError(error.message);
+          return;
+        }
+
+        // Just so the user sees the actual message.
+        setTimeout(onInstalled, 3000);
+      });
+  }, []);
+
+  return (
+    <SimpleForm>
+      <CircularProgress label={t`Installing CMS...`} />
+      {error && (
+        <Alert title={t`Something went wrong`} type={"danger"}>
+          {error}
+        </Alert>
+      )}
+      <SimpleFormContent>
+        <SimpleFormPlaceholder />
+      </SimpleFormContent>
+    </SimpleForm>
+  );
+};
+
+const plugin: InstallationPlugin = {
+  name: "installation-cms",
+  type: "installation",
+  title: t`Headless CMS`,
+  dependencies: [],
+  secure: true,
+  async isInstalled({ client }) {
+    const { data } = await client.query({ query: IS_INSTALLED });
+    return data.cms.isInstalled.data;
+  },
+  render({ onInstalled }) {
+    return <CMSInstaller onInstalled={onInstalled} />;
+  }
+};
+
+export default plugin;


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #808 
Headless CMS - Create Installation
## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Implement installation plugin for headless cms
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by following these steps:
1. Add a new DB URL in env file
2. Deploy API to local env and run/visit admin app
3. Headless cms installation should appear as the last step of the admin app installation process
4. After successful installation/login user should be able to 
   -  A production environment created for him to use
   - A production environment alias created for him to use
   - A generic content model group created for him to use when creating a new content model


## Screenshots (if relevant):
https://www.loom.com/share/89d7d51051f24e1f91739a3527f7bd6a