### PR TITLE
Supporting jwt auth in /read and /preview apis + [New] Headless CMS Security scopes

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/index.ts
@@ -55,6 +55,17 @@ export default (
                 return;
             }
 
+            if (
+                context.user &&
+                context.user.id &&
+                context.user.access &&
+                context.user.access.fullAccess
+            ) {
+                // A valid JWT was provided and context.user was populated with our user's data, including their user ID.
+                // If they have fullAccess, then they're admins which are allowed to access the API...
+                return;
+            }
+
             if (context.cms.READ || context.cms.PREVIEW) {
                 const accessToken =
                     context.event.headers["authorization"] ||
@@ -76,10 +87,10 @@ export default (
                         `You are not authorized to access "${currentEnvironment.name}" environment!`
                     );
                 }
-            }
-
-            if (context.cms.MANAGE && !context.user) {
-                throw new Error("Not authorized!");
+            } else if (context.cms.MANAGE) {
+                throw new Error(
+                    "Not authorized! Make sure you provided a valid JWT in the 'authorization' header."
+                );
             }
         }
     },

--- a/packages/app-headless-cms/src/admin/plugins/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/index.ts
@@ -12,6 +12,7 @@ import contentRevisions from "./contentDetails/contentRevisions";
 import contentModelEditorPlugins from "./../editor/plugins";
 import appTemplateRenderer from "./appTemplatePlugins";
 import welcomeScreenWidget from "./welcomeScreenWidget";
