### PR TITLE
Fix(CMS, Page Builder): Preview Background Color and Rich Text Color on Dark Theme

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/IndexesTab/IndexesTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/IndexesTab/IndexesTab.tsx
@@ -27,7 +27,6 @@ const t = i18n.ns("app-headless-cms/admin/components/editor/tabs/indexes");
 const style = {
     previewWrapper: css({
         padding: 40,
-        backgroundColor: "var(--webiny-theme-color-surface, #fff) !important",
         margin: 40,
         boxSizing: "border-box"
     }),

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/PreviewTab/PreviewTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/PreviewTab/PreviewTab.tsx
@@ -11,7 +11,6 @@ const t = i18n.ns("app-headless-cms/admin/components/editor/tabs/preview");
 
 const formPreviewWrapper = css({
     padding: 40,
-    backgroundColor: "var(--webiny-theme-color-surface, #fff) !important",
     margin: 40,
     boxSizing: "border-box"
 });

--- a/packages/app-page-builder-theme/src/styles/base.scss
+++ b/packages/app-page-builder-theme/src/styles/base.scss
@@ -5,7 +5,6 @@
 }
 
 .webiny-pb-page-document{
-  background-color: var(--webiny-theme-color-surface, #fff);
   min-height: calc(100vh + 150px);
   max-width: 100%;
 

--- a/packages/app-page-builder-theme/src/styles/base.scss
+++ b/packages/app-page-builder-theme/src/styles/base.scss
@@ -5,6 +5,7 @@
 }
 
 .webiny-pb-page-document{
+  background-color: var(--webiny-theme-color-surface, #fff);
   min-height: calc(100vh + 150px);
   max-width: 100%;
 

--- a/packages/app-page-builder-theme/src/styles/variables.scss
+++ b/packages/app-page-builder-theme/src/styles/variables.scss
@@ -41,5 +41,6 @@ body{
 }
 
 body.dark-theme {
-  --webiny-theme-color-text-primary: var(--mdc-theme-text-primary-on-background);
+  --webiny-theme-color-text-primary: rgba(255, 255, 255, 0.87);
+  --webiny-theme-color-surface: #242424;
 }

--- a/packages/app-page-builder-theme/src/styles/variables.scss
+++ b/packages/app-page-builder-theme/src/styles/variables.scss
@@ -39,3 +39,7 @@ body{
   --webiny-theme-color-border: #{$webiny-pb-theme-color-border};
   --webiny-theme-border-radius: #{$webiny-pb-theme-border-radius};
 }
+
+body.dark-theme {
+  --webiny-theme-color-text-primary: var(--mdc-theme-text-primary-on-background);
+}

--- a/packages/app-page-builder-theme/src/styles/variables.scss
+++ b/packages/app-page-builder-theme/src/styles/variables.scss
@@ -15,6 +15,10 @@ $webiny-pb-theme-text-primary: rgb(10, 10, 10) !default;
 $webiny-pb-theme-text-secondary: #616161 !default;
 $webiny-pb-theme-color-border: #e8ebee !default;
 
+// dark theme
+$webiny-theme-dark-surface: #242424 !default;
+$webiny-theme-dark-text-primary-on-background: rgba(255, 255, 255, 0.87) !default;
+
 // media queries
 $webiny-pb-theme-mobile-width: 480px;
 $webiny-pb-theme-tablet-width: 768px;
@@ -41,6 +45,6 @@ body{
 }
 
 body.dark-theme {
-  --webiny-theme-color-text-primary: rgba(255, 255, 255, 0.87);
-  --webiny-theme-color-surface: #242424;
+  --webiny-theme-color-text-primary: #{$webiny-theme-dark-text-primary-on-background};
+  --webiny-theme-color-surface: #{$webiny-theme-dark-surface};
 }


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/webiny/webiny-js/issues/953

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
There were a couple ways to fix this (I am not familiar with preferred standards), however I removed a collision the styled components were creating with enforced background colors that were still on the light theme but were redundant due to ` mdc-elevation--z${VALUE}` styles. For the rich text editor I updated the value for the variable when the page is within the `.dark-theme`. Was debating updating `--webiny-theme-color-surface` instead of removing the styled css declarations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually (locally) checking before and after styles based on attached screens shots. Looked through the app also to see where else these styles may have been used.

## Screenshots (if relevant):
<img width="819" alt="content--after" src="https://user-images.githubusercontent.com/4745679/85318892-c31c7800-b48e-11ea-98e4-2eabe6acbf46.png">
<img width="864" alt="content--before" src="https://user-images.githubusercontent.com/4745679/85318893-c3b50e80-b48e-11ea-9bbe-c21e22bd09eb.png">
<img width="799" alt="index-tab--before" src="https://user-images.githubusercontent.com/4745679/85318894-c3b50e80-b48e-11ea-9832-0991ed4e0269.png">
<img width="827" alt="indexes-tab--after" src="https://user-images.githubusercontent.com/4745679/85318895-c3b50e80-b48e-11ea-813c-3fdb0f299027.png">
<img width="827" alt="page-preview--after" src="https://user-images.githubusercontent.com/4745679/85318896-c3b50e80-b48e-11ea-8b29-dff118dcb5fb.png">
<img width="824" alt="page-preview--before" src="https://user-images.githubusercontent.com/4745679/85318897-c3b50e80-b48e-11ea-8010-de95ca144cea.png">
