### PR TITLE
fix(cwp-template-aws): add missing workspace

### DIFF
--- a/packages/cwp-template-aws/template/dependencies.json
+++ b/packages/cwp-template-aws/template/dependencies.json
@@ -46,6 +46,7 @@
       "apps/admin/code",
       "apps/website/code",
       "apps/theme",
+      "api/code/dynamoToElastic",
       "api/code/fileManager/*",
       "api/code/graphql",
       "api/code/headlessCMS",


### PR DESCRIPTION
Add missing CWP template workspace to new projects.