### PR TITLE
fix(app-headless-cms): number input removes decimal point

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
@@ -30,7 +30,6 @@ const plugin: CmsEditorFieldRendererPlugin = {
                             <Input
                                 {...bindProps}
                                 onChange={value => {
-                                    value = parseFloat(value);
                                     return bindProps.onChange(value);
                                 }}
                                 label={field.label}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
@@ -29,7 +29,6 @@ const plugin: CmsEditorFieldRendererPlugin = {
                         <Input
                             {...bind.index}
                             onChange={value => {
-                                value = parseFloat(value);
                                 return bind.index.onChange(value);
                             }}
                             autoFocus


### PR DESCRIPTION
When typing a number with a decimal point and first next number iz zero, point is removed.