### PR TITLE
fix: 🐛  Fixed bug of #871 pressing Esc closes the edit field dialog

### DIFF
--- a/packages/app-i18n/package.json
+++ b/packages/app-i18n/package.json
@@ -33,7 +33,8 @@
     "react-apollo": "^3.1.3",
     "react-helmet": "^5.2.0",
     "slate": "^0.42.2",
-    "slate-react": "^0.19.3"
+    "slate-react": "^0.19.3",
+    "react-hotkeyz": "^1.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/app-i18n/src/admin/components/I18NInputLocalesOverlay.tsx
+++ b/packages/app-i18n/src/admin/components/I18NInputLocalesOverlay.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import ReactDOM from "react-dom";
+import { useHotkeys } from "react-hotkeyz";
 import { Input } from "@webiny/ui/Input";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import I18NRichTextEditor from "./I18NRichTextEditor";
@@ -37,6 +38,15 @@ type ContentProps = {
 };
 
 const Content = ({ richText, onClose, values, onSubmit }: ContentProps) => {
+    useHotkeys({
+        zIndex: 121,
+        keys: {
+            esc: (event: KeyboardEvent) => {
+                event.stopPropagation();
+                onClose();
+            }
+        }
+    });
     const { getLocales } = useI18N();
     const [activeLocaleIndex, setActiveLocaleIndex] = React.useState(0);
 


### PR DESCRIPTION
## Related Issue
Closes #871 

The `I18NInputLocalesOverlay` component being present at a higher z-index was not being closed alone, but also closed its parent component `I18NInput` before.

## Your solution
This bug was fixed by isolating the child component via stopping the event propagation and then closing only the dialog of the child component. React Hotkeyz' `useHotkeys` hook was super useful, as the keys object came with properties embedded with the event object.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A