### PR TITLE
feat(app-plugin-security-cognito-theme): plugin for to modify login logo

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import adminTemplate from "@webiny/app-template-admin-full";
 import "./App.scss";
 

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,4 +1,4 @@
-import {CognitoViewLogoPlugin} from "@webiny/app-plugin-security-cognito-theme/admin/types";
+import React from "react";
 import adminTemplate from "@webiny/app-template-admin-full";
 import "./App.scss";
 
@@ -7,12 +7,5 @@ export default adminTemplate({
         region: process.env.REACT_APP_USER_POOL_REGION,
         userPoolId: process.env.REACT_APP_USER_POOL_ID,
         userPoolWebClientId: process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID
-    },
-    plugins: [
-        {
-            type: "cognito-view",
-            name: "cognito-view-logo",
-            src: "some_string.jpg",
-        } as CognitoViewLogoPlugin,
-    ],
+    }
 });

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,3 +1,4 @@
+import {CognitoViewLogoPlugin} from "@webiny/app-plugin-security-cognito-theme/admin/types";
 import adminTemplate from "@webiny/app-template-admin-full";
 import "./App.scss";
 
@@ -6,5 +7,12 @@ export default adminTemplate({
         region: process.env.REACT_APP_USER_POOL_REGION,
         userPoolId: process.env.REACT_APP_USER_POOL_ID,
         userPoolWebClientId: process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID
-    }
+    },
+    plugins: [
+        {
+            type: "cognito-view",
+            name: "cognito-view-logo",
+            src: "some_string.jpg",
+        } as CognitoViewLogoPlugin,
+    ],
 });

--- a/packages/app-plugin-security-cognito-theme/package.json
+++ b/packages/app-plugin-security-cognito-theme/package.json
@@ -10,6 +10,7 @@
     "@webiny/app-plugin-security-cognito": "^4.12.1",
     "@webiny/app-security": "^4.12.1",
     "@webiny/form": "^4.12.1",
+    "@webiny/plugins": "^4.12.1",
     "@webiny/ui": "^4.12.1",
     "@webiny/validation": "^4.12.1",
     "classnames": "^2.2.6",

--- a/packages/app-plugin-security-cognito-theme/src/admin/types.ts
+++ b/packages/app-plugin-security-cognito-theme/src/admin/types.ts
@@ -1,0 +1,9 @@
+import React from "react";
+import { Plugin } from "@webiny/app/types";
+
+export type CognitoViewLogoPlugin = Plugin & {
+    name: "cognito-view-logo";
+    type: "cognito-view";
+    component?: React.FunctionComponent;
+    src?: string;
+};

--- a/packages/app-plugin-security-cognito-theme/src/admin/views/StateContainer.tsx
+++ b/packages/app-plugin-security-cognito-theme/src/admin/views/StateContainer.tsx
@@ -1,12 +1,18 @@
+import { CognitoViewLogoPlugin } from "@webiny/app-plugin-security-cognito-theme/admin/types";
 import * as React from "react";
 import { LoginContent, Logo, Wrapper } from "./StyledComponents";
+import { plugins } from "@webiny/plugins";
 import logoOrange from "./webiny-orange-logo.svg";
 
-const StateContainer = ({ children }) => (
-    <Wrapper>
-        <Logo src={logoOrange} />
-        <LoginContent>{children}</LoginContent>
-    </Wrapper>
-);
+const StateContainer = ({ children }) => {
+    const logoPlugin = plugins.byName<CognitoViewLogoPlugin>("cognito-view-logo");
+    const LogoComponent = logoPlugin?.component;
+    return (
+        <Wrapper>
+            {LogoComponent ? <LogoComponent /> : <Logo src={logoPlugin?.src || logoOrange} />}
+            <LoginContent>{children}</LoginContent>
+        </Wrapper>
+    );
+};
 
 export default StateContainer;

--- a/packages/app-plugin-security-cognito-theme/tsconfig.build.json
+++ b/packages/app-plugin-security-cognito-theme/tsconfig.build.json
@@ -22,6 +22,7 @@
     { "path": "../app-plugin-security-cognito/tsconfig.build.json" },
     { "path": "../form/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
-    { "path": "../validation/tsconfig.build.json" }
+    { "path": "../validation/tsconfig.build.json" },
+    { "path": "../plugins/tsconfig.build.json" }
   ]
 }

--- a/packages/app-plugin-security-cognito-theme/tsconfig.build.json
+++ b/packages/app-plugin-security-cognito-theme/tsconfig.build.json
@@ -9,7 +9,8 @@
     "../app-plugin-security-cognito",
     "../form",
     "../ui",
-    "../validation"
+    "../validation",
+    "../plugins"
   ],
   "compilerOptions": {
     "rootDir": "./src",

--- a/packages/app-plugin-security-cognito-theme/tsconfig.json
+++ b/packages/app-plugin-security-cognito-theme/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "../app-plugin-security-cognito" },
     { "path": "../form" },
     { "path": "../ui" },
-    { "path": "../validation" }
+    { "path": "../validation" },
+    { "path": "../plugins" }
   ]
 }


### PR DESCRIPTION
## Related Issue
Closes #1270 

## Your solution
Added plugin type that enables to change login logo in the administration

## How Has This Been Tested?
Registered plugin in apps/admin/src/App.tsx and checked in Webiny administration login page

## Screenshots (if relevant):
Logo as a component example:
![logo-as-component](https://user-images.githubusercontent.com/10399339/94712783-38c79800-034a-11eb-9ee6-6b095278a07d.png)
Logo as a src example:
![logo-as-src](https://user-images.githubusercontent.com/10399339/94712801-3d8c4c00-034a-11eb-8998-35a53d1ff6f1.png)


Sample code (note that component is taken first and then src if there is no component):
```
plugins: [
    {
        type: "cognito-view",
        name: "cognito-view-logo",
        component() {
            return (
                <div style={{
                    background: 'grey',
                    textAlign: 'center',
                    padding: '5px',
                    color: 'white',
                    maxWidth: '500px',
                    margin: '0 auto',
                }}>INSERTED LOGO COMPONENT</div>
            );
        },
        src: 'https://picsum.photos/seed/picsum/100/100',
    } as CognitoViewLogoPlugin,
],
```