### PR TITLE
fix(cwp): fix initialize git step so on error it runs task.skip

### DIFF
--- a/packages/create-webiny-project/init.js
+++ b/packages/create-webiny-project/init.js
@@ -83,7 +83,7 @@ module.exports = async function({ root, appName, templateName, tag, log }) {
         },
         {
             title: `Initialize git`,
-            task: task => {
+            task: (ctx, task) => {
                 try {
                     execa.sync("git", ["--version"]);
                     execa.sync("git", ["init"], { cwd: root });


### PR DESCRIPTION
## Related Issue
Closes #1022 

## Your solution
Passed a context variable as well as a task variable

## How Has This Been Tested?
Ran a new project that automatically threw an error to ensure that task.skip code piece was run:
I got this output (see below)

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/9532882/85057081-4035ad80-b16e-11ea-9069-2f09b6aa3a07.png)
