### PR TITLE
fix: add "compress: true" to cache behaviours

### DIFF
--- a/api/pulumi/cloudfront.ts
+++ b/api/pulumi/cloudfront.ts
@@ -8,6 +8,7 @@ class Cloudfront {
         this.cloudfront = new aws.cloudfront.Distribution("api-cloudfront", {
             waitForDeployment: false,
             defaultCacheBehavior: {
+                compress: true,
                 allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                 cachedMethods: ["GET", "HEAD", "OPTIONS"],
                 defaultTtl: 0,
@@ -28,6 +29,7 @@ class Cloudfront {
             enabled: true,
             orderedCacheBehaviors: [
                 {
+                    compress: true,
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD", "OPTIONS"],
                     forwardedValues: {

--- a/apps/admin/pulumi/cloudfront.ts
+++ b/apps/admin/pulumi/cloudfront.ts
@@ -20,6 +20,7 @@ class Cloudfront {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: appS3Bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/apps/website/pulumi/app.ts
+++ b/apps/website/pulumi/app.ts
@@ -53,6 +53,7 @@ class App {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: this.bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/apps/website/pulumi/delivery.ts
+++ b/apps/website/pulumi/delivery.ts
@@ -40,6 +40,7 @@ class Delivery {
             ],
             orderedCacheBehaviors: [
                 {
+                    compress: true,
                     allowedMethods: ["GET", "HEAD", "OPTIONS"],
                     cachedMethods: ["GET", "HEAD", "OPTIONS"],
                     forwardedValues: {
@@ -57,6 +58,7 @@ class Delivery {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: this.bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/packages/cwp-template-aws/template/api/pulumi_custom_vpc/cloudfront.ts
+++ b/packages/cwp-template-aws/template/api/pulumi_custom_vpc/cloudfront.ts
@@ -8,6 +8,7 @@ class Cloudfront {
         this.cloudfront = new aws.cloudfront.Distribution("api-cloudfront", {
             waitForDeployment: false,
             defaultCacheBehavior: {
+                compress: true,
                 allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                 cachedMethods: ["GET", "HEAD", "OPTIONS"],
                 defaultTtl: 0,
@@ -28,6 +29,7 @@ class Cloudfront {
             enabled: true,
             orderedCacheBehaviors: [
                 {
+                    compress: true,
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD", "OPTIONS"],
                     forwardedValues: {

--- a/packages/cwp-template-aws/template/api/pulumi_default_vpc/cloudfront.ts
+++ b/packages/cwp-template-aws/template/api/pulumi_default_vpc/cloudfront.ts
@@ -8,6 +8,7 @@ class Cloudfront {
         this.cloudfront = new aws.cloudfront.Distribution("api-cloudfront", {
             waitForDeployment: false,
             defaultCacheBehavior: {
+                compress: true,
                 allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                 cachedMethods: ["GET", "HEAD", "OPTIONS"],
                 defaultTtl: 0,
@@ -28,6 +29,7 @@ class Cloudfront {
             enabled: true,
             orderedCacheBehaviors: [
                 {
+                    compress: true,
                     allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
                     cachedMethods: ["GET", "HEAD", "OPTIONS"],
                     forwardedValues: {

--- a/packages/cwp-template-aws/template/apps/admin/pulumi/cloudfront.ts
+++ b/packages/cwp-template-aws/template/apps/admin/pulumi/cloudfront.ts
@@ -20,6 +20,7 @@ class Cloudfront {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: appS3Bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/packages/cwp-template-aws/template/apps/website/pulumi/app.ts
+++ b/packages/cwp-template-aws/template/apps/website/pulumi/app.ts
@@ -53,6 +53,7 @@ class App {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: this.bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/packages/cwp-template-aws/template/apps/website/pulumi/delivery.ts
+++ b/packages/cwp-template-aws/template/apps/website/pulumi/delivery.ts
@@ -40,6 +40,7 @@ class Delivery {
             ],
             orderedCacheBehaviors: [
                 {
+                    compress: true,
                     allowedMethods: ["GET", "HEAD", "OPTIONS"],
                     cachedMethods: ["GET", "HEAD", "OPTIONS"],
                     forwardedValues: {
@@ -57,6 +58,7 @@ class Delivery {
             ],
             defaultRootObject: "index.html",
             defaultCacheBehavior: {
+                compress: true,
                 targetOriginId: this.bucket.arn,
                 viewerProtocolPolicy: "redirect-to-https",
                 allowedMethods: ["GET", "HEAD", "OPTIONS"],


### PR DESCRIPTION
This PR adds `compress: true` to all defined cache behaviors across all deployed CloudFront distributions.

The CWP template was updated too.

## How Has This Been Tested?
Manual

## Screenshots (if relevant):
N/A