### PR TITLE
fix(app-headless-cms): date validators error because nothing in render

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldValidators/dateGte.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldValidators/dateGte.tsx
@@ -22,10 +22,10 @@ export default (): CmsEditorFieldValidatorPlugin => ({
                     <Cell span={12}>
                         <Bind name={"settings.type"}>
                             {bind => {
-                                if (bind.value === type) {
-                                    return null;
+                                if (bind.value !== type) {
+                                    bind.onChange(type);
                                 }
-                                bind.onChange(type);
+                                return <></>;
                             }}
                         </Bind>
                         <Bind

--- a/packages/app-headless-cms/src/admin/plugins/fieldValidators/dateLte.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldValidators/dateLte.tsx
@@ -22,10 +22,10 @@ export default (): CmsEditorFieldValidatorPlugin => ({
                     <Cell span={12}>
                         <Bind name={"settings.type"}>
                             {bind => {
-                                if (bind.value === type) {
-                                    return null;
+                                if (bind.value !== type) {
+                                    bind.onChange(type);
                                 }
-                                bind.onChange(type);
+                                return <></>;
                             }}
                         </Bind>
                         <Bind

--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/ValidatorsTab.tsx
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/ValidatorsTab.tsx
@@ -11,7 +11,7 @@ import { Form } from "@webiny/form";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { validation } from "@webiny/validation";
 import { Input } from "@webiny/ui/Input";
-import { CmsEditorField, CmsEditorFieldValidatorPlugin } from "@webiny/app-headless-cms/types";
+import { CmsEditorField } from "@webiny/app-headless-cms/types";
 
 const onEnabledChange = ({ data, validationValue, onChangeValidation, validator }) => {
     if (data) {
@@ -47,7 +47,7 @@ const noMargin = css({
 
 interface ValidatorsTabProps {
     name: string;
-    validators: CmsEditorFieldValidatorPlugin[];
+    validators: any[];
     form: any;
     field: CmsEditorField;
 }

--- a/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/ValidatorsTab.tsx
+++ b/packages/app-headless-cms/src/admin/views/components/ContentModelEditor/Tabs/EditTab/EditFieldDialog/ValidatorsTab.tsx
@@ -11,7 +11,7 @@ import { Form } from "@webiny/form";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { validation } from "@webiny/validation";
 import { Input } from "@webiny/ui/Input";
-import { CmsEditorField } from "@webiny/app-headless-cms/types";
+import { CmsEditorField, CmsEditorFieldValidatorPlugin } from "@webiny/app-headless-cms/types";
 
 const onEnabledChange = ({ data, validationValue, onChangeValidation, validator }) => {
     if (data) {
@@ -47,7 +47,7 @@ const noMargin = css({
 
 interface ValidatorsTabProps {
     name: string;
-    validators: any[];
+    validators: CmsEditorFieldValidatorPlugin[];
     form: any;
     field: CmsEditorField;
 }


### PR DESCRIPTION
A bug that occurs when trying to use date lte or gte validators.
Fixed by returning a react fragment in the render.