### PR TITLE
Feature/issue 1154 create simple crud

### DIFF
--- a/packages/cli-plugin-scaffold-app-graphql/.babelrc.js
+++ b/packages/cli-plugin-scaffold-app-graphql/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.node");

--- a/packages/cli-plugin-scaffold-app-graphql/index.js
+++ b/packages/cli-plugin-scaffold-app-graphql/index.js
@@ -1,0 +1,249 @@
+const fs = require("fs");
+const path = require("path");
+const util = require("util");
+const ncp = util.promisify(require("ncp").ncp);
+const findUp = require("find-up");
+const kebabCase = require("lodash.kebabcase");
+const pluralize = require("pluralize");
+const Case = require("case");
+const {replaceInPath} = require("replace-in-path");
+const fastGlob = require('fast-glob');
+
+const appsPluginsLocation = "apps/admin/src/plugins";
+
+const createPackageLocation = name => {
+	return `${appsPluginsLocation}/${name}`;
+};
+
+const readApiPackageModelName = (file) => {
+	const fileContent = fs
+		.readFileSync(file, {
+			encoding: "utf-8",
+			flag: "r"
+		})
+		.toString();
+	if(!fileContent) {
+		throw new Error(`Could not load any content from file ${file}`);
+	}
+	
+	const nameMatched = fileContent.match(/withName\("([a-zA-Z]+)"\)/);
+	if(!nameMatched) {
+		throw new Error(
+			`Could not find withName() in ${file} which is needed to detect model name.`
+		);
+	}
+	return nameMatched[1];
+};
+
+const findDataModels = (location) => {
+	const target = path.resolve(`${location}/**/*.model.ts`);
+	const files = fastGlob
+		.sync(target, {
+			unique: true,
+		});
+	if(files.length === 0) {
+		throw new Error(`Could not find any models with fast-glob pattern "${target}"`);
+	}
+	return files.map(file => ({
+		fileName: path.basename(file),
+		filePath: file,
+		modelName: readApiPackageModelName(file),
+	}))
+};
+
+module.exports = [
+	{
+		name: "cli-plugin-scaffold-template-graphql-app",
+		type: "cli-plugin-scaffold-template",
+		scaffold: {
+			name: "GraphQL Apollo Service App",
+			questions: () => {
+				return [
+					{
+						name: "apiLocation",
+						message: "Enter existing GraphQL API location (relative to the project root) or empty for none",
+						validate: apiLocation => {
+							if(!apiLocation) {
+								return true;
+							}
+							if(fs.existsSync(apiLocation) === false) {
+								return "There is no GraphQL API in given location";
+							}
+							try {
+								findDataModels(apiLocation);
+							}
+							catch (ex) {
+								return `Could not find existing API model in ${apiLocation}, error: ${ex.message}`;
+							}
+							return true;
+						}
+					},
+					{
+						name: "existingDataModelName",
+						message: "Choose data model to use",
+						type: "list",
+						when: ({apiLocation}) => {
+							return !!apiLocation;
+						},
+						choices: ({apiLocation}) => {
+							const names = findDataModels(apiLocation);
+							return names.map(({modelName}) => modelName);
+						},
+						validate: (name, {apiLocation}) => {
+							if(!name) {
+								return "Please enter a data model name";
+							}
+							else if(!name.match(/^([a-z]+)$/i)) {
+								return "A valid entity name must consist of letters only.";
+							}
+							try {
+								const names = findDataModels(apiLocation).map(({modelName}) => modelName);
+								if(!names.includes(name)) {
+									throw new Error();
+								}
+								return true;
+							}
+							catch (ex) {
+								return `A data model with name "${name}" does not exist`;
+							}
+						}
+					},
+					{
+						name: "packageLocation",
+						message: `Enter package location (will be located in "${appsPluginsLocation}" directory)`,
+						default: "books",
+						validate: name => {
+							if(!name) {
+								return "Please enter a package location";
+							}
+							const packageLocation = createPackageLocation(name);
+							
+							const locationFullPath = path.resolve(packageLocation);
+							if(fs.existsSync(locationFullPath)) {
+								return `The target location already exists: ${packageLocation}`;
+							}
+							
+							const rootResourcesPath = findUp.sync("resources.js", {
+								cwd: locationFullPath
+							});
+							
+							if(!rootResourcesPath) {
+								return `Resources file was not found. Make sure your package is inside of your project's root and that either it or one of its parent directories contains resources.js`;
+							}
+							
+							return true;
+						}
+					},
+					{
+						name: "dataModelName",
+						message: "Enter name of the data model",
+						default: "Book",
+						when: ({existingDataModelName}) => {
+							return !existingDataModelName;
+						},
+						validate: (name) => {
+							if(!name.match(/^([a-z]+)$/i)) {
+								return "A valid entity name must consist of letters only.";
+							}
+							return true;
+						}
+					}
+				];
+			},
+			generate: async ({input, oraSpinner}) => {
+				const {existingDataModelName, packageLocation, dataModelName} = input;
+				
+				const modelName = existingDataModelName || dataModelName;
+				
+				const fullPackageLocation = path.resolve(createPackageLocation(packageLocation));
+				
+				const packageName = kebabCase(packageLocation);
+				
+				// Then we also copy the template folder
+				const sourceFolder = path.join(__dirname, "template");
+				
+				if(fs.existsSync(fullPackageLocation)) {
+					throw new Error(`Destination folder ${fullPackageLocation} already exists!`);
+				}
+				
+				await fs.mkdirSync(fullPackageLocation, {recursive: true});
+				
+				// Get base TS config path
+				const baseTsConfigPath = path
+					.relative(
+						fullPackageLocation,
+						findUp.sync("tsconfig.json", {
+							cwd: fullPackageLocation
+						})
+					)
+					.replace(/\\/g, "/");
+				
+				// Copy template files
+				await ncp(sourceFolder, fullPackageLocation);
+				
+				// Replace generic "Entity" with received "input.existingDataModelName" or "input.dataModelName" argument.
+				const entity = {
+					plural: pluralize(Case.camel(modelName)),
+					singular: pluralize.singular(Case.camel(modelName))
+				};
+				
+				const codeReplacements = [
+					{find: "entities", replaceWith: Case.camel(entity.plural)},
+					{find: "Entities", replaceWith: Case.pascal(entity.plural)},
+					{find: "ENTITIES", replaceWith: Case.constant(entity.plural)},
+					{find: "entity", replaceWith: Case.camel(entity.singular)},
+					{find: "Entity", replaceWith: Case.pascal(entity.singular)},
+					{find: "ENTITY", replaceWith: Case.constant(entity.singular)}
+				];
+				
+				replaceInPath(path.join(fullPackageLocation, "**/*.ts"), codeReplacements);
+				replaceInPath(path.join(fullPackageLocation, "**/*.tsx"), codeReplacements);
+				
+				// Make sure to also rename base file names.
+				const fileNameReplacements = [
+					{
+						find: "views/EntitiesDataList.tsx",
+						replaceWith: `views/${Case.pascal(entity.plural)}DataList.tsx`,
+					},
+					{
+						find: "views/Entities.tsx",
+						replaceWith: `views/${Case.pascal(entity.plural)}.tsx`,
+					},
+					{
+						find: "views/EntityForm.tsx",
+						replaceWith: `views/${Case.pascal(entity.singular)}Form.tsx`,
+					},
+					{
+						find: "example.tsconfig.json",
+						replaceWith: "tsconfig.json"
+					}
+				];
+				
+				for (const key in fileNameReplacements) {
+					if(!fileNameReplacements.hasOwnProperty(key)) {
+						continue;
+					}
+					const fileNameReplacement = fileNameReplacements[key];
+					fs.renameSync(
+						path.join(fullPackageLocation, fileNameReplacement.find),
+						path.join(fullPackageLocation, fileNameReplacement.replaceWith)
+					);
+				}
+				
+				// Update the package's name
+				const packageJsonPath = path.resolve(fullPackageLocation, "package.json");
+				let packageJson = fs.readFileSync(packageJsonPath, "utf8");
+				packageJson = packageJson.replace(/\[PACKAGE_NAME\]/g, packageName);
+				fs.writeFileSync(packageJsonPath, packageJson);
+				
+				// Update tsconfig "extends" path
+				const tsConfigPath = path.join(fullPackageLocation, "tsconfig.json");
+				const tsconfig = require(tsConfigPath);
+				tsconfig.extends = baseTsConfigPath;
+				fs.writeFileSync(tsConfigPath, JSON.stringify(tsconfig, null, 2));
+				
+				oraSpinner.info('You must register generated GraphQL app in your app factory "plugins" property');
+			}
+		}
+	}
+];

