### PR TITLE
Correct broken link in validation/README

### DIFF
--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -15,7 +15,7 @@ A simple data validation library, packed with frequently used validators like `r
 -   [Installation](#installation)
 -   [Get Started](#get-started)
 -   [Classes](#classes)
-    -   [Validation](#validation)
+    -   [Validation](#validation-1)
         -   [setValidator](#setvalidator)
         -   [getValidator](#getvalidator)
         -   [validate](#validate)


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #653

## Your solution
I have corrected the Classes>Validation link to correctly link to the Validation heading.
