### PR TITLE
fix: remove redundant "server" args

### DIFF
--- a/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts
+++ b/packages/api-headless-cms/src/content/apolloHandler/createApolloHandler.ts
@@ -44,7 +44,6 @@ export default async function createApolloHandler({
         // @ts-ignore Not sure why it doesn't work, "boolean" function does return a boolean value.
         playground: boolean(server.playground),
         debug: boolean(process.env.DEBUG),
-        ...server,
         schema,
         context: async ({ event }) => ({
             event,

--- a/packages/handler-apollo-gateway/src/gatewayHandler.ts
+++ b/packages/handler-apollo-gateway/src/gatewayHandler.ts
@@ -142,7 +142,6 @@ const getHandler = async ({ args, options, context }: GetHandlerOptions) => {
             // @ts-ignore Not sure why it doesn't work, "boolean" function does return a boolean value.
             playground: boolean(server.playground),
             debug: boolean(process.env.DEBUG),
-            ...server,
             schema,
             executor,
             context: async ({ event }) => {

--- a/packages/handler-apollo-server/src/plugins/apolloHandler.ts
+++ b/packages/handler-apollo-server/src/plugins/apolloHandler.ts
@@ -43,7 +43,6 @@ const plugin: CreateApolloHandlerPlugin = {
             // @ts-ignore Not sure why it doesn't work, "boolean" function does return a boolean value.
             playground: boolean(server.playground),
             debug: boolean(process.env.DEBUG),
-            ...server,
             schema,
             context: async ({ event }) => ({
                 event,


### PR DESCRIPTION
## Related Issue
Closes #1283 

## Your solution
Remove redundant "server" option in "ApolloServer" constructor from:
- `@webiny/handler-apollo-server`
- `@webiny/handler-apollo-gateway`
- `@webiny/api-headless-cms`

## How Has This Been Tested?
Manually, by changing Changing `GRAPHQL_PLAYGROUND: false` in the `api/.env.json` and redeploying the API stack.

## Screenshots:
![image](https://user-images.githubusercontent.com/13612227/95056681-b147a380-0712-11eb-91df-abd64921a81c.png)

