### PR TITLE
The concurrency limit for the DB Proxy lambda function increased from 15 to 50

### DIFF
--- a/packages/cwp-template-cms/template/api/resources.js
+++ b/packages/cwp-template-cms/template/api/resources.js
@@ -65,7 +65,7 @@ module.exports = () => ({
                     region: process.env.AWS_REGION,
                     description: "Handles interaction with MongoDB",
                     code: "./databaseProxy/build",
-                    concurrencyLimit: 15,
+                    concurrencyLimit: 50,
                     handler: "handler.handler",
                     memory: 512,
                     timeout: 30,

--- a/packages/cwp-template-full/template/api/resources.js
+++ b/packages/cwp-template-full/template/api/resources.js
@@ -67,7 +67,7 @@ module.exports = () => ({
                     region: process.env.AWS_REGION,
                     description: "Handles interaction with MongoDB",
                     code: "./databaseProxy/build",
-                    concurrencyLimit: 15,
+                    concurrencyLimit: 50,
                     handler: "handler.handler",
                     memory: 512,
                     timeout: 30,

--- a/packages/cwp-template-full/template/apps/resources.js
+++ b/packages/cwp-template-full/template/apps/resources.js
@@ -25,7 +25,7 @@ module.exports = ({ cli }) => {
                         region: process.env.AWS_REGION,
                         description: "Handles interaction with MongoDB",
                         code: "./databaseProxy/build",
-                        concurrencyLimit: 15,
+                        concurrencyLimit: 50,
                         handler: "handler.handler",
                         memory: 512,
                         timeout: 30,

--- a/sample-project/api/resources.js
+++ b/sample-project/api/resources.js
@@ -67,7 +67,7 @@ module.exports = () => ({
                     region: process.env.AWS_REGION,
                     description: "Handles interaction with MongoDB",
                     code: "./databaseProxy/build",
-                    concurrencyLimit: 15,
+                    concurrencyLimit: 50,
                     handler: "handler.handler",
                     memory: 512,
                     timeout: 30,


### PR DESCRIPTION
## Related Issue
For the DB Proxy Lambda function, which is handling everything database related (more information in [this](https://blog.webiny.com/using-aws-lambda-to-create-a-mongodb-connection-proxy-2bb53c4a0af4) blog post), we had the default Lambda function concurrency limit set to 15. Basically, this means that we can have 15 concurrent invocations of the DB Proxy Lambda function, which, as it turned out, is not hard to reach, even in local development. To prevent this, we decided to increase this value to 50, which will significantly help in preventing the concurrency limit to be reached again.

Note that the `concurrencyLimit` parameter can still be found in `api/resources.js` and `apps/resources.js` files. So, if further adjustments are needed, they can be made there.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A