### PR TITLE
fix(handler-graphql): number scalar output

### DIFF
--- a/packages/handler-graphql/__tests__/NumberScalar.test.ts
+++ b/packages/handler-graphql/__tests__/NumberScalar.test.ts
@@ -1,0 +1,58 @@
+import { Number as NumberScalar } from "../src/builtInTypes";
+
+describe("NumberScalar", () => {
+    const correctInputValues = [
+        [1, 1],
+        [103232, 103232],
+        [50932.123, 50932.123],
+        [95032493.001, 95032493.001],
+        ["1234", 1234],
+        ["9832.110", 9832.11],
+        ["0.00001", 0.00001]
+    ];
+    test.each(correctInputValues)(
+        "it should parse number correctly",
+        (value: any, expected: number) => {
+            const result = NumberScalar.parseValue(value);
+            expect(result).toEqual(expected);
+        }
+    );
+
+    const incorrectInputValues = [
+        ["fdlms", "Value sent must be a number."],
+        ["hf91nhfd", "Value sent must be a number."],
+        ["0x005", "Value sent must be a non-hex number."]
+    ];
+
+    test.each(incorrectInputValues)(
+        "it should throw an error on incorrect value",
+        (value: any, message: string) => {
+            expect(() => {
+                NumberScalar.parseValue(value);
+            }).toThrow(message);
+        }
+    );
+    const correctOutputValues = [
+        [1, 1],
+        [103232, 103232],
+        [50932.123, 50932.123],
+        [95032493.001, 95032493.001],
+        ["1234", 1234],
+        ["9832.110", 9832.11],
+        ["0.00001", 0.00001]
+    ];
+    test.each(correctOutputValues)(
+        "should serialize number correctly",
+        (value: any, expected: number) => {
+            const result = NumberScalar.serialize(value);
+            expect(result).toEqual(expected);
+        }
+    );
+
+    const incorrectOutputValues = [["fdlms"], ["hf91nhfd"], ["0x005"]];
+
+    test.each(incorrectOutputValues)("should return null on incorrect value", (value: any) => {
+        const result = NumberScalar.serialize(value);
+        expect(result).toEqual(null);
+    });
+});

--- a/packages/handler-graphql/src/builtInTypes/NumberScalar.ts
+++ b/packages/handler-graphql/src/builtInTypes/NumberScalar.ts
@@ -1,26 +1,42 @@
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
+import WebinyError from "@webiny/error";
 
-const getNumber = (value: any): any => {
-    if (typeof value !== "number") {
+const parseValue = (value: any) => {
+    if (String(value).match(/^0x/) !== null) {
+        throw new WebinyError("Value sent must be a non-hex number.", "INVALID_VALUE", {
+            value
+        });
+    } else if (typeof value === "number") {
+        return value;
+    } else if (value === null || value === undefined) {
         return null;
+    } else if (isNaN(value) === true) {
+        throw new WebinyError("Value sent must be a number.", "INVALID_VALUE", {
+            value
+        });
     }
-
-    return value;
+    return parseFloat(value);
 };
 
 export const Number = new GraphQLScalarType({
     name: "Number",
     description: "A custom input type to be used with numbers. Supports Int and Float.",
-    serialize: (value: string | number) => {
-        if (typeof value === "number") {
-            return value;
-        } else if (value === null || value === undefined || isNaN(value as any) === true) {
+    serialize: (value: any) => {
+        try {
+            return parseValue(value);
+        } catch (ex) {
+            console.log({
+                message: "Value sent must be a number.",
+                code: "INVALID_VALUE",
+                data: {
+                    value
+                }
+            });
             return null;
         }
-        return parseFloat(value);
     },
-    parseValue: getNumber,
+    parseValue,
     parseLiteral: (ast: any) => {
         if (ast.kind === Kind.INT || ast.kind === Kind.FLOAT) {
             return ast.value;

--- a/packages/handler-graphql/src/builtInTypes/NumberScalar.ts
+++ b/packages/handler-graphql/src/builtInTypes/NumberScalar.ts
@@ -12,7 +12,14 @@ const getNumber = (value: any): any => {
 export const Number = new GraphQLScalarType({
     name: "Number",
     description: "A custom input type to be used with numbers. Supports Int and Float.",
-    serialize: getNumber,
+    serialize: (value: string | number) => {
+        if (typeof value === "number") {
+            return value;
+        } else if (value === null || value === undefined || isNaN(value as any) === true) {
+            return null;
+        }
+        return parseFloat(value);
+    },
     parseValue: getNumber,
     parseLiteral: (ast: any) => {
         if (ast.kind === Kind.INT || ast.kind === Kind.FLOAT) {


### PR DESCRIPTION
Number scalar parsing now accepts string numbers that will be transformed to numbers.
Output returns a number even if it is a string number.