### PR TITLE
feat: show published version of webiny in admin app

### DIFF
--- a/packages/app-admin/src/plugins/Menu/Navigation/index.tsx
+++ b/packages/app-admin/src/plugins/Menu/Navigation/index.tsx
@@ -116,6 +116,15 @@ const Navigation = () => {
                             </p>
                         </div>
                     </ListItem>
+                    <ListItem ripple={false} className={subFooter}>
+                        <div>
+                            <p>
+                                {t`Powered by Webiny v{version}`({
+                                    version: process.env.REACT_APP_WEBINY_VERSION
+                                })}
+                            </p>
+                        </div>
+                    </ListItem>
                 </List>
 
                 <ApiInformationDialog open={infoOpened} onClose={() => setInfoOpened(false)} />

--- a/packages/project-utils/bundling/app/index.js
+++ b/packages/project-utils/bundling/app/index.js
@@ -1,6 +1,9 @@
+const { version } = require("@webiny/project-utils/package.json");
+
 module.exports.buildApp = options => {
     process.env.NODE_ENV = "production";
     process.env.REACT_APP_ENV = "browser";
+    process.env.REACT_APP_WEBINY_VERSION = version;
     process.env.REACT_APP_USER_ID = require("@webiny/cli/config").getId();
 
     return require("./createProdConfig")(options);
@@ -9,6 +12,7 @@ module.exports.buildApp = options => {
 module.exports.startApp = options => {
     process.env.NODE_ENV = "development";
     process.env.REACT_APP_ENV = "browser";
+    process.env.REACT_APP_WEBINY_VERSION = version;
     process.env.REACT_APP_USER_ID = require("@webiny/cli/config").getId();
 
     return require("./createDevConfig")(options);


### PR DESCRIPTION
show published version of webiny in navigation sidebar footer in admin app

## Related Issue
Closes #1195

## Your solution
Pulling version of webiny from `@webiny/project-utils/package.json` and setting it into an environment variable `REACT_APP_WEBINY_VERSION`. Using it in navigation sidebar

## How Has This Been Tested?

## Screenshots (if relevant):
![Screenshot from 2020-10-26 22-51-26](https://user-images.githubusercontent.com/45600289/97230743-81b32500-1800-11eb-9c24-86e194ca8b8a.png)
