### PR TITLE
Headless CMS - "multipleValues" renderer for Date/Time field

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
@@ -72,8 +72,8 @@ const DateTimeWithTimezone = props => {
                         ...props.bind,
                         value: time,
                         onChange: value => {
-                            setTime(`${value}:00`);
-                            return props.bind.onChange(`${date}T${value}:00${timezone}`);
+                            setTime(value);
+                            return props.bind.onChange(`${date}T${value}${timezone}`);
                         }
                     }}
                     field={{
@@ -81,6 +81,7 @@ const DateTimeWithTimezone = props => {
                         label: appendTextToLabel(props.field.label, " time")
                     }}
                     type={"time"}
+                    step={5}
                 />
             </Cell>
             <Cell span={cellSize}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import Input from "./Input";
 import Select from "./Select";
 import { Grid, Cell } from "@webiny/ui/Grid";
-import { UTC_TIMEZONES, getCurrentDateString, appendTextToLabel } from "./utils";
-
-const DEFAULT_TIME = "00:00:00";
-const DEFAULT_DATE = getCurrentDateString();
-const DEFAULT_TIMEZONE = "+01:00";
+import {
+    UTC_TIMEZONES,
+    DEFAULT_TIME,
+    DEFAULT_DATE,
+    DEFAULT_TIMEZONE,
+    appendTextToLabel,
+    RemoveFieldButton
+} from "./utils";
 
 const DateTimeWithTimezone = props => {
     // "2020-05-18T09:00+10:00"
@@ -42,11 +45,12 @@ const DateTimeWithTimezone = props => {
         }
     }, [props.bind.value]);
 
