### PR TITLE
Wait for environment to load before mounting content form

### DIFF
--- a/packages/app-headless-cms/src/admin/views/Content/Content.tsx
+++ b/packages/app-headless-cms/src/admin/views/Content/Content.tsx
@@ -4,6 +4,7 @@ import { useDataList } from "@webiny/app/hooks/useDataList";
 import ContentDataList from "./ContentDataList";
 import ContentDetails from "./ContentDetails";
 import { createListQuery } from "@webiny/app-headless-cms/admin/components/ContentModelForm/graphql";
+import { useCms } from "@webiny/app-headless-cms/admin/hooks";
 import get from "lodash.get";
 import { useApolloClient, useQuery } from "@webiny/app-headless-cms/admin/hooks";
 import { GET_CONTENT_MODEL_BY_MODEL_ID } from "./graphql";
@@ -104,4 +105,16 @@ const Content = () => {
     return <ContentRender contentModel={contentModel} key={contentModel.modelId} />;
 };
 
-export default Content;
+const AwaitEnvironment = () => {
+    const {
+        environments: { apolloClient }
+    } = useCms();
+
+    if (!apolloClient) {
+        return null;
+    }
+
+    return <Content/>;
+};
+
+export default AwaitEnvironment;


### PR DESCRIPTION
## Related Issue
When you open a content form to create a new entry and reload the browser, API calls are made to the wrong API endpoint because CMS environments are not yet loaded and the appropriate Apollo client instance is not yet set.

## Your solution
Wait for CMS Apollo client instance to be available before mounting the content form.

## How Has This Been Tested?
Manually, by reloading the browser and observing the network requests.