### PR TITLE
fix(cli-plugin-deploy-components): disable status messages in CI

### DIFF
--- a/packages/cli-plugin-deploy-components/execute/Status.js
+++ b/packages/cli-plugin-deploy-components/execute/Status.js
@@ -20,6 +20,10 @@ class Status {
     }
 
     start() {
+        if (process.env.CI) {
+            return;
+        }
+
         // Hide cursor always, to keep it clean
         process.stdout.write(ansiEscapes.cursorHide);
         this.status.running = true;
@@ -65,6 +69,10 @@ class Status {
     }
 
     async render(status) {
+        if (process.env.CI) {
+            return;
+        }
+
         // Start Status engine, if it isn't running yet
         if (!this.isRunning()) {
             this.start();


### PR DESCRIPTION
## Related Issue
Closes #1219 

## Your solution
Exit `render` and `start` methods of Status class if `process.env.CI` is set.

## How Has This Been Tested?
Manually, by running a deploy with `process.env.CI` set to `true` (it can be any value, as long as the CI key is set).