### PR TITLE
feat(system-upgrade): add system upgrade package

### DIFF
--- a/packages/system-upgrade/.babelrc.js
+++ b/packages/system-upgrade/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.node");

--- a/packages/system-upgrade/CHANGELOG.md
+++ b/packages/system-upgrade/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/system-upgrade/LICENSE
+++ b/packages/system-upgrade/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/system-upgrade/README.md
+++ b/packages/system-upgrade/README.md
@@ -5,3 +5,25 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 A set of upgrade utils, plugins and types.
+
+
+Each application will need to maintain its own upgrade plugins, this package is just help to ease the running of the upgrade plugins and to check if upgrade is actually necessary.
+
+#### Usage
+
+
+```ts
+// register your upgrade plugins
+context.plugins.register([
+    upgrade500beta2(),
+    upgrade500beta3(),
+    upgrade500beta4(),
+]);
+
+// will find the first available upgrade and return true in that case
+const isSystemUpgradeable = await isSystemUpgradeable(context);
+if (isSystemUpgradeable) {
+    // run the upgrade
+    await systemUpgrade(context);
+}
+```

--- a/packages/system-upgrade/README.md
+++ b/packages/system-upgrade/README.md
@@ -1,0 +1,7 @@
+# @webiny/system-upgrade
+[![](https://img.shields.io/npm/dw/@webiny/system-upgrade.svg)](https://www.npmjs.com/package/@webiny/system-upgrade) 
+[![](https://img.shields.io/npm/v/@webiny/system-upgrade.svg)](https://www.npmjs.com/package/@webiny/system-upgrade)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+A set of upgrade utils, plugins and types.

--- a/packages/system-upgrade/__tests__/mocks/plugins.ts
+++ b/packages/system-upgrade/__tests__/mocks/plugins.ts
@@ -1,0 +1,132 @@
+import { SystemUpgrade } from "../../src/types";
+import { ContextInterface } from "@webiny/handler/types";
+
+export interface DummyContext extends ContextInterface {
+    applied: string[];
+}
+
+export const version500Beta1 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.1",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.1");
+    }
+});
+
+export const version500Beta2 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.2",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.2");
+    }
+});
+
+export const version500Beta3 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.3",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.3");
+    }
+});
+
+export const version500Beta4 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.4",
+    isApplicable: async context => {
+        // pretend that if context version is 5.0.0-beta.4
+        // we do some async call to check the db version and return false in that case
+        if (context.WEBINY_VERSION === "5.0.0-beta.4") {
+            return false;
+        }
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.4");
+    }
+});
+
+export const version500Beta5 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.5",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.5");
+    }
+});
+
+export const version500Beta6 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0-beta.6",
+    isApplicable: async () => {
+        return false;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0-beta.6");
+    }
+});
+
+export const version500 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.0",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.0");
+    }
+});
+
+export const version501 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.1",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.1");
+    }
+});
+
+export const version507 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.0.7",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.0.7");
+    }
+});
+
+export const version510 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.1.0",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.1.0");
+    }
+});
+
+export const version539 = (): SystemUpgrade<DummyContext> => ({
+    type: "system-upgrade",
+    version: "5.3.9",
+    isApplicable: async () => {
+        return true;
+    },
+    apply: async context => {
+        context.applied.push("5.3.9");
+    }
+});

