### PR TITLE
Referenced models cannot be deleted anymore

### DIFF
--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
@@ -9,16 +9,6 @@ export default /* GraphQL */ `
         value(locale: String): Category
         values: [CmsRefProductCategoryLocalized]!
     }
-
-    type CmsRefProductReviewsListLocalized {
-        value: [Review]
-        locale: ID!
-    }
-
-    type CmsRefProductReviewsList {
-        value(locale: String): [Review]
-        values: [CmsRefProductReviewsListLocalized]!
-    }
     type Product {
         id: ID
         createdBy: SecurityUser
@@ -29,7 +19,6 @@ export default /* GraphQL */ `
         meta: ProductMeta
         title: CmsText
         category: CmsRefProductCategory
-        reviews: CmsRefProductReviewsList
         price: CmsNumber
         inStock: CmsBoolean
         itemsInStock: CmsNumber
@@ -53,7 +42,6 @@ export default /* GraphQL */ `
     input ProductInput {
         title: CmsTextInput
         category: CmsRefInput
-        reviews: CmsRefListInput
         price: CmsNumberInput
         inStock: CmsBooleanInput
         itemsInStock: CmsNumberInput

--- a/packages/api-headless-cms/__tests__/mocks/contentModels.js
+++ b/packages/api-headless-cms/__tests__/mocks/contentModels.js
@@ -60,59 +60,6 @@ export default [
         ]
     },
     {
-        name: "Review",
-        description: "Product review",
-        modelId: "review",
-        group: contentModelGroup.id,
-        indexes: [{ fields: ["id"] }],
-        getUniqueIndexFields() {
-            return ["id"];
-        },
-        fields: [
-            {
-                _id: shortId.generate(),
-                label: {
-                    values: [{ locale: locales.en.id, value: "Text" }]
-                },
-                type: "text",
-
-                fieldId: "text",
-                validation: [
-                    {
-                        name: "required",
-                        message: {
-                            values: [{ locale: locales.en.id, value: "This field is required" }]
-                        }
-                    }
-                ]
-            },
-            {
-                _id: shortId.generate(),
-                label: {
-                    values: [{ locale: locales.en.id, value: "Product" }]
-                },
-                type: "ref",
-
-                fieldId: "product",
-                validation: [],
-                settings: {
-                    type: "one",
-                    modelId: "product"
-                }
-            },
-            {
-                _id: shortId.generate(),
-                label: {
-                    values: [{ locale: locales.en.id, value: "Rating" }]
-                },
-                type: "number",
-
-                fieldId: "rating",
-                validation: []
-            }
-        ]
-    },
-    {
         name: "Product",
         modelId: "product",
         description: "Products being sold in our webshop",
@@ -162,20 +109,7 @@ export default [
                     modelId: "category"
                 }
             },
-            {
-                _id: shortId.generate(),
-                label: {
-                    values: [{ locale: locales.en.id, value: "Reviews" }]
-                },
-                fieldId: "reviews",
-                multipleValues: true,
-                type: "ref",
-                validation: [],
-                settings: {
-                    type: "many",
-                    modelId: "review"
-                }
-            },
+
             {
                 _id: shortId.generate(),
                 label: {
@@ -234,5 +168,55 @@ export default [
                 ]
             }
         ]
-    }
+    },
+    {
+        name: "Review",
+        description: "Product review",
+        modelId: "review",
+        group: contentModelGroup.id,
+        indexes: [{ fields: ["id"] }],
+        getUniqueIndexFields() {
+            return ["id"];
+        },
+        fields: [
+            {
+                _id: shortId.generate(),
+                label: {
+                    values: [{ locale: locales.en.id, value: "Text" }]
+                },
+                type: "text",
+                fieldId: "text",
+                validation: [
+                    {
+                        name: "required",
+                        message: {
+                            values: [{ locale: locales.en.id, value: "This field is required" }]
+                        }
+                    }
+                ]
+            },
+            {
+                _id: shortId.generate(),
+                label: {
+                    values: [{ locale: locales.en.id, value: "Product" }]
+                },
+                type: "ref",
+                fieldId: "product",
+                validation: [],
+                settings: {
+                    type: "one",
+                    modelId: "product"
+                }
+            },
+            {
+                _id: shortId.generate(),
+                label: {
+                    values: [{ locale: locales.en.id, value: "Rating" }]
+                },
+                type: "number",
+                fieldId: "rating",
+                validation: []
+            }
+        ]
+    },
 ];

--- a/packages/api-headless-cms/__tests__/mocks/fields/refReferencedIn.js
+++ b/packages/api-headless-cms/__tests__/mocks/fields/refReferencedIn.js
@@ -1,0 +1,162 @@
+import { locales } from "@webiny/api-i18n/testing";
+
+const mocks = {
+    authorContentModel: ({ contentModelGroupId }) => ({
+        name: "Author",
+        group: contentModelGroupId,
+        fields: [
+            {
+                _id: "vqk-UApa0",
+                fieldId: "title",
+                type: "text",
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Title"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Titel"
+                        }
+                    ]
+                }
+            },
+            {
+                _id: "id-favorite-book",
+                fieldId: "favoriteBook",
+                type: "ref",
+                settings: {
+                    modelId: "book"
+                },
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Favorite Book"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Lieblingsbuch"
+                        }
+                    ]
+                }
+            },
+            {
+                _id: "id-other-books",
+                fieldId: "otherBooks",
+                type: "ref",
+                multipleValues: true,
+                settings: {
+                    modelId: "book"
+                },
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Other Books"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Andere Bücher"
+                        }
+                    ]
+                }
+            }
+        ]
+    }),
+    bookContentModel: ({ contentModelGroupId }) => ({
+        name: "Book",
+        group: contentModelGroupId,
+        fields: [
+            {
+                _id: "vqk-UApa0",
+                fieldId: "title",
+                type: "text",
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Title"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Titel"
+                        }
+                    ]
+                }
+            }
+        ]
+    }),
+    removeFavoriteBookField: ({ contentModelId }) => ({
+        id: contentModelId,
+        data: {
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "id-other-books",
+                    fieldId: "otherBooks",
+                    type: "ref",
+                    multipleValues: true,
+                    settings: {
+                        modelId: "book"
+                    },
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Other Books"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Andere Bücher"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    removeOtherBooksField: ({ contentModelId }) => ({
+        id: contentModelId,
+        data: {
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};
+
+export default mocks;

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
@@ -9,7 +9,6 @@ export default /* GraphQL */ `
         savedOn: DateTime
         title(locale: String): String
         category(locale: String): Category
