### PR TITLE
fix: 🐛 api unavailable error for sample project admin app

### DIFF
--- a/sample-project/apps/admin/package.json
+++ b/sample-project/apps/admin/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "analyze": "source-map-explorer build/static/js/main.*",
-    "start": "env-cmd -r .env.json -e default,local webiny run start",
+    "start": "env-cmd -r .env.json -e default,dev webiny run start",
     "build:dev": "env-cmd -r .env.json -e default,dev webiny run build",
     "build:prod": "env-cmd -r .env.json -e default,prod webiny run build"
   },

--- a/sample-project/apps/site/package.json
+++ b/sample-project/apps/site/package.json
@@ -55,7 +55,7 @@
     "build:prod": "env-cmd -r .env.json -e default,prod webiny run build",
     "build:ssr:dev":  "env-cmd -r .env.json -e default,dev webiny run build-ssr",
     "build:ssr:prod":  "env-cmd -r .env.json -e default,prod webiny run build-ssr",
-    "start": "env-cmd -r .env.json -e default,local webiny run start"
+    "start": "env-cmd -r .env.json -e default,dev webiny run start"
   },
   "browserslist": {
     "development": [


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
sample project admin and site app cannot access api

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
change env the yarn start in package.json

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
can access admin and site app on http://localhost:3001 and http://localhost:3000 without error

## Screenshots (if relevant):
before
<img width="960" alt="api-error" src="https://user-images.githubusercontent.com/8401511/82567514-d05cf300-9bc0-11ea-9f90-4500e59ac278.png">

<img width="1474" alt="Screen Shot 2020-05-22 at 8 30 33 pm" src="https://user-images.githubusercontent.com/8401511/82658868-1cfd0880-9c6b-11ea-8b14-893c312be38f.png">

after
<img width="1278" alt="success-admin" src="https://user-images.githubusercontent.com/8401511/82567531-d652d400-9bc0-11ea-89b4-905468ee1486.png">

<img width="1365" alt="Screen Shot 2020-05-22 at 8 20 46 pm" src="https://user-images.githubusercontent.com/8401511/82658897-271f0700-9c6b-11ea-957c-81f121f39ac1.png">

