### PR TITLE
Prevent missing displayName in a React component definition

### DIFF
--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -78,7 +78,6 @@ const Element = (props: ElementProps) => {
         if (element.type === "document") {
             return;
         }
-
         e.stopPropagation();
         if (!highlight) {
             highlightElement({ element: element.id });


### PR DESCRIPTION
const renderDraggable = useHandler(props, ({ element }) => ({ drag }) => { 89        return ( 90            <div ref={drag} className={"type " + typeStyle}> 91                <div className="background" onClick={onClick} /> 92                <div className={"element-holder"} onClick={onClick}> 93                    {renderPlugins("pb-editor-page-element-action", { element, plugin })} 94                    <span>{plugin.elementType}</span> 95                </div> 96            </div> 97        ); 98    });



DisplayName allows you to name your component. This name is used by React in debugging messages.

Example - The not-preferred way :

var Hello = createReactClass({
  render: function() {
    return <div>Hello {this.props.name}</div>;
  }
});

Example - The preferred way :

var Hello = createReactClass({
  displayName: 'Hello',
  render: function() {
    return <div>Hello {this.props.name}</div>;
  }
});

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #ISSUE_NUMBER

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
