### PR TITLE
fix(app-headless-cms): ref field not showing selected value

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeDelete.hook.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeDelete.hook.ts
@@ -11,9 +11,21 @@ export const beforeDeleteHook = async (args: Args) => {
     const { context, model } = args;
     const { modelId } = model;
     const manager = await context.cms.getModel(modelId);
-    const [entries] = await manager.list({
-        limit: 1
-    });
+    let entries = [];
+    try {
+        [entries] = await manager.list({
+            limit: 1
+        });
+    } catch (ex) {
+        throw new WebinyError(
+            "Could not retrieve a list of content entries from the model.",
+            "ENTRIES_ERROR",
+            {
+                modelId,
+                error: ex
+            }
+        );
+    }
     if (entries.length > 0) {
         throw new WebinyError(
             `Cannot delete content model "${modelId}" because there are existing entries.`,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
@@ -10,7 +10,11 @@ const t = i18n.ns("app-headless-cms/admin/fields/ref");
 const label = t`Selected content entry is not published. Make sure to {publishItLink} before publishing the main content entry.`;
 
 function ContentEntriesAutocomplete({ bind, field }) {
-    const { options, setSearch, value, loading, onChange } = useReference({ bind, field });
+    const { options, setSearch, value, loading, onChange } = useReference({
+        bind,
+        field,
+        assignValueEntry: true
+    });
 
     // Currently we only support 1 model in the `ref` field, so we use index 0 (this will be upgraded in the future).
     const { modelId } = field.settings.models[0];


### PR DESCRIPTION
When ref field is having a selected value that is not in initially loaded autocomplete data, autocomplete thinks its empty.

Selected value is now added to both the search entry list and initially loaded one