### PR TITLE
Headless CMS - automatically unlock all fields on entries removal

### DIFF
--- a/packages/api-headless-cms/__tests__/lockedFields.test.js
+++ b/packages/api-headless-cms/__tests__/lockedFields.test.js
@@ -35,7 +35,7 @@ describe("Used fields", () => {
             mocks.withTitleFieldOnly({ contentModelGroupId: ids.contentModelGroup })
         );
 
-        expect(contentModel.lockedFields).toBe(null);
+        expect(contentModel.lockedFields).toEqual([]);
 
         // 2. Create a new product entry.
         const products = await content("product");

--- a/packages/api-headless-cms/__tests__/mocks/unlockingFields.js
+++ b/packages/api-headless-cms/__tests__/mocks/unlockingFields.js
@@ -1,0 +1,147 @@
+import { locales } from "./../mocks/I18NLocales";
+
+const fields = [
+    {
+        _id: "vqk-UApa0-1",
+        fieldId: "title",
+        type: "text",
+        label: {
+            values: [
+                {
+                    locale: locales.en.id,
+                    value: "Title"
+                },
+                {
+                    locale: locales.de.id,
+                    value: "Titel"
+                }
+            ]
+        }
+    },
+    {
+        _id: "vqk-UApa0-2",
+        fieldId: "age",
+        type: "number",
+        label: {
+            values: [
+                {
+                    locale: locales.en.id,
+                    value: "Age"
+                },
+                {
+                    locale: locales.de.id,
+                    value: "Jahre"
+                }
+            ]
+        }
+    }
+];
+
+export default {
+    fields,
+    book: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields
+        }
+    }),
+
+    book1: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book1-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book1-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 1
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 1
+                    }
+                ]
+            }
+        }
+    },
+    book2: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book2-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book2-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 2
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 2
+                    }
+                ]
+            }
+        }
+    },
+
+    updateBook1: ({ contentModelGroupId }) => ({
+        data: {
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "jahre",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};

--- a/packages/api-headless-cms/__tests__/removeFieldPresentInIndexes.test.js
+++ b/packages/api-headless-cms/__tests__/removeFieldPresentInIndexes.test.js
@@ -12,7 +12,7 @@ describe("Removing fields that are present in indexes", () => {
         initial.contentModelGroup = await createContentModelGroup({ database });
     });
 
-    it(`should not allow deletion of a field that is present in one or more indexes`, async () => {
+    it(`should allow deletion of a field that is present in one or more indexes`, async () => {
         const { createContentModel, getContentModel, updateContentModel } = environment(
             initial.environment.id
         );
@@ -21,9 +21,9 @@ describe("Removing fields that are present in indexes", () => {
             mocks.authorContentModel({ contentModelGroupId: initial.contentModelGroup.id })
         );
 
-        const getAuthorContentModel = await getContentModel(authorContentModel);
-        let error;
+        let getAuthorContentModel = await getContentModel(authorContentModel);
 
+        let error = null;
         await updateContentModel(
             mocks.updatedAuthorContentModel({
                 authorContentModelId: getAuthorContentModel.id,
@@ -42,8 +42,27 @@ describe("Removing fields that are present in indexes", () => {
             error = e;
         }
 
-        expect(error.message).toBe(
-            'Before removing the "title" field, please remove all of the indexes that include it in in their list of fields.'
-        );
+        expect(error).toBe(null);
+
+        getAuthorContentModel = await getContentModel(authorContentModel);
+        expect(getAuthorContentModel).toEqual({
+            id: getAuthorContentModel.id,
+            name: "Author",
+            titleFieldId: null,
+            indexes: [
+                {
+                    fields: ["id"]
+                }
+            ],
+            lockedFields: [],
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "age",
+                    multipleValues: false
+                }
+            ],
+            layout: []
+        });
     });
 });

--- a/packages/api-headless-cms/__tests__/unlockingFields.test.js
+++ b/packages/api-headless-cms/__tests__/unlockingFields.test.js
@@ -1,0 +1,134 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/unlockingFields";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Unlocking Fields Test", () => {
+    const { environment, database } = useContentHandler();
+
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it("should unlock all fields if when all content entries are deleted", async () => {
+        const { content, createContentModel, updateContentModel, getContentModel } = environment(
+            initial.environment.id
+        );
+
+        let contentModel = await createContentModel(
+            mocks.book({ contentModelGroupId: initial.contentModelGroup.id })
+        );
+        const books = await content("book");
+
+        const book1 = await books.create(mocks.book1);
+        const book2 = await books.create(mocks.book2);
+
+        // Should work.
+        await updateContentModel({
+            id: contentModel.id,
+            data: {
+                fields: mocks.fields
+            }
+        });
+
+        // Removing a single field must not be allowed.
+        let errors = [];
+        for (let i = 0; i < mocks.fields.length; i++) {
+            try {
+                await updateContentModel({
+                    id: contentModel.id,
+                    data: {
+                        fields: mocks.fields[i]
+                    }
+                });
+            } catch (e) {
+                errors.push(e.message);
+            }
+        }
+
+        expect(errors).toEqual([
+            `Cannot remove the field "age" because it's already in use in created content.`,
+            `Cannot remove the field "title" because it's already in use in created content.`
+        ]);
+
+        // Deleting fields should still not be allowed. We still have book2 existing.
+        await books.delete({ revision: book1.id });
+        errors = [];
+        for (let i = 0; i < mocks.fields.length; i++) {
+            try {
+                await updateContentModel({
+                    id: contentModel.id,
+                    data: {
+                        fields: mocks.fields[i]
+                    }
+                });
+            } catch (e) {
+                errors.push(e.message);
+            }
+        }
+
+        expect(errors).toEqual([
+            `Cannot remove the field "age" because it's already in use in created content.`,
+            `Cannot remove the field "title" because it's already in use in created content.`
+        ]);
+
+        // Removing fields should be now allowed, since both entries are deleted.
+        await books.delete({ revision: book2.id });
+
+        await updateContentModel({
+            id: contentModel.id,
+            data: {
+                fields: mocks.fields[0]
+            }
+        });
+
+        contentModel = await getContentModel({ id: contentModel.id });
+        expect(contentModel).toEqual({
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "title",
+                    multipleValues: false
+                }
+            ],
+            id: contentModel.id,
+            indexes: [
+                {
+                    fields: ["id"]
+                },
+                {
+                    fields: ["title"]
+                }
+            ],
+            layout: [],
+            lockedFields: [],
+            name: "Book",
+            titleFieldId: "title"
+        });
+
+        await updateContentModel({
+            id: contentModel.id,
+            data: {
+                fields: []
+            }
+        });
+
+        contentModel = await getContentModel({ id: contentModel.id });
+        expect(contentModel).toEqual({
+            id: contentModel.id,
+            name: "Book",
+            titleFieldId: null,
+            indexes: [
+                {
+                    fields: ["id"]
+                }
+            ],
+            lockedFields: [],
+            fields: [],
+            layout: []
+        });
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -27,7 +27,7 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
 
     const CmsContentModel = pipe(
         withName(`CmsContentModel`),
-        withFields({
+        withFields(() => ({
             name: string({
                 validation: validation.create("required,maxLength:100"),
                 value: "Untitled"
@@ -40,14 +40,14 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
 
             // Contains a list of all fields that were utilized by existing content entries. If a field is on the list,
             // it cannot be removed/edited anymore.
-            lockedFields: skipOnPopulate()(fields({ list: true, instanceOf: LockedFieldsModel })),
+            lockedFields: skipOnPopulate()(fields({ list: true, instanceOf: LockedFieldsModel, value: [] })),
             fields: fields({
                 list: true,
                 value: [],
                 instanceOf: ContentModelFieldsModel
             }),
             indexes: indexes()
-        }),
+        })),
         withProps({
             get totalFields() {
                 return Array.isArray(this.fields) ? this.fields.length : 0;

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -173,7 +173,8 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                 }
 
                 // Check if the indexes list contains all fields that actually exists.
-                for (let i = 0; i < this.indexes.length; i++) {
+                const updatedIndexes = [];
+                indexesFor: for (let i = 0; i < this.indexes.length; i++) {
                     const index = this.indexes[i];
                     if (Array.isArray(index.fields)) {
                         for (let j = 0; j < index.fields.length; j++) {
@@ -182,14 +183,16 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                             if (field === "id") {
                                 continue;
                             }
+
                             if (!this.fields.find(item => item.fieldId === field)) {
-                                throw new Error(
-                                    `Before removing the "${field}" field, please remove all of the indexes that include it in in their list of fields.`
-                                );
+                                break indexesFor;
                             }
                         }
                     }
+                    updatedIndexes.push(index);
                 }
+
+                this.indexes = updatedIndexes;
 
                 if (this.isDirty()) {
                     const removeCallback = this.hook("afterSave", async () => {

--- a/packages/api-headless-cms/src/content/plugins/utils/createDataModel.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/createDataModel.ts
@@ -273,7 +273,14 @@ export const createDataModel = (
                         query: { parent: this.meta.parent }
                     });
 
-                    return Promise.all(revisions.map(rev => rev.delete()));
+                    await Promise.all(revisions.map(rev => rev.delete()));
+
+                    if (await Model.count() === 0) {
+                        // Also, let's check if we have zero entries. If so, unlock all of the fields in the content model.
+                        contentModel.lockedFields = [];
+                        await contentModel.save();
+
+                    }
                 }
             }
         }),


### PR DESCRIPTION
## Related Issue
Closes #943
Closes #944 

## Your solution
Every time a model is deleted, a count of all entries will be performed. If `0`, then we unlock all fields.

## How Has This Been Tested?
Jest.

## Screenshots (if relevant):
N/A