### PR TITLE
Fix/environment incorrect url

### DIFF
--- a/packages/api-headless-cms/__tests__/environmentUrl.test.js
+++ b/packages/api-headless-cms/__tests__/environmentUrl.test.js
@@ -1,37 +1,22 @@
 import useContentHandler from "./utils/useContentHandler";
-import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
 
 describe("Invalid type and environment URL params test", () => {
-    /*
-    beforeAll(async () => {
-        // Let's create a basic environment and a content model group.
-        initial.environment = await createEnvironment({ database });
-        initial.contentModelGroup = await createContentModelGroup({ database });
-    });*/
     it("should respond with proper error messages", async () => {
         const { invoke } = useContentHandler();
         let [body1] = await invoke({
             pathParameters: { key: "read123/xyz" }
         });
 
-        expect(body1.error).toEqual({
-            name: "Error",
-            message:
-                "Could not load environment, please check if the passed environment alias slug or environment ID is correct.",
-            stack:
-                "Error: Could not load environment, please check if the passed environment alias slug or environment ID is correct.\n    at apply (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/plugins/models.ts:68:19)\n    at applyContextPlugins (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/contextPlugins.ts:13:13)\n    at prepareSchema (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/prepareSchema.ts:20:5)\n    at Object.createSchema [as create] (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema.ts:21:31)\n    at createApolloHandler (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts:37:24)\n    at Object.create (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler.ts:17:28)\n    at handle (/Users/adrian/dev/webiny-js/packages/handler-apollo-server/src/plugins/createHandlerApolloServer.ts:25:33)\n    at /Users/adrian/dev/webiny-js/packages/handler/src/middleware.ts:21:40"
-        });
+        expect(body1.error.message).toEqual(
+            "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
+        );
 
         let [body2] = await invoke({
             pathParameters: { key: "read/xyz" }
         });
 
-        expect(body2.error).toEqual({
-            name: "Error",
-            message:
-                "Could not load environment, please check if the passed environment alias slug or environment ID is correct.",
-            stack:
-                "Error: Could not load environment, please check if the passed environment alias slug or environment ID is correct.\n    at apply (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/plugins/models.ts:68:19)\n    at applyContextPlugins (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/contextPlugins.ts:13:13)\n    at prepareSchema (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/prepareSchema.ts:20:5)\n    at Object.createSchema [as create] (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema.ts:21:31)\n    at createApolloHandler (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts:37:24)\n    at Object.create (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler.ts:17:28)\n    at handle (/Users/adrian/dev/webiny-js/packages/handler-apollo-server/src/plugins/createHandlerApolloServer.ts:25:33)\n    at /Users/adrian/dev/webiny-js/packages/handler/src/middleware.ts:21:40"
-        });
+        expect(body2.error.message).toEqual(
+            "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
+        );
     });
 });

