### PR TITLE
Headless CMS - model and field IDs can only start with letters (a-z)

### DIFF
--- a/packages/api-headless-cms/__tests__/mocks/modelDeletionGqlFieldsHiding.js
+++ b/packages/api-headless-cms/__tests__/mocks/modelDeletionGqlFieldsHiding.js
@@ -1,0 +1,48 @@
+import { locales } from "@webiny/api-i18n/testing";
+
+const mocks = {
+    authorContentModel: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Author",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Number"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Numer"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};
+
+export default mocks;

--- a/packages/api-headless-cms/__tests__/mocks/preventIdsStartingWithNumbers.js
+++ b/packages/api-headless-cms/__tests__/mocks/preventIdsStartingWithNumbers.js
@@ -1,0 +1,230 @@
+import { locales } from "./../mocks/I18NLocales";
+
+export default {
+    failModel1: ({ contentModelGroupId }) => ({
+        data: {
+            name: "123-Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "123-title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "123-age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    failModel2: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "123-title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "123-age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    failModel3: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "123-title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    failModel4: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    failModel5: ({ contentModelId }) => ({
+        id: contentModelId,
+        data: {
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "age",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Age"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Jahre"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "vqk-UApa0-2",
+                    fieldId: "123-something",
+                    type: "number",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Something"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Smt"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};

--- a/packages/api-headless-cms/__tests__/modelDeletionGqlFieldsHiding.test.js
+++ b/packages/api-headless-cms/__tests__/modelDeletionGqlFieldsHiding.test.js
@@ -1,0 +1,82 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/modelDeletionGqlFieldsHiding";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Refresh schema on content model deletion", () => {
+    const { environment, database } = useContentHandler();
+
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it("should refresh schema on model deletion", async () => {
+        const { createContentModel, deleteContentModel, content } = environment(
+            initial.environment.id
+        );
+
+        const contentModel = await createContentModel(
+            mocks.authorContentModel({ contentModelGroupId: initial.contentModelGroup.id })
+        );
+
+        const authors = await content("author");
+
+        const authorsList = await authors.list();
+
+        // 1. Listing authors should work.
+        expect(authorsList).toEqual([]);
+
+        // 2. Let's delete the content model, and check if the model was removed from the schema.
+        await deleteContentModel({ id: contentModel.id });
+
+        // This should result in an error (types no longer existing).
+        let error = null;
+        try {
+            await authors.list();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toEqual([
+            {
+                extensions: {
+                    code: "GRAPHQL_VALIDATION_FAILED"
+                },
+                locations: [
+                    {
+                        column: 35,
+                        line: 2
+                    }
+                ],
+                message: 'Unknown type "AuthorListWhereInput".'
+            },
+            {
+                extensions: {
+                    code: "GRAPHQL_VALIDATION_FAILED"
+                },
+                locations: [
+                    {
+                        column: 65,
+                        line: 2
+                    }
+                ],
+                message: 'Unknown type "AuthorListSorter".'
+            },
+            {
+                extensions: {
+                    code: "GRAPHQL_VALIDATION_FAILED"
+                },
+                locations: [
+                    {
+                        column: 13,
+                        line: 3
+                    }
+                ],
+                message: 'Cannot query field "listAuthors" on type "Query".'
+            }
+        ]);
+    });
+});

--- a/packages/api-headless-cms/__tests__/preventIdsStartingWithNumbers.test.js
+++ b/packages/api-headless-cms/__tests__/preventIdsStartingWithNumbers.test.js
@@ -1,0 +1,98 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/preventIdsStartingWithNumbers";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Unlocking Fields Test", () => {
+    const { environment, database } = useContentHandler();
+
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it("should unlock all fields if when all content entries are deleted", async () => {
+        const { createContentModel, updateContentModel } = environment(initial.environment.id);
+
+        let error = null;
+        try {
+            await createContentModel(
+                mocks.failModel1({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                modelId: "Provided ID 123Book is not valid - must not start with a number.",
+                "fields.fieldId":
+                    "Provided ID 123-title is not valid - must not start with a number."
+            }
+        });
+
+        error = null;
+        try {
+            await createContentModel(
+                mocks.failModel2({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                "fields.fieldId":
+                    "Provided ID 123-title is not valid - must not start with a number."
+            }
+        });
+
+        error = null;
+        try {
+            await createContentModel(
+                mocks.failModel3({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                "fields.fieldId":
+                    "Provided ID 123-title is not valid - must not start with a number."
+            }
+        });
+
+        error = null;
+        let contentModel;
+        try {
+            contentModel = await createContentModel(
+                mocks.failModel4({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBe(null);
+
+        error = null;
+        try {
+            await updateContentModel(
+                mocks.failModel5({
+                    contentModelId: contentModel.id
+                })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                "fields.fieldId":
+                    "Provided ID 123-something is not valid - must not start with a number."
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/utils/useContentHandler.js
+++ b/packages/api-headless-cms/__tests__/utils/useContentHandler.js
@@ -13,6 +13,7 @@ import {
     CREATE_CONTENT_MODEL,
     UPDATE_CONTENT_MODEL,
     GET_CONTENT_MODEL,
+    DELETE_CONTENT_MODEL,
     createCreateMutation,
     createListQuery,
     createDeleteMutation,
@@ -92,6 +93,16 @@ export default ({ database, type = "manage" } = {}) => {
                     const [body] = await environmentApi.invoke({
                         body: {
                             query: GET_CONTENT_MODEL,
+                            variables
+                        }
+                    });
+
+                    return getData(body);
+                },
+                async deleteContentModel(variables) {
+                    const [body] = await environmentApi.invoke({
+                        body: {
+                            query: DELETE_CONTENT_MODEL,
                             variables
                         }
                     });

--- a/packages/api-headless-cms/__tests__/utils/useContentHandler/getData.js
+++ b/packages/api-headless-cms/__tests__/utils/useContentHandler/getData.js
@@ -3,10 +3,13 @@ export default body => {
         throw body.errors;
     }
 
-    const { data, error } = body.data.content;
-    if (error) {
-        throw error;
+    if (typeof body.data.content === "object") {
+        const { data, error } = body.data.content;
+        if (error) {
+            throw error;
+        }
+        return data;
     }
 
-    return data;
+    return body.data.content;
 };

--- a/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
+++ b/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
@@ -127,6 +127,15 @@ export const UPDATE_CONTENT_MODEL = /* GraphQL */ `
     }
 `;
 
+export const DELETE_CONTENT_MODEL = /* GraphQL */ `
+    mutation HeadlessCmsDeleteContentModel($id: ID!) {
+        deleteContentModel(id: $id) {
+            data
+            error ${ERROR_FIELD}
+        }
+    }
+`;
+
 export const GET_CONTENT_MODEL = /* GraphQL */ `
     query GetContentModel($id: ID!) {
         content: getContentModel(id: $id) {

--- a/packages/api-headless-cms/src/content/plugins/models/ContentModel/createFieldsModel.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/ContentModel/createFieldsModel.ts
@@ -2,6 +2,7 @@ import { validation } from "@webiny/validation";
 import { withFields, string, object, setOnce, boolean, fields } from "@webiny/commodo";
 import { i18nField } from "@webiny/api-headless-cms/content/plugins/modelFields/i18nFields";
 import { any } from "@webiny/api-headless-cms/content/plugins/models/anyField";
+import idValidation from "./idValidation";
 
 const requiredShortString = validation.create("required,maxLength:256");
 const shortString = validation.create("maxLength:265");
@@ -13,7 +14,7 @@ export default context => {
 
     return withFields({
         _id: setOnce()(string({ validation: requiredShortString })),
-        fieldId: setOnce()(string({ validation: requiredShortString })),
+        fieldId: setOnce()(string({ validation: idValidation })),
         label: i18nField({
             field: string({ validation: requiredShortString }),
             context

--- a/packages/api-headless-cms/src/content/plugins/models/ContentModel/idValidation.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/ContentModel/idValidation.ts
@@ -1,0 +1,8 @@
+import { validation } from "@webiny/validation";
+
+export default async (value: string) => {
+    await validation.validate(value, "required,maxLength:100");
+    if (!value.charAt(0).match(/[a-zA-Z]/)) {
+        throw new Error(`Provided ID ${value} is not valid - must not start with a number.`);
+    }
+};

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -18,6 +18,7 @@ import camelCase from "lodash/camelCase";
 import pluralize from "pluralize";
 import { indexes } from "./indexesField";
 import { CmsContext } from "@webiny/api-headless-cms/types";
+import idValidation from "./ContentModel/idValidation";
 
 const required = validation.create("required");
 
@@ -32,7 +33,7 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                 validation: validation.create("required,maxLength:100"),
                 value: "Untitled"
             }),
-            modelId: setOnce()(string({ validation: validation.create("required,maxLength:100") })),
+            modelId: setOnce()(string({ validation: idValidation })),
             description: string({ validation: validation.create("maxLength:200") }),
             layout: object({ value: [] }),
             group: ref({ instanceOf: context.models.CmsContentModelGroup, validation: required }),
@@ -40,7 +41,9 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
 
             // Contains a list of all fields that were utilized by existing content entries. If a field is on the list,
             // it cannot be removed/edited anymore.
-            lockedFields: skipOnPopulate()(fields({ list: true, instanceOf: LockedFieldsModel, value: [] })),
+            lockedFields: skipOnPopulate()(
+                fields({ list: true, instanceOf: LockedFieldsModel, value: [] })
+            ),
             fields: fields({
                 list: true,
                 value: [],

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -86,6 +86,11 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                     );
                 }
             },
+            async afterDelete() {
+                const environment = context.cms.getEnvironment();
+                environment.changedOn = new Date();
+                await environment.save();
+            },
             async beforeSave() {
                 if (this.getField("indexes").isDirty()) {
                     const removeCallback = this.hook("afterSave", async () => {


### PR DESCRIPTION
## Related Issue
Closes #887 
Closes #987

## Your solution
#### Model and field IDs can only start with letters, no numbers allowed.
I added necessary validation on `fieldId` and `modelId` fields. 

#### Fixed validation errors still not properly sent in GraphQL responses.
While working on #887, I also discovered that validation errors are still not returned properly in GQL responses. While working on it, I also discovered [another issue in the Commodo library](https://github.com/webiny/commodo/issues/9). I documented it and hopefully, we'll be able to revisit it soon.

#### Refresh schema on content model deletion.
Schema refreshing is now triggered in the `afterDelete` in the `packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts:92`

## How Has This Been Tested?
Jest.

## Screenshots (if relevant):
N/A