### PR TITLE
fix: 🐛  fix the query in return args

### DIFF
--- a/packages/api-headless-cms/src/handler/plugins/utils/createEnvironmentBase.ts
+++ b/packages/api-headless-cms/src/handler/plugins/utils/createEnvironmentBase.ts
@@ -2,7 +2,7 @@ import { pipe, withFields, withStaticProps, setOnce, withHooks } from "@webiny/c
 import { cloneDeep } from "lodash";
 
 const modifyQueryArgs = (args = {}, environment) => {
-    const returnArgs = cloneDeep(args);
+    const returnArgs: any = cloneDeep(args);
     if (returnArgs.query) {
         returnArgs.query = {
             $and: [{ environment: environment.id }, returnArgs.query]


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
when run yarn setup-repo, there is an error:
@webiny/api-headless-cms: src/handler/plugins/utils/createEnvironmentBase.ts(6,20): error TS2339: Property 'query' does not exist on type '{}'.

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
assign the returnArgs to type any

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run yarn setup-repo successfully without error

## Screenshots (if relevant):
<img width="691" alt="Screen Shot 2020-05-21 at 11 09 16 pm" src="https://user-images.githubusercontent.com/8401511/82562213-1d889700-9bb8-11ea-83a7-14ac429229f3.png">
