### PR TITLE
Greetings and Stale Bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 120
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - do not merge yet
+  - help wanted
+  - high priority
+  - pinned
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Please reopen this issue once you commit the changes requested or
+  make improvements on the code. Thank you for your contributions.

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,13 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Hola! @${{ github.actor }} 🥳, You just created  an Issue!🌟 Thanks for making the Project Better and empowering Learners'
+        pr-message: 'Submitted a PR already ?? Thats amazing @${{ github.actor }} . Sit tight until one of our amazing maintainers review it . Make sure you read our Contributing Guidelines'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Mark Stale Issues and Pull Requests
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            Please reopen this issue once you add more information and updates here.
+            If this is not the case and you need some help, feel free to seek help
+            from our [Slack Community](https://www.webiny.com/slack) or ping one of the
+            reviewers. Thank you for your contributions!
+          stale-pr-message: >
+            Please reopen this pull request once you commit the changes requested
+            or make improvements on the code. If this is not the case and you need
+            some help, feel free to seek help from our [Slack Community](https://www.webiny.com/slack)
+            or ping one of the reviewers. Thank you for your contributions!
+          stale-issue-label: "no-issue-activity"
+          stale-pr-label: "no-pr-activity"


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1289 
## Note
For the Action to work successfully run it needs GITHUB_TOKEN which I don't have permission for this Repository so reviewers kindly please feel free to try .github/workflow/greetings.yml before merging it :)
## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
I have added 2 Github Actions which does 2 task
Greeting Bot
* Gives a warm welcome personalized message to Contributors <br>

Stale Bot
* Marks Issues which have seen no activity for 120 days as stale and it is closed within the next 30 days with a message.
* Maintainers can change this duration at the .github/stale.yml file. I have added comments to make it easier to understand and work with.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have used this bot on a lot of my Open Source Projects and on projects that I am a maintainer of. Made me live so much easy as the Project picked up.