-        reviews(locale: String): [Review]
         price(locale: String): Number
         inStock(locale: String): Boolean
         itemsInStock(locale: String): Number

--- a/packages/api-headless-cms/__tests__/refFieldReferencedIn.test.js
+++ b/packages/api-headless-cms/__tests__/refFieldReferencedIn.test.js
@@ -1,0 +1,100 @@
+import useContentHandler from "./utils/useContentHandler";
+import refMocks from "./mocks/fields/refReferencedIn";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Ref Field - Referenced In Test", () => {
+    const { database, environment } = useContentHandler();
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it(`should only be able to publish entries that have all linked refs published as well`, async () => {
+        const { createContentModel, deleteContentModel, updateContentModel } = environment(
+            initial.environment.id
+        );
+
+        await createContentModel({
+            data: refMocks.bookContentModel({ contentModelGroupId: initial.contentModelGroup.id })
+        });
+
+        await createContentModel({
+            data: refMocks.authorContentModel({ contentModelGroupId: initial.contentModelGroup.id })
+        });
+
+        let [authorModel, bookModel] = await database
+            .collection("CmsContentModel")
+            .find()
+            .sort({ modelId: 1 });
+
+        expect(authorModel.modelId).toEqual("author");
+        expect(authorModel.refFields).toEqual([
+            {
+                fieldId: "favoriteBook",
+                modelId: "book"
+            },
+            {
+                fieldId: "otherBooks",
+                modelId: "book"
+            }
+        ]);
+        expect(authorModel.referencedIn).toEqual([]);
+
+        expect(bookModel.modelId).toEqual("book");
+        expect(bookModel.refFields).toEqual([]);
+
+        expect(bookModel.referencedIn).toEqual([
+            {
+                fieldId: "favoriteBook",
+                modelId: "author"
+            },
+            {
+                fieldId: "otherBooks",
+                modelId: "author"
+            }
+        ]);
+
+        let error;
+
+        try {
+            await deleteContentModel({ id: bookModel.id });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.message).toBe(
+            `Cannot delete content model because it's referenced in the "author" model ("favoriteBook" field).`
+        );
+
+        await updateContentModel(
+            refMocks.removeFavoriteBookField({ contentModelId: authorModel.id })
+        );
+
+        error = null;
+
+        try {
+            await deleteContentModel({ id: bookModel.id });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.message).toBe(
+            `Cannot delete content model because it's referenced in the "author" model ("otherBooks" field).`
+        );
+
+        await updateContentModel(
+            refMocks.removeOtherBooksField({ contentModelId: authorModel.id })
+        );
+
+        await deleteContentModel({ id: bookModel.id });
+
+        let [deletedBookModel] = await database
+            .collection("CmsContentModel")
+            .find({ deleted: true });
+
+        expect(deletedBookModel.id).toBe(bookModel.id);
+    });
+});

