### PR TITLE
Add support for data manager hooks

### DIFF
--- a/api/cms/dataManager/src/index.ts
+++ b/api/cms/dataManager/src/index.ts
@@ -2,6 +2,7 @@ import { createHandler } from "@webiny/handler";
 import dataManager from "@webiny/api-headless-cms/dataManager/handler";
 import mongodb from "@webiny/api-plugin-commodo-mongodb";
 import i18nServicePlugins from "@webiny/api-i18n/plugins/service";
+import { CmsDataManagerEntryHookPlugin } from "@webiny/api-headless-cms/dataManager/types";
 
 /**
  * In this lambda we're using `api-plugin-commodo-mongodb` instead of `api-plugin-commodo-db-proxy`.
@@ -15,5 +16,12 @@ export const handler = createHandler(
     i18nServicePlugins({
         localesFunction: process.env.I18N_LOCALES_FUNCTION
     }),
-    dataManager()
+    dataManager(),
+    {
+        type: "cms-data-manager-entry-hook",
+        async hook(params, context) {
+            // Process the hook however you want :)
+            // See `CmsDataManagerEntryHookPlugin` type for available hook parameters
+        }
+    } as CmsDataManagerEntryHookPlugin
 );

--- a/packages/api-headless-cms/__tests__/dataManagerClient.test.js
+++ b/packages/api-headless-cms/__tests__/dataManagerClient.test.js
@@ -143,4 +143,31 @@ describe("Data Manager Client", () => {
         await category.save();
         expect(spy.callCount).toBe(0);
     });
+
+    it(`should call "deleteRevisionIndexes" when content model entry is deleted`, async () => {
+        const spy = sandbox.spy(context.cms.dataManager, "deleteRevisionIndexes");
+
+        const category = new context.models.category();
+        category.populate({
+            title: {
+                values: [
+                    { locale: locales.en.id, value: "Test EN" },
+                    { locale: locales.de.id, value: "Test DE" }
+                ]
+            },
+            slug: {
+                values: [
+                    { locale: locales.en.id, value: "test-en" },
+                    { locale: locales.de.id, value: "test-de" }
+                ]
+            }
+        });
+
+        await category.save();
+        await category.delete();
+
+        sandbox.restore();
+
+        expect(spy.callCount).toBe(1);
+    });
 });

--- a/packages/api-headless-cms/__tests__/dataManagerHandler.test.js
+++ b/packages/api-headless-cms/__tests__/dataManagerHandler.test.js
@@ -118,7 +118,11 @@ describe("Data Manager Handler", () => {
         expect(count).toBe(16);
 
         // Restore indexes
-        categoryModel.indexes = [{ fields: ["title"] }, { fields: ["title", "slug"] }];
+        categoryModel.indexes = [
+            { fields: ["id"] },
+            { fields: ["title", "slug"] },
+            { fields: ["slug"] }
+        ];
         await categoryModel.save();
     });
 
@@ -132,7 +136,7 @@ describe("Data Manager Handler", () => {
         });
 
         let count = await collection("CmsContentEntrySearch").countDocuments();
-        expect(count).toBe(22);
+        expect(count).toBe(28);
 
         // Update exiting content model entry
         const category = categories[0].model;
@@ -168,6 +172,25 @@ describe("Data Manager Handler", () => {
         expect(entries.find(({ locale }) => locale === locales.en.id).v0).toBe("Headless EN");
         expect(entries.find(({ locale }) => locale === locales.de.id).v0).toBe("Headless DE");
         expect(entries.find(({ locale }) => locale === locales.it.id).v0).toBe("Headless IT");
+    });
+
+    it(`should delete index entries for a specific entry revision`, async () => {
+        // Generate initial search catalog
+        const { invoke } = useDataManagerHandler();
+        await invoke({
+            environment: "production",
+            action: "generateContentModelIndexes",
+            contentModel: "category"
+        });
+
+        let count = await collection("CmsContentEntrySearch").countDocuments();
+        expect(count).toBe(28);
+
+        // Delete content model entry (this should delete 9 entries from Search table)
+        await categories[0].model.delete();
+
+        count = await collection("CmsContentEntrySearch").countDocuments();
+        expect(count).toBe(19);
     });
 
     it(`should copy environment data`, async () => {

--- a/packages/api-headless-cms/__tests__/dataManagerHooks.test.js
+++ b/packages/api-headless-cms/__tests__/dataManagerHooks.test.js
@@ -40,7 +40,7 @@ describe("Data Manager Hooks", () => {
         let hookExecuted = null;
         const { invoke } = useDataManagerHandler([
             {
-                type: "cms-data-manager-hook",
+                type: "cms-data-manager-entry-hook",
                 hook(payload) {
                     hookExecuted = payload;
                 }
@@ -76,7 +76,7 @@ describe("Data Manager Hooks", () => {
         let hookExecuted = null;
         const { invoke } = useDataManagerHandler([
             {
-                type: "cms-data-manager-hook",
+                type: "cms-data-manager-entry-hook",
                 hook(payload) {
                     hookExecuted = payload;
                 }
@@ -111,7 +111,7 @@ describe("Data Manager Hooks", () => {
     it(`should ignore errors in hook plugins`, async () => {
         const { invoke } = useDataManagerHandler([
             {
-                type: "cms-data-manager-hook",
+                type: "cms-data-manager-entry-hook",
                 hook() {
                     throw Error("Broken hook!");
                 }

--- a/packages/api-headless-cms/__tests__/dataManagerHooks.test.js
+++ b/packages/api-headless-cms/__tests__/dataManagerHooks.test.js
@@ -1,0 +1,138 @@
+import { createUtils } from "./utils";
+import setupContentModels from "./setup/setupContentModels";
+import setupDefaultEnvironment from "./setup/setupDefaultEnvironment";
+import headlessPlugins from "../src/content/plugins";
+import createCategories from "./mocks/createCategories.manage";
+
+describe("Data Manager Hooks", () => {
+    const { useDatabase, useContext, useDataManagerHandler } = createUtils([
+        headlessPlugins({ type: "manage", environment: "production" })
+    ]);
+
+    let environmentId;
+    let categories;
+    let models;
+    const db = useDatabase();
+    const collection = db.getCollection;
+
+    beforeAll(async () => {
+        environmentId = await setupDefaultEnvironment(db);
+        let context = await useContext();
+        await setupContentModels(context);
+    });
+
+    beforeEach(async () => {
+        const context = await useContext();
+        models = {
+            CmsContentModel: context.models.CmsContentModel,
+            CmsContentModelGroup: context.models.CmsContentModelGroup,
+            Category: context.models.category
+        };
+        categories = await createCategories(context);
+    });
+
+    afterEach(async () => {
+        await collection("CmsContentEntry").deleteMany();
+        await collection("CmsContentEntrySearch").deleteMany();
+    });
+
+    it(`should execute hook plugin (update)`, async () => {
+        let hookExecuted = null;
+        const { invoke } = useDataManagerHandler([
+            {
+                type: "cms-data-manager-hook",
+                hook(payload) {
+                    hookExecuted = payload;
+                }
+            }
+        ]);
+
+        // Setup initial search catalog
+        await invoke({
+            environment: "production",
+            action: "generateContentModelIndexes",
+            contentModel: "category"
+        });
+
+        // Update entry to trigger hooks
+        await invoke({
+            environment: "production",
+            action: "generateRevisionIndexes",
+            contentModel: "category",
+            revision: categories[0].model.id
+        });
+
+        expect(hookExecuted).toMatchObject({
+            type: "entry-update",
+            environment: "production",
+            contentModel: "category",
+            entry: {
+                id: categories[0].model.id
+            }
+        });
+    });
+
+    it(`should execute hook plugin (delete)`, async () => {
+        let hookExecuted = null;
+        const { invoke } = useDataManagerHandler([
+            {
+                type: "cms-data-manager-hook",
+                hook(payload) {
+                    hookExecuted = payload;
+                }
+            }
+        ]);
+
+        // Setup initial search catalog
+        await invoke({
+            environment: "production",
+            action: "generateContentModelIndexes",
+            contentModel: "category"
+        });
+
+        // Update entry to trigger hooks
+        await invoke({
+            environment: "production",
+            action: "deleteRevisionIndexes",
+            contentModel: "category",
+            revision: categories[0].model.id
+        });
+
+        expect(hookExecuted).toMatchObject({
+            type: "entry-delete",
+            environment: "production",
+            contentModel: "category",
+            entry: {
+                id: categories[0].model.id
+            }
+        });
+    });
+
+    it(`should ignore errors in hook plugins`, async () => {
+        const { invoke } = useDataManagerHandler([
+            {
+                type: "cms-data-manager-hook",
+                hook() {
+                    throw Error("Broken hook!");
+                }
+            }
+        ]);
+
+        // Setup initial search catalog
+        await invoke({
+            environment: "production",
+            action: "generateContentModelIndexes",
+            contentModel: "category"
+        });
+
+        // Update entry to trigger hooks
+        const [result] = await invoke({
+            environment: "production",
+            action: "generateRevisionIndexes",
+            contentModel: "category",
+            revision: categories[0].model.id
+        });
+
+        expect(result.error).toBeUndefined();
+    });
+});

--- a/packages/api-headless-cms/__tests__/mocks/dataManagerClient.js
+++ b/packages/api-headless-cms/__tests__/mocks/dataManagerClient.js
@@ -1,4 +1,5 @@
 import { generateRevisionIndexes } from "../../src/dataManager/handler/generateRevisionIndexes";
+import { deleteRevisionIndexes } from "../../src/dataManager/handler/deleteRevisionIndexes";
 import { generateContentModelIndexes } from "../../src/dataManager/handler/generateContentModelIndexes";
 import { deleteEnvironmentData } from "../../src/dataManager/handler/deleteEnvironmentData";
 import { copyEnvironment } from "../../src/dataManager/handler/copyEnvironment";
@@ -10,6 +11,14 @@ export class DataManagerClient {
 
     async generateRevisionIndexes({ revision }) {
         await generateRevisionIndexes({
+            context: this.context,
+            revision: revision.id,
+            contentModel: revision.contentModel.modelId
+        });
+    }
+
+    async deleteRevisionIndexes({ revision }) {
+        await deleteRevisionIndexes({
             context: this.context,
             revision: revision.id,
             contentModel: revision.contentModel.modelId

--- a/packages/api-headless-cms/__tests__/utils/useDataManagerHandler.js
+++ b/packages/api-headless-cms/__tests__/utils/useDataManagerHandler.js
@@ -3,8 +3,8 @@ import dataManager from "../../src/dataManager/handler";
 
 const createDataManagerHandler = plugins => createHandler(plugins, dataManager());
 
-export default plugins => () => {
-    const handler = createDataManagerHandler(plugins);
+export default plugins => (extraPlugins = []) => {
+    const handler = createDataManagerHandler([...plugins, ...extraPlugins]);
     return {
         handler,
         invoke: async event => {

--- a/packages/api-headless-cms/src/content/plugins/utils/createDataModel.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/createDataModel.ts
@@ -13,8 +13,7 @@ import {
     skipOnPopulate,
     setOnce,
     string,
-    date,
-    getName
+    date
 } from "@webiny/commodo";
 
 import {
@@ -28,20 +27,6 @@ import { createValidation } from "./createValidation";
 import pick from "lodash/pick";
 import omit from "lodash/omit";
 import upperFirst from "lodash/upperFirst";
-
-async function deleteRevisionIndexes(revision, context) {
-    const { CmsContentEntrySearch } = context.models;
-    const query = {
-        model: revision.meta.model,
-        revision: revision.id,
-        environment: revision.meta.environment
-    };
-
-    await context.commodo.driver.delete({
-        name: getName(CmsContentEntrySearch),
-        options: { query }
-    });
-}
 
 export const createDataModel = (
     createBase: Function,
@@ -141,7 +126,9 @@ export const createDataModel = (
                                 revision: this
                             });
                         } else if (mustDeleteIndexes) {
-                            await deleteRevisionIndexes(this, context);
+                            await context.cms.dataManager.deleteRevisionIndexes({
+                                revision: this
+                            });
                         }
                     });
                 }
@@ -280,7 +267,9 @@ export const createDataModel = (
             },
             async afterDelete() {
                 // Delete indexes for this revision
-                await deleteRevisionIndexes(this, context);
+                await context.cms.dataManager.deleteRevisionIndexes({
+                    revision: this
+                });
 
                 // If the deleted page is the parent page - delete its revisions.
                 if (this.id === this.meta.parent) {

--- a/packages/api-headless-cms/src/dataManager/client/DataManagerClient.ts
+++ b/packages/api-headless-cms/src/dataManager/client/DataManagerClient.ts
@@ -35,6 +35,15 @@ export class DataManagerClient implements CmsDataManager {
         });
     }
 
+    async deleteRevisionIndexes({ revision }: any) {
+        await this.invokeDataManager({
+            environment: this.context.cms.getEnvironment().id,
+            action: "deleteRevisionIndexes",
+            contentModel: revision.contentModel.modelId,
+            revision: revision.id
+        });
+    }
+
     async generateContentModelIndexes({ contentModel }: { contentModel: CmsContentModel }) {
         return await this.invokeDataManager({
             environment: this.context.cms.getEnvironment().id,

--- a/packages/api-headless-cms/src/dataManager/handler/deleteRevisionIndexes.ts
+++ b/packages/api-headless-cms/src/dataManager/handler/deleteRevisionIndexes.ts
@@ -1,0 +1,30 @@
+export const deleteRevisionIndexes = async ({ context, contentModel, revision }) => {
+    const { CmsContentEntrySearch } = context.models;
+    const driver = CmsContentEntrySearch.getStorageDriver();
+    const environment = context.cms.getEnvironment();
+
+    const query: any = {
+        model: contentModel,
+        environment: environment.id,
+        id: revision,
+        deleted: { $ne: true }
+    };
+
+    const entry = await driver.findOne({
+        name: "CmsContentEntry",
+        options: { query }
+    });
+
+    await driver.delete({
+        name: "CmsContentEntrySearch",
+        options: {
+            query: {
+                model: contentModel,
+                revision: revision,
+                environment: environment.id
+            }
+        }
+    });
+
+    return entry;
+};

--- a/packages/api-headless-cms/src/dataManager/handler/generateRevisionIndexes.ts
+++ b/packages/api-headless-cms/src/dataManager/handler/generateRevisionIndexes.ts
@@ -24,7 +24,6 @@ export const generateRevisionIndexes = async ({ context, contentModel, revision 
         $or: [{ published: true }, { latestVersion: true }]
     };
 
-    // We set `limit` to 101 to know if there is more data to fetch
     const entry = await driver.findOne({
         name: "CmsContentEntry",
         options: { query, fields: indexFields }
@@ -32,5 +31,5 @@ export const generateRevisionIndexes = async ({ context, contentModel, revision 
 
     await createRevisionIndexes({ model, entry, context });
 
-    return true;
+    return entry;
 };

--- a/packages/api-headless-cms/src/dataManager/handler/index.ts
+++ b/packages/api-headless-cms/src/dataManager/handler/index.ts
@@ -1,18 +1,32 @@
 import { applyContextPlugins } from "@webiny/graphql";
-import { HandlerPlugin } from "@webiny/handler/types";
+import { HandlerContext, HandlerPlugin } from "@webiny/handler/types";
 import { createResponse } from "@webiny/handler";
 import headlessPlugins from "../../content/plugins";
 import { generateContentModelIndexes } from "./generateContentModelIndexes";
 import { generateRevisionIndexes } from "./generateRevisionIndexes";
+import { deleteRevisionIndexes } from "./deleteRevisionIndexes";
 import { deleteEnvironmentData } from "./deleteEnvironmentData";
 import { Action } from "../types";
 import { copyEnvironment } from "./copyEnvironment";
+import { CmsDataManagerHookPlugin } from "@webiny/api-headless-cms/dataManager/types";
 
 // Setup plugins for given environment
 async function setupEnvironment(context, environment) {
     context.plugins.register(await headlessPlugins({ type: "manage", environment }));
     await applyContextPlugins(context);
 }
+
+const processHooks = async (payload, context: HandlerContext) => {
+    const plugins = context.plugins.byType<CmsDataManagerHookPlugin>("cms-data-manager-hook");
+    for (let i = 0; i < plugins.length; i++) {
+        const plugin = plugins[i];
+        try {
+            await plugin.hook(payload, context);
+        } catch {
+            // We completely ignore errors in hooks, since those are 3rd party plugins.
+        }
+    }
+};
 
 export default () => [
     {
@@ -44,6 +58,39 @@ export default () => [
                         await setupEnvironment(context, environment);
 
                         result = await generateRevisionIndexes({ context, ...params });
+
+                        await processHooks(
+                            {
+                                type: "entry-update",
+                                environment,
+                                contentModel: params.contentModel,
+                                entry: result
+                            },
+                            context
+                        );
+
+                        break;
+                    case "deleteRevisionIndexes":
+                        if (!params.contentModel || !params.revision) {
+                            throw Error(
+                                `[${action}] Missing required parameters "contentModel" and "revision"!`
+                            );
+                        }
+
+                        await setupEnvironment(context, environment);
+
+                        result = await deleteRevisionIndexes({ context, ...params });
+
+                        await processHooks(
+                            {
+                                type: "entry-delete",
+                                environment,
+                                contentModel: params.contentModel,
+                                entry: result
+                            },
+                            context
+                        );
+
                         break;
                     case "copyEnvironment":
                         if (!params.copyFrom || !params.copyTo) {

--- a/packages/api-headless-cms/src/dataManager/handler/index.ts
+++ b/packages/api-headless-cms/src/dataManager/handler/index.ts
@@ -8,7 +8,7 @@ import { deleteRevisionIndexes } from "./deleteRevisionIndexes";
 import { deleteEnvironmentData } from "./deleteEnvironmentData";
 import { Action } from "../types";
 import { copyEnvironment } from "./copyEnvironment";
-import { CmsDataManagerHookPlugin } from "@webiny/api-headless-cms/dataManager/types";
+import { CmsDataManagerEntryHookPlugin } from "@webiny/api-headless-cms/dataManager/types";
 
 // Setup plugins for given environment
 async function setupEnvironment(context, environment) {
@@ -16,8 +16,11 @@ async function setupEnvironment(context, environment) {
     await applyContextPlugins(context);
 }
 
-const processHooks = async (payload, context: HandlerContext) => {
-    const plugins = context.plugins.byType<CmsDataManagerHookPlugin>("cms-data-manager-hook");
+const processEntryHooks = async (payload, context: HandlerContext) => {
+    const plugins = context.plugins.byType<CmsDataManagerEntryHookPlugin>(
+        "cms-data-manager-entry-hook"
+    );
+
     for (let i = 0; i < plugins.length; i++) {
         const plugin = plugins[i];
         try {
@@ -59,7 +62,7 @@ export default () => [
 
                         result = await generateRevisionIndexes({ context, ...params });
 
-                        await processHooks(
+                        await processEntryHooks(
                             {
                                 type: "entry-update",
                                 environment,
@@ -81,7 +84,7 @@ export default () => [
 
                         result = await deleteRevisionIndexes({ context, ...params });
 
-                        await processHooks(
+                        await processEntryHooks(
                             {
                                 type: "entry-delete",
                                 environment,

--- a/packages/api-headless-cms/src/dataManager/types.ts
+++ b/packages/api-headless-cms/src/dataManager/types.ts
@@ -1,5 +1,22 @@
+import { HandlerContext } from "@webiny/handler/types";
+
 export type Action =
     | "copyEnvironment"
     | "deleteEnvironment"
     | "generateRevisionIndexes"
+    | "deleteRevisionIndexes"
     | "generateContentModelIndexes";
+
+export type CmsDataManagerHookType = "entry-update" | "entry-delete";
+
+interface CmsDataManagerHookParams {
+    type: CmsDataManagerHookType;
+    environment: string;
+    contentModel: string;
+    entry: { [key: string]: any };
+}
+
+export type CmsDataManagerHookPlugin = Plugin & {
+    type: "cms-data-manager-hook";
+    hook(params: CmsDataManagerHookParams, context: HandlerContext): Promise<void>;
+};

--- a/packages/api-headless-cms/src/dataManager/types.ts
+++ b/packages/api-headless-cms/src/dataManager/types.ts
@@ -7,16 +7,16 @@ export type Action =
     | "deleteRevisionIndexes"
     | "generateContentModelIndexes";
 
-export type CmsDataManagerHookType = "entry-update" | "entry-delete";
+export type CmsDataManagerEntryHookType = "entry-update" | "entry-delete";
 
-interface CmsDataManagerHookParams {
-    type: CmsDataManagerHookType;
+interface CmsDataManagerEntryHookParams {
+    type: CmsDataManagerEntryHookType;
     environment: string;
     contentModel: string;
-    entry: { [key: string]: any };
+    entry: { id: string; published: boolean; latestVersion: boolean };
 }
 
-export type CmsDataManagerHookPlugin = Plugin & {
-    type: "cms-data-manager-hook";
-    hook(params: CmsDataManagerHookParams, context: HandlerContext): Promise<void>;
+export type CmsDataManagerEntryHookPlugin = Plugin & {
+    type: "cms-data-manager-entry-hook";
+    hook(params: CmsDataManagerEntryHookParams, context: HandlerContext): Promise<void>;
 };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -5,6 +5,7 @@ import { Context as CommodoContext } from "@webiny/api-plugin-commodo-db-proxy/t
 
 export interface CmsDataManager {
     generateRevisionIndexes({ revision }): Promise<void>;
+    deleteRevisionIndexes({ revision }): Promise<void>;
     generateContentModelIndexes({ contentModel }): Promise<void>;
     deleteEnvironment({ environment }): Promise<void>;
     copyEnvironment({ copyFrom, copyTo }): Promise<void>;


### PR DESCRIPTION
## Related Issue
Closes #1133

## Your solution
Add `cms-data-manager-entry-hook` plugin processing to DataManager handler, when a content entry is being updated or deleted. 

Plugin types are as follows:

```typescript
export type CmsDataManagerEntryHookType = "entry-update" | "entry-delete";

interface CmsDataManagerEntryHookParams {
    type: CmsDataManagerEntryHookType;
    environment: string;
    contentModel: string;
    entry: { id: string; published: boolean; latestVersion: boolean };
}

export type CmsDataManagerEntryHookPlugin = Plugin & {
    type: "cms-data-manager-entry-hook";
    hook(params: CmsDataManagerEntryHookParams, context: HandlerContext): Promise<void>;
};
```

## How Has This Been Tested?
All the functionality is covered by Jest tests.

## Screenshots (if relevant):
The following screenshot shows how to add plugins to the Data Manager handler:

![image](https://user-images.githubusercontent.com/3920893/87857579-1ec01100-c928-11ea-9f5b-db4ba443099d.png)

## Blog
**Title**:  Add support for CMS hooks via plugins
**Body**: Up until now, there was no way to trigger a webhook when a content entry was updated or deleted. In this release, we've added support for hook plugins which will allow you to hook into the CMS Data Manager, and process `entry-update` and `entry-delete` events, and trigger whatever logic you want, be it a webhook, Slack notification, or something else.
