### PR TITLE
Fix: Headless CMS - cannot focus Rich Text Editor

### DIFF
--- a/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
@@ -25,8 +25,8 @@ const EditorContent = styled("div")({
     resize: "vertical",
     padding: "0px 8px",
     /*
-    * Make content editable slate editor height tall enough,
-    * so that when user click inside editor content wrapper it get `focus`
+    * Increases the height of Slate editor's "content editable" area,
+    * so that when a user clicks on it, it's always focused properly.
     * https://github.com/webiny/webiny-js/issues/1013
     * */
     "& > div": {

--- a/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/app-i18n/src/admin/components/RichTextEditor/RichTextEditor.tsx
@@ -19,11 +19,19 @@ const EditorWrapper = styled("div")({
 });
 
 const EditorContent = styled("div")({
-    height: "45vh",
+    height: 250,
     minHeight: 200,
     overflow: "auto",
     resize: "vertical",
     padding: "0px 8px",
+    /*
+    * Make content editable slate editor height tall enough,
+    * so that when user click inside editor content wrapper it get `focus`
+    * https://github.com/webiny/webiny-js/issues/1013
+    * */
+    "& > div": {
+        height: "90%",
+    },
 
     "> div > div": {
         boxSizing: "border-box",


### PR DESCRIPTION
## Related Issue
Closes #1013 #1014 

## Your solution

- Fix cannot focus on Rich Text Editor issue

- Use a fixed height instead of viewport responsive


## How Has This Been Tested?
Manually, using the Admin app

## Screenshots:
https://www.loom.com/share/57d762de2dd7452a9379977ba876bb50