--- a/packages/system-upgrade/__tests__/upgrade.test.ts
+++ b/packages/system-upgrade/__tests__/upgrade.test.ts
@@ -1,0 +1,163 @@
+import {
+    DummyContext,
+    version500Beta1,
+    version500Beta2,
+    version500Beta3,
+    version500Beta4,
+    version500Beta5,
+    version500Beta6,
+    version500,
+    version501,
+    version507,
+    version510,
+    version539
+} from "./mocks/plugins";
+import { PluginsContainer } from "@webiny/plugins";
+import { isSystemUpgradeable, systemUpgrade, systemUpgradePlugins } from "../src";
+import { SystemUpgrade } from "../src/types";
+
+const defaultPlugins = [
+    version500Beta5(),
+    version507(),
+    version539(),
+    version500Beta6(),
+    version500Beta4(),
+    version510(),
+    version500Beta3(),
+    version501(),
+    version500Beta2(),
+    version500(),
+    version500Beta1()
+];
+
+const createContext = (version: string, plugins?: SystemUpgrade<DummyContext>[]): DummyContext => {
+    const context: DummyContext = {
+        plugins: new PluginsContainer(),
+        args: [],
+        WEBINY_VERSION: version,
+        applied: []
+    };
+
+    context.plugins.register(plugins || defaultPlugins);
+
+    return context;
+};
+
+describe("system upgrade", () => {
+    it("should not run any upgrades because there are no plugins", async () => {
+        const context = createContext("5.0.0", []);
+
+        await systemUpgrade<DummyContext>(context);
+
+        expect(context.applied).toEqual([]);
+    });
+
+    it("should not run any upgrades because there are applicable plugins", async () => {
+        const context = createContext("5.0.0-beta.4", [version500Beta4()]);
+
+        await systemUpgrade<DummyContext>(context);
+
+        expect(context.applied).toEqual([]);
+    });
+
+    it("should run applicable upgrade plugins in correct order", async () => {
+        const context = createContext("5.0.0-beta.7", [
+            version500Beta6(),
+            version500Beta5(),
+            version500Beta4()
+        ]);
+
+        await systemUpgrade<DummyContext>(context);
+
+        expect(context.applied).toEqual(["5.0.0-beta.4", "5.0.0-beta.5"]);
+    });
+
+    it("should throw an error because at least one plugin has greater version than the code allows", async () => {
+        const context = createContext("5.0.0-beta.7", [
+            version500Beta6(),
+            version500Beta5(),
+            version500Beta4(),
+            version500()
+        ]);
+
+        let ex;
+        try {
+            await systemUpgrade<DummyContext>(context);
+        } catch ({ message, code, data }) {
+            ex = {
+                message,
+                code,
+                data
+            };
+        }
+
+        expect(ex).toEqual({
+            message: "Plugin has greater version than the code version is allowing.",
+            code: "PLUGIN_VERSION_ERROR",
+            data: {
+                version: "5.0.0-beta.7",
+                plugin: {
+                    name: expect.any(String),
+                    version: "5.0.0"
+                }
+            }
+        });
+    });
+
+    it("should run upgrades on all the mock plugins that are applicable", async () => {
+        const context = createContext("5.3.10");
+
+        await systemUpgrade<DummyContext>(context);
+
+        expect(context.applied).toEqual([
+            "5.0.0-beta.1",
+            "5.0.0-beta.2",
+            "5.0.0-beta.3",
+            "5.0.0-beta.4",
+            "5.0.0-beta.5",
+            "5.0.0",
+            "5.0.1",
+            "5.0.7",
+            "5.1.0",
+            "5.3.9"
+        ]);
+    });
+
+    it("should determine that system is upgradeable", async () => {
+        const context = createContext("5.3.10");
+        const result = await isSystemUpgradeable(context);
+
+        expect(result).toEqual(true);
+    });
+
+    it("should determine that system is not upgradeable", async () => {
+        const context = createContext("5.0.0-beta.4", [version500Beta4()]);
+        const result = await isSystemUpgradeable(context);
+
+        expect(result).toEqual(false);
+    });
+
+    it("should fetch all plugins that are applicable", async () => {
+        const context = createContext("5.0.1", [
+            version500Beta5(),
+            version500Beta2(),
+            version501(),
+            version500Beta4(),
+            version500(),
+            version500Beta3(),
+            version500Beta1()
+        ]);
+
+        const results = await systemUpgradePlugins(context);
+
+        expect(results.map(pl => pl.version)).toEqual([
+            "5.0.0-beta.1",
+            "5.0.0-beta.2",
+            "5.0.0-beta.3",
+            "5.0.0-beta.4",
+            "5.0.0-beta.5",
+            "5.0.0",
+            "5.0.1"
+        ]);
+    });
+});

--- a/packages/system-upgrade/jest.config.js
+++ b/packages/system-upgrade/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/system-upgrade/package.json
+++ b/packages/system-upgrade/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@webiny/system-upgrade",
+  "version": "5.0.0-beta.4",
+  "main": "index.js",
+  "types": "types.ts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "description": "A set of upgrade utils, plugins and types.",
+  "contributors": [
+    "Pavel Denisjuk <pavel@webiny.com>",
+    "Sven Al Hamad <sven@webiny.com>",
+    "Adrian Smijulj <adrian@webiny.com>",
+    "Bruno Zorić <bruno@webiny.com>"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.5.5",
+    "@webiny/error": "^5.0.0-beta.4",
+    "@webiny/handler": "^5.0.0-beta.4",
+    "@webiny/plugins": "^5.0.0-beta.4",
+    "semver": "^7.3.4"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@types/semver": "^7.3.4",
+    "jest": "^26.6.3",
+    "jest-mock-console": "^1.0.0",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.1.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "rimraf ./dist '*.tsbuildinfo' && babel src -d dist --source-maps --copy-files --extensions \".ts,.tsx\" && yarn postbuild",
+    "watch": "babel src -d dist --source-maps --copy-files --extensions \".ts,.tsx\" --watch",
+    "postbuild": "cp package.json LICENSE README.md dist/ && tsc -p tsconfig.build.json"
+  },
+  "gitHead": "b8aec8a1be3f25c3b428b357fe1e352c7cbff9ae"
+}

