### PR TITLE
fix: Allow Relative Paths in Page Builder Links.

### DIFF
--- a/packages/app-page-builder/src/admin/plugins/menuItems/link/LinkForm.tsx
+++ b/packages/app-page-builder/src/admin/plugins/menuItems/link/LinkForm.tsx
@@ -32,7 +32,12 @@ const LinkForm = ({ data, onSubmit, onCancel }) => {
                         </Grid>
                         <Grid>
                             <Cell span={12}>
-                                <Bind name="url" validators={validation.create("required,url:allowRelative")}>
+                                <Bind
+                                    name="url"
+                                    validators={validation.create(
+                                        "required,url:allowRelative:allowHref"
+                                    )}
+                                >
                                     <Input label="URL" />
                                 </Bind>
                             </Cell>

--- a/packages/app-page-builder/src/admin/plugins/menuItems/link/LinkForm.tsx
+++ b/packages/app-page-builder/src/admin/plugins/menuItems/link/LinkForm.tsx
@@ -32,7 +32,7 @@ const LinkForm = ({ data, onSubmit, onCancel }) => {
                         </Grid>
                         <Grid>
                             <Cell span={12}>
-                                <Bind name="url" validators={validation.create("required,url")}>
+                                <Bind name="url" validators={validation.create("required,url:allowRelative")}>
                                     <Input label="URL" />
                                 </Bind>
                             </Cell>

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/link/LinkSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/link/LinkSettings.tsx
@@ -42,7 +42,12 @@ class LinkSettings extends React.Component<any> {
                             <React.Fragment>
                                 <Grid>
                                     <Cell span={12}>
-                                        <Bind name={"href"} validators={validation.create("url:allowRelative")}>
+                                        <Bind
+                                            name={"href"}
+                                            validators={validation.create(
+                                                "url:allowRelative:allowHref"
+                                            )}
+                                        >
                                             <DelayedOnChange>
                                                 {props => <Input {...props} label={"URL"} />}
                                             </DelayedOnChange>

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/link/LinkSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/link/LinkSettings.tsx
@@ -42,7 +42,7 @@ class LinkSettings extends React.Component<any> {
                             <React.Fragment>
                                 <Grid>
                                     <Cell span={12}>
-                                        <Bind name={"href"} validators={validation.create("url")}>
+                                        <Bind name={"href"} validators={validation.create("url:allowRelative")}>
                                             <DelayedOnChange>
                                                 {props => <Input {...props} label={"URL"} />}
                                             </DelayedOnChange>

--- a/packages/validation/__tests__/url.test.js
+++ b/packages/validation/__tests__/url.test.js
@@ -55,4 +55,19 @@ describe("url test", () => {
             true
         );
     });
+
+    it("should pass - href URL", () => {
+        expect(validation.validate("#", "url")).rejects.toThrow(ValidationError);
+        expect(validation.validate("mailto:foo@bar.com", "url")).rejects.toThrow(ValidationError);
+        expect(validation.validate("#", "url:allowHref")).resolves.toBe(true);
+        expect(validation.validate("mailto:foo@bar.com", "url:allowHref")).resolves.toBe(true);
+        expect(validation.validate("mailt:", "url:allowHref")).rejects.toThrow(ValidationError);
+        expect(validation.validate("mailto:foo @ bar.com", "url:allowHref")).rejects.toThrow(
+            ValidationError
+        );
+        expect(validation.validate("tele:", "url:allowHref")).rejects.toThrow(ValidationError);
+        expect(validation.validate("#hello world", "url:allowHref")).rejects.toThrow(
+            ValidationError
+        );
+    });
 });

--- a/packages/validation/src/validators/url.ts
+++ b/packages/validation/src/validators/url.ts
@@ -12,6 +12,10 @@ const regex = {
     relative: new RegExp(
         // eslint-disable-next-line
         /^\/.*$/
+    ),
+    href: new RegExp(
+        // eslint-disable-next-line
+        /^(#|mailto:|tel:)\S*$/
     )
 };
 
@@ -37,6 +41,12 @@ export default (value: any, params: Array<string>) => {
 
     if (params.includes("allowRelative")) {
         if (regex.relative.test(value)) {
+            return;
+        }
+    }
+
+    if (params.includes("allowHref")) {
+        if (regex.href.test(value)) {
             return;
         }
     }


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1260

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
The solution is to pass in allowRelative flag in the validator.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests in the url.test.js test the allowRelative flag.
## Screenshots (if relevant):
