### PR TITLE
feat: add API name in CDN distribution comment

### DIFF
--- a/packages/cwp-template-cms/template/apps/resources.js
+++ b/packages/cwp-template-cms/template/apps/resources.js
@@ -54,6 +54,7 @@ module.exports = ({ cli }) => {
             cdn: {
                 component: "@webiny/serverless-aws-cloudfront",
                 inputs: {
+                    comment: "${api.name}",
                     forwardIdViaHeaders: true,
                     defaults: {
                         ttl: 300,

--- a/packages/cwp-template-full/template/apps/resources.js
+++ b/packages/cwp-template-full/template/apps/resources.js
@@ -125,6 +125,7 @@ module.exports = ({ cli }) => {
             cdn: {
                 component: "@webiny/serverless-aws-cloudfront",
                 inputs: {
+                    comment: "${api.name}",
                     forwardIdViaHeaders: true,
                     defaults: {
                         ttl: 300,


### PR DESCRIPTION
## Related Issue
Closes #1169

## Your solution
Added a comment input to the resources.js files in all cwp-template-* packages to contain the name of the API the CDN is pointing to

## How Has This Been Tested?

