### PR TITLE
feat(app-page-builder): add ability to remove selected icon on button

### DIFF
--- a/packages/app-page-builder/src/editor/components/IconPicker.tsx
+++ b/packages/app-page-builder/src/editor/components/IconPicker.tsx
@@ -8,6 +8,7 @@ import { DelayedOnChange } from "@webiny/app-page-builder/editor/components/Dela
 import { Menu } from "@webiny/ui/Menu";
 import { Input } from "@webiny/ui/Input";
 import { PbIcon, PbIconsPlugin } from "@webiny/app-page-builder/types";
+import classNames from "classnames";
 
 const COLUMN_COUNT = 6;
 
@@ -148,11 +149,14 @@ const IconPicker = ({ value, onChange, removable = true }) => {
                 }
                 const isSelectedIcon =
                     item.id[0] === selectedIconPrefix && item.id[1] === selectedIconName;
+                const gridItemClassName = classNames(gridItem, {
+                    [gridItemSelected]: isSelectedIcon
+                });
                 return (
                     <div
                         key={key}
                         style={style}
-                        className={gridItem + (isSelectedIcon ? ` ${gridItemSelected}` : "")}
+                        className={gridItemClassName}
                         onClick={() => {
                             onChange(item);
                             closeMenu();

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/IconPicker.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/IconPicker.tsx
@@ -8,6 +8,7 @@ type Props = {
     label: string;
     value: string;
     updateValue: (value: any) => void;
+    removable?: boolean;
 };
 
 class IconPicker extends React.Component<Props> {
@@ -16,14 +17,18 @@ class IconPicker extends React.Component<Props> {
     }
 
     render() {
-        const { label, value, updateValue } = this.props;
+        const { label, value, updateValue, removable } = this.props;
         return (
             <Grid>
                 <Cell span={4}>
                     <Typography use={"overline"}>{label}</Typography>
                 </Cell>
                 <Cell span={8}>
-                    <IconPickerComponent value={value} onChange={updateValue} />
+                    <IconPickerComponent
+                        value={value}
+                        onChange={updateValue}
+                        removable={removable}
+                    />
                 </Cell>
             </Grid>
         );

--- a/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
@@ -20,10 +20,9 @@ const excludePlugins = [
 const ButtonContainer = props => {
     const { getAllClasses, elementStyle, elementAttributes, element } = props;
     const { type = "default", icon = {} } = element.data || {};
-    const svg = icon.svg || null;
     const { alignItems } = elementStyle;
 
-    const { position = "left" } = icon;
+    const { svg = null, position = "left" } = icon || {};
 
     const onChange = useHandler(props, ({ element, updateElement }) => (value: string) => {
         updateElement({ element: set(element, "data.text", value) });

--- a/packages/app-page-builder/src/editor/plugins/elements/button/ButtonSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/ButtonSettings.tsx
@@ -27,10 +27,20 @@ const ButtonSettings = ({ element, updateElement }) => {
         return (name, value, history = true) => {
             const attrKey = `data.${name}`;
 
-            let newElement = set(element, attrKey, value);
-            if (name.startsWith("icon")) {
-                const { id, width, color } = get(newElement, "data.icon");
-                newElement = set(newElement, "data.icon.svg", getSvg(id, { width, color }));
+            const newElement = set(element, attrKey, value);
+            const isIcon = name.startsWith("icon");
+            if (isIcon) {
+                const { id, width, color } = newElement.data?.icon || {};
+
+                const isSelectedIcon =
+                    icon.id && id ? icon.id[0] === id[0] && icon.id[1] === id[1] : false;
+
+                const updatedIcon = isSelectedIcon ? {} : newElement.data.icon || {};
+
+                newElement.data.icon = {
+                    ...updatedIcon,
+                    svg: id && !isSelectedIcon ? getSvg(id, { width, color }) : undefined
+                };
             }
 
             if (!history) {
@@ -38,7 +48,7 @@ const ButtonSettings = ({ element, updateElement }) => {
                 return;
             }
 
-            if (historyUpdated[name] !== value) {
+            if (historyUpdated[name] !== value || (value === undefined && isIcon)) {
                 historyUpdated[name] = value;
                 updateElement({ element: newElement });
             }
@@ -46,7 +56,7 @@ const ButtonSettings = ({ element, updateElement }) => {
     }, [element, updateElement]);
 
     const updateType = useCallback(value => setData("type", value), [setData]);
-    const updateIcon = useCallback(value => setData("icon.id", value.id), [setData]);
+    const updateIcon = useCallback(value => setData("icon.id", value?.id), [setData]);
     const updateIconColor = useCallback((value: string) => setData("icon.color", value), [setData]);
     const updateIconColorPreview = useCallback(
         (value: string) => setData("icon.color", value, false),
@@ -77,11 +87,15 @@ const ButtonSettings = ({ element, updateElement }) => {
                     </Grid>
                 </Tab>
                 <Tab label={"Icon"}>
-                    <IconPicker label={"Icon"} value={icon.id} updateValue={updateIcon} />
-                    <Input label={"Width"} value={icon.width || 50} updateValue={updateIconWidth} />
+                    <IconPicker label={"Icon"} value={icon?.id} updateValue={updateIcon} />
+                    <Input
+                        label={"Width"}
+                        value={icon?.width || 50}
+                        updateValue={updateIconWidth}
+                    />
                     <ColorPicker
                         label={"Color"}
-                        value={icon.color}
+                        value={icon?.color}
                         updateValue={updateIconColor}
                         updatePreview={updateIconColorPreview}
                     />
@@ -90,7 +104,7 @@ const ButtonSettings = ({ element, updateElement }) => {
                             <Typography use={"overline"}>Position</Typography>
                         </Cell>
                         <Cell span={6}>
-                            <Select value={icon.position || "left"} onChange={updateIconPosition}>
+                            <Select value={icon?.position || "left"} onChange={updateIconPosition}>
                                 <option value={"left"}>Left</option>
                                 <option value={"right"}>Right</option>
                                 <option value={"top"}>Top</option>

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/IconSettings.tsx
@@ -43,7 +43,12 @@ const IconSettings = ({ element, updateElement }) => {
         <React.Fragment>
             <Tabs>
                 <Tab label={"Icon"}>
-                    <IconPicker label={"Icon"} value={icon.id} updateValue={updateIcon} />
+                    <IconPicker
+                        label={"Icon"}
+                        value={icon.id}
+                        updateValue={updateIcon}
+                        removable={false}
+                    />
                     <Input
                         label={"Width"}
                         value={icon.width}


### PR DESCRIPTION
## Related Issue
Closes #379

## Your solution
Selected icon is first in the icons display grid and is greyed a bit. You can now click it to remove the selected icon.

## How Has This Been Tested?
Button:
add button -> select any icon -> publish and refresh -> go to settings and click on selected icon
Icon:
add icon -> go to settings -> select any other icon (there should be no possibility to remove selected icon in the icon list)

## Screenshots (if relevant):
Button
![Screenshot 2020-10-02 at 13 38 01](https://user-images.githubusercontent.com/10399339/94919303-94159980-04b4-11eb-8695-20f50064b355.png)

Icon
![Screenshot 2020-10-02 at 13 38 07](https://user-images.githubusercontent.com/10399339/94919319-9972e400-04b4-11eb-906d-0ab77d0dfebb.png)
