### PR TITLE
Fix/issue 1333

### DIFF
--- a/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
@@ -43,8 +43,10 @@ const Image = props => {
     return (
         <ElementRoot
             element={props.element}
-            style={{ display: "flex", justifyContent: position[horizontalAlign] }}
             className={"webiny-pb-base-page-element-style webiny-pb-page-element-image"}
+            // alignItems: position[horizontalAlign] is here because of a Safari CSS bug when flex is enabled on an image
+            // container with height is set to auto and the width is configured
+            style={{ display: "flex", alignItems: position[horizontalAlign], justifyContent: position[horizontalAlign] }}
         >
             <Link link={link}>
                 <WebinyImage

--- a/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/image/Image.tsx
@@ -15,6 +15,8 @@ const Link = ({ link, children }) => {
     return children;
 };
 
+const position = { left: "flex-start", center: "center", right: "flex-end" };
+
 const Image = props => {
     const { image = {}, link = {}, settings = {} } = get(props, "element.data", {});
     if (!image || !image.file) {
@@ -41,7 +43,7 @@ const Image = props => {
     return (
         <ElementRoot
             element={props.element}
-            style={{ textAlign: horizontalAlign }}
+            style={{ display: "flex", justifyContent: position[horizontalAlign] }}
             className={"webiny-pb-base-page-element-style webiny-pb-page-element-image"}
         >
             <Link link={link}>


### PR DESCRIPTION


see the issue for details

Refs #1333

## Related Issue

Closes #1333

## Your solution
As per the ticket, added two lines to interpret the alignment correctly (hopefully).

## How Has This Been Tested?
Tested locally and again when published to our live environment, using MacOS with Chrome (86.0.4240.193) and Safari 14.0 (15610.1.28.1.9, 15610).

## Screenshots (if relevant):

db.econtentmaps.remove( { } );