### PR TITLE
Fix: error when clicking add index with nothing selected

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/IndexesTab/NewIndexDialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/IndexesTab/NewIndexDialog.tsx
@@ -58,6 +58,8 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
             >
                 {({ Bind, submit, data: formData }) => {
                     const selectedFields = get(formData, "fields", []);
+
+                    const nothingSelected = selectedFields.length === 0;
                     const justIdSelected =
                         selectedFields.length === 1 && selectedFields[0] === "id";
 
@@ -152,7 +154,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
                             </DialogContent>
                             <DialogActions>
                                 <ButtonDefault
-                                    disabled={justIdSelected || isExisting}
+                                    disabled={nothingSelected || justIdSelected || isExisting}
                                     onClick={submit}
                                 >
                                     + {t`Add index`}


### PR DESCRIPTION
## Related Issue
Closes #1129 

## Your solution
disable the `add index` button when nothing is selected in the new index dialog.

## How Has This Been Tested?
Manually using the Admin app UI

## Screenshots:
https://www.loom.com/share/8ed67f5cf3af491d9585c68b8b98cb97