### PR TITLE
Fixed a crash that occurred upon adding the Date/Time field

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -25,6 +25,9 @@ const plugin: CmsEditorFieldTypePlugin = {
         createField() {
             return {
                 type: this.type,
+                settings: {
+                    type: "date"
+                },
                 validation: [],
                 renderer: {
                     name: ""


### PR DESCRIPTION
## Related Issue
Closes #893

## Your solution
The problem occurred in cases where the user didn't select a date/time format in the field settings dialog.

![image](https://user-images.githubusercontent.com/5121148/82930055-0a454500-9f85-11ea-8357-448243dce0d0.png)

Although it seems like the format is selected, because there is a value in the input, the actual data in the state was empty.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/82929851-a589ea80-9f84-11ea-8858-c5991605de8e.png)
