### PR TITLE
Headless CMS - parallel GraphQL querying works correctly

### DIFF
--- a/packages/api-headless-cms/__tests__/mocks/parallelQueries.js
+++ b/packages/api-headless-cms/__tests__/mocks/parallelQueries.js
@@ -1,0 +1,131 @@
+import { locales } from "./I18NLocales";
+
+export default {
+    contentModel: ({ contentModelGroupId }) => ({
+        data: {
+            name: "Product",
+            group: contentModelGroupId,
+            fields: [
+                {
+                    _id: "vqk-UApa0",
+                    fieldId: "title",
+                    type: "text",
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Title"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Titel"
+                            }
+                        ]
+                    }
+                },
+                {
+                    _id: "id-text",
+                    fieldId: "tags",
+                    type: "text",
+                    multipleValues: true,
+                    label: {
+                        values: [
+                            {
+                                locale: locales.en.id,
+                                value: "Tags-en"
+                            },
+                            {
+                                locale: locales.de.id,
+                                value: "Tags-de"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }),
+    product1: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Product En 1"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Produkt De 1"
+                    }
+                ]
+            },
+            tags: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: ["product", "1"]
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: ["produkt", "1"]
+                    }
+                ]
+            }
+        }
+    },
+    product2: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Product En 2"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Produkt De 2"
+                    }
+                ]
+            },
+            tags: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: ["product", "2"]
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: ["produkt", "2"]
+                    }
+                ]
+            }
+        }
+    },
+    product3: {
+        data: {
+            title: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: "Product En 3"
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: "Produkt De 3"
+                    }
+                ]
+            },
+            tags: {
+                values: [
+                    {
+                        locale: locales.en.id,
+                        value: ["product", "3"]
+                    },
+                    {
+                        locale: locales.de.id,
+                        value: ["produkt", "3"]
+                    }
+                ]
+            }
+        }
+    }
+};

