### PR TITLE
Page Builder - fixed Menus not being rendered completely

### DIFF
--- a/packages/api-page-builder/src/plugins/graphql/menuResolvers/prepareMenuItems.ts
+++ b/packages/api-page-builder/src/plugins/graphql/menuResolvers/prepareMenuItems.ts
@@ -89,6 +89,7 @@ export default async ({ menu, context }: { [key: string]: any }) => {
                             const ids = Object.keys(context.distinctParents.data);
 
                             await listPublishedPages({
+                                limit: 200,
                                 args: { parent: ids },
                                 context
                             }).then(results => {
@@ -113,6 +114,7 @@ export default async ({ menu, context }: { [key: string]: any }) => {
                         const { category, sortBy, sortDir, tags } = item;
 
                         item.children = await listPublishedPages({
+                            limit: 200,
                             args: { tags, category, sort: { [sortBy]: parseInt(sortDir) } },
                             context
                         });

--- a/packages/api-page-builder/src/plugins/graphql/pageResolvers/getPublishedPage.ts
+++ b/packages/api-page-builder/src/plugins/graphql/pageResolvers/getPublishedPage.ts
@@ -3,6 +3,7 @@ import { listPublishedPages } from "./listPublishedPages";
 import get from "lodash.get";
 
 const createNotFoundResponse = async ({ returnFallbackPage, context, page, message }) => {
+    const { PbPage } = context.models;
     const response = new NotFoundResponse(message);
     if (returnFallbackPage === true) {
         const { PbSettings } = context.models;
@@ -12,7 +13,11 @@ const createNotFoundResponse = async ({ returnFallbackPage, context, page, messa
             return response;
         }
 
-        const [foundPage] = await listPublishedPages({ context, args: { parent, limit: 1 } });
+        const [foundPage] = await listPublishedPages({
+            pageModel: PbPage,
+            context,
+            args: { parent, limit: 1 }
+        });
         response.data = foundPage;
     }
 
@@ -20,7 +25,7 @@ const createNotFoundResponse = async ({ returnFallbackPage, context, page, messa
 };
 
 export default async (root: any, args: { [key: string]: any }, context: { [key: string]: any }) => {
-    const { PbSettings } = context.models;
+    const { PbSettings, PbPage } = context.models;
     const settings = await PbSettings.load();
     if (!settings.data.installation.completed) {
         // We don't need to load the error page here, since PB is not installed at all, so it doesn't exist.
@@ -38,7 +43,11 @@ export default async (root: any, args: { [key: string]: any }, context: { [key: 
         // 1. If "parent" of "id" were passed, get the page based on those.
         //    Note that the "preview" mode is only available for the "id" filter.
         if (args.parent || args.id) {
-            const [page] = await listPublishedPages({ context, args: { ...args, perPage: 1 } });
+            const [page] = await listPublishedPages({
+                pageModel: PbPage,
+                context,
+                args: { ...args, perPage: 1 }
+            });
             if (page) {
                 return new Response(page);
             }
@@ -57,7 +66,11 @@ export default async (root: any, args: { [key: string]: any }, context: { [key: 
             const settings = await PbSettings.load();
             const parent = get(settings, `data.pages.home`);
 
-            const [page] = await listPublishedPages({ context, args: { parent, limit: 1 } });
+            const [page] = await listPublishedPages({
+                pageModel: PbPage,
+                context,
+                args: { parent, limit: 1 }
+            });
             if (page) {
                 return new Response(page);
             }
@@ -71,7 +84,11 @@ export default async (root: any, args: { [key: string]: any }, context: { [key: 
         }
 
         // 3. Otherwise, just try to load the page via passed "url".
-        const [page] = await listPublishedPages({ context, args: { ...args, limit: 1 } });
+        const [page] = await listPublishedPages({
+            pageModel: PbPage,
+            context,
+            args: { ...args, limit: 1 }
+        });
         if (page) {
             return new Response(page);
         }

--- a/packages/api-page-builder/src/plugins/graphql/pageResolvers/listPages.ts
+++ b/packages/api-page-builder/src/plugins/graphql/pageResolvers/listPages.ts
@@ -1,7 +1,7 @@
 import { ListResponse, requiresTotalCount } from "@webiny/graphql";
 
 export const listPages = async ({ context, args, info }) => {
-    const { PbPage } = context.models;
+    const { PbPagesListPage } = context.models;
     const { limit = 10, after, before, sort = null, parent = null } = args;
 
     const query: any = {
@@ -21,7 +21,7 @@ export const listPages = async ({ context, args, info }) => {
         };
     }
 
-    return await PbPage.find({
+    return await PbPagesListPage.find({
         sort,
         limit,
         after,

--- a/packages/api-page-builder/src/plugins/graphql/pageResolvers/listPublishedPages.ts
+++ b/packages/api-page-builder/src/plugins/graphql/pageResolvers/listPublishedPages.ts
@@ -2,8 +2,10 @@ import { ListResponse, requiresTotalCount } from "@webiny/graphql";
 import { GraphQLResolveInfo } from "graphql";
 
 export const listPublishedPages = async params => {
-    const { context, args, info = null } = params;
-    const { PbCategory, PbPage } = context.models;
+    const { pageModel, context, args, info = null } = params;
+    const { PbCategory, PbPagesListPage } = context.models;
+
+    const PbPageModel = pageModel || PbPagesListPage;
 
     const {
         search,
@@ -73,7 +75,7 @@ export const listPublishedPages = async params => {
         }
     }
 
-    return PbPage.find({
+    return PbPageModel.find({
         query: { $and: baseFilters },
         sort,
         limit,

--- a/packages/api-page-builder/src/plugins/models.ts
+++ b/packages/api-page-builder/src/plugins/models.ts
@@ -5,6 +5,7 @@ import pbCategory from "./models/pbCategory.model";
 import pbPageElement from "./models/pbPageElement.model";
 import pbMenu from "./models/pbMenu.model";
 import pbPage from "./models/pbPage.model";
+import pbPagesListPage from "./models/pbPagesListPage.model";
 import pbSettings from "./models/pbSettings.model";
 import got from "got";
 
@@ -37,6 +38,7 @@ export default () => [
             const PbPageElement = pbPageElement({ createBase, context });
             const PbSettings = pbSettings({ createBase, context });
             const PbPage = pbPage({ createBase, context, PbCategory, PbSettings });
+            const PbPagesListPage = pbPagesListPage({ createBase, PbCategory, PbSettings });
 
             context.models = {
                 PbCategory,
@@ -44,6 +46,7 @@ export default () => [
                 PbMenu,
                 PbSettings,
                 PbPage,
+                PbPagesListPage,
                 createBase
             };
         }

--- a/packages/api-page-builder/src/plugins/models/pbPagesListPage.model.ts
+++ b/packages/api-page-builder/src/plugins/models/pbPagesListPage.model.ts
@@ -1,0 +1,75 @@
+import { flow } from "lodash";
+import {
+    withFields,
+    string,
+    number,
+    boolean,
+    date,
+    withName,
+    withProps,
+    ref
+} from "@webiny/commodo";
+
+/**
+ * A read-only model, used when listing pages. The most important thing here is that we don't load the content.
+ * @param createBase
+ * @param PbCategory
+ * @param PbSettings
+ */
+export default ({ createBase, PbCategory, PbSettings }) => {
+    const PbPagesListPage: any = flow(
+        withName("PbPage"),
+        withFields({
+            category: ref({ instanceOf: PbCategory }),
+            publishedOn: date(),
+            title: string(),
+            snippet: string(),
+            url: string(),
+            version: number(),
+            parent: string(),
+            published: boolean(),
+            locked: boolean()
+        }),
+        withProps({
+            get isHomePage() {
+                return new Promise(async resolve => {
+                    const settings = await PbSettings.load();
+                    resolve(settings.data.pages.home === this.parent);
+                }).catch(() => false);
+            },
+            get isErrorPage() {
+                return new Promise(async resolve => {
+                    const settings = await PbSettings.load();
+                    resolve(settings.data.pages.error === this.parent);
+                }).catch(() => false);
+            },
+            get isNotFoundPage() {
+                return new Promise(async resolve => {
+                    const settings = await PbSettings.load();
+                    resolve(settings.data.pages.notFound === this.parent);
+                }).catch(() => false);
+            },
+            get revisions() {
+                return new Promise(async resolve => {
+                    const revisions = await PbPagesListPage.find({
+                        query: { parent: this.parent },
+                        sort: { version: -1 }
+                    });
+                    resolve(revisions);
+                });
+            },
+            get fullUrl() {
+                return new Promise(async (resolve, reject) => {
+                    try {
+                        const settings = await PbSettings.load();
+                        resolve(settings.data.domain.replace(/\/+$/g, "") + this.url);
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+            }
+        })
+    )(createBase());
+
+    return PbPagesListPage;
+};

--- a/packages/api-plugin-page-builder-resolvers-mongodb/src/index.ts
+++ b/packages/api-plugin-page-builder-resolvers-mongodb/src/index.ts
@@ -36,21 +36,7 @@ export default () => [
             // TODO: in "content" field. We will only store an immutable file "key", which is enough for us to
             // TODO: construct the whole path to the file (we'll only load URL prefix via GRAPHQL)
             try {
-                if (!context.files) {
-                    context.files = {
-                        settings: await driver.getClient().runOperation({
-                            collection: "Settings",
-                            operation: [
-                                "findOne",
-                                {
-                                    key: "file-manager",
-                                    deleted: { $ne: true }
-                                }
-                            ]
-                        })
-                    };
-                }
-
+                const filesSettings = await context.settingsManager.getSettings("file-manager");
                 const result = await driver.getClient().runOperation({
                     collection: "File",
                     operation: ["findOne", { id, deleted: { $ne: true } }]
@@ -62,7 +48,7 @@ export default () => [
 
                 return {
                     id: result.id,
-                    src: get(context, "files.settings.data.srcPrefix") + result.key
+                    src: get(filesSettings, "srcPrefix") + result.key
                 };
             } catch (e) {
                 return null;

--- a/packages/api-settings-manager/src/client/SettingsManagerClient.ts
+++ b/packages/api-settings-manager/src/client/SettingsManagerClient.ts
@@ -7,15 +7,40 @@ interface SettingsManagerOperation {
     data?: { [key: string]: any };
 }
 
+class SettingsManagerClientCache {
+    data?: { [key: string]: any };
+    constructor() {
+        this.data = {};
+    }
+
+    set(key, data) {
+        this.data[key] = data;
+    }
+
+    get(key) {
+        return this.data[key];
+    }
+
+    flush(key) {
+        delete this.data[key];
+    }
+}
+
 export class SettingsManagerClient {
     settingsManagerFunction: string;
     lambda: LambdaClient;
-
+    cache: SettingsManagerClientCache;
     constructor({ functionName }) {
         this.settingsManagerFunction = functionName;
+        this.cache = new SettingsManagerClientCache();
     }
 
     private async invoke(operation: SettingsManagerOperation) {
+        const cached = this.cache.get(operation.key);
+        if (cached) {
+            return cached;
+        }
+
         if (!this.lambda) {
             this.lambda = new LambdaClient({ region: process.env.AWS_REGION });
         }
@@ -33,6 +58,8 @@ export class SettingsManagerClient {
             throw Error(error);
         }
 
+        this.cache.set(operation.key, data);
+
         return data;
     }
 
@@ -46,5 +73,9 @@ export class SettingsManagerClient {
 
     async deleteSettings(key: string) {
         await this.invoke({ action: "deleteSettings", key });
+    }
+
+    getCache() {
+        return this.cache;
     }
 }


### PR DESCRIPTION
## Related Issue
When printing out menus, on the backend, the default limit of `10` was applied to the `listPublishedPages` query, which would cause menus on the public website to not render completely when there were more than 10 pages to load.

## Your solution
I increased the limit to `200` (`packages/api-page-builder/src/plugins/graphql/menuResolvers/prepareMenuItems.ts`).

## Additional
I noticed that even when we are just listing pages, we are loading the content for each page, which means loading the images as well. This is redundant, so I made a fragment Commodo model `PbPagesListPage`, that is used when listing pages. It's a simple model, without any hooks / advanced fields and behavior.

### Results?
Although, while testing, I noticed more places ready to be optimized, a nice result can be seen while executing this basic pages list query:
![image](https://user-images.githubusercontent.com/5121148/89990150-3ae27400-dc82-11ea-941a-614375588cbb.png)

Initially, this would execute 6 database calls, now it executes just one. Note that additional DB calls still may be seen if you add `category` or `createdBy` / `updatedBy` fields to this GQL query.

## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
