### PR TITLE
fix(snackbar): fix close button in snackbar at account page

### DIFF
--- a/packages/app-security/src/admin/views/Account.tsx
+++ b/packages/app-security/src/admin/views/Account.tsx
@@ -15,6 +15,7 @@ import AvatarImage from "./Components/AvatarImage";
 import { validation } from "@webiny/validation";
 import { useSecurity } from "@webiny/app-security/hooks/useSecurity";
 import AccuntTokens from "./AccountTokens";
+import { SnackbarAction } from "@webiny/ui/Snackbar";
 
 import {
     SimpleForm,
@@ -102,7 +103,7 @@ const UserAccountForm = () => {
         setState({ loading: false });
         if (error) {
             return showSnackbar(error.message, {
-                action: "Close"
+                action: <SnackbarAction label="Close" onClick={() => showSnackbar(null)} />
             });
         }
 

--- a/packages/ui/src/Snackbar/index.ts
+++ b/packages/ui/src/Snackbar/index.ts
@@ -1,1 +1,1 @@
-export { Snackbar } from "./Snackbar";
+export { Snackbar, SnackbarAction } from "./Snackbar";


### PR DESCRIPTION
Sets the message to null on clicking close thus closing snackbar

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #766 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
It seems that the functionality for close button wasn't implemented. The solution was to import `SnackbarAction` component and attach `onClick` handler to it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and verified that snackbar closes on clicking `close`

## Screenshots (if relevant):
As per the current implementation of Snackbar component - `open` prop is handled with `message` itself.

```JSX
const SnackbarMain = () => {
    const ui = useUi();
    const message = get(ui, "snackbar.message");
    const options = get(ui, "snackbar.options", {});

    const hideSnackbar = useCallback(() => {
        ui.setState(ui => ({ ...ui, snackbar: null }));
    }, [ui]);

    return <Snackbar open={!!message} onClose={hideSnackbar} message={message} {...options} />;
};
```

In which case to close the snackbar, we must set message to `null` (or falsy). This causes the message to disappear while snackbar is still in closing transition. It is better visible when the message is very large. See attached GIF below (slowed down to 20% speed for emphasis).

![ezgif-6-d5a5dacbca2a](https://user-images.githubusercontent.com/14029371/84683289-a1823480-af54-11ea-9d81-161216cba897.gif)

Most users wouldn't notice on normal speed and it could be taken care of in the future.