### PR TITLE
fix(headless): remove createdBy and updateBy for api of headless cms

### DIFF
--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
@@ -112,7 +112,6 @@ export default /* GraphQL */ `
 
     extend type Query {
         getCategory(where: CategoryGetWhereInput!): CategoryResponse
-
         listCategories(
             where: CategoryListWhereInput
             sort: [CategoryListSorter]

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
@@ -112,6 +112,7 @@ export default /* GraphQL */ `
 
     extend type Query {
         getCategory(where: CategoryGetWhereInput!): CategoryResponse
+
         listCategories(
             where: CategoryListWhereInput
             sort: [CategoryListSorter]

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
@@ -2,8 +2,6 @@ export default /* GraphQL */ `
     "Product category"
     type Category {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
@@ -11,8 +11,6 @@ export default /* GraphQL */ `
     }
     type Product {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/review.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/review.js
@@ -11,8 +11,6 @@ export default /* GraphQL */ `
     }
     type Review {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/category.js
@@ -2,8 +2,6 @@ export default /* GraphQL */ `
     "Product category"
     type Category {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
@@ -2,8 +2,6 @@ export default /* GraphQL */ `
     "Products being sold in our webshop"
     type Product {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/review.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/review.js
@@ -2,8 +2,6 @@ export default /* GraphQL */ `
     "Product review"
     type Review {
         id: ID
-        createdBy: SecurityUser
-        updatedBy: SecurityUser
         createdOn: DateTime
         updatedOn: DateTime
         savedOn: DateTime

--- a/packages/api-headless-cms/src/content/plugins/graphql.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphql.ts
@@ -121,7 +121,6 @@ export default ({ type }) => [
                     layout: [[String]]
                     createdOn: DateTime
                     savedOn: DateTime
-                    createdBy: SecurityUser
                     titleFieldId: String
                     fields: [CmsContentModelField]
                     totalFields: Int

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
@@ -38,8 +38,6 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
             .join("\n")}
         type ${mTypeName} {
             id: ID
-            createdBy: SecurityUser
-            updatedBy: SecurityUser
             createdOn: DateTime
             updatedOn: DateTime
             savedOn: DateTime

--- a/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
@@ -33,8 +33,6 @@ export const createReadSDL: CreateManageSDL = ({ model, fieldTypePlugins }): str
         "${model.description}"
         type ${rTypeName} {
             id: ID
-            createdBy: SecurityUser
-            updatedBy: SecurityUser
             createdOn: DateTime
             updatedOn: DateTime
             savedOn: DateTime

--- a/packages/api-headless-cms/src/content/plugins/utils/commonFieldResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/commonFieldResolvers.ts
@@ -1,10 +1,4 @@
 // TODO: send graphql query to `security` service
 export const commonFieldResolvers = () => ({
-    id: entry => (entry.id ? entry.id : null),
-    createdBy: entry => {
-        return !entry.createdBy ? null : { __typename: "SecurityUser", id: entry.createdBy };
-    },
-    updatedBy: entry => {
-        return !entry.createdBy ? null : { __typename: "SecurityUser", id: entry.createdBy };
-    }
+    id: entry => (entry.id ? entry.id : null)
 });


### PR DESCRIPTION
## Related Issue
Closes #828 

## Your solution
The original idea was to figure out how make sure the first/last name appear, but it was later decided to remove the `createdBy` property. Because `createdBy` is referenced by `updatedBy`, I took the liberty of removing references to `updatedBy` since it seemed in the same vein of issue. This change is limited to only `api-headless-cms`.

## How Has This Been Tested?

## Screenshots (if relevant):
I also kept the last modified since this is still relevant to the user.
