### PR TITLE
Fix: `limit` param in list content model query not working

### DIFF
--- a/packages/api-headless-cms/__tests__/limitListContentEntries.test.js
+++ b/packages/api-headless-cms/__tests__/limitListContentEntries.test.js
@@ -29,11 +29,17 @@ describe("List content entries with limit param test", () => {
 
         expect(bookList.length).toBe(4);
 
-        // TODO: Should be clean up the entries
-        await books.delete({ revision: book1.id });
-        await books.delete({ revision: book2.id });
-        await books.delete({ revision: book3.id });
-        await books.delete({ revision: book4.id });
+        expect(bookList[0].id).toEqual(book4.id);
+        expect(bookList[0].meta.value).toEqual(book4.title.value);
+
+        expect(bookList[1].id).toEqual(book3.id);
+        expect(bookList[1].meta.value).toEqual(book3.title.value);
+
+        expect(bookList[2].id).toEqual(book2.id);
+        expect(bookList[2].meta.value).toEqual(book2.title.value);
+
+        expect(bookList[3].id).toEqual(book1.id);
+        expect(bookList[3].meta.value).toEqual(book1.title.value);
     });
 
     it("should return two entries when limit is set to 2", async () => {
@@ -51,10 +57,10 @@ describe("List content entries with limit param test", () => {
 
         expect(bookList.length).toBe(2);
 
-        // TODO: Should be clean up the entries
-        await books.delete({ revision: book1.id });
-        await books.delete({ revision: book2.id });
-        await books.delete({ revision: book3.id });
-        await books.delete({ revision: book4.id });
+        expect(bookList[0].id).toEqual(book4.id);
+        expect(bookList[0].meta.value).toEqual(book4.title.value);
+
+        expect(bookList[1].id).toEqual(book3.id);
+        expect(bookList[1].meta.value).toEqual(book3.title.value);
     });
 });

--- a/packages/api-headless-cms/__tests__/limitListContentEntries.test.js
+++ b/packages/api-headless-cms/__tests__/limitListContentEntries.test.js
@@ -1,0 +1,60 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/limitListContentEntries";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("List content entries with limit param test", () => {
+    const { environment, database } = useContentHandler();
+
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it("should return all 4 entries when no limit specified", async () => {
+        const { content, createContentModel } = environment(initial.environment.id);
+
+        await createContentModel(mocks.book({ contentModelGroupId: initial.contentModelGroup.id }));
+
+        const books = await content("book");
+
+        const book1 = await books.create(mocks.book1);
+        const book2 = await books.create(mocks.book2);
+        const book3 = await books.create(mocks.book3);
+        const book4 = await books.create(mocks.book4);
+
+        const bookList = await books.list({});
+
+        expect(bookList.length).toBe(4);
+
+        // TODO: Should be clean up the entries
+        await books.delete({ revision: book1.id });
+        await books.delete({ revision: book2.id });
+        await books.delete({ revision: book3.id });
+        await books.delete({ revision: book4.id });
+    });
+
+    it("should return two entries when limit is set to 2", async () => {
+        const { content, createContentModel } = environment(initial.environment.id);
+
+        await createContentModel(mocks.book({ contentModelGroupId: initial.contentModelGroup.id }));
+        const books = await content("book");
+
+        const book1 = await books.create(mocks.book1);
+        const book2 = await books.create(mocks.book2);
+        const book3 = await books.create(mocks.book3);
+        const book4 = await books.create(mocks.book4);
+
+        const bookList = await books.list({ limit: 2 });
+
+        expect(bookList.length).toBe(2);
+
+        // TODO: Should be clean up the entries
+        await books.delete({ revision: book1.id });
+        await books.delete({ revision: book2.id });
+        await books.delete({ revision: book3.id });
+        await books.delete({ revision: book4.id });
+    });
+});