--- a/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
+++ b/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
@@ -129,7 +129,7 @@ export const UPDATE_CONTENT_MODEL = /* GraphQL */ `
 
 export const DELETE_CONTENT_MODEL = /* GraphQL */ `
     mutation HeadlessCmsDeleteContentModel($id: ID!) {
-        deleteContentModel(id: $id) {
+        content: deleteContentModel(id: $id) {
             data
             error ${ERROR_FIELD}
         }

--- a/packages/api-headless-cms/src/content/plugins/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/index.ts
@@ -5,6 +5,7 @@ import filterOperators from "./filterOperators";
 import graphqlFields from "./graphqlFields";
 import graphql from "./graphql";
 import { TypeValueEmitter } from "./utils/TypeValueEmitter";
+import addRefFieldHooks from "./modelFields/refField/addRefFieldHooks";
 
 type HeadlessPluginsOptions = {
     type: string;
@@ -37,6 +38,7 @@ export default (
             }
         }
     } as ContextPlugin,
+    addRefFieldHooks(),
     models(),
     {
         name: "context-cms-validate-access-token",

--- a/packages/api-headless-cms/src/content/plugins/modelFields/refField/addRefFieldHooks.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelFields/refField/addRefFieldHooks.ts
@@ -1,0 +1,194 @@
+import { withFields, pipe, string, withProps, withHooks, fields } from "@webiny/commodo";
+
+const RefFieldListItemModel = withFields({
+    modelId: string({ validation: "required" }),
+    fieldId: string({ validation: "required" })
+})();
+
+export default () => {
+    return {
+        type: "context-before-content-models",
+        name: "context-before-content-models-ref-field-hooks",
+        apply(context) {
+            const { CmsContentModel } = context.models;
+            pipe(
+                withFields(() => ({
+                    refFields: fields({
+                        list: true,
+                        value: [],
+                        instanceOf: RefFieldListItemModel
+                    }),
+                    referencedIn: fields({
+                        list: true,
+                        value: [],
+                        instanceOf: RefFieldListItemModel
+                    })
+                })),
+                withHooks({
+                    beforeDelete() {
+                        // Prevent deletion of content model was referenced in another content model.
+                        for (let i = 0; i < this.referencedIn.length; i++) {
+                            const item = this.referencedIn[i];
+                            throw new Error(
+                                `Cannot delete content model because it's referenced in the "${item.modelId}" model ("${item.fieldId}" field).`
+                            );
+                        }
+                    },
+                    async beforeSave() {
+                        // If content model is referenced in "ref" fields of other models, prevent removing all fields.
+                        // This is because the model will be removed from the GraphQL schema and make it invalid.
+                        if (!this.totalFields) {
+                            for (let i = 0; i < this.referencedIn.length; i++) {
+                                const item = this.referencedIn[i];
+                                throw new Error(
+                                    `Cannot remove all fields because the content model because it's referenced in the "${item.modelId}" model ("${item.fieldId}" field).`
+                                );
+                            }
+                        }
+                    }
+                }),
+                withHooks({
+                    async beforeSave() {
+                        if (!Array.isArray(this.fields)) {
+                            this.fields = [];
+                        }
+
+                        if (!Array.isArray(this.refFields)) {
+                            this.refFields = [];
+                        }
+
+                        const refFields = [];
+                        const changesOnRefFields = {
+                            added: [],
+                            removed: []
+                        };
+
+                        for (let i = 0; i < this.fields.length; i++) {
+                            const field = this.fields[i];
+                            if (field.type !== "ref") {
+                                continue;
+                            }
+
+                            const refFieldsItem = {
+                                fieldId: field.fieldId,
+                                modelId: field.settings.modelId
+                            };
+
+                            const fieldListedInRefFields = this.refFields.find(
+                                item => item.fieldId === field.fieldId
+                            );
+
+                            if (!fieldListedInRefFields) {
+                                changesOnRefFields.added.push(refFieldsItem);
+                            }
+
+                            // Let's also create an up-to-date list of ref fields.
+                            refFields.push(refFieldsItem);
+                        }
+
+                        for (let i = 0; i < this.refFields.length; i++) {
+                            const refFieldsField = this.refFields[i];
+                            const refFieldListedInFields = this.fields.find(
+                                field => field.fieldId === refFieldsField.fieldId
+                            );
+
+                            if (!refFieldListedInFields) {
+                                changesOnRefFields.removed.push(refFieldsField);
+                            }
+                        }
+
+                        this.refFields = refFields;
+
+                        if (
+                            changesOnRefFields.added.length === 0 &&
+                            changesOnRefFields.removed.length === 0
+                        ) {
+                            return;
+                        }
+
+                        const removeCallback = this.hook("afterSave", async () => {
+                            removeCallback();
+                            const loadedContentModels = {};
+                            const contentModelsToSave = {};
+
+                            // Let's optimize loading of content models - we don't want to make redundant database queries.
+                            const getContentModel = async modelId => {
+                                if (loadedContentModels[modelId]) {
+                                    return loadedContentModels[modelId];
+                                }
+
+                                const { CmsContentModel } = context.models;
+                                const contentModel = await CmsContentModel.findOne({
+                                    query: { modelId }
+                                });
+
+                                if (!contentModel) {
+                                    throw new Error(
+                                        `Could not load "${modelId}" model while managing "ref" fields on "${this.modelId}" model.`
+                                    );
+                                }
+
+                                if (!Array.isArray(contentModel.referencedIn)) {
+                                    contentModel.referencedIn = [];
+                                }
+
+                                loadedContentModels[modelId] = contentModel;
+                                return loadedContentModels[modelId];
+                            };
+
+                            // Let's first add added ref fields to referenced models (into the "refFields" field).
+                            for (let i = 0; i < changesOnRefFields.added.length; i++) {
+                                const addedRefField = changesOnRefFields.added[i];
+
+                                const referencedContentModel = await getContentModel(
+                                    addedRefField.modelId
+                                );
+
+                                referencedContentModel.referencedIn = [
+                                    ...referencedContentModel.referencedIn,
+                                    {
+                                        modelId: this.modelId,
+                                        fieldId: addedRefField.fieldId
+                                    }
+                                ];
+
+                                contentModelsToSave[
+                                    referencedContentModel.modelId
+                                ] = referencedContentModel;
+                            }
+
+                            // Now, let's remove removed ref fields in the referenced models' "refFields" field.
+                            for (let i = 0; i < changesOnRefFields.removed.length; i++) {
+                                const removedRefField = changesOnRefFields.removed[i];
+                                const referencedContentModel = await getContentModel(
+                                    removedRefField.modelId
+                                );
+
+                                const newReferencedIn = [...referencedContentModel.referencedIn];
+                                const index = newReferencedIn.findIndex(
+                                    item =>
+                                        item.fieldId === removedRefField.fieldId &&
+                                        item.modelId === this.modelId
+                                );
+
+                                if (index >= 0) {
+                                    newReferencedIn.splice(index, 1);
+                                    referencedContentModel.referencedIn = newReferencedIn;
+                                    contentModelsToSave[
+                                        referencedContentModel.modelId
+                                    ] = referencedContentModel;
+                                }
+                            }
+
+                            const contentModelsToSaveArray = Object.values(contentModelsToSave);
+                            for (let i = 0; i < contentModelsToSaveArray.length; i++) {
+                                // @ts-ignore
+                                await contentModelsToSaveArray[i].save();
+                            }
+                        });
+                    }
+                })
+            )(CmsContentModel);
+        }
+    };
+};

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -11,9 +11,10 @@ import contentModelGroup from "./models/contentModelGroup.model";
 import contentEntrySearch from "./models/contentEntrySearch.model";
 import { createDataModel } from "./utils/createDataModel";
 import { createEnvironmentBase as createEnvironmentBaseFactory } from "./utils/createEnvironmentBase";
+import { CmsContext, ContextBeforeContentModelsPlugin } from "@webiny/api-headless-cms/types";
 
 export default () => {
-    async function apply(context) {
+    async function apply(context: CmsContext) {
         const driver = context.commodo && context.commodo.driver;
 
         if (!driver) {
@@ -91,6 +92,14 @@ export default () => {
         });
 
         context.models.createEnvironmentBase = createEnvironmentBase;
+
+        const beforeContentModelsPlugins = context.plugins.byType<ContextBeforeContentModelsPlugin>(
+            "context-before-content-models"
+        );
+
+        for (let i = 0; i < beforeContentModelsPlugins.length; i++) {
+            await beforeContentModelsPlugins[i].apply(context);
+        }
 
         // Build Commodo models from CmsContentModels
         const contentModels = await context.models.CmsContentModel.find();

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -1,7 +1,6 @@
 import { withUser } from "@webiny/api-security";
 import { pipe, withStorage, withCrudLogs, withSoftDelete, withFields } from "@webiny/commodo";
 import { ContextPlugin } from "@webiny/graphql/types";
-import { Context } from "@webiny/api-plugin-commodo-db-proxy/types";
 import contentModel from "./models/contentModel.model";
 import cmsAccessToken from "../../plugins/models/accessToken.model";
 import CmsEnvironment2AccessToken from "../../plugins/models/environment2accessToken";
@@ -125,6 +124,6 @@ export default () => {
             apply(context) {
                 return apply(context);
             }
-        } as ContextPlugin<Context>
+        } as ContextPlugin<CmsContext>
     ];
 };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -142,6 +142,11 @@ export type CmsModelFieldToCommodoFieldPlugin<TContext = CmsContext> = Plugin & 
     }): void;
 };
 
+export type ContextBeforeContentModelsPlugin<T = Context> = Plugin & {
+    type: "context-before-content-models";
+    apply?: (context: T) => void | Promise<void>;
+};
+
 export type CmsModelFieldDefinition = {
     fields: string;
     typeDefs?: string;


### PR DESCRIPTION
## Related Issue
Closes #938 

## Your solution
Previously, you would be able to delete a content model, even if it was referenced by another one. This is no longer the case. In order to delete the referenced content model, you need to remove the "ref" fields first.

## How Has This Been Tested?
Jest.

## Screenshots (if relevant):
N/A