### PR TITLE
Webiny logo now links to the welcome screen

### DIFF
--- a/packages/app-admin/src/plugins/Logo/Logo.tsx
+++ b/packages/app-admin/src/plugins/Logo/Logo.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { isEqual } from "lodash";
 import { ReactComponent as WebinyLogo } from "@webiny/app-admin/assets/images/webiny-logo.svg";
+import { Link } from "@webiny/react-router";
 
 class Logo extends React.Component<any> {
     static defaultProps = {
@@ -9,7 +10,8 @@ class Logo extends React.Component<any> {
         mobileWidth: 100,
         mobileHeight: 36,
         altText: "Webiny",
-        className: ""
+        className: "",
+        white: false
     };
 
     checkDisplayInterval = null;
@@ -31,14 +33,19 @@ class Logo extends React.Component<any> {
     }
 
     render() {
-        const { className, altText } = this.props;
+        const { className, altText, white } = this.props;
 
         const style = {
             width: this.props.width,
             height: this.props.height,
             display: this.props.display,
-            marginTop: 12
+            marginTop: 12,
+            color: undefined
         };
+
+        if (white) {
+            style.color = "white";
+        }
 
         if (this.state.display !== "desktop") {
             style.width = this.props.mobileWidth;
@@ -46,11 +53,13 @@ class Logo extends React.Component<any> {
         }
 
         return (
-            <WebinyLogo
-                className={["webiny-logo", className].join(" ")}
-                style={style}
-                alt={altText}
-            />
+            <Link to={"/"}>
+                <WebinyLogo
+                    className={["webiny-logo", className].join(" ")}
+                    style={style}
+                    alt={altText}
+                />
+            </Link>
         );
     }
 }

--- a/packages/app-admin/src/plugins/Logo/index.tsx
+++ b/packages/app-admin/src/plugins/Logo/index.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 import Logo from "./Logo";
 import { TopAppBarTitle } from "@webiny/ui/TopAppBar";
-import { AdminHeaderLeftPlugin } from "@webiny/app-admin/types";
+import { AdminHeaderLeftPlugin, AdminMenuLogoPlugin } from "@webiny/app-admin/types";
 
-const plugin: AdminHeaderLeftPlugin = {
-    name: "admin-header-logo",
-    type: "admin-header-left",
-    render() {
-        return (
-            <TopAppBarTitle>
-                <Logo />
-            </TopAppBarTitle>
-        );
-    }
-};
-
-export default plugin;
+export default [
+    {
+        name: "admin-header-logo",
+        type: "admin-header-left",
+        render() {
+            return (
+                <TopAppBarTitle>
+                    <Logo white />
+                </TopAppBarTitle>
+            );
+        }
+    } as AdminHeaderLeftPlugin,
+    {
+        name: "admin-menu-logo",
+        type: "admin-menu-logo",
+        render() {
+            return (
+                <TopAppBarTitle>
+                    <Logo />
+                </TopAppBarTitle>
+            );
+        }
+    } as AdminMenuLogoPlugin
+];

--- a/packages/app-admin/src/plugins/Menu/Navigation/index.tsx
+++ b/packages/app-admin/src/plugins/Menu/Navigation/index.tsx
@@ -5,7 +5,7 @@ import { List, ListItem, ListItemGraphic } from "@webiny/ui/List";
 import { IconButton } from "@webiny/ui/Button";
 import { Icon } from "@webiny/ui/Icon";
 import { getPlugin, getPlugins } from "@webiny/plugins";
-import { AdminHeaderLogoPlugin, AdminMenuPlugin } from "@webiny/app-admin/types";
+import { AdminMenuLogoPlugin, AdminMenuPlugin } from "@webiny/app-admin/types";
 import { useNavigation, Menu, Item, Section } from "./components";
 import { logoStyle, MenuFooter, MenuHeader, navContent, navHeader, subFooter } from "./Styled";
 import { ReactComponent as MenuIcon } from "@webiny/app-admin/assets/icons/baseline-menu-24px.svg";
@@ -22,7 +22,7 @@ const Navigation = () => {
     useEffect(initSections, []);
 
     const logo = useMemo(() => {
-        const logoPlugin = getPlugin<AdminHeaderLogoPlugin>("admin-header-logo");
+        const logoPlugin = getPlugin<AdminMenuLogoPlugin>("admin-menu-logo");
         if (logoPlugin) {
             return React.cloneElement(logoPlugin.render(), { className: logoStyle });
         }

--- a/packages/app-admin/src/types.ts
+++ b/packages/app-admin/src/types.ts
@@ -27,9 +27,9 @@ export type AdminGlobalSearchPreventHotkeyPlugin = Plugin & {
     preventOpen(e: React.KeyboardEvent): boolean | void;
 };
 
-export type AdminHeaderLogoPlugin = Plugin & {
-    name: "admin-header-logo";
-    type: "admin-header-logo";
+export type AdminMenuLogoPlugin = Plugin & {
+    name: "admin-menu-logo";
+    type: "admin-menu-logo";
     render(): React.ReactElement;
 };
 


### PR DESCRIPTION
One of the users noticed that there is no way of going back to the initial welcome screen in the Admin app. As suggested, we made the Webiny logos, located in the header bar and in the main menu, link to the welcome screen, so that it can be easily revisited.

![image](https://user-images.githubusercontent.com/5121148/86026174-63464400-ba2f-11ea-981c-30c6ff6997a4.png)

## How Has This Been Tested?
Manual testing.
