### PR TITLE
Feat: Headless CMS - add Save & Publish button

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
@@ -5,6 +5,12 @@ import { Grid, Cell } from "@webiny/ui/Grid";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { getPlugins } from "@webiny/plugins";
 import RenderFieldElement from "./ContentFormRender/RenderFieldElement";
+import styled from "@emotion/styled";
+
+const FormWrapper = styled("div")({
+    height: "65vh",
+    overflow: "auto",
+})
 
 export const ContentFormRender = ({
     getFields,
@@ -38,7 +44,7 @@ export const ContentFormRender = ({
             ref={ref}
         >
             {({ Bind }) => (
-                <div data-testid={"cms-content-form"}>
+                <FormWrapper data-testid={"cms-content-form"}>
                     {loading && <CircularProgress />}
                     <Grid>
                         {/* Let's render all form fields. */}
@@ -58,7 +64,7 @@ export const ContentFormRender = ({
                             </React.Fragment>
                         ))}
                     </Grid>
-                </div>
+                </FormWrapper>
             )}
         </Form>
     );

--- a/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelForm/ContentFormRender.tsx
@@ -8,7 +8,7 @@ import RenderFieldElement from "./ContentFormRender/RenderFieldElement";
 import styled from "@emotion/styled";
 
 const FormWrapper = styled("div")({
-    height: "65vh",
+    height: "70vh",
     overflow: "auto",
 })
 

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/contentFormOptionsMenu/ContentFormOptionsMenu.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/contentFormOptionsMenu/ContentFormOptionsMenu.tsx
@@ -16,7 +16,7 @@ import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDi
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/plugins/content-details/header/content-form-options-menu");
 
-import { ReactComponent as MoreVerticalIcon } from "@webiny/app-page-builder/admin/assets/more_vert.svg";
+import { ReactComponent as MoreVerticalIcon } from "@webiny/app-headless-cms/admin/icons/more_vert.svg";
 import { ReactComponent as EditIcon } from "@webiny/app-headless-cms/admin/icons/edit.svg";
 import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/delete.svg";
 

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/contentFormOptionsMenu/ContentFormOptionsMenu.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/contentFormOptionsMenu/ContentFormOptionsMenu.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useMemo } from "react";
+import { css } from "emotion";
+import get from "lodash/get";
+import { IconButton } from "@webiny/ui/Button";
+import I18NValue from "@webiny/app-i18n/components/I18NValue";
+import { Menu, MenuItem } from "@webiny/ui/Menu";
+import { ListItemGraphic } from "@webiny/ui/List";
+import { Icon } from "@webiny/ui/Icon";
+import { useRouter } from "@webiny/react-router";
+import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
+import { useDialog } from "@webiny/app-admin/hooks/useDialog";
+import { createDeleteMutation } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
+import { useMutation } from "@webiny/app-headless-cms/admin/hooks";
+import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
+
+import { i18n } from "@webiny/app/i18n";
+const t = i18n.ns("app-headless-cms/admin/plugins/content-details/header/content-form-options-menu");
+
+import { ReactComponent as MoreVerticalIcon } from "@webiny/app-page-builder/admin/assets/more_vert.svg";
+import { ReactComponent as EditIcon } from "@webiny/app-headless-cms/admin/icons/edit.svg";
+import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/delete.svg";
+
+const menuStyles = css({
+    width: 250,
+    right: -105,
+    left: "auto !important",
+    ".disabled": {
+        opacity: 0.5,
+        pointerEvents: "none"
+    }
+});
+
+const ContentFormOptionsMenu = ({ contentModel, content, dataList, getLoading, setLoading }) => {
+
+    const { showSnackbar } = useSnackbar();
+    const { history } = useRouter();
+    const { showDialog } = useDialog();
+
+    const DELETE_CONTENT = useMemo(() => {
+        return createDeleteMutation(contentModel);
+    }, [contentModel.modelId]);
+
+    const [deleteContentMutation] = useMutation(DELETE_CONTENT);
+
+    const title = I18NValue({ value: get(content, "meta.title") });
+
+    const { showConfirmation } = useConfirmationDialog({
+        title: t`Delete content entry`,
+        message: (
+            <p>
+                {t`You are about to delete this content entry and all of its revisions!
+                    Are you sure you want to permanently delete {title}?`({
+                    title: <strong>{title}</strong>
+                })}
+            </p>
+        )
+    });
+
+    const confirmDelete = useCallback(() => {
+        showConfirmation(async () => {
+            setLoading(true);
+            const { data: res } = await deleteContentMutation({
+                variables: { revision: content.meta.parent }
+            });
+
+            setLoading(false);
+
+            dataList.refresh();
+
+            const { error } = get(res, "content");
+            if (error) {
+                return showDialog(error.message, { title: t`Could not delete content` });
+            }
+
+            showSnackbar(t`{title} was deleted successfully!`({ title: <strong>{title}</strong> }));
+
+            const query = new URLSearchParams(location.search);
+            query.delete("id");
+            history.push({ search: query.toString() });
+        });
+    }, null);
+
+    return (
+        <Menu className={menuStyles} handle={<IconButton icon={<MoreVerticalIcon />} />}>
+            <MenuItem onClick={confirmDelete} disabled={!content.id || getLoading()}>
+                <ListItemGraphic>
+                    <Icon icon={<DeleteIcon />} />
+                </ListItemGraphic>
+                Delete
+            </MenuItem>
+            <MenuItem onClick={() => history.push(`/cms/content-models/${contentModel.id}`)}>
+                <ListItemGraphic>
+                    <Icon icon={<EditIcon />} />{" "}
+                </ListItemGraphic>
+                Edit model
+            </MenuItem>
+        </Menu>
+    );
+};
+
+export default ContentFormOptionsMenu;

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/index.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/index.tsx
@@ -3,10 +3,9 @@ import { CmsContentDetailsPlugin } from "@webiny/app-headless-cms/types";
 import Header from "./Header";
 import RevisionSelector from "./revisionSelector/RevisionSelector";
 import LocaleSelector from "./localeSelector/LocaleSelector";
-import PublishRevision from "./publishRevision/PublishRevision";
-import DeleteContent from "./deleteContent/DeleteContent";
 import SaveContentButton from "./saveContent/SaveContent";
 import SaveAndPublishButton from "./saveAndPublishContent/SaveAndPublishContent";
+import ContentFormOptionsMenu from "./contentFormOptionsMenu/ContentFormOptionsMenu";
 
 const plugins: CmsContentDetailsPlugin[] = [
     {
@@ -31,20 +30,6 @@ const plugins: CmsContentDetailsPlugin[] = [
         }
     },
     {
-        name: "cms-content-details-header-publish",
-        type: "cms-content-details-header-left",
-        render(props) {
-            return <PublishRevision {...props} />;
-        }
-    },
-    {
-        name: "cms-content-details-header-delete",
-        type: "cms-content-details-header-left",
-        render(props) {
-            return <DeleteContent {...props} />;
-        }
-    },
-    {
         name: "cms-content-details-header-save",
         type: "cms-content-details-header-right",
         render: props => {
@@ -56,6 +41,13 @@ const plugins: CmsContentDetailsPlugin[] = [
         type: "cms-content-details-header-right",
         render: props => {
             return <SaveAndPublishButton {...props} />;
+        }
+    },
+    {
+        name: "cms-content-details-header-option-menu",
+        type: "cms-content-details-header-right",
+        render: props => {
+            return <ContentFormOptionsMenu {...props} />;
         }
     }
 ];

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/index.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/index.tsx
@@ -5,6 +5,8 @@ import RevisionSelector from "./revisionSelector/RevisionSelector";
 import LocaleSelector from "./localeSelector/LocaleSelector";
 import PublishRevision from "./publishRevision/PublishRevision";
 import DeleteContent from "./deleteContent/DeleteContent";
+import SaveContentButton from "./saveContent/SaveContent";
+import SaveAndPublishButton from "./saveAndPublishContent/SaveAndPublishContent";
 
 const plugins: CmsContentDetailsPlugin[] = [
     {
@@ -15,13 +17,6 @@ const plugins: CmsContentDetailsPlugin[] = [
         }
     },
     {
-        name: "cms-content-details-revision-selector",
-        type: "cms-content-details-header-right",
-        render(props) {
-            return <RevisionSelector {...props} />;
-        }
-    },
-    {
         name: "cms-content-details-locale-selector",
         type: "cms-content-details-header-left",
         render(props) {
@@ -29,17 +24,38 @@ const plugins: CmsContentDetailsPlugin[] = [
         }
     },
     {
+        name: "cms-content-details-revision-selector",
+        type: "cms-content-details-header-left",
+        render(props) {
+            return <RevisionSelector {...props} />;
+        }
+    },
+    {
         name: "cms-content-details-header-publish",
-        type: "cms-content-details-header-right",
+        type: "cms-content-details-header-left",
         render(props) {
             return <PublishRevision {...props} />;
         }
     },
     {
         name: "cms-content-details-header-delete",
-        type: "cms-content-details-header-right",
+        type: "cms-content-details-header-left",
         render(props) {
             return <DeleteContent {...props} />;
+        }
+    },
+    {
+        name: "cms-content-details-header-save",
+        type: "cms-content-details-header-right",
+        render: props => {
+            return <SaveContentButton {...props} />;
+        }
+    },
+    {
+        name: "cms-content-details-header-save-and-publish",
+        type: "cms-content-details-header-right",
+        render: props => {
+            return <SaveAndPublishButton {...props} />;
         }
     }
 ];

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveAndPublishContent/SaveAndPublishContent.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveAndPublishContent/SaveAndPublishContent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { i18n } from "@webiny/app/i18n";
-import { ButtonDefault } from "@webiny/ui/Button";
+import { ButtonPrimary } from "@webiny/ui/Button";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { createPublishMutation } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
 import { useMutation } from "@webiny/app-headless-cms/admin/hooks";
@@ -54,7 +54,7 @@ const SaveAndPublishButton = ({
         )
     });
     return (
-        <ButtonDefault
+        <ButtonPrimary
             className={buttonStyles}
             onClick={() => {
                 state.contentForm.submit();
@@ -63,7 +63,7 @@ const SaveAndPublishButton = ({
             disabled={!content.id || getLoading()}
         >
             {t`Save & Publish`}
-        </ButtonDefault>
+        </ButtonPrimary>
     );
 };
 

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveAndPublishContent/SaveAndPublishContent.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveAndPublishContent/SaveAndPublishContent.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useMemo } from "react";
+import { i18n } from "@webiny/app/i18n";
+import { ButtonDefault } from "@webiny/ui/Button";
+import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
+import { createPublishMutation } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
+import { useMutation } from "@webiny/app-headless-cms/admin/hooks";
+import { get } from "lodash";
+import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
+import { css } from "emotion";
+const t = i18n.ns("app-headless-cms/admin/plugins/content-details/header/publish-revision");
+
+const buttonStyles = css({
+    marginLeft: 16
+});
+
+const SaveAndPublishButton = ({
+    content,
+    contentModel,
+    getLoading,
+    setLoading,
+    revisionsList,
+    state
+}) => {
+    const { showSnackbar } = useSnackbar();
+
+    const { PUBLISH_CONTENT } = useMemo(() => {
+        return {
+            PUBLISH_CONTENT: createPublishMutation(contentModel)
+        };
+    }, [contentModel.modelId]);
+
+    const [publishContentMutation] = useMutation(PUBLISH_CONTENT);
+
+    const onPublish = useCallback(async () => {
+        setLoading(true);
+        const response = await publishContentMutation({
+            variables: { revision: content.id }
+        });
+
+        const contentData = get(response, "data.content");
+        setLoading(false);
+        if (contentData.error) {
+            return showSnackbar(contentData.error.message);
+        }
+
+        showSnackbar(t`Content published successfully.`);
+        revisionsList.refetch();
+    }, [content.id]);
+
+    const { showConfirmation } = useConfirmationDialog({
+        title: t`Publish content`,
+        message: (
+            <p>{t`You are about to publish a new revision. Are you sure you want to continue?`}</p>
+        )
+    });
+    return (
+        <ButtonDefault
+            className={buttonStyles}
+            onClick={() => {
+                state.contentForm.submit();
+                showConfirmation(onPublish);
+            }}
+            disabled={!content.id || getLoading()}
+        >
+            {t`Save & Publish`}
+        </ButtonDefault>
+    );
+};
+
+export default SaveAndPublishButton;

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveContent/SaveContent.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveContent/SaveContent.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { i18n } from "@webiny/app/i18n";
-import { ButtonPrimary } from "@webiny/ui/Button";
+import { ButtonSecondary } from "@webiny/ui/Button";
 const t = i18n.ns("app-headless-cms/admin/plugins/content-details/header/publish-revision");
 
 const SaveContentButton = ({ state }) => {
-
-    return <ButtonPrimary onClick={() => state.contentForm.submit()}>{t`Save`}</ButtonPrimary>;
+    return <ButtonSecondary onClick={() => state.contentForm.submit()}>{t`Save`}</ButtonSecondary>;
 };
 
 export default SaveContentButton;

--- a/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveContent/SaveContent.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/contentDetails/header/saveContent/SaveContent.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { i18n } from "@webiny/app/i18n";
+import { ButtonPrimary } from "@webiny/ui/Button";
+const t = i18n.ns("app-headless-cms/admin/plugins/content-details/header/publish-revision");
+
+const SaveContentButton = ({ state }) => {
+
+    return <ButtonPrimary onClick={() => state.contentForm.submit()}>{t`Save`}</ButtonPrimary>;
+};
+
+export default SaveContentButton;

--- a/packages/app-headless-cms/src/admin/plugins/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/index.ts
@@ -8,7 +8,6 @@ import install from "./install";
 import revisionContent from "./contentDetails/revisionContent";
 import header from "./contentDetails/header";
 import contentForm from "./contentDetails/contentForm";
-import footer from "./contentDetails/footer";
 import contentRevisions from "./contentDetails/contentRevisions";
 import contentModelEditorPlugins from "./../editor/plugins";
 import appTemplateRenderer from "./appTemplatePlugins";
@@ -23,7 +22,6 @@ export default () => [
     header,
     revisionContent,
     contentForm,
-    footer,
     contentRevisions,
 
     // Editor


### PR DESCRIPTION
## Related Issue

Closes #966 

## Your solution
Changes:

1. Now, we will no longer have the footer. The save button is now moved to the form header.
2. There is also a Save & Publish button right beside Save
3. The actions like Revision menu and delete content has been moved to the left side.
4. The Publish action has been removed because now we have Save & Publish
5. Form header is fixed and only the form's body is scrollable (if the content extend beyond the fixed height)
6. Move `delete` action in 3 dot menu

## How Has This Been Tested?
Manually, using the Admin app

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/84668141-db494000-af40-11ea-91af-40766d6cc51e.png)

