### PR TITLE
[Draft] Feature: Unique validator for form fields

### DIFF
--- a/packages/api-form-builder/src/plugins/graphql/formSubmission.ts
+++ b/packages/api-form-builder/src/plugins/graphql/formSubmission.ts
@@ -2,6 +2,7 @@ import { resolveGet, resolveList } from "@webiny/commodo-graphql";
 import { hasScope } from "@webiny/api-security";
 import exportFormSubmissions from "./formSubmissionResolvers/exportFormSubmissions";
 import createFormSubmission from "./formSubmissionResolvers/createFormSubmission";
+import getFormSubmissionByFieldAndValue from './formSubmissionResolvers/getFormSubmission';
 
 const getFormSubmission = ctx => ctx.models.FormSubmission;
 
@@ -52,6 +53,12 @@ export default {
                 sort: String
             ): FormSubmissionResponse
             
+            getFormSubmissionByFieldAndValue(
+                formId: ID!
+                fieldId: String!
+                value: String!
+            ): FormSubmissionsListResponse
+            
             listFormSubmissions(
                 sort: JSON
                 search: String
@@ -81,7 +88,8 @@ export default {
     resolvers: {
         FormsQuery: {
             listFormSubmissions: hasScope("forms:form:crud")(resolveList(getFormSubmission)),
-            getFormSubmission: resolveGet(getFormSubmission)
+            getFormSubmission: resolveGet(getFormSubmission),
+            getFormSubmissionByFieldAndValue: getFormSubmissionByFieldAndValue
         },
         FormsMutation: {
             createFormSubmission,

--- a/packages/api-form-builder/src/plugins/graphql/formSubmissionResolvers/getFormSubmission.ts
+++ b/packages/api-form-builder/src/plugins/graphql/formSubmissionResolvers/getFormSubmission.ts
@@ -1,0 +1,37 @@
+import { Response, NotFoundResponse, ListResponse } from "@webiny/graphql";
+import { GraphQLFieldResolver } from "@webiny/graphql/types";
+
+export async function getFormSubmission(context, formId, fieldId, value) {
+    const { FormSubmission } = context.models;
+
+    const query = {
+        "form.parent": formId
+    };
+    const fieldName = `data.${fieldId}`;
+    query[fieldName] = value;
+
+    console.log(`Got unique info ${formId} ${fieldId} ${value}. Running query: ${JSON.stringify(query)}`);
+    const submissions = await FormSubmission.find({ query });
+    if (!submissions) {
+        return new NotFoundResponse("The requested form was not found.");
+    }
+    console.log(`Found ${submissions.length} submissions`);
+    return submissions;
+}
+
+/**
+ * Returns form submission by given form ID, field ID, and value
+ * @param root
+ * @param args
+ * @param context
+ * @returns {Promise<NotFoundResponse|Response>}
+ */
+const resolver: GraphQLFieldResolver = async (root, args, context, info) => {
+    if (!args.formId && !args.fieldId && !args.value) {
+        return new NotFoundResponse("Form ID, Field ID, or Value is missing.");
+    }
+    const submissions = await getFormSubmission(context, args.formId, args.fieldId, args.value);
+    return new ListResponse(submissions, submissions.getMeta());
+};
+
+export default resolver;

--- a/packages/api-form-builder/src/plugins/models/form.model.ts
+++ b/packages/api-form-builder/src/plugins/models/form.model.ts
@@ -250,6 +250,8 @@ export default ({ context, createBase, FormSettings }) => {
                             let isInvalid = true;
                             try {
                                 const result = await validatorPlugin.validator.validate(
+                                    this,
+                                    field,
                                     data[field.fieldId],
                                     validator
                                 );

--- a/packages/api-form-builder/src/plugins/validators/gte.ts
+++ b/packages/api-form-builder/src/plugins/validators/gte.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-gte",
     validator: {
         name: "gte",
-        validate: (value, validator) => {
+        validate: (form, field, value, validator) => {
             const gteValue = validator.settings.value;
             if (typeof gteValue !== "undefined") {
                 return validation.validate(value, `gte:${gteValue}`);

--- a/packages/api-form-builder/src/plugins/validators/in.ts
+++ b/packages/api-form-builder/src/plugins/validators/in.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-in",
     validator: {
         name: "in",
-        validate: (value, validator) => {
+        validate: (form, field, value, validator) => {
             const values = validator.settings.values;
             if (Array.isArray(values)) {
                 return validation.validate(value, `in:${values.join(":")}`);

--- a/packages/api-form-builder/src/plugins/validators/index.ts
+++ b/packages/api-form-builder/src/plugins/validators/index.ts
@@ -6,5 +6,6 @@ import minLength from "./minLength";
 import pattern from "./pattern";
 import required from "./required";
 import patternPlugins from "./patternPlugins";
+import uniquePlugins from "./unique";
 
-export default [gte, inValidator, lte, pattern, required, minLength, maxLength, patternPlugins];
+export default [gte, inValidator, lte, pattern, required, minLength, maxLength, patternPlugins, uniquePlugins];

--- a/packages/api-form-builder/src/plugins/validators/lte.ts
+++ b/packages/api-form-builder/src/plugins/validators/lte.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-lte",
     validator: {
         name: "lte",
-        validate: (value, validator) => {
+        validate: (form, field, value, validator) => {
             const lteValue = validator.settings.value;
             if (typeof lteValue !== "undefined") {
                 return validation.validate(value, `lte:${lteValue}`);

--- a/packages/api-form-builder/src/plugins/validators/maxLength.ts
+++ b/packages/api-form-builder/src/plugins/validators/maxLength.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-max-length",
     validator: {
         name: "maxLength",
-        validate: (value, validator) => {
+        validate: (form, field, value, validator) => {
             const maxLengthValue = validator.settings.value;
             if (typeof maxLengthValue !== "undefined") {
                 return validation.validate(value, `maxLength:${maxLengthValue}`);

--- a/packages/api-form-builder/src/plugins/validators/minLength.ts
+++ b/packages/api-form-builder/src/plugins/validators/minLength.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-min-length",
     validator: {
         name: "minLength",
-        validate: (value, validator) => {
+        validate: (form, field, value, validator) => {
             const minLengthValue = validator.settings.value;
             if (typeof minLengthValue !== "undefined") {
                 return validation.validate(value, `minLength:${minLengthValue}`);

--- a/packages/api-form-builder/src/plugins/validators/pattern.ts
+++ b/packages/api-form-builder/src/plugins/validators/pattern.ts
@@ -14,7 +14,7 @@ export default {
             name: "form-field-validator-pattern",
             validator: {
                 name: "pattern",
-                validate: (value, validator) => {
+                validate: (form, field, value, validator) => {
                     if (!value) {
                         return true;
                     }

--- a/packages/api-form-builder/src/plugins/validators/required.ts
+++ b/packages/api-form-builder/src/plugins/validators/required.ts
@@ -6,7 +6,7 @@ export default {
     name: "form-field-validator-required",
     validator: {
         name: "required",
-        validate: value => {
+        validate: (form, field, value) => {
             return validation.validate(value, "required");
         }
     }

--- a/packages/api-form-builder/src/plugins/validators/unique.ts
+++ b/packages/api-form-builder/src/plugins/validators/unique.ts
@@ -1,0 +1,26 @@
+/**
+ * Since form-field-validator plugin needs access to the request context, we create a context plugin which
+ * registers the actual validation plugin with access to the request context.
+ */
+import { ContextPlugin } from "@webiny/graphql/types";
+import { getFormSubmission } from '@webiny/api-form-builder/plugins/graphql/formSubmissionResolvers/getFormSubmission';
+
+export default {
+    name: "context-form-field-unique-validator",
+    type: "context",
+    apply(context) {
+        context.plugins.register({
+            type: "form-field-validator",
+            name: "form-field-validator-unique",
+            validator: {
+                name: "unique",
+                serverSideOnly: true,
+                validate: async (form, field, value) => {
+                    const fieldId = field.fieldId;
+                    const submissions = await getFormSubmission(context, form.parent, fieldId, value);
+                    return submissions.length === 0;
+                }
+            }
+        });
+    }
+} as ContextPlugin;

--- a/packages/app-form-builder/src/admin/plugins/fields/text.tsx
+++ b/packages/app-form-builder/src/admin/plugins/fields/text.tsx
@@ -11,7 +11,7 @@ const plugin: FbBuilderFieldPlugin = {
     field: {
         name: "text",
         type: "text",
-        validators: ["required", "minLength", "maxLength", "pattern"],
+        validators: ["required", "minLength", "maxLength", "pattern", "unique"],
         label: "Short Text",
         description: "Titles, names, single line input",
         icon: <TextIcon />,

--- a/packages/app-form-builder/src/admin/plugins/validators/index.ts
+++ b/packages/app-form-builder/src/admin/plugins/validators/index.ts
@@ -6,5 +6,6 @@ import minLength from "./minLength";
 import maxLength from "./maxLength";
 import pattern from "./pattern";
 import patternPlugins from "./patternPlugins";
+import unique from "./unique";
 
-export default [gte, inValidator, lte, pattern, patternPlugins, required, maxLength, minLength];
+export default [gte, inValidator, lte, pattern, patternPlugins, required, maxLength, minLength, unique];

--- a/packages/app-form-builder/src/admin/plugins/validators/unique.tsx
+++ b/packages/app-form-builder/src/admin/plugins/validators/unique.tsx
@@ -1,0 +1,12 @@
+import { FbBuilderFormFieldValidatorPlugin } from "@webiny/app-form-builder/types";
+
+export default {
+    type: "form-editor-field-validator",
+    name: "form-editor-field-validator-unique",
+    validator: {
+        name: "unique",
+        label: "Unique",
+        description: "You won't be able to submit the form if the field value is not unique",
+        defaultMessage: "Unique value is required."
+    }
+} as FbBuilderFormFieldValidatorPlugin;

--- a/packages/app-headless-cms/src/admin/plugins/validators/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/validators/index.ts
@@ -6,5 +6,6 @@ import minLength from "./minLength";
 import maxLength from "./maxLength";
 import pattern from "./pattern";
 import patternPlugins from "./patternPlugins";
+import unique from "./unique";
 
-export default [gte, inValidator, lte, pattern, patternPlugins, required, maxLength, minLength];
+export default [gte, inValidator, lte, pattern, patternPlugins, required, maxLength, minLength, unique];

--- a/packages/app-headless-cms/src/admin/plugins/validators/unique.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/validators/unique.tsx
@@ -1,0 +1,12 @@
+import { CmsEditorFieldValidatorPlugin } from '@webiny/app-headless-cms/types';
+
+export default {
+    type: "cms-editor-field-validator",
+    name: "cms-editor-field-validator-unique",
+    validator: {
+        name: "unique",
+        label: "Unique",
+        description: "You won't be able to submit the form if the field value is not unique",
+        defaultMessage: "Unique value is required."
+    }
+} as CmsEditorFieldValidatorPlugin;


### PR DESCRIPTION
Draft PR to mark story as in-progress

## Related Issue
Closes #822 

## Currently Done
- Added new unique validator components to `app-headless-cms` and `app-form-builder`
- Added unique validator logic to `api-form-builder`
- Validated that the unique validator is working; values can not be duplicated for the same form field

## To-Do
- Add unique logic to `api-headless-cms`
- Add error message on client when unique validation fails on server-side
- Look into creating plugins for `api-` logic and `app-` logic that can be shared in the respective `form-builder` and `headless-cms` plugins (de-duplicate code)

## How Has This Been Tested?
- Tests have been done by creating a form with a unique text field and validating that entering the same value more than once for that form and field combination gets rejected

## Screenshots (if relevant):
*Will be adding these as I go along*