### PR TITLE
fix: create webiny project

### DIFF
--- a/packages/create-webiny-project/index.js
+++ b/packages/create-webiny-project/index.js
@@ -238,11 +238,11 @@ async function run({ root, appName, template, tag, log }) {
         ]);
 
         await tasks.run().catch(async err => {
-            let basePath = path.join("./", "cwp-logs.txt");
-            if (log.startsWith(".") || log.startsWitch("file:")) {
+            let basePath = "cwp-logs.txt";
+            if (log.startsWith(".") || log.startsWith("file:")) {
                 basePath = log;
             }
-            fs.writeFileSync(path.join(basePath), JSON.stringify(err, null, 2) + os.EOL);
+            fs.writeFileSync(basePath, JSON.stringify(err, null, 2) + os.EOL);
             console.log("\nCleaning up project...");
             rimraf.sync(root);
             console.log("Project cleaned!");

--- a/packages/create-webiny-project/index.js
+++ b/packages/create-webiny-project/index.js
@@ -219,8 +219,11 @@ async function run({ root, appName, template, tag, log }) {
 
         if (template.startsWith(".") || template.startsWith("file:")) {
             templateName = "file:" + path.relative(appName, template.replace("file:", ""));
+            dependencies.push(templateName);
+        } else {
+            dependencies.push(`${templateName}@${tag}`);
         }
-        dependencies.push(`${templateName}@${tag}`);
+
         const tasks = new Listr([
             {
                 title: `Install template package`,

--- a/packages/create-webiny-project/index.js
+++ b/packages/create-webiny-project/index.js
@@ -65,6 +65,7 @@ yargs.command(
             describe:
                 "Creates a log file to see output of installation. Defaults to creating cwp-logs.txt in current directory.",
             alias: "l",
+            default: "",
             type: "string",
             demandOption: false
         });

--- a/packages/create-webiny-project/index.js
+++ b/packages/create-webiny-project/index.js
@@ -206,7 +206,9 @@ async function install({ root, dependencies }) {
     try {
         await execa(command, args);
     } catch (err) {
-        throw new Error("Unable to install core dependencies for create-webiny-project.", err);
+        throw new Error(
+            "Unable to install core dependencies for create-webiny-project: " + err.message
+        );
     }
 }
 
@@ -222,11 +224,11 @@ async function run({ root, appName, template, tag, log }) {
         const tasks = new Listr([
             {
                 title: `Install template package`,
-                task: async ctx => {
+                task: async () => {
                     try {
                         await install({ root, dependencies });
                     } catch (err) {
-                        throw new Error("Failed to install template package", err, ctx);
+                        throw new Error(`Failed to install template package: ${err.message}`);
                     }
                 }
             }

--- a/packages/create-webiny-project/init.js
+++ b/packages/create-webiny-project/init.js
@@ -19,7 +19,7 @@ const writeJsonFile = require("write-json-file");
 const { getPackageVersion } = require("./utils");
 const rimraf = require("rimraf");
 
-let basePath = path.join("./", "cwp-logs.txt");
+let basePath = "cwp-logs.txt";
 
 module.exports = async function({ root, appName, templateName, tag, log }) {
     const appPackage = require(path.join(root, "package.json"));
@@ -211,7 +211,7 @@ module.exports = async function({ root, appName, templateName, tag, log }) {
                     };
                     let logStream;
                     if (log) {
-                        if (log.startsWith(".") || log.startsWitch("file:")) {
+                        if (log.startsWith(".") || log.startsWith("file:")) {
                             basePath = log;
                         }
                         logStream = fs.createWriteStream(basePath, {
@@ -245,11 +245,11 @@ module.exports = async function({ root, appName, templateName, tag, log }) {
     ]);
 
     await tasks.run().catch(async err => {
-        if (log.startsWith(".") || log.startsWitch("file:")) {
+        if (log.startsWith(".") || log.startsWith("file:")) {
             basePath = log;
         }
 
-        fs.appendFileSync(path.join(basePath), JSON.stringify(err, null, 2) + os.EOL);
+        fs.appendFileSync(basePath, JSON.stringify(err, null, 2) + os.EOL);
 
         await sendEvent({
             event: "create-webiny-project-error",


### PR DESCRIPTION
## Related Issue
Closes #1093 

## Your solution
Added a default value `""` to `log` parameter.
Besides this main issue, I also removed unnecessary calls to `path.join`, and added error messages to the errors being thrown.

## How Has This Been Tested?
Manually, by creating projects locally.
