### PR TITLE
fix: 🐛  make circle area outside user-menu clickable

### DIFF
--- a/packages/app-admin/src/plugins/UserMenu/UserMenu.tsx
+++ b/packages/app-admin/src/plugins/UserMenu/UserMenu.tsx
@@ -18,28 +18,28 @@ const menuDialog = css({
 
 const UserMenu = () => {
     return (
-        <TopAppBarActionItem
-            icon={
-                <Menu
-                    className={menuDialog}
-                    anchor={"topEnd"}
-                    handle={
+        <Menu
+            className={menuDialog}
+            anchor={"topEnd"}
+            handle={
+                <TopAppBarActionItem
+                    icon={
                         <div>
                             {renderPlugin<AdminHeaderUserMenuHandlePlugin>(
                                 "admin-header-user-menu-handle"
                             )}
                         </div>
                     }
-                >
-                    <List data-testid="logged-in-user-menu-list">
-                        {renderPlugin<AdminHeaderUserMenuUserInfoPlugin>(
-                            "admin-header-user-menu-user-info"
-                        )}
-                        {renderPlugins<AdminHeaderUserMenuPlugin>("admin-header-user-menu")}
-                    </List>
-                </Menu>
+                />
             }
-        />
+        >
+            <List data-testid="logged-in-user-menu-list">
+                {renderPlugin<AdminHeaderUserMenuUserInfoPlugin>(
+                    "admin-header-user-menu-user-info"
+                )}
+                {renderPlugins<AdminHeaderUserMenuPlugin>("admin-header-user-menu")}
+            </List>
+        </Menu>
     );
 };
 


### PR DESCRIPTION
Makes the entire TopActionBarItem as the Menu handle instead of just the Avatar

BREAKING CHANGE:
N.A.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #773 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
This PR makes sure that both the User avatar as well as white ripple outside the avatar are clickable and open the user menu.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and visually

## Screenshots (if relevant):
N.A.