### PR TITLE
Fixed "setup-repo" script

### DIFF
--- a/packages/cwp-template-aws/template/dependencies.json
+++ b/packages/cwp-template-aws/template/dependencies.json
@@ -56,7 +56,7 @@
     ]
   },
   "scripts": {
-    "setup-repo": "node ./scripts/setupRepository.js",
+    "setup-repo": "node ./scripts/setupRepo.js",
     "setup-env-files": "node ./scripts/setupEnvFiles.js",
     "link-workspaces": "node ./scripts/linkWorkspaces.js",
     "postinstall": "yarn link-workspaces",


### PR DESCRIPTION
## Related Issue
Running `yarn setup-repo` script would throw an error, because the path of the script was incorrect.

## Your solution
Corrected the path to the script.

## How Has This Been Tested?
Manual.

## Screenshots (if relevant):
N/A