### PR TITLE
fix: remove unnecessary "$" sign in the label

### DIFF
--- a/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
@@ -37,7 +37,7 @@ const FullName = ({ submission }) => {
 };
 
 const FormVersion = ({ submission }) => {
-    return <span>Form revision #${submission.form.revision.version}</span>;
+    return <span>Form revision #{submission.form.revision.version}</span>;
 };
 
 const renderExportFormSubmissionsTooltip = dataList => {


### PR DESCRIPTION
## Related Issue
Closes #1027

## Your solution
Remove `$` sign from the label

## How Has This Been Tested?
Manually

## Screenshots (if relevant):
