### PR TITLE
Fix: Headless CMS - finish date field

### DIFF
--- a/packages/api-headless-cms/src/handler/plugins/graphqlFields/datetime.ts
+++ b/packages/api-headless-cms/src/handler/plugins/graphqlFields/datetime.ts
@@ -2,7 +2,6 @@ import gql from "graphql-tag";
 import { CmsModelFieldToGraphQLPlugin } from "@webiny/api-headless-cms/types";
 
 const createListFilters = ({ field }) => {
-
     return `
         # Matches if the field is equal to the given value
         ${field.fieldId}: String
@@ -44,12 +43,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             };
         },
         createTypeField({ field }) {
-            const { type } = field.settings;
             const localeArg = "(locale: String)";
-
-            if (type === "dateTimeWithTimezone") {
-                return `${field.fieldId}${localeArg}: String`;
-            }
 
             return `${field.fieldId}${localeArg}: String`;
         }

--- a/packages/api-headless-cms/src/handler/plugins/graphqlFields/datetime.ts
+++ b/packages/api-headless-cms/src/handler/plugins/graphqlFields/datetime.ts
@@ -2,58 +2,30 @@ import gql from "graphql-tag";
 import { CmsModelFieldToGraphQLPlugin } from "@webiny/api-headless-cms/types";
 
 const createListFilters = ({ field }) => {
-    if (field.settings.type === "dateTimeWithTimezone") {
-        return `
-            # Matches if the field is equal to the given value
-            ${field.fieldId}: DateTime
-            
-            # Matches if the field is not equal to the given value
-            ${field.fieldId}_not: DateTime
-    
-            
-            # Matches if the field value equal one of the given values
-            ${field.fieldId}_in: [DateTime]
-            
-            # Matches if the field value does not equal any of the given values
-            ${field.fieldId}_not_in: [DateTime]
-            
-            # Matches if the field value is strictly smaller than the given value
-            ${field.fieldId}_lt: DateTime
-            
-            # Matches if the field value is smaller than or equal to the given value
-            ${field.fieldId}_lte: DateTime
-            
-            # Matches if the field value is strictly greater than the given value
-            ${field.fieldId}_gt: DateTime
-            
-            # Matches if the field value is greater than or equal to the given value
-            ${field.fieldId}_gte: DateTime
-        `;
-    }
 
     return `
         # Matches if the field is equal to the given value
         ${field.fieldId}: String
-        
+
         # Matches if the field is not equal to the given value
         ${field.fieldId}_not: String
 
-        
+
         # Matches if the field value equal one of the given values
         ${field.fieldId}_in: [String]
-        
+
         # Matches if the field value does not equal any of the given values
         ${field.fieldId}_not_in: [String]
-        
+
         # Matches if the field value is strictly smaller than the given value
         ${field.fieldId}_lt: String
-        
+
         # Matches if the field value is smaller than or equal to the given value
         ${field.fieldId}_lte: String
-        
+
         # Matches if the field value is strictly greater than the given value
         ${field.fieldId}_gt: String
-        
+
         # Matches if the field value is greater than or equal to the given value
         ${field.fieldId}_gte: String
     `;
@@ -76,7 +48,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             const localeArg = "(locale: String)";
 
             if (type === "dateTimeWithTimezone") {
-                return `${field.fieldId}${localeArg}: DateTime`;
+                return `${field.fieldId}${localeArg}: String`;
             }
 
             return `${field.fieldId}${localeArg}: String`;
@@ -94,7 +66,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 typeDefs: gql`
                     # dateTimeWithTimezone types
                     input CmsDateTimeWithTzLocalizedInput {
-                        value: DateTime
+                        value: String
                         locale: ID!
                     }
 
@@ -103,12 +75,12 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                     }
 
                     type CmsDateTimeWithTzLocalized {
-                        value: DateTime
+                        value: String
                         locale: ID!
                     }
 
                     type CmsDateTimeWithTz {
-                        value: DateTime
+                        value: String
                         values: [CmsDateTimeWithTzLocalized]!
                     }
 

