### PR TITLE
fix: Page Builder - preventing category deletion with linked pages.

### DIFF
--- a/packages/api-page-builder/src/plugins/models.ts
+++ b/packages/api-page-builder/src/plugins/models.ts
@@ -32,7 +32,7 @@ export default () => [
                     withCrudLogs()
                 )();
 
-            const PbCategory = pbCategory({ createBase });
+            const PbCategory = pbCategory({ createBase, context });
             const PbMenu = pbMenu({ createBase });
             const PbPageElement = pbPageElement({ createBase, context });
             const PbSettings = pbSettings({ createBase, context });

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -3,9 +3,6 @@ import { validation } from "@webiny/validation";
 
 import { withFields, string, withHooks, withName } from "@webiny/commodo";
 
-/*import { PbContext } from "@webiny/api-page-builder/types";
-
-export default ({ createBase, context } : { createBase: Function, context: PbContext }) =>*/
 export default ({ createBase, context }) =>
     flow(
         withName("PbCategory"),

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -1,15 +1,15 @@
 import { flow } from "lodash";
 import { validation } from "@webiny/validation";
 
-import { withFields, string, withName } from "@webiny/commodo";
+import { withFields, string, withHooks, withName } from "@webiny/commodo";
 
 export default ({ createBase }) =>
     flow(
         withName("PbCategory"),
         withHooks({
             async beforeDelete() {
-                const Model = context.models[this.modelId];
-                if (await Model.findOne()) {
+                const { PbPage } = context.models[this.modelId];
+                if (await PbPage.findOne()) {
                     throw new Error(
                         "Cannot delete category because some pages are linked to it."
                     );

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -3,9 +3,10 @@ import { validation } from "@webiny/validation";
 
 import { withFields, string, withHooks, withName } from "@webiny/commodo";
 
-import { PbContext } from "@webiny/api-page-builder/types";
+/*import { PbContext } from "@webiny/api-page-builder/types";
 
-export default ({ createBase, context } : { createBase: Function, context: PbContext }) =>
+export default ({ createBase, context } : { createBase: Function, context: PbContext }) =>*/
+export default ({ createBase, context }) =>
     flow(
         withName("PbCategory"),
         withHooks({

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -3,7 +3,9 @@ import { validation } from "@webiny/validation";
 
 import { withFields, string, withHooks, withName } from "@webiny/commodo";
 
-export default ({ createBase }) =>
+import { PbContext } from "@webiny/api-page-builder/types";
+
+export default ({ createBase, context } : { createBase: Function, context: PbContext }) =>
     flow(
         withName("PbCategory"),
         withHooks({

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -11,7 +11,7 @@ export default ({ createBase, context }) =>
         withName("PbCategory"),
         withHooks({
             async beforeDelete() {
-                const { PbPage } = context.models[this.modelId];
+                const { PbPage } = context.models;
                 if (await PbPage.findOne()) {
                     throw new Error(
                         "Cannot delete category because some pages are linked to it."

--- a/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbCategory.model.ts
@@ -6,6 +6,16 @@ import { withFields, string, withName } from "@webiny/commodo";
 export default ({ createBase }) =>
     flow(
         withName("PbCategory"),
+        withHooks({
+            async beforeDelete() {
+                const Model = context.models[this.modelId];
+                if (await Model.findOne()) {
+                    throw new Error(
+                        "Cannot delete category because some pages are linked to it."
+                    );
+                }
+            }
+        }),
         withFields({
             name: string({ validation: validation.create("required") }),
             slug: string({ validation: validation.create("required") }),


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1054

## Your solution
Catch page Categories with existing linked pages, so when attempting to delete a category with pages it will throw an error.
<!--- Please describe your solution, have you encountered any issues along the way? -->

## How Has This Been Tested?
Not tested yet. Just a base for the code based on an [existing example](packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts:81) has been added.
Much of its content doesn't apply to what is needed to be done.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
Screen shot of existing example for reference:
<img width="688" alt="Screenshot 2020-06-27 at 00 06 23" src="https://user-images.githubusercontent.com/22279028/85907654-159cc200-b80a-11ea-856b-6c2d074e25b9.png">

