### PR TITLE
fix: display of image list in preview mode in PB

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,6 @@
   },
   "resolutions": {
     "pretty-format": "25.5.0",
-	"apollo-server-core": "2.17.0"
+    "apollo-server-core": "2.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     }
   },
   "resolutions": {
-    "pretty-format": "25.5.0"
+    "pretty-format": "25.5.0",
+	"apollo-server-core": "2.17.0"
   }
 }

--- a/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
@@ -3,7 +3,7 @@ import warning from "warning";
 import { getPlugins } from "@webiny/plugins";
 import { PbPageElementImagesListComponentPlugin } from "@webiny/app-page-builder/types";
 
-const ImagesList = ({data, theme}) => {
+const ImagesList = ({ data, theme }) => {
     const { component } = data;
     const plugins = getPlugins<PbPageElementImagesListComponentPlugin>(
         "pb-page-element-images-list-component"

--- a/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
@@ -9,13 +9,13 @@ const ImagesList = ({ data, theme }) => {
         "pb-page-element-images-list-component"
     );
 
-    const pageList = plugins.find(cmp => cmp.componentName === component);
-    if (!pageList) {
+    const imagesList = plugins.find(cmp => cmp.componentName === component);
+    if (!imagesList) {
         warning(false, `Images list component "${component}" is missing!`);
         return null;
     }
 
-    const { component: ListComponent } = pageList;
+    const { component: ListComponent } = imagesList;
 
     if (!ListComponent) {
         warning(false, `React component is not defined for "${component}"!`);

--- a/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/imagesList/ImagesList.tsx
@@ -3,8 +3,7 @@ import warning from "warning";
 import { getPlugins } from "@webiny/plugins";
 import { PbPageElementImagesListComponentPlugin } from "@webiny/app-page-builder/types";
 
-const ImagesList = props => {
-    const { data = {} } = props;
+const ImagesList = ({data, theme}) => {
     const { component } = data;
     const plugins = getPlugins<PbPageElementImagesListComponentPlugin>(
         "pb-page-element-images-list-component"
@@ -12,7 +11,7 @@ const ImagesList = props => {
 
     const pageList = plugins.find(cmp => cmp.componentName === component);
     if (!pageList) {
-        warning(false, `Pages list component "${component}" is missing!`);
+        warning(false, `Images list component "${component}" is missing!`);
         return null;
     }
 
@@ -23,7 +22,7 @@ const ImagesList = props => {
         return null;
     }
 
-    return null;
+    return <ListComponent data={data.images || []} theme={theme} />;
 };
 
 export default React.memo(ImagesList);

--- a/packages/handler-apollo-gateway/package.json
+++ b/packages/handler-apollo-gateway/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "apollo-server": "^2.12.0",
+    "apollo-server": "2.17.0",
     "apollo-server-types": "^0.3.1",
     "jest-mock-console": "^1.0.0"
   },


### PR DESCRIPTION
## Related Issue
Closes #1263 

## Your solution
Returned ListComponent and renamed the file to tsx

## How Has This Been Tested?
create new page -> add empty block -> add image list and select few images -> check both preview and edit mode that images are displayed

### Note
Had to lock apollo-server and apollo-server-core to 2.17.0 due to TS compiling error on 2.18.0-1