### PR TITLE
fix(app-headless-cms): item click clears the ref field

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
@@ -12,8 +12,7 @@ const label = t`Selected content entry is not published. Make sure to {publishIt
 function ContentEntriesAutocomplete({ bind, field }) {
     const { options, setSearch, value, loading, onChange } = useReference({
         bind,
-        field,
-        assignValueEntry: true
+        field
     });
 
     // Currently we only support 1 model in the `ref` field, so we use index 0 (this will be upgraded in the future).


### PR DESCRIPTION
A fix of ref field autocomplete field.
When having two items with same name and clicked on second one field was cleared.