### PR TITLE
Remove trailing slashes from domain in PB settings

### DIFF
--- a/packages/api-page-builder/src/plugins/models/pbPage.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbPage.model.ts
@@ -126,7 +126,7 @@ export default ({ createBase, context, PbCategory, PbSettings }) => {
                 return new Promise(async (resolve, reject) => {
                     try {
                         const settings = await PbSettings.load();
-                        resolve(settings.data.domain + this.url);
+                        resolve(settings.data.domain.replace(/\/+$/g, "") + this.url);
                     } catch (e) {
                         reject(e);
                     }

--- a/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbSettings.model.ts
@@ -8,7 +8,8 @@ import {
     fields,
     withFields,
     setOnce,
-    boolean
+    boolean,
+    onSet
 } from "@webiny/commodo";
 
 const SETTINGS_KEY = "page-builder";
@@ -107,7 +108,7 @@ export default ({ createBase, context }) => {
                     }),
                     installation: fields({ instanceOf: InstallationFields, value: {} }),
                     name: string(),
-                    domain: string(),
+                    domain: onSet(value => value.replace(/\/+$/g, ""))(string()),
                     favicon: id(),
                     logo: id(),
                     social: fields({

--- a/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/components/generalSettings/GeneralSettings.tsx
@@ -35,16 +35,21 @@ const GeneralSettings = () => {
 
                             if (updatedSettings) {
                                 cache.writeQuery({
-                                     query: DOMAIN_QUERY,
-                                     data: set(dataFromCache, "pageBuilder.getSettings.data", updatedSettings)
+                                    query: DOMAIN_QUERY,
+                                    data: set(
+                                        dataFromCache,
+                                        "pageBuilder.getSettings.data",
+                                        updatedSettings
+                                    )
                                 });
                             }
                         }}
                     >
-                        {(update, {loading: mutationInProgress}) => (
+                        {(update, { loading: mutationInProgress }) => (
                             <Form
                                 data={settings}
                                 onSubmit={async data => {
+                                    data.domain = data.domain.replace(/\/+$/g, "");
                                     await update({
                                         variables: {
                                             data


### PR DESCRIPTION
## Related Issue
If users paste the URL from the browser into the settings, they may accidentally leave the trailing `/` which causes all sorts of weird problems with link rendering in `site` app, especially with SSR.

## Your solution
Remove trailing slash(es) in PB Settings model using `onSet`, in React on settings form submission, and also during generation of `fullUrl` in Page model, to be extra safe.

## How Has This Been Tested?
Manually

## Screenshots (if relevant):
For better context, this is the relevant form:

![image](https://user-images.githubusercontent.com/3920893/87821523-45bb0c00-c870-11ea-860b-dab4cc066d25.png)
