### PR TITLE
Feat: Project Utils: source path options for buildAppSSR

### DIFF
--- a/packages/project-utils/bundling/ssr/buildAppSSR.js
+++ b/packages/project-utils/bundling/ssr/buildAppSSR.js
@@ -1,7 +1,10 @@
 const path = require("path");
 const fs = require("fs-extra");
 
-module.exports.buildAppSSR = async ({ app = null, output, ...options }, context) => {
+module.exports.buildAppSSR = async (
+    { app = null, indexHtmlPath = null, createAppPath = null, output, ...options },
+    context
+) => {
     if (!app) {
         throw new Error(`Specify an "app" path to use for SSR bundle.`);
     }
@@ -12,8 +15,11 @@ module.exports.buildAppSSR = async ({ app = null, output, ...options }, context)
     process.env.NODE_ENV = "production";
     process.env.REACT_APP_ENV = "ssr";
 
-    const indexHtml = path.resolve(app, "build", "index.html").replace(/\\/g, "\\\\");
-    const appComponent = path.resolve(app, "src", "App").replace(/\\/g, "\\\\");
+    indexHtmlPath = indexHtmlPath || path.resolve(app, "build", "index.html");
+    createAppPath = createAppPath || path.resolve(app, "src", "App");
+
+    const indexHtml = indexHtmlPath.replace(/\\/g, "\\\\");
+    const appComponent = createAppPath.replace(/\\/g, "\\\\");
 
     const chalk = require("chalk");
 


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1218

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Added the options as discussed with @Pavel910 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'm using this solution for a few weeks now 😅 

## Blog
**Title**: Customize your SSR build
**Content**: You can now customize your SSR build by providing paths to your app HTML file and app component factory. In most cases, you won't need it and Webiny defaults will work fine for you. But if you do find yourself in a situation where you need to tweak your HTML or app component - now you can do it. A shout out goes to [Latotty](https://github.com/latotty) for this and many other improvements in this release!