--- a/packages/cli-plugin-scaffold-app-graphql/index.js
+++ b/packages/cli-plugin-scaffold-app-graphql/index.js
@@ -8,6 +8,7 @@ const pluralize = require("pluralize");
 const Case = require("case");
 const {replaceInPath} = require("replace-in-path");
 const fastGlob = require('fast-glob');
+const {green} = require("chalk");
 
 const appsPluginsLocation = "apps/admin/src/plugins";
 
@@ -23,7 +24,7 @@ const readApiPackageEntityName = (file) => {
 		})
 		.toString();
 	if(!fileContent) {
-		throw new Error(`Could not load any content from file ${file}`);
+		throw new Error(`Could not load any content from file ${file}.`);
 	}
 	
 	const nameMatched = fileContent.match(/withName\("([a-zA-Z]+)"\)/);
@@ -42,7 +43,7 @@ const findEntities = (location) => {
 			unique: true,
 		});
 	if(files.length === 0) {
-		throw new Error(`Could not find any entities with fast-glob pattern "${target}"`);
+		throw new Error(`Could not find any entities with fast-glob pattern "${target}".`);
 	}
 	return files.map(file => ({
 		fileName: path.basename(file),
@@ -73,7 +74,7 @@ module.exports = [
 								findEntities(apiLocation);
 							}
 							catch (ex) {
-								return `Could not find existing API entity in ${apiLocation}, error: ${ex.message}.`;
+								return `Could not find existing API entity in "${apiLocation}".`;
 							}
 							return true;
 						}
@@ -120,7 +121,7 @@ module.exports = [
 							
 							const locationFullPath = path.resolve(packageLocation);
 							if(fs.existsSync(locationFullPath)) {
-								return `The target location already exists: ${packageLocation}`;
+								return `The target location already exists "${packageLocation}".`;
 							}
 							
 							const rootResourcesPath = findUp.sync("resources.js", {
@@ -156,6 +157,9 @@ module.exports = [
 				const entityName = existingEntityName || newEntityName;
 				
 				const fullPackageLocation = path.resolve(createPackageLocation(packageLocation));
+				const applicationFilePath = findUp.sync('App.tsx', {
+					cwd: fullPackageLocation,
+				});
 				
 				const packageName = kebabCase(packageLocation);
 				
@@ -163,7 +167,7 @@ module.exports = [
 				const sourceFolder = path.join(__dirname, "template");
 				
 				if(fs.existsSync(fullPackageLocation)) {
-					throw new Error(`Destination folder ${fullPackageLocation} already exists!`);
+					throw new Error(`Destination folder ${fullPackageLocation} already exists.`);
 				}
 				
 				await fs.mkdirSync(fullPackageLocation, {recursive: true});
@@ -242,7 +246,11 @@ module.exports = [
 				tsconfig.extends = baseTsConfigPath;
 				fs.writeFileSync(tsConfigPath, JSON.stringify(tsconfig, null, 2));
 				
-				oraSpinner.info('You must register generated GraphQL app in your app factory "plugins" property');
+				const appPath = applicationFilePath || 'app tsx file';
+				
+				oraSpinner.info('You must register the generated plugins in order for them to appear in your app.');
+				oraSpinner.info(`Open your ${green(appPath)} and pass your new plugins to the app template via the "plugins" option.`);
+				oraSpinner.info('Learn more about Webiny app development at https://docs.webiny.com/docs/app-development/introduction.')
 			}
 		}
 	}

--- a/packages/cli-plugin-scaffold-app-graphql/jest.config.js
+++ b/packages/cli-plugin-scaffold-app-graphql/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/cli-plugin-scaffold-app-graphql/package.json
+++ b/packages/cli-plugin-scaffold-app-graphql/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/webiny/webiny-js#readme",
   "dependencies": {
     "case": "^1.6.3",
+	"chalk": "^4.1.0",
     "find-up": "^4.1.0",
     "lodash.kebabcase": "^4.1.1",
     "ncp": "^2.0.0",

--- a/packages/cli-plugin-scaffold-app-graphql/package.json
+++ b/packages/cli-plugin-scaffold-app-graphql/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@webiny/cli-plugin-scaffold-graphql-app",
+  "version": "4.6.0",
+  "description": "Generate Webiny GraphQL React App",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webiny/webiny-js.git",
+    "directory": "packages/cli-plugin-scaffold-graphql-app"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/webiny/webiny-js/issues"
+  },
+  "homepage": "https://github.com/webiny/webiny-js#readme",
+  "dependencies": {
+    "@babel/core": "^7.9.6",
+    "case": "^1.6.3",
+    "execa": "^4.0.2",
+    "find-up": "^4.1.0",
+    "load-json-file": "^6.2.0",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.kebabcase": "^4.1.1",
+    "ncp": "^2.0.0",
+    "pluralize": "^8.0.0",
+    "prettier": "^2.0.5",
+    "replace-in-path": "^1.0.2",
+    "write-json-file": "^4.3.0"
+  },
+  "devDependencies": {
+    "@shelf/jest-mongodb": "^1.1.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "."
+  },
+  "adio": {
+    "ignoreDirs": [
+      "template",
+      "node_modules",
+      "__tests__"
+    ]
+  }
+}

--- a/packages/cli-plugin-scaffold-app-graphql/package.json
+++ b/packages/cli-plugin-scaffold-app-graphql/package.json
@@ -19,7 +19,7 @@
     "find-up": "^4.1.0",
     "lodash.kebabcase": "^4.1.1",
     "ncp": "^2.0.0",
-    "prettier": "^2.0.5",
+	"pluralize": "^8.0.0",
     "replace-in-path": "^1.0.2",
 	"fast-glob": "^3.2.4",
 	"util": "^0.10.3"

--- a/packages/cli-plugin-scaffold-app-graphql/package.json
+++ b/packages/cli-plugin-scaffold-app-graphql/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@webiny/cli-plugin-scaffold-graphql-app",
+  "name": "@webiny/cli-plugin-scaffold-app-graphql",
   "version": "4.6.0",
   "description": "Generate Webiny GraphQL React App",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/webiny/webiny-js.git",
-    "directory": "packages/cli-plugin-scaffold-graphql-app"
+    "directory": "packages/cli-plugin-scaffold-app-graphql"
   },
   "author": "",
   "license": "MIT",
@@ -15,18 +15,14 @@
   },
   "homepage": "https://github.com/webiny/webiny-js#readme",
   "dependencies": {
-    "@babel/core": "^7.9.6",
     "case": "^1.6.3",
-    "execa": "^4.0.2",
     "find-up": "^4.1.0",
-    "load-json-file": "^6.2.0",
-    "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "ncp": "^2.0.0",
-    "pluralize": "^8.0.0",
     "prettier": "^2.0.5",
     "replace-in-path": "^1.0.2",
-    "write-json-file": "^4.3.0"
+	"fast-glob": "^3.2.4",
+	"util": "^0.10.3"
   },
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.5"

--- a/packages/cli-plugin-scaffold-app-graphql/template/.babelrc.js
+++ b/packages/cli-plugin-scaffold-app-graphql/template/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.node");

--- a/packages/cli-plugin-scaffold-app-graphql/template/example.tsconfig.json
+++ b/packages/cli-plugin-scaffold-app-graphql/template/example.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "references": []
+}

--- a/packages/cli-plugin-scaffold-app-graphql/template/index.ts
+++ b/packages/cli-plugin-scaffold-app-graphql/template/index.ts
@@ -1,0 +1,7 @@
+import menus from './menus';
+import routes from "./routes";
+
+export default [
+    menus,
+    routes,
+];

--- a/packages/cli-plugin-scaffold-app-graphql/template/jest.config.js
+++ b/packages/cli-plugin-scaffold-app-graphql/template/jest.config.js
@@ -1,0 +1,3 @@
+const base = require("../../jest.config.base");
+
+module.exports = base({ path: __dirname });

--- a/packages/cli-plugin-scaffold-app-graphql/template/menus.tsx
+++ b/packages/cli-plugin-scaffold-app-graphql/template/menus.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {AdminMenuPlugin} from '@webiny/app-admin/types';
+import {ReactComponent as Icon} from "@webiny/app-page-builder/admin/assets/round-ballot-24px.svg";
+
+
+const plugin: AdminMenuPlugin = {
+    type: "admin-menu",
+    name: "admin-menu-graphql-entities",
+    render({Menu, Item}) {
+        return (
+            <Menu name="menu-entities" label={"Entities"} icon={<Icon/>}>
+                <Item label={"Entities"} path={'/entities/'}/>
+            </Menu>
+        );
+    }
+};
+
+
+export default plugin;

--- a/packages/cli-plugin-scaffold-app-graphql/template/package.json
+++ b/packages/cli-plugin-scaffold-app-graphql/template/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "app-graphql-[PACKAGE_NAME]",
+  "version": "1.0.0",
+  "description": "GraphQL React [PACKAGE_NAME] App",
+  "license": "MIT",
+  "scripts": {
+    "build": "webiny run build"
+  },
+  "dependencies": {
+    "@webiny/app": "^4.6.0",
+    "@webiny/app-admin": "^4.6.0",
+    "@webiny/app-page-builder": "^4.6.0",
+    "@webiny/project-utils": "^4.0.2",
+    "@webiny/react-router": "^4.6.0",
+    "@webiny/ui": "^4.6.0",
+    "@webiny/form": "^4.6.0",
+	"@webiny/validation": "^4.6.0"
+  },
+  "devDependencies": {
+
+  }
+}