+import scopesList from "./scopesList";
 
 export default () => [
     install,
@@ -31,5 +32,6 @@ export default () => [
     contentModelEditorPlugins,
     appTemplateRenderer,
 
-    welcomeScreenWidget
+    welcomeScreenWidget,
+    scopesList
 ];

--- a/packages/app-headless-cms/src/admin/plugins/scopesList.ts
+++ b/packages/app-headless-cms/src/admin/plugins/scopesList.ts
@@ -1,0 +1,30 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-security/admin/scopesList");
+
+const generateCmsScopes = async () => {
+    try {
+        // TODO: add actual scopes here. There are two options:
+        //  -query the db, get <environments>, generate the scopes
+        //  -receive <scopes> as a parameter
+        return [
+            {
+                scope: "cms:read:production:potatoes",
+                title: t`Cms "potatoes" /read api permissions`,
+                description: t`Allows you to use the /read api against model "potatoes"`
+            }
+        ];
+    } catch (e) {
+        console.log("Failed to fetch cms scopes:");
+        console.log(e);
+    }
+};
+
+export default [
+    {
+        name: "security-scopes-list-access-tokens",
+        type: "security-scopes-list",
+        scopes: generateCmsScopes
+    } as SecurityScopesListPlugin
+];

--- a/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
+++ b/packages/app-headless-cms/src/admin/views/AccessTokens/AccessTokensForm.tsx
@@ -8,6 +8,7 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import { useCrud } from "@webiny/app-admin/hooks/useCrud";
 import { i18n } from "@webiny/app/i18n";
 import { CheckboxGroup, Checkbox } from "@webiny/ui/Checkbox";
+import { ScopesMultiAutoComplete } from "@webiny/app-security/admin/components";
 
 import { useCms } from "@webiny/app-headless-cms/admin/hooks";
 
@@ -28,6 +29,15 @@ function EnvironmentAliasesForm() {
     const { showSnackbar } = useSnackbar();
     const { form: crudForm } = useCrud();
     const environments = useCms().environments.environments;
+
+    const filterReadScope = ({ scope }) => {
+        if (!scope) {
+            return;
+        }
+
+        const scopeSegments = scope.split(":");
+        return scopeSegments[0] === "cms" && scopeSegments[1] === "read";
+    };
 
     return (
         <Form {...crudForm}>
@@ -56,6 +66,11 @@ function EnvironmentAliasesForm() {
                                             label={t`Description`}
                                         />
                                     )}
+                                </Bind>
+                            </Cell>
+                            <Cell span={12}>
+                                <Bind name="scopes">
+                                    <ScopesMultiAutoComplete filter={filterReadScope} />
                                 </Bind>
                             </Cell>
                             <Cell span={12}>

--- a/packages/app-security/src/admin/components/ScopesMultiAutoComplete.tsx
+++ b/packages/app-security/src/admin/components/ScopesMultiAutoComplete.tsx
@@ -22,7 +22,7 @@ const ScopesMultiAutoComplete = props => {
     useEffect(() => {
         const getScopesList = async () => {
             const plugins = getPlugins<SecurityScopesListPlugin>("security-scopes-list");
-            const scopes = [];
+            let scopes = [];
             for (let i = 0; i < plugins.length; i++) {
                 const plugin = plugins[i];
                 if (!plugin.scopes) {
@@ -39,6 +39,11 @@ const ScopesMultiAutoComplete = props => {
                 }
 
                 scopes.push(...pluginScopes);
+            }
+
+            if (props.filter) {
+                // An optional "filter" callback can be provided
+                scopes = scopes.filter(props.filter);
             }
 
             setScopesList(scopes);

--- a/packages/ui/src/List/CollapsibleList/index.css
+++ b/packages/ui/src/List/CollapsibleList/index.css
@@ -1,33 +1,31 @@
 .rmwc-collapsible-list {
-    width: 100%;
+  width: 100%;
 }
 
 .rmwc-collapsible-list__children {
-    overflow: hidden;
-    max-height: 0;
-    transition: max-height 0.3s, opacity 0.3s;
-    opacity: 0;
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s, opacity 0.3s;
+  opacity: 0;
 }
 
 .rmwc-collapsible-list--open > .rmwc-collapsible-list__children {
-    opacity: 1;
+  opacity: 1;
 }
 
 .rmwc-collapsible-list__handle .mdc-list-item__meta {
-    transition: transform 0.3s;
-    user-select: none;
+  transition: transform 0.3s;
+  user-select: none;
 }
 
-.rmwc-collapsible-list--open
-> .rmwc-collapsible-list__handle
-.mdc-list-item__meta {
-    transform: rotate(90deg);
+.rmwc-collapsible-list--open > .rmwc-collapsible-list__handle .mdc-list-item__meta {
+  transform: rotate(90deg);
 }
 
 .rmwc-collapsible-list__children .mdc-list-item {
-    padding-left: 2rem;
+  padding-left: 2rem;
 }
 
 .rmwc-collapsible-list__children-inner {
-    overflow: auto;
+  overflow: auto;
 }

--- a/sample-project/api/resources.js
+++ b/sample-project/api/resources.js
@@ -18,8 +18,7 @@ const apolloGatewayServices = {
     LAMBDA_SERVICE_FILES: "${filesGraphQL.name}",
     LAMBDA_SERVICE_PAGE_BUILDER: "${pageBuilderGraphQL.name}",
     LAMBDA_SERVICE_FORM_BUILDER: "${formBuilderGraphQL.name}",
-    LAMBDA_SERVICE_HEADLESS_CMS: "${cmsGraphQL.name}",
-    LAMBDA_SERVICE_API_TEST_667: "${apiTest667.name}"
+    LAMBDA_SERVICE_HEADLESS_CMS: "${cmsGraphQL.name}"
 };
 
 module.exports = () => ({
@@ -518,24 +517,6 @@ module.exports = () => ({
                         }
                     }
                 ]
-            }
-        },
-        apiTest667: {
-            watch: ["./test667/build"],
-            build: {
-                root: "./test667",
-                script: "yarn build"
-            },
-            deploy: {
-                component: "@webiny/serverless-function",
-                inputs: {
-                    region: process.env.AWS_REGION,
-                    description: "GraphQL API",
-                    code: "./test667/build",
-                    handler: "handler.handler",
-                    memory: 512,
-                    env: apolloServiceEnv
-                }
             }
         }
     }

--- a/sample-project/api/resources.js
+++ b/sample-project/api/resources.js
@@ -18,7 +18,8 @@ const apolloGatewayServices = {
     LAMBDA_SERVICE_FILES: "${filesGraphQL.name}",
     LAMBDA_SERVICE_PAGE_BUILDER: "${pageBuilderGraphQL.name}",
     LAMBDA_SERVICE_FORM_BUILDER: "${formBuilderGraphQL.name}",
-    LAMBDA_SERVICE_HEADLESS_CMS: "${cmsGraphQL.name}"
+    LAMBDA_SERVICE_HEADLESS_CMS: "${cmsGraphQL.name}",
+    LAMBDA_SERVICE_API_TEST_667: "${apiTest667.name}"
 };
 
 module.exports = () => ({
@@ -276,10 +277,7 @@ module.exports = () => ({
                     code: "./files/graphql/build",
                     handler: "handler.handler",
                     memory: 512,
-                    env: {
-                        ...apolloServiceEnv,
-                        S3_BUCKET: process.env.S3_BUCKET
-                    }
+                    env: { ...apolloServiceEnv, S3_BUCKET: process.env.S3_BUCKET }
                 }
             }
         },
@@ -379,10 +377,7 @@ module.exports = () => ({
                     handler: "handler.handler",
                     memory: 512,
                     timeout: 30,
-                    env: {
-                        ...apolloServiceEnv,
-                        I18N_LOCALES_FUNCTION: "${i18nLocales.name}"
-                    }
+                    env: { ...apolloServiceEnv, I18N_LOCALES_FUNCTION: "${i18nLocales.name}" }
                 }
             }
         },
@@ -523,6 +518,24 @@ module.exports = () => ({
                         }
                     }
                 ]
+            }
+        },
+        apiTest667: {
+            watch: ["./test667/build"],
+            build: {
+                root: "./test667",
+                script: "yarn build"
+            },
+            deploy: {
+                component: "@webiny/serverless-function",
+                inputs: {
+                    region: process.env.AWS_REGION,
+                    description: "GraphQL API",
+                    code: "./test667/build",
+                    handler: "handler.handler",
+                    memory: 512,
+                    env: apolloServiceEnv
+                }
             }
         }
     }


### PR DESCRIPTION
## Related Issue
resolves #1034
addresses part of #994

## Your solution
I looked into `context.user` which is populated automatically when a valid JWT is passed in `context.event.headers.[Aa]uthorization`. Admins will also have `access.fullAccess` field `true` - they will be allowed to access the API.

I used this information to authorize users using JWTs on all 3 APIs (manage, read, preview).

## How Has This Been Tested?
Locally with my admin account's JWT and another created account's (non-admin) JWT

## Screenshots:
A user couldn't be fetched in `context.user` from the authorization header:
![image](https://user-images.githubusercontent.com/16700631/84852898-a8996780-b066-11ea-9c72-3d8657fe6624.png)

A user was filled in `context.user` along with its `id` and `access` fields:
![image](https://user-images.githubusercontent.com/16700631/84852983-da123300-b066-11ea-81a5-2b96473ce7bd.png)
