### PR TITLE
Fix: Page Builder - updating domain in PB settings doesn't get immediately reflected in the rest of the app

### DIFF
--- a/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
@@ -4,7 +4,7 @@ import gql from "graphql-tag";
 import { get } from "lodash";
 import getPagePreviewUrlFunction from "./getPagePreviewUrl";
 
-const DOMAIN_QUERY = gql`
+export const DOMAIN_QUERY = gql`
     query PbGetDomain {
         pageBuilder {
             getSettings {

--- a/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
@@ -9,7 +9,7 @@ import { Query, Mutation } from "react-apollo";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import graphql from "./graphql";
 import { CircularProgress } from "@webiny/ui/Progress";
-import { get } from "lodash";
+import { get, set } from "lodash";
 import { validation } from "@webiny/validation";
 
 import {
@@ -18,6 +18,7 @@ import {
     SimpleFormContent,
     SimpleFormHeader
 } from "@webiny/app-admin/components/SimpleForm";
+import {DOMAIN_QUERY} from "@webiny/app-page-builder/admin/hooks/usePageBuilderSettings/usePageBuilderSettings";
 
 const GeneralSettings = () => {
     const { showSnackbar } = useSnackbar();
@@ -26,8 +27,21 @@ const GeneralSettings = () => {
             {({ data, loading: queryInProgress }) => {
                 const settings = get(data, "pageBuilder.getSettings.data") || {};
                 return (
-                    <Mutation mutation={graphql.mutation}>
-                        {(update, { loading: mutationInProgress }) => (
+                    <Mutation
+                        mutation={graphql.mutation}
+                        update={(cache, { data }) => {
+                            const dataFromCache = cache.readQuery({ query: DOMAIN_QUERY });
+                            const updatedSettings = get(data, "pageBuilder.updateSettings.data");
+
+                            if (updatedSettings) {
+                                cache.writeQuery({
+                                     query: DOMAIN_QUERY,
+                                     data: set(dataFromCache, "pageBuilder.getSettings.data", updatedSettings)
+                                });
+                            }
+                        }}
+                    >
+                        {(update, {loading: mutationInProgress}) => (
                             <Form
                                 data={settings}
                                 onSubmit={async data => {

--- a/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
@@ -18,7 +18,7 @@ import {
     SimpleFormContent,
     SimpleFormHeader
 } from "@webiny/app-admin/components/SimpleForm";
-import {DOMAIN_QUERY} from "@webiny/app-page-builder/admin/hooks/usePageBuilderSettings/usePageBuilderSettings";
+import { DOMAIN_QUERY } from "@webiny/app-page-builder/admin/hooks/usePageBuilderSettings/usePageBuilderSettings";
 
 const GeneralSettings = () => {
     const { showSnackbar } = useSnackbar();


### PR DESCRIPTION
## Related Issue
Closes #962 

## Your solution
update `pageBuilder` settings in the cache after `updateSettings` mutation in file
`packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx`

## How Has This Been Tested?
Manually, via the Admin app UI

## Screenshots:
https://www.loom.com/share/81a083db4f404e3cb725e4d0090c1016
