### PR TITLE
Feat/v5/content model editor

### DIFF
--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/ContentModelEditor.tsx
@@ -8,6 +8,7 @@ import DragPreview from "./DragPreview";
 import { useContentModelEditor } from "./Context";
 
 import { i18n } from "@webiny/app/i18n";
+import { CircularProgress } from "@webiny/ui/Progress";
 const t = i18n.ns("app-headless-cms/admin/editor");
 
 const prompt = t`There are some unsaved changes! Are you sure you want to navigate away and discard all changes?`;
@@ -29,7 +30,7 @@ const ContentModelEditor = () => {
     }, [modelId]);
 
     if (!data) {
-        return null;
+        return <CircularProgress label={"Loading content model..."} />;
     }
 
     return (

--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/ContentModelEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useRouter } from "@webiny/react-router";
+import { useRouter, Prompt } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 // Components
 import EditorBar from "./Bar";
@@ -10,10 +10,12 @@ import { useContentModelEditor } from "./Context";
 import { i18n } from "@webiny/app/i18n";
 const t = i18n.ns("app-headless-cms/admin/editor");
 
+const prompt = t`There are some unsaved changes! Are you sure you want to navigate away and discard all changes?`;
+
 const ContentModelEditor = () => {
     const {
         getContentModel,
-        state: { data, modelId }
+        state: { data, modelId, isPristine }
     } = useContentModelEditor();
 
     const { history } = useRouter();
@@ -32,6 +34,7 @@ const ContentModelEditor = () => {
 
     return (
         <div className={"content-model-editor"}>
+            <Prompt when={!isPristine} message={prompt} />
             <EditorBar />
             <EditorContent />
             <DragPreview />

--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Context/contentModelEditorReducer.ts
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Context/contentModelEditorReducer.ts
@@ -7,13 +7,11 @@ export function init(props: UseContentModelEditorReducerState) {
 }
 
 export function contentModelEditorReducer(state: any, action: { data: any; type: string }) {
-    const next = { ...state };
     switch (action.type) {
-        case "data": {
-            next.data = action.data;
-            break;
-        }
-    }
+        case "state":
+            return { ...state, ...action.data };
 
-    return next;
+        case "data":
+            return { ...state, data: action.data };
+    }
 }

--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Context/useContentModelEditorFactory.ts
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Context/useContentModelEditorFactory.ts
@@ -25,6 +25,10 @@ export default ContentModelEditorContext => {
 
         const { state, dispatch } = context;
 
+        const setPristine = flag => {
+            dispatch({ type: "state", data: { isPristine: flag } });
+        };
+
         const self = {
             apollo: state.apollo,
             data: state.data,
@@ -40,7 +44,10 @@ export default ContentModelEditorContext => {
                     throw new Error(error);
                 }
 
-                self.setData(() => cloneDeep(data), false);
+                self.setData(() => {
+                    setPristine(true);
+                    return cloneDeep(data);
+                }, false);
                 return response;
             },
             saveContentModel: async (data = state.data) => {
@@ -59,6 +66,8 @@ export default ContentModelEditorContext => {
                     }
                 });
 
+                setPristine(true);
+
                 return get(response, "data.updateContentModel");
             },
             /**
@@ -68,6 +77,7 @@ export default ContentModelEditorContext => {
              * @param saveContentModel
              */
             setData(setter: Function, saveContentModel = false) {
+                setPristine(false);
                 const data = setter(cloneDeep(self.data));
                 dispatch({ type: "data", data });
                 return saveContentModel !== false && self.saveContentModel(data);


### PR DESCRIPTION
## Related Issue
Content model editor doesn't auto-save on changes, and when navigating away from the editor it doesn't warn you of unsaved changes, so often you lose your work.

## Your solution
Add a react-router prompt which is triggered when there are changes in the model editor. If there are no changes, the prompt is not shown.

## How Has This Been Tested?
Manually, by making changes to the model and trying to navigate away using both in-app "Back" button but also browser "Back" button.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/3920893/106502275-7557fb80-64c4-11eb-964b-a4eed15635de.png)

