### PR TITLE
Check if bucket still exists before attempting to remove S3 object

### DIFF
--- a/packages/serverless-aws-s3-object/serverless.js
+++ b/packages/serverless-aws-s3-object/serverless.js
@@ -30,7 +30,21 @@ class ServerlessAwsS3Object extends Component {
     }
 
     async remove() {
+        if (!this.state.object || !this.state.object.key) {
+            return;
+        }
+
         const s3 = new S3({ region: this.state.region });
+
+        // Check that bucket exists
+        try {
+            await s3.headBucket({ Bucket: this.state.bucket }).promise();
+        } catch (e) {
+            // If bucket doesn't exist, it was most likely deleted.
+            this.state = {};
+            await this.save();
+            return;
+        }
 
         this.context.instance.debug(
             "Removing object %o from %o",


### PR DESCRIPTION
## Related Issue
When removing a stack, the bucket gets removed before the `s3-object` (that's how dependencies are structured), and an error would occur the moment execution reaches the `serverless-aws-s3-object` component.

## Your solution
Before attempting to remove files, check if bucket still exists. If not, consider files removed.

## How Has This Been Tested?
Manually, by deploying a new stack, and removing it.

## Blog summary
**Title**: Gracefully handle S3 files removal
**Body**: With the recent changes to how we handle S3 buckets during stack removal, a new bug was revealed in another component. When attempting to remove your stack, S3 bucket is removed together with all of its contents, and once the `@webiny/serverless-aws-s3-object` component starts the removal procedure, it has no bucket to work with. With this release we now handle this case and stack removal will no longer cause your state to become corrupted.
