### PR TITLE
fix: 🐛  update `plugin` name

### DIFF
--- a/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
+++ b/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
@@ -7,7 +7,7 @@ export default function getFileTypePlugin(file) {
         return null;
     }
 
-    const plugins = getPlugins<AdminFileManagerFileTypePlugin>("file-manager-file-type");
+    const plugins = getPlugins<AdminFileManagerFileTypePlugin>("admin-file-manager-file-type");
 
     let plugin = null;
     for (let i = 0; i < plugins.length; i++) {


### PR DESCRIPTION
## Related Issue
No related issue on Github

## Your solution
add missing `admin` prefix in plugin name when fetching plugins for that type

## How Has This Been Tested?
Manually, by following these steps:
- Visit the admin app and try selecting user profile avatar
- When file manager loads up, select one image
- User should be able to see the image preview

## Screenshots:
https://www.loom.com/share/cb6d0c927ee34444b2db082a4b2ac728