### PR TITLE
fix: email addresses with hyphens shouldn't wrap in the UserMenu

### DIFF
--- a/packages/app-security/src/admin/plugins/UserMenu/UserInfo.tsx
+++ b/packages/app-security/src/admin/plugins/UserMenu/UserInfo.tsx
@@ -52,6 +52,12 @@ const linkStyles = css({
             textOverflow: "ellipsis",
             maxWidth: 180,
             display: "block"
+        },
+        ".mdc-typography--subtitle2": {
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            maxWidth: 180
         }
     }
 });


### PR DESCRIPTION
## Related Issue
Closes #1196

## Your solution
Add the same CSS to the email address span that the user name header above already has.

## How Has This Been Tested?
Tested in Chrome and Safari only (are there any other relevant rendering engines now?). Just a quick visual check.

## Screenshots (if relevant):
<img width="266" alt="Screenshot 2020-08-21 at 15 28 24" src="https://user-images.githubusercontent.com/979220/90901560-04fc6880-e3c3-11ea-9984-7428dc5c26a6.png">
