### PR TITLE
fix: prepend empty object when doing merge.recursive

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -4,7 +4,7 @@ const tsPreset = require("ts-jest/presets/js-with-babel/jest-preset");
 
 module.exports = ({ path }, presets = []) => {
     const name = basename(path);
-    return merge.recursive(tsPreset, ...presets, {
+    return merge.recursive({}, tsPreset, ...presets, {
         name: name,
         displayName: name,
         modulePaths: [`${path}/src`],

--- a/packages/cwp-template-cms/template/jest.config.base.js
+++ b/packages/cwp-template-cms/template/jest.config.base.js
@@ -4,7 +4,7 @@ const tsPreset = require("ts-jest/presets/js-with-babel/jest-preset");
 
 module.exports = ({ path }, presets = []) => {
     const name = basename(path);
-    return merge.recursive(tsPreset, ...presets, {
+    return merge.recursive({}, tsPreset, ...presets, {
         name: name,
         displayName: name,
         modulePaths: [`${path}/src`],

--- a/packages/cwp-template-full/template/jest.config.base.js
+++ b/packages/cwp-template-full/template/jest.config.base.js
@@ -4,7 +4,7 @@ const tsPreset = require("ts-jest/presets/js-with-babel/jest-preset");
 
 module.exports = ({ path }, presets = []) => {
     const name = basename(path);
-    return merge.recursive(tsPreset, ...presets, {
+    return merge.recursive({}, tsPreset, ...presets, {
         name: name,
         displayName: name,
         modulePaths: [`${path}/src`],


### PR DESCRIPTION
## Related Issue
When creating new projects with CWP, `yarn test` would stop working as soon as you added the 2nd package into the `api` folder. The error was happening because of an incorrect merge, happening in the `jest.config.base.js` config file.

## Your solution
I fixed the merge happening in the `jest.config.base.js` config file.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A

## Blog
**Title**: Running Jest tests now works as expected
**Body**: We had a couple of reports of Jest tests not executing properly as soon as two or more custom packages are created (e.g. two Apollo GraphQL Services). This now works as expected, so you can continue writing your tests as usual and be confident that your app works as expected.