### PR TITLE
Headless CMS - entries list is now being refreshed properly

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/graphql.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/graphql.ts
@@ -134,7 +134,11 @@ export const createCreateMutation = model => {
             content: create${ucFirstModelId}(data: $data) {
                 data {
                     id
+                    savedOn
                     ${createFieldsList(model)}
+                    meta {
+                        ${CONTENT_META_FIELDS}
+                    }
                 }
                 error ${ERROR_FIELD}
             }
@@ -150,10 +154,9 @@ export const createCreateFromMutation = model => {
             content: create${ucFirstModelId}From(revision: $revision, data: $data) {
                 data {
                     id
+                    savedOn
                     meta {
-                        published
-                        status
-                        locked
+                        ${CONTENT_META_FIELDS}
                     }
                 }
                 error ${ERROR_FIELD}
@@ -170,6 +173,8 @@ export const createUpdateMutation = model => {
                 data {
                     id
                     ${createFieldsList(model)}
+                    savedOn
+                    meta { ${CONTENT_META_FIELDS} }
                 }
                 error ${ERROR_FIELD}
             }

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/graphql.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/graphql.ts
@@ -87,7 +87,7 @@ export const createListQuery = model => {
 
     return gql`
         query list${ucFirstPluralizedModelId}($where: ${ucFirstModelId}ListWhereInput, $sort: [${ucFirstModelId}ListSorter], $limit: Int, $after: String, $before: String) {
-            list${ucFirstPluralizedModelId}(
+            content: list${ucFirstPluralizedModelId}(
                 where: $where
                 sort: $sort
                 limit: $limit

--- a/packages/app-headless-cms/src/admin/views/Content/Content.tsx
+++ b/packages/app-headless-cms/src/admin/views/Content/Content.tsx
@@ -22,7 +22,16 @@ const ContentRender = ({ contentModel }) => {
 
     const dataList = useDataList({
         client: apolloClient,
-        query: LIST_QUERY
+        query: LIST_QUERY,
+        getData: response => {
+            return get(response, "content.data");
+        },
+        getMeta: response => {
+            return get(response, "content.meta");
+        },
+        getError: response => {
+            return get(response, "content.error");
+        }
     });
 
     return (

--- a/packages/app/src/hooks/useDataList/useDataList.ts
+++ b/packages/app/src/hooks/useDataList/useDataList.ts
@@ -73,9 +73,9 @@ const useDataList = (params: UseDataListParams) => {
     const prevLoadParamsRef = useRef({});
 
     const dataListProps: ReturnProps = {
-        data: get(queryData, "list.getData", getData)(queryData.data),
-        meta: get(queryData, "list.getMeta", getMeta)(queryData.data),
-        error: get(queryData, "list.getError", getError)(queryData.data),
+        data: get(params, "getData", getData)(queryData.data),
+        meta: get(params, "getMeta", getMeta)(queryData.data),
+        error: get(params, "getError", getError)(queryData.data),
 
         loading: queryData.loading,
         init() {


### PR DESCRIPTION
## Related Issue
Closes #888 

## Your solution
Instead of doing plain refreshes of the actual list, we are manually updating the Apollo cache. Besides the actual fix described in the issue, we also get the bonus of not making requests to the backend and a faster UI.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/83298030-ffdcb280-a1f3-11ea-99e7-392fd2801763.png)