--- a/packages/cli-plugin-scaffold-app-graphql/template/routes.tsx
+++ b/packages/cli-plugin-scaffold-app-graphql/template/routes.tsx
@@ -1,0 +1,39 @@
+import React, {Suspense, lazy} from 'react';
+import Helmet from "react-helmet";
+import {Route} from "@webiny/react-router";
+import {RoutePlugin} from "@webiny/app/types";
+import {CircularProgress} from "@webiny/ui/Progress";
+import {AdminLayout} from "@webiny/app-admin/components/AdminLayout";
+
+const Loader = ({children, ...props}) => (
+    <Suspense fallback={<CircularProgress/>}>{React.cloneElement(children, props)}</Suspense>
+);
+
+const Entities = lazy(() => import('./views/Entities'));
+
+const entitiesRoute: RoutePlugin = {
+    type: 'route',
+    name: 'route-admin-entities',
+    route: (
+        <Route
+            path={'/entities'}
+            exact
+            render={() => (
+                <AdminLayout>
+                    <Helmet>
+                        <title>Entities</title>
+                    </Helmet>
+                    <Loader>
+                        <Entities/>
+                    </Loader>
+                </AdminLayout>
+            )}
+        />
+    ),
+};
+
+const routes: RoutePlugin[] = [
+    entitiesRoute,
+];
+
+export default routes;

