### PR TITLE
Feat: App Admin: hide settings group if empty

### DIFF
--- a/packages/app-admin/src/plugins/init.tsx
+++ b/packages/app-admin/src/plugins/init.tsx
@@ -20,12 +20,21 @@ const plugin: WebinyInitPlugin = {
             type: "admin-menu",
             order: 100,
             render({ Menu, Section, Item }) {
+                const items = settingsPlugins
+                    .map(plugin => ({
+                        name: plugin.name,
+                        element: plugin.render({ Section, Item })
+                    }))
+                    .filter(({ element }) => !!element);
+
+                if (!items.length) {
+                    return null;
+                }
+
                 return (
                     <Menu name="settings" label={t`Settings`} icon={<SettingsIcon />}>
-                        {settingsPlugins.map(plugin => (
-                            <React.Fragment key={plugin.name}>
-                                {plugin.render({ Section, Item })}
-                            </React.Fragment>
+                        {items.map(({ name, element }) => (
+                            <React.Fragment key={name}>{element}</React.Fragment>
                         ))}
                     </Menu>
                 );


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1223

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Checking the amount of actually rendered settings plugins. And if the list is empty, we return null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally agains my codebase. Tested with no settings plugin, and with settings plugin which rendered null.
