### PR TITLE
fix(snackbar): fix close button in snackbar at account page

### DIFF
--- a/packages/app-security/src/admin/views/Account.tsx
+++ b/packages/app-security/src/admin/views/Account.tsx
@@ -15,6 +15,7 @@ import AvatarImage from "./Components/AvatarImage";
 import { validation } from "@webiny/validation";
 import { useSecurity } from "@webiny/app-security/hooks/useSecurity";
 import AccuntTokens from "./AccountTokens";
+import { SnackbarAction } from "@webiny/ui/Snackbar";
 
 import {
     SimpleForm,
@@ -102,7 +103,7 @@ const UserAccountForm = () => {
         setState({ loading: false });
         if (error) {
             return showSnackbar(error.message, {
-                action: "Close"
+                action: <SnackbarAction label="Close" onClick={() => showSnackbar(null)} />
             });
         }
 

--- a/packages/ui/src/Snackbar/index.ts
+++ b/packages/ui/src/Snackbar/index.ts
@@ -1,1 +1,1 @@
-export { Snackbar } from "./Snackbar";
+export { Snackbar, SnackbarAction } from "./Snackbar";


### PR DESCRIPTION
Sets the message to null on clicking close thus closing snackbar

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #766 

## Your solution
Please refer to #1010 
