### PR TITLE
fix(headless-cms): view full search text in safari browser

### DIFF
--- a/packages/app-admin/src/plugins/GlobalSearch/styled.ts
+++ b/packages/app-admin/src/plugins/GlobalSearch/styled.ts
@@ -37,7 +37,7 @@ export const searchBarInput = css({
         paddingTop: "5px !important",
         paddingLeft: "10px !important",
         borderBottom: "none !important",
-        height: "25px !important",
+        height: "28px !important",
         color: "var(--mdc-theme-surface)",
         "&::placeholder": {
             color: "var(--mdc-theme-surface) !important",


### PR DESCRIPTION
bottom of search text was not visible only in safari

## Related Issue
Closes #898 

## Your solution
Search text in headless CMS wasn't fully visible in safari. Changed the height of the container from 25px to 28px


## How Has This Been Tested?
Tested locally in Chrome and Safari

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/1332395/96830449-64164200-1433-11eb-813d-0d465bd252a7.png)
