### PR TITLE
Fix: headless CMS model description

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,5 +195,8 @@
         ]
       ]
     }
+  },
+  "resolutions": {
+    "pretty-format": "^25.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -197,6 +197,6 @@
     }
   },
   "resolutions": {
-    "pretty-format": "^25.5.0"
+    "pretty-format": "25.5.0"
   }
 }

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/category.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Product category"
+    """
+    Product category
+    """
     type Category {
         id: ID
         createdOn: DateTime

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/product.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Products being sold in our webshop"
+    """
+    Products being sold in our webshop
+    """
     type CmsRefProductCategoryLocalized {
         value: Category
         locale: ID!

--- a/packages/api-headless-cms/__tests__/manageAPI/snapshots/review.js
+++ b/packages/api-headless-cms/__tests__/manageAPI/snapshots/review.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Product review"
+    """
+    Product review
+    """
     type CmsRefReviewProductLocalized {
         value: Product
         locale: ID!

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/category.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/category.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Product category"
+    """
+    Product category
+    """
     type Category {
         id: ID
         createdOn: DateTime

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/product.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Products being sold in our webshop"
+    """
+    Products being sold in our webshop
+    """
     type Product {
         id: ID
         createdOn: DateTime

--- a/packages/api-headless-cms/__tests__/readAPI/snapshots/review.js
+++ b/packages/api-headless-cms/__tests__/readAPI/snapshots/review.js
@@ -1,5 +1,7 @@
 export default /* GraphQL */ `
-    "Product review"
+    """
+    Product review
+    """
     type Review {
         id: ID
         createdOn: DateTime

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
@@ -31,7 +31,7 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
     const fields = renderFields({ model, type: "manage", fieldTypePlugins });
 
     return /* GraphQL */ `
-        "${model.description}"
+        """${model.description}"""
         ${fields
             .map(f => f.typeDefs)
             .filter(Boolean)

--- a/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
@@ -30,7 +30,7 @@ export const createReadSDL: CreateManageSDL = ({ model, fieldTypePlugins }): str
     const fieldsRender = renderFields({ model, type: "read", fieldTypePlugins });
 
     return `
-        "${model.description}"
+        """${model.description}"""
         type ${rTypeName} {
             id: ID
             createdOn: DateTime


### PR DESCRIPTION
## Issue
Using quotes in `model.description` make the CMS GraphQL server to crash.

## Your solution
Fix multi-line comment format in CMS GraphQL schema.

## How Has This Been Tested?
Manually, using the Admin app and GraphQL playground.

## Screenshots:
![model-description](https://user-images.githubusercontent.com/13612227/91435382-db8c8280-e883-11ea-8a72-d46f4410566b.png)

