### PR TITLE
fix: correct behavior of plugins retrieval functions

### DIFF
--- a/packages/plugins/src/PluginsContainer.ts
+++ b/packages/plugins/src/PluginsContainer.ts
@@ -45,12 +45,12 @@ export class PluginsContainer {
         return this.plugins[name] as T;
     }
 
-    byType<T extends Plugin>(type?: string): T[] {
-        if (!type) {
-            return Object.values(this.plugins) as T[];
-        }
-
+    byType<T extends Plugin>(type: string): T[] {
         return Object.values(this.plugins).filter((pl: Plugin) => pl.type === type) as T[];
+    }
+
+    all<T extends Plugin>(): T[] {
+        return Object.values(this.plugins) as T[];
     }
 
     register(...args: any): void {

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -8,6 +8,9 @@ const registerPlugins = (...args: any): void => {
 };
 
 const getPlugins = <T extends Plugin = Plugin>(type?: string) => {
+    if (!type) {
+        return plugins.all<T>();
+    }
     return plugins.byType<T>(type);
 };
 


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1308 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Changed the `byType` method to no longer accept `undefined` as a valid type. Added the `all` method to `PluginsContainer` as the correct way to retrieve all plugins. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran my changes against the existing tests, making sure that `plugins.test.js`, `modelFields.test.js`, `validators.test.js`, and `contentModelToSDL.test.js` passed in particular.

I also checked all uses of the `byType` method within the codebase to ensure that it was never being passed a value of `undefined` as a means for retrieving all plugins. As a result of this check, I updated the `getPlugins` function in `index.ts` to return all plugins when passed a value of `undefined`. This is expected behavior based on the tests found in `plugins.test.js`.

## Screenshots (if relevant):
N/A