### PR TITLE
fix: make sure newly added ref fields cannot reference a model with n…

### DIFF
--- a/packages/api-headless-cms/__tests__/mocks/fields/refInvalidReferences.js
+++ b/packages/api-headless-cms/__tests__/mocks/fields/refInvalidReferences.js
@@ -1,0 +1,98 @@
+import { locales } from "@webiny/api-i18n/testing";
+
+const mocks = {
+    bookContentModel: ({ contentModelGroupId }) => ({
+        name: "Book",
+        group: contentModelGroupId,
+        fields: []
+    }),
+    authorContentModel: ({ contentModelGroupId }) => ({
+        name: "Author",
+        group: contentModelGroupId,
+        fields: [
+            {
+                _id: "vqk-UApa0",
+                fieldId: "title",
+                type: "text",
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Title"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Titel"
+                        }
+                    ]
+                }
+            },
+            {
+                _id: "id-favorite-book",
+                fieldId: "favoriteBook",
+                type: "ref",
+                settings: {
+                    modelId: "book"
+                },
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Favorite Book"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Lieblingsbuch"
+                        }
+                    ]
+                }
+            },
+            {
+                _id: "id-other-books",
+                fieldId: "otherBooks",
+                type: "ref",
+                multipleValues: true,
+                settings: {
+                    modelId: "book"
+                },
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Other Books"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Andere Bücher"
+                        }
+                    ]
+                }
+            }
+        ]
+    }),
+    authorWithoutBookRefFields: ({ contentModelGroupId }) => ({
+        name: "Author",
+        group: contentModelGroupId,
+        fields: [
+            {
+                _id: "vqk-UApa0",
+                fieldId: "title",
+                type: "text",
+                label: {
+                    values: [
+                        {
+                            locale: locales.en.id,
+                            value: "Title"
+                        },
+                        {
+                            locale: locales.de.id,
+                            value: "Titel"
+                        }
+                    ]
+                }
+            }
+        ]
+    })
+};
+
+export default mocks;

--- a/packages/api-headless-cms/__tests__/refFieldInvalidReferences.test.js
+++ b/packages/api-headless-cms/__tests__/refFieldInvalidReferences.test.js
@@ -1,0 +1,50 @@
+import useContentHandler from "./utils/useContentHandler";
+import refMocks from "./mocks/fields/refInvalidReferences";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Ref Field - Invalid References In Test", () => {
+    const { database, environment } = useContentHandler();
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it(`should not allow selection of a ref model that doesn't have a title field`, async () => {
+        const { createContentModel } = environment(initial.environment.id);
+
+        await createContentModel({
+            data: refMocks.bookContentModel({ contentModelGroupId: initial.contentModelGroup.id })
+        });
+
+        let error;
+        try {
+            await createContentModel({
+                data: refMocks.authorContentModel({
+                    contentModelGroupId: initial.contentModelGroup.id
+                })
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.message).toBe(
+            `Cannot save content model because the ref field "favoriteBook" references a content model (book) that has no title field assigned.`
+        );
+
+        error = null;
+        try {
+            await createContentModel({
+                data: refMocks.authorWithoutBookRefFields({
+                    contentModelGroupId: initial.contentModelGroup.id
+                })
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBe(null);
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/modelFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelFields/ref.ts
@@ -200,4 +200,45 @@ const lockedFieldPlugin: CmsModelLockedFieldPlugin = {
     }
 };
 
-export default [plugin, lockedFieldPlugin];
+const checkRefFieldsBeforeSave = {
+    name: "context-cms-model-ref-field-check-referenced-model",
+    type: "context",
+    apply(context) {
+        const { CmsContentModel } = context.models;
+        withHooks({
+            async beforeSave() {
+                const refFields = this.fields.filter(field => {
+                    if (field.type !== "ref") {
+                        return false;
+                    }
+
+                    const isLockedField = this.lockedFields.find(
+                        item => item.fieldId === field.fieldId
+                    );
+                    return !isLockedField;
+                });
+
+                // Now that we have non-locked "ref" fields, let's check if the actual model that is referenced
+                // is ready to be selected. In other words, we don't want to allow models without a title field,
+                // because basically, all search inputs in the UI will stop working. And not only that, with this
+                // check, we ensure that the referenced model contains at least one field. Otherwise, the GraphQL
+                // schema that would be generated after saving this content model, would be invalid, and the
+                // GraphQL server wouldn't be able to start.
+                for (let i = 0; i < refFields.length; i++) {
+                    const refField = refFields[i];
+                    const contentModel = await CmsContentModel.findOne({
+                        modelId: refField.settings.modelId
+                    });
+
+                    if (!contentModel.titleFieldId) {
+                        throw new Error(
+                            `Cannot save content model because the ref field "${refField.fieldId}" references a content model (${refField.settings.modelId}) that has no title field assigned.`
+                        );
+                    }
+                }
+            }
+        })(CmsContentModel);
+    }
+};
+
+export default [plugin, lockedFieldPlugin, checkRefFieldsBeforeSave];


### PR DESCRIPTION
## Related Issue
Closes #928 

## Your solution
Added a check for all new ref fields (non-locked) - if the referenced model doesn't have a title field, an error will be thrown.

## How Has This Been Tested?
Jest.

## Screenshots (if relevant):
N/A