### PR TITLE
fix(app-template): revert change to getting route plugins

### DIFF
--- a/packages/app-template/src/Routes.tsx
+++ b/packages/app-template/src/Routes.tsx
@@ -5,14 +5,11 @@ import { RoutePlugin } from "@webiny/app/types";
 
 export const Routes = () => {
     const plugins = getPlugins<RoutePlugin>("route").sort((a, b) => {
-        const pathA = a.route.props.path || "*";
-        const pathB = b.route.props.path || "*";
-
-        if (pathA === "*" || pathA === "/") {
+        if (a.name === "route-not-found" || a.name === "route-root") {
             return 1;
         }
 
-        if (pathB === "*" || pathB === "/") {
+        if (b.name === "route-not-found" || b.name === "route-root") {
             return -1;
         }
 


### PR DESCRIPTION
## Related Issue
Fixes the bug introduced by: https://github.com/webiny/webiny-js/commit/9b5841b15c2b3103d13dd80ed09446a9a047039b

## Your solution
Reverts the method of which to grab the route plugins to the previous method

## How Has This Been Tested?
Manually:

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/9532882/86080405-d7e5a680-ba60-11ea-9b1f-149fd1ab1949.png)