--- a/packages/cli-plugin-scaffold-app-graphql/template/views/Entities.tsx
+++ b/packages/cli-plugin-scaffold-app-graphql/template/views/Entities.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import {pick} from "lodash";
+import {SplitView, LeftPanel, RightPanel} from "@webiny/app-admin/components/SplitView";
+import {FloatingActionButton} from "@webiny/app-admin/components/FloatingActionButton";
+import EntitiesDataList from "./EntitiesDataList";
+import EntitiesForm from "./EntityForm";
+import {READ_ENTITY, LIST_ENTITIES, CREATE_ENTITY, UPDATE_ENTITY, DELETE_ENTITY} from "./graphql";
+import {CrudProvider} from "@webiny/app-admin/contexts/Crud";
+
+const Entities = ({scopes, formProps, listProps}: any) => {
+    const variables = data => ({
+        data: {
+            ...pick(data, ["title", "description", "isNice"]),
+        }
+    });
+    
+    return (
+        <React.Fragment>
+            <CrudProvider
+                delete={DELETE_ENTITY}
+                read={READ_ENTITY}
+                list={{
+                    query: LIST_ENTITIES,
+                    variables: {sort: {savedOn: -1}}
+                }}
+                update={{
+                    mutation: UPDATE_ENTITY,
+                    variables
+                }}
+                create={{
+                    mutation: CREATE_ENTITY,
+                    variables
+                }}
+            >
+                {({actions}) => (
+                    <>
+                        <SplitView>
+                            <LeftPanel>
+                                <EntitiesDataList {...listProps} />
+                            </LeftPanel>
+                            <RightPanel>
+                                <EntitiesForm scopes={scopes} {...formProps} />
+                            </RightPanel>
+                        </SplitView>
+                        <FloatingActionButton
+                            data-testid="new-record-button"
+                            onClick={actions.resetForm}
+                        />
+                    </>
+                )}
+            </CrudProvider>
+        </React.Fragment>
+    );
+};
+
+export default Entities;

