### PR TITLE
fix(api-headless-cms): allow to list models without throwing error

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -21,6 +21,7 @@ import {
     beforeDeleteHook,
     afterDeleteHook
 } from "./contentModel/hooks";
+import { NotAuthorizedError } from "@webiny/api-security";
 
 export default (): ContextPlugin<CmsContext> => ({
     type: "context",
@@ -77,6 +78,20 @@ export default (): ContextPlugin<CmsContext> => ({
                 return {
                     get: modelsGet,
                     list: modelsList
+                };
+            },
+            silentAuth: () => {
+                return {
+                    list: async () => {
+                        try {
+                            return models.list();
+                        } catch (ex) {
+                            if (ex instanceof NotAuthorizedError) {
+                                return [];
+                            }
+                            throw ex;
+                        }
+                    }
                 };
             },
             async get(modelId) {

--- a/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
@@ -71,11 +71,11 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
         resolvers = {
             CmsContentModelGroup: {
                 contentModels: async (group, args, context) => {
-                    const models = await context.cms.models.list();
+                    const models = await context.cms.models.silentAuth().list();
                     return models.filter(m => m.group.id === group.id);
                 },
                 totalContentModels: async (group, args, context) => {
-                    const models = await context.cms.models.list();
+                    const models = await context.cms.models.silentAuth().list();
                     return models.filter(m => m.group === group.id).length;
                 }
             },

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1074,6 +1074,15 @@ export interface CmsContentModelContext {
         list: () => Promise<CmsContentModel[]>;
     };
     /**
+     * A function defining usage of a method with authenticating the user but not throwing an error.
+     */
+    silentAuth: () => {
+        /**
+         * Get all content models.
+         */
+        list: () => Promise<CmsContentModel[]>;
+    };
+    /**
      * Get a single content model.
      */
     get: (modelId: string) => Promise<CmsContentModel | null>;


### PR DESCRIPTION
Fix an error when listing models internally without proper authentication - return empty array instead of throwing an error