### PR TITLE
fix: Content Model validation message for name field

### DIFF
--- a/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
@@ -60,7 +60,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
 
     const nameValidator = useCallback(name => {
         if (!name.charAt(0).match(/[a-zA-Z]/)) {
-            throw new Error('Value is not valid - must not start with a number.');
+            throw new Error("Value is not valid - must not start with a number.");
         }
         if (name.trim().toLowerCase() === "id") {
             throw new Error('Value is not valid - "id" is an auto-generated field.');
@@ -112,7 +112,10 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
                                     <Cell span={12}>
                                         <Bind
                                             name={"name"}
-                                            validators={[validation.create("required,maxLength:100"), nameValidator]}
+                                            validators={[
+                                                validation.create("required,maxLength:100"),
+                                                nameValidator
+                                            ]}
                                         >
                                             <Input
                                                 label={t`Name`}

--- a/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentModels/NewContentModelDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { css } from "emotion";
 import { useRouter } from "@webiny/react-router";
 import { Form } from "@webiny/form";
@@ -58,6 +58,16 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
         return { value: item.id, label: item.name };
     });
 
+    const nameValidator = useCallback(name => {
+        if (!name.charAt(0).match(/[a-zA-Z]/)) {
+            throw new Error('Value is not valid - must not start with a number.');
+        }
+        if (name.trim().toLowerCase() === "id") {
+            throw new Error('Value is not valid - "id" is an auto-generated field.');
+        }
+        return true;
+    }, undefined);
+
     return (
         <Dialog
             open={open}
@@ -102,7 +112,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({
                                     <Cell span={12}>
                                         <Bind
                                             name={"name"}
-                                            validators={validation.create("required,maxLength:100")}
+                                            validators={[validation.create("required,maxLength:100"), nameValidator]}
                                         >
                                             <Input
                                                 label={t`Name`}


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1124 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Added a new custom validator to check the name pattern in `NewContentModelDialog` component. It will show messages inside the dialog if the name starts with a number or it equals `"id"`.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
For the name which starts with a number character: 
1. Open New Model dialog
2. Enter "3D Asset" or any other name which starts with a number for the model name.
3. Click Create button

For the name equals to `"id"`: 
1. Open New Model dialog
2. Enter "id" for the model name.
3. Click Create button

## Screenshots (if relevant):

> 
Name starts with a number message:
![error1](https://user-images.githubusercontent.com/9274112/95798368-cf3b7800-0cbf-11eb-90d5-85987a898994.png)
Name equals to `"id"`:
![error2](https://user-images.githubusercontent.com/9274112/95798366-cea2e180-0cbf-11eb-9a16-ea64072cc71e.png)