--- a/packages/api-headless-cms/src/handler/plugins/modelFields/datetime.ts
+++ b/packages/api-headless-cms/src/handler/plugins/modelFields/datetime.ts
@@ -16,10 +16,6 @@ function createValidation(validation, format, checkLength = true) {
             return;
         }
 
-        if (typeof validation === "function") {
-            await validation(value);
-        }
-
         const error = Error(`Enter a string in the following format "${format}"`);
         if (checkLength && format.length !== value.length) {
             throw error;
@@ -28,6 +24,10 @@ function createValidation(validation, format, checkLength = true) {
         const date = parse(value, format);
         if (!date) {
             throw error;
+        }
+
+        if (typeof validation === "function") {
+            await validation(value);
         }
     };
 }

--- a/packages/api-headless-cms/src/handler/plugins/modelFields/datetime.ts
+++ b/packages/api-headless-cms/src/handler/plugins/modelFields/datetime.ts
@@ -1,5 +1,5 @@
 import { CmsModelFieldToCommodoFieldPlugin } from "@webiny/api-headless-cms/types";
-import { withFields, date, string } from "@webiny/commodo";
+import { withFields, string } from "@webiny/commodo";
 import { parse } from "fecha";
 import { i18nField } from "./i18nFields";
 
@@ -10,7 +10,7 @@ enum DATE_TYPE {
     TIME = "time"
 }
 