+    const cellSize = props.trailingIcon ? 3 : 4;
+
     return (
         <Grid>
             <Cell span={4}>
                 <Input
-                    {...props}
                     bind={{
                         ...props.bind,
                         value: date,
@@ -64,7 +68,6 @@ const DateTimeWithTimezone = props => {
             </Cell>
             <Cell span={4}>
                 <Input
-                    {...props}
                     bind={{
                         ...props.bind,
                         value: time,
@@ -80,7 +83,7 @@ const DateTimeWithTimezone = props => {
                     type={"time"}
                 />
             </Cell>
-            <Cell span={4}>
+            <Cell span={cellSize}>
                 <Select
                     label="Timezone"
                     value={timezone}
@@ -91,6 +94,7 @@ const DateTimeWithTimezone = props => {
                     options={UTC_TIMEZONES.map(t => ({ value: t.value, label: t.label }))}
                 />
             </Cell>
+            <RemoveFieldButton trailingIcon={props.trailingIcon}/>
         </Grid>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
@@ -95,7 +95,7 @@ const DateTimeWithTimezone = props => {
                     options={UTC_TIMEZONES.map(t => ({ value: t.value, label: t.label }))}
                 />
             </Cell>
-            <RemoveFieldButton trailingIcon={props.trailingIcon}/>
+            <RemoveFieldButton trailingIcon={props.trailingIcon} />
         </Grid>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -54,8 +54,8 @@ const DateTimeWithoutTimezone = props => {
                         ...props.bind,
                         value: time,
                         onChange: value => {
-                            setTime(`${value}:00`);
-                            return props.bind.onChange(`${date} ${value}:00`);
+                            setTime(value);
+                            return props.bind.onChange(`${date} ${value}`);
                         }
                     }}
                     field={{
@@ -63,6 +63,7 @@ const DateTimeWithoutTimezone = props => {
                         label: appendTextToLabel(props.field.label, " time")
                     }}
                     type={"time"}
+                    step={5}
                 />
             </Cell>
             <RemoveFieldButton trailingIcon={props.trailingIcon} />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Input from "./Input";
 import { Grid, Cell } from "@webiny/ui/Grid";
-import {DEFAULT_DATE, DEFAULT_TIME, appendTextToLabel, RemoveFieldButton} from "./utils";
+import { DEFAULT_DATE, DEFAULT_TIME, appendTextToLabel, RemoveFieldButton } from "./utils";
 
 const DateTimeWithoutTimezone = props => {
     // "2020-05-18 09:00:00"

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import Input from "./Input";
 import { Grid, Cell } from "@webiny/ui/Grid";
-import { getCurrentDateString, appendTextToLabel } from "./utils";
-
-const DEFAULT_TIME = "00:00:00";
-const DEFAULT_DATE = getCurrentDateString();
+import {DEFAULT_DATE, DEFAULT_TIME, appendTextToLabel, RemoveFieldButton} from "./utils";
 
 const DateTimeWithoutTimezone = props => {
     // "2020-05-18 09:00:00"
@@ -30,11 +27,12 @@ const DateTimeWithoutTimezone = props => {
         }
     }, [props.bind.value]);
 
+    const cellSize = props.trailingIcon ? 5 : 6;
+
     return (
         <Grid>
             <Cell span={6}>
                 <Input
-                    {...props}
                     bind={{
                         ...props.bind,
                         value: date,
@@ -50,9 +48,8 @@ const DateTimeWithoutTimezone = props => {
                     type={"date"}
                 />
             </Cell>
-            <Cell span={6}>
+            <Cell span={cellSize}>
                 <Input
-                    {...props}
                     bind={{
                         ...props.bind,
                         value: time,
@@ -68,6 +65,7 @@ const DateTimeWithoutTimezone = props => {
                     type={"time"}
                 />
             </Cell>
+            <RemoveFieldButton trailingIcon={props.trailingIcon} />
         </Grid>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -3,11 +3,18 @@ import { I18NValue } from "@webiny/app-i18n/components";
 import { CmsEditorField } from "@webiny/app-headless-cms/types";
 import { BindComponentRenderProp } from "@webiny/form";
 import { Input as UiInput } from "@webiny/ui/Input";
+import {ReactNode} from "react";
+
+type TrailingIconType = {
+    icon: ReactNode,
+    onClick: any
+}
 
 type Props = {
     type?: string;
     bind: BindComponentRenderProp;
     field: CmsEditorField;
+    trailingIcon?: TrailingIconType;
 };
 
 const Input = (props: Props) => {
@@ -24,6 +31,7 @@ const Input = (props: Props) => {
             placeholder={I18NValue({ value: props.field.placeholderText })}
             description={I18NValue({ value: props.field.helpText })}
             type={props.type}
+            trailingIcon={props.trailingIcon}
         />
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -3,12 +3,11 @@ import { I18NValue } from "@webiny/app-i18n/components";
 import { CmsEditorField } from "@webiny/app-headless-cms/types";
 import { BindComponentRenderProp } from "@webiny/form";
 import { Input as UiInput } from "@webiny/ui/Input";
-import {ReactNode} from "react";
 
 type TrailingIconType = {
-    icon: ReactNode,
-    onClick: any
-}
+    icon: React.ReactNode;
+    onClick: any;
+};
 
 type Props = {
     step?: number;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -11,6 +11,7 @@ type TrailingIconType = {
 }
 
 type Props = {
+    step?: number;
     type?: string;
     bind: BindComponentRenderProp;
     field: CmsEditorField;
@@ -20,6 +21,7 @@ type Props = {
 const Input = (props: Props) => {
     return (
         <UiInput
+            {...props}
             {...props.bind}
             onChange={value => {
                 if (props.type === "number") {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -14,9 +14,10 @@ const Time = props => {
             }}
             field={{
                 ...props.field,
-                label: null // TODO: Add relevant Icon or label
+                label: props.label
             }}
             type={"time"}
+            trailingIcon={props.trailingIcon}
         />
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -6,17 +6,12 @@ const Time = props => {
     return (
         <Input
             {...props}
-            bind={{
-                ...props.bind,
-                onChange: value => {
-                    return props.bind.onChange(`${value}:00`);
-                }
-            }}
             field={{
                 ...props.field,
                 label: props.label
             }}
             type={"time"}
+            step={5}
             trailingIcon={props.trailingIcon}
         />
     );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
@@ -16,7 +16,11 @@ const plugin: CmsEditorFieldRendererPlugin = {
         name: t`Date/Time Input`,
         description: t`Renders input for various formats of date and time.`,
         canUse({ field }) {
-            return field.type === "datetime" && !field.multipleValues && !get(field, "predefinedValues.enabled");
+            return (
+                field.type === "datetime" &&
+                !field.multipleValues &&
+                !get(field, "predefinedValues.enabled")
+            );
         },
         render({ field, getBind }) {
             const Bind = getBind();

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
+import { Input } from "@webiny/ui/Input";
+import DateTimeWithoutTimezone from "./DateTimeWithoutTimezone";
+import DateTimeWithTimezone from "./DateTimeWithTimezone";
+import Time from "./Time";
+import { i18n } from "@webiny/app/i18n";
+const t = i18n.ns("app-headless-cms/admin/fields/date-time");
+import get from "lodash/get";
+
+const plugin: CmsEditorFieldRendererPlugin = {
+    type: "cms-editor-field-renderer",
+    name: "cms-editor-field-renderer-date-time",
+    renderer: {
+        rendererName: "date-time-input",
+        name: t`Date/Time Input`,
+        description: t`Renders input for various formats of date and time.`,
+        canUse({ field }) {
+            return field.type === "datetime" && !field.multipleValues && !get(field, "predefinedValues.enabled");
+        },
+        render({ field, getBind }) {
+            const Bind = getBind();
+
+            return (
+                <Bind>
+                    {bind => {
+                        if (field.settings.type === "dateTimeWithoutTimezone") {
+                            return <DateTimeWithoutTimezone field={field} bind={bind} />;
+                        }
+                        if (field.settings.type === "dateTimeWithTimezone") {
+                            return <DateTimeWithTimezone field={field} bind={bind} />;
+                        }
+                        if (field.settings.type === "time") {
+                            return <Time field={field} bind={bind} />;
+                        }
+
+                        return <Input {...bind} type={field.settings.type} />;
+                    }}
+                </Bind>
+            );
+        }
+    }
+};
+
+export default plugin;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -7,7 +7,7 @@ import Time from "./Time";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 import get from "lodash/get";
-import {ReactComponent as DeleteIcon} from "@webiny/app-headless-cms/admin/icons/close.svg";
+import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/close.svg";
 import DynamicListMultipleValues from "@webiny/app-headless-cms/admin/plugins/fieldRenderers/DynamicListMultipleValues";
 
 const plugin: CmsEditorFieldRendererPlugin = {
@@ -18,49 +18,63 @@ const plugin: CmsEditorFieldRendererPlugin = {
         name: t`Date/Time Inputs`,
         description: t`Renders inputs for various formats of dates and times.`,
         canUse({ field }) {
-            return field.type === "datetime" && field.multipleValues && !get(field, "predefinedValues.enabled");
+            return (
+                field.type === "datetime" &&
+                field.multipleValues &&
+                !get(field, "predefinedValues.enabled")
+            );
         },
         render(props) {
             const field = props.field;
 
-            return <DynamicListMultipleValues {...props}>
-                {({ bind, index }) => {
-                    const trailingIcon = index > 0  && {
+            return (
+                <DynamicListMultipleValues {...props}>
+                    {({ bind, index }) => {
+                        const trailingIcon = index > 0 && {
                             icon: <DeleteIcon />,
                             onClick: bind.index.removeValue
-                    };
+                        };
 
-                    if (field.settings.type === "dateTimeWithoutTimezone") {
-                        return <DateTimeWithoutTimezone
-                            field={field}
-                            bind={bind.index}
-                            trailingIcon={trailingIcon}
-                        />;
-                    }
-                    if (field.settings.type === "dateTimeWithTimezone") {
-                        return <DateTimeWithTimezone
-                            field={field}
-                            bind={bind.index}
-                            trailingIcon={trailingIcon}
-                        />;
-                    }
-                    if (field.settings.type === "time") {
-                        return <Time
-                            field={field}
-                            bind={bind.index}
-                            label={t`Value {number}`({ number: index + 1 })}
-                            trailingIcon={trailingIcon}
-                        />;
-                    }
+                        if (field.settings.type === "dateTimeWithoutTimezone") {
+                            return (
+                                <DateTimeWithoutTimezone
+                                    field={field}
+                                    bind={bind.index}
+                                    trailingIcon={trailingIcon}
+                                />
+                            );
+                        }
+                        if (field.settings.type === "dateTimeWithTimezone") {
+                            return (
+                                <DateTimeWithTimezone
+                                    field={field}
+                                    bind={bind.index}
+                                    trailingIcon={trailingIcon}
+                                />
+                            );
+                        }
+                        if (field.settings.type === "time") {
+                            return (
+                                <Time
+                                    field={field}
+                                    bind={bind.index}
+                                    label={t`Value {number}`({ number: index + 1 })}
+                                    trailingIcon={trailingIcon}
+                                />
+                            );
+                        }
 
-                    return <Input
-                        {...bind.index}
-                        type={field.settings.type}
-                        label={t`Value {number}`({ number: index + 1 })}
-                        trailingIcon={trailingIcon}
-                    />;
-                }}
-            </DynamicListMultipleValues>
+                        return (
+                            <Input
+                                {...bind.index}
+                                type={field.settings.type}
+                                label={t`Value {number}`({ number: index + 1 })}
+                                trailingIcon={trailingIcon}
+                            />
+                        );
+                    }}
+                </DynamicListMultipleValues>
+            );
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -7,37 +7,60 @@ import Time from "./Time";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 import get from "lodash/get";
+import {ReactComponent as DeleteIcon} from "@webiny/app-headless-cms/admin/icons/close.svg";
+import DynamicListMultipleValues from "@webiny/app-headless-cms/admin/plugins/fieldRenderers/DynamicListMultipleValues";
 
 const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
-    name: "cms-editor-field-renderer-date-time",
+    name: "cms-editor-field-renderer-date-times",
     renderer: {
-        rendererName: "date-time-input",
+        rendererName: "date-time-inputs",
         name: t`Date/Time Inputs`,
         description: t`Renders inputs for various formats of dates and times.`,
         canUse({ field }) {
-            return field.type === "datetime" && !field.multipleValues && !get(field, "predefinedValues.enabled");
+            return field.type === "datetime" && field.multipleValues && !get(field, "predefinedValues.enabled");
         },
-        render({ field, getBind }) {
-            const Bind = getBind();
+        render(props) {
+            const field = props.field;
 
-            return (
-                <Bind>
-                    {bind => {
-                        if (field.settings.type === "dateTimeWithoutTimezone") {
-                            return <DateTimeWithoutTimezone field={field} bind={bind} />;
-                        }
-                        if (field.settings.type === "dateTimeWithTimezone") {
-                            return <DateTimeWithTimezone field={field} bind={bind} />;
-                        }
-                        if (field.settings.type === "time") {
-                            return <Time field={field} bind={bind} />;
-                        }
+            return <DynamicListMultipleValues {...props}>
+                {({ bind, index }) => {
+                    const trailingIcon = index > 0  && {
+                            icon: <DeleteIcon />,
+                            onClick: bind.index.removeValue
+                    };
 
-                        return <Input {...bind} type={field.settings.type} />;
-                    }}
-                </Bind>
-            );
+                    if (field.settings.type === "dateTimeWithoutTimezone") {
+                        return <DateTimeWithoutTimezone
+                            field={field}
+                            bind={bind.index}
+                            trailingIcon={trailingIcon}
+                        />;
+                    }
+                    if (field.settings.type === "dateTimeWithTimezone") {
+                        return <DateTimeWithTimezone
+                            field={field}
+                            bind={bind.index}
+                            trailingIcon={trailingIcon}
+                        />;
+                    }
+                    if (field.settings.type === "time") {
+                        return <Time
+                            field={field}
+                            bind={bind.index}
+                            label={t`Value {number}`({ number: index + 1 })}
+                            trailingIcon={trailingIcon}
+                        />;
+                    }
+
+                    return <Input
+                        {...bind.index}
+                        type={field.settings.type}
+                        label={t`Value {number}`({ number: index + 1 })}
+                        trailingIcon={trailingIcon}
+                    />;
+                }}
+            </DynamicListMultipleValues>
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/index.ts
@@ -1,3 +1,4 @@
+import dateTimeField from "./dateTimeField";
 import dateTimeFields from "./dateTimeFields";
 
-export default [dateTimeFields];
+export default [dateTimeField, dateTimeFields];

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -1,3 +1,8 @@
+import React from "react";
+import {css} from "emotion";
+import {Cell} from "@webiny/ui/Grid";
+import {ButtonDefault} from "@webiny/ui/Button";
+
 export const UTC_TIMEZONES = [
     {
         value: "-12:00",
@@ -177,3 +182,25 @@ export const getCurrentDateString = () => {
 export const appendTextToLabel = (label, text) => {
     return { values: label.values.map(el => ({ ...el, value: `${el.value}${text}` })) };
 };
+
+
+export const DEFAULT_TIME = "00:00:00";
+export const DEFAULT_DATE = getCurrentDateString();
+export const DEFAULT_TIMEZONE = "+01:00";
+
+const deleteIconStyles = css ({
+    color: 'var(--mdc-theme-text-secondary-on-background) !important'
+});
+
+export const RemoveFieldButton = ({ trailingIcon }) => {
+    if (!trailingIcon) {
+        return null;
+    }
+    return (
+        <Cell span={1}>
+            <ButtonDefault className={deleteIconStyles} onClick={trailingIcon.onClick}>
+            {trailingIcon.icon}
+            </ButtonDefault>
+        </Cell>
+    )
+}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {css} from "emotion";
 import {Cell} from "@webiny/ui/Grid";
-import {ButtonDefault} from "@webiny/ui/Button";
+import {IconButton} from "@webiny/ui/Button";
 
 export const UTC_TIMEZONES = [
     {
@@ -189,7 +189,9 @@ export const DEFAULT_DATE = getCurrentDateString();
 export const DEFAULT_TIMEZONE = "+01:00";
 
 const deleteIconStyles = css ({
-    color: 'var(--mdc-theme-text-secondary-on-background) !important'
+    width: "100% !important",
+    height: "100% !important",
+    color: "var(--mdc-theme-text-secondary-on-background) !important"
 });
 
 export const RemoveFieldButton = ({ trailingIcon }) => {
@@ -198,9 +200,7 @@ export const RemoveFieldButton = ({ trailingIcon }) => {
     }
     return (
         <Cell span={1}>
-            <ButtonDefault className={deleteIconStyles} onClick={trailingIcon.onClick}>
-            {trailingIcon.icon}
-            </ButtonDefault>
+            <IconButton className={deleteIconStyles} onClick={trailingIcon.onClick} icon={trailingIcon.icon} />
         </Cell>
     )
 }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {css} from "emotion";
-import {Cell} from "@webiny/ui/Grid";
-import {IconButton} from "@webiny/ui/Button";
+import { css } from "emotion";
+import { Cell } from "@webiny/ui/Grid";
+import { IconButton } from "@webiny/ui/Button";
 
 export const UTC_TIMEZONES = [
     {
@@ -183,12 +183,11 @@ export const appendTextToLabel = (label, text) => {
     return { values: label.values.map(el => ({ ...el, value: `${el.value}${text}` })) };
 };
 
-
 export const DEFAULT_TIME = "00:00:00";
 export const DEFAULT_DATE = getCurrentDateString();
 export const DEFAULT_TIMEZONE = "+01:00";
 
-const deleteIconStyles = css ({
+const deleteIconStyles = css({
     width: "100% !important",
     height: "100% !important",
     color: "var(--mdc-theme-text-secondary-on-background) !important"
@@ -200,7 +199,11 @@ export const RemoveFieldButton = ({ trailingIcon }) => {
     }
     return (
         <Cell span={1}>
-            <IconButton className={deleteIconStyles} onClick={trailingIcon.onClick} icon={trailingIcon.icon} />
+            <IconButton
+                className={deleteIconStyles}
+                onClick={trailingIcon.onClick}
+                icon={trailingIcon.icon}
+            />
         </Cell>
-    )
-}
+    );
+};

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -16,7 +16,7 @@ const plugin: CmsEditorFieldTypePlugin = {
         description: t`Store date and time.`,
         icon: <DateTimeIcon />,
         validators: ["required", "gte", "lte"],
-        allowMultipleValues: false, // TODO: set to true once the multiValue renderer is created.
+        allowMultipleValues: true,
         allowPredefinedValues: false, // TODO: implement "renderPredefinedValues" and set to true.
         allowIndexes: {
             singleValue: true,

--- a/packages/ui/src/Input/Input.tsx
+++ b/packages/ui/src/Input/Input.tsx
@@ -57,6 +57,7 @@ export class Input extends React.Component<InputProps> {
     static rmwcProps = [
         "label",
         "type",
+        "step",
         "disabled",
         "placeholder",
         "outlined",


### PR DESCRIPTION
closes #914 

## Related Issue
#914 
Headless CMS - "multipleValues" renderer for Date/Time field 

## Your solution
Use `DynamicListMultipleValues` component 

## How Has This Been Tested?
Manually, using the Admin app

## Screenshots:
https://www.loom.com/share/ed8b97db76e8426ba86af1aa70e4572f