--- a/packages/system-upgrade/src/components/helpers.ts
+++ b/packages/system-upgrade/src/components/helpers.ts
@@ -1,0 +1,107 @@
+import { ContextInterface } from "@webiny/handler/types";
+import { SystemUpgrade } from "./../types";
+import WebinyError from "@webiny/error";
+import { compare as semverCompare, parse as semverParse, SemVer } from "semver";
+
+export interface SystemUpgradeWithVersion<T extends ContextInterface>
+    extends Omit<SystemUpgrade<T>, "version"> {
+    version: SemVer;
+}
+
+export const validatePluginVersion = <T extends ContextInterface>(pl: SystemUpgrade<T>): SemVer => {
+    const ver = semverParse(pl.version);
+    if (ver) {
+        return ver;
+    }
+    throw new WebinyError("Plugin version is not a valid semver value.", "INVALID_VERSION", {
+        plugin: {
+            name: pl.name,
+            version: pl.version
+        }
+    });
+};
+
+export const getSystemUpgradePlugins = <T extends ContextInterface>(context: T) => {
+    return (
+        context.plugins
+            .byType<SystemUpgrade<T>>("system-upgrade")
+            .map<SystemUpgradeWithVersion<T>>(pl => {
+                return {
+                    ...pl,
+                    version: validatePluginVersion(pl)
+                };
+            })
+            // we immediately sort depending on semver
+            .sort((a, b) => {
+                return semverCompare(a.version, b.version);
+            })
+            // and reverse to check which plugins do we run
+            .reverse()
+    );
+};
+
+export const validateCodeVersionAgainstPlugin = (
+    codeVersion: SemVer,
+    plugin: SystemUpgradeWithVersion<ContextInterface>
+) => {
+    if (semverCompare(plugin.version, codeVersion) !== 1) {
+        return;
+    }
+    throw new WebinyError(
+        "Plugin has greater version than the code version is allowing.",
+        "PLUGIN_VERSION_ERROR",
+        {
+            version: codeVersion.format(),
+            plugin: {
+                name: plugin.name,
+                version: plugin.version.format()
+            }
+        }
+    );
+};
+
+export const filterPlugins = async <T extends ContextInterface>(
+    context: T,
+    codeVersion: SemVer
+): Promise<SystemUpgradeWithVersion<T>[]> => {
+    const plugins = getSystemUpgradePlugins(context);
+    const filteredPlugins = [];
+    for (const plugin of plugins) {
+        // there should be no plugin that has greater version than the codeVersion
+        validateCodeVersionAgainstPlugin(codeVersion, plugin);
+        try {
+            const result = await plugin.isApplicable(context, codeVersion);
+            if (!result) {
+                // todo determine if to skip all next plugins
+                // or just this one
+                continue;
+            }
+        } catch (ex) {
+            throw new WebinyError(
+                "Could not check if plugin is applicable to run the upgrade.",
+                "PLUGIN_IS_APPLICABLE_ERROR",
+                {
+                    version: codeVersion,
+                    plugin: {
+                        name: plugin.name,
+                        version: plugin.version.format()
+                    }
+                }
+            );
+        }
+        filteredPlugins.push(plugin);
+    }
+    return filteredPlugins.sort((a, b) => {
+        return semverCompare(a.version, b.version);
+    });
+};
+
+export const parseCodeVersion = <T extends ContextInterface>(context: T): SemVer => {
+    const codeVersion: SemVer | null = semverParse(context.WEBINY_VERSION);
+    if (codeVersion) {
+        return codeVersion;
+    }
+    throw new WebinyError("Could not figure minimum upgrade version.", "MIN_VERSION_ERROR", {
+        version: context.WEBINY_VERSION
+    });
+};

