### PR TITLE
feat: i18n support for app-google-tag-manager

### DIFF
--- a/packages/app-google-tag-manager/src/admin/components/GoogleTagManagerSettings.tsx
+++ b/packages/app-google-tag-manager/src/admin/components/GoogleTagManagerSettings.tsx
@@ -9,6 +9,7 @@ import { Input } from "@webiny/ui/Input";
 import graphql from "./graphql";
 import { CircularProgress } from "@webiny/ui/Progress";
 import get from "lodash.get";
+import { i18n } from "@webiny/app/i18n";
 
 import {
     SimpleForm,
@@ -16,6 +17,9 @@ import {
     SimpleFormContent,
     SimpleFormHeader
 } from "@webiny/app-admin/components/SimpleForm";
+
+const t = i18n.ns("app-google-tag-manager/admin");
+
 
 const GoogleTagManagerSettings = () => {
     const { showSnackbar } = useSnackbar();
@@ -35,7 +39,7 @@ const GoogleTagManagerSettings = () => {
                                             data: data
                                         }
                                     });
-                                    showSnackbar("Settings updated successfully.");
+                                    showSnackbar(t`Settings updated successfully.`);
                                 }}
                             >
                                 {({ Bind, form, data }) => (
@@ -43,7 +47,7 @@ const GoogleTagManagerSettings = () => {
                                         {(queryInProgress || mutationInProgress) && (
                                             <CircularProgress />
                                         )}
-                                        <SimpleFormHeader title="Google Tag Manager Settings">
+                                        <SimpleFormHeader title={t`Google Tag Manager Settings`}>
                                             <Bind
                                                 name={"enabled"}
                                                 afterChange={enabled => {
@@ -52,7 +56,7 @@ const GoogleTagManagerSettings = () => {
                                                     }
                                                 }}
                                             >
-                                                <Switch label="Enabled" />
+                                                <Switch label={t`Enabled`} />
                                             </Bind>
                                         </SimpleFormHeader>
                                         {data.enabled ? (
@@ -66,7 +70,7 @@ const GoogleTagManagerSettings = () => {
                                                                         <Input
                                                                             label="Container ID"
                                                                             description={
-                                                                                'Formatted as "GTM-XXXXXX".'
+                                                                                t`Formatted as "GTM-XXXXXX".`
                                                                             }
                                                                         />
                                                                     </Bind>
@@ -77,7 +81,7 @@ const GoogleTagManagerSettings = () => {
                                                 </SimpleFormContent>
                                                 <SimpleFormFooter>
                                                     <ButtonPrimary onClick={form.submit}>
-                                                        Save
+                                                        {t`Save`}
                                                     </ButtonPrimary>
                                                 </SimpleFormFooter>
                                             </>

--- a/packages/app-google-tag-manager/src/admin/index.tsx
+++ b/packages/app-google-tag-manager/src/admin/index.tsx
@@ -21,7 +21,7 @@ export default () => [
                 path="/settings/page-builder/google-tag-manager"
                 render={() => (
                     <AdminLayout>
-                        <Helmet title={"Page Builder - Google Tag Manager Settings"} />
+                        <Helmet title={t`Page Builder - Google Tag Manager Settings`} />
                         <SecureRoute scopes={ROLE_PB_SETTINGS}>
                             <GoogleTagManagerSettings />
                         </SecureRoute>


### PR DESCRIPTION
## Related Issue
Closes #619 

## Your solution
```tsx
import { i18n } from "@webiny/app/i18n";
const t = i18n.ns("app-google-tag-manager/admin");
```
Now wrap strings into `t` template literal

## How Has This Been Tested?
Manually
## Screenshots (if relevant):
