### PR TITLE
Fix: Headless CMS - sync environments with aliases

### DIFF
--- a/packages/app-headless-cms/src/admin/views/EnvironmentAliases/EnvironmentAliases.tsx
+++ b/packages/app-headless-cms/src/admin/views/EnvironmentAliases/EnvironmentAliases.tsx
@@ -11,16 +11,26 @@ import {
     UPDATE_ENVIRONMENT_ALIAS,
     DELETE_ENVIRONMENT_ALIAS
 } from "./graphql";
+import { LIST_ENVIRONMENTS } from "@webiny/app-headless-cms/admin/views/Environments/graphql";
+import { updateCacheAfterCreate } from "./environmentAliasesUtils";
 
 function EnvironmentAliases() {
     return (
         <CrudProvider
             delete={{
-                mutation: DELETE_ENVIRONMENT_ALIAS
+                mutation: DELETE_ENVIRONMENT_ALIAS,
+                options: {
+                    refetchQueries: [
+                        { query: LIST_ENVIRONMENTS, variables: { sort: { savedOn: -1 } } }
+                    ]
+                }
             }}
             read={READ_ENVIRONMENT_ALIAS}
             create={{
-                mutation: CREATE_ENVIRONMENT_ALIAS
+                mutation: CREATE_ENVIRONMENT_ALIAS,
+                options: {
+                    update: updateCacheAfterCreate
+                }
             }}
             update={{
                 mutation: UPDATE_ENVIRONMENT_ALIAS

--- a/packages/app-headless-cms/src/admin/views/EnvironmentAliases/environmentAliasesUtils.ts
+++ b/packages/app-headless-cms/src/admin/views/EnvironmentAliases/environmentAliasesUtils.ts
@@ -1,0 +1,43 @@
+import { LIST_ENVIRONMENTS } from "@webiny/app-headless-cms/admin/views/Environments/graphql";
+import { cloneDeep, get, pick } from "lodash";
+
+export const updateCacheAfterCreate = (cache, updated) => {
+    const error = get(updated, "data.cms.environmentAlias.error");
+    const updatedData = get(updated, "data.cms.environmentAlias.data");
+
+    if (error) {
+        // If the updated result has error, we return immediately
+        return;
+    }
+
+    const gqlParams = {
+        query: LIST_ENVIRONMENTS,
+        variables: { sort: { savedOn: -1 } }
+    };
+
+    let data: any;
+    try {
+        data = cloneDeep(cache.readQuery(gqlParams));
+    } catch (error) {
+        // If the entry for `gqlParams` doesn't exist is cache, we return immediately.
+        return;
+    }
+    // Update the cms environments data
+    data.cms.environments.data = data.cms.environments.data.map(item => {
+        if (item.id !== updatedData.environment.id) {
+            return item;
+        }
+        return {
+            ...item,
+            environmentAliases: [
+                ...item.environmentAliases,
+                pick(updatedData, ["id", "name", "__typename"])
+            ]
+        };
+    });
+
+    cache.writeQuery({
+        ...gqlParams,
+        data
+    });
+};

--- a/packages/app-headless-cms/src/admin/views/Environments/EnvironmentsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/Environments/EnvironmentsDataList.tsx
@@ -84,6 +84,7 @@ const EnvironmentsDataList = () => {
                                         {item.environmentAliases &&
                                             item.environmentAliases.map((envAlias, index) => (
                                                 <Link
+                                                    key={envAlias.id}
                                                     onClick={e => e.stopPropagation()}
                                                     to={`/settings/cms/environments/aliases?id=${envAlias.id}`}
                                                     title={t`This environment is linked with the "{environmentAlias}" alias.`(

--- a/typings/shared/index.d.ts
+++ b/typings/shared/index.d.ts
@@ -24,10 +24,3 @@ declare module "*.svg" {
     const src: string;
     export default src;
 }
-
-// Hot fix - check https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45927 for a fix.
-declare namespace NodeJS {
-    interface Module {
-        path: any;
-    }
-}


### PR DESCRIPTION
## Related Issue
Closes #1114 

## Your solution

- add `refetchQueries` to delete operation

- add `updateCacheAfterCreate` as update on create operation

## How Has This Been Tested?
Manually using the Admin app.

## Screenshots:
https://www.loom.com/share/44e758172bfe41978a41b939aa27b241