-function createValidation(validation, format) {
+function createValidation(validation, format, checkLength = true) {
     return async value => {
         if (validation === false) {
             return;
@@ -21,7 +21,7 @@ function createValidation(validation, format) {
         }
 
         const error = Error(`Enter a string in the following format "${format}"`);
-        if (format.length !== value.length) {
+        if (checkLength && format.length !== value.length) {
             throw error;
         }
 
@@ -37,7 +37,9 @@ function getDateField({ field, validation }) {
     let cField;
     switch (type) {
         case DATE_TYPE.DATE_TIME_WITH_TIMEZONE:
-            cField = date({ validation });
+            cField = string({
+                validation: createValidation(validation, "YYYY-MM-DDTHH:mm:ssZ", false)
+            });
             break;
         case DATE_TYPE.DATE_TIME_WITHOUT_TIMEZONE:
             cField = string({

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithTimezone.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import Input from "./Input";
 import Select from "./Select";
 import { Grid, Cell } from "@webiny/ui/Grid";
-import { UTC_TIMEZONES } from './utils'
+import { UTC_TIMEZONES, getCurrentDateString, appendTextToLabel } from './utils'
 
 const DEFAULT_TIME = "00:00:00"
-const DEFAULT_DATE = "";
+const DEFAULT_DATE = getCurrentDateString();
 const DEFAULT_TIMEZONE = "+01:00";
 
 const DateTimeWithTimezone = (props) => {
@@ -55,7 +55,10 @@ const DateTimeWithTimezone = (props) => {
               return props.bind.onChange(`${value}T${time}${timezone}`);
             }
           }}
-
+          field={{
+            ...props.field,
+            label: appendTextToLabel(props.field.label, ' date')
+          }}
           type={"date"} />
       </Cell>
       <Cell span={4}>
@@ -65,35 +68,25 @@ const DateTimeWithTimezone = (props) => {
             ...props.bind,
             value: time,
             onChange: value => {
-              // FIXME: better input handling
               setTime(`${value}:00`);
               return props.bind.onChange(`${date}T${value}:00${timezone}`);
             }
           }}
-
+          field={{
+            ...props.field,
+            label: appendTextToLabel(props.field.label, ' time')
+          }}
           type={"time"} />
       </Cell>
       <Cell span={4}>
         <Select
-          {...props}
-          bind={{
-            ...props.bind,
-            value: timezone,
-            onChange: value => {
-              setTimezone(value);
-              return props.bind.onChange(`${date}T${time}${value}`);
-            }
+          label="Timezone"
+          value={timezone}
+          onChange={value => {
+            setTimezone(value);
+            return props.bind.onChange(`${date}T${time}${value}`);
           }}
-          field={{
-            ...props.field,
-            label: null, // TODO: Add relevant Icon or label
-            options: [
-              ...UTC_TIMEZONES.map(t => ({
-                value: t.value,
-                label: { values: [{ value: t.label, locale: "5eb7e468d4955f0008b58fdb" }] },
-              })),
-            ]
-          }}
+          options={UTC_TIMEZONES.map(t => ({ value: t.value, label: t.label }))}
         />
       </Cell>
     </Grid>

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithTimezone.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import Input from "./Input";
+import Select from "./Select";
+import { Grid, Cell } from "@webiny/ui/Grid";
+import { UTC_TIMEZONES } from './utils'
+
+const DEFAULT_TIME = "00:00:00"
+const DEFAULT_DATE = "";
+const DEFAULT_TIMEZONE = "+01:00";
+
+const DateTimeWithTimezone = (props) => {
+  // "2020-05-18T09:00+10:00"
+  const [date, setDate] = React.useState("")
+  const [time, setTime] = React.useState("")
+  const [timezone, setTimezone] = React.useState("")
+
+  React.useEffect(() => {
+    if (props.bind.value === null) {
+      // Set initial values
+      setDate(DEFAULT_DATE)
+      setTime(DEFAULT_TIME)
+      setTimezone(DEFAULT_TIMEZONE)
+      return
+    }
+    const [isoDate, rest] = props.bind.value.split('T')
+    const sign = rest.includes('+') ? '+' : '-'
+    const [fullTime, zone] = rest.split(sign)
+
+    const formattedDate = isoDate
+    const formattedTime = fullTime
+    const formattedTimezone = sign + zone
+
+    // Set previously saved values
+    if (date !== formattedDate) {
+      setDate(formattedDate)
+    }
+    if (time !== formattedTime) {
+      setTime(formattedTime)
+    }
+    if (timezone !== formattedTimezone) {
+      setTimezone(formattedTimezone)
+    }
+  }, [props.bind.value])
+
+  return (
+    <Grid>
+      <Cell span={4}>
+        <Input
+          {...props}
+          bind={{
+            ...props.bind,
+            value: date,
+            onChange: value => {
+              setDate(value);
+              return props.bind.onChange(`${value}T${time}${timezone}`);
+            }
+          }}
+
+          type={"date"} />
+      </Cell>
+      <Cell span={4}>
+        <Input
+          {...props}
+          bind={{
+            ...props.bind,
+            value: time,
+            onChange: value => {
+              // FIXME: better input handling
+              setTime(`${value}:00`);
+              return props.bind.onChange(`${date}T${value}:00${timezone}`);
+            }
+          }}
+
+          type={"time"} />
+      </Cell>
+      <Cell span={4}>
+        <Select
+          {...props}
+          bind={{
+            ...props.bind,
+            value: timezone,
+            onChange: value => {
+              setTimezone(value);
+              return props.bind.onChange(`${date}T${time}${value}`);
+            }
+          }}
+          field={{
+            ...props.field,
+            label: null, // TODO: Add relevant Icon or label
+            options: [
+              ...UTC_TIMEZONES.map(t => ({
+                value: t.value,
+                label: { values: [{ value: t.label, locale: "5eb7e468d4955f0008b58fdb" }] },
+              })),
+            ]
+          }}
+        />
+      </Cell>
+    </Grid>
+  )
+}
+
+
+export default DateTimeWithTimezone;

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithoutTimezone.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import Input from "./Input";
+import { Grid, Cell } from "@webiny/ui/Grid";
+
+const DEFAULT_TIME = "00:00:00"
+const DEFAULT_DATE = "";
+
+const DateTimeWithoutTimezone = (props) => {
+  // "2020-05-18 09:00:00"
+  const [date, setDate] = React.useState("")
+  const [time, setTime] = React.useState("")
+  React.useEffect(() => {
+    if (props.bind.value === null) {
+      setDate(DEFAULT_TIME)
+      setTime(DEFAULT_DATE)
+      return
+    }
+    const [isoDate, fullTime] = props.bind.value.split(' ')
+
+    const formattedDate = isoDate
+    const formattedTime = fullTime
+
+    // Set previously saved values
+    if (date !== formattedDate) {
+      setDate(formattedDate)
+    }
+    if (time !== formattedTime) {
+      setTime(formattedTime)
+    }
+
+  }, [props.bind.value])
+
+  return (
+    <Grid>
+      <Cell span={6}>
+        <Input
+          {...props}
+          bind={{
+            ...props.bind,
+            value: date,
+            onChange: value => {
+              setDate(value);
+              return props.bind.onChange(`${value} ${time}`);
+            }
+          }}
+          type={"date"} />
+      </Cell>
+      <Cell span={6}>
+        <Input
+          {...props}
+          bind={{
+            ...props.bind,
+            value: time,
+            onChange: value => {
+              setTime(`${value}:00`);
+              return props.bind.onChange(`${date} ${value}:00`);
+            }
+          }}
+          type={"time"} />
+      </Cell>
+    </Grid>
+  )
+}
+
+export default DateTimeWithoutTimezone

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/DateTimeWithoutTimezone.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import Input from "./Input";
 import { Grid, Cell } from "@webiny/ui/Grid";
+import { getCurrentDateString, appendTextToLabel } from "./utils";
 
 const DEFAULT_TIME = "00:00:00"
-const DEFAULT_DATE = "";
+const DEFAULT_DATE = getCurrentDateString();
 
 const DateTimeWithoutTimezone = (props) => {
   // "2020-05-18 09:00:00"
@@ -11,8 +12,8 @@ const DateTimeWithoutTimezone = (props) => {
   const [time, setTime] = React.useState("")
   React.useEffect(() => {
     if (props.bind.value === null) {
-      setDate(DEFAULT_TIME)
-      setTime(DEFAULT_DATE)
+      setDate(DEFAULT_DATE)
+      setTime(DEFAULT_TIME)
       return
     }
     const [isoDate, fullTime] = props.bind.value.split(' ')
@@ -43,6 +44,10 @@ const DateTimeWithoutTimezone = (props) => {
               return props.bind.onChange(`${value} ${time}`);
             }
           }}
+          field={{
+            ...props.field,
+            label: appendTextToLabel(props.field.label, ' date')
+          }}
           type={"date"} />
       </Cell>
       <Cell span={6}>
@@ -55,6 +60,10 @@ const DateTimeWithoutTimezone = (props) => {
               setTime(`${value}:00`);
               return props.bind.onChange(`${date} ${value}:00`);
             }
+          }}
+          field={{
+            ...props.field,
+            label: appendTextToLabel(props.field.label, ' time')
           }}
           type={"time"} />
       </Cell>

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Select.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Select.tsx
@@ -1,50 +1,17 @@
 import * as React from "react";
-import { CmsContentModelModelField } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
-import HelperMessage from "../components/HelperMessage";
-import { BindComponentRenderProp } from "@webiny/form";
-import { css } from "emotion"
+import { Select as UiSelect } from "@webiny/ui/Select";
 
-const selectBox = css({
-    padding: '16px !important',
-    height: '55px !important'
-})
-
-type Props = {
-    bind: BindComponentRenderProp;
-    field: CmsContentModelModelField;
-};
-
-const Select = (props: Props) => {
-    const { onChange, value, validation } = props.bind;
-
+const Select = (props) => {
     return (
-        <div className="webiny-fb-form-field webiny-fb-form-field--select">
-            {props.field.label && <label className="webiny-fb-form-field__label webiny-pb-typography-body">
-                <I18NValue value={props.field.label} />
-            </label>}
-            <select
-                value={value}
-                onChange={e => onChange(e.target.value)}
-                id={props.field.fieldId}
-                name={props.field.fieldId}
-                className={`webiny-fb-form-field__select ${selectBox}`}
-            >
-                <option disabled value={""}>
-                    {I18NValue({ value: props.field.placeholderText })}
-                </option>
-                {props.field.options.map(option => (
-                    <option key={option.value} value={option.value}>
-                        {I18NValue({ value: option.label })}
+        <UiSelect {...props}>
+            {props.options.map(t => {
+                return (
+                    <option key={t.value} value={t.value}>
+                        {t.label}
                     </option>
-                ))}
-            </select>
-            <HelperMessage
-                isValid={validation.isValid}
-                errorMessage={validation.message}
-                helperMessage={<I18NValue value={props.field.helpText} />}
-            />
-        </div>
+                )
+            })}
+        </UiSelect>
     );
 };
 

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Select.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Select.tsx
@@ -3,6 +3,12 @@ import { CmsContentModelModelField } from "@webiny/app-headless-cms/types";
 import { I18NValue } from "@webiny/app-i18n/components";
 import HelperMessage from "../components/HelperMessage";
 import { BindComponentRenderProp } from "@webiny/form";
+import { css } from "emotion"
+
+const selectBox = css({
+    padding: '16px !important',
+    height: '55px !important'
+})
 
 type Props = {
     bind: BindComponentRenderProp;
@@ -14,15 +20,15 @@ const Select = (props: Props) => {
 
     return (
         <div className="webiny-fb-form-field webiny-fb-form-field--select">
-            <label className="webiny-fb-form-field__label webiny-pb-typography-body">
+            {props.field.label && <label className="webiny-fb-form-field__label webiny-pb-typography-body">
                 <I18NValue value={props.field.label} />
-            </label>
+            </label>}
             <select
                 value={value}
                 onChange={e => onChange(e.target.value)}
                 id={props.field.fieldId}
                 name={props.field.fieldId}
-                className="webiny-fb-form-field__select"
+                className={`webiny-fb-form-field__select ${selectBox}`}
             >
                 <option disabled value={""}>
                     {I18NValue({ value: props.field.placeholderText })}

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Time.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/Time.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Input from "./Input";
+
+const Time = (props) => {
+  // "09:00:00"
+  return (
+    <Input
+      {...props}
+      bind={{
+        ...props.bind,
+        onChange: value => {
+          return props.bind.onChange(`${value}:00`);
+        }
+      }}
+      field={{
+        ...props.field,
+        label: null // TODO: Add relevant Icon or label
+      }}
+      type={"time"} />
+  )
+}
+
+export default Time;

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/utils.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/utils.ts
@@ -1,0 +1,159 @@
+// TODO: FInd a better way to get UTC timezones
+export const UTC_TIMEZONES = [
+    {
+        value: "-12:00",
+        label: "UTC-12:00"
+    },
+    {
+        value: "-11:00",
+        label: "UTC-11:00"
+    },
+    {
+        value: "-10:00",
+        label: "UTC-10:00"
+    },
+    {
+        value: "-09:30",
+        label: "UTC-09:30"
+    },
+    {
+        value: "-09:00",
+        label: "UTC-09:00"
+    },
+    {
+        value: "-08:00",
+        label: "UTC-08:00"
+    },
+    {
+        value: "-07:00",
+        label: "UTC-07:00"
+    },
+    {
+        value: "-06:00",
+        label: "UTC-06:00"
+    },
+    {
+        value: "-05:00",
+        label: "UTC-05:00"
+    },
+    {
+        value: "-04:30",
+        label: "UTC-04:30"
+    },
+    {
+        value: "-04:00",
+        label: "UTC-04:00"
+    },
+    {
+        value: "-03:30",
+        label: "UTC-03:30"
+    },
+    {
+        value: "-03:00",
+        label: "UTC-03:00"
+    },
+    {
+        value: "-02:00",
+        label: "UTC-02:00"
+    },
+    {
+        value: "-01:00",
+        label: "UTC-01:00"
+    },
+    {
+        value: "+00:00",
+        label: "UTC+00:00"
+    },
+    {
+        value: "+01:00",
+        label: "UTC+01:00"
+    },
+    {
+        value: "+02:00",
+        label: "UTC+02:00"
+    },
+    {
+        value: "+03:00",
+        label: "UTC+03:00"
+    },
+    {
+        value: "+03:30",
+        label: "UTC+03:30"
+    },
+    {
+        value: "+04:00",
+        label: "UTC+04:00"
+    },
+    {
+        value: "+04:30",
+        label: "UTC+04:30"
+    },
+    {
+        value: "+05:30",
+        label: "UTC+05:30"
+    },
+    {
+        value: "+05:45",
+        label: "UTC+05:45"
+    },
+    {
+        value: "+06:00",
+        label: "UTC+06:00"
+    },
+    {
+        value: "+06:30",
+        label: "UTC+06:30"
+    },
+    {
+        value: "+07:00",
+        label: "UTC+07:00"
+    },
+    {
+        value: "+08:00",
+        label: "UTC+08:00"
+    },
+    {
+        value: "+08:45",
+        label: "UTC+08:45"
+    },
+    {
+        value: "+09:00",
+        label: "UTC+09:00"
+    },
+    {
+        value: "+09:30",
+        label: "UTC+09:30"
+    },
+    {
+        value: "+10:00",
+        label: "UTC+10:00"
+    },
+    {
+        value: "+10:30",
+        label: "UTC+10:30"
+    },
+    {
+        value: "+11:00",
+        label: "UTC+11:00"
+    },
+    {
+        value: "+11:30",
+        label: "UTC+11:30"
+    },
+    {
+        value: "+12:00",
+        label: "UTC+12:00"
+    },
+    {
+        value: "+12:45",
+        label: "UTC+12:45"
+    },
+    {
+        value: "+13:00",
+        label: "UTC+13:00"
+    },
+    {
+        value: "+14:00",
+        label: "UTC+14:00"
+    }
+];

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/utils.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/fields/utils.ts
@@ -1,4 +1,3 @@
-// TODO: FInd a better way to get UTC timezones
 export const UTC_TIMEZONES = [
     {
         value: "-12:00",
@@ -157,3 +156,24 @@ export const UTC_TIMEZONES = [
         label: "UTC+14:00"
     }
 ];
+/**
+ * @returns Current date string in format `YYYY-MM-DD`
+ */
+export const getCurrentDateString = () => {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth() + 1; // months start from 0
+    const formattedMonth = month < 10 ? `0${month}` : month;
+    const date = today.getDate();
+    return `${year}-${formattedMonth}-${date}`;
+};
+/**
+ *
+ * @param {Object} label - I18NString instance
+ * @param {String} text - text to append
+ *
+ * @return new updated instance of I18NString
+ */
+export const appendTextToLabel = (label, text) => {
+    return { values: label.values.map(el => ({ ...el, value: `${el.value}${text}` })) };
+};

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentModelFormRender/index.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import Input from "./fields/Input";
 import Switch from "./fields/Switch";
+import Time from "./fields/Time";
+import DateTimeWithoutTimezone from './fields/DateTimeWithoutTimezone';
+import DateTimeWithTimezone from './fields/DateTimeWithTimezone';
 import { BindComponentRenderProp, Form } from "@webiny/form";
 import { CmsContentModelModelField } from "@webiny/app-headless-cms/types";
 import { Grid, Cell } from "@webiny/ui/Grid";
@@ -48,6 +51,17 @@ const renderFieldElement = (props: {
             return <Input {...props} type="number" />;
         case "boolean":
             return <Switch {...props} />;
+        case "datetime":
+            if (props.field.settings.type === 'dateTimeWithoutTimezone') {
+                return <DateTimeWithoutTimezone {...props} />;
+            }
+            if (props.field.settings.type === 'dateTimeWithTimezone') {
+                return <DateTimeWithTimezone {...props} />;
+            }
+            if (props.field.settings.type === 'time') {
+                return <Time {...props} />;
+            }
+            return <Input {...props} type={props.field.settings.type} />;
         // ---
         default:
             return <span>Cannot render field.</span>;

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -43,10 +43,10 @@ const plugin: FbBuilderFieldPlugin = {
                                 label={t`Format`}
                                 description={t`Cannot be changed later`}
                             >
-                                <option value="date">Date only</option>
-                                <option value="time">Time only</option>
-                                <option value="dateTimeWithTimezone">Date and time with timezone</option>
-                                <option value="dateTimeWithoutTimezone">Date and time without timezone</option>
+                                <option value={t`date`}>Date only</option>
+                                <option value={t`time`}>Time only</option>
+                                <option value={t`dateTimeWithTimezone`}>Date and time with timezone</option>
+                                <option value={t`dateTimeWithoutTimezone`}>Date and time without timezone</option>
                             </Select>
                         </Bind>
                     </Cell>

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -41,7 +41,7 @@ const plugin: FbBuilderFieldPlugin = {
                         <Bind name={"settings.type"}>
                             <Select
                                 label={"Format"}
-                                description={"Once set it can't be changed later on"}
+                                description={"Cannot be changed later"}
                             >
                                 <option value="date">Date only</option>
                                 <option value="time">Time only</option>

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -40,8 +40,8 @@ const plugin: FbBuilderFieldPlugin = {
                     <Cell span={12}>
                         <Bind name={"settings.type"}>
                             <Select
-                                label={"Format"}
-                                description={"Cannot be changed later"}
+                                label={t`Format`}
+                                description={t`Cannot be changed later`}
                             >
                                 <option value="date">Date only</option>
                                 <option value="time">Time only</option>

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import { ReactComponent as DateTimeIcon } from "./icons/schedule-black-24px.svg";
 import { Grid, Cell } from "@webiny/ui/Grid";
+import { Select } from "@webiny/ui/Select";
 import { I18NInput } from "@webiny/app-i18n/admin/components";
 import { FbBuilderFieldPlugin } from "@webiny/app-headless-cms/types";
 import { i18n } from "@webiny/app/i18n";
-const t = i18n.ns("app-headless-cms/fields");
+const t = i18n.ns("app-headless-cms/admin/fields");
 
 const plugin: FbBuilderFieldPlugin = {
     type: "content-model-editor-field-type",
     name: "content-model-editor-field-type-dateTime",
     field: {
-        type: "dateTime",
+        type: "datetime",
         label: t`Date/Time`,
         description: t`Store date and time.`,
         icon: <DateTimeIcon />,
@@ -34,6 +35,19 @@ const plugin: FbBuilderFieldPlugin = {
                                 label={t`Placeholder text`}
                                 description={t`Placeholder text (optional)`}
                             />
+                        </Bind>
+                    </Cell>
+                    <Cell span={12}>
+                        <Bind name={"settings.type"}>
+                            <Select
+                                label={"Format"}
+                                description={"Once set it can't be changed later on"}
+                            >
+                                <option value="date">Date only</option>
+                                <option value="time">Time only</option>
+                                <option value="dateTimeWithTimezone">Date and time with timezone</option>
+                                <option value="dateTimeWithoutTimezone">Date and time without timezone</option>
+                            </Select>
                         </Bind>
                     </Cell>
                 </Grid>


### PR DESCRIPTION
## Related Issue

Issue #831 
Headless CMS - finish date field
## Your solution
Following the solution suggested in the issue #831 
Finish up the UI for date field in headless CMS

## How Has This Been Tested?
Manually, by creating a content model with
## Screenshots (if relevant):
**date time with timezone**
![image](https://user-images.githubusercontent.com/13612227/81797224-1dd7c100-952c-11ea-80ad-60abb384ebc9.png)

**date time without timezone**
![image](https://user-images.githubusercontent.com/13612227/81797489-7dce6780-952c-11ea-8690-171274ae260a.png)

**time**
![image](https://user-images.githubusercontent.com/13612227/81797425-67c0a700-952c-11ea-9eb7-8a4fdfb942b6.png)

**date**
![image](https://user-images.githubusercontent.com/13612227/81797614-a7878e80-952c-11ea-86a0-910d84532471.png)
