### PR TITLE
fix: Project utils: disable webpack progressbar in non interactive teminal

### DIFF
--- a/packages/project-utils/bundling/function/webpack.config.js
+++ b/packages/project-utils/bundling/function/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = ({ entry, output, debug = false, babelOptions, define }) => {
         },
         plugins: [
             new webpack.DefinePlugin({ ...definitions, ...packageVersions }),
-            new WebpackBar({ name: path.basename(process.cwd()), reporters: ["fancy"] })
+            new WebpackBar({ name: path.basename(process.cwd()) })
         ],
         // Run babel on all .js files and skip those in node_modules
         module: {


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1230

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Removed explicit mode setting, and relying on build in functionality: https://www.npmjs.com/package/webpackbar#fancy

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In user mode (`yarn build`) the progress bar is still there.
In non user mode (`yarn lerna run build --concurrency 10  --stream`) the progress bar is hidden, and only text notifications are used.
