### PR TITLE
Introduce useRouter and remove withRouter HOC

### DIFF
--- a/packages/app-admin/package.json
+++ b/packages/app-admin/package.json
@@ -39,8 +39,7 @@
     "react-transition-group": "^4.3.0",
     "shortid": "^2.2.12",
     "store": "^2.0.12",
-    "timeago-react": "^2.0.0",
-    "use-react-router": "^1.0.7"
+    "timeago-react": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/app-admin/src/contexts/Crud/CrudContext.tsx
+++ b/packages/app-admin/src/contexts/Crud/CrudContext.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery } from "react-apollo";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { useDialog } from "@webiny/app-admin/hooks/useDialog";
 import { useDataList } from "@webiny/app/hooks/useDataList";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { getData, getError } from "./functions";
 import { get } from "lodash";
 import { i18n } from "@webiny/app/i18n";
@@ -31,7 +31,7 @@ export type CrudContextValue = {
 export const CrudProvider = ({ children, ...props }: CrudProviderProps) => {
     const { showSnackbar } = useSnackbar();
     const { showDialog } = useDialog();
-    const { location, history } = useReactRouter();
+    const { location, history } = useRouter();
 
     const list = useDataList({
         query: get(props, "list.query", props.list),

--- a/packages/app-admin/src/plugins/GlobalSearch/SearchBar.tsx
+++ b/packages/app-admin/src/plugins/GlobalSearch/SearchBar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { set } from "dot-prop-immutable";
-import { withRouter, WithRouterProps } from "@webiny/react-router";
+import { useRouter, UseRouter } from "@webiny/react-router";
 import Downshift from "downshift";
 import { getPlugins } from "@webiny/plugins";
 import {
@@ -28,7 +28,7 @@ import {
     searchWrapper
 } from "./styled";
 
-type SearchBarProps = WithRouterProps<{}>;
+type SearchBarProps = UseRouter;
 
 type SearchBarState = {
     active: boolean;
@@ -241,4 +241,10 @@ class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     }
 }
 
-export default withRouter<SearchBarProps>(SearchBar);
+const SearchBarContainer = () => {
+    const routerProps = useRouter();
+
+    return <SearchBar {...routerProps} />;
+};
+
+export default SearchBarContainer;

--- a/packages/app-form-builder/package.json
+++ b/packages/app-form-builder/package.json
@@ -44,8 +44,7 @@
     "react-router": "^5.1.2",
     "react-sortable-hoc": "^1.9.1",
     "shortid": "^2.2.14",
-    "timeago-react": "^2.0.0",
-    "use-react-router": "^1.0.7"
+    "timeago-react": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/app-form-builder/src/admin/components/FormEditor/FormEditor.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/FormEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 // Components
 import EditorBar from "./Bar";
@@ -13,7 +13,7 @@ const FormEditor = () => {
         state: { data, id }
     } = useFormEditor();
 
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
 
     React.useEffect(() => {

--- a/packages/app-form-builder/src/admin/components/FormEditor/FormEditorApp.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/FormEditorApp.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useApolloClient } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { FormEditorProvider } from "./Context";
 import FormEditor from "./FormEditor";
 import { match } from "react-router";
 
 const FormEditorApp = () => {
-    const router = useReactRouter();
+    const router = useRouter();
     const client = useApolloClient();
 
     const matched: match<{

--- a/packages/app-form-builder/src/admin/plugins/formDetails/formRevisions/useRevision.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formRevisions/useRevision.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useApolloClient } from "react-apollo";
 import { cloneDeep, get } from "lodash";
 import { useHandlers } from "@webiny/app/hooks/useHandlers";
@@ -19,7 +19,7 @@ export type UseRevisionProps = {
 }
 
 export const useRevision = ({ revision, form }: UseRevisionProps) => {
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
     const client = useApolloClient();
 

--- a/packages/app-form-builder/src/admin/plugins/formDetails/previewContent/HeaderComponents/DeleteForm.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/previewContent/HeaderComponents/DeleteForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useApolloClient } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { IconButton } from "@webiny/ui/Button";
 import { Tooltip } from "@webiny/ui/Tooltip";
@@ -12,7 +12,7 @@ import { cloneDeep, get } from "lodash";
 const DeleteForm = ({ form, revision, selectRevision }) => {
     const { showSnackbar } = useSnackbar();
     const client = useApolloClient();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const parentRevision = revision.parent === revision.id;
     let message = "You are about to delete this form revision, are you sure want to continue?";

--- a/packages/app-form-builder/src/admin/plugins/formDetails/previewContent/HeaderComponents/EditRevision.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/previewContent/HeaderComponents/EditRevision.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { IconButton } from "@webiny/ui/Button";
 import { Tooltip } from "@webiny/ui/Tooltip";
 import { ReactComponent as EditIcon } from "@webiny/app-form-builder/admin/icons/edit.svg";
@@ -7,7 +7,7 @@ import { useRevision } from "../../formRevisions/useRevision";
 
 const EditRevision = ({ revision, form }) => {
     const { createRevision } = useRevision({ revision, form });
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     if (revision.status === "draft") {
         return (

--- a/packages/app-form-builder/src/admin/views/Forms/FormDetails.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormDetails.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Query } from "react-apollo";
 import { renderPlugins } from "@webiny/app/plugins";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { Elevation } from "@webiny/ui/Elevation";
 import { GET_FORM } from "@webiny/app-form-builder/admin/viewsGraphql";
@@ -50,7 +50,7 @@ export type FormDetailsProps = {
 };
 
 const FormDetails = ({ refreshForms }: FormDetailsProps) => {
-    const { location, history } = useReactRouter();
+    const { location, history } = useRouter();
     const { showSnackbar } = useSnackbar();
     const query = new URLSearchParams(location.search);
     const formId = query.get("id");

--- a/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback } from "react";
 import TimeAgo from "timeago-react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { css } from "emotion";
 import { get, upperFirst } from "lodash";
 import { Typography } from "@webiny/ui/Typography";
@@ -41,7 +41,7 @@ const FormsDataList = (props: FormsDataListProps) => {
 
     const { dataList } = props;
 
-    const { location, history } = useReactRouter();
+    const { location, history } = useRouter();
     const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
 

--- a/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/NewFormDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { Mutation } from "react-apollo";
 import { Form } from "@webiny/form";
 import { Input } from "@webiny/ui/Input";
@@ -37,7 +37,7 @@ export type NewFormDialogProps = {
 const NewFormDialog: React.FC<NewFormDialogProps> = ({ open, onClose, formsDataList }) => {
     const [loading, setLoading] = React.useState(false);
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     return (
         <Dialog

--- a/packages/app-form-builder/src/editor/plugins/defaultBar/BackButton.tsx
+++ b/packages/app-form-builder/src/editor/plugins/defaultBar/BackButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { IconButton } from "@webiny/ui/Button";
 import { ReactComponent as BackIcon } from "./icons/round-arrow_back-24px.svg";
 import { css } from "emotion";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { match } from "react-router";
 
 const backStyles = css({
@@ -10,7 +10,7 @@ const backStyles = css({
 });
 
 const BackButton = React.memo(() => {
-    const router = useReactRouter();
+    const router = useRouter();
 
     const matched: match<{
         id?: string;

--- a/packages/app-form-builder/src/editor/plugins/defaultBar/PublishFormButton.tsx
+++ b/packages/app-form-builder/src/editor/plugins/defaultBar/PublishFormButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Mutation } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { ButtonPrimary } from "@webiny/ui/Button";
 import { ConfirmationDialog } from "@webiny/ui/ConfirmationDialog";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
@@ -16,7 +16,7 @@ const PublishFormButton = () => {
     } = useFormEditor();
 
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     return (
         <ConfirmationDialog

--- a/packages/app-form-builder/src/editor/plugins/defaultBar/Revisions.tsx
+++ b/packages/app-form-builder/src/editor/plugins/defaultBar/Revisions.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { Menu, MenuItem } from "@webiny/ui/Menu";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { Icon } from "@webiny/ui/Icon";
@@ -31,7 +31,7 @@ const Revisions = () => {
         state: { data }
     } = useFormEditor();
 
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const revisions = data.revisions || [];
     return (

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -53,8 +53,7 @@
     "react-virtualized": "^9.21.2",
     "shortid": "^2.2.14",
     "slugify": "^1.4.0",
-    "timeago-react": "^2.0.0",
-    "use-react-router": "^1.0.7"
+    "timeago-react": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 // Components
 import EditorBar from "./Bar";
@@ -16,7 +16,7 @@ const ContentModelEditor = () => {
         state: { data, id }
     } = useContentModelEditor();
 
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
 
     React.useEffect(() => {

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorApp.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorApp.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { ContentModelEditorProvider } from "./Context";
 import ContentModelEditor from "./ContentModelEditor";
 import { match } from "react-router";
@@ -10,7 +10,7 @@ type QueryMatch = {
 };
 
 const ContentModelEditorApp = () => {
-    const router = useReactRouter();
+    const router = useRouter();
 
     const {
         environments: { apolloClient }

--- a/packages/app-headless-cms/src/admin/components/EnvironmentSelectorDialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/EnvironmentSelectorDialog.tsx
@@ -4,7 +4,7 @@ import { i18n } from "@webiny/app/i18n";
 import { Dialog, DialogTitle, DialogContent } from "@webiny/ui/Dialog";
 import { useCms } from "@webiny/app-headless-cms/admin/hooks";
 import { ButtonDefault, ButtonIcon } from "@webiny/ui/Button";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { ReactComponent as DoneIcon } from "@webiny/app-headless-cms/admin/icons/done-24px.svg";
 import { ReactComponent as ForwardIcon } from "@webiny/app-headless-cms/admin/icons/arrow_forward-24px.svg";
 
@@ -60,7 +60,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
         environments: { currentEnvironment, environments, selectEnvironment }
     } = useCms();
 
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     return (
         <Dialog

--- a/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/BackButton.tsx
+++ b/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/BackButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { IconButton } from "@webiny/ui/Button";
 import { ReactComponent as BackIcon } from "./icons/round-arrow_back-24px.svg";
 import { css } from "emotion";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { match } from "react-router";
 
 const backStyles = css({
@@ -10,7 +10,7 @@ const backStyles = css({
 });
 
 const BackButton = React.memo(() => {
-    const router = useReactRouter();
+    const router = useRouter();
 
     const matched: match<{
         id?: string;

--- a/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/CreateContentButton.tsx
+++ b/packages/app-headless-cms/src/admin/editor/plugins/defaultBar/CreateContentButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ButtonDefault } from "@webiny/ui/Button";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useContentModelEditor } from "@webiny/app-headless-cms/admin/components/ContentModelEditor/Context";
 
 import { i18n } from "@webiny/app/i18n";
@@ -8,7 +8,7 @@ const t = i18n.namespace("app-headless-cms/admin/editor/top-bar/save-button");
 
 const CreateContentButton = () => {
     const [loading] = useState(false);
-    const router = useReactRouter();
+    const router = useRouter();
     const { data } = useContentModelEditor();
 
     return (

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/contentForm/ContentForm.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/contentForm/ContentForm.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ContentModelForm } from "@webiny/app-headless-cms/admin/components/ContentModelForm";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import {
     createCreateFromMutation,
     createCreateMutation,
@@ -15,7 +15,7 @@ import cloneDeep from "lodash/cloneDeep";
 
 const ContentForm = ({ contentModel, content, getLocale, setLoading, getLoading, setState }) => {
     const query = new URLSearchParams(location.search);
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
 
     const { CREATE_CONTENT, UPDATE_CONTENT, CREATE_CONTENT_FROM, LIST_CONTENT } = useMemo(() => {

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/contentRevisions/Revision.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/contentRevisions/Revision.tsx
@@ -22,7 +22,7 @@ import { ReactComponent as AddIcon } from "@webiny/app-headless-cms/admin/icons/
 import { ReactComponent as EditIcon } from "@webiny/app-headless-cms/admin/icons/edit.svg";
 import { ReactComponent as PublishIcon } from "@webiny/app-headless-cms/admin/icons/publish.svg";
 import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/delete.svg";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { CmsEditorContentModel } from "@webiny/app-headless-cms/types";
 import { I18NValue } from "@webiny/app-i18n/components";
 import { i18n } from "@webiny/app/i18n";
@@ -61,7 +61,7 @@ const Revision = props => {
     const { revision, createContentFrom, deleteContent, publishContent, switchTab } = props;
     const { icon, text: tooltipText } = getIcon(revision);
 
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     return (
         <ConfirmationDialog

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/contentRevisions/RevisionsList.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/contentRevisions/RevisionsList.tsx
@@ -12,7 +12,7 @@ import {
     createPublishMutation
 } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/plugins/content-details/content-revisions");
 
@@ -41,7 +41,7 @@ const style = {
 const RevisionsList = props => {
     const { showSnackbar } = useSnackbar();
     const { content, contentModel, setLoading, dataList, revisionsList } = props;
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const { CREATE_CONTENT_FROM, DELETE_CONTENT, PUBLISH_CONTENT } = useMemo(() => {
         return {

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/deleteContent/DeleteContent.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/deleteContent/DeleteContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
 import { useDialog } from "@webiny/app-admin/hooks/useDialog";
@@ -15,7 +15,7 @@ const t = i18n.ns("app-headless-cms/admin/plugins/content/header/delete");
 
 const DeleteContent = ({ contentModel, content, dataList, getLoading, setLoading }) => {
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showDialog } = useDialog();
 
     const DELETE_CONTENT = useMemo(() => {

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/revisionSelector/RevisionSelector.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/revisionSelector/RevisionSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import { withRouter } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { Icon } from "@webiny/ui/Icon";
 import { ReactComponent as DownButton } from "@webiny/app-headless-cms/admin/icons/round-arrow_drop_down-24px.svg";
@@ -24,7 +24,8 @@ const menuStyles = css({
     }
 });
 
-const RevisionSelector = ({ location, history, content, getLoading, revisionsList }) => {
+const RevisionSelector = ({ content, getLoading, revisionsList }) => {
+    const { location, history } = useRouter();
     const query = new URLSearchParams(location.search);
 
     const currentRevision = {
@@ -62,4 +63,4 @@ const RevisionSelector = ({ location, history, content, getLoading, revisionsLis
     );
 };
 
-export default withRouter(RevisionSelector);
+export default RevisionSelector;

--- a/packages/app-headless-cms/src/admin/plugins/contentForm/header/revisionSelector/RevisionSelector.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentForm/header/revisionSelector/RevisionSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import { withRouter } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { Typography } from "@webiny/ui/Typography";
 import { Menu, MenuItem } from "@webiny/ui/Menu";
@@ -21,7 +21,8 @@ const menuList = css({
     }
 });
 
-const RevisionSelector = ({ location, history, entry }) => {
+const RevisionSelector = ({ entry }) => {
+    const { location, history } = useRouter();
     const query = new URLSearchParams(location.search);
 
     return (
@@ -47,4 +48,4 @@ const RevisionSelector = ({ location, history, entry }) => {
     );
 };
 
-export default withRouter(RevisionSelector);
+export default RevisionSelector;

--- a/packages/app-headless-cms/src/admin/views/Content/Content.tsx
+++ b/packages/app-headless-cms/src/admin/views/Content/Content.tsx
@@ -4,19 +4,18 @@ import { useDataList } from "@webiny/app/hooks/useDataList";
 import ContentDataList from "./ContentDataList";
 import ContentDetails from "./ContentDetails";
 import { createListQuery } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
-import useRouter from "use-react-router";
 import get from "lodash.get";
 import { useApolloClient, useQuery } from "@webiny/app-headless-cms/admin/hooks";
 import { GET_CONTENT_MODEL_BY_MODEL_ID } from "./graphql";
 import { FloatingActionButton } from "@webiny/app-admin/components/FloatingActionButton";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/content");
 
 const ContentRender = ({ contentModel }) => {
     const apolloClient = useApolloClient();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const LIST_QUERY = useMemo(() => createListQuery(contentModel), [contentModel.modelId]);
 
@@ -59,7 +58,7 @@ const ContentRender = ({ contentModel }) => {
 const Content = () => {
     const { match } = useRouter();
     const [contentModel, setContentModel] = useState();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const modelId = get(match, "params.modelId");
     const { showSnackbar } = useSnackbar();
 

--- a/packages/app-headless-cms/src/admin/views/Content/ContentDetails.tsx
+++ b/packages/app-headless-cms/src/admin/views/Content/ContentDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { renderPlugins } from "@webiny/app/plugins";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
@@ -30,7 +30,7 @@ declare global {
     }
 }
 const ContentDetails = ({ contentModel, dataList }) => {
-    const { history, location } = useReactRouter();
+    const { history, location } = useRouter();
     const { showSnackbar } = useSnackbar();
     const [state, setState] = useState({});
 

--- a/packages/app-headless-cms/src/admin/views/ContentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentModels/ContentModelsDataList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from "react";
 import TimeAgo from "timeago-react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { css } from "emotion";
 import get from "lodash/get";
 import { ConfirmationDialog } from "@webiny/ui/ConfirmationDialog";
@@ -47,7 +47,7 @@ export type ContentModelsDataListProps = {
 const ContentModelsDataList = (props: ContentModelsDataListProps) => {
     const { dataList } = props;
 
-    const { location, history } = useReactRouter();
+    const { location, history } = useRouter();
     const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
 

--- a/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { Form } from "@webiny/form";
 import { Input } from "@webiny/ui/Input";
 import { Select } from "@webiny/ui/Select";
@@ -47,7 +47,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
 }) => {
     const [loading, setLoading] = React.useState(false);
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const [createContentModel] = useMutation(CREATE_CONTENT_MODEL);
     const { data } = useQuery(LIST_MENU_CONTENT_GROUPS_MODELS, {

--- a/packages/app-page-builder/package.json
+++ b/packages/app-page-builder/package.json
@@ -66,7 +66,6 @@
     "store": "^2.0.12",
     "timeago-react": "^2.0.0",
     "uniqid": "^5.0.3",
-    "use-react-router": "^1.0.7",
     "warning": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/app-page-builder/src/admin/hooks/usePageDetails/usePageDetails.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageDetails/usePageDetails.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
-import { PageDetailsContext } from "../../contexts/PageDetails";
+import { PageDetailsContext, PbPageDetailsContextValue } from "../../contexts/PageDetails";
 
-export function usePageDetails() {
+export function usePageDetails(): PbPageDetailsContextValue {
     return useContext(PageDetailsContext);
 }

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/deletePage/DeletePage.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/deletePage/DeletePage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import dot from "dot-prop-immutable";
 import { useApolloClient } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { get } from "lodash";
 import { useHandler } from "@webiny/app/hooks/useHandler";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
@@ -15,7 +15,7 @@ import { DELETE_PAGE } from "@webiny/app-page-builder/admin/graphql/pages";
 const DeletePage = props => {
     const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showDialog } = useDialog();
 
     const title = get(props, "pageDetails.page.title", "N/A");

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/editRevision/EditRevision.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/editRevision/EditRevision.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { IconButton } from "@webiny/ui/Button";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useApolloClient } from "react-apollo";
 import { Tooltip } from "@webiny/ui/Tooltip";
 import { ReactComponent as EditIcon } from "@webiny/app-page-builder/admin/assets/edit.svg";
@@ -12,7 +12,7 @@ import { get } from "lodash";
 const EditRevision = () => {
     const { showSnackbar } = useSnackbar();
     const client = useApolloClient();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { page } = usePageDetails();
     const [inProgress, setInProgress] = useState();
 

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/revisionSelector/RevisionSelector.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/revisionSelector/RevisionSelector.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { css } from "emotion";
-import { withRouter } from "@webiny/react-router";
+import { get } from "lodash";
+import { useRouter } from "@webiny/react-router";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { Icon } from "@webiny/ui/Icon";
 import { ReactComponent as DownButton } from "@webiny/app-page-builder/admin/assets/round-arrow_drop_down-24px.svg";
 import { MenuItem } from "@rmwc/menu";
 import { Typography } from "@webiny/ui/Typography";
 import { Menu } from "@webiny/ui/Menu";
-import { get } from "lodash";
+import { usePageDetails } from "@webiny/app-page-builder/admin/hooks/usePageDetails";
+
 const buttonStyle = css({
     "&.mdc-button": {
         color: "var(--mdc-theme-text-primary-on-background) !important"
@@ -23,7 +25,9 @@ const menuList = css({
     }
 });
 
-const RevisionSelector = ({ location, history, pageDetails: { page } }) => {
+const RevisionSelector = () => {
+    const { page } = usePageDetails();
+    const { location, history } = useRouter();
     const query = new URLSearchParams(location.search);
 
     return (
@@ -59,4 +63,4 @@ const RevisionSelector = ({ location, history, pageDetails: { page } }) => {
     );
 };
 
-export default withRouter(RevisionSelector);
+export default RevisionSelector;

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/useRevisionHandlers.ts
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/useRevisionHandlers.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useApolloClient } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import {
     CREATE_REVISION_FORM,
     DELETE_REVISION
@@ -11,7 +11,7 @@ import { usePageDetails } from "@webiny/app-page-builder/admin/hooks/usePageDeta
 
 export function useRevisionHandlers({ rev }) {
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const client = useApolloClient();
     const { page } = usePageDetails();
     const { publishRevision } = usePublishRevisionHandler({ page });

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/revisionContent/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/revisionContent/index.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { renderPlugins } from "@webiny/app/plugins";
-import { PbPageDetailsPlugin } from "@webiny/app-page-builder/types";
+import {
+    PbPageDetailsPlugin,
+    PbPageDetailsRevisionContentPlugin
+} from "@webiny/app-page-builder/types";
 import { Tabs } from "@webiny/ui/Tabs";
 
 const plugin: PbPageDetailsPlugin = {
@@ -9,7 +12,7 @@ const plugin: PbPageDetailsPlugin = {
     render({ pageDetails, ...rest }) {
         return (
             <Tabs>
-                {renderPlugins(
+                {renderPlugins<PbPageDetailsRevisionContentPlugin>(
                     "pb-page-details-revision-content",
                     { pageDetails, ...rest },
                     { wrapper: false }

--- a/packages/app-page-builder/src/admin/views/Categories/CategoriesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/Categories/CategoriesDataList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { withRouter } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { i18n } from "@webiny/app/i18n";
 import { ConfirmationDialog } from "@webiny/ui/ConfirmationDialog";
 import { DeleteIcon } from "@webiny/ui/List/DataList/icons";
@@ -73,4 +73,4 @@ const CategoriesDataList = () => {
     );
 };
 
-export default withRouter(CategoriesDataList);
+export default CategoriesDataList;

--- a/packages/app-page-builder/src/admin/views/Categories/CategoriesDialog.tsx
+++ b/packages/app-page-builder/src/admin/views/Categories/CategoriesDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-import { withRouter, WithRouterProps } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { Query } from "react-apollo";
 import {
     Dialog,
@@ -26,21 +26,20 @@ const narrowDialog = css({
     }
 });
 
-export type CategoriesDialogProps = WithRouterProps<{
+export type CategoriesDialogProps = {
     open: boolean;
     onClose: DialogOnClose;
     onSelect: Function;
-    history: History;
     children: any;
-}>;
+};
 
 const CategoriesDialog: React.FC<CategoriesDialogProps> = ({
     open,
     onClose,
     onSelect,
-    history,
     children
 }) => {
+    const { history } = useRouter();
     return (
         <Dialog
             open={open}
@@ -87,4 +86,4 @@ const CategoriesDialog: React.FC<CategoriesDialogProps> = ({
     );
 };
 
-export default withRouter<CategoriesDialogProps>(CategoriesDialog);
+export default CategoriesDialog;

--- a/packages/app-page-builder/src/admin/views/Pages/Editor.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Editor.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { Provider } from "react-redux";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { Query, useApolloClient } from "react-apollo";
 import { get } from "lodash";
 import { Editor as PbEditor } from "@webiny/app-page-builder/editor";
@@ -35,9 +35,11 @@ let pageSet = null;
 
 const Editor = () => {
     const client = useApolloClient();
-    const { match, history } = useReactRouter<any>();
+    const { match, history } = useRouter();
     const { showSnackbar } = useSnackbar();
     const ready = useSavedElements();
+
+    const params: { id: string } = match.params as any;
 
     const renderEditor = useCallback(
         ({ data, loading }) => {
@@ -97,7 +99,7 @@ const Editor = () => {
     return (
         <Query
             query={GET_PAGE()}
-            variables={{ id: match.params.id }}
+            variables={{ id: params.id }}
             onCompleted={data => {
                 const error = get(data, "pageBuilder.page.error.message");
                 if (error) {

--- a/packages/app-page-builder/src/admin/views/Pages/PageDetails.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PageDetails.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Query } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { Elevation } from "@webiny/ui/Elevation";
 import { renderPlugins } from "@webiny/app/plugins";
@@ -58,7 +58,7 @@ const EmptyPageDetails = () => {
 };
 
 const PageDetails = ({ refreshPages }) => {
-    const { history, location } = useReactRouter();
+    const { history, location } = useRouter();
     const { showSnackbar } = useSnackbar();
 
     const query = new URLSearchParams(location.search);

--- a/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { useApolloClient } from "react-apollo";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { useHandler } from "@webiny/app/hooks/useHandler";
 import { SplitView, LeftPanel, RightPanel } from "@webiny/app-admin/components/SplitView";
 import { FloatingActionButton } from "@webiny/app-admin/components/FloatingActionButton";
@@ -17,7 +17,7 @@ const Pages = props => {
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
     const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
-    const { history } = useReactRouter();
+    const { history } = useRouter();
 
     const dataList = useDataList({
         query: LIST_PAGES,

--- a/packages/app-page-builder/src/admin/views/Pages/PagesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PagesDataList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import TimeAgo from "timeago-react";
-import { withRouter, WithRouterProps } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { i18n } from "@webiny/app/i18n";
 import { css } from "emotion";
 import { Typography } from "@webiny/ui/Typography";
@@ -20,12 +20,13 @@ const rightAlign = css({
     alignItems: "flex-end !important"
 });
 
-export type PagesDataListProps = WithRouterProps<{
+export type PagesDataListProps = {
     dataList: any;
-}>;
+};
 
 const PagesDataList: React.FC<PagesDataListProps> = props => {
-    const { dataList, location, history } = props;
+    const { location, history } = useRouter();
+    const { dataList } = props;
     const query = new URLSearchParams(location.search);
 
     return (
@@ -83,4 +84,4 @@ const PagesDataList: React.FC<PagesDataListProps> = props => {
     );
 };
 
-export default withRouter<PagesDataListProps>(PagesDataList);
+export default PagesDataList;

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/BackButton.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/BackButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { IconButton } from "@webiny/ui/Button";
 import { ReactComponent as BackIcon } from "./icons/round-arrow_back-24px.svg";
 import { css } from "emotion";
@@ -9,12 +9,13 @@ const backStyles = css({
 });
 
 const BackButton = () => {
-    const { match, history } = useReactRouter<any>();
+    const { match, history } = useRouter();
+    const params: { id: string } = match.params as any;
     return (
         <IconButton
             data-testid="pb-editor-back-button"
             className={backStyles}
-            onClick={() => history.push(`/page-builder/pages?id=${match.params.id}`)}
+            onClick={() => history.push(`/page-builder/pages?id=${params.id}`)}
             icon={<BackIcon />}
         />
     );

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/PreviewPageButton.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/PreviewPageButton.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { connect } from "@webiny/app-page-builder/editor/redux";
 import { getPage } from "@webiny/app-page-builder/editor/selectors";
 import { omit, isEqual } from "lodash";
-import { withRouter } from "@webiny/react-router";
 import { MenuItem } from "@webiny/ui/Menu";
 import { usePageBuilderSettings } from "@webiny/app-page-builder/admin/hooks/usePageBuilderSettings";
 import { ListItemGraphic } from "@webiny/ui/List";
@@ -31,4 +30,4 @@ export default connect<any, any, any>(
     null,
     null,
     { areStatePropsEqual: isEqual }
-)(withRouter(PreviewPageButton));
+)(PreviewPageButton);

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/PublishPageButton.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/PublishPageButton.tsx
@@ -6,10 +6,11 @@ import { getPage } from "@webiny/app-page-builder/editor/selectors";
 import { omit, isEqual } from "lodash";
 import { Mutation } from "react-apollo";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
-import { withRouter } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { PUBLISH_REVISION } from "./PublishPageButton/graphql";
 
-const PublishPageButton = ({ page, history }) => {
+const PublishPageButton = ({ page }) => {
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
     return (
         <ConfirmationDialog
@@ -57,4 +58,4 @@ export default connect<any, any, any>(
     null,
     null,
     { areStatePropsEqual: isEqual }
-)(withRouter(PublishPageButton));
+)(PublishPageButton);

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/Revisions.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/Revisions.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "@webiny/app-page-builder/editor/redux";
 import { css } from "emotion";
-import { withRouter } from "@webiny/react-router";
+import { useRouter } from "@webiny/react-router";
 import { Menu, MenuItem } from "@webiny/ui/Menu";
 import { getRevisions } from "@webiny/app-page-builder/editor/selectors";
 import { ButtonDefault } from "@webiny/ui/Button";
@@ -24,7 +24,8 @@ const menuList = css({
     }
 });
 
-const Revisions = ({ revisions, history }) => {
+const Revisions = ({ revisions }) => {
+    const { history } = useRouter();
     return (
         <Menu
             className={menuList}
@@ -58,5 +59,5 @@ const Revisions = ({ revisions, history }) => {
 };
 
 export default connect<any, any, any>(state => ({ revisions: getRevisions(state) }))(
-    withRouter(React.memo(Revisions))
+    React.memo(Revisions)
 );

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/SetAsHomepageButton.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/SetAsHomepageButton.tsx
@@ -3,7 +3,7 @@ import { connect } from "@webiny/app-page-builder/editor/redux";
 import { getPage } from "@webiny/app-page-builder/editor/selectors";
 import { omit, isEqual } from "lodash";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
-import useReactRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { MenuItem } from "@webiny/ui/Menu";
 import { ListItemGraphic } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
@@ -25,7 +25,7 @@ const setHomePage = gql`
 `;
 
 const SetAsHomepageButton = ({ page }) => {
-    const { history } = useReactRouter();
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
 
     return (

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "@babel/runtime": "^7.5.5",
     "@webiny/i18n": "^4.0.2",
     "@webiny/i18n-react": "^4.0.2",
+    "@webiny/react-router": "^4.0.2",
     "@webiny/plugins": "^4.0.2",
     "@webiny/ui": "^4.0.2",
     "apollo-client": "^2.6.8",
@@ -29,7 +30,6 @@
     "react": "^16.8.6",
     "react-apollo": "^3.1.3",
     "react-dom": "^16.6.0",
-    "use-react-router": "^1.0.7",
     "warning": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/app/src/hooks/useDataList/useDataList.ts
+++ b/packages/app/src/hooks/useDataList/useDataList.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery } from "react-apollo";
-import useRouter from "use-react-router";
+import { useRouter } from "@webiny/react-router";
 import { get, isEqual } from "lodash";
 import { prepareLoadListParams } from "./utils";
 import { getData, getError, getMeta } from "./functions";

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -1,13 +1,22 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["./src"],
-  "exclude": ["node_modules", "./dist", "../plugins", "../i18n", "../i18n-react", "../ui"],
+  "exclude": [
+    "node_modules",
+    "./dist",
+    "../plugins",
+    "../i18n",
+    "../i18n-react",
+    "../react-router",
+    "../ui"
+  ],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
     "declarationDir": "./dist"
   },
   "references": [
+    { "path": "../react-router/tsconfig.build.json" },
     { "path": "../plugins/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
     { "path": "../i18n/tsconfig.build.json" },

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "references": [
+    { "path": "../react-router" },
     { "path": "../plugins" },
     { "path": "../ui" },
     { "path": "../i18n" },

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -1,27 +1,23 @@
-import React from "react";
-
-import { BrowserRouter as RBrowserRouter, StaticRouter as RStaticRouter } from "react-router-dom";
-import { withRouter as RWithRouter, RouteComponentProps } from "react-router";
-import { RouterConsumer } from "./context/RouterContext";
+import React, { useContext } from "react";
+import {
+    BrowserRouter as RBrowserRouter,
+    RouteChildrenProps,
+    StaticRouter as RStaticRouter
+} from "react-router-dom";
+import { __RouterContext } from "react-router";
+import { RouterContext, ReactRouterContextValue } from "./context/RouterContext";
 
 export * from "react-router-dom";
 
 export { Link } from "./Link";
 
-export type WithRouterProps<TProps> = TProps &
-    RouteComponentProps & {
-        onLink(link: string): void;
-    };
+export type UseRouter = RouteChildrenProps & ReactRouterContextValue;
 
-export function withRouter<T extends {}>(
-    BaseComponent
-): React.ComponentType<Omit<T, keyof WithRouterProps<{}>>> {
-    // eslint-disable-next-line react/display-name
-    return RWithRouter(props => (
-        <RouterConsumer>
-            <BaseComponent {...props} />
-        </RouterConsumer>
-    ));
+export function useRouter(): UseRouter {
+    return {
+        ...useContext(RouterContext),
+        ...useContext(__RouterContext)
+    };
 }
 
 import enhancer from "./routerEnhancer";


### PR DESCRIPTION
## Related Issue
Closes #1000 

## Your solution
Introduced our own `useRouter` hook within `@webiny/react-router` package. With this we no longer need `withRouter` HOC which was creating problems described in #1000. Moreover, we got rid of 1 extra dependency, `use-react-router`. 

## How Has This Been Tested?
Manually, by running the admin app and clicking through some views that were using `withRouter` HOC and `use-react-router` package.
