### PR TITLE
fix(app-page-builder): remove outlined prop

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/pageSettings/components/GeneralSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/pageSettings/components/GeneralSettings.tsx
@@ -61,7 +61,7 @@ const GeneralSettings = ({ form, Bind }) => {
                 </Cell>
                 <Cell span={12}>
                     <Bind name={"snippet"}>
-                        <Input rows={4} label="Snippet" description="Page snippet" outlined />
+                        <Input rows={4} label="Snippet" description="Page snippet" />
                     </Bind>
                 </Cell>
                 <Cell span={12}>


### PR DESCRIPTION
## Related Issue
General settings in Page Builder Editor have a `snippet` field and for some reason it's still using the `outlined` prop, which changes the look and feel of the input. All other textareas are not using it.

## Your solution
Remove the `outlined` prop.

## How Has This Been Tested?
Manually

