### PR TITLE
Fix link preloading

### DIFF
--- a/packages/app-page-builder/src/site/plugins/linkPreload.ts
+++ b/packages/app-page-builder/src/site/plugins/linkPreload.ts
@@ -21,8 +21,9 @@ export default (): ReactRouterOnLinkPlugin => {
                 apolloClient.query({
                     query: GET_PUBLISHED_PAGE(),
                     variables: {
-                        url: link,
                         id: null,
+                        url: link,
+                        preview: false,
                         returnErrorPage: true,
                         returnNotFoundPage: true
                     }

--- a/packages/react-router/src/Link.tsx
+++ b/packages/react-router/src/Link.tsx
@@ -7,15 +7,23 @@ export type LinkProps = RouterLinkProps;
 function Link({ children, ...props }: LinkProps) {
     const { onLink } = useContext(RouterContext);
 
-    useEffect(() => {
-        onLink(props.to as string);
-    }, [props.to]);
+    let { to } = props;
 
-    const isInternal = typeof props.to === "string" ? props.to.startsWith("/") : true;
+    if (process.env.REACT_APP_ENV === "browser") {
+        if (typeof to === "string" && to.startsWith(window.location.origin)) {
+            to = to.replace(window.location.origin, "");
+        }
+    }
+
+    useEffect(() => {
+        onLink(to as string);
+    }, [to]);
+
+    const isInternal = typeof to === "string" ? to.startsWith("/") : true;
     const LinkComponent = isInternal ? RouterLink : "a";
     const componentProps = {
         ...props,
-        [isInternal ? "to" : "href"]: props.to
+        [isInternal ? "to" : "href"]: to
     };
 
     return <LinkComponent {...componentProps}>{children}</LinkComponent>;


### PR DESCRIPTION
## Related Issue
When `site` app was loaded in the browser, preloading of linked pages was broken for 2 reasons:
1) links in `pagesList` element were rendered with `fullUrl` which automatically skipped `onLink` handler (`fullUrl` is required for links to work properly inside local `admin` app, so we can't just use relative URLs).
2) `onLink` plugin in `app-page-builder` was missing a GraphQL query variable causing wrong cache key to be stored in Apollo Client's cache.

## Your solution
`<Link>` component now strips `window.location.origin` from links if origin is the same. This ensures that links on same origin will be treated as in-app links. This will properly trigger `onLink` plugins and avoid browser reloads.

## How Has This Been Tested?
Manually