--- a/packages/system-upgrade/src/components/isSystemUpgradeable.ts
+++ b/packages/system-upgrade/src/components/isSystemUpgradeable.ts
@@ -1,0 +1,40 @@
+import { ContextInterface } from "@webiny/handler/types";
+import WebinyError from "@webiny/error";
+import {
+    getSystemUpgradePlugins,
+    parseCodeVersion,
+    validateCodeVersionAgainstPlugin
+} from "./helpers";
+
+/**
+ * Check if system is upgradeable by at least one upgrade plugin.
+ */
+export const isSystemUpgradeable = async <T extends ContextInterface>(
+    context: T
+): Promise<boolean> => {
+    const codeVersion = parseCodeVersion(context);
+    const plugins = getSystemUpgradePlugins(context);
+    for (const plugin of plugins) {
+        // there should be no plugin that has greater version than the codeVersion
+        validateCodeVersionAgainstPlugin(codeVersion, plugin);
+        try {
+            const result = await plugin.isApplicable(context, codeVersion);
+            if (result) {
+                return true;
+            }
+        } catch (ex) {
+            throw new WebinyError(
+                "Could not check if plugin is applicable to run the upgrade.",
+                "PLUGIN_IS_APPLICABLE_ERROR",
+                {
+                    version: codeVersion,
+                    plugin: {
+                        name: plugin.name,
+                        version: plugin.version.format()
+                    }
+                }
+            );
+        }
+    }
+    return false;
+};

--- a/packages/system-upgrade/src/components/systemUpgrade.ts
+++ b/packages/system-upgrade/src/components/systemUpgrade.ts
@@ -1,0 +1,37 @@
+import { ContextInterface } from "@webiny/handler/types";
+import WebinyError from "@webiny/error";
+import { filterPlugins, parseCodeVersion } from "./helpers";
+
+/**
+ * Run the loaded upgrade plugins.
+ * It will throw an error if plugin is greater version than the WEBINY_VERSION.
+ * It will throw an error if system upgrade fails.
+ */
+export const systemUpgrade = async <T extends ContextInterface>(context: T): Promise<void> => {
+    const codeVersion = parseCodeVersion(context);
+
+    const plugins = await filterPlugins(context, codeVersion);
+
+    for (const plugin of plugins) {
+        try {
+            await plugin.apply(context);
+        } catch (ex) {
+            throw new WebinyError(
+                "Could not finish the system upgrade. A plugin error occurred.",
+                "PLUGIN_APPLY_ERROR",
+                {
+                    version: codeVersion,
+                    plugin: {
+                        name: plugin.name,
+                        version: plugin.version.format()
+                    },
+                    error: {
+                        message: ex.message,
+                        code: ex.code,
+                        data: ex.data
+                    }
+                }
+            );
+        }
+    }
+};

--- a/packages/system-upgrade/src/components/systemUpgradePlugins.ts
+++ b/packages/system-upgrade/src/components/systemUpgradePlugins.ts
@@ -1,0 +1,25 @@
+import { ContextInterface } from "@webiny/handler/types";
+import { filterPlugins, parseCodeVersion } from "./helpers";
+import { compare as semverCompare } from "semver";
+import { SystemUpgrade } from "../types";
+
+/**
+ * Fetches all the system upgrade plugins filtered by isApplicable() and sorted from lowest to highest version.
+ */
+export const systemUpgradePlugins = async <T extends ContextInterface>(
+    context: T
+): Promise<SystemUpgrade<T>[]> => {
+    const codeVersion = parseCodeVersion(context);
+    const plugins = await filterPlugins(context, codeVersion);
+
+    return plugins
+        .sort((a, b) => {
+            return semverCompare(a.version, b.version);
+        })
+        .map(plugin => {
+            return {
+                ...plugin,
+                version: plugin.version.format()
+            } as SystemUpgrade<T>;
+        });
+};

--- a/packages/system-upgrade/src/index.ts
+++ b/packages/system-upgrade/src/index.ts
@@ -1,0 +1,5 @@
+import { isSystemUpgradeable } from "./components/isSystemUpgradeable";
+import { systemUpgrade } from "./components/systemUpgrade";
+import { systemUpgradePlugins } from "./components/systemUpgradePlugins";
+
+export { isSystemUpgradeable, systemUpgradePlugins, systemUpgrade };

--- a/packages/system-upgrade/src/types.ts
+++ b/packages/system-upgrade/src/types.ts
@@ -1,0 +1,30 @@
+import { Plugin } from "@webiny/plugins/types";
+import { ContextInterface } from "@webiny/handler/types";
+import { SemVer } from "semver";
+
+/**
+ * A plugin type that defines how the system upgrade will look like.
+ */
+export interface SystemUpgrade<T extends ContextInterface> extends Plugin {
+    /**
+     * A plugin type.
+     */
+    type: "system-upgrade";
+    /**
+     * A version of the Webiny that this plugin upgrades the system to.
+     * Also uses as a check if plugin should be applied.
+     */
+    version: string;
+    /**
+     * Run checks if system upgrade should be applied.
+     * This is meant to have check logic before the apply method.
+     *
+     * @param context Current application context.
+     * @param codeVersion A version of the code built.
+     */
+    isApplicable: (context: T, codeVersion: SemVer) => Promise<boolean>;
+    /**
+     * Method that applies the upgrade. Will not run unless version and isApplicable are allowing it.
+     */
+    apply: (context: T) => Promise<void>;
+}

