### PR TITLE
fix(api-headless-cms): schema cache rebuild

### DIFF
--- a/packages/api-headless-cms/src/content/contextSetup.ts
+++ b/packages/api-headless-cms/src/content/contextSetup.ts
@@ -1,5 +1,5 @@
 import { Context, ContextPlugin } from "@webiny/handler/types";
-import { CmsContext, CmsSettings } from "../types";
+import { CmsContext } from "../types";
 
 interface CmsHttpParameters {
     type: string;
@@ -31,18 +31,6 @@ const setContextCmsVariables = async (context: CmsContext): Promise<void> => {
         throw new Error(`There is no locale "${context.cms.locale}" in the system.`);
     }
     context.cms.getLocale = () => locale;
-
-    context.cms.getSettings = async (): Promise<CmsSettings> => {
-        // Need to load settings because of the timestamp of last change to content models.
-        // Based on that timestamp, we cache/refresh the schema definition.
-        const settings = await context.cms.settings.noAuth().get();
-        const dbLastChange = settings?.contentModelLastChange || new Date();
-        const lastChange = context.cms.settings?.contentModelLastChange || new Date();
-        return {
-            ...(settings || ({} as any)),
-            contentModelLastChange: lastChange > dbLastChange ? lastChange : dbLastChange
-        };
-    };
 };
 // eslint-disable-next-line
 export default (options: any = {}): ContextPlugin<CmsContext> => ({

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -45,9 +45,10 @@ const respond = (http, result: unknown) => {
 const schemaList = new Map<string, SchemaCache>();
 const generateCacheKey = async (args: Args): Promise<string> => {
     const { context, locale, type } = args;
+    const tenantId = context.security.getTenant().id;
     const settings = await context.cms.getSettings();
     const lastModelChange = settings?.contentModelLastChange || new Date();
-    return [lastModelChange.toISOString(), locale.code, type].join("#");
+    return [tenantId, locale.code, type, lastModelChange.toISOString()].join("#");
 };
 
 const generateSchema = async (args: Args): Promise<GraphQLSchema> => {
@@ -72,8 +73,9 @@ const generateSchema = async (args: Args): Promise<GraphQLSchema> => {
 // gets an existing schema or rewrites existing one or creates a completely new one
 // depending on the schemaId created from type and locale parameters
 const getSchema = async (args: Args): Promise<GraphQLSchema> => {
-    const { type, locale } = args;
-    const id = `${type}#${locale.code}`;
+    const { context, type, locale } = args;
+    const tenantId = context.security.getTenant().id;
+    const id = `${tenantId}#${type}#${locale.code}`;
 
     const cacheKey = await generateCacheKey(args);
     if (!schemaList.has(id)) {

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -45,10 +45,9 @@ const respond = (http, result: unknown) => {
 const schemaList = new Map<string, SchemaCache>();
 const generateCacheKey = async (args: Args): Promise<string> => {
     const { context, locale, type } = args;
-    const tenantId = context.security.getTenant().id;
     const settings = await context.cms.getSettings();
     const lastModelChange = settings?.contentModelLastChange || new Date();
-    return [tenantId, locale.code, type, lastModelChange.toISOString()].join("#");
+    return [locale.code, type, lastModelChange.toISOString()].join("#");
 };
 
 const generateSchema = async (args: Args): Promise<GraphQLSchema> => {

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -1,7 +1,7 @@
 import { boolean } from "boolean";
 import { GraphQLSchema } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import { CmsContext } from "../types";
+import { CmsContext, CmsSettings } from "../types";
 import { I18NLocale } from "@webiny/api-i18n/types";
 import { NotAuthorizedError, NotAuthorizedResponse } from "@webiny/api-security";
 import { ErrorResponse } from "@webiny/handler-graphql";
@@ -43,10 +43,24 @@ const respond = (http, result: unknown) => {
     });
 };
 const schemaList = new Map<string, SchemaCache>();
+
+const getLastModelChange = (settings?: CmsSettings): Date => {
+    if (!settings || !settings.contentModelLastChange) {
+        return new Date();
+    }
+    if (settings.contentModelLastChange instanceof Date) {
+        return settings.contentModelLastChange;
+    }
+    try {
+        return new Date(settings.contentModelLastChange);
+    } catch {
+        return new Date();
+    }
+};
 const generateCacheKey = async (args: Args): Promise<string> => {
     const { context, locale, type } = args;
-    const settings = await context.cms.getSettings();
-    const lastModelChange = settings?.contentModelLastChange || new Date();
+    const settings = await context.cms.settings.noAuth().get();
+    const lastModelChange = getLastModelChange(settings);
     return [locale.code, type, lastModelChange.toISOString()].join("#");
 };
 

--- a/packages/api-headless-cms/src/plugins/crud/settings.crud.ts
+++ b/packages/api-headless-cms/src/plugins/crud/settings.crud.ts
@@ -66,23 +66,6 @@ export default {
                     throw new Error("The app is already installed.", "CMS_INSTALLATION_ERROR");
                 }
 
-                // Create ES index if it doesn't already exist.
-                // const esIndex = utils.defaults.es(context);
-                // const { body: exists } = await elasticSearch.indices.exists(esIndex);
-                // if (!exists) {
-                //     await elasticSearch.indices.create({
-                //         ...esIndex,
-                //         body: {
-                //             // we are disabling indexing of rawValues property in object that is inserted into ES
-                //             mappings: {
-                //                 properties: {
-                //                     rawValues: { type: "object", enabled: false }
-                //                 }
-                //             }
-                //         }
-                //     });
-                // }
-
                 // Add default content model group.
                 let contentModelGroup: CmsContentModelGroup;
                 try {
@@ -133,8 +116,23 @@ export default {
                     contentModelLastChange: updatedDate
                 };
             },
-            getContentModelLastChange: (): Date => {
-                return context.cms.settings.contentModelLastChange;
+            getContentModelLastChange: async (): Promise<Date> => {
+                const settings = await settingsGet();
+                if (!settings.contentModelLastChange) {
+                    return new Date();
+                }
+                try {
+                    return new Date(settings.contentModelLastChange);
+                } catch (ex) {
+                    console.log({
+                        error: {
+                            message: ex.message,
+                            code: ex.code || "COULD_NOT_PARSE_CONTENT_MODEL_LAST_CHANGE",
+                            data: ex
+                        }
+                    });
+                }
+                return new Date();
             }
         };
         context.cms = {

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -23,10 +23,6 @@ interface BaseCmsValuesObject {
      */
     getLocale: () => I18NLocale;
     /**
-     * returns instance of app settings
-     */
-    getSettings: () => Promise<CmsSettings>;
-    /**
      * Means this request is a READ API
      */
     READ: boolean;

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -25,7 +25,7 @@ interface BaseCmsValuesObject {
     /**
      * returns instance of app settings
      */
-    getSettings: () => CmsSettings;
+    getSettings: () => Promise<CmsSettings>;
     /**
      * Means this request is a READ API
      */
@@ -669,7 +669,7 @@ export interface CmsSettingsContext {
     /**
      * Get the datetime when content model last changed.
      */
-    getContentModelLastChange: () => Date;
+    getContentModelLastChange: () => Promise<Date>;
 }
 
 /**


### PR DESCRIPTION
When model is updated schema was not regenerated on other lambdas.
Added per-tenant scheme cache keys.