### PR TITLE
Added missing "cache-control" headers

### DIFF
--- a/api/pulumi/cloudfront.ts
+++ b/api/pulumi/cloudfront.ts
@@ -19,7 +19,6 @@ class Cloudfront {
                     headers: ["Accept", "Accept-Language"],
                     queryString: true
                 },
-                compress: true,
                 maxTtl: 86400,
                 minTtl: 0,
                 targetOriginId: apiGateway.api.name,

--- a/apps/admin/pulumi/app.ts
+++ b/apps/admin/pulumi/app.ts
@@ -27,7 +27,8 @@ class App {
                     acl: "public-read",
                     bucket: this.bucket,
                     contentType: mime.getType(filePath) || undefined,
-                    source: new pulumi.asset.FileAsset(filePath)
+                    source: new pulumi.asset.FileAsset(filePath),
+                    cacheControl: "max-age=31536000"
                 },
                 {
                     parent: this.bucket

--- a/apps/website/pulumi/app.ts
+++ b/apps/website/pulumi/app.ts
@@ -28,7 +28,8 @@ class App {
                     acl: "public-read",
                     bucket: this.bucket,
                     contentType: mime.getType(filePath) || undefined,
-                    source: new pulumi.asset.FileAsset(filePath)
+                    source: new pulumi.asset.FileAsset(filePath),
+                    cacheControl: "max-age=31536000"
                 },
                 {
                     parent: this.bucket

--- a/cypress/integration/admin/pageBuilder/cacheControlHeaders.spec.js
+++ b/cypress/integration/admin/pageBuilder/cacheControlHeaders.spec.js
@@ -1,0 +1,54 @@
+import uniqid from "uniqid";
+
+describe("Cache-Control Headers", () => {
+    const id = uniqid();
+    let createdPage;
+
+    before(() => cy.login());
+    after(() => cy.pbDeletePage({ id: createdPage.id }));
+
+    it(`Create a page, publish it, and check headers`, () => {
+        cy.pbCreatePage({ category: "static" }).then(page => {
+            createdPage = page;
+            cy.pbUpdatePage({
+                id: page.id,
+                data: {
+                    category: "static",
+                    path: `/page-${id}`,
+                    title: `Page-${id}`
+                }
+            });
+            cy.pbPublishPage({ id: page.id });
+        });
+
+        const url = Cypress.env("WEBSITE_URL") + `/page-${id}/`;
+
+        cy.visit(url);
+        cy.reloadUntil(
+            () => {
+                // We wait until the document contains the newly added menu.
+                const [title] = Cypress.$("title");
+                return title.outerText === `Page-${id}`;
+            },
+            { repeat: 3 }
+        );
+
+        cy.intercept("GET", url).as("page");
+        cy.intercept("GET", /.*static\/.*\.js/).as("js");
+        cy.intercept("GET", /.*static\/.*\.css/).as("css");
+
+        cy.visit(url);
+
+        cy.wait("@page")
+            .its("response.headers")
+            .should("have.property", "cache-control", "max-age=31536000");
+
+        cy.wait("@js")
+            .its("response.headers")
+            .should("have.property", "cache-control", "max-age=31536000");
+
+        cy.wait("@css")
+            .its("response.headers")
+            .should("have.property", "cache-control", "max-age=31536000");
+    });
+});

--- a/cypress/integration/admin/pageBuilder/cacheControlHeaders.spec.js
+++ b/cypress/integration/admin/pageBuilder/cacheControlHeaders.spec.js
@@ -8,6 +8,7 @@ describe("Cache-Control Headers", () => {
     after(() => cy.pbDeletePage({ id: createdPage.id }));
 
     it(`Create a page, publish it, and check headers`, () => {
+        // eslint-disable-next-line
         cy.pbCreatePage({ category: "static" }).then(page => {
             createdPage = page;
             cy.pbUpdatePage({

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,6 +4,7 @@ import "./reloadUntil";
 import "./pageBuilder/pbCreatePage";
 import "./pageBuilder/pbUpdatePage";
 import "./pageBuilder/pbPublishPage";
+import "./pageBuilder/pbDeletePage";
 
 Cypress.Commands.overwrite("visit", (orig, url, options) => {
     return orig(url, { ...options, failOnStatusCode: false });

--- a/cypress/support/pageBuilder/graphql.js
+++ b/cypress/support/pageBuilder/graphql.js
@@ -35,3 +35,17 @@ export const PUBLISH_PAGE = gql`
         }
     }
 `;
+
+export const DELETE_PAGE = gql`
+    mutation DeletePage($id: ID!) {
+        pageBuilder {
+            deletePage(id: $id) {
+                error {
+                    message
+                    data
+                    code
+                }
+            }
+        }
+    }
+`;

--- a/cypress/support/pageBuilder/pbDeletePage.js
+++ b/cypress/support/pageBuilder/pbDeletePage.js
@@ -1,0 +1,16 @@
+import { GraphQLClient } from "graphql-request";
+import { DELETE_PAGE } from "./graphql";
+
+Cypress.Commands.add("pbDeletePage", variables => {
+    cy.login().then(user => {
+        const client = new GraphQLClient(Cypress.env("GRAPHQL_API_URL"), {
+            headers: {
+                authorization: `Bearer ${user.idToken.jwtToken}`
+            }
+        });
+
+        return client
+            .request(DELETE_PAGE, variables)
+            .then(response => response.pageBuilder.deletePage.data);
+    });
+});

--- a/packages/api-prerendering-service/src/render/index.ts
+++ b/packages/api-prerendering-service/src/render/index.ts
@@ -30,6 +30,7 @@ const storeFile = ({ key, contentType, body, storageName }) => {
             Key: key,
             ACL: "public-read",
             ContentType: contentType,
+            CacheControl: "max-age=31536000",
             Body: body
         })
         .promise();

--- a/packages/cwp-template-aws/template/api/pulumi_custom_vpc/cloudfront.ts
+++ b/packages/cwp-template-aws/template/api/pulumi_custom_vpc/cloudfront.ts
@@ -19,7 +19,6 @@ class Cloudfront {
                     headers: ["Accept", "Accept-Language"],
                     queryString: true
                 },
-                compress: true,
                 maxTtl: 86400,
                 minTtl: 0,
                 targetOriginId: apiGateway.api.name,

--- a/packages/cwp-template-aws/template/api/pulumi_default_vpc/cloudfront.ts
+++ b/packages/cwp-template-aws/template/api/pulumi_default_vpc/cloudfront.ts
@@ -19,7 +19,6 @@ class Cloudfront {
                     headers: ["Accept", "Accept-Language"],
                     queryString: true
                 },
-                compress: true,
                 maxTtl: 86400,
                 minTtl: 0,
                 targetOriginId: apiGateway.api.name,

--- a/packages/cwp-template-aws/template/apps/admin/pulumi/app.ts
+++ b/packages/cwp-template-aws/template/apps/admin/pulumi/app.ts
@@ -27,7 +27,8 @@ class App {
                     acl: "public-read",
                     bucket: this.bucket,
                     contentType: mime.getType(filePath) || undefined,
-                    source: new pulumi.asset.FileAsset(filePath)
+                    source: new pulumi.asset.FileAsset(filePath),
+                    cacheControl: "max-age=31536000"
                 },
                 {
                     parent: this.bucket

--- a/packages/cwp-template-aws/template/apps/website/pulumi/app.ts
+++ b/packages/cwp-template-aws/template/apps/website/pulumi/app.ts
@@ -28,7 +28,8 @@ class App {
                     acl: "public-read",
                     bucket: this.bucket,
                     contentType: mime.getType(filePath) || undefined,
-                    source: new pulumi.asset.FileAsset(filePath)
+                    source: new pulumi.asset.FileAsset(filePath),
+                    cacheControl: "max-age=31536000"
                 },
                 {
                     parent: this.bucket


### PR DESCRIPTION
## Related Issue
`cache-control` header was missing in a couple of places:

- static prerender-related files - HTML and `graphql.json`
- static assets of React apps (images, JS, CSS)

## Your solution
I added the header, where needed.

## How Has This Been Tested?
Cypress test.

## Screenshots (if relevant):
N/A