### PR TITLE
feat: add select to fieldRenderers

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/index.ts
@@ -6,6 +6,7 @@ import boolean from "./boolean";
 import dateTime from "./dateTime";
 import file from "./file";
 import radioButtons from "./radioButtons";
+import select from "./select";
 import checkboxes from "./checkboxes";
 import ref from "./ref";
 
@@ -19,5 +20,6 @@ export default [
     file,
     ref,
     radioButtons,
+    select,
     checkboxes
 ];

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
+import { I18NValue } from "@webiny/app-i18n/components";
+import { Select } from "@webiny/ui/Select";
+import { i18n } from "@webiny/app/i18n";
+import get from "lodash/get";
+
+const t = i18n.ns("app-headless-cms/admin/fields/text");
+
+const plugin: CmsEditorFieldRendererPlugin = {
+    type: "cms-editor-field-renderer",
+    name: "cms-editor-field-renderer-select-box",
+    renderer: {
+        rendererName: "select-box",
+        name: t`Select Box`,
+        description: t`Renders a select box, allowing selection of a single value.`,
+        canUse({ field }) {
+            return !field.multipleValues && get(field, "predefinedValues.enabled");
+        },
+        render({ field, getBind, locale }) {
+            const Bind = getBind();
+
+            const valuesItem = field.predefinedValues.values.values.find(
+                item => item.locale === locale
+            );
+            
+            const options = valuesItem && Array.isArray(valuesItem.value) ? valuesItem.value : [];
+
+            return (
+                <Bind>
+                    <Select
+                        label={I18NValue({ value: field.label })}
+                        description={I18NValue({ value: field.helpText })}
+                        options={options}
+                    />
+                </Bind>
+            );
+        }
+    }
+};
+
+export default plugin;


### PR DESCRIPTION
## Related Issue
Relates to #1076

## Your solution
Feels a bit like too easy 👍  but I have added a `select` fieldRenderer based heavily on the radio button as per suggestion by @Pavel910.

## How Has This Been Tested?
To be honest I may need help with testing as I am new to using / contributing to the framework. I checked the select box appears in the edit content-model preview panel.

![image](https://user-images.githubusercontent.com/6464260/85933462-219e8780-b8cf-11ea-831e-42def3709da6.png)

And `cms/content-models/manage` page

![image](https://user-images.githubusercontent.com/6464260/85933489-6a564080-b8cf-11ea-891c-3661b8198f67.png)

I did look to add unit and integration tests but it seems you folks have some integration ones but not around this part of the app, I felt adding integration tests to test the content models groups and models fell outside the scope of this PR.
