### PR TITLE
Do not use limit when checking for existing slug.

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
@@ -115,8 +115,7 @@ export default (): ContextPlugin<CmsContext> => ({
             const { where, limit } = args || {};
             const [groups] = await db.read<CmsContentModelGroup>({
                 ...utils.defaults.db,
-                query: { PK: PK_GROUP(), SK: { $gt: " " } },
-                limit
+                query: { PK: PK_GROUP(), SK: { $gt: " " } }
             });
 
             const whereKeys = Object.keys(where || {});
@@ -124,7 +123,9 @@ export default (): ContextPlugin<CmsContext> => ({
                 return groups;
             }
 
-            return groups.filter(whereFilterFactory(where));
+            const filteredGroups = groups.filter(whereFilterFactory(where));
+
+            return typeof limit !== "undefined" ? filteredGroups.slice(0, limit) : filteredGroups;
         };
 
         const groups: CmsContentModelGroupContext = {

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup/beforeCreate.hook.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup/beforeCreate.hook.ts
@@ -13,8 +13,7 @@ export const beforeCreateHook = async (
         const groups = await context.cms.groups.noAuth().list({
             where: {
                 slug
-            },
-            limit: 1
+            }
         });
         if (groups.length === 0) {
             return;
@@ -30,8 +29,7 @@ export const beforeCreateHook = async (
     const groups = await context.cms.groups.noAuth().list({
         where: {
             slug: newSlug
-        },
-        limit: 1
+        }
     });
 
     if (groups.length === 0) {

--- a/packages/cli/commands/index.js
+++ b/packages/cli/commands/index.js
@@ -1,7 +1,8 @@
 const run = require("./run");
+const tracking = require("./tracking");
 
 module.exports.createCommands = (yargs, context) => {
-    context.plugins.register(run);
+    context.plugins.register(run, tracking);
 
     context.loadUserPlugins();
 

--- a/packages/cli/commands/tracking/index.js
+++ b/packages/cli/commands/tracking/index.js
@@ -1,3 +1,4 @@
+const { sendEvent } = require("@webiny/tracking");
 const { setTracking } = require("../../config");
 
 module.exports = {
@@ -5,17 +6,16 @@ module.exports = {
     name: "cli-command-tracking",
     create({ yargs, context }) {
         yargs.command("enable-tracking", "Enable tracking of Webiny stats.", async () => {
-            setTracking(true);
+            await setTracking(true);
+            await sendEvent({ event: "enable-tracking" });
             context.info(
                 "Tracking of Webiny stats is now ENABLED! Thank you for helping us with anonymous data."
             );
         });
 
         yargs.command("disable-tracking", "Disable tracking of Webiny stats.", async () => {
-            const { sendEvent } = require("@webiny/tracking");
-
+            await setTracking(false);
             await sendEvent({ event: "disable-tracking" });
-            setTracking(false);
             context.info("Tracking of Webiny stats is now DISABLED!");
         });
     }

--- a/packages/cli/config/index.js
+++ b/packages/cli/config/index.js
@@ -2,6 +2,7 @@ const os = require("os");
 const path = require("path");
 const readJson = require("load-json-file");
 const writeJson = require("write-json-file");
+const publicIp = require("public-ip");
 
 const configPath = path.join(os.homedir(), ".webiny", "config");
 
@@ -15,7 +16,6 @@ const verifyConfig = async () => {
             throw Error("Invalid Webiny config!");
         }
     } catch (e) {
-        const publicIp = require("public-ip");
         // A new config file is written if it doesn't exist or is invalid.
         config = { id: await publicIp.v4() };
         await writeJson(configPath, config);
@@ -25,7 +25,21 @@ const verifyConfig = async () => {
 };
 
 const getId = () => {
-    return `${process.env.WEBINY_TRACKING_PREFIX || ""}${config.id}`;
+    return config.id;
 };
 
-module.exports = { verifyConfig, getId };
+const setTracking = async enabled => {
+    try {
+        const config = readJson.sync(configPath);
+        if (!config.id) {
+            config.id = await publicIp.v4();
+        }
+        config.tracking = enabled;
+        writeJson.sync(configPath, config);
+    } catch (e) {
+        // A new config file is written if it doesn't exist.
+        writeJson.sync(configPath, { id: await publicIp.v4(), tracking: enabled });
+    }
+};
+
+module.exports = { verifyConfig, getId, setTracking };

--- a/packages/cwp-template-aws/__tests__/telemetry.test.js
+++ b/packages/cwp-template-aws/__tests__/telemetry.test.js
@@ -1,0 +1,16 @@
+const path = require("path");
+const fs = require("fs-extra");
+
+describe("Telemetry events test", () => {
+    test("should send telemetry events", async () => {
+        const events = ["project-deploy-start", "project-deploy-end", "project-deploy-error"];
+
+        const deployScript = await fs.readFile(
+            path.resolve(__dirname, "..", "cli", "deploy", "deploy.js")
+        );
+
+        for (const event of events) {
+            expect(deployScript.includes(event)).toBe(true);
+        }
+    });
+});

--- a/packages/cwp-template-aws/package.json
+++ b/packages/cwp-template-aws/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@webiny/cli": "5.0.0-beta.4",
     "@webiny/cli-plugin-deploy-pulumi": "^5.0.0-beta.4",
+    "@webiny/tracking": "^5.0.0-beta.4",
     "chalk": "4.1.0",
     "create-webiny-project": "^5.0.0-beta.4",
     "execa": "4.1.0",

--- a/packages/tracking/index.js
+++ b/packages/tracking/index.js
@@ -15,7 +15,7 @@ const getConfig = async () => {
                 config.id = "unknown";
             }
         } catch (e) {
-            config = { id: "unknown", tracking: true };
+            config = { id: "unknown" };
         }
     }
     return config;
@@ -23,6 +23,10 @@ const getConfig = async () => {
 
 module.exports.sendEvent = async ({ event, data }) => {
     const config = await getConfig();
+
+    if (config.tracking === false) {
+        return;
+    }
 
     data = data || {};
     if (!data.version) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8429,6 +8429,7 @@ __metadata:
   dependencies:
     "@webiny/cli": 5.0.0-beta.4
     "@webiny/cli-plugin-deploy-pulumi": ^5.0.0-beta.4
+    "@webiny/tracking": ^5.0.0-beta.4
     chalk: 4.1.0
     create-webiny-project: ^5.0.0-beta.4
     dotenv: ^8.2.0


### PR DESCRIPTION
## Related Issue
When creating content model groups, the check for existing slug is failing because it is only fetching 1 group from DB.

## Your solution
Do not forward the `limit` param to DB query; if a `limit` is provided, slice the resulting array after all other filters are applied.

## How Has This Been Tested?
Manually, by programatically importing different content model groups from another system.
