### PR TITLE
fix(api-security): handle authentication errors

### DIFF
--- a/packages/api-security/src/plugins/security.ts
+++ b/packages/api-security/src/plugins/security.ts
@@ -19,7 +19,13 @@ export default (options: SecurityOptions) => [
 
             const securityPlugins = context.plugins.byType<SecurityPlugin>("graphql-security");
             for (let i = 0; i < securityPlugins.length; i++) {
-                await securityPlugins[i].authenticate(context);
+                try {
+                    await securityPlugins[i].authenticate(context);
+                } catch (e) {
+                    // Authentication errors should not exposed to the client,
+                    // and should be treated as an authentication failure
+                    continue;
+                }
             }
 
             if (options.public === false && !context.user) {


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1300
See #1330 for the same fix for `v5`

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Currently, uncaught errors in `SecurityPlugin`s will cause APIs to return HTTP `500`, and expose the stack trace to the client.
This PR adds a try-catch block to ignore errors in `SecurityPlugin`s, essentially treating them as a failed authentication.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
