### PR TITLE
FIx- Headless CMS - number inputs field not working

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
@@ -28,6 +28,10 @@ const plugin: CmsEditorFieldRendererPlugin = {
                     {({ bind, index }) => (
                         <Input
                             {...bind.index}
+                            onChange={value => {
+                                value = parseFloat(value);
+                                return bind.index.onChange(value);
+                            }}
                             autoFocus
                             onEnter={() => bind.field.appendValue("")}
                             label={t`Value {number}`({ number: index + 1 })}


### PR DESCRIPTION
## Related Issue
Closes #997 
Headless CMS - number field (multiple values) not working
## Your solution

Save value as a `number` instead of `string`

## How Has This Been Tested?
Manually, using the Admin app

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/84574003-84692c80-adc1-11ea-8acc-82272f406dae.png)

