### PR TITLE
Fix: Headless CMS - cannot erase first character in input field

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
@@ -9,9 +9,11 @@ import { getPlugins } from "@webiny/plugins";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/components/content-form");
 
+const empty = [null, undefined];
+
 const setValue = ({ value, bind, locale }) => {
     const newValue = cloneDeep({ values: [], ...bind.value });
-    const index = value ? newValue.values.findIndex(item => item.locale === locale) : -1;
+    const index = empty.includes(value) ? -1 : newValue.values.findIndex(item => item.locale === locale);
     if (index >= 0) {
         newValue.values[index].value = value;
     } else {


### PR DESCRIPTION
## Related Issue
Issue #874 
Headless CMS - cannot erase the first character in the input field

## Your solution
Don't create new value entry for the empty string

## How Has This Been Tested?
Manually, by following these steps:
- Visit the admin app and create a content model entry with `text` field
- Try adding some text and then try erasing it
- User should be able to erase all of the text including the first character
## Screenshots:
https://www.loom.com/share/51871c4f962a42f18292c5dadc85f2db