### PR TITLE
Feat: PB dynamic element settings plugin

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/bar/ElementSettingsBar.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/bar/ElementSettingsBar.tsx
@@ -9,6 +9,7 @@ import { useKeyHandler } from "@webiny/app-page-builder/editor/hooks/useKeyHandl
 import Menu from "./components/Menu";
 import { ReactComponent as NavigateBeforeIcon } from "@webiny/app-page-builder/editor/assets/icons/navigate_before.svg";
 import { PbEditorPageElementPlugin } from "@webiny/app-page-builder/types";
+import { userSettingsPlugins } from "@webiny/app-page-builder/editor/utils";
 
 const divider = "pb-editor-page-element-settings-divider";
 
@@ -17,7 +18,9 @@ const getElementActions = plugin => {
         return [];
     }
 
-    const actions = plugin.settings.map(pl => {
+    const pluginSettings = [...userSettingsPlugins(plugin.elementType), ...plugin.settings];
+
+    const actions = pluginSettings.map(pl => {
         if (typeof pl === "string") {
             return { plugin: getPlugin(pl || divider), options: {} };
         }
@@ -29,11 +32,24 @@ const getElementActions = plugin => {
         return null;
     });
 
-    return [
+    const elementActions = [
         ...actions,
-        { plugin: getPlugin("pb-editor-page-element-settings-advanced") },
-        { plugin: getPlugin("pb-editor-page-element-settings-save") }
-    ].filter(pl => pl);
+        { plugin: getPlugin("pb-editor-page-element-settings-advanced"), options: {} },
+        { plugin: getPlugin("pb-editor-page-element-settings-save"), options: {} }
+    ];
+
+    return (
+        elementActions
+            // Eliminate empty plugins
+            .filter(pl => {
+                return pl && pl.plugin;
+            })
+            // Eliminate duplicate plugins
+            .filter(
+                (pl, index, array) =>
+                    array.findIndex(item => item.plugin.name === pl.plugin.name) === index
+            )
+    );
 };
 
 const ElementSettingsBar = ({ elementType, deactivateElement }) => {

--- a/packages/app-page-builder/src/editor/utils.ts
+++ b/packages/app-page-builder/src/editor/utils.ts
@@ -2,11 +2,12 @@ import shortid from "shortid";
 import invariant from "invariant";
 import { set } from "dot-prop-immutable";
 import { isPlainObject, omit } from "lodash";
-import { getPlugin, getPlugins } from "@webiny/plugins";
+import { getPlugin, getPlugins, plugins } from "@webiny/plugins";
 import {
-    PbElement,
+    PbEditorBlockPlugin,
     PbEditorPageElementPlugin,
-    PbEditorBlockPlugin
+    PbEditorPageElementSettingsPlugin,
+    PbElement
 } from "@webiny/app-page-builder/types";
 
 export const updateChildPaths = (element: PbElement) => {
@@ -107,4 +108,20 @@ export const cloneElement = (element: PbElement) => {
     clone.elements = clone.elements.map(el => cloneElement(el));
 
     return clone;
+};
+
+export const userSettingsPlugins = (elementType: string) => {
+    return plugins
+        .byType<PbEditorPageElementSettingsPlugin>("pb-editor-page-element-settings")
+        .filter(pl => {
+            if (typeof pl.elements === "boolean") {
+                return pl.elements === true;
+            }
+            if (Array.isArray(pl.elements)) {
+                return pl.elements.includes(elementType);
+            }
+
+            return false;
+        })
+        .map(pl => pl.name);
 };

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -424,6 +424,7 @@ export type PbEditorPageElementSettingsPlugin = Plugin & {
     type: "pb-editor-page-element-settings";
     renderAction(params: { options?: any }): ReactElement;
     renderMenu?: (params: { options?: any }) => ReactElement;
+    elements?: boolean | string[];
 };
 
 export type PbEditorPageElementAdvancedSettingsPlugin = Plugin & {


### PR DESCRIPTION
## Your solution
Add a way to load element settings to page element by defining element is `pb-editor-page-element-settings` plugin so that  a new settings plugin can also be applied to existing page elements 

## How Has This Been Tested?
Manually, by using page builder app UI

