### PR TITLE
Corrected plugin type

### DIFF
--- a/packages/handler-ssr/src/cdnSsrCacheInvalidation.ts
+++ b/packages/handler-ssr/src/cdnSsrCacheInvalidation.ts
@@ -2,7 +2,7 @@ import CloudFront from "aws-sdk/clients/cloudfront";
 import { withHooks } from "@webiny/commodo/hooks";
 
 export default () => ({
-    type: "context",
+    type: "handler-context",
     name: "context-cdn-ssr-cache-invalidation",
     apply(options) {
         if (!options.context.models || !options.context.models.SsrCache) {


### PR DESCRIPTION
## Issue
I corrected the plugin type in `packages/handler-ssr/src/cdnSsrCacheInvalidation.ts:5` (changed `context` to `handler-context`). This plugin is responsible for issuing CDN invalidation requests.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A