### PR TITLE
feat: i18n support for typeform app using t template literal

### DIFF
--- a/packages/app-typeform/package.json
+++ b/packages/app-typeform/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "@webiny/app": "^4.1.0",
     "@emotion/styled": "^10.0.17",
     "@webiny/app-page-builder": "^4.1.0",
     "@webiny/ui": "^4.1.0",

--- a/packages/app-typeform/src/admin/TypeFormEmbed.tsx
+++ b/packages/app-typeform/src/admin/TypeFormEmbed.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { connect } from "@webiny/app-page-builder/editor/redux";
 import { getElement } from "@webiny/app-page-builder/editor/selectors";
+import { i18n } from "@webiny/app/i18n";
+const t = i18n.ns("app-typeform/admin");
 
 const TypeFormEmbed = (props: { element }) => {
     const { source } = props.element.data;
     if (!source || !source.url) {
-        return <span>You must configure your embed in the settings!</span>;
+        return <span>{t`You must configure your embed in the settings!`}</span>;
     }
 
     return <iframe frameBorder="0" src={source.url} style={{ height: "100%", width: "100%" }} />;

--- a/packages/app-typeform/src/admin/index.tsx
+++ b/packages/app-typeform/src/admin/index.tsx
@@ -13,6 +13,8 @@ import {
     PbEditorPageElementPlugin,
     PbEditorPageElementAdvancedSettingsPlugin
 } from "@webiny/app-page-builder/types";
+import { i18n } from "@webiny/app/i18n";
+const t = i18n.ns("app-typeform/admin");
 
 const PreviewBox = styled("div")({
     textAlign: "center",
@@ -73,7 +75,7 @@ export default () => [
         elementType: "typeform",
         render({ Bind }) {
             return (
-                <Tab icon={<CodeIcon />} label="Typeform">
+                <Tab icon={<CodeIcon />} label={t`Typeform`}>
                     <Grid>
                         <Cell span={12}>
                             <Bind
@@ -81,8 +83,8 @@ export default () => [
                                 validators={validation.create("required,url")}
                             >
                                 <Input
-                                    label={"Typeform URL"}
-                                    description={"Enter a Typeform URL"}
+                                    label={t`Typeform URL`}
+                                    description={t`Enter a Typeform URL`}
                                 />
                             </Bind>
                         </Cell>


### PR DESCRIPTION
## Related Issue
Closes #617 

## Your solution
```tsx
import { i18n } from "@webiny/app/i18n";
const t = i18n.ns("app-typeform/admin");
```
Now wrap strings into `t` template literal

## How Has This Been Tested?
Manually

## Screenshots (if relevant):
