### PR TITLE
fix: configurations for development tools

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
-node_modules/**
-dist/**
-build/**
+**/node_modules/
+**/dist/
+**/build/
 **/.out/
 **/__tests__
 **/*.d.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
-**/node_modules/
-**/dist/
-**/build/
+node_modules/**
+dist/**
+build/**
 **/.out/
 **/__tests__
 **/*.d.ts

--- a/package.json
+++ b/package.json
@@ -157,8 +157,8 @@
   "lint-staged": {
     "**/*.{js,ts,tsx}": [
       "adio",
-      "yarn prettier:fix",
-      "yarn eslint:fix",
+      "prettier --write",
+      "eslint",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -155,10 +155,10 @@
     }
   },
   "lint-staged": {
-    "**/*.js": [
+    "**/*.{js,ts,tsx}": [
       "adio",
       "yarn prettier:fix",
-      "eslint",
+      "yarn eslint:fix",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "fsevents": "^2.0.7"
   },
   "scripts": {
-    "eslint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
+    "eslint": "eslint \"**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "eslint:fix": "yarn eslint --fix",
     "build": "lerna run build --stream",
     "build:apps": "lerna run build --scope=@webiny/app* --stream",
@@ -156,10 +156,9 @@
   },
   "lint-staged": {
     "**/*.{js,ts,tsx}": [
-      "adio",
-      "prettier --write",
-      "eslint",
-      "git add"
+      "prettier --check",
+      "eslint --max-warnings=0",
+      "adio"
     ]
   },
   "yargs": {


### PR DESCRIPTION
## Related Issue
Closes #1251 

## Your solution
- changes made in `.eslintignore` file paths
- Have updated the `lint-staged` rules to check the `ts & tsx` file paths too

### Fixes the following things:
- [x] 1. Prettier - the whole project scanned
- [x] 2. lint-staged - incorrect file filter applied
- [x] 3. ESLint - not ignoring build files

## Screenshots (if relevant):
N/A
