### PR TITLE
chore(cz-adapter): add an input for commit scope

### DIFF
--- a/scripts/cz-adapter/index.js
+++ b/scripts/cz-adapter/index.js
@@ -54,6 +54,11 @@ module.exports = {
                 }
             },
             {
+                type: "input",
+                name: "scope",
+                message: "Provide a scope of your commit (if any):\n"
+            },
+            {
                 type: "maxlength-input",
                 maxLength: 60,
                 name: "subject",
@@ -71,9 +76,6 @@ module.exports = {
                 message: "List any breaking changes:\n"
             }
         ]).then(async answers => {
-            // Add emoji to commit message
-            answers.subject = commitTypes[answers.type].emoji + "  " + answers.subject;
-
             // Build commit message
             const message = buildCommit(answers, { breaklineChar: "\n" });
             console.log("\n\nCommit message:");


### PR DESCRIPTION
## Related Issue
Closes #974 

## Your solution
Added a missing input for scope.

## How Has This Been Tested?
Manually, by running `yarn commit`.