### PR TITLE
Generate JWT_SECRET, S3_BUCKET, and MONGODB_NAME for all environments

### DIFF
--- a/packages/cwp-template-cms/index.js
+++ b/packages/cwp-template-cms/index.js
@@ -7,8 +7,8 @@ const loadJsonFile = require("load-json-file");
 const writeJsonFile = require("write-json-file");
 const { v4: uuidv4 } = require("uuid");
 
-const s3BucketName = (projectId, appName) => {
-    return `${projectId}-${appName.toLowerCase().replace(/_/g, "-")}-files`;
+const s3BucketName = (projectId, appName, env) => {
+    return `${projectId}-${appName.toLowerCase().replace(/_/g, "-")}-${env}`;
 };
 
 module.exports = async ({ appName, root }) => {
@@ -30,18 +30,25 @@ module.exports = async ({ appName, root }) => {
         .split("-")
         .shift();
 
-    const jwtSecret = crypto
-        .randomBytes(128)
-        .toString("base64")
-        .slice(0, 60);
+    const jwtSecret = () =>
+        crypto
+            .randomBytes(128)
+            .toString("base64")
+            .slice(0, 60);
 
-    apiEnv.default["JWT_SECRET"] = jwtSecret;
-    apiEnv.default["S3_BUCKET"] = s3BucketName(projectId, appName);
+    apiEnv.local["JWT_SECRET"] = jwtSecret();
+    apiEnv.dev["JWT_SECRET"] = jwtSecret();
+    apiEnv.prod["JWT_SECRET"] = jwtSecret();
+    apiEnv.local["S3_BUCKET"] = s3BucketName(projectId, appName, "local");
+    apiEnv.dev["S3_BUCKET"] = s3BucketName(projectId, appName, "dev");
+    apiEnv.prod["S3_BUCKET"] = s3BucketName(projectId, appName, "prod");
     await writeJsonFile(apiEnvJson, apiEnv);
 
     const baseEnvPath = path.join(root, ".env.json");
     const baseEnv = await loadJsonFile(baseEnvPath);
-    baseEnv.default["MONGODB_NAME"] = appName;
+    baseEnv.local["MONGODB_NAME"] = `${appName}-local`;
+    baseEnv.dev["MONGODB_NAME"] = `${appName}-dev`;
+    baseEnv.prod["MONGODB_NAME"] = `${appName}-prod`;
     await writeJsonFile(baseEnvPath, baseEnv);
 
     let webinyRoot = fs.readFileSync(path.join(root, "webiny.root.js"), "utf-8");

--- a/packages/cwp-template-cms/template/api/example.env.json
+++ b/packages/cwp-template-cms/template/api/example.env.json
@@ -1,8 +1,18 @@
 {
   "default": {
     "GRAPHQL_INTROSPECTION": true,
-    "GRAPHQL_PLAYGROUND": true,
-    "S3_BUCKET": "[BUCKET]",
-    "JWT_SECRET": "[JWT_SECRET]"
+    "GRAPHQL_PLAYGROUND": true
+  },
+  "local": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
+  },
+  "dev": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
+  },
+  "prod": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
   }
 }

--- a/packages/cwp-template-cms/template/example.env.json
+++ b/packages/cwp-template-cms/template/example.env.json
@@ -1,8 +1,18 @@
 {
   "default": {
     "AWS_PROFILE": "default",
-    "AWS_REGION": "us-east-1",
+    "AWS_REGION": "us-east-1"
+  },
+  "local": {
     "MONGODB_SERVER": "[MONGODB_SERVER]",
-    "MONGODB_NAME": "webiny"
+    "MONGODB_NAME": "[MONGODB_NAME]"
+  },
+  "dev": {
+    "MONGODB_SERVER": "[MONGODB_SERVER]",
+    "MONGODB_NAME": "[MONGODB_NAME]"
+  },
+  "prod": {
+    "MONGODB_SERVER": "[MONGODB_SERVER]",
+    "MONGODB_NAME": "[MONGODB_NAME]"
   }
 }

--- a/packages/cwp-template-full/template/api/example.env.json
+++ b/packages/cwp-template-full/template/api/example.env.json
@@ -1,8 +1,18 @@
 {
   "default": {
     "GRAPHQL_INTROSPECTION": true,
-    "GRAPHQL_PLAYGROUND": true,
-    "S3_BUCKET": "[BUCKET]",
-    "JWT_SECRET": "[JWT_SECRET]"
+    "GRAPHQL_PLAYGROUND": true
+  },
+  "local": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
+  },
+  "dev": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
+  },
+  "prod": {
+    "JWT_SECRET": "[JWT_SECRET]",
+    "S3_BUCKET": "[BUCKET]"
   }
 }

--- a/packages/cwp-template-full/template/example.env.json
+++ b/packages/cwp-template-full/template/example.env.json
@@ -1,8 +1,18 @@
 {
   "default": {
     "AWS_PROFILE": "default",
-    "AWS_REGION": "us-east-1",
+    "AWS_REGION": "us-east-1"
+  },
+  "local": {
     "MONGODB_SERVER": "[MONGODB_SERVER]",
-    "MONGODB_NAME": "webiny"
+    "MONGODB_NAME": "[MONGODB_NAME]"
+  },
+  "dev": {
+    "MONGODB_SERVER": "[MONGODB_SERVER]",
+    "MONGODB_NAME": "[MONGODB_NAME]"
+  },
+  "prod": {
+    "MONGODB_SERVER": "[MONGODB_SERVER]",
+    "MONGODB_NAME": "[MONGODB_NAME]"
   }
 }


### PR DESCRIPTION
## Related Issue
While writing a document about Project State Management (#1099), it became clear that the environment files we generate are not complete, and can confuse our users. This in turn can cause all kinds of side effects, from mixing data, removing wrong buckets, etc.

## Your solution
To avoid any ambiguity, we now generate JWT_SECRET, S3_BUCKET, and MONGODB_NAME for all 3 environments (local, dev and prod) during project creation. Now when you deploy your stacks for specific environments, they will have clearly separated buckets and databases.

## How Has This Been Tested?
Manually, by creating a project locally.

## Screenshots (if relevant):
This is what your `.env.json` files will look like. In this example I used a project name `s3-buckets`.

![image](https://user-images.githubusercontent.com/3920893/86530577-214b5100-beba-11ea-8bbb-20ee8ccb3ea2.png)

## Blog summary
**Title**: Generate ENV variables for default environments
**Body**: With this release we improved generation of environment variables to avoid any accidents when deploying different environments. Each environment now has a clear definition of S3 bucket name and MongoDB database name. There are no more fallback values, and the contents of `.env.json` files is much more clear. Developers are still free to do whatever they want with the default configuration, but out-of-the-box, there is no more ambiguity and your environments are clearly separated.