### PR TITLE
feat(api-headless-cms): index ref fields in Elasticsearch

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -6,7 +6,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
     type: "cms-model-field-to-graphql",
     fieldType: "ref",
     isSortable: false,
-    isSearchable: false,
+    isSearchable: true,
     read: {
         createTypeField({ field }) {
             const { models } = field.settings;


### PR DESCRIPTION
## Related Issue
Currently we do not index `ref` fields in Elasticsearch.

## Your solution
Make `ref` fields searchable, by enabling the `isSearchable` flag on the ref field plugin.

## How Has This Been Tested?
Manually

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/3920893/107980568-cc7bc700-6fc0-11eb-9b7f-b06df1fe948b.png)
