### PR TITLE
Fix/broken style issues

### DIFF
--- a/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/Name/NameStyled.tsx
+++ b/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/Name/NameStyled.tsx
@@ -28,6 +28,7 @@ export const NameWrapper = styled("div")({
 export const FormName = styled("div")({
     border: "1px solid transparent",
     fontSize: 20,
+    lineHeight: 1.25,
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",

--- a/packages/app-security/src/admin/views/Components/AvatarImage.tsx
+++ b/packages/app-security/src/admin/views/Components/AvatarImage.tsx
@@ -1,8 +1,17 @@
 import * as React from "react";
 import SingleImageUpload from "@webiny/app-admin/components/SingleImageUpload";
 
+const getImagePreviewStyles = (round: boolean) => ({
+    width: '100%',
+    height: '100%',
+    maxWidth: 150,
+    maxHeight: 150,
+    borderRadius: round ? "50%" : "unset",
+    objectFit: "cover"
+});
+
 const AvatarImage = props => {
-    return <SingleImageUpload {...props} imagePreviewProps={{ transform: { width: 300 } }} />;
+    return <SingleImageUpload {...props} imagePreviewProps={{ transform: { width: 300 }, style: getImagePreviewStyles(props.round) }} />;
 };
 
 export default AvatarImage;


### PR DESCRIPTION
## Related Issue
No related Github issue

## Your solution
**For**: In the content editor, the content model title field seems to trim the bottom part of the content model name -> visible if you have characters like `gqp`.
**Add**: a line-height so that text won't get cut off from the bottom

**For**: Under /account the file avatar image doesn't have max-width/max-height, uploading a large image breaks the page design. There should also be a CSS part which makes the avatar round. I believe that was there before.
**Add**: styles missing styles like `max-width` and `max-height`
## How Has This Been Tested?
Manually

## Screenshots:
https://www.loom.com/share/483d23614b4047c1be822aab0d58b45b

https://www.loom.com/share/7a3cd11c3219487a99bd5b706d43c447