### PR TITLE
Fix: App Admin: plugins export type fix

### DIFF
--- a/packages/app-admin/src/plugins/index.ts
+++ b/packages/app-admin/src/plugins/index.ts
@@ -1,3 +1,5 @@
+import { PluginCollection } from '@webiny/plugins/types';
+
 // Layout plug
 import Header from "@webiny/app-admin/plugins/Header";
 import Content from "@webiny/app-admin/plugins/Content";
@@ -20,7 +22,7 @@ import install from "@webiny/app-admin/plugins/install";
 
 import init from "./init";
 
-export default () => [
+export default (): PluginCollection => [
     // Layout plugins
     Header,
     Content,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -6,3 +6,5 @@ export type Plugin = {
     init?: () => void;
     [key: string]: any;
 };
+
+export type PluginCollection = (Plugin | PluginCollection)[];


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1221

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
As described in the issue:
I've added a new type for the plugin collections, and used that to explicitly define the return type for the exported plugin collection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Builded the d.ts files locally.

Before:
```typescript
/// <reference types="react" />
declare const _default: () => (import("../types").AdminLayoutComponentPlugin | import("../types").AdminFileManagerFileTypePlugin[] | import("../types").AdminInstallationPlugin | import("../types").AdminHeaderMiddlePlugin | import("../types").AdminHeaderRightPlugin | import("../types").AdminLayoutComponentPlugin[] | {
    name: string;
    type: any;
    render(): JSX.Element;
} | (import("../types").ApiInformationDialogPlugin | import("../types").AdminHeaderLeftPlugin)[] | (import("../types").AdminHeaderLeftPlugin | import("../types").AdminMenuLogoPlugin)[] | import("../types").AdminHeaderUserMenuPlugin | {
    type: string;
    name: string;
    preventOpen(e: any): boolean;
} | import("../../../app/src/types").WebinyInitPlugin)[];
export default _default;
```

After:
```typescript
import { PluginCollection } from '@webiny/plugins/types';
declare const _default: () => PluginCollection;
export default _default;
```