### PR TITLE
Fix: Headless CMS - Rich Text Editor Max Height

### DIFF
--- a/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
@@ -15,11 +15,7 @@ const EditorWrapper = styled("div")({
     border: "1px solid var(--mdc-theme-on-background)",
     borderRadius: 2,
     boxSizing: "border-box",
-    padding: 10,
-
-    "& > div:first-of-type": {
-        marginLeft: "-8px"
-    },
+    padding: 10
 });
 
 const EditorContent = styled("div")({
@@ -27,6 +23,7 @@ const EditorContent = styled("div")({
     minHeight: 200,
     overflow: "auto",
     resize: "vertical",
+    padding: "0px 8px",
 
     "> div > div": {
         boxSizing: "border-box",

--- a/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
@@ -10,16 +10,24 @@ import { MenuButton } from "./index";
 import { Menu } from "./Menu";
 import { FormComponentProps } from "@webiny/ui/types";
 import { pluginsToProps } from "./pluginsToProps";
-import { Range, Descendant } from "slate";
 
 const EditorWrapper = styled("div")({
     border: "1px solid var(--mdc-theme-on-background)",
     borderRadius: 2,
     boxSizing: "border-box",
-    padding: 10
+    padding: 10,
+
+    "& > div:first-of-type": {
+        marginLeft: "-8px"
+    },
 });
 
 const EditorContent = styled("div")({
+    height: "45vh",
+    minHeight: 200,
+    overflow: "auto",
+    resize: "vertical",
+
     "> div > div": {
         boxSizing: "border-box",
         padding: 10,


### PR DESCRIPTION
## Related Issue
Closes #970 #933 
Headless CMS - Rich Text Editor Max Height
## Your solution
- Fix content getting too tall that toolbar hide due to scroll, by adding `height` property
- Add resizer so that the user can resize the editor if needed

## How Has This Been Tested?
Manually, via the Admin app

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/84160095-6cc13980-aa8b-11ea-832d-164911e80a1c.png)
