### PR TITLE
Page Builder - handle missing object properties and prevent editor from crashing

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/row/RowChild.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/row/RowChild.tsx
@@ -85,8 +85,8 @@ const RowChild = React.memo((props: Props) => {
                     {resizeProps => (
                         <ResizeHandle
                             {...resizeProps}
-                            leftWidth={leftElement.data.width}
-                            rightWidth={element.data.width}
+                            leftWidth={get(leftElement, "data.width")}
+                            rightWidth={get(element, "data.width")}
                         />
                     )}
                 </Resizer>


### PR DESCRIPTION
## Related Issue
Closes #1258 

In some weird case that I haven't been able to reproduce, the `element.data` property becomes undefined, and further accessing values on it, in the `RowChild` component, throws an error (check code changes).

But that's not the worst part. The worst part is that the whole editor crashes, preventing the user from editing the page completely.

After some testing, I figured it's just better to handle this specific case in the mentioned `RowChild` component, and create a [separate issue](https://github.com/webiny/webiny-js/issues/1288) (since we'll be rebuilding PB with Recoil). Check the issue for more details.


## How Has This Been Tested?
Manual testing.

## Screenshots (if relevant):
N/A