--- a/packages/api-headless-cms/__tests__/environmentUrl.test.js
+++ b/packages/api-headless-cms/__tests__/environmentUrl.test.js
@@ -1,0 +1,37 @@
+import useContentHandler from "./utils/useContentHandler";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Invalid type and environment URL params test", () => {
+    /*
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });*/
+    it("should respond with proper error messages", async () => {
+        const { invoke } = useContentHandler();
+        let [body1] = await invoke({
+            pathParameters: { key: "read123/xyz" }
+        });
+
+        expect(body1.error).toEqual({
+            name: "Error",
+            message:
+                "Could not load environment, please check if the passed environment alias slug or environment ID is correct.",
+            stack:
+                "Error: Could not load environment, please check if the passed environment alias slug or environment ID is correct.\n    at apply (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/plugins/models.ts:68:19)\n    at applyContextPlugins (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/contextPlugins.ts:13:13)\n    at prepareSchema (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/prepareSchema.ts:20:5)\n    at Object.createSchema [as create] (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema.ts:21:31)\n    at createApolloHandler (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts:37:24)\n    at Object.create (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler.ts:17:28)\n    at handle (/Users/adrian/dev/webiny-js/packages/handler-apollo-server/src/plugins/createHandlerApolloServer.ts:25:33)\n    at /Users/adrian/dev/webiny-js/packages/handler/src/middleware.ts:21:40"
+        });
+
+        let [body2] = await invoke({
+            pathParameters: { key: "read/xyz" }
+        });
+
+        expect(body2.error).toEqual({
+            name: "Error",
+            message:
+                "Could not load environment, please check if the passed environment alias slug or environment ID is correct.",
+            stack:
+                "Error: Could not load environment, please check if the passed environment alias slug or environment ID is correct.\n    at apply (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/plugins/models.ts:68:19)\n    at applyContextPlugins (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/contextPlugins.ts:13:13)\n    at prepareSchema (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema/prepareSchema.ts:20:5)\n    at Object.createSchema [as create] (/Users/adrian/dev/webiny-js/packages/graphql/src/createSchema.ts:21:31)\n    at createApolloHandler (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts:37:24)\n    at Object.create (/Users/adrian/dev/webiny-js/packages/api-headless-cms/src/content/apolloHandler.ts:17:28)\n    at handle (/Users/adrian/dev/webiny-js/packages/handler-apollo-server/src/plugins/createHandlerApolloServer.ts:25:33)\n    at /Users/adrian/dev/webiny-js/packages/handler/src/middleware.ts:21:40"
+        });
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -50,18 +50,19 @@ export default () => {
         // Before continuing with the rest of the models, we must load the environment and assign it to the context.
         let environment = null;
         let environmentAlias = null;
-        if (context.cms.environment && typeof context.cms.environment === "string") {
-            if (context.models.CmsEnvironment.isId(context.cms.environment)) {
-                environment = await context.models.CmsEnvironment.findById(context.cms.environment);
-            } else {
-                environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
-                    query: { slug: context.cms.environment }
-                });
-                environment = await environmentAlias.environment;
-            }
-        }
 
-        if (!environment) {
+        try {
+            if (context.cms.environment && typeof context.cms.environment === "string") {
+                if (context.models.CmsEnvironment.isId(context.cms.environment)) {
+                    environment = await context.models.CmsEnvironment.findById(context.cms.environment);
+                } else {
+                    environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
+                        query: {slug: context.cms.environment}
+                    });
+                    environment = await environmentAlias.environment;
+                }
+            }
+        } catch (err) {
             throw Error(
                 "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
             );

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -58,13 +58,13 @@ export default () => {
                 environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
                     query: {slug: context.cms.environment}
                 });
-                if(environmentAlias) {
+                if (environmentAlias) {
                     environment = await environmentAlias.environment;
                 }
             }
         }
 
-        if(!environment) {
+        if (!environment) {
             throw Error(
                 "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
             );

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -51,18 +51,20 @@ export default () => {
         let environment = null;
         let environmentAlias = null;
 
-        try {
-            if (context.cms.environment && typeof context.cms.environment === "string") {
-                if (context.models.CmsEnvironment.isId(context.cms.environment)) {
-                    environment = await context.models.CmsEnvironment.findById(context.cms.environment);
-                } else {
-                    environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
-                        query: {slug: context.cms.environment}
-                    });
+        if (context.cms.environment && typeof context.cms.environment === "string")  {
+            if (context.models.CmsEnvironment.isId(context.cms.environment)) {
+                environment = await context.models.CmsEnvironment.findById(context.cms.environment);
+            } else {
+                environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
+                    query: {slug: context.cms.environment}
+                });
+                if(environmentAlias) {
                     environment = await environmentAlias.environment;
                 }
             }
-        } catch (err) {
+        }
+
+        if(!environment) {
             throw Error(
                 "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
             );


### PR DESCRIPTION
## Related Issue

Closes #936 

## Your solution
Added try/catch block around the logic that would try to grab environments based on the alias name provided.
Wrote test case to make sure this behavior is enforced and checked for.

## How Has This Been Tested?
Looked at urls with incorrect aliases to see if error message was updated

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/9532882/86405109-ca0d6c80-bc7e-11ea-9a21-05f9df43f438.png)
![image](https://user-images.githubusercontent.com/9532882/86405134-d72a5b80-bc7e-11ea-9005-056ee5d064c2.png)