### PR TITLE
feat: 

### DIFF
--- a/packages/cwp-template-aws/cli/info/index.js
+++ b/packages/cwp-template-aws/cli/info/index.js
@@ -1,6 +1,60 @@
 const getStackOutput = require("@webiny/cli-plugin-deploy-pulumi/utils/getStackOutput");
 const { green } = require("chalk");
 
+const line = `-------------------------`;
+
+const printEnvOutput = async (env, context) => {
+    console.log(line);
+    console.log(`Environment: ${green(env)}`);
+    console.log(line);
+
+    let stacksDeployedCount = 0;
+    let output = await getStackOutput("api", env);
+    if (output) {
+        stacksDeployedCount++;
+        console.log(
+            [
+                `➜ Main GraphQL API: ${green(output.apiUrl + "/graphql")}`,
+                `➜ Headless CMS GraphQL API:`,
+                `   - Manage API: ${green(output.apiUrl + "/cms/manage/{LOCALE_CODE}")}`,
+                `   - Read API: ${green(output.apiUrl + "/cms/read/{LOCALE_CODE}")}`,
+                `   - Preview API: ${green(output.apiUrl + "/cms/preview/{LOCALE_CODE}")}`
+            ].join("\n")
+        );
+    } else {
+        context.info(`Stack ${green("api")} not deployed yet.`);
+    }
+
+    output = await getStackOutput("apps/admin", env);
+    if (output) {
+        stacksDeployedCount++;
+        console.log([`➜ Admin app: ${green(output.appUrl)}`].join("\n"));
+    } else {
+        context.info(`Stack ${green("apps/admin")} not deployed yet.`);
+    }
+
+    output = await getStackOutput("apps/website", env);
+    if (output) {
+        stacksDeployedCount++;
+        console.log(
+            [
+                `➜ Public website:`,
+                `   - Website URL: ${green(output.deliveryUrl)}`,
+                `   - Website preview URL: ${green(output.appUrl)}`
+            ].join("\n")
+        );
+    } else {
+        context.info(`Stack ${green("apps/website")} not deployed yet.`);
+    }
+
+    if (stacksDeployedCount === 0) {
+        context.info("It seems none of the stacks were deployed, so no info could be provided.");
+        context.info(`Please check if the provided environment ${green(env)} is correct.`);
+    }
+
+    console.log(line + "\n");
+};
+
 module.exports = {
     type: "cli-command",
     name: "cli-command-info",
@@ -12,7 +66,7 @@ module.exports = {
                 yargs.option("env", {
                     describe: `Environment`,
                     type: "string",
-                    required: true
+                    required: false
                 });
                 yargs.option("debug", {
                     describe: `Debug`,
@@ -22,58 +76,31 @@ module.exports = {
             async args => {
                 const { env } = args;
 
-                let stacksDeployedCount = 0;
-                let output = await getStackOutput("api", env);
-                if (output) {
-                    stacksDeployedCount++;
-                    console.log(
-                        [
-                            `➜ Main GraphQL API: ${green(output.apiUrl + "/graphql")}`,
-                            `➜ Headless CMS GraphQL API:`,
-                            `   - Manage API: ${green(
-                                output.apiUrl + "/cms/manage/{LOCALE_CODE}"
-                            )}`,
-                            `   - Read API: ${green(output.apiUrl + "/cms/read/{LOCALE_CODE}")}`,
-                            `   - Preview API: ${green(
-                                output.apiUrl + "/cms/preview/{LOCALE_CODE}"
-                            )}`
-                        ].join("\n")
-                    );
-                } else {
-                    context.info(`Stack ${green("api")} not deployed yet.`);
+                if (!env) {
+                    // Get all existing environments
+                    const glob = require("fast-glob");
+                    const pulumiFiles = await glob(["**/Pulumi.*.yaml"], {
+                        cwd: context.paths.projectRoot,
+                        onlyFiles: true,
+                        ignore: ["**/node_modules/**"]
+                    });
+
+                    const existingEnvs = new Set();
+                    const regex = /Pulumi\.(\w+)\.yaml/;
+                    pulumiFiles.forEach(file => {
+                        if (file.match(regex)) {
+                            existingEnvs.add(RegExp.$1);
+                        }
+                    });
+
+                    for (const env of existingEnvs) {
+                        await printEnvOutput(env, context);
+                    }
+
+                    return;
                 }
 
-                output = await getStackOutput("apps/admin", env);
-                if (output) {
-                    stacksDeployedCount++;
-                    console.log([`➜ Admin app: ${green(output.appUrl)}`].join("\n"));
-                } else {
-                    context.info(`Stack ${green("apps/admin")} not deployed yet.`);
-                }
-
-                output = await getStackOutput("apps/website", env);
-                if (output) {
-                    stacksDeployedCount++;
-                    console.log(
-                        [
-                            `➜ Public website:`,
-                            `   - Website URL: ${green(output.deliveryUrl)}`,
-                            `   - Website preview URL: ${green(output.appUrl)}`
-                        ].join("\n")
-                    );
-                } else {
-                    context.info(`Stack ${green("apps/website")} not deployed yet.`);
-                }
-
-                if (stacksDeployedCount === 0) {
-                    console.log();
-                    context.info(
-                        "It seems none of the stacks were deployed, so no info could be provided."
-                    );
-                    context.info(
-                        `Please check if the provided environment ${green(env)} is correct.`
-                    );
-                }
+                await printEnvOutput(env, context);
             }
         );
     }

--- a/packages/cwp-template-aws/package.json
+++ b/packages/cwp-template-aws/package.json
@@ -1,35 +1,36 @@
 {
-	"name": "@webiny/cwp-template-aws",
-	"version": "5.0.0-beta.0",
-	"main": "index.js",
-	"repository": {
-		"type": "git",
-		"directory": "packages/cwp-template-aws"
-	},
-	"publishConfig": {
-		"access": "public",
-		"directory": "."
-	},
-	"dependencies": {
-		"@webiny/cli-plugin-deploy-pulumi": "^5.0.0-beta.0",
-		"chalk": "4.1.0",
-		"create-webiny-project": "^5.0.0-beta.0",
-		"execa": "4.1.0",
-		"fs-extra": "9.0.1",
-		"get-yarn-workspaces": "1.0.2",
-		"inquirer": "7.3.3",
-		"load-json-file": "6.2.0",
-		"lodash": "4.17.20",
-		"ora": "4.1.1",
-		"write-json-file": "4.3.0"
-	},
-	"devDependencies": {
-		"dotenv": "^8.2.0"
-	},
-	"adio": {
-		"ignoreDirs": [
-			"/template/"
-		]
-	},
-	"gitHead": "8476da73b653c89cc1474d968baf55c1b0ae0e5f"
+  "name": "@webiny/cwp-template-aws",
+  "version": "5.0.0-beta.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "directory": "packages/cwp-template-aws"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "."
+  },
+  "dependencies": {
+    "@webiny/cli-plugin-deploy-pulumi": "^5.0.0-beta.0",
+    "chalk": "4.1.0",
+    "create-webiny-project": "^5.0.0-beta.0",
+    "execa": "4.1.0",
+    "fast-glob": "^3.2.5",
+    "fs-extra": "9.0.1",
+    "get-yarn-workspaces": "1.0.2",
+    "inquirer": "7.3.3",
+    "load-json-file": "6.2.0",
+    "lodash": "4.17.20",
+    "ora": "4.1.1",
+    "write-json-file": "4.3.0"
+  },
+  "devDependencies": {
+    "dotenv": "^8.2.0"
+  },
+  "adio": {
+    "ignoreDirs": [
+      "/template/"
+    ]
+  },
+  "gitHead": "8476da73b653c89cc1474d968baf55c1b0ae0e5f"
 }


### PR DESCRIPTION
## Related Issue
Running `yarn webiny info` required the `--env` parameter to be passed. Sometimes we want to see everything that's deployed. This PR allows us to do that.

## Your solution
Make `--env` parameter optional and if it's not passed, find all files that match `/Pulumi\.(\w+)\.yaml/` pattern, and output respective environment information.

## How Has This Been Tested?
Manually.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/3920893/105204696-c40ca980-5b44-11eb-92fc-5e95ab34005d.png)

![image](https://user-images.githubusercontent.com/3920893/105204719-c838c700-5b44-11eb-98c9-408907422e3f.png)

