### PR TITLE
docs: fix url linking to package-content

### DIFF
--- a/docs/DEVELOPMENT_OVERVIEW.md
+++ b/docs/DEVELOPMENT_OVERVIEW.md
@@ -108,7 +108,7 @@ This is the reason we use yarn because its workspace management makes working wi
 
 Let's see an example package, the `api-cookie-policy`. 
 
-![Package content](/img/deep-dive/architecture/webiny-package-content.png)
+![Package content](https://docs.webiny.com/img/deep-dive/architecture/webiny-package-content.png)
 
 The package contains the `dist` and the `src` folders.
 


### PR DESCRIPTION
This PR aims to fix the broken url in the **What happens when we build packages?** section of DEVELOPMENT_OVERVIEW.md file. The hyperlink originally linked to a 404 page when instead, it should link to https://docs.webiny.com/img/deep-dive/architecture/webiny-package-content.png
Made the necessary changes :) 