### PR TITLE
fix: add missing `security-scopes-list` plugin

### DIFF
--- a/packages/app-file-manager/src/admin/plugins/index.ts
+++ b/packages/app-file-manager/src/admin/plugins/index.ts
@@ -1,3 +1,4 @@
 import menus from "./menus";
+import scopesList from "./scopesList";
 
-export default [menus];
+export default [menus, scopesList];

--- a/packages/app-file-manager/src/admin/plugins/scopesList.ts
+++ b/packages/app-file-manager/src/admin/plugins/scopesList.ts
@@ -1,0 +1,18 @@
+import { i18n } from "@webiny/app/i18n";
+import { SecurityScopesListPlugin } from "@webiny/app-security/types";
+
+const t = i18n.ns("app-file-manager/admin/scopesList");
+
+export default [
+    {
+        name: "security-scopes-list-file-manager",
+        type: "security-scopes-list",
+        scopes: [
+            {
+                scope: "files:file:crud",
+                title: t`Files CRUD`,
+                description: t`Allows basic CRUD operations on all files.`
+            }
+        ]
+    } as SecurityScopesListPlugin
+];


### PR DESCRIPTION
## Related Issue
Closes #1255 

## Your solution
add missing `security-scopes-list` plugin in `app-file-manager`

## How Has This Been Tested?
Manually, using the Admin app UI and the GQL playground.
Played with resolvers that needed `files:file:crud` scope for example `getFile`

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/93751329-8e00fc80-fc1a-11ea-8fef-3e7250ab637d.png)
