### PR TITLE
fix(api-headless-cms): add track_total_hits flag to get real total count

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry/es/createElasticsearchQueryBody.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry/es/createElasticsearchQueryBody.ts
@@ -347,6 +347,8 @@ export const createElasticsearchQueryBody = (params: CreateElasticsearchParams) 
         sort: createElasticsearchSortParams({ sort, modelFields, parentObject, model }),
         size: limit + 1,
         // eslint-disable-next-line
-        search_after: decodeElasticsearchCursor(after) || undefined
+        search_after: decodeElasticsearchCursor(after) || undefined,
+        // eslint-disable-next-line
+        track_total_hits: true
     };
 };


### PR DESCRIPTION
## Related Issue
By default, ES only returns a total count up to 10000. Anything greater than that is  not counted, for optimization reasons. If Even if you have more records, the `totalCount` will always be `10000`.

## Your solution
Add a `track_total_hits` parameter to ES queries in Headless CMS. It brings some performance penalty, but we'll worry about it when it actually becomes a problem.

## How Has This Been Tested?
Manually, in Kibana.