--- a/packages/system-upgrade/tsconfig.build.json
+++ b/packages/system-upgrade/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["node_modules", "./dist", "../handler", "../plugins", "../error"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist"
+  },
+  "references": [
+    {
+      "path": "../plugins/tsconfig.build.json"
+    },
+    {
+      "path": "../handler/tsconfig.build.json"
+    },
+    {
+      "path": "../error/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/system-upgrade/tsconfig.json
+++ b/packages/system-upgrade/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig",
+  "references": [
+    {
+      "path": "../plugins"
+    },
+    {
+      "path": "../handler"
+    },
+    {
+      "path": "../error"
+    }
+  ]
+}

--- a/scripts/buildWithCache.js
+++ b/scripts/buildWithCache.js
@@ -46,8 +46,8 @@ async function build() {
         const packageMeta = metaJson.packages[workspacePackage.packageJson.name] || {};
         console.log("testing", workspacePackage.packageJson.name);
 
-        console.log('packageMeta.sourceHash', packageMeta.sourceHash)
-        console.log('sourceHash', sourceHash)
+        console.log("packageMeta.sourceHash", packageMeta.sourceHash);
+        console.log("sourceHash", sourceHash);
 
         if (packageMeta.sourceHash === sourceHash) {
             packagesUseCache.push(workspacePackage);
@@ -115,7 +115,7 @@ function getPackageCacheFolderPath(workspacePackage) {
 
 async function getPackageSourceHash(workspacePackage) {
     const { hash } = await hashElement(workspacePackage.packageFolder, {
-        algo: 'md5',
+        algo: "md5",
         folders: { exclude: ["dist"] }
     });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -134,7 +134,8 @@
       "@webiny/validation": ["./packages/validation/src"],
       "@webiny/validation/*": ["./packages/validation/src/*"],
       "@webiny/ui/*": ["./packages/ui/src/*"],
-      "@webiny/cli-plugin-scaffold/*": ["./packages/cli-plugin-scaffold/src/*"]
+      "@webiny/cli-plugin-scaffold/*": ["./packages/cli-plugin-scaffold/src/*"],
+      "@webiny/system-upgrade/*": ["./packages/system-upgrade/src/*"]
     },
     "typeRoots": ["./typings", "./node_modules/@types", "@types/testing-library__cypress"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6742,6 +6742,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.4":
+  version: 7.3.4
+  resolution: "@types/semver@npm:7.3.4"
+  checksum: 7e8588aa55ecb344eda6954674b83a3c568d97d478e70e4617bd3ab22902590ac416ccf2cea48b58fb2f0fbd80f9ad1896332c9b3c3189ffd24e4350ff22094a
+  languageName: node
+  linkType: hard
+
 "@types/shallowequal@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/shallowequal@npm:1.1.1"
@@ -9436,6 +9443,26 @@ __metadata:
     react-highlight.js: ^1.0.7
     react-remarkable: ^1.1.3
     rimraf: ^3.0.2
+    typescript: ^4.1.3
+  languageName: unknown
+  linkType: soft
+
+"@webiny/system-upgrade@workspace:packages/system-upgrade":
+  version: 0.0.0-use.local
+  resolution: "@webiny/system-upgrade@workspace:packages/system-upgrade"
+  dependencies:
+    "@babel/cli": ^7.5.5
+    "@babel/core": ^7.5.5
+    "@babel/preset-env": ^7.5.5
+    "@babel/runtime": ^7.5.5
+    "@types/semver": ^7.3.4
+    "@webiny/error": ^5.0.0-beta.4
+    "@webiny/handler": ^5.0.0-beta.4
+    "@webiny/plugins": ^5.0.0-beta.4
+    jest: ^26.6.3
+    jest-mock-console: ^1.0.0
+    rimraf: ^3.0.2
+    semver: ^7.3.4
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
@@ -30973,7 +31000,7 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.4, semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2":
+"semver@npm:7.3.4, semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4":
   version: 7.3.4
   resolution: "semver@npm:7.3.4"
   dependencies:


### PR DESCRIPTION
Package that is used to run upgrade plugins per application basis.
Plugin type has `version` string to determine for which version is the upgrade for.
Plugin type has `isApplicable()` method to test if a plugin should be run.