### PR TITLE
Access Tokens Improvements v2

### DIFF
--- a/packages/api-headless-cms/__tests__/accessTokensAuthentication.test.js
+++ b/packages/api-headless-cms/__tests__/accessTokensAuthentication.test.js
@@ -92,7 +92,7 @@ describe.skip("Access Tokens Authentication Test", () => {
         [body] = await environmentRead(ids.environment).invoke({
             headers: {
                 foo: "bar",
-                "access-token": accessToken.token
+                authorization: accessToken.token
             },
             body: {
                 query: LIST_PRODUCTS

--- a/packages/api-headless-cms/src/content/plugins/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/index.ts
@@ -56,7 +56,9 @@ export default (
             }
 
             if (context.cms.READ || context.cms.PREVIEW) {
-                const accessToken = context.event.headers["access-token"];
+                const accessToken =
+                    context.event.headers["authorization"] ||
+                    context.event.headers["Authorization"];
                 const { CmsAccessToken } = context.models;
 
                 const token = await CmsAccessToken.findOne({

--- a/packages/api-headless-cms/src/plugins/models/accessToken.model.ts
+++ b/packages/api-headless-cms/src/plugins/models/accessToken.model.ts
@@ -15,7 +15,7 @@ export default ({ createBase, context }) =>
         withChangedOnFields(),
         withFields(() => ({
             name: string({ validation: validation.create("required,maxLength:100") }),
-            description: string({ validation: validation.create("required,maxLength:100") }),
+            description: string({ validation: validation.create("maxLength:100") }),
             token: skipOnPopulate()(
                 string({
                     validation: validation.create("maxLength:64"),

--- a/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
+++ b/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
@@ -20,10 +20,12 @@ import {
 import { validation } from "@webiny/validation";
 import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 import { webinyCheckboxTitle } from "@webiny/ui/Checkbox/Checkbox.styles";
+import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 
 const t = i18n.ns("app-headless-cms/admin/accessTokens/form");
 
 function EnvironmentAliasesForm() {
+    const { showSnackbar } = useSnackbar();
     const { form: crudForm } = useCrud();
     const environments = useCms().environments.environments;
 
@@ -86,7 +88,10 @@ function EnvironmentAliasesForm() {
                                                 <span
                                                     style={{ position: "absolute", right: "32px" }}
                                                 >
-                                                    <CopyButton value={data.token} />
+                                                    <CopyButton
+                                                        value={data.token}
+                                                        showSnackbar={showSnackbar}
+                                                    />
                                                 </span>
                                             </div>
                                         ) : (

--- a/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
+++ b/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
@@ -90,7 +90,9 @@ function EnvironmentAliasesForm() {
                                                 >
                                                     <CopyButton
                                                         value={data.token}
-                                                        onCopy={showSnackbar}
+                                                        onCopy={() =>
+                                                            showSnackbar("Succesfully copied!")
+                                                        }
                                                     />
                                                 </span>
                                             </div>

--- a/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
+++ b/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
@@ -90,7 +90,7 @@ function EnvironmentAliasesForm() {
                                                 >
                                                     <CopyButton
                                                         value={data.token}
-                                                        showSnackbar={showSnackbar}
+                                                        onCopy={showSnackbar}
                                                     />
                                                 </span>
                                             </div>

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -5,7 +5,7 @@ import { FormComponentProps } from "../../types";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
-    showSnackbar?: (message: string) => any;
+    onCopy?: (message: string) => any;
 };
 
 /**
@@ -15,11 +15,11 @@ export type CopyButtonProps = FormComponentProps & {
  * @constructor
  */
 const CopyButton = (props: CopyButtonProps) => {
-    const { value, showSnackbar, ...otherProps } = props;
+    const { value, onCopy, ...otherProps } = props;
 
     const copyToClipboard = () => {
         navigator.clipboard.writeText(value);
-        showSnackbar("Succesfully copied!");
+        onCopy("Succesfully copied!");
     };
 
     return <IconButton {...otherProps} onClick={copyToClipboard} icon={<CopyToClipboardIcon />} />;

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { ReactComponent as CopyToClipboardIcon } from "../assets/file_copy-24px.svg";
 import { IconButton } from "../index";
 import { FormComponentProps } from "../../types";
-import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
+    showSnackbar?: (message: string) => any;
 };
 
 /**
@@ -15,8 +15,7 @@ export type CopyButtonProps = FormComponentProps & {
  * @constructor
  */
 const CopyButton = (props: CopyButtonProps) => {
-    const { showSnackbar } = useSnackbar();
-    const { value, ...otherProps } = props;
+    const { value, showSnackbar, ...otherProps } = props;
 
     const copyToClipboard = () => {
         navigator.clipboard.writeText(value);

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ReactComponent as CopyToClipboardIcon } from "../assets/file_copy-24px.svg";
 import { IconButton } from "../index";
 import { FormComponentProps } from "../../types";
+import { useCallback } from "react";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
@@ -17,10 +18,12 @@ export type CopyButtonProps = FormComponentProps & {
 const CopyButton = (props: CopyButtonProps) => {
     const { value, onCopy, ...otherProps } = props;
 
-    const copyToClipboard = () => {
+    const copyToClipboard = useCallback(() => {
         navigator.clipboard.writeText(value);
-        onCopy();
-    };
+        if (typeof onCopy === "function") {
+            onCopy();
+        }
+    }, [value]);
 
     return <IconButton {...otherProps} onClick={copyToClipboard} icon={<CopyToClipboardIcon />} />;
 };

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ReactComponent as CopyToClipboardIcon } from "../assets/file_copy-24px.svg";
 import { IconButton } from "../index";
 import { FormComponentProps } from "../../types";
+import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
@@ -14,15 +15,15 @@ export type CopyButtonProps = FormComponentProps & {
  * @constructor
  */
 const CopyButton = (props: CopyButtonProps) => {
+    const { showSnackbar } = useSnackbar();
     const { value, ...otherProps } = props;
 
-    return (
-        <IconButton
-            {...otherProps}
-            onClick={() => navigator.clipboard.writeText(value)}
-            icon={<CopyToClipboardIcon />}
-        />
-    );
+    const copyToClipboard = () => {
+        navigator.clipboard.writeText(value);
+        showSnackbar("Succesfully copied!");
+    };
+
+    return <IconButton {...otherProps} onClick={copyToClipboard} icon={<CopyToClipboardIcon />} />;
 };
 
 export { CopyButton };

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -5,7 +5,7 @@ import { FormComponentProps } from "../../types";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
-    onCopy?: (message: string) => any;
+    onCopy?: () => any;
 };
 
 /**
@@ -19,7 +19,7 @@ const CopyButton = (props: CopyButtonProps) => {
 
     const copyToClipboard = () => {
         navigator.clipboard.writeText(value);
-        onCopy("Succesfully copied!");
+        onCopy();
     };
 
     return <IconButton {...otherProps} onClick={copyToClipboard} icon={<CopyToClipboardIcon />} />;

--- a/packages/ui/src/Button/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/Button/CopyButton/CopyButton.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 
 export type CopyButtonProps = FormComponentProps & {
     value: string;
-    onCopy?: () => any;
+    onCopy?: () => void;
 };
 
 /**


### PR DESCRIPTION
## Related Issue
-fixed AT creation when you don't specify a description
-added a nice Snackbar message to the ButtonCopy UI component
-`access-token` header is now `authorization` / `Authorization`

## Your solution
See the code, it's pretty small. I've just implemented/fixed the stuff...

## How Has This Been Tested?
Locally
