### PR TITLE
Fix: CMS: Adding a field named `id` to the content model leads to a server crash

### DIFF
--- a/packages/api-headless-cms/__tests__/mocks/preventIdsWithWrongFormat.js
+++ b/packages/api-headless-cms/__tests__/mocks/preventIdsWithWrongFormat.js
@@ -1,0 +1,104 @@
+import { locales } from "./I18NLocales";
+
+export default {
+    modelWithFieldIdSetToId: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "id",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    modelWithFieldIdSetToIdIncludingWhiteSpace: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "  iD ",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    modelWithFieldIdContainingWhiteSpace: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "    title   ",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    modelWithValidFieldIds: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Book",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0-1",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+};

--- a/packages/api-headless-cms/__tests__/preventIdsWithWrongFormat.test.js
+++ b/packages/api-headless-cms/__tests__/preventIdsWithWrongFormat.test.js
@@ -1,0 +1,98 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/preventIdsWithWrongFormat";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+
+describe("Fields ID Test", () => {
+    const { environment, database } = useContentHandler();
+
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it(`should not allow fields with fieldId set to "id"`, async () => {
+        const { createContentModel } = environment(initial.environment.id);
+
+        let error = null;
+        try {
+            await createContentModel(
+                mocks.modelWithFieldIdSetToId({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                "fields.fieldId": 'Provided ID id is not valid - "id" is an auto-generated field.'
+            }
+        });
+
+        error = null;
+        try {
+            await createContentModel(
+                mocks.modelWithFieldIdSetToIdIncludingWhiteSpace({
+                    contentModelGroupId: initial.contentModelGroup.id
+                })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error.data).toEqual({
+            invalidFields: {
+                "fields.fieldId": 'Provided ID iD is not valid - "id" is an auto-generated field.'
+            }
+        });
+
+        error = null;
+        try {
+            await createContentModel(
+                mocks.modelWithValidFieldIds({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBe(null);
+
+        error = null;
+    });
+
+    it(`should trim the "fieldId" before saving to DB`, async () => {
+        const { createContentModel } = environment(initial.environment.id);
+
+        let error = null;
+
+        let contentModel;
+        try {
+            contentModel = await createContentModel(
+                mocks.modelWithFieldIdContainingWhiteSpace({
+                    contentModelGroupId: initial.contentModelGroup.id
+                })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBe(null);
+
+        expect(contentModel.fields[0].fieldId).toEqual("title");
+
+        error = null;
+        try {
+            await createContentModel(
+                mocks.modelWithValidFieldIds({ contentModelGroupId: initial.contentModelGroup.id })
+            );
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBe(null);
+
+        error = null;
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/models/ContentModel/createFieldsModel.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/ContentModel/createFieldsModel.ts
@@ -1,5 +1,5 @@
 import { validation } from "@webiny/validation";
-import { withFields, string, object, setOnce, boolean, fields } from "@webiny/commodo";
+import { withFields, string, object, setOnce, onSet, boolean, fields, pipe } from "@webiny/commodo";
 import { i18nField } from "@webiny/api-headless-cms/content/plugins/modelFields/i18nFields";
 import { any } from "@webiny/api-headless-cms/content/plugins/models/anyField";
 import idValidation from "./idValidation";
@@ -14,7 +14,10 @@ export default context => {
 
     return withFields({
         _id: setOnce()(string({ validation: requiredShortString })),
-        fieldId: setOnce()(string({ validation: idValidation })),
+        fieldId: pipe(
+            onSet(value => value && value.trim()),
+            setOnce()
+        )(string({ validation: idValidation })),
         label: i18nField({
             field: string({ validation: requiredShortString }),
             context

--- a/packages/api-headless-cms/src/content/plugins/models/ContentModel/idValidation.ts
+++ b/packages/api-headless-cms/src/content/plugins/models/ContentModel/idValidation.ts
@@ -5,4 +5,7 @@ export default async (value: string) => {
     if (!value.charAt(0).match(/[a-zA-Z]/)) {
         throw new Error(`Provided ID ${value} is not valid - must not start with a number.`);
     }
+    if (value.trim().toLowerCase() === "id") {
+        throw new Error(`Provided ID ${value} is not valid - "id" is an auto-generated field.`);
+    }
 };

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
@@ -38,6 +38,14 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
         setValue("fieldId", camelCase(getValue(value)));
     }, []);
 
+    const fieldIdValidator = useCallback(fieldId => {
+        if (fieldId.trim().toLowerCase() !== "id") {
+            return true;
+        }
+
+        throw new Error(`Cannot use "id" as Field ID.`);
+    }, undefined);
+
     const uniqueFieldIdValidator = useCallback(fieldId => {
         const existingField = getField({ fieldId });
         if (!existingField) {
@@ -47,7 +55,7 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
         if (existingField._id === field._id) {
             return true;
         }
-        throw new Error("Please enter a unique Field ID");
+        throw new Error("Please enter a unique Field ID.");
     }, undefined);
 
     let additionalSettings = null;
@@ -82,7 +90,11 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
                 <Cell span={6}>
                     <Bind
                         name={"fieldId"}
-                        validators={[validation.create("required"), uniqueFieldIdValidator]}
+                        validators={[
+                            validation.create("required"),
+                            uniqueFieldIdValidator,
+                            fieldIdValidator
+                        ]}
                     >
                         <Input label={"Field ID"} disabled={!!field._id} />
                     </Bind>

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/GeneralTab.tsx
@@ -38,6 +38,12 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
         setValue("fieldId", camelCase(getValue(value)));
     }, []);
 
+    const beforeChangeFieldId = useCallback((value, baseOnChange) => {
+        const newValue = value.trim();
+
+        baseOnChange(newValue);
+    }, []);
+
     const fieldIdValidator = useCallback(fieldId => {
         if (fieldId.trim().toLowerCase() !== "id") {
             return true;
@@ -95,6 +101,7 @@ const GeneralTab = ({ field, form, fieldPlugin }: GeneralTabProps) => {
                             uniqueFieldIdValidator,
                             fieldIdValidator
                         ]}
+                        beforeChange={beforeChangeFieldId}
                     >
                         <Input label={"Field ID"} disabled={!!field._id} />
                     </Bind>


### PR DESCRIPTION
## Related Issue
Closes #1211 

## Your solution
Add proper field validation for the same both on App and API side.

## How Has This Been Tested?
Manually using the Admin app UI

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/92243131-95b46780-eede-11ea-984e-f3b2364a8ae7.png)
