### PR TITLE
fix: rendering images in correct dimensions for editor and preview.

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/image/Image.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/Image.tsx
@@ -3,6 +3,8 @@ import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementR
 import ImageContainer from "./ImageContainer";
 
 const Image = ({ element }) => {
+    console.log("editor element");
+    console.log(element);
     return (
         <ElementRoot
             element={element}

--- a/packages/app-page-builder/src/editor/plugins/elements/image/ImageContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/ImageContainer.tsx
@@ -17,16 +17,45 @@ const AlignImage = styled("div")((props: any) => ({
 
 const ImageContainer = props => {
     const { horizontalAlign, updateElement, element } = props;
-    const image = { ...props.image };
+    console.log("IMAGE CONTAINER");
 
+    let image = { ...props.image };
+    let imageDimensions = document.createElement('img');
+    imageDimensions.src = file.src;
+    console.log(image);
     const imgStyle = { width: null, height: null };
     if (image.width) {
         const { width } = image;
         imgStyle.width = isNumeric(width) ? parseInt(width) : width;
+    } else {
+        console.log("no width");
+        let poll = setInterval(function () {
+            if (imageDimensions.naturalWidth) {
+                clearInterval(poll);
+            }
+        }, 10);
+        imageDimensions.onload = function () { 
+            console.log('Fully loaded'); 
+            console.log(imageDimensions.naturalWidth);
+            image.width = imageDimensions.naturalWidth;
+        }
     }
+
     if (image.height) {
         const { height } = image;
         imgStyle.height = isNumeric(height) ? parseInt(height) : height;
+    } else {
+        console.log("no heigth");
+        let poll = setInterval(function () {
+            if (imageDimensions.naturalHeight) {
+                clearInterval(poll);
+            }
+        }, 10);
+        imageDimensions.onload = function () { 
+            console.log('Fully loaded');
+            console.log(imageDimensions.naturalHeight);
+            image.height = imageDimensions.naturalHeight;
+        }
     }
 
     const onChange = useCallback(

--- a/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
@@ -20,14 +20,19 @@ const Image = props => {
     if (!image || !image.file) {
         return null;
     }
-
-    const { width, height, title } = image;
+    console.log("render image");
+    const { file, width, height, title } = image;
+    
+    console.log(image);
+    console.log(file);
+    console.log(width);
+    console.log(height);
 
     const { horizontalAlign = "center" } = settings;
 
     const style = { width, height };
     if (!style.width) {
-        style.width = "100%";
+        style.width = "100%"; 
     } else {
         style.width += style.width.endsWith("px") ? "" : "px";
     }


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #699

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
When image file is loaded through ```editor``` ... ```ImageContainer``` file, check if contains the ```width``` and ```height``` values aswell as the ```src``` value/key and other values.

***Here is a possible solution (from the ImageContainer file changes):***

```
if (image.width) {
        const { width } = image;
        imgStyle.width = isNumeric(width) ? parseInt(width) : width;
    } else {
        console.log("no width");
        let poll = setInterval(function () {
            if (imageDimensions.naturalWidth) {
                clearInterval(poll);
            }
        }, 10);
        imageDimensions.onload = function () { 
            console.log('Fully loaded'); 
            console.log(imageDimensions.naturalWidth);
            image.width = imageDimensions.naturalWidth;
        }
    }
```

When passed through to the ```render/``` ... ```image.tsx``` file it is not displaying width and height keys and this is because they arent determined in the ImageRender file I think. 

These should be checked for in the ImageContainer file, am I right?

## How Has This Been Tested?
So far manually through console.log
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
None yet.