--- a/packages/api-headless-cms/__tests__/mocks/limitListContentEntries.js
+++ b/packages/api-headless-cms/__tests__/mocks/limitListContentEntries.js
@@ -1,0 +1,162 @@
+import { locales } from "./I18NLocales";
+
+const fields = [
+    {
+        _id: "vqk-UApa0-1",
+        fieldId: "title",
+        type: "text",
+        label: {
+            values: [
+                {
+                    locale: locales.en.id,
+                    value: "Title"
+                },
+                {
+                    locale: locales.de.id,
+                    value: "Titel"
+                }
+            ]
+        }
+    },
+    {
+        _id: "vqk-UApa0-2",
+        fieldId: "age",
+        type: "number",
+        label: {
+            values: [
+                {
+                    locale: locales.en.id,
+                    value: "Age"
+                },
+                {
+                    locale: locales.de.id,
+                    value: "Jahre"
+                }
+            ]
+        }
+    }
+];
+
+export default {
+    fields,
+    book: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields
+        }
+    }),
+
+    book1: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book1-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book1-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 12
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 12
+                    }
+                ]
+            }
+        }
+    },
+    book2: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book2-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book2-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 22
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 22
+                    }
+                ]
+            }
+        }
+    },
+    book3: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book3-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book3-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 33
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 33
+                    }
+                ]
+            }
+        }
+    },
+    book4: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Book4-en"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Book4-de"
+                    }
+                ]
+            },
+            age: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: 44
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: 44
+                    }
+                ]
+            }
+        }
+    }
+};

--- a/packages/api-headless-cms/src/content/plugins/utils/createFindParameters.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/createFindParameters.ts
@@ -60,11 +60,12 @@ export const createFindParameters = ({
     });
 
     if (!allFields.length) {
-        return { query: { fields: "id" }, sort: {} };
+        return { query: { fields: "id", model: model.modelId }, sort: {} };
     }
 
     return {
         query: {
+            model: model.modelId,
             fields: allFields.join(","),
             $and: conditions
         },

--- a/packages/api-headless-cms/src/content/plugins/utils/findEntries.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/findEntries.ts
@@ -52,6 +52,15 @@ export default async function findEntries<T = CmsContext>({
         query.locale = context.cms.locale.id;
     }
 
+    // For `manage` API we always want to multiple `limit` by available locales
+    if (context.cms.MANAGE) {
+        const locales = context.i18n.getLocales();
+        const newLimit = limit * locales.length;
+
+        // cap max limit to 100, to avoid `MAX_PER_PAGE_EXCEEDED` error
+        limit = Math.min(newLimit, 100);
+    }
+
     // Find IDs using search collection
     const searchEntries = await CmsContentEntrySearch.find({
         query,

--- a/packages/api-headless-cms/src/content/plugins/utils/findEntries.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/findEntries.ts
@@ -52,7 +52,30 @@ export default async function findEntries<T = CmsContext>({
         query.locale = context.cms.locale.id;
     }
 
-    // For `manage` API we always want to multiple `limit` by available locales
+    /*
+       The following code resolves the "limit" issue that happens when accessing the MANAGE API.
+
+       Description:
+       There is a difference in how the data is being queries/filtered when comparing READ/PREVIEW and MANAGE APIs.
+       When accessing READ/PREVIEW APIs, we always have single-locale filtering, and in that case, applying "limit" to
+       queries works correctly. But, when performing queries against the MANAGE API, internally, locale filtering is
+       not applied, which introduces an interesting problem.
+
+       If you take a look at the code below, you'll see that we are actually performing two queries:
+       1) Query the "CmsContentEntrySearch" collection - we only use the received content model entries IDs.
+       2) Use the IDs received from the first query to load the actual content model entries.
+
+       The problem occurs when the "limit" parameter is applied and there are multiple locales in the system. Because
+       the single-locale filtering is not applied in the MANAGE API, the result set received from the first query
+       might actually contain duplicates - rows that are actually referencing the same content model entry, but are
+       representing search entries for different locales. So, having duplicate content model entry IDs in the first
+       query result set would cause the final one to contain less results than specified by the "limit" parameter.
+
+       In order to ensure that the final result set always contains the needed number of entries specified by the
+       "limit" param, we just multiply it by the number of locales and use that as a new limit when performing the
+       first query. Received IDs are then deduplicated and only the first {limit} entries are taken into consideration,
+       while the rest is simply discarded.
+    */
     if (context.cms.MANAGE) {
         const locales = context.i18n.getLocales();
         const newLimit = limit * locales.length;


### PR DESCRIPTION


## Related Issue
Closes #983 
Headless CMS - `limit` param in list content model query not working 

## Your solution

- Add `model` in query
- Scale `limit` by locales for MANAGE API

## How Has This Been Tested?
Manually, using GraphQL playground for `manage` API

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/84468649-feec5c00-ac9c-11ea-811e-df42e929efa3.png)
