### PR TITLE
Fix: Hiding settings tab if no permissions / user roles set

### DIFF
--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -4,7 +4,8 @@ import { registerPlugins, getPlugins } from "@webiny/plugins";
 import { ReactComponent as SettingsIcon } from "@webiny/app-admin/assets/icons/round-settings-24px.svg";
 import { WebinyInitPlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
-import { hasScopes } from "@webiny/app-security"; 
+
+import { hasScopes } from "@webiny/app-security"; // remove later
 
 const t = i18n.namespace("app-admin/menus");
 
@@ -14,14 +15,19 @@ const plugin: WebinyInitPlugin = {
     init() {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
-        const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
 
         registerPlugins({
             name: "menu-settings",
             type: "admin-menu",
             order: 100,
             render({ Menu, Section, Item }) {    
+                const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
+                
+                //replace pl.scopes with pl.permitted to check a boolean value instead
                 const canSeeAnySettings = settingsPlugins.some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
+                
+                console.log("checking PB Settings permission from init file:::::::")
+                console.log(hasScopes(["pb:settings"], { forceBoolean: true }));
                 console.log("canSeeAnyScope");
                 console.log(canSeeAnySettings);
                 console.log(settingsPlugins);

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -4,7 +4,6 @@ import { registerPlugins, getPlugins } from "@webiny/plugins";
 import { ReactComponent as SettingsIcon } from "@webiny/app-admin/assets/icons/round-settings-24px.svg";
 import { WebinyInitPlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
-import { hasScopes } from "@webiny/app-security"; // remove later
 
 const t = i18n.namespace("app-admin/menus");
 

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -4,7 +4,6 @@ import { registerPlugins, getPlugins } from "@webiny/plugins";
 import { ReactComponent as SettingsIcon } from "@webiny/app-admin/assets/icons/round-settings-24px.svg";
 import { WebinyInitPlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
-
 import { hasScopes } from "@webiny/app-security"; // remove later
 
 const t = i18n.namespace("app-admin/menus");
@@ -23,28 +22,31 @@ const plugin: WebinyInitPlugin = {
             render({ Menu, Section, Item }) {    
                 const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
                 
-                //replace pl.scopes with pl.permitted to check a boolean value instead
-                const canSeeAnySettings = settingsPlugins.some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
+                //retrieves permitted key and value for settingsPlugins and receives data for display
+                const renderedSettingsPlugins = settingsPlugins.map(pl => {
+                    return {
+                        name: pl.name,
+                        rendered: pl.render({ Section, Item })
+                    }
+                });
                 
-                console.log("checking PB Settings permission from init file:::::::")
-                console.log(hasScopes(["pb:settings"], { forceBoolean: true }));
-                console.log("canSeeAnyScope");
+                //set to true, if atleast one settings plugins are permitted for the user
+                const canSeeAnySettings = settingsPlugins.some(pl => pl.permitted == true, { forceBoolean: true });
+                console.log("canSeeAnySettings::::::");
                 console.log(canSeeAnySettings);
-                console.log(settingsPlugins);
                 if (canSeeAnySettings) {
                     return (
                         <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
-                            {settingsPlugins.map(plugin => (
+                            {renderedSettingsPlugins.map(plugin => (
                                 <React.Fragment key={plugin.name}>
-                                    {plugin.render({ Section, Item })}
+                                    {plugin.rendered}
                                 </React.Fragment>
                             ))}
                         </Menu>
                     );
                 } else {
-                    return (
-                        <h1>Welcome to Webiny!</h1>
-                    )
+                    //returning blank for now, incase other tabs are available in side nav
+                    return;
                 }
             }
         });

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -14,17 +14,18 @@ const plugin: WebinyInitPlugin = {
     init() {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
+        const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
+
         registerPlugins({
             name: "menu-settings",
             type: "admin-menu",
             order: 100,
-            render({ Menu, Section, Item }) {
-                const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
-                const canSeeAnyScope = settingsPlugins.some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
+            render({ Menu, Section, Item }) {    
+                const canSeeAnySettings = settingsPlugins.some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
                 console.log("canSeeAnyScope");
-                console.log(canSeeAnyScope);
+                console.log(canSeeAnySettings);
                 console.log(settingsPlugins);
-                if (canSeeAnyScope) {
+                if (canSeeAnySettings) {
                     return (
                         <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
                             {settingsPlugins.map(plugin => (

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -31,8 +31,7 @@ const plugin: WebinyInitPlugin = {
                 
                 //set to true, if atleast one settings plugins are permitted for the user
                 const canSeeAnySettings = settingsPlugins.some(pl => pl.permitted == true, { forceBoolean: true });
-                console.log("canSeeAnySettings::::::");
-                console.log(canSeeAnySettings);
+   
                 if (canSeeAnySettings) {
                     return (
                         <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -21,23 +21,28 @@ const plugin: WebinyInitPlugin = {
             render({ Menu, Section, Item }) {    
                 const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
                 
-                //retrieves permitted key and value for settingsPlugins and receives data for display
+                //renders the settings plugins to receive data for both display and permissions checks
                 const renderedSettingsPlugins = settingsPlugins.map(pl => {
                     return {
                         name: pl.name,
-                        rendered: pl.render({ Section, Item })
+                        data: pl.render({ Section, Item })
                     }
                 });
                 
+                console.log("renderedSettingsPlugins:::::::");
+                console.log(renderedSettingsPlugins);
+
                 //set to true, if atleast one settings plugins are permitted for the user
-                const canSeeAnySettings = settingsPlugins.some(pl => pl.permitted == true, { forceBoolean: true });
+                let canSeeAnySettings = renderedSettingsPlugins.some(pl => pl.data.props.permitted == true, { forceBoolean: true });
    
                 if (canSeeAnySettings) {
+
+                    //displays plugin data
                     return (
                         <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
-                            {renderedSettingsPlugins.map(plugin => (
+                            {settingsPlugins.map(plugin => (
                                 <React.Fragment key={plugin.name}>
-                                    {plugin.rendered}
+                                    {plugin.data}
                                 </React.Fragment>
                             ))}
                         </Menu>

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -15,17 +15,11 @@ const plugin: WebinyInitPlugin = {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
         
-        /*const canSeeAnyScope = getPlugins<AdminMenuSettingsPlugin>(
-            "admin-menu-settings"
-        ).some(pl => {
-            hasScopes(pl[0].scopes, { forceBoolean: true }));
-        }*/
-    
         const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
 
-        const canSeeAnyScope = settingsPlugins.some(pl => {
-            hasScopes(pl.scopes, { forceBoolean: true })
-        });
+        const canSeeAnyScope = getPlugins<AdminMenuSettingsPlugin>(
+            "admin-menu-settings"
+        ).some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
 
         console.log("canSeeAnyScope");
         console.log(canSeeAnyScope);

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -14,6 +14,9 @@ const plugin: WebinyInitPlugin = {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
         const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
+        console.log("settingsPlugins");
+        console.log(settingsPlugins);
+        console.log(settingsPlugins.length);
 
         registerPlugins({
             name: "menu-settings",

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -34,7 +34,7 @@ const plugin: WebinyInitPlugin = {
 
                 //set to true, if atleast one settings plugins are permitted for the user
                 let canSeeAnySettings = renderedSettingsPlugins.some(pl => pl.data.props.permitted == true, { forceBoolean: true });
-   
+
                 if (canSeeAnySettings) {
 
                     //displays plugin data

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -4,6 +4,7 @@ import { registerPlugins, getPlugins } from "@webiny/plugins";
 import { ReactComponent as SettingsIcon } from "@webiny/app-admin/assets/icons/round-settings-24px.svg";
 import { WebinyInitPlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
+import { hasScopes } from "@webiny/app-security"; 
 
 const t = i18n.namespace("app-admin/menus");
 
@@ -13,10 +14,22 @@ const plugin: WebinyInitPlugin = {
     init() {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
+        
+        /*const canSeeAnyScope = getPlugins<AdminMenuSettingsPlugin>(
+            "admin-menu-settings"
+        ).some(pl => {
+            hasScopes(pl[0].scopes, { forceBoolean: true }));
+        }*/
+    
         const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
-        console.log("settingsPlugins");
+
+        const canSeeAnyScope = settingsPlugins.some(pl => {
+            hasScopes(pl.scopes, { forceBoolean: true })
+        });
+
+        console.log("canSeeAnyScope");
+        console.log(canSeeAnyScope);
         console.log(settingsPlugins);
-        console.log(settingsPlugins.length);
 
         registerPlugins({
             name: "menu-settings",

--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -14,31 +14,31 @@ const plugin: WebinyInitPlugin = {
     init() {
         // Settings
         // Apps / integrations can register settings plugins and add menu items like the following.
-        
-        const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
-
-        const canSeeAnyScope = getPlugins<AdminMenuSettingsPlugin>(
-            "admin-menu-settings"
-        ).some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
-
-        console.log("canSeeAnyScope");
-        console.log(canSeeAnyScope);
-        console.log(settingsPlugins);
-
         registerPlugins({
             name: "menu-settings",
             type: "admin-menu",
             order: 100,
             render({ Menu, Section, Item }) {
-                return (
-                    <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
-                        {settingsPlugins.map(plugin => (
-                            <React.Fragment key={plugin.name}>
-                                {plugin.render({ Section, Item })}
-                            </React.Fragment>
-                        ))}
-                    </Menu>
-                );
+                const settingsPlugins = getPlugins<AdminMenuSettingsPlugin>("admin-menu-settings");
+                const canSeeAnyScope = settingsPlugins.some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
+                console.log("canSeeAnyScope");
+                console.log(canSeeAnyScope);
+                console.log(settingsPlugins);
+                if (canSeeAnyScope) {
+                    return (
+                        <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
+                            {settingsPlugins.map(plugin => (
+                                <React.Fragment key={plugin.name}>
+                                    {plugin.render({ Section, Item })}
+                                </React.Fragment>
+                            ))}
+                        </Menu>
+                    );
+                } else {
+                    return (
+                        <h1>Welcome to Webiny!</h1>
+                    )
+                }
             }
         });
     }

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -16,6 +16,7 @@ export default [
     {
         type: "route",
         name: "route-file-manager-settings-general",
+        scopes: ROLE_FM_SETTINGS,
         route: (
             <Route
                 path="/settings/file-manager/general"

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -16,7 +16,6 @@ export default [
     {
         type: "route",
         name: "route-file-manager-settings-general",
-        scopes: ROLE_FM_SETTINGS,
         route: (
             <Route
                 path="/settings/file-manager/general"
@@ -34,6 +33,7 @@ export default [
     {
         type: "admin-menu-settings",
         name: "menu-file-manager-settings",
+        scopes: ROLE_FM_SETTINGS,
         render({ Section, Item }) {
             return (
                 <SecureView scopes={ROLE_FM_SETTINGS}>

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -36,8 +36,6 @@ export default [
         name: "menu-file-manager-settings",
         render({ Section, Item }) {
             this.permitted = hasScopes(ROLE_FM_SETTINGS, { forceBoolean: true });
-            console.log("checking PB Settings permission from MENU FILE MANAGER file:::::::");
-            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_FM_SETTINGS}>
                     <Section label={t`File Manager`}>

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -35,9 +35,8 @@ export default [
         type: "admin-menu-settings",
         name: "menu-file-manager-settings",
         render({ Section, Item }) {
-            this.permitted = hasScopes(ROLE_FM_SETTINGS, { forceBoolean: true });
             return (
-                <SecureView scopes={ROLE_FM_SETTINGS}>
+                <SecureView scopes={ROLE_FM_SETTINGS} permitted={hasScopes(ROLE_FM_SETTINGS, { forceBoolean: true })}>
                     <Section label={t`File Manager`}>
                         <Item label={t`General`} path="/settings/file-manager/general" />
                     </Section>

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -4,6 +4,7 @@ import { Helmet } from "react-helmet";
 import { AdminLayout } from "@webiny/app-admin/components/AdminLayout";
 import FileManagerSettings from "../views/FileManagerSettings";
 import { SecureRoute, SecureView } from "@webiny/app-security/components";
+import { hasScopes } from "@webiny/app-security"; 
 import { RoutePlugin } from "@webiny/app/types";
 import { i18n } from "@webiny/app/i18n";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
@@ -33,8 +34,10 @@ export default [
     {
         type: "admin-menu-settings",
         name: "menu-file-manager-settings",
-        scopes: ROLE_FM_SETTINGS,
         render({ Section, Item }) {
+            this.permitted = hasScopes(ROLE_FM_SETTINGS, { forceBoolean: true });
+            console.log("checking PB Settings permission from MENU FILE MANAGER file:::::::");
+            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_FM_SETTINGS}>
                     <Section label={t`File Manager`}>

--- a/packages/app-form-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-form-builder/src/admin/plugins/settings/index.tsx
@@ -6,9 +6,9 @@ import { SecureRoute, SecureView } from "@webiny/app-security/components";
 import Helmet from "react-helmet";
 import { RoutePlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
-
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-form-builder/admin/menus");
+import { hasScopes } from "@webiny/app-security"; 
 
 const ROLE_FORMS_SETTINGS = ["forms:settings"];
 
@@ -16,7 +16,6 @@ const plugins = [
     {
         type: "route",
         name: "route-settings-form-builder",
-        scopes: ROLE_FORMS_SETTINGS,
         route: (
             <Route
                 path="/settings/form-builder/recaptcha"
@@ -34,8 +33,10 @@ const plugins = [
     {
         type: "admin-menu-settings",
         name: "menu-settings-form-builder",
-        scopes: ROLE_FORMS_SETTINGS,
         render({ Item, Section }) {
+            this.permitted = hasScopes(ROLE_FORMS_SETTINGS, { forceBoolean: true });
+            console.log("checking PB Settings permission from APP FORMS BUILDER SETTINGS file:::::::");
+            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_FORMS_SETTINGS}>
                     <Section label={t`Form Builder`}>

--- a/packages/app-form-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-form-builder/src/admin/plugins/settings/index.tsx
@@ -6,6 +6,7 @@ import { SecureRoute, SecureView } from "@webiny/app-security/components";
 import Helmet from "react-helmet";
 import { RoutePlugin } from "@webiny/app/types";
 import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
+
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-form-builder/admin/menus");
 import { hasScopes } from "@webiny/app-security"; 
@@ -35,8 +36,6 @@ const plugins = [
         name: "menu-settings-form-builder",
         render({ Item, Section }) {
             this.permitted = hasScopes(ROLE_FORMS_SETTINGS, { forceBoolean: true });
-            console.log("checking PB Settings permission from APP FORMS BUILDER SETTINGS file:::::::");
-            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_FORMS_SETTINGS}>
                     <Section label={t`Form Builder`}>

--- a/packages/app-form-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-form-builder/src/admin/plugins/settings/index.tsx
@@ -16,6 +16,7 @@ const plugins = [
     {
         type: "route",
         name: "route-settings-form-builder",
+        scopes: ROLE_FORMS_SETTINGS,
         route: (
             <Route
                 path="/settings/form-builder/recaptcha"
@@ -33,6 +34,7 @@ const plugins = [
     {
         type: "admin-menu-settings",
         name: "menu-settings-form-builder",
+        scopes: ROLE_FORMS_SETTINGS,
         render({ Item, Section }) {
             return (
                 <SecureView scopes={ROLE_FORMS_SETTINGS}>

--- a/packages/app-form-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-form-builder/src/admin/plugins/settings/index.tsx
@@ -35,9 +35,8 @@ const plugins = [
         type: "admin-menu-settings",
         name: "menu-settings-form-builder",
         render({ Item, Section }) {
-            this.permitted = hasScopes(ROLE_FORMS_SETTINGS, { forceBoolean: true });
             return (
-                <SecureView scopes={ROLE_FORMS_SETTINGS}>
+                <SecureView scopes={ROLE_FORMS_SETTINGS} permitted={hasScopes(ROLE_FORMS_SETTINGS, { forceBoolean: true })}>
                     <Section label={t`Form Builder`}>
                         <Item label={t`reCAPTCHA`} path={"/settings/form-builder/recaptcha"} />
                     </Section>

--- a/packages/app-headless-cms/src/admin/plugins/menus.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/menus.tsx
@@ -50,9 +50,8 @@ export default [
         type: "admin-menu-settings",
         name: "menu-settings-cms-environments",
         render({ Section, Item }) {
-            this.permitted = hasScopes(ROLE_CMS_SETTINGS, { forceBoolean: true });
             return (
-                <SecureView scopes={ROLE_CMS_SETTINGS}>
+                <SecureView scopes={ROLE_CMS_SETTINGS} permitted={hasScopes(ROLE_CMS_SETTINGS, { forceBoolean: true })}>
                     <Section label={t`Headless CMS`}>
                         <Item label={t`Environments`} path={"/settings/cms/environments"} />
                         <Item label={t`Aliases`} path={"/settings/cms/environments/aliases"} />

--- a/packages/app-headless-cms/src/admin/plugins/menus.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/menus.tsx
@@ -12,6 +12,7 @@ export default [
     {
         type: "admin-menu",
         name: "menu-headless-cms",
+        scopes: ROLE_CMS_SETTINGS,
         render({ Menu, Section, Item }) {
             return (
                 <SecureView
@@ -48,6 +49,7 @@ export default [
     {
         type: "admin-menu-settings",
         name: "menu-settings-cms-environments",
+        scopes: ROLE_CMS_SETTINGS,
         render({ Section, Item }) {
             return (
                 <SecureView scopes={ROLE_CMS_SETTINGS}>

--- a/packages/app-headless-cms/src/admin/plugins/menus.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/menus.tsx
@@ -51,8 +51,6 @@ export default [
         name: "menu-settings-cms-environments",
         render({ Section, Item }) {
             this.permitted = hasScopes(ROLE_CMS_SETTINGS, { forceBoolean: true });
-            console.log("checking PB Settings permission from APP HEADLESS CMS file:::::::");
-            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_CMS_SETTINGS}>
                     <Section label={t`Headless CMS`}>

--- a/packages/app-headless-cms/src/admin/plugins/menus.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/menus.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { i18n } from "@webiny/app/i18n";
 import { SecureView } from "@webiny/app-security/components";
+import { hasScopes } from "@webiny/app-security"; 
 import { AdminMenuPlugin, AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
 import HeadlessCmsMenu from "./menus/HeadlessCmsMenu";
 import ContentModelMenuItems from "./menus/ContentModelMenuItems";
@@ -12,7 +13,6 @@ export default [
     {
         type: "admin-menu",
         name: "menu-headless-cms",
-        scopes: ROLE_CMS_SETTINGS,
         render({ Menu, Section, Item }) {
             return (
                 <SecureView
@@ -49,8 +49,10 @@ export default [
     {
         type: "admin-menu-settings",
         name: "menu-settings-cms-environments",
-        scopes: ROLE_CMS_SETTINGS,
         render({ Section, Item }) {
+            this.permitted = hasScopes(ROLE_CMS_SETTINGS, { forceBoolean: true });
+            console.log("checking PB Settings permission from APP HEADLESS CMS file:::::::");
+            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_CMS_SETTINGS}>
                     <Section label={t`Headless CMS`}>

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -3,10 +3,8 @@ import { Route } from "@webiny/react-router";
 import { AdminLayout } from "@webiny/app-admin/components/AdminLayout";
 import PageBuilderSettings from "./components/PageBuilderSettings";
 import GeneralSettings from "./components/generalSettings/GeneralSettings";
-
 import { SecureRoute, SecureView } from "@webiny/app-security/components";
 import { hasScopes } from "@webiny/app-security"; 
-
 import { i18n } from "@webiny/app/i18n";
 import { getPlugins } from "@webiny/plugins";
 import Helmet from "react-helmet";
@@ -17,7 +15,7 @@ import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
 const t = i18n.ns("app-page-builder/admin/menus");
 
 const ROLE_PB_SETTINGS = ["pb:settings"];
-const PERMITTED = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
+
 const plugins = [
     {
         type: "route",
@@ -56,12 +54,8 @@ const plugins = [
     {
         type: "admin-menu-settings",
         name: "menu-settings-page-builder",
-        scopes: ROLE_PB_SETTINGS,
-        permitted: false,
-        render({ Section, Item }) {
-       
+        render({ Section, Item }) {  
             this.permitted = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
-            
             console.log("checking PB Settings permission from APP PAGE BUILDER SETTINGS file:::::::");
             console.log(this.permitted);
             return (

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -3,7 +3,10 @@ import { Route } from "@webiny/react-router";
 import { AdminLayout } from "@webiny/app-admin/components/AdminLayout";
 import PageBuilderSettings from "./components/PageBuilderSettings";
 import GeneralSettings from "./components/generalSettings/GeneralSettings";
+
 import { SecureRoute, SecureView } from "@webiny/app-security/components";
+import { hasScopes } from "@webiny/app-security"; 
+
 import { i18n } from "@webiny/app/i18n";
 import { getPlugins } from "@webiny/plugins";
 import Helmet from "react-helmet";
@@ -14,7 +17,9 @@ import { AdminMenuSettingsPlugin } from "@webiny/app-admin/types";
 const t = i18n.ns("app-page-builder/admin/menus");
 
 const ROLE_PB_SETTINGS = ["pb:settings"];
-
+const PERMITTED = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
+console.log("checking PB Settings permission from APP PAGE BUILDER SETTINGS file:::::::")
+console.log(PERMITTED);
 const plugins = [
     {
         type: "route",
@@ -54,6 +59,7 @@ const plugins = [
         type: "admin-menu-settings",
         name: "menu-settings-page-builder",
         scopes: ROLE_PB_SETTINGS,
+        permitted: hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true }),
         render({ Section, Item }) {
             return (
                 <SecureView scopes={ROLE_PB_SETTINGS}>

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -19,7 +19,7 @@ const ROLE_PB_SETTINGS = ["pb:settings"];
 const plugins = [
     {
         type: "route",
-        name: "route-settings-website",  
+        name: "route-settings-website",
         route: (
             <Route
                 path="/settings/page-builder/website"
@@ -56,8 +56,6 @@ const plugins = [
         name: "menu-settings-page-builder",
         render({ Section, Item }) {  
             this.permitted = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
-            console.log("checking PB Settings permission from APP PAGE BUILDER SETTINGS file:::::::");
-            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_PB_SETTINGS}>
                     <Section label={t`Page Builder`}>

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -18,8 +18,7 @@ const ROLE_PB_SETTINGS = ["pb:settings"];
 const plugins = [
     {
         type: "route",
-        name: "route-settings-website",
-        scopes: ROLE_PB_SETTINGS,
+        name: "route-settings-website",  
         route: (
             <Route
                 path="/settings/page-builder/website"
@@ -54,6 +53,7 @@ const plugins = [
     {
         type: "admin-menu-settings",
         name: "menu-settings-page-builder",
+        scopes: ROLE_PB_SETTINGS,
         render({ Section, Item }) {
             return (
                 <SecureView scopes={ROLE_PB_SETTINGS}>

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -19,6 +19,7 @@ const plugins = [
     {
         type: "route",
         name: "route-settings-website",
+        scopes: ROLE_PB_SETTINGS,
         route: (
             <Route
                 path="/settings/page-builder/website"

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -18,8 +18,6 @@ const t = i18n.ns("app-page-builder/admin/menus");
 
 const ROLE_PB_SETTINGS = ["pb:settings"];
 const PERMITTED = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
-console.log("checking PB Settings permission from APP PAGE BUILDER SETTINGS file:::::::")
-console.log(PERMITTED);
 const plugins = [
     {
         type: "route",
@@ -59,8 +57,13 @@ const plugins = [
         type: "admin-menu-settings",
         name: "menu-settings-page-builder",
         scopes: ROLE_PB_SETTINGS,
-        permitted: hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true }),
+        permitted: false,
         render({ Section, Item }) {
+       
+            this.permitted = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
+            
+            console.log("checking PB Settings permission from APP PAGE BUILDER SETTINGS file:::::::");
+            console.log(this.permitted);
             return (
                 <SecureView scopes={ROLE_PB_SETTINGS}>
                     <Section label={t`Page Builder`}>

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -55,9 +55,8 @@ const plugins = [
         type: "admin-menu-settings",
         name: "menu-settings-page-builder",
         render({ Section, Item }) {  
-            this.permitted = hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true });
             return (
-                <SecureView scopes={ROLE_PB_SETTINGS}>
+                <SecureView scopes={ROLE_PB_SETTINGS} permitted={hasScopes(ROLE_PB_SETTINGS, { forceBoolean: true })}>
                     <Section label={t`Page Builder`}>
                         {getPlugins<PbMenuSettingsItemPlugin>("menu-settings-page-builder").map(
                             plugin => (

--- a/packages/app-plugin-admin-welcome-screen/src/components/Welcome.tsx
+++ b/packages/app-plugin-admin-welcome-screen/src/components/Welcome.tsx
@@ -125,8 +125,7 @@ const Welcome = () => {
     const canSeeAnyWidget = getPlugins<AdminWelcomeScreenWidgetPlugin>(
         "admin-welcome-screen-widget"
     ).some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
-    console.log("checking WIDGETS AGAIN::::")
-    console.log(getPlugins<AdminWelcomeScreenWidgetPlugin>("admin-welcome-screen-widget"));
+
     return (
         <Grid>
             <Cell span={12} className={cellClass}>

--- a/packages/app-plugin-admin-welcome-screen/src/components/Welcome.tsx
+++ b/packages/app-plugin-admin-welcome-screen/src/components/Welcome.tsx
@@ -125,7 +125,8 @@ const Welcome = () => {
     const canSeeAnyWidget = getPlugins<AdminWelcomeScreenWidgetPlugin>(
         "admin-welcome-screen-widget"
     ).some(pl => hasScopes(pl.scopes, { forceBoolean: true }));
-
+    console.log("checking WIDGETS AGAIN::::")
+    console.log(getPlugins<AdminWelcomeScreenWidgetPlugin>("admin-welcome-screen-widget"));
     return (
         <Grid>
             <Cell span={12} className={cellClass}>


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1073 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Use the ```hasScopes``` function from each plugin's ```render```, to check each permission. Set a ```permitted``` key to true if permitted.
Determine if there is at least 1  permission scope set from the app-admin init file. Do this by using the ```some``` function on all permitted keys to find atleast one true value.

This is an updated method in comparison to the previous attempt of using hasScopes from ```app-admin``` which was causing security related errors. The previous attempt was done successfully in [PR 1078](https://github.com/webiny/webiny-js/pull/1078) to display a separate message (instead of welcome widgets) for user accounts with no permissions.

## How Has This Been Tested?

Checking both administrative accounts and users with no permissions:

- Settings tab is removed for none authorised accounts successfully.
- Settings tab remains in place for administrators accounts and when toggled a menu appears.

- I may need to test accounts with only 1 and/or 2 ```settings``` permissions.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
For none authorized users, Settings tab removed:
<img width="255" alt="Screenshot 2020-07-18 at 19 32 31" src="https://user-images.githubusercontent.com/22279028/87859516-8167db80-c92d-11ea-8cb1-89ae6ec85b91.png">