--- a/packages/cli-plugin-scaffold-app-graphql/template/views/EntitiesDataList.tsx
+++ b/packages/cli-plugin-scaffold-app-graphql/template/views/EntitiesDataList.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import {i18n} from "@webiny/app/i18n";
+import {ConfirmationDialog} from "@webiny/ui/ConfirmationDialog";
+import {
+    DataList,
+    ScrollList,
+    ListItem,
+    ListItemText,
+    ListItemTextSecondary,
+    ListItemMeta,
+    ListActions
+} from "@webiny/ui/List";
+
+import {DeleteIcon} from "@webiny/ui/List/DataList/icons";
+import {useCrud} from "@webiny/app-admin/hooks/useCrud";
+
+const t = i18n.ns("app-graphql-app-entity/data-list");
+
+const EntitiesDataList = () => {
+    const {actions, list} = useCrud();
+    return (
+        <DataList
+            {...list}
+            title={t`Entities`}
+            sorters={[
+                {
+                    label: t`Newest to oldest`,
+                    sorters: {createdOn: -1}
+                },
+                {
+                    label: t`Oldest to newest`,
+                    sorters: {createdOn: 1}
+                },
+                {
+                    label: t`Name A-Z`,
+                    sorters: {title: 1}
+                },
+                {
+                    label: t`Name Z-A`,
+                    sorters: {title: -1}
+                }
+            ]}
+        >
+            {({data, select, isSelected}) => (
+                <ScrollList data-testid="default-data-list">
+                    {data.map(item => (
+                        <ListItem key={item.id} selected={isSelected(item)}>
+                            <ListItemText onClick={() => select(item)}>
+                                {item.name}
+                                <ListItemTextSecondary>{item.description}</ListItemTextSecondary>
+                            </ListItemText>
+
+                            <ListItemMeta>
+                                <ListActions>
+                                    <ConfirmationDialog>
+                                        {({showConfirmation}) => (
+                                            <DeleteIcon
+                                                onClick={() =>
+                                                    showConfirmation(() => actions.delete(item))
+                                                }
+                                            />
+                                        )}
+                                    </ConfirmationDialog>
+                                </ListActions>
+                            </ListItemMeta>
+                        </ListItem>
+                    ))}
+                </ScrollList>
+            )}
+        </DataList>
+    );
+};
+
+export default EntitiesDataList;

