### PR TITLE
Headless CMS - add field description

### DIFF
--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.10",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
+    "pluralize": "^8.0.0",
     "react-apollo": "^3.1.0",
     "react-dnd": "^9.3.4",
     "react-dnd-html5-backend": "^9.3.4",

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.10",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "pluralize": "^8.0.0",
     "react-apollo": "^3.1.0",
     "react-dnd": "^9.3.4",
     "react-dnd-html5-backend": "^9.3.4",

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Fields.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Fields.tsx
@@ -24,10 +24,17 @@ const FieldContainer = styled("div")({
     }
 });
 
+const FileInfo = styled("div")({});
+
 const FieldLabel = styled("div")({
     textTransform: "uppercase",
     lineHeight: "145%",
     color: "var(--mdc-theme-on-surface)"
+});
+
+const FieldDescription = styled("div")({
+    fontSize: 14,
+    color: "var(--mdc-theme-text-secondary-on-background)"
 });
 
 const FieldHandle = styled("div")({
@@ -35,7 +42,7 @@ const FieldHandle = styled("div")({
     color: "var(--mdc-theme-on-surface)"
 });
 
-const Field = ({ onFieldDragStart, fieldType: { type, label, icon } }) => {
+const Field = ({ onFieldDragStart, fieldType: { type, label, icon, description } }) => {
     return (
         <Draggable beginDrag={{ ui: "field", type }}>
             {({ drag }) => (
@@ -44,7 +51,10 @@ const Field = ({ onFieldDragStart, fieldType: { type, label, icon } }) => {
                         <FieldHandle>
                             <Icon icon={icon} />
                         </FieldHandle>
-                        <FieldLabel>{label}</FieldLabel>
+                        <FileInfo>
+                            <FieldLabel>{label}</FieldLabel>
+                            <FieldDescription>{description}</FieldDescription>
+                        </FileInfo>
                     </FieldContainer>
                 </div>
             )}

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
@@ -9,6 +9,7 @@ import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { validation } from "@webiny/validation";
 import { CmsEditorField, CmsEditorFieldTypePlugin } from "@webiny/app-headless-cms/types";
 import { FormChildrenFunctionParams } from "@webiny/form/Form";
+import pluralize from "pluralize";
 
 type GeneralTabProps = {
     field: CmsEditorField;
@@ -65,6 +66,11 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
             typeof fieldPlugin.field.renderPredefinedValues === "function",
         [field.fieldId]
     );
+    
+    const multipleValuesLabel = useMemo(() => {
+        const defaultLabel = `Use as a list of ${pluralize(fieldPlugin.field.label.toLowerCase())}`;
+        return fieldPlugin.field.multipleValuesLabel || defaultLabel;
+    }, [fieldPlugin.field.type]);
 
     return (
         <>
@@ -90,7 +96,7 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
                 <Cell span={6}>
                     <Bind name={"multipleValues"}>
                         <Switch
-                            label={"Multiple values"}
+                            label={multipleValuesLabel}
                             disabled={!fieldPlugin.field.allowMultipleValues}
                         />
                     </Bind>

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
@@ -9,7 +9,6 @@ import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { validation } from "@webiny/validation";
 import { CmsEditorField, CmsEditorFieldTypePlugin } from "@webiny/app-headless-cms/types";
 import { FormChildrenFunctionParams } from "@webiny/form/Form";
-import pluralize from "pluralize";
 
 type GeneralTabProps = {
     field: CmsEditorField;
@@ -66,11 +65,6 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
             typeof fieldPlugin.field.renderPredefinedValues === "function",
         [field.fieldId]
     );
-    
-    const multipleValuesLabel = useMemo(() => {
-        const defaultLabel = `Use as a list of ${pluralize(fieldPlugin.field.label.toLowerCase())}`;
-        return fieldPlugin.field.multipleValuesLabel || defaultLabel;
-    }, [fieldPlugin.field.type]);
 
     return (
         <>
@@ -96,7 +90,7 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
                 <Cell span={6}>
                     <Bind name={"multipleValues"}>
                         <Switch
-                            label={multipleValuesLabel}
+                            label={fieldPlugin.field.multipleValuesLabel}
                             disabled={!fieldPlugin.field.allowMultipleValues}
                         />
                     </Bind>

--- a/packages/app-headless-cms/src/admin/plugins/fields/boolean.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/boolean.tsx
@@ -18,6 +18,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of booleans`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -22,6 +22,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of dates and times`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/file.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/file.tsx
@@ -19,7 +19,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
-        multipleValuesLabel: "Use as a list of files or an image gallery",
+        multipleValuesLabel: t`Use as a list of files or an image gallery`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/file.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/file.tsx
@@ -19,6 +19,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
+        multipleValuesLabel: "Use as a list of files or an image gallery",
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/longText.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/longText.tsx
@@ -21,6 +21,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: false,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of long texts`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/number.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/number.tsx
@@ -24,6 +24,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of numbers`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/ref.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/ref.tsx
@@ -20,7 +20,7 @@ const plugin: CmsEditorFieldTypePlugin = {
         type: "ref",
         validators: [],
         label: t`Reference`,
-        description: t`For example a Product can ref its category(s).`,
+        description: t`Reference existing content entries. For example, a book can reference one or more authors.`,
         icon: <RefIcon />,
         allowMultipleValues: true,
         allowPredefinedValues: false,
@@ -28,6 +28,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: false,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of references`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/richText.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/richText.tsx
@@ -20,6 +20,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: false,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of rich texts`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/admin/plugins/fields/text.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/text.tsx
@@ -23,6 +23,7 @@ const plugin: CmsEditorFieldTypePlugin = {
             singleValue: true,
             multipleValues: false
         },
+        multipleValuesLabel: t`Use as a list of texts`,
         createField() {
             return {
                 type: this.type,

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -21,6 +21,7 @@ export type CmsEditorFieldTypePlugin = Plugin & {
             singleValue: boolean;
             multipleValues: false; // At the moment, we don't support indexing fields with multiple values.
         };
+        multipleValuesLabel?: string;
         createField: ({ i18n: any }) => CmsEditorField;
         renderSettings?: (params: {
             form: FormChildrenFunctionParams;

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -21,7 +21,7 @@ export type CmsEditorFieldTypePlugin = Plugin & {
             singleValue: boolean;
             multipleValues: false; // At the moment, we don't support indexing fields with multiple values.
         };
-        multipleValuesLabel?: string;
+        multipleValuesLabel: React.ReactNode;
         createField: ({ i18n: any }) => CmsEditorField;
         renderSettings?: (params: {
             form: FormChildrenFunctionParams;


### PR DESCRIPTION
## Related Issue
Closes #967 

## Your solution

I think having a separate field for Image and Image gallery is not necessary.

Provide more context/clarity to users by:

1. Adding a description for each field in the editor.
2. Reworded multi values toggle label such that it will be more clear to the user what is means. something like use as a list of <field type> i.e use as a list of file

## How Has This Been Tested?
Manually, by the Admin app UI

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/84493325-340ca480-acc5-11ea-93a0-47c8893604c3.png)

![image](https://user-images.githubusercontent.com/13612227/84493391-4c7cbf00-acc5-11ea-84c2-0f683c3e5590.png)