--- a/packages/api-headless-cms/__tests__/parallelQueries.test.js
+++ b/packages/api-headless-cms/__tests__/parallelQueries.test.js
@@ -1,0 +1,72 @@
+import useContentHandler from "./utils/useContentHandler";
+import mocks from "./mocks/parallelQueries";
+import { createContentModelGroup, createEnvironment } from "@webiny/api-headless-cms/testing";
+import { Database } from "@commodo/fields-storage-nedb";
+
+describe("parallel queries test", () => {
+    const database = new Database();
+
+    const { environment: environmentManage } = useContentHandler({ database });
+    const { environment: environmentRead } = useContentHandler({ database, type: "read" });
+    const initial = {};
+
+    beforeAll(async () => {
+        // Let's create a basic environment and a content model group.
+        initial.environment = await createEnvironment({ database });
+        initial.contentModelGroup = await createContentModelGroup({ database });
+    });
+
+    it("should be able to run multiple queries in parallel", async () => {
+        const { content, createContentModel } = environmentManage(initial.environment.id);
+        const { invoke: invokeRead } = environmentRead(initial.environment.id);
+
+        await createContentModel(
+            mocks.contentModel({ contentModelGroupId: initial.contentModelGroup.id })
+        );
+
+        const products = await content("product");
+        const product1 = await products.create(mocks.product1);
+        const product2 = await products.create(mocks.product2);
+        const product3 = await products.create(mocks.product3);
+
+        await products.publish({ revision: product1.id });
+        await products.publish({ revision: product2.id });
+        await products.publish({ revision: product3.id });
+
+        const PARALLEL_LIST_PRODUCTS = /* GraphQL */ `
+            {
+                cms1: listProducts {
+                    data {
+                        tags
+                        title
+                    }
+                }
+                cms2: listProducts {
+                    data {
+                        tags
+                        title
+                    }
+                }
+                cms3: listProducts {
+                    data {
+                        tags
+                        title
+                    }
+                }
+            }
+        `;
+
+        for (let i = 0; i < 10; i++) {
+            let [response] = await invokeRead({
+                body: {
+                    query: PARALLEL_LIST_PRODUCTS
+                }
+            });
+
+            expect(response.data.cms1.data.length).toBe(3)
+            expect(response.data.cms2.data.length).toBe(3)
+            expect(response.data.cms3.data.length).toBe(3)
+
+        }
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -17,143 +17,141 @@ import {
 } from "@webiny/api-headless-cms/types";
 
 export default () => {
-    async function apply(context: CmsContext) {
-        if (context.modelsInit) {
-            await context.modelsInit.promise;
-            return;
-        }
-
-        context.modelsInit = {
-            resolve: null,
-            promise: null
-        };
-
-        context.modelsInit.promise = new Promise(resolve => {
-            context.modelsInit.resolve = resolve;
-        });
-
-        const driver = context.commodo && context.commodo.driver;
-
-        if (!driver) {
-            throw Error(
-                `Commodo driver is not configured! Make sure you add a Commodo driver plugin to your service.`
-            );
-        }
-
-        const createBase = () =>
-            pipe(
-                withFields({
-                    id: context.commodo.fields.id()
-                }),
-                withStorage({ driver }),
-                withUser(context),
-                withSoftDelete(),
-                withCrudLogs()
-            )() as Function;
-
-        context.models = {
-            createBase,
-            CmsEnvironment: environmentModel({ createBase, context }),
-            CmsEnvironmentAlias: environmentModelAlias({
-                createBase,
-                context
-            }),
-            CmsEnvironment2AccessToken: CmsEnvironment2AccessToken({
-                createBase,
-                context
-            }),
-            CmsAccessToken: cmsAccessToken({ createBase, context })
-        };
-
-        // Before continuing with the rest of the models, we must load the environment and assign it to the context.
-        let environment = null;
-        let environmentAlias = null;
-
-        if (context.cms.environment && typeof context.cms.environment === "string") {
-            if (context.models.CmsEnvironment.isId(context.cms.environment)) {
-                environment = await context.models.CmsEnvironment.findById(context.cms.environment);
-            } else {
-                environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
-                    query: { slug: context.cms.environment }
-                });
-                if (environmentAlias) {
-                    environment = await environmentAlias.environment;
-                }
-            }
-        }
-
-        if (!environment) {
-            throw Error(
-                "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
-            );
-        }
-
-        context.cms.environment = environment.slug;
-        context.cms.getEnvironment = () => environment;
-        context.cms.getEnvironmentAlias = () => environmentAlias;
-
-        const createEnvironmentBase = createEnvironmentBaseFactory({
-            context,
-            addEnvironmentField: true
-        });
-
-        context.models.CmsContentModelGroup = contentModelGroup({
-            createBase: createEnvironmentBase,
-            context
-        });
-
-        context.models.CmsContentModel = contentModel({
-            createBase: createEnvironmentBase,
-            context
-        });
-
-        context.models.CmsContentEntrySearch = contentEntrySearch({
-            createBase: createEnvironmentBase
-        });
-
-        context.models.createEnvironmentBase = createEnvironmentBase;
-
-        const beforeContentModelsPlugins = context.plugins.byType<ContextBeforeContentModelsPlugin>(
-            "context-before-content-models"
-        );
-
-        for (let i = 0; i < beforeContentModelsPlugins.length; i++) {
-            await beforeContentModelsPlugins[i].apply(context);
-        }
-
-        // Build Commodo models from CmsContentModels
-        const contentModels = await context.models.CmsContentModel.find();
-        const createdContentModels = {};
-        for (let i = 0; i < contentModels.length; i++) {
-            const contentModel = contentModels[i];
-            createdContentModels[contentModel.modelId] = createDataModel(
-                createEnvironmentBaseFactory({ context, addEnvironmentField: false }),
-                contentModel,
-                context
-            );
-        }
-
-        Object.assign(context.models, createdContentModels);
-
-        context.models.contentModels = createdContentModels;
-
-        const afterContentModelsPlugins = context.plugins.byType<ContextAfterContentModelsPlugin>(
-            "context-after-content-models"
-        );
-
-        for (let i = 0; i < afterContentModelsPlugins.length; i++) {
-            await afterContentModelsPlugins[i].apply(context);
-        }
-
-        context.modelsInit.resolve();
-    }
-
     return [
         {
             name: "context-cms-models",
             type: "context",
-            apply(context) {
-                return apply(context);
+            async apply(context: CmsContext) {
+                if (context.modelsInit) {
+                    await context.modelsInit.promise;
+                    return;
+                }
+
+                context.modelsInit = {
+                    resolve: null,
+                    promise: null
+                };
+
+                context.modelsInit.promise = new Promise(resolve => {
+                    context.modelsInit.resolve = resolve;
+                });
+
+                const driver = context.commodo && context.commodo.driver;
+
+                if (!driver) {
+                    throw Error(
+                        `Commodo driver is not configured! Make sure you add a Commodo driver plugin to your service.`
+                    );
+                }
+
+                const createBase = () =>
+                    pipe(
+                        withFields({
+                            id: context.commodo.fields.id()
+                        }),
+                        withStorage({ driver }),
+                        withUser(context),
+                        withSoftDelete(),
+                        withCrudLogs()
+                    )() as Function;
+
+                context.models = {
+                    createBase,
+                    CmsEnvironment: environmentModel({ createBase, context }),
+                    CmsEnvironmentAlias: environmentModelAlias({
+                        createBase,
+                        context
+                    }),
+                    CmsEnvironment2AccessToken: CmsEnvironment2AccessToken({
+                        createBase,
+                        context
+                    }),
+                    CmsAccessToken: cmsAccessToken({ createBase, context })
+                };
+
+                // Before continuing with the rest of the models, we must load the environment and assign it to the context.
+                let environment = null;
+                let environmentAlias = null;
+
+                if (context.cms.environment && typeof context.cms.environment === "string") {
+                    if (context.models.CmsEnvironment.isId(context.cms.environment)) {
+                        environment = await context.models.CmsEnvironment.findById(
+                            context.cms.environment
+                        );
+                    } else {
+                        environmentAlias = await context.models.CmsEnvironmentAlias.findOne({
+                            query: { slug: context.cms.environment }
+                        });
+                        if (environmentAlias) {
+                            environment = await environmentAlias.environment;
+                        }
+                    }
+                }
+
+                if (!environment) {
+                    throw Error(
+                        "Could not load environment, please check if the passed environment alias slug or environment ID is correct."
+                    );
+                }
+
+                context.cms.environment = environment.slug;
+                context.cms.getEnvironment = () => environment;
+                context.cms.getEnvironmentAlias = () => environmentAlias;
+
+                const createEnvironmentBase = createEnvironmentBaseFactory({
+                    context,
+                    addEnvironmentField: true
+                });
+
+                context.models.CmsContentModelGroup = contentModelGroup({
+                    createBase: createEnvironmentBase,
+                    context
+                });
+
+                context.models.CmsContentModel = contentModel({
+                    createBase: createEnvironmentBase,
+                    context
+                });
+
+                context.models.CmsContentEntrySearch = contentEntrySearch({
+                    createBase: createEnvironmentBase
+                });
+
+                context.models.createEnvironmentBase = createEnvironmentBase;
+
+                const beforeContentModelsPlugins = context.plugins.byType<
+                    ContextBeforeContentModelsPlugin
+                >("context-before-content-models");
+
+                for (let i = 0; i < beforeContentModelsPlugins.length; i++) {
+                    await beforeContentModelsPlugins[i].apply(context);
+                }
+
+                // Build Commodo models from CmsContentModels
+                const contentModels = await context.models.CmsContentModel.find();
+                const createdContentModels = {};
+                for (let i = 0; i < contentModels.length; i++) {
+                    const contentModel = contentModels[i];
+                    createdContentModels[contentModel.modelId] = createDataModel(
+                        createEnvironmentBaseFactory({ context, addEnvironmentField: false }),
+                        contentModel,
+                        context
+                    );
+                }
+
+                Object.assign(context.models, createdContentModels);
+
+                context.models.contentModels = createdContentModels;
+
+                const afterContentModelsPlugins = context.plugins.byType<
+                    ContextAfterContentModelsPlugin
+                >("context-after-content-models");
+
+                for (let i = 0; i < afterContentModelsPlugins.length; i++) {
+                    await afterContentModelsPlugins[i].apply(context);
+                }
+
+                context.modelsInit.resolve();
             }
         } as ContextPlugin<CmsContext>
     ];

--- a/packages/api-headless-cms/src/content/plugins/models.ts
+++ b/packages/api-headless-cms/src/content/plugins/models.ts
@@ -18,6 +18,20 @@ import {
 
 export default () => {
     async function apply(context: CmsContext) {
+        if (context.modelsInit) {
+            await context.modelsInit.promise;
+            return;
+        }
+
+        context.modelsInit = {
+            resolve: null,
+            promise: null
+        };
+
+        context.modelsInit.promise = new Promise(resolve => {
+            context.modelsInit.resolve = resolve;
+        });
+
         const driver = context.commodo && context.commodo.driver;
 
         if (!driver) {
@@ -130,6 +144,8 @@ export default () => {
         for (let i = 0; i < afterContentModelsPlugins.length; i++) {
             await afterContentModelsPlugins[i].apply(context);
         }
+
+        context.modelsInit.resolve();
     }
 
     return [


### PR DESCRIPTION
## Related Issue
One of our users noticed the following error happening while doing parallel querying via GraphQL:
![image](https://user-images.githubusercontent.com/5121148/93325609-db92f900-f817-11ea-97e9-46c7f17ef166.png)

The thing is, it's only happening when doing parallel queries, and also very randomly, which made it a bit harder to debug.

## Your solution
I did some research on how the `context` object is behaving when parallel queries are executed. It behaves like the following.

Let's say we have three queries. So, at the beginning of this whole operation, a new `context` object is created and is passed to all context plugins we have registered, **for every query**. This means that, if we are talking about the `context` plugin that is setting the models into the context object, we are setting models into the context **three times**, but everytime on the *same* `context` object!

And what's problematic here, since it's all happening asynchronously, is that the first plugin execution that defines models may be overridden by the second or the third one.

So what would happen in our particular case... For the first query, all models would be registered, and then, let's say, a simple `listBooks` resolver was triggered. While it's executing, the 2nd query might be still in progress, and the plugins registration as well, in which the `context.models = {}` would happen (previously in `packages/api-headless-cms/src/content/plugins/models.ts:31`), and cause the first resolver execution to fail, since suddenly, the context doesn't contain the needed models anymore.

For this release, I just ensured that the models are only registered one, and only when that's done, the resolvers may do their thing.

## Future solution
For v5, we'll have to think of a better solution in order to handle these cases. Will be creating a separate issue for that.

## How Has This Been Tested?
Jest.

I started writing a Jest test, which was mimicking the same steps explained above, but for unknown reasons to me, locally everything works just fine. I left the test, it can't hurt.

## Screenshots (if relevant):
N/A