--- a/packages/cli-plugin-scaffold-app-graphql/template/views/EntityForm.tsx
+++ b/packages/cli-plugin-scaffold-app-graphql/template/views/EntityForm.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import {i18n} from "@webiny/app/i18n";
+import {Form} from "@webiny/form";
+import {Grid, Cell} from "@webiny/ui/Grid";
+import {Input} from "@webiny/ui/Input";
+import {ButtonPrimary} from "@webiny/ui/Button";
+import {CircularProgress} from "@webiny/ui/Progress";
+import {useCrud} from "@webiny/app-admin/hooks/useCrud";
+import {Checkbox} from "@webiny/ui/Checkbox";
+import { validation } from "@webiny/validation";
+import {
+    SimpleForm,
+    SimpleFormFooter,
+    SimpleFormContent,
+    SimpleFormHeader
+} from "@webiny/app-admin/components/SimpleForm";
+
+const t = i18n.ns("app-graphql-app-entity/form");
+
+const EntityForm = () => {
+    const {form: crudForm} = useCrud();
+    return (
+        <Form {...crudForm}>
+            {({data, form, Bind}) => (
+                <SimpleForm>
+                    {crudForm.loading && <CircularProgress/>}
+                    <SimpleFormHeader title={data.title || 'Untitled'}/>
+                    <SimpleFormContent>
+                    <Grid>
+                        <Cell span={6}>
+                            <Bind name="title" validators={validation.create('required')}>
+                                <Input
+                                    label={'Title'}
+                                    description={'This is the title of the Entity model.'}
+                                />
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                    <Grid>
+                        <Cell span={6}>
+                            <Bind name="description" validators={validation.create('maxLength:500')}>
+                                <Input
+                                    label={'Description'}
+                                    description={'This is the description of the Entity model.'}
+                                    rows={4}
+                                />
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                    <Grid>
+                        <Cell span={6}>
+                            <Bind name="isNice">
+                                <Checkbox
+                                    label={'Is this Entity nice?'}
+                                    description={'Please select if Entity is really nice :)'}
+                                />
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                    </SimpleFormContent>
+                    <SimpleFormFooter>
+                        <ButtonPrimary onClick={form.submit}>{t`Save entity`}</ButtonPrimary>
+                    </SimpleFormFooter>
+                </SimpleForm>
+            )}
+        </Form>
+    );
+};
+
+export default EntityForm;

