### PR TITLE
Fix: Headless CMS - edit field dialog - dropdown not visible

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fields/ref.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/ref.tsx
@@ -3,14 +3,15 @@ import { ReactComponent as RefIcon } from "./icons/round-link-24px.svg";
 import { useQuery } from "@webiny/app-headless-cms/admin/hooks";
 import { LIST_CONTENT_MODELS } from "../../viewsGraphql";
 import { validation } from "@webiny/validation";
-import { Grid, Cell } from "@webiny/ui/Grid";
-import { AutoComplete } from "@webiny/ui/AutoComplete";
+import { Cell, Grid } from "@webiny/ui/Grid";
+import { AutoComplete, Placement } from "@webiny/ui/AutoComplete";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { CmsEditorFieldTypePlugin } from "@webiny/app-headless-cms/types";
 import get from "lodash/get";
 
 import { i18n } from "@webiny/app/i18n";
+
 const t = i18n.ns("app-headless-cms/admin/fields");
 
 const plugin: CmsEditorFieldTypePlugin = {
@@ -74,6 +75,7 @@ const plugin: CmsEditorFieldTypePlugin = {
                                         label={t`Content Model`}
                                         description={t`Cannot be changed later`}
                                         options={options}
+                                        placement={Placement.top}
                                     />
                                 );
                             }}

--- a/packages/ui/src/AutoComplete/AutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/AutoComplete.tsx
@@ -10,8 +10,22 @@ import { AutoCompleteBaseProps } from "./types";
 import { getOptionValue, getOptionText } from "./utils";
 import { isEqual } from "lodash";
 import MaterialSpinner from "react-spinner-material";
+import { css } from "emotion";
+
+const menuStyles = css({
+    top: "unset !important",
+    bottom: 75
+});
+
+export enum Placement {
+    top = "top",
+    bottom = "bottom"
+}
 
 export type AutoCompleteProps = AutoCompleteBaseProps & {
+    /* Placement position of dropdown menu, can be either `top` or `bottom` */
+    placement?: Placement;
+
     /* A callback that is executed each time a value is changed. */
     onChange?: (value: any, selection: any) => void;
 
@@ -36,6 +50,7 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
         valueProp: "id",
         textProp: "name",
         options: [],
+        placement: Placement.bottom,
         renderItem(item: any) {
             return <Typography use={"body2"}>{getOptionText(item, this.props)}</Typography>;
         }
@@ -82,7 +97,8 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
         highlightedIndex,
         selectedItem,
         getMenuProps,
-        getItemProps
+        getItemProps,
+        placement
     }: any) {
         if (!isOpen) {
             return null;
@@ -114,7 +130,7 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
         }
 
         return (
-            <Elevation z={1}>
+            <Elevation z={1} className={classNames({ [menuStyles]: placement === Placement.top })}>
                 <ul {...getMenuProps()}>
                     {filtered.map((item, index) => {
                         const itemValue = getOptionValue(item, this.props);
@@ -162,6 +178,7 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
             textProp, // eslint-disable-line
             onInput,
             validation = { isValid: null },
+            placement,
             ...otherInputProps
         } = this.props;
 
@@ -232,7 +249,7 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
                                     }
                                 })}
                             />
-                            {this.renderOptions({ ...rest, options })}
+                            {this.renderOptions({ ...rest, options, placement })}
                         </div>
                     )}
                 </Downshift>

--- a/packages/ui/src/AutoComplete/AutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/AutoComplete.tsx
@@ -23,7 +23,7 @@ export enum Placement {
 }
 
 export type AutoCompleteProps = AutoCompleteBaseProps & {
-    /* Placement position of dropdown menu, can be either `top` or `bottom` */
+    /* Placement position of dropdown menu, can be either `top` or `bottom`. */
     placement?: Placement;
 
     /* A callback that is executed each time a value is changed. */


### PR DESCRIPTION
## Related Issue
Closes #1011 

## Your solution
Add a placement prop on `AutoComplete` with which we can switch the placement position of the dropdown menu

## How Has This Been Tested?
Manually, using the Admin app

## Screenshots:
https://www.loom.com/share/89dbac07167f4bcc9fada2e93a519079
