### PR TITLE
chore: import resources from "default" folder

### DIFF
--- a/api/pulumi/index.ts
+++ b/api/pulumi/index.ts
@@ -8,7 +8,7 @@ export = async () => {
     });
 
     // Import resources factory.
-    return await import("./benchmark").then(module => {
+    return await import("./default").then(module => {
         // Configure resources and return the expected outputs.
         return module.default();
     });


### PR DESCRIPTION
Set `default` to be the main source of infrastructure resources.