### PR TITLE
feat: ✨  make PB Editor loader image stay at screen after animation

### DIFF
--- a/packages/app-page-builder/src/admin/views/Pages/EditorStyled.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/EditorStyled.ts
@@ -16,18 +16,12 @@ const imageAnim = keyframes`
         opacity: 1;
         width: 320px;
     }
-    80% {
+    100% {
         transform: translateY(0) scaleY(1) scaleX(1);
         transform-origin: 50% 50%;
         filter: blur(0);
         opacity: 1;
         width: 320px;
-    }
-    100% {
-        transform: translateY(300px) scaleY(2.5) scaleX(0.2);
-        transform-origin: 50% 0%;
-        filter: blur(40px);
-        opacity: 0;
     }
 `;
 


### PR DESCRIPTION
Make image that accompanies `Loading Editor...` text stay at the screen after animation finishes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/webiny/webiny-js/issues/798

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Removed animation step that made image disappear from the screen. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually at localhost (https://cl.ly/88b9bf308042)

## Screenshots (if relevant):

