### PR TITLE
Project Setup - Update existing ".yarnrc.yml" instead of creating a new one

### DIFF
--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -129,3 +129,20 @@ Once you're done, do the following:
 | Version and publish to Verdaccio  | `yarn lerna:version:verdaccio && yarn lerna:publish:verdaccio`                                                                                                     |
 | Create a new Webiny project       | `npx create-webiny-project@beta my-test-project --tag beta --assign-to-yarnrc '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}'` |
 | Revert versioning commit          | `git reset HEAD~ && git reset --hard HEAD`                                                                                                                         |
+
+## Troubleshooting
+
+#### I made a new release to Verdaccio, but I still receive old code.
+
+This is probably because of one of the Yarn package caching mechanisms.
+
+Yarn has two levels of cache - local and shared. 
+
+When you install a package, it gets cached in the local cache folder (located in your project), and in the shared cache folder. This makes it much faster when you're working on a couple of projects on your local machine, and you're pulling the same package in each. If the package doesn't exist in local cache, it will be pulled from share cache. 
+
+On Windows, it should be in `C:\Users\{USER-NAME}\AppData\Local\Yarn`. 
+On Linux/Mac, it should be in `/Users/adrian/Library/Caches/Yarn`.
+
+In these folders, most probably, you'll also have the `\Berry\cache` folder. But, there were also cases where this folder did not exist.
+
+Deleting the mentioned cache folders should help with the issue of still receiving old packages in your testing sessions.

--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -138,10 +138,10 @@ This is probably because of one of the Yarn package caching mechanisms.
 
 Yarn has two levels of cache - local and shared. 
 
-When you install a package, it gets cached in the local cache folder (located in your project), and in the shared cache folder. This makes it much faster when you're working on a couple of projects on your local machine, and you're pulling the same package in each. If the package doesn't exist in local cache, it will be pulled from share cache. 
+When you install a package, it gets cached in the local cache folder (located in your project), and in the shared cache folder. This makes it much faster when you're working on a couple of projects on your local machine, and you're pulling the same package in each. If the package doesn't exist in local cache, it will be pulled from shared cache. 
 
-On Windows, it should be in `C:\Users\{USER-NAME}\AppData\Local\Yarn`. 
-On Linux/Mac, it should be in `/Users/adrian/Library/Caches/Yarn`.
+On Windows, the shared cache folder should be located in: `C:\Users\{USER-NAME}\AppData\Local\Yarn`. 
+On Linux/Mac, the shared cache folder should be located in: `/Users/adrian/Library/Caches/Yarn`.
 
 In these folders, most probably, you'll also have the `\Berry\cache` folder. But, there were also cases where this folder did not exist.
 

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -91,16 +91,13 @@ module.exports = async function createProject({
                 // Setup yarn@2
                 title: "Setup yarn@^2",
                 task: async () => {
-                    const yarnVersion = await getYarnVersion();
-                    if (semver.satisfies(yarnVersion, "^1.22.0")) {
-                        await execa("yarn", ["set", "version", "berry"], { cwd: projectRoot });
-                    }
+                    await execa("yarn", ["set", "version", "berry"], { cwd: projectRoot });
 
-                    fs.copySync(
-                        path.join(__dirname, "files", "example.yarnrc.yml"),
-                        path.join(projectRoot, ".yarnrc.yml"),
-                        { overwrite: true }
-                    );
+                    const yamlPath = path.join(projectRoot, ".yarnrc.yml");
+                    const parsedYaml = yaml.load(fs.readFileSync(yamlPath, "utf-8"));
+
+                    // Default settings are applied here. Currently we only apply the `nodeLinker` param.
+                    parsedYaml.nodeLinker = "node-modules";
 
                     // Enables adding additional params into the `.yarnrc.yml` file.
                     if (assignToYarnRc) {
@@ -114,12 +111,11 @@ module.exports = async function createProject({
                         }
 
                         if (parsedAssignToYarnRc) {
-                            const yamlPath = path.join(projectRoot, ".yarnrc.yml");
-                            const parsedYaml = yaml.load(fs.readFileSync(yamlPath, "utf-8"));
                             Object.assign(parsedYaml, parsedAssignToYarnRc);
-                            fs.writeFileSync(yamlPath, yaml.dump(parsedYaml));
                         }
                     }
+
+                    fs.writeFileSync(yamlPath, yaml.dump(parsedYaml));
                 }
             },
             {

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -10,8 +10,6 @@ const { sendEvent } = require("@webiny/tracking");
 const getPackageJson = require("./getPackageJson");
 const checkProjectName = require("./checkProjectName");
 const yaml = require("js-yaml");
-const getYarnVersion = require("./getYarnVersion");
-const semver = require("semver");
 
 module.exports = async function createProject({
     projectName,

--- a/packages/create-webiny-project/utils/files/example.yarnrc.yml
+++ b/packages/create-webiny-project/utils/files/example.yarnrc.yml
@@ -1,2 +1,0 @@
-yarnPath: ".yarn/releases/yarn-berry.cjs"
-nodeLinker: node-modules


### PR DESCRIPTION
Over time, we've figured it's better to not create the `.yarnrc.yml` file within our script, but let `yarn2`create it, and just add the necessary configuration params to it.

## How Has This Been Tested?
Manual.

## Screenshots (if relevant):
N/A