### PR TITLE
wip(headless): add test case to include setting multiple values as index

### DIFF
--- a/packages/api-headless-cms/__tests__/createIndexOnMultipleValuesField.test.js
+++ b/packages/api-headless-cms/__tests__/createIndexOnMultipleValuesField.test.js
@@ -1,0 +1,44 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/createIndexOnMultipleValuesField";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Multiple Values Test", () => {
+    const { database, environment } = useContentHandler();
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it(`should prevent the creation of an index that includes a multiple values field in the fields list`, async () => {
+        const { createContentModel, updateContentModel } = environment(initial.environment.id);
+
+        let error;
+        const productContentModel = await createContentModel(
+            mocks.blogWithTagsSetToMultipleValue({
+                contentModelGroupId: initial.contentModelGroup.id
+            })
+        );
+
+        let newSome;
+        const field = "tags";
+        try {
+            newSome = await updateContentModel({
+                id: productContentModel.id,
+                data: {
+                    indexes: {
+                        fields: ["tags"]
+                    }
+                }
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.message).toBe(
+            `Cannot create a new index with the "${field}" field included because the field accepts multiple values.`
+        );
+    });
+});

--- a/packages/api-headless-cms/__tests__/mocks/createIndexOnMultipleValuesField.js
+++ b/packages/api-headless-cms/__tests__/mocks/createIndexOnMultipleValuesField.js
@@ -1,0 +1,47 @@
+import { locales } from "./../mocks/I18NLocales";
+
+export default {
+    blogWithTagsSetToMultipleValue: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Blog",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "id-text",
+                    fieldId: "tags",
+                    type: "text",
+                    multipleValues: true,
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Tags"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Stichworte"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};

--- a/packages/api-headless-cms/__tests__/multipleValues.test.js
+++ b/packages/api-headless-cms/__tests__/multipleValues.test.js
@@ -121,31 +121,4 @@ describe("Multiple Values Test", () => {
             `Cannot change "multipleValues" for the "tags" field because it's already in use in created content.`
         );
     });
-
-    it(`should not be able to set "multipleValues" as index`, async () => {
-        const { createContentModel, updateContentModel, content } = environment(ids.environment);
-
-        let error;
-        const productContentModel = await createContentModel(
-            mocks.blogWithTagsSetToMultipleValue({ contentModelGroupId: ids.contentModelGroup })
-        );
-
-        let newSome;
-        try {
-            newSome = await updateContentModel({
-                id: productContentModel.id,
-                data: {
-                    indexes: {
-                        fields: ["tags"]
-                    }
-                }
-            });
-        } catch (e) {
-            error = e;
-        }
-
-        expect(error.message).toBe(
-            `Cannot create an index with a field with "multipleValues" set to true`
-        );
-    });
 });

--- a/packages/api-headless-cms/__tests__/multipleValues.test.js
+++ b/packages/api-headless-cms/__tests__/multipleValues.test.js
@@ -121,4 +121,27 @@ describe("Multiple Values Test", () => {
             `Cannot change "multipleValues" for the "tags" field because it's already in use in created content.`
         );
     });
+
+    it(`should not be able to set "multipleValues" as index`, async () => {
+        const { createContentModel, updateContentModel, content } = environment(ids.environment);
+
+        let error;
+        const productContentModel = await createContentModel(
+            mocks.blogWithTagsSetToMultipleValue({ contentModelGroupId: ids.contentModelGroup })
+        );
+
+        let newSome;
+        try {
+            newSome = await updateContentModel({
+                id: productContentModel.id,
+                data: {
+                    indexes: {
+                        fields: ["tags"]
+                    }
+                }
+            });
+        } catch (e) {
+            error = e;
+        }
+    });
 });

--- a/packages/api-headless-cms/__tests__/multipleValues.test.js
+++ b/packages/api-headless-cms/__tests__/multipleValues.test.js
@@ -143,5 +143,9 @@ describe("Multiple Values Test", () => {
         } catch (e) {
             error = e;
         }
+
+        expect(error.message).toBe(
+            `Cannot create an index with a field with "multipleValues" set to true`
+        );
     });
 });

--- a/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
+++ b/packages/api-headless-cms/__tests__/utils/useContentHandler/graphql.js
@@ -109,6 +109,9 @@ export const UPDATE_CONTENT_MODEL = /* GraphQL */ `
                 name
                 titleFieldId
                 lockedFields
+                indexes {
+                    fields
+                }
                 fields {
                     ${FIELDS_FIELDS}
                 }

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -212,12 +212,16 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                             if (field === "id") {
                                 continue;
                             }
-                            if (!this.fields.find(item => item.fieldId === field )) {
+                            if (!this.fields.find(item => item.fieldId === field)) {
                                 break indexesFor;
                             }
 
                             //if the fieldId is found, and it has multipleValues set to "true" it should return an error
-                            if (this.fields.find(item => item.fieldId === field && item.multipleValues)) {
+                            if (
+                                this.fields.find(
+                                    item => item.fieldId === field && item.multipleValues
+                                )
+                            ) {
                                 throw new Error(
                                     `Cannot create an index with a field with "multipleValues" set to true`
                                 );

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -212,9 +212,15 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                             if (field === "id") {
                                 continue;
                             }
-
-                            if (!this.fields.find(item => item.fieldId === field)) {
+                            if (!this.fields.find(item => item.fieldId === field )) {
                                 break indexesFor;
+                            }
+
+                            //if the fieldId is found, and it has multipleValues set to "true" it should return an error
+                            if (this.fields.find(item => item.fieldId === field && item.multipleValues)) {
+                                throw new Error(
+                                    `Cannot create an index with a field with "multipleValues" set to true`
+                                );
                             }
                         }
                     }

--- a/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/contentModel.model.ts
@@ -216,14 +216,14 @@ export default ({ createBase, context }: { createBase: Function; context: CmsCon
                                 break indexesFor;
                             }
 
-                            //if the fieldId is found, and it has multipleValues set to "true" it should return an error
+                            // If the fieldId is found, and it has multipleValues set to "true" it should return an error
                             if (
                                 this.fields.find(
                                     item => item.fieldId === field && item.multipleValues
                                 )
                             ) {
                                 throw new Error(
-                                    `Cannot create an index with a field with "multipleValues" set to true`
+                                    `Cannot create a new index with the "${field}" field included because the field accepts multiple values.`
                                 );
                             }
                         }


### PR DESCRIPTION
## Related Issue
Closes #910

## Your solution
Essentially added a test case to test for when a field within Content Models has `multipleValues` attribute to true, it should NOT be able to be set as an index.

## How Has This Been Tested?
Writing a test case for the following scenario above and fix the endpoint so that it won't allow it.

## Screenshots (if relevant):