--- a/packages/cli-plugin-scaffold-app-graphql/template/views/graphql.ts
+++ b/packages/cli-plugin-scaffold-app-graphql/template/views/graphql.ts
@@ -1,0 +1,99 @@
+import gql from "graphql-tag";
+
+
+export const LIST_ENTITIES = gql`
+    query ListEntities (
+        $sort: EntityListSort
+        $sort: EntityListSort
+        $where: EntityListWhere
+        $limit: Int
+        $after: String
+        $before: String
+    ) {
+        entities {
+            listEntities (
+                sort: $sort
+                where: $where
+                limit: $limit
+                after: $after
+                before: $before
+            ) {
+                data {
+                    id
+                    title
+                    description
+                    isNice
+                    createdOn
+                }
+            }
+        }
+    }
+`;
+
+export const CREATE_ENTITY = gql`
+    mutation CreateEntity($input: EntityInput!) {
+        createEntity (input: $input) {
+            data {
+                id
+                title
+                description
+                isNice
+                createdOn
+            }
+            error {
+                code
+                message
+                data
+            }
+        }
+    }
+`;
+
+
+export const READ_ENTITY = gql`
+    query GetEntity ($id: ID!) {
+        entities {
+            entity: getEntity(id: $id) {
+                data {
+                    id
+                    title
+                    description
+                    isNice
+                    createdOn
+                }
+            }
+        }
+    }
+`;
+
+export const DELETE_ENTITY = gql`
+    mutation DeleteEntity ($id: ID!) {
+        deleteEntity(id: $id) {
+            data
+            error {
+                code
+                message
+                data
+            }
+        }
+    }
+`;
+
+export const UPDATE_ENTITY = gql`
+    mutation UpdateEntity ($id: ID!, $data: EntityInput!) {
+        updateEntity(id: $id, data: $data) {
+            data {
+                id
+                title
+                description
+                isNice
+                createdOn
+            }
+            error {
+                code
+                message
+                data
+            }
+        }
+    }
+`;

--- a/packages/cli-plugin-scaffold-app-graphql/template/webiny.config.js
+++ b/packages/cli-plugin-scaffold-app-graphql/template/webiny.config.js
@@ -1,0 +1,7 @@
+const { buildFunction } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: buildFunction
+    }
+};

--- a/packages/cli-plugin-scaffold-app-graphql/tsconfig.json
+++ b/packages/cli-plugin-scaffold-app-graphql/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "include": ["src", "__tests__/**/*.ts"]
+}

--- a/webiny.root.js
+++ b/webiny.root.js
@@ -7,7 +7,8 @@ module.exports = {
             require("@webiny/cwp-template-full/hooks/apps")(),
             require("@webiny/cli-plugin-scaffold"),
             require("@webiny/cli-plugin-scaffold-graphql-service"),
-            require("@webiny/cli-plugin-scaffold-lambda")
+            require("@webiny/cli-plugin-scaffold-lambda"),
+            require("@webiny/cli-plugin-scaffold-app-graphql")
         ]
     }
 };


### PR DESCRIPTION
## Related Issue
Closes [#1154](https://github.com/webiny/webiny-js/issues/1154)

## Your solution
I have created a scaffold package that will create a GraphQL React App.
It is a simple scaffold that asks you for location of existing GraphQL API (generated by GraphQL API scaffold), data model name (either automatically detected from existing API or manual input) and location for your generated app.

## How Has This Been Tested?
I was testing manually by going through the options.
Scenario 1
1. Leave existing API empty
2. Write package location “webiny”
3. Write name of the data model “scaffold”

Scenario 2
1. Create GraphQL API with location “api/webiny” and data model “Webiny”
2. Write existing API name “api/webiny”
3. Choose data model “Webiny”
4. Write package location “webinyApp”

## Screenshots (if relevant):
Existing GraphQL API
![with-existing-api](https://user-images.githubusercontent.com/10399339/88842814-61170700-d1e0-11ea-95ec-079f3215f008.gif)

No existing API
![no-existing-api](https://user-images.githubusercontent.com/10399339/88842806-5e1c1680-d1e0-11ea-9df1-ce78e4864fb5.gif)
