### PR TITLE
Fix: field labels not shown for current locale

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicListMultipleValues.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicListMultipleValues.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { i18n } from "@webiny/app/i18n";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { css } from "emotion";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -14,22 +14,22 @@ const style = {
     })
 };
 
-const DynamicListMultipleValues = ({ field, getBind, Label, children }) => {
+const DynamicListMultipleValues = ({ field, getBind, Label, children, locale }) => {
     const Bind = getBind();
     const FirstFieldBind = getBind(0);
+    const { getValue } = useI18N();
 
     return (
         <Bind>
             {bindField => {
                 const { value, appendValue } = bindField;
+
+                const label = getValue(field.label, locale);
+
                 return (
                     <Grid>
                         <Cell span={12}>
-                            {field.label && (
-                                <Label>
-                                    <I18NValue value={field.label} />
-                                </Label>
-                            )}
+                            {field.label && <Label>{label}</Label>}
 
                             <FirstFieldBind>
                                 {bindIndex =>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/boolean/booleanSwitch.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/boolean/booleanSwitch.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Switch } from "@webiny/ui/Switch";
 import get from "lodash/get";
-
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/boolean");
 
@@ -21,18 +20,16 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
-                    {bindProps => (
-                        <Switch
-                            {...bindProps}
-                            label={I18NValue({ value: field.label })}
-                            description={I18NValue({ value: field.helpText })}
-                        />
-                    )}
+                    {bindProps => <Switch {...bindProps} label={label} description={helpText} />}
                 </Bind>
             );
         }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/checkboxes.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/checkboxes.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Checkbox, CheckboxGroup } from "@webiny/ui/Checkbox";
 import { i18n } from "@webiny/app/i18n";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -28,12 +28,14 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 options = Array.isArray(valuesItem.value) ? valuesItem.value : [];
             }
 
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const helpText = getValue(field.helpText, locale);
+
             return (
                 <Bind>
-                    <CheckboxGroup
-                        label={I18NValue({ value: field.label })}
-                        description={I18NValue({ value: field.helpText })}
-                    >
+                    <CheckboxGroup label={label} description={helpText}>
                         {({ onChange, getValue }) => (
                             <React.Fragment>
                                 {options.map((option, index) => (

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
@@ -64,6 +64,7 @@ const DateTimeWithTimezone = props => {
                         label: appendTextToLabel(props.field.label, " date")
                     }}
                     type={"date"}
+                    locale={props.locale}
                 />
             </Cell>
             <Cell span={4}>
@@ -82,6 +83,7 @@ const DateTimeWithTimezone = props => {
                     }}
                     type={"time"}
                     step={5}
+                    locale={props.locale}
                 />
             </Cell>
             <Cell span={cellSize}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -46,6 +46,7 @@ const DateTimeWithoutTimezone = props => {
                         label: appendTextToLabel(props.field.label, " date")
                     }}
                     type={"date"}
+                    locale={props.locale}
                 />
             </Cell>
             <Cell span={cellSize}>
@@ -64,6 +65,7 @@ const DateTimeWithoutTimezone = props => {
                     }}
                     type={"time"}
                     step={5}
+                    locale={props.locale}
                 />
             </Cell>
             <RemoveFieldButton trailingIcon={props.trailingIcon} />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { CmsEditorField } from "@webiny/app-headless-cms/types";
 import { BindComponentRenderProp } from "@webiny/form";
 import { Input as UiInput } from "@webiny/ui/Input";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 type TrailingIconType = {
     icon: React.ReactNode;
@@ -15,9 +15,16 @@ type Props = {
     bind: BindComponentRenderProp;
     field: CmsEditorField;
     trailingIcon?: TrailingIconType;
+    locale?: string;
 };
 
 const Input = (props: Props) => {
+    const { getValue } = useI18N();
+
+    const label = getValue(props.field.label, props.locale);
+    const placeholderText = getValue(props.field.placeholderText, props.locale);
+    const helpText = getValue(props.field.helpText, props.locale);
+
     return (
         <UiInput
             {...props}
@@ -28,9 +35,9 @@ const Input = (props: Props) => {
                 }
                 return props.bind.onChange(value);
             }}
-            label={I18NValue({ value: props.field.label })}
-            placeholder={I18NValue({ value: props.field.placeholderText })}
-            description={I18NValue({ value: props.field.helpText })}
+            label={label}
+            placeholder={placeholderText}
+            description={helpText}
             type={props.type}
             trailingIcon={props.trailingIcon}
         />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -3,18 +3,7 @@ import Input from "./Input";
 
 const Time = props => {
     // "09:00:00"
-    return (
-        <Input
-            {...props}
-            field={{
-                ...props.field,
-                label: props.label || props.field.label
-            }}
-            type={"time"}
-            step={5}
-            trailingIcon={props.trailingIcon}
-        />
-    );
+    return <Input {...props} type={"time"} step={5} trailingIcon={props.trailingIcon} />;
 };
 
 export default Time;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -8,7 +8,7 @@ const Time = props => {
             {...props}
             field={{
                 ...props.field,
-                label: props.label
+                label: props.label || props.field.label
             }}
             type={"time"}
             step={5}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { Input } from "@webiny/ui/Input";
 import DateTimeWithoutTimezone from "./DateTimeWithoutTimezone";
 import DateTimeWithTimezone from "./DateTimeWithTimezone";
 import Time from "./Time";
+import Input from "./Input";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 import get from "lodash/get";
@@ -22,23 +22,38 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
 
             return (
                 <Bind>
                     {bind => {
                         if (field.settings.type === "dateTimeWithoutTimezone") {
-                            return <DateTimeWithoutTimezone field={field} bind={bind} />;
+                            return (
+                                <DateTimeWithoutTimezone
+                                    field={field}
+                                    bind={bind}
+                                    locale={locale}
+                                />
+                            );
                         }
                         if (field.settings.type === "dateTimeWithTimezone") {
-                            return <DateTimeWithTimezone field={field} bind={bind} />;
+                            return (
+                                <DateTimeWithTimezone field={field} bind={bind} locale={locale} />
+                            );
                         }
                         if (field.settings.type === "time") {
-                            return <Time field={field} bind={bind} />;
+                            return <Time field={field} bind={bind} locale={locale} />;
                         }
 
-                        return <Input {...bind} type={field.settings.type} />;
+                        return (
+                            <Input
+                                bind={bind}
+                                field={field}
+                                locale={locale}
+                                type={field.settings.type}
+                            />
+                        );
                     }}
                 </Bind>
             );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { Input } from "@webiny/ui/Input";
 import DateTimeWithoutTimezone from "./DateTimeWithoutTimezone";
 import DateTimeWithTimezone from "./DateTimeWithTimezone";
 import Time from "./Time";
+import Input from "./Input";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 import get from "lodash/get";
@@ -25,7 +25,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
             );
         },
         render(props) {
-            const field = props.field;
+            const { field, locale } = props;
 
             return (
                 <DynamicListMultipleValues {...props}>
@@ -41,6 +41,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                     field={field}
                                     bind={bind.index}
                                     trailingIcon={trailingIcon}
+                                    locale={locale}
                                 />
                             );
                         }
@@ -50,6 +51,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                     field={field}
                                     bind={bind.index}
                                     trailingIcon={trailingIcon}
+                                    locale={locale}
                                 />
                             );
                         }
@@ -60,16 +62,21 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                     bind={bind.index}
                                     label={t`Value {number}`({ number: index + 1 })}
                                     trailingIcon={trailingIcon}
+                                    locale={locale}
                                 />
                             );
                         }
 
                         return (
                             <Input
-                                {...bind.index}
+                                bind={{
+                                    ...bind.index,
+                                    label: t`Value {number}`({ number: index + 1 })
+                                }}
+                                field={field}
                                 type={field.settings.type}
-                                label={t`Value {number}`({ number: index + 1 })}
                                 trailingIcon={trailingIcon}
+                                locale={locale}
                             />
                         );
                     }}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -9,6 +9,7 @@ const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 import get from "lodash/get";
 import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/close.svg";
 import DynamicListMultipleValues from "@webiny/app-headless-cms/admin/plugins/fieldRenderers/DynamicListMultipleValues";
+import { appendTextToLabel } from "@webiny/app-headless-cms/admin/plugins/fieldRenderers/dateTime/utils";
 
 const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
@@ -58,7 +59,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
                         if (field.settings.type === "time") {
                             return (
                                 <Time
-                                    field={field}
+                                    field={{
+                                        ...props.field,
+                                        label: appendTextToLabel(
+                                            props.field.label,
+                                            t` Value {number}`({ number: index + 1 })
+                                        )
+                                    }}
                                     bind={bind.index}
                                     label={t`Value {number}`({ number: index + 1 })}
                                     trailingIcon={trailingIcon}
@@ -69,11 +76,14 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
                         return (
                             <Input
-                                bind={{
-                                    ...bind.index,
-                                    label: t`Value {number}`({ number: index + 1 })
+                                bind={bind.index}
+                                field={{
+                                    ...props.field,
+                                    label: appendTextToLabel(
+                                        props.field.label,
+                                        t` Value {number}`({ number: index + 1 })
+                                    )
                                 }}
-                                field={field}
                                 type={field.settings.type}
                                 trailingIcon={trailingIcon}
                                 locale={locale}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/SingleFile.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/SingleFile.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useCallback } from "react";
 import { createRenderImagePreview, imageExtensions } from "./utils";
 import FileUpload from "./FileUpload";
 import fileIcon from "../../fields/icons/round_insert_drive_file-24px.svg";
+import { CmsEditorField } from "@webiny/app-headless-cms/types";
+import { BindComponentRenderProp } from "@webiny/form";
 
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/file");
@@ -11,7 +13,13 @@ const imagePreviewProps = {
     style: { width: "100%", height: 300, objectFit: "contain" }
 };
 
-const SingleFile = props => {
+type SingleFileProps = {
+    bind: BindComponentRenderProp;
+    field: CmsEditorField;
+    description?: string;
+};
+
+const SingleFile = (props: SingleFileProps) => {
     const [previewURL, setPreviewURL] = useState(null);
     const [isImage, setIsImage] = useState(true);
     // Update `previewURL`
@@ -57,6 +65,7 @@ const SingleFile = props => {
             value={getValue()}
             imagePreviewProps={imagePreviewProps}
             placeholder={t`Select a file"`}
+            description={props.description}
             renderImagePreview={
                 !isImage && createRenderImagePreview({ value: props.bind.value, imagePreviewProps })
             }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
@@ -29,10 +29,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
                         <Label>{label}</Label>
                         <Bind>
                             {bind => (
-                                <SingleFile
-                                    field={field}
-                                    bind={{ ...bind, description: helpText }}
-                                />
+                                <SingleFile field={field} bind={bind} description={helpText} />
                             )}
                         </Bind>
                     </Cell>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
 import SingleFile from "./SingleFile";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { i18n } from "@webiny/app/i18n";
 import { Cell, Grid } from "@webiny/ui/Grid";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 const t = i18n.ns("app-headless-cms/admin/fields/file");
 
 const plugin: CmsEditorFieldRendererPlugin = {
@@ -16,16 +16,25 @@ const plugin: CmsEditorFieldRendererPlugin = {
         canUse({ field }) {
             return field.type === "file" && !field.multipleValues;
         },
-        render({ field, getBind, Label }) {
+        render({ field, getBind, Label, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Grid>
                     <Cell span={12}>
-                        <Label>
-                            <I18NValue value={field.label} />
-                        </Label>
-                        <Bind>{bind => <SingleFile field={field} bind={bind} />}</Bind>
+                        <Label>{label}</Label>
+                        <Bind>
+                            {bind => (
+                                <SingleFile
+                                    field={field}
+                                    bind={{ ...bind, description: helpText }}
+                                />
+                            )}
+                        </Bind>
                     </Cell>
                 </Grid>
             );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -1,26 +1,27 @@
 import React, { useState } from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { i18n } from "@webiny/app/i18n";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import MultipleFile from "./MultipleFile";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/file");
 
-function CmsEditorFieldRenderer({ field, getBind, Label }) {
+function CmsEditorFieldRenderer({ field, getBind, Label, locale }) {
     const [previewURLs, setPreviewURLs] = useState({});
 
     const Bind = getBind();
     const FirstFieldBind = getBind(0);
+
+    const { getValue } = useI18N();
+    const label = getValue(field.label, locale);
 
     return (
         <Bind>
             {({ appendValues, value, appendValue }) => (
                 <Grid>
                     <Cell span={12}>
-                        <Label>
-                            <I18NValue value={field.label} />
-                        </Label>
+                        <Label>{label}</Label>
                     </Cell>
                     <Cell span={3}>
                         <FirstFieldBind>
@@ -84,8 +85,15 @@ const plugin: CmsEditorFieldRendererPlugin = {
         canUse({ field }) {
             return field.type === "file" && field.multipleValues;
         },
-        render({ field, getBind, Label }) {
-            return <CmsEditorFieldRenderer field={field} getBind={getBind} Label={Label} />;
+        render({ field, getBind, Label, locale }) {
+            return (
+                <CmsEditorFieldRenderer
+                    field={field}
+                    getBind={getBind}
+                    Label={Label}
+                    locale={locale}
+                />
+            );
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/longText/longTextTextArea.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/longText/longTextTextArea.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
 import { Input } from "@webiny/ui/Input";
-import { I18NValue } from "@webiny/app-i18n/components";
-import { i18n } from "@webiny/app/i18n";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
+import { i18n } from "@webiny/app/i18n";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -21,8 +21,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const placeholderText = getValue(field.placeholderText, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
@@ -31,7 +36,9 @@ const plugin: CmsEditorFieldRendererPlugin = {
                             {...bind}
                             autoFocus
                             rows={5}
-                            label={I18NValue({ value: field.label })}
+                            label={label}
+                            placeholder={placeholderText}
+                            description={helpText}
                         />
                     )}
                 </Bind>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Input } from "@webiny/ui/Input";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/number");
 
@@ -20,8 +20,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const placeholderText = getValue(field.placeholderText, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
@@ -33,9 +38,9 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                     value = parseFloat(value);
                                     return bindProps.onChange(value);
                                 }}
-                                label={I18NValue({ value: field.label })}
-                                placeholder={I18NValue({ value: field.placeholderText })}
-                                description={I18NValue({ value: field.helpText })}
+                                label={label}
+                                placeholder={placeholderText}
+                                description={helpText}
                                 type="number"
                             />
                         );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/radioButtons.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/radioButtons.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Radio, RadioGroup } from "@webiny/ui/Radio";
 import { i18n } from "@webiny/app/i18n";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -28,12 +28,14 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 options = Array.isArray(valuesItem.value) ? valuesItem.value : [];
             }
 
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const helpText = getValue(field.helpText, locale);
+
             return (
                 <Bind>
-                    <RadioGroup
-                        label={I18NValue({ value: field.label })}
-                        description={I18NValue({ value: field.helpText })}
-                    >
+                    <RadioGroup label={label} description={helpText}>
                         {({ onChange, getValue }) => (
                             <React.Fragment>
                                 {options.map((option, index) => (

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
@@ -4,7 +4,6 @@ import { useQuery } from "@webiny/app-headless-cms/admin/hooks";
 import get from "lodash/get";
 import debounce from "lodash/debounce";
 import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { createListQuery, createGetQuery, GET_CONTENT_MODEL } from "./graphql";
 import { i18n } from "@webiny/app/i18n";
 import { Link } from "@webiny/react-router";
@@ -92,16 +91,19 @@ function ContentEntriesAutocomplete({ bind, field, locale }) {
             }
         );
 
+    const label = getValue(field.label, locale);
+    const helpText = getValue(field.helpText, locale);
+
     return (
         <AutoComplete
             {...bind}
             loading={loading}
             value={{ id, name }}
             options={search ? options : defaultOptions}
-            label={<I18NValue value={field.label} />}
+            label={label}
             description={
                 <>
-                    <I18NValue value={field.helpText} />
+                    {helpText}
                     {unpublishedEntryInfo}
                 </>
             }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesMultiAutoComplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesMultiAutoComplete.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useMemo } from "react";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { MultiAutoComplete } from "@webiny/ui/AutoComplete";
 import { useQuery } from "@webiny/app-headless-cms/admin/hooks";
 import get from "lodash/get";
 import debounce from "lodash/debounce";
 import { createListQuery, GET_CONTENT_MODEL } from "./graphql";
-import { i18n } from "@webiny/app/i18n";
 import { Link } from "@webiny/react-router";
 import { useI18NHelpers } from "./refInputUtils";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
+import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/ref");
 
 function ContentEntriesMultiAutocomplete({ bind, field, locale }) {
@@ -15,6 +15,7 @@ function ContentEntriesMultiAutocomplete({ bind, field, locale }) {
     const value = bind.value.map(item => {
         return get(item, "id", item);
     });
+    const { getValue } = useI18N();
     const [search, setSearch] = useState("");
 
     const { getAutoCompleteOptionsFromList } = useI18NHelpers();
@@ -115,17 +116,20 @@ function ContentEntriesMultiAutocomplete({ bind, field, locale }) {
         });
     }
 
+    const label = getValue(field.label, locale);
+    const helpText = getValue(field.helpText, locale);
+
     return (
         <MultiAutoComplete
             {...bind}
             loading={loading}
             value={valueForAutoComplete}
             options={search ? options : defaultOptions}
-            label={<I18NValue value={field.label} />}
+            label={label}
             onInput={debounce(search => setSearch(search), 250)}
             description={
                 <>
-                    <I18NValue value={field.helpText} />
+                    {helpText}
                     {unpublishedEntriesInfo}
                 </>
             }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { i18n } from "@webiny/app/i18n";
 import I18NRichTextEditor from "@webiny/app-i18n/admin/components/I18NRichTextEditor";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
@@ -21,8 +21,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const placeholderText = getValue(field.placeholderText, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
@@ -30,9 +35,9 @@ const plugin: CmsEditorFieldRendererPlugin = {
                         <I18NRichTextEditor
                             {...bind}
                             onChange={bind.onChange}
-                            label={I18NValue({ value: field.label })}
-                            placeholder={I18NValue({ value: field.placeholderText })}
-                            description={I18NValue({ value: field.helpText })}
+                            label={label}
+                            placeholder={placeholderText}
+                            description={helpText}
                         />
                     )}
                 </Bind>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
@@ -6,6 +6,7 @@ import I18NRichTextEditor from "@webiny/app-i18n/admin/components/I18NRichTextEd
 import { ReactComponent as DeleteIcon } from "@webiny/app-headless-cms/admin/icons/close.svg";
 import get from "lodash/get";
 import DynamicListMultipleValues from "@webiny/app-headless-cms/admin/plugins/fieldRenderers/DynamicListMultipleValues";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
@@ -24,15 +25,20 @@ const plugin: CmsEditorFieldRendererPlugin = {
             );
         },
         render(props) {
-            const { field } = props;
+            const { field, locale } = props;
+            const { getValue } = useI18N();
+
+            const placeholderText = getValue(field.placeholderText, locale);
+            const helpText = getValue(field.helpText, locale);
+
             return (
                 <DynamicListMultipleValues {...props}>
                     {({ bind, index }) => (
                         <I18NRichTextEditor
                             {...bind.index}
                             label={I18NValue({ value: `Value ${index + 1}` })}
-                            placeholder={I18NValue({ value: field.placeholderText })}
-                            description={I18NValue({ value: field.helpText })}
+                            placeholder={placeholderText}
+                            description={helpText}
                             trailingIcon={
                                 index > 0 && {
                                     icon: <DeleteIcon />,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Select } from "@webiny/ui/Select";
 import { i18n } from "@webiny/app/i18n";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -23,16 +23,17 @@ const plugin: CmsEditorFieldRendererPlugin = {
             const valuesItem = field.predefinedValues.values.values.find(
                 item => item.locale === locale
             );
-            
+
             const options = valuesItem && Array.isArray(valuesItem.value) ? valuesItem.value : [];
+
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
-                    <Select
-                        label={I18NValue({ value: field.label })}
-                        description={I18NValue({ value: field.helpText })}
-                        options={options}
-                    />
+                    <Select label={label} description={helpText} options={options} />
                 </Bind>
             );
         }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/textInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/textInput.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "@webiny/app-headless-cms/types";
-import { I18NValue } from "@webiny/app-i18n/components";
 import { Input } from "@webiny/ui/Input";
 import get from "lodash/get";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -20,17 +20,22 @@ const plugin: CmsEditorFieldRendererPlugin = {
                 !get(field, "predefinedValues.enabled")
             );
         },
-        render({ field, getBind }) {
+        render({ field, getBind, locale }) {
             const Bind = getBind();
+            const { getValue } = useI18N();
+
+            const label = getValue(field.label, locale);
+            const placeholderText = getValue(field.placeholderText, locale);
+            const helpText = getValue(field.helpText, locale);
 
             return (
                 <Bind>
                     {bind => (
                         <Input
                             {...bind}
-                            label={I18NValue({ value: field.label })}
-                            placeholder={I18NValue({ value: field.placeholderText })}
-                            description={I18NValue({ value: field.helpText })}
+                            label={label}
+                            placeholder={placeholderText}
+                            description={helpText}
                         />
                     )}
                 </Bind>


### PR DESCRIPTION
## Related Issue

Closes #1096 

## Your solution
Use `getValue` function from `useI18N` hook to get values like `label and description` for current locale.

## How Has This Been Tested?
Manually using the Admin app.

## Screenshots (if relevant):
https://www.loom.com/share/6144458813ec4d4dbb38693b464942de