### PR TITLE
Improvements on Pulumi-related code

### DIFF
--- a/api/pulumi/dev/fileManager.ts
+++ b/api/pulumi/dev/fileManager.ts
@@ -88,7 +88,7 @@ class FileManager {
             memorySize: 512,
             description: "Serves previously uploaded files.",
             code: new pulumi.asset.AssetArchive({
-                ".": new pulumi.asset.FileArchive("../code/fileManager/download//build")
+                ".": new pulumi.asset.FileArchive("../code/fileManager/download/build")
             }),
             environment: {
                 variables: {

--- a/api/pulumi/prod/fileManager.ts
+++ b/api/pulumi/prod/fileManager.ts
@@ -97,7 +97,7 @@ class FileManager {
             memorySize: 512,
             description: "Serves previously uploaded files.",
             code: new pulumi.asset.AssetArchive({
-                ".": new pulumi.asset.FileArchive("../code/fileManager/download//build")
+                ".": new pulumi.asset.FileArchive("../code/fileManager/download/build")
             }),
             environment: {
                 variables: {

--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -51,7 +51,7 @@ Start by running the `yarn verdaccio:start` command, which will, as the script n
 Once you have Verdaccio up and running, you'll also need to change the default NPM registry. Meaning, when you run `npx create-webiny-project ...`, you want it to start fetching packages from Verdaccio, not real NPM. Verdaccio runs on localhost, on port 4873, so, in your terminal, run the following command:
 
 ```
-npm config set registry http://localhost:4873/
+npm config set registry http://localhost:4873
 ```
 
 Note that this will only help you with `npx`, but won't help you when a new project foundation is created, and the dependencies start to get pulled. This is because we're using yarn2, which actually doesn't respect the values that were written by the `npm config set ...` command we just executed.

--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -146,3 +146,9 @@ On Linux/Mac, the shared cache folder should be located in: `/Users/adrian/Libra
 In these folders, most probably, you'll also have the `\Berry\cache` folder. But, there were also cases where this folder did not exist.
 
 Deleting the mentioned cache folders should help with the issue of still receiving old packages in your testing sessions.
+
+With all of this being said, you can also try the [following command](https://yarnpkg.com/features/offline-cache#cleaning-the-cache):
+
+```bash
+yarn cache clean --mirror
+````

--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -84,6 +84,11 @@ yarn lerna:publish:verdaccio
 
 This will publish the packages to Verdaccio. Once it's done, you can start testing.
 
+> You can also execute both commands immediately with: 
+> ```
+> yarn lerna:version:verdaccio && yarn lerna:publish:verdaccio
+> ```
+
 #### 4. Test
 
 Test your changes with the following command:

--- a/packages/create-webiny-project/README.md
+++ b/packages/create-webiny-project/README.md
@@ -62,7 +62,7 @@ It's super important that, when you're testing your npx project, you also pass t
 --assign-to-yarnrc '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}'
 ```
 
-This will set the necessary values in yarn2 config file, which will be located in your newly created project.
+This will set the necessary values in yarn2 config file, which will be located in your newly created project. But don't worry about it right now, this will be revisited in step 4.
 
 > Yarn2 projects don't rely on global configurations and is not installed globally, but on per-project basis. This allows having multiple versions of yarn2, for different projects.
 

--- a/packages/cwp-template-aws/template/api/pulumi/dev/fileManager.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/fileManager.ts
@@ -88,7 +88,7 @@ class FileManager {
             memorySize: 512,
             description: "Serves previously uploaded files.",
             code: new pulumi.asset.AssetArchive({
-                ".": new pulumi.asset.FileArchive("../code/fileManager/download//build")
+                ".": new pulumi.asset.FileArchive("../code/fileManager/download/build")
             }),
             environment: {
                 variables: {

--- a/packages/cwp-template-aws/template/api/pulumi/prod/cognito.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/cognito.ts
@@ -3,68 +3,72 @@ import * as aws from "@pulumi/aws";
 class Cognito {
     userPoolClient: aws.cognito.UserPoolClient;
     userPool: aws.cognito.UserPool;
-    constructor() {
-        this.userPool = new aws.cognito.UserPool("api-user-pool", {
-            passwordPolicy: {
-                minimumLength: 8,
-                requireLowercase: false,
-                requireNumbers: false,
-                requireSymbols: false,
-                requireUppercase: false,
-                temporaryPasswordValidityDays: 7
-            },
-            adminCreateUserConfig: {
-                allowAdminCreateUserOnly: true
-            },
-            autoVerifiedAttributes: ["email"],
-            emailConfiguration: {
-                emailSendingAccount: "COGNITO_DEFAULT"
-            },
-            lambdaConfig: {},
-            mfaConfiguration: "OFF",
-            userPoolAddOns: {
-                advancedSecurityMode: "OFF" /* required */
-            },
-            usernameAttributes: ["email"],
-            verificationMessageTemplate: {
-                defaultEmailOption: "CONFIRM_WITH_CODE"
-            },
-            schemas: [
-                {
-                    attributeDataType: "String",
-                    name: "email",
-                    required: true,
-                    developerOnlyAttribute: false,
-                    mutable: true,
-                    stringAttributeConstraints: {
-                        maxLength: "2048",
-                        minLength: "0"
-                    }
+    constructor({ protectedEnvironment }: { protectedEnvironment: boolean }) {
+        this.userPool = new aws.cognito.UserPool(
+            "api-user-pool",
+            {
+                passwordPolicy: {
+                    minimumLength: 8,
+                    requireLowercase: false,
+                    requireNumbers: false,
+                    requireSymbols: false,
+                    requireUppercase: false,
+                    temporaryPasswordValidityDays: 7
                 },
-                {
-                    attributeDataType: "String",
-                    name: "family_name",
-                    required: true,
-                    developerOnlyAttribute: false,
-                    mutable: true,
-                    stringAttributeConstraints: {
-                        maxLength: "2048",
-                        minLength: "0"
-                    }
+                adminCreateUserConfig: {
+                    allowAdminCreateUserOnly: true
                 },
-                {
-                    attributeDataType: "String",
-                    name: "given_name",
-                    required: true,
-                    developerOnlyAttribute: false,
-                    mutable: true,
-                    stringAttributeConstraints: {
-                        maxLength: "2048",
-                        minLength: "0"
+                autoVerifiedAttributes: ["email"],
+                emailConfiguration: {
+                    emailSendingAccount: "COGNITO_DEFAULT"
+                },
+                lambdaConfig: {},
+                mfaConfiguration: "OFF",
+                userPoolAddOns: {
+                    advancedSecurityMode: "OFF" /* required */
+                },
+                usernameAttributes: ["email"],
+                verificationMessageTemplate: {
+                    defaultEmailOption: "CONFIRM_WITH_CODE"
+                },
+                schemas: [
+                    {
+                        attributeDataType: "String",
+                        name: "email",
+                        required: true,
+                        developerOnlyAttribute: false,
+                        mutable: true,
+                        stringAttributeConstraints: {
+                            maxLength: "2048",
+                            minLength: "0"
+                        }
+                    },
+                    {
+                        attributeDataType: "String",
+                        name: "family_name",
+                        required: true,
+                        developerOnlyAttribute: false,
+                        mutable: true,
+                        stringAttributeConstraints: {
+                            maxLength: "2048",
+                            minLength: "0"
+                        }
+                    },
+                    {
+                        attributeDataType: "String",
+                        name: "given_name",
+                        required: true,
+                        developerOnlyAttribute: false,
+                        mutable: true,
+                        stringAttributeConstraints: {
+                            maxLength: "2048",
+                            minLength: "0"
+                        }
                     }
-                }
-            ]
-        });
+                ]
+            },
+            { protect: protectedEnvironment }
+        );
 
         this.userPoolClient = new aws.cognito.UserPoolClient("api-user-pool-client", {
             userPoolId: this.userPool.id

--- a/packages/cwp-template-aws/template/api/pulumi/prod/dynamoDb.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/dynamoDb.ts
@@ -2,26 +2,30 @@ import * as aws from "@pulumi/aws";
 
 class DynamoDB {
     table: aws.dynamodb.Table;
-    constructor() {
-        this.table = new aws.dynamodb.Table("webiny", {
-            attributes: [
-                { name: "PK", type: "S" },
-                { name: "SK", type: "S" },
-                { name: "GSI1_PK", type: "S" },
-                { name: "GSI1_SK", type: "S" }
-            ],
-            billingMode: "PAY_PER_REQUEST",
-            hashKey: "PK",
-            rangeKey: "SK",
-            globalSecondaryIndexes: [
-                {
-                    name: "GSI1",
-                    hashKey: "GSI1_PK",
-                    rangeKey: "GSI1_SK",
-                    projectionType: "ALL"
-                }
-            ]
-        });
+    constructor({ protectedEnvironment }: { protectedEnvironment: boolean }) {
+        this.table = new aws.dynamodb.Table(
+            "webiny",
+            {
+                attributes: [
+                    { name: "PK", type: "S" },
+                    { name: "SK", type: "S" },
+                    { name: "GSI1_PK", type: "S" },
+                    { name: "GSI1_SK", type: "S" }
+                ],
+                billingMode: "PAY_PER_REQUEST",
+                hashKey: "PK",
+                rangeKey: "SK",
+                globalSecondaryIndexes: [
+                    {
+                        name: "GSI1",
+                        hashKey: "GSI1_PK",
+                        rangeKey: "GSI1_SK",
+                        projectionType: "ALL"
+                    }
+                ]
+            },
+            { protect: protectedEnvironment }
+        );
     }
 }
 

--- a/packages/cwp-template-aws/template/api/pulumi/prod/elasticSearch.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/elasticSearch.ts
@@ -21,7 +21,7 @@ class ElasticSearch {
                 }
             },
             vpcOptions: {
-                subnetIds: [vpc.subnets.private[0].id],
+                subnetIds: [vpc.subnets.private[0].id, vpc.subnets.private[1].id],
                 securityGroupIds: [vpc.vpc.defaultSecurityGroupId]
             },
             ebsOptions: {

--- a/packages/cwp-template-aws/template/api/pulumi/prod/fileManager.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/fileManager.ts
@@ -97,7 +97,7 @@ class FileManager {
             memorySize: 512,
             description: "Serves previously uploaded files.",
             code: new pulumi.asset.AssetArchive({
-                ".": new pulumi.asset.FileArchive("../code/fileManager/download//build")
+                ".": new pulumi.asset.FileArchive("../code/fileManager/download/build")
             }),
             environment: {
                 variables: {

--- a/packages/cwp-template-aws/template/api/pulumi/prod/fileManager.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/fileManager.ts
@@ -16,19 +16,24 @@ class FileManager {
         transform: aws.lambda.Function;
         download: aws.lambda.Function;
     };
-    constructor() {
-        this.bucket = new aws.s3.Bucket("fm-bucket", {
-            acl: "private",
-            forceDestroy: true,
-            corsRules: [
-                {
-                    allowedHeaders: ["*"],
-                    allowedMethods: ["POST", "GET"],
-                    allowedOrigins: ["*"],
-                    maxAgeSeconds: 3000
-                }
-            ]
-        });
+    constructor({ protectedEnvironment }: { protectedEnvironment: boolean }) {
+        this.bucket = new aws.s3.Bucket(
+            "fm-bucket",
+            {
+                acl: "private",
+                // We definitely don't want to force-destroy if "protectedEnvironment" flag is true.
+                forceDestroy: !protectedEnvironment,
+                corsRules: [
+                    {
+                        allowedHeaders: ["*"],
+                        allowedMethods: ["POST", "GET"],
+                        allowedOrigins: ["*"],
+                        maxAgeSeconds: 3000
+                    }
+                ]
+            },
+            { protect: protectedEnvironment }
+        );
 
         this.role = new aws.iam.Role("fm-lambda-role", {
             assumeRolePolicy: {

--- a/packages/cwp-template-aws/template/api/pulumi/prod/index.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/index.ts
@@ -9,11 +9,19 @@ import FileManager from "./fileManager";
 import PageBuilder from "./pageBuilder";
 import PrerenderingService from "./prerenderingService";
 
+/**
+ * We protect mission critical cloud infrastructure resource against accidental deletion. We do this
+ * only for the "prod" environment, but, if needed, feel free to additional environments.
+ * @see https://www.pulumi.com/docs/intro/concepts/resources/#protect
+ */
+const protectedEnvironment = process.env.WEBINY_ENV === "prod";
+
 export default () => {
-    const dynamoDb = new DynamoDB();
-    const cognito = new Cognito();
-    const elasticSearch = new ElasticSearch();
-    const fileManager = new FileManager();
+    const dynamoDb = new DynamoDB({ protectedEnvironment });
+    const cognito = new Cognito({ protectedEnvironment });
+
+    const elasticSearch = new ElasticSearch({ protectedEnvironment });
+    const fileManager = new FileManager({ protectedEnvironment });
 
     const prerenderingService = new PrerenderingService({
         env: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,8 +122,8 @@ __metadata:
   linkType: hard
 
 "@babel/cli@npm:^7.0.0, @babel/cli@npm:^7.12.10, @babel/cli@npm:^7.5.5":
-  version: 7.13.0
-  resolution: "@babel/cli@npm:7.13.0"
+  version: 7.13.10
+  resolution: "@babel/cli@npm:7.13.10"
   dependencies:
     "@nicolo-ribaudo/chokidar-2": 2.1.8-no-fsevents
     chokidar: ^3.4.0
@@ -145,7 +145,7 @@ __metadata:
   bin:
     babel: ./bin/babel.js
     babel-external-helpers: ./bin/babel-external-helpers.js
-  checksum: a887d985e45a5b97e0d6b4ae403d63033ad8b539b86d1d77b98f1766b2bc219e09797b36eedb03fc9d35f61622b108a38111c5e55d7bf7101de74d788335cf00
+  checksum: 2b79fb80de05c11ae88a221d536da7b5d2073d4dd85beec808a31facba56580a5da8f1ad85b13a91b348651d18a41a43751533ff2edb89ac3c255c61525fe6dc
   languageName: node
   linkType: hard
 
@@ -215,16 +215,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.13.8, @babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.4.5, @babel/core@npm:^7.5.5, @babel/core@npm:^7.7.5":
-  version: 7.13.8
-  resolution: "@babel/core@npm:7.13.8"
+"@babel/core@npm:7.13.10, @babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.4.5, @babel/core@npm:^7.5.5, @babel/core@npm:^7.7.5":
+  version: 7.13.10
+  resolution: "@babel/core@npm:7.13.10"
   dependencies:
     "@babel/code-frame": ^7.12.13
-    "@babel/generator": ^7.13.0
-    "@babel/helper-compilation-targets": ^7.13.8
+    "@babel/generator": ^7.13.9
+    "@babel/helper-compilation-targets": ^7.13.10
     "@babel/helper-module-transforms": ^7.13.0
-    "@babel/helpers": ^7.13.0
-    "@babel/parser": ^7.13.4
+    "@babel/helpers": ^7.13.10
+    "@babel/parser": ^7.13.10
     "@babel/template": ^7.12.13
     "@babel/traverse": ^7.13.0
     "@babel/types": ^7.13.0
@@ -235,7 +235,7 @@ __metadata:
     lodash: ^4.17.19
     semver: ^6.3.0
     source-map: ^0.5.0
-  checksum: f3c61e635aa41e127775d1191a65aedd4cf90008625eb93ddbd86214ebae6b0793cefd10503b2a4df8aa510d0e1108dfd15e29bde9bbffc899a50015f56f49c4
+  checksum: 728249a0bae293547d987e4d9886a14dda663d8cb629eb59c9d9ad3ee455048c2ccc3858c82305229ad4a415c2f39579abaa3982b653d40de348c39a3beb5e4d
   languageName: node
   linkType: hard
 
@@ -263,7 +263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.10, @babel/generator@npm:^7.13.0, @babel/generator@npm:^7.9.0":
+"@babel/generator@npm:^7.12.10, @babel/generator@npm:^7.13.0, @babel/generator@npm:^7.13.9, @babel/generator@npm:^7.9.0":
   version: 7.13.9
   resolution: "@babel/generator@npm:7.13.9"
   dependencies:
@@ -293,9 +293,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.13.8, @babel/helper-compilation-targets@npm:^7.8.7":
-  version: 7.13.8
-  resolution: "@babel/helper-compilation-targets@npm:7.13.8"
+"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.13.10, @babel/helper-compilation-targets@npm:^7.13.8, @babel/helper-compilation-targets@npm:^7.8.7":
+  version: 7.13.10
+  resolution: "@babel/helper-compilation-targets@npm:7.13.10"
   dependencies:
     "@babel/compat-data": ^7.13.8
     "@babel/helper-validator-option": ^7.12.17
@@ -303,13 +303,13 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: dbee371e5ff226bb03a036d1af858f038ab6e71fac1ff5014bf69411b71af187bcdb0e49d5352ec5ef5e83186c9b88ee83b74295ba900691095b31017ec59f89
+  checksum: 80eb7a380d01d785de42006370e13bbda63b76745a8da1c68dcbf3dc4bff630bd9db8a76cf3053628c61d91c1452328a4ad9a8d9fc24ed65c02f635327234678
   languageName: node
   linkType: hard
 
 "@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.13.0, @babel/helper-create-class-features-plugin@npm:^7.8.3":
-  version: 7.13.8
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.13.8"
+  version: 7.13.10
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.13.10"
   dependencies:
     "@babel/helper-function-name": ^7.12.13
     "@babel/helper-member-expression-to-functions": ^7.13.0
@@ -318,7 +318,7 @@ __metadata:
     "@babel/helper-split-export-declaration": ^7.12.13
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: b0cda9616cb0413865fe3c5c55453cfff08739b276584bcf6a7aed1bb53fac276a0eecd288ea1201db7744ccb5c248b6b1b09110b28e0d77fc236df066ab67bd
+  checksum: 9d331528e12807a1697d4d24a5e98ca3587944d38927fe389880bb7882eaf6b004295d0c459aa3870090dfeb177bb787be1b2062a2e2587f34700c9c620681b8
   languageName: node
   linkType: hard
 
@@ -518,34 +518,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.13.0, @babel/helpers@npm:^7.9.0":
-  version: 7.13.0
-  resolution: "@babel/helpers@npm:7.13.0"
+"@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.13.10, @babel/helpers@npm:^7.9.0":
+  version: 7.13.10
+  resolution: "@babel/helpers@npm:7.13.10"
   dependencies:
     "@babel/template": ^7.12.13
     "@babel/traverse": ^7.13.0
     "@babel/types": ^7.13.0
-  checksum: 6c435aefe108e85b999570eed9fc2ec10944cb1ed4c3ff6656936c90a6f986174bd5c80ec48ecbbb7042e5eca5761364f484d7e0238a3aa77c2f5099dcac8df0
+  checksum: 1bc93126957b51108080ab1aa24997a9a10d5f395de54621ce9df7825cdbce878ad9d26886c927c3d9bcfd75d24972037ed5fb904fcd83fb92e5c8f8628f6b40
   languageName: node
   linkType: hard
 
 "@babel/highlight@npm:^7.0.0, @babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.12.13, @babel/highlight@npm:^7.8.3":
-  version: 7.13.8
-  resolution: "@babel/highlight@npm:7.13.8"
+  version: 7.13.10
+  resolution: "@babel/highlight@npm:7.13.10"
   dependencies:
     "@babel/helper-validator-identifier": ^7.12.11
     chalk: ^2.0.0
     js-tokens: ^4.0.0
-  checksum: a25fc49b803ed103f829b949636d6ead219a13f325d16f959e19b69c995322d9ef15464d4d865a4b2b7779053b2c64788d2d1e171144b5d941d89abd46bd0534
+  checksum: 8f23d3b728422713bfab45bee1e7584f2a3d2e20c9c4d6153312b898c82e776bdc5b1b2afaf9433fddb21d70417f5b477c0bb1a48613324fd761117e19a5702b
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.10, @babel/parser@npm:^7.12.13, @babel/parser@npm:^7.13.0, @babel/parser@npm:^7.13.4, @babel/parser@npm:^7.6.4, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.9.0":
-  version: 7.13.9
-  resolution: "@babel/parser@npm:7.13.9"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.10, @babel/parser@npm:^7.12.13, @babel/parser@npm:^7.13.0, @babel/parser@npm:^7.13.10, @babel/parser@npm:^7.6.4, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.9.0":
+  version: 7.13.10
+  resolution: "@babel/parser@npm:7.13.10"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: de61d40db87a09a2bf230b06cd33121e25a650cf82efb3af7d348e9e5d5ca9426fa76f264eb7c9c5f16a11d17cf66adbe2f807d5a6126c370017ea4ca506fcea
+  checksum: 2eec48a075e11ad45031e82acf51061970ca8044cc296df1281512d8de0a8b478b04416ae411aa56f4ac99ed8cf2f40b9eeec27b6a99062c7b06628a1a7c6a69
   languageName: node
   linkType: hard
 
@@ -1327,13 +1327,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-constant-elements@npm:^7.0.0, @babel/plugin-transform-react-constant-elements@npm:^7.2.0, @babel/plugin-transform-react-constant-elements@npm:^7.6.3":
-  version: 7.12.13
-  resolution: "@babel/plugin-transform-react-constant-elements@npm:7.12.13"
+  version: 7.13.10
+  resolution: "@babel/plugin-transform-react-constant-elements@npm:7.13.10"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.12.13
+    "@babel/helper-plugin-utils": ^7.13.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 24defddd608e8d8a26f2e654c3ee6643617fc39d6a6df712b0ac089d9eb0b9b95c7b35719445094484ba7360322dc4642585d9ccf26e9ee17a48ee505d792e16
+  checksum: 4f94183d28f5bbcfa8749b51b995e226a729751d41e953e029a8d22ae983571332fb8657fea137de5091f5539fae7d70587f9818a1d01a665201bce120772706
   languageName: node
   linkType: hard
 
@@ -1456,8 +1456,8 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-runtime@npm:^7.5.5":
-  version: 7.13.9
-  resolution: "@babel/plugin-transform-runtime@npm:7.13.9"
+  version: 7.13.10
+  resolution: "@babel/plugin-transform-runtime@npm:7.13.10"
   dependencies:
     "@babel/helper-module-imports": ^7.12.13
     "@babel/helper-plugin-utils": ^7.13.0
@@ -1467,7 +1467,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 79fd9e6ff154c6005acd1478a5e5c44b4d33ef9d96f67b83dabba59ad816a7ea5b77800ff222fd565c4e6178831165d4bc848bc07c1d88c5deaa67609af58682
+  checksum: 2b36d86770696e80bf1aed9f97d4d7bb684a6dc1bb407f2da607a13f190fd1feed06a454a6f89d6d60da9bc554c3aef942f5ad307217a48ac9ddcf8edd57894e
   languageName: node
   linkType: hard
 
@@ -1720,11 +1720,11 @@ __metadata:
   linkType: hard
 
 "@babel/preset-env@npm:^7.4.5, @babel/preset-env@npm:^7.5.5":
-  version: 7.13.9
-  resolution: "@babel/preset-env@npm:7.13.9"
+  version: 7.13.10
+  resolution: "@babel/preset-env@npm:7.13.10"
   dependencies:
     "@babel/compat-data": ^7.13.8
-    "@babel/helper-compilation-targets": ^7.13.8
+    "@babel/helper-compilation-targets": ^7.13.10
     "@babel/helper-plugin-utils": ^7.13.0
     "@babel/helper-validator-option": ^7.12.17
     "@babel/plugin-proposal-async-generator-functions": ^7.13.8
@@ -1793,7 +1793,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 55ef45c648da2cf98d703a3f5128eeb883285580f02717059c1ac708ac8cb291e40705838dfdd4f4c59da3c96b816c13e2d2d0d9a7490e3bace4cf41ec8ba151
+  checksum: 1f23eb25dea448fd75a3e525f71181d535d2884fe50c7fbb9aa29918b997a7d92ba27cfb55f8b4070bc1b0507ab3d2d7ba9ee612a972e0f0b7447d4455d2b447
   languageName: node
   linkType: hard
 
@@ -1924,12 +1924,12 @@ __metadata:
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.13.9
-  resolution: "@babel/runtime-corejs3@npm:7.13.9"
+  version: 7.13.10
+  resolution: "@babel/runtime-corejs3@npm:7.13.10"
   dependencies:
     core-js-pure: ^3.0.0
     regenerator-runtime: ^0.13.4
-  checksum: bcc0d6171f1b045e81ed0dd7949f570969ffd984139a3bb685625f8281863d48d1f466d1862bd3b4b5d679bdac7271bbfc21fba1cd7b974719b14f532e8c43e1
+  checksum: cbf4de5c0e73197447c112b31e1e7bb48b7940c815fdc6e8aee28a9e33f57f5c3991ba0598dfbfb8bc4d22a7cfe3b2eced0f08c12f8e618aa2ccf73684ced051
   languageName: node
   linkType: hard
 
@@ -1943,18 +1943,18 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.13.9
-  resolution: "@babel/runtime@npm:7.13.9"
+  version: 7.13.10
+  resolution: "@babel/runtime@npm:7.13.10"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: e6f79d20e10c2921520c499f3cf295a9ee5c137e73f77f77eedde9f9073bc3541c1fc7fa6c97b0613f4140303ac00d08506e9f090068d219c58781d2b62c662d
+  checksum: 22014226b96a8c8e8d4e8bcdb011f317d1b32881aef424a669dc6ceaee14993d3609172967853cbf9c25c724c25145d45885b6c9df56ba241c12820776607f1f
   languageName: node
   linkType: hard
 
 "@babel/standalone@npm:^7.4.5":
-  version: 7.13.9
-  resolution: "@babel/standalone@npm:7.13.9"
-  checksum: f73b1dd6acd967f2a7627dd4b29930977a74f080b59df312d79283802d81b5a8e52db8de08587e993637861b3a646c071621381136ff535ed9619fb9b86da31f
+  version: 7.13.10
+  resolution: "@babel/standalone@npm:7.13.10"
+  checksum: f2d3e3733c3bb7ff3c6aa8c435198052145d9b01150c6b52a90594f9c4178d4c74df7861b30f4e70e3330918bf4e8ac71376adbd603aca34ab05b78587519271
   languageName: node
   linkType: hard
 
@@ -2733,26 +2733,26 @@ __metadata:
   linkType: hard
 
 "@graphql-tools/utils@npm:^7.1.2":
-  version: 7.5.0
-  resolution: "@graphql-tools/utils@npm:7.5.0"
+  version: 7.5.2
+  resolution: "@graphql-tools/utils@npm:7.5.2"
   dependencies:
     "@ardatan/aggregate-error": 0.0.6
     camel-case: 4.1.2
     tslib: ~2.1.0
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
-  checksum: ce409ce5bd365e04f8333c00bfebf51a8cbeed62b70cf820b7608394c153edb82ce6d23770c7d6c4890453dfd5990dedc832dac7f24ffc5ff9a1e40acac0b3c1
+  checksum: 555b2b50f80ab68080c8c52e59b8db18edee73829ddbfcf643c08b3015b5238b5a2c9f6432165727d6327cb82bae1f76083e8705cb36b46f1467bb815c817f0d
   languageName: node
   linkType: hard
 
 "@grpc/grpc-js@npm:^1.2.7":
-  version: 1.2.8
-  resolution: "@grpc/grpc-js@npm:1.2.8"
+  version: 1.2.10
+  resolution: "@grpc/grpc-js@npm:1.2.10"
   dependencies:
     "@types/node": ">=12.12.47"
     google-auth-library: ^6.1.1
     semver: ^6.2.0
-  checksum: 47b6a51ab8efe6cc50e9660c1ae2fb2814fb3c8de99ae80650a1c4fcbfb2591b2ed0b4bc529091209ee6305cee8fbc5f7e2211dfbabf5356994814a8b98cc3a5
+  checksum: 96e71fbeedbcac4c9e41886bbdaaa3ed87cd9934bf8d3f362067cbeb02cc29ec0f47117f2a41fa532682bf73e9252b4ffd0d5199c8d31b569c88562fa490dd17
   languageName: node
   linkType: hard
 
@@ -4539,10 +4539,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "@octokit/openapi-types@npm:5.2.1"
-  checksum: 6e81bfa3320a52fa46029f5d14212f00733ad3d6c8d9150bdb8b5c0a6f3f4df5a3c3fa5c12fcb79cced2ee832a380ccaf804997824a1e44e3da7548178073750
+"@octokit/openapi-types@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "@octokit/openapi-types@npm:5.3.2"
+  checksum: 5c5f2f2f6ea26192072b408b3e5ce8087d4eb256addda5ebcd2e58a0a94af49e135482c0e15768ee2998c329ed178d8f491b5d229bb2f283dede2389b0bb20c9
   languageName: node
   linkType: hard
 
@@ -4653,11 +4653,11 @@ __metadata:
   linkType: hard
 
 "@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.7.1":
-  version: 6.11.1
-  resolution: "@octokit/types@npm:6.11.1"
+  version: 6.12.2
+  resolution: "@octokit/types@npm:6.12.2"
   dependencies:
-    "@octokit/openapi-types": ^5.2.1
-  checksum: 1fb0105137958d88bdb0ee1ceeeef947cbf35dec5bfc6245d11ca0c26c73afd2e12f1cf0e57c99218f7addfc1cbf61ad6c182e582f91012926e7c993193d96fd
+    "@octokit/openapi-types": ^5.3.2
+  checksum: d96bb9fae7f71c849f952432ffbcecc5ce2d00c18044bfb8d993625b9c9852ad6a672f2c144ab198f4e6a3618c744bdc833158b7c02e810659b006736ab73ed5
   languageName: node
   linkType: hard
 
@@ -4844,8 +4844,8 @@ __metadata:
   linkType: hard
 
 "@pulumi/aws@npm:^3.22.0":
-  version: 3.31.0
-  resolution: "@pulumi/aws@npm:3.31.0"
+  version: 3.32.0
+  resolution: "@pulumi/aws@npm:3.32.0"
   dependencies:
     "@pulumi/pulumi": ^2.17.0
     aws-sdk: ^2.0.0
@@ -4853,13 +4853,13 @@ __metadata:
     mime: ^2.0.0
     read-package-tree: ^5.2.1
     resolve: ^1.7.1
-  checksum: fcb6712f9312995ee73aa4fc3b357ef2b446cd3f9250bf258ebaf2cbb4d57b739f942ae5f09af1244ef9c0298c47176e825fa53953587353d5ed5f5e8668e928
+  checksum: 4b72afeb37076844856e0aa99add2be1958bd24af1a05016addb151cdfc064f7832d2943fc289213c8b69c22539a90ef52395da341a0a0c66f08f8ceb51acb74
   languageName: node
   linkType: hard
 
 "@pulumi/pulumi@npm:^2.17.0, @pulumi/pulumi@npm:^2.21.2":
-  version: 2.21.2
-  resolution: "@pulumi/pulumi@npm:2.21.2"
+  version: 2.22.0
+  resolution: "@pulumi/pulumi@npm:2.22.0"
   dependencies:
     "@grpc/grpc-js": ^1.2.7
     "@pulumi/query": ^0.3.0
@@ -4875,7 +4875,7 @@ __metadata:
     ts-node: ^7.0.1
     typescript: ~3.7.3
     upath: ^1.1.0
-  checksum: 5efb3fc633f8613e0486d6b94426f82c254069cdc6f50fc78ce724e9597d5467ac1bb353327175bbd712ba1230c35d91982ddfe207997beac46e93a34000a61d
+  checksum: e84ab18bc718d4355f417034654828b9ff05ae5b14e97d42a3b1e506c9bc8164a32f9eeb2732aa7c66523eea6c46e64f5f4b1cd5e1f6d72cd386d0cd2098fb01
   languageName: node
   linkType: hard
 
@@ -6075,8 +6075,8 @@ __metadata:
   linkType: hard
 
 "@testing-library/dom@npm:^7.28.1":
-  version: 7.29.6
-  resolution: "@testing-library/dom@npm:7.29.6"
+  version: 7.30.0
+  resolution: "@testing-library/dom@npm:7.30.0"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
@@ -6086,7 +6086,7 @@ __metadata:
     dom-accessibility-api: ^0.5.4
     lz-string: ^1.4.4
     pretty-format: ^26.6.2
-  checksum: 6102dabce8526f9ccfd4c4e08d60d1c7f2bd125482587cb4664cd652b9c00dd430faf5e08701513f3d5bfa90e89fdcca26313b9ffe644fd1936bbf449ac62a14
+  checksum: 5af9f762ff43265cf9c36bb62bba37d73da2858a6149a2f11f159c61bfb46d60f66d9c7c10ab9f201cf0749c9e0039494005379355b0a0d494c60f6b759cea34
   languageName: node
   linkType: hard
 
@@ -6282,16 +6282,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:26.x":
-  version: 26.0.20
-  resolution: "@types/jest@npm:26.0.20"
-  dependencies:
-    jest-diff: ^26.0.0
-    pretty-format: ^26.0.0
-  checksum: 221e39c7c9ce8d71ae4b2ba6abeef1a5b04f1cd96419b9fbbb65534bef4c4215b650561183073dcf47584ff1888d1f4fa7d2af2a38492b7feb9a3bfdcd24c44f
-  languageName: node
-  linkType: hard
-
 "@types/jest@npm:^24.0.24":
   version: 24.9.1
   resolution: "@types/jest@npm:24.9.1"
@@ -6395,9 +6385,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:>=12.12.47, @types/node@npm:>=6":
-  version: 14.14.31
-  resolution: "@types/node@npm:14.14.31"
-  checksum: 635dc8a0898a923621e02ca179e17baa39fdfa44f0096fcc1b7046c9b32317e74a99956a7b45ca0e8069874f51f4e7873a418239a318a4b6e7936f6510ac5992
+  version: 14.14.33
+  resolution: "@types/node@npm:14.14.33"
+  checksum: f269fc728f6547345e000a0d86e1be802b475bb6759493208d7bc1cf8d49e838d3952ae54b8c7cd2ce168f9ef50c30e0d7084064a5f98db87efc833a38d955af
   languageName: node
   linkType: hard
 
@@ -6409,23 +6399,23 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^10.0.0":
-  version: 10.17.54
-  resolution: "@types/node@npm:10.17.54"
-  checksum: 6f718d5d37f40586228b490b9635a1b44f3990766c75fc5af933858ad2bc6eac7cc5dca2b8a1389e0663542c5cb671d01eb45f847783e53aba0318a9fe11a66b
+  version: 10.17.55
+  resolution: "@types/node@npm:10.17.55"
+  checksum: 03924314a7a6bd74f5d710b35b602f82b14e0bc95d650724a4296ed99aec9b8680885b78422a5e21586b2cb2b1d8148cd58ec99009e2ae6e2beaf1590c71a444
   languageName: node
   linkType: hard
 
 "@types/node@npm:^12.12.22":
-  version: 12.20.4
-  resolution: "@types/node@npm:12.20.4"
-  checksum: 16d002434239f11379819fc3d2a85f0c2652cf9fb0dcaf581e8652b85aef3816bba915552388d7db72f4f6d079822ab0f16a571980eeedb2acceedf2a9e5c940
+  version: 12.20.5
+  resolution: "@types/node@npm:12.20.5"
+  checksum: d94e5418588be39df12ad3088f922d6ce53dec286f69f517dd1c4e39fc64ae84b65c107053a2076c744fefdb5d53c22f30b5ce67665ae040665196b157ccdbd7
   languageName: node
   linkType: hard
 
 "@types/node@npm:^13.7.0":
-  version: 13.13.45
-  resolution: "@types/node@npm:13.13.45"
-  checksum: f168574f1ecb9c9598742b99c55e9b62bfc97aa2ead0e54ea85208c3021e353452944869a8ee6d6f6a9636f777a6fbf474dba5c1afa728fa34001fb38996de66
+  version: 13.13.46
+  resolution: "@types/node@npm:13.13.46"
+  checksum: 3786ac15b21b489c0c807d769edf64f732788b3e8f7f66ac04d63580c658fbafd5c9352c958199a37b2393c6132b16f4bbc43ced25bf4bcb90cbae9d75e61f17
   languageName: node
   linkType: hard
 
@@ -6458,9 +6448,9 @@ __metadata:
   linkType: hard
 
 "@types/prettier@npm:^2.0.0":
-  version: 2.2.1
-  resolution: "@types/prettier@npm:2.2.1"
-  checksum: 9dc257dfc51eab6bc1e9ce58df94b309a206b2cdc6768709de3d20f70ae545c616bbc46add6d66f66cfa6cfbb0613dd09e6b6028ff6ff8ba9d3625f38d85cc66
+  version: 2.2.2
+  resolution: "@types/prettier@npm:2.2.2"
+  checksum: 907c2dac93899961706017ecf17d0038b500f499f61d6f1d31e439dae88f7cb90ee944760b1348856baa7befa42761fc53f9bde5add08feccfc810280347d681
   languageName: node
   linkType: hard
 
@@ -6507,11 +6497,11 @@ __metadata:
   linkType: hard
 
 "@types/react-dom@npm:^17.0.0":
-  version: 17.0.1
-  resolution: "@types/react-dom@npm:17.0.1"
+  version: 17.0.2
+  resolution: "@types/react-dom@npm:17.0.2"
   dependencies:
     "@types/react": "*"
-  checksum: 695dd4bbef4fabdc726359e4031b2887b913d65fb2ff59e5a9e81f9ae20ca4dd8f2b6fe1f39fa5c1197babdb86f6b81b385f5d4438536f2ceeb5ff136102f45b
+  checksum: abaadaa2629640870f4b982e3f32cf8f719773cfa97f02931baebef1993c0e2d70fd17f94b29bcf00d45ea099d5f04a042cf55ecb5e2bf8804c4e4cabdb4adc0
   languageName: node
   linkType: hard
 
@@ -6662,11 +6652,11 @@ __metadata:
   linkType: hard
 
 "@types/uglify-js@npm:*":
-  version: 3.12.0
-  resolution: "@types/uglify-js@npm:3.12.0"
+  version: 3.13.0
+  resolution: "@types/uglify-js@npm:3.13.0"
   dependencies:
     source-map: ^0.6.1
-  checksum: d9a68a01dcb06897afc03b85b4d4a971c35f075bda52aefb0c913f062d331c31d0d47b30856f772da21adf5ab90abeeb09384f8d1091223b1ebf14dfc4c490eb
+  checksum: 1815a3628aeed41212ae411728267a29e99a309f0cff4d84f90bc7188125be0996d81ca4e7c747751f598749edad426a4c1fe9d78df2110022ca24455d45ca43
   languageName: node
   linkType: hard
 
@@ -6742,11 +6732,11 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^4.14.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.16.1"
+  version: 4.17.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.17.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.16.1
-    "@typescript-eslint/scope-manager": 4.16.1
+    "@typescript-eslint/experimental-utils": 4.17.0
+    "@typescript-eslint/scope-manager": 4.17.0
     debug: ^4.1.1
     functional-red-black-tree: ^1.0.1
     lodash: ^4.17.15
@@ -6759,23 +6749,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 873347906fdfe9a70dc80b80f1cbcc6dff00fae5a367ec186e52c6ce616941aa757cd5bc8dbba706f86633df4af396e6c33d68b890983444417a3e76a94c9ad4
+  checksum: d836f5ec39c878df1352e86d0869562519c982e26f772179e7f7f49318305a1c1e1ea388b154d379a1d58a9a799d4403fc96597ce1bf10dc051a0a832db27771
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/experimental-utils@npm:4.16.1"
+"@typescript-eslint/experimental-utils@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@typescript-eslint/experimental-utils@npm:4.17.0"
   dependencies:
     "@types/json-schema": ^7.0.3
-    "@typescript-eslint/scope-manager": 4.16.1
-    "@typescript-eslint/types": 4.16.1
-    "@typescript-eslint/typescript-estree": 4.16.1
+    "@typescript-eslint/scope-manager": 4.17.0
+    "@typescript-eslint/types": 4.17.0
+    "@typescript-eslint/typescript-estree": 4.17.0
     eslint-scope: ^5.0.0
     eslint-utils: ^2.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 526ca13632841963ed29fcd3688ff300d5ee3ecd442b8e1e540bee7fe09e4595cd43da7aa6c3c5f27c8876f55c823b4fd34e9639ceaf1f8af2a5db4561c57e82
+  checksum: 47ce799425c766cd8b6b4b81f1091c2485cf273925c328315af66b0e68241f3d6af1732bbe00f446474e6e269c4e84dab1d2ede6e5d7393099dd182b0458b096
   languageName: node
   linkType: hard
 
@@ -6794,36 +6784,36 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^4.14.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/parser@npm:4.16.1"
+  version: 4.17.0
+  resolution: "@typescript-eslint/parser@npm:4.17.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.16.1
-    "@typescript-eslint/types": 4.16.1
-    "@typescript-eslint/typescript-estree": 4.16.1
+    "@typescript-eslint/scope-manager": 4.17.0
+    "@typescript-eslint/types": 4.17.0
+    "@typescript-eslint/typescript-estree": 4.17.0
     debug: ^4.1.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 9ce7c8b2ec9679c6428b44fe06f6a56f145b54b72549691d97e3d6a4ffd0fc116ca61bdef695e77c3217fc30f2988434078e09009ab2dc5ec028e6f3cecb9a16
+  checksum: 69e56c3916e43896e13a823cb79d4ebe45adffc45e7d6f7bbc96ed842916735abada3dd6651436c024aaf4fe6eb747465e42a869c4863bf7d1104b0f943eceda
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/scope-manager@npm:4.16.1"
+"@typescript-eslint/scope-manager@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@typescript-eslint/scope-manager@npm:4.17.0"
   dependencies:
-    "@typescript-eslint/types": 4.16.1
-    "@typescript-eslint/visitor-keys": 4.16.1
-  checksum: 2872ae6b3c1afe6d0de2168cf4c14864ac6183de8db081f8efc236a4a6f6448d59f80abc529ab3b50b48b8a9a5b21c4bacbad8936a384ca3c2f1bb4b950fd4de
+    "@typescript-eslint/types": 4.17.0
+    "@typescript-eslint/visitor-keys": 4.17.0
+  checksum: 0b4eedc7c209b5006db027b58883356657352483baba61eecbbaa78c3255daadfdbde24dfc6bfae504e4208bf84b6b9e010fcf5187870ee9144e9075597d2912
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/types@npm:4.16.1"
-  checksum: 5df220b8dff372540921d8ef478f4107e6eb51824e7346c942dafc2d181cd937983fa80f44c2e94abf28b57a303e72205915d2bca13ac37c028a98710fd37baa
+"@typescript-eslint/types@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@typescript-eslint/types@npm:4.17.0"
+  checksum: a94e1b1d0284f04a0e73b1b7acfcf732a7eb489e06bff671fdbf1ec1c964a01987bff8701cb6e6b54c3450bf976444ae2fcbae6d76177cc04ddc4c452fd6d75f
   languageName: node
   linkType: hard
 
@@ -6845,12 +6835,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/typescript-estree@npm:4.16.1"
+"@typescript-eslint/typescript-estree@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@typescript-eslint/typescript-estree@npm:4.17.0"
   dependencies:
-    "@typescript-eslint/types": 4.16.1
-    "@typescript-eslint/visitor-keys": 4.16.1
+    "@typescript-eslint/types": 4.17.0
+    "@typescript-eslint/visitor-keys": 4.17.0
     debug: ^4.1.1
     globby: ^11.0.1
     is-glob: ^4.0.1
@@ -6859,17 +6849,17 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: d09de17eb15f08a44574d62a3eadcacd6d331372bd7525cfb7d08d9caeb8d09c2f5a195927ea48a71996337baab47bf9c7d50549c160b901be6a6bc1df9c3f39
+  checksum: 502af03c3ab2f58520afa77e772a7fd8bf428f504f776c04435b7038eecb89368463a3a5147a6a35f500de2c780449d9a33b30b17b149905344524eae9a6f2d3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.16.1":
-  version: 4.16.1
-  resolution: "@typescript-eslint/visitor-keys@npm:4.16.1"
+"@typescript-eslint/visitor-keys@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@typescript-eslint/visitor-keys@npm:4.17.0"
   dependencies:
-    "@typescript-eslint/types": 4.16.1
+    "@typescript-eslint/types": 4.17.0
     eslint-visitor-keys: ^2.0.0
-  checksum: 7b3f87165fc3533e80c8e5848306dca7ffbe7a6c04c40895cb5cdbfdf55bca606933efae20c16d91576e0ab926f8f539257b1fb13231aac3b0c8ad9d741042c9
+  checksum: 04156bce01aafde8127f1a87d356ee7c1ecb84eb223a11b3ede91722ffd704e2ba51161a9636185e2a95f0b80fddaeb2411edb233a820ab2b5dc16390254aa06
   languageName: node
   linkType: hard
 
@@ -6892,29 +6882,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/local-storage@npm:9.7.4":
-  version: 9.7.4
-  resolution: "@verdaccio/local-storage@npm:9.7.4"
+"@verdaccio/local-storage@npm:9.7.5":
+  version: 9.7.5
+  resolution: "@verdaccio/local-storage@npm:9.7.5"
   dependencies:
     "@verdaccio/commons-api": ^9.7.1
     "@verdaccio/file-locking": ^9.7.2
     "@verdaccio/streams": ^9.7.2
     async: 3.2.0
     level: 5.0.1
-    lodash: 4.17.20
+    lodash: 4.17.21
     mkdirp: 0.5.5
-  checksum: a8cf532694a725dfe0d2a66d3c63ecd1bc2ea0b85841f4dc804aae08838cf19320187629b09e921818cc17ad203dd2162a9d0a0294620ba47edd7df7fab083c4
+  checksum: 98989ecf635a68dcac2debbcd5bbede41f25a82dd090426031c74bb99eee783a2dcc25e81055ab040da8f52e07131b2a3cd1b0db6e78d290353ea9b78dde728a
   languageName: node
   linkType: hard
 
-"@verdaccio/readme@npm:9.7.3":
-  version: 9.7.3
-  resolution: "@verdaccio/readme@npm:9.7.3"
+"@verdaccio/readme@npm:9.7.5":
+  version: 9.7.5
+  resolution: "@verdaccio/readme@npm:9.7.5"
   dependencies:
-    dompurify: 2.0.8
+    dompurify: ^2.2.6
     jsdom: 15.2.1
-    marked: 1.1.1
-  checksum: 72eb013673bcb3804da79b13a56a23527eef4a1017e06d89e683bff5a9b64556b6c46d659999190d54de2a8280b449fd914e07bf233d4add5da294244f6a4c67
+    marked: ^2.0.1
+  checksum: 177bb41a3ae339df067abac744b1c4fea7edb632bcb9b05dbe9ed6db5116f49c6daf52aeb06615340af6b8fc13da2e51cb54f7b01772eb5419c4a7bd1d2849a5
   languageName: node
   linkType: hard
 
@@ -9342,7 +9332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abab@npm:^2.0.0, abab@npm:^2.0.3":
+"abab@npm:^2.0.0, abab@npm:^2.0.3, abab@npm:^2.0.5":
   version: 2.0.5
   resolution: "abab@npm:2.0.5"
   checksum: a42b91bd9dd2451a3fc6996bc8953139904ff7b1a793719205041148da892337afc97ed0589ef2c44765c4da3d688eed145781db1623b611621d805294c367a3
@@ -9492,6 +9482,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 2bde98c28c1be9a08e41e581179b776b43396c9486ce52b2b9848d73c53df38c516b7edba4bacdc84cabc9d7a3299f3b46ef240ae261c38dbf8ddd89f635bd32
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.0.5":
+  version: 8.1.0
+  resolution: "acorn@npm:8.1.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 99ccf30832b00ff7e19dff353479fd303c5a82c4ae0a5c5904a6c03316658b89bbdca40f5d8473e6aedd988a404190abd7b431dbd3160df4c09a10398b84bf1c
   languageName: node
   linkType: hard
 
@@ -9698,14 +9697,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^7.0.2":
-  version: 7.1.1
-  resolution: "ajv@npm:7.1.1"
+  version: 7.2.1
+  resolution: "ajv@npm:7.2.1"
   dependencies:
     fast-deep-equal: ^3.1.1
     json-schema-traverse: ^1.0.0
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
-  checksum: fe4e138529363bf1c8c429e1f3e88480918b538fe4a44660b989cea863714715af75e874aad129ccd5cbcf6647fa457e20b735bb3279a3bca08f11193bae5d19
+  checksum: 34044f60ca45ef8ec850f5d09e4db340bb870639efc1694d54bec7ff4b06b12b077872949223f703d1507bbf3d553b59752f4c327ffcd25726ee27919d586037
   languageName: node
   linkType: hard
 
@@ -9728,15 +9727,15 @@ __metadata:
   linkType: hard
 
 "amazon-cognito-identity-js@npm:^4.5.3":
-  version: 4.5.12
-  resolution: "amazon-cognito-identity-js@npm:4.5.12"
+  version: 4.5.13
+  resolution: "amazon-cognito-identity-js@npm:4.5.13"
   dependencies:
     buffer: 4.9.2
     crypto-js: ^3.3.0
     fast-base64-decode: ^1.0.0
     isomorphic-unfetch: ^3.0.0
     js-cookie: ^2.2.1
-  checksum: 800cb7e88ccb4684cfcca58076f0740b35de3e46a0af9c71b13949c52e1a1ccc04dcec83f516efbc7f4190454a4f1729c0dd94133ee889bc0e37421348311312
+  checksum: 3153f164c8cd020341f5722d5ae5328aa5a42c9208fe9db9c92285fc36f9953500dc9b191f8544e8fbb98c66540d8e8da2be333cce8dc535b0af54be9eb03b0c
   languageName: node
   linkType: hard
 
@@ -10740,8 +10739,8 @@ __metadata:
   linkType: hard
 
 "aws-sdk@npm:^2.0.0, aws-sdk@npm:^2.539.0":
-  version: 2.854.0
-  resolution: "aws-sdk@npm:2.854.0"
+  version: 2.861.0
+  resolution: "aws-sdk@npm:2.861.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -10752,7 +10751,7 @@ __metadata:
     url: 0.10.3
     uuid: 3.3.2
     xml2js: 0.4.19
-  checksum: 0bee9b303ce70ba6d5914c6e48aba838ed04b33c5d49b480a9dadaae90e730377cace2fff6cece0494f8ab69934b9a3e2620ed4a17749acc1e2e454b0af9ace4
+  checksum: b8040824ad1439c66e45477fde327b98e19f1ac91a45fee304a100a7a7df6bf8263f906a56054375b25295367dc56ebeddd022d7cbbbfb2e472845c901c38efa
   languageName: node
   linkType: hard
 
@@ -11169,15 +11168,15 @@ __metadata:
   linkType: hard
 
 "babel-plugin-polyfill-corejs2@npm:^0.1.4":
-  version: 0.1.9
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.1.9"
+  version: 0.1.10
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.1.10"
   dependencies:
     "@babel/compat-data": ^7.13.0
     "@babel/helper-define-polyfill-provider": ^0.1.5
     semver: ^6.1.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 54bb83d6a6302be9c42b779fcff8d6c3204f0a73d345c7daa619bd8e7b08714b68644e7062b57dc8dcfb3b4e97cb1f4202bcff60dc1bbd2eb8d3487ac632ce99
+  checksum: b11a01d9d3a078de5f26eeef8216f29b104239eee3ae93767dccdff9df558d07d159a35941ce5d77d6c658b9017475922831a232f8e60d94056412ba6ef2692b
   languageName: node
   linkType: hard
 
@@ -11486,9 +11485,9 @@ __metadata:
   linkType: hard
 
 "before-after-hook@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "before-after-hook@npm:2.1.1"
-  checksum: 07b84cf850593a22e8d333e2ff3fe9af8d6f6cb661b2a81a88fcd25afc8360413f513d5b7d76dfe877f8d5fe3fa8f8c533d26961955b335b4977ba73692b32e5
+  version: 2.2.0
+  resolution: "before-after-hook@npm:2.2.0"
+  checksum: 93e5f6532752d7136d871f4da57430cf61357a8fef81ee2c4981d9808483ddeb73a5f3d1c3eafcbb3ee079bdc0dc030cdc279ba3b793f0008fd86e30430f4787
   languageName: node
   linkType: hard
 
@@ -12362,9 +12361,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30000989, caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001181":
-  version: 1.0.30001194
-  resolution: "caniuse-lite@npm:1.0.30001194"
-  checksum: e2a47728f3fef1ac54ab0b6efb6f87943a99b8a4a402a567708b5c9a3a0ca0b6f56c436972b6dafd4268304fc1685e58aec3dc7fd5826a5081a76a60dd17f12e
+  version: 1.0.30001198
+  resolution: "caniuse-lite@npm:1.0.30001198"
+  checksum: fe1ac01934933ab2e8db93f68972be9271be3a5505f855cf37e1e1bc716d1cd8e3addeed960a3740ac13d27108bf5492478f7c626d0a237451bdc0d1d6386a26
   languageName: node
   linkType: hard
 
@@ -12793,13 +12792,13 @@ __metadata:
   linkType: hard
 
 "clipboard@npm:^2.0.0":
-  version: 2.0.6
-  resolution: "clipboard@npm:2.0.6"
+  version: 2.0.8
+  resolution: "clipboard@npm:2.0.8"
   dependencies:
     good-listener: ^1.2.2
     select: ^1.1.2
     tiny-emitter: ^2.0.0
-  checksum: 25e2e6b595f764ebb541dfda5c77051200567b5dd2de42ac6ab9681febe1256a977be450ab1d6f0d41554799106cc92e79e167797c8e8b8e88edcb0aec5b5dcb
+  checksum: 8eab011ad8cf2dc794b717483f913550c1be1298c84550917f99734b8c5d6674ab86fe6c074234a9597bf60efddffa2ca11ce0df0f78f7c64c4e6a64302437f8
   languageName: node
   linkType: hard
 
@@ -12981,12 +12980,12 @@ __metadata:
   linkType: hard
 
 "color-string@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "color-string@npm:1.5.4"
+  version: 1.5.5
+  resolution: "color-string@npm:1.5.5"
   dependencies:
     color-name: ^1.0.0
     simple-swizzle: ^0.2.2
-  checksum: 181ab2a0a13dc87b13db1bceab8585c159f1cbf169c4210df61d24349f90e5f6087a18c8c12842dbdd5d4cff9a1008ef86c153201429bc456fb7bf9c9495d366
+  checksum: 3d7799f70d389214757c83bdc27380081dbeee18f90148b883ff7e86e9a599c68ccb8a956b7175e761dcd98d1061fdc58ca89ca4b1f6ca20f8ce05cc8c4e564a
   languageName: node
   linkType: hard
 
@@ -14268,7 +14267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^2.0.0, cssstyle@npm:^2.2.0":
+"cssstyle@npm:^2.0.0, cssstyle@npm:^2.3.0":
   version: 2.3.0
   resolution: "cssstyle@npm:2.3.0"
   dependencies:
@@ -14530,14 +14529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:1.10.3":
-  version: 1.10.3
-  resolution: "dayjs@npm:1.10.3"
-  checksum: df7d13e99a2932c12efb3fc9c36e537ee6722ed1763fb2b74559bf9a864828b3d3eac6d3ae59f0c1dbef8dae52444059d8c8bc540c7edb13d665fcd2b08028e6
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:^1.10.4, dayjs@npm:^1.9.3":
+"dayjs@npm:1.10.4, dayjs@npm:^1.10.4, dayjs@npm:^1.9.3":
   version: 1.10.4
   resolution: "dayjs@npm:1.10.4"
   checksum: 3b7bb2232fff808209870bc72d4b2000941a1aa45f0226e2907f9dd1dda306d4b3a1eb9058450fd2c324b01a007a37809ac6f9b525806a86902c55e2934cd5d5
@@ -14552,9 +14544,9 @@ __metadata:
   linkType: hard
 
 "debounce@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "debounce@npm:1.2.0"
-  checksum: 3eb07f76c54f3563d9183aff9a28c61864aa65c3f5f17acc227ce28dc55fb96faa680aebe3c898af17d3e4dfb6cfb92df6179fa9d5566111b129e1de19cfc7e0
+  version: 1.2.1
+  resolution: "debounce@npm:1.2.1"
+  checksum: 04a00c6c45173ac6fb03ad3a7cf742fa4a86f6bf86b22f5b867085f739d0010ad98cbb92e80d60293faf6efb5452c637941092bd8d783cfeabe55c2000b1b07f
   languageName: node
   linkType: hard
 
@@ -14630,7 +14622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decimal.js@npm:^10.2.0":
+"decimal.js@npm:^10.2.1":
   version: 10.2.1
   resolution: "decimal.js@npm:10.2.1"
   checksum: ba28b27bb8aca6bbb73fbdb51d759961d9ff82218c4aa737b4f4826dee4244618a61c410201bb152950c4915e3d82a86211d1c2a4e23f805ee577574ba115e59
@@ -14748,7 +14740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:^1.0.1":
+"deep-equal@npm:^1.0.1, deep-equal@npm:^1.1.1":
   version: 1.1.1
   resolution: "deep-equal@npm:1.1.1"
   dependencies:
@@ -15410,10 +15402,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:2.0.8":
-  version: 2.0.8
-  resolution: "dompurify@npm:2.0.8"
-  checksum: 3089aeaf76d0889a7233102355ca8a394208a69a5060d777d0db61d9ffd96a40af48d0462107ffe19e81cd2d3389baf77203d4cb557bc9145185e58c7551412a
+"dompurify@npm:^2.2.6":
+  version: 2.2.6
+  resolution: "dompurify@npm:2.2.6"
+  checksum: dfc77c2c603d84d4385a419acbda3f14777bf97f7a33a1de43d8a4f264171d12c916eda923715bc0199bcece20d3d6d3de730f3470d178c8ffdf25ba7ca18aee
   languageName: node
   linkType: hard
 
@@ -15438,13 +15430,13 @@ __metadata:
   linkType: hard
 
 "domutils@npm:^2.4.2":
-  version: 2.4.4
-  resolution: "domutils@npm:2.4.4"
+  version: 2.5.0
+  resolution: "domutils@npm:2.5.0"
   dependencies:
     dom-serializer: ^1.0.1
     domelementtype: ^2.0.1
     domhandler: ^4.0.0
-  checksum: abee29c1aade78506fb9ccb7bd7a2720fb18a87f230a7f7f2e3438458c27dee03b8abad4f3e448ed39da86d2a573e8bc7323d8dd0f2a473f26a455c017e303ce
+  checksum: 92a68066d3abfc821438e0610d656f1a51fe695c993c6b10faf9a4ffa565c23d71907e976c674b83e64d41e2a6c108cfd489a34068a7d9f3d240c44509216670
   languageName: node
   linkType: hard
 
@@ -15687,9 +15679,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.3.247, electron-to-chromium@npm:^1.3.378, electron-to-chromium@npm:^1.3.649":
-  version: 1.3.677
-  resolution: "electron-to-chromium@npm:1.3.677"
-  checksum: bb0c4fa3403af00b2739d0bf2cdf2418641c1ebd1cdfb3084a99aa1efb24e12418a2b0d2d8572d5da04deea61425f67afd94ed2a6dc5ddf3c2c73f785d6d5e32
+  version: 1.3.685
+  resolution: "electron-to-chromium@npm:1.3.685"
+  checksum: 469c41eeb243c378a4bc9ecd3939c6dfc71afb17d9942931dcf90f34b37ba75613d14c5c13abf68d92cdb3db363aafa6346034791091c0ff9e4c2bd0ca520f50
   languageName: node
   linkType: hard
 
@@ -15907,9 +15899,9 @@ __metadata:
   linkType: hard
 
 "env-paths@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "env-paths@npm:2.2.0"
-  checksum: 09de4fd1c068d5965aa8aede852a764b7fb6fa8f1299ba7789bc29c22840ab1985e0c9c55bc6bf40b4276834b8adfa1baf82ec9bc58445d9e75800dc32d78a4f
+  version: 2.2.1
+  resolution: "env-paths@npm:2.2.1"
+  checksum: 9579868bc73526de31682625d89aa08c83f3c87850218f9251f953bf4242428a1020e75cb201ca16b42f2874c3ca175ffc8aa47a88423b546711b7dbf86f79a8
   languageName: node
   linkType: hard
 
@@ -15925,16 +15917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:7.7.3":
-  version: 7.7.3
-  resolution: "envinfo@npm:7.7.3"
-  bin:
-    envinfo: dist/cli.js
-  checksum: 1372214a3f7ab4d5f3cbe112f5bf590c9c5ce8b672ab84a1f15eb09c1df273980e18679eefc96f9e442a5dd7e51ac5f4d8727b36f4db9f4ce00b7ad77c3628ad
-  languageName: node
-  linkType: hard
-
-"envinfo@npm:^7.3.1":
+"envinfo@npm:7.7.4, envinfo@npm:^7.3.1":
   version: 7.7.4
   resolution: "envinfo@npm:7.7.4"
   bin:
@@ -15970,28 +15953,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.2":
-  version: 1.17.7
-  resolution: "es-abstract@npm:1.17.7"
-  dependencies:
-    es-to-primitive: ^1.2.1
-    function-bind: ^1.1.1
-    has: ^1.0.3
-    has-symbols: ^1.0.1
-    is-callable: ^1.2.2
-    is-regex: ^1.1.1
-    object-inspect: ^1.8.0
-    object-keys: ^1.1.1
-    object.assign: ^4.1.1
-    string.prototype.trimend: ^1.0.1
-    string.prototype.trimstart: ^1.0.1
-  checksum: e8dfb81bbabcde46d2309436f107d3e795e4bcb83d78614e0c65ca7baac50522603e363be1b81ad5b1943c93fc02ed550198a7dd0580a671a6171960f2490a97
-  languageName: node
-  linkType: hard
-
-"es-abstract@npm:^1.18.0-next.1, es-abstract@npm:^1.18.0-next.2":
-  version: 1.18.0-next.3
-  resolution: "es-abstract@npm:1.18.0-next.3"
+"es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.2, es-abstract@npm:^1.18.0-next.1, es-abstract@npm:^1.18.0-next.2":
+  version: 1.18.0
+  resolution: "es-abstract@npm:1.18.0"
   dependencies:
     call-bind: ^1.0.2
     es-to-primitive: ^1.2.1
@@ -16009,7 +15973,7 @@ __metadata:
     string.prototype.trimend: ^1.0.4
     string.prototype.trimstart: ^1.0.4
     unbox-primitive: ^1.0.0
-  checksum: 046a82acbeb727f19efed7f7f1692d5f6699dee78a6788d37361374c4cfb4cf68371136d2660dc87e7265f6ed015c10289430900814533977c0b175f50f706d5
+  checksum: 019fa7c51e10532cd07ca3aa9b76e4c6ad6f421e15064205d144da08da54f8fc057edc262f6f95775e0b249ecbb753b497050dd75ab69a3c1c89cb9b734e42ca
   languageName: node
   linkType: hard
 
@@ -16151,7 +16115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:1.x.x, escodegen@npm:^1.11.1, escodegen@npm:^1.14.1":
+"escodegen@npm:1.x.x, escodegen@npm:^1.11.1":
   version: 1.14.3
   resolution: "escodegen@npm:1.14.3"
   dependencies:
@@ -16167,6 +16131,25 @@ __metadata:
     escodegen: bin/escodegen.js
     esgenerate: bin/esgenerate.js
   checksum: 548c5a83a81a51122f1006309a392e1412bb00657f15aca60f01f9d4553851bdaf0519d898fd3ee2bb46f116e03ee48757f4d9a28a7b58bc8c096fd4b33f6cbc
+  languageName: node
+  linkType: hard
+
+"escodegen@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "escodegen@npm:2.0.0"
+  dependencies:
+    esprima: ^4.0.1
+    estraverse: ^5.2.0
+    esutils: ^2.0.2
+    optionator: ^0.8.1
+    source-map: ~0.6.1
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: c49da32cd173570f2076f0d52b80761b2a876dfea2046bfc8c5dc84f76b70105e35b2fed10fe0a8487df14674d46bc30245f3a27e8838601c3c85e68f693f363
   languageName: node
   linkType: hard
 
@@ -18449,11 +18432,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.0, glob-parent@npm:~5.1.0":
-  version: 5.1.1
-  resolution: "glob-parent@npm:5.1.1"
+  version: 5.1.2
+  resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: ^4.0.1
-  checksum: 2af6e196fba4071fb07ba261366e446ba2b320e6db0a2069cf8e12117c5811abc6721f08546148048882d01120df47e56aa5a965517a6e5ba19bfeb792655119
+  checksum: 82fcaa4ce102a0ae01370ed8fd5299ca32184af0418e1c1b613ed851240160558c0cc9712868eb9ca1924f687b07cd9c70c25f303f39f9f376d9a32f94f28e76
   languageName: node
   linkType: hard
 
@@ -18720,9 +18703,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "google-protobuf@npm:^3.5.0":
-  version: 3.15.3
-  resolution: "google-protobuf@npm:3.15.3"
-  checksum: 67bca57bbc2b7278ecf3cab43dcbc4d160867347d5a269fd5a46ec6ac985ad40a1513d83b4e81d1a44f774824347a324004c285c33926889e72ce8549539274e
+  version: 3.15.5
+  resolution: "google-protobuf@npm:3.15.5"
+  checksum: 1268d7eedb61a3b72ae8ff7eda15c8da6aea7d4e54ac84d6d7472ed4b5be4e8e48511b84dd82af1990ad432c61d91a0ba81f85d2dcfce7d47711a97f294db94d
   languageName: node
   linkType: hard
 
@@ -18838,13 +18821,13 @@ fsevents@^1.2.7:
   linkType: hard
 
 "graphql-scalars@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "graphql-scalars@npm:1.8.0"
+  version: 1.9.0
+  resolution: "graphql-scalars@npm:1.9.0"
   dependencies:
     tslib: ~2.1.0
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: 38afa19d8b92558fdf5a5a155e8b74577cd2663e931293f48193aee892a4a4259a16fad46eec2218785b63515f10a2b898bebba5b9a68b89bcb3eca482457763
+  checksum: 8b287771004c00fcdc95e42e81b7b95f254c3ba70bbac75ea775140df8e94dc083a48b071233547936d8eaec61b56b96f800392374e2961226131badded6b704
   languageName: node
   linkType: hard
 
@@ -18946,25 +18929,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.6":
-  version: 4.7.6
-  resolution: "handlebars@npm:4.7.6"
-  dependencies:
-    minimist: ^1.2.5
-    neo-async: ^2.6.0
-    source-map: ^0.6.1
-    uglify-js: ^3.1.4
-    wordwrap: ^1.0.0
-  dependenciesMeta:
-    uglify-js:
-      optional: true
-  bin:
-    handlebars: bin/handlebars
-  checksum: 50276715da3e410f1d485635029b77e09b8c9244d9e49119d5f39ed978a3d44ce94f5d6120efeb707da0ba9dd0cddf140d8d2ac160721d93aa9f4234474ad318
-  languageName: node
-  linkType: hard
-
-"handlebars@npm:^4.7.6":
+"handlebars@npm:4.7.7, handlebars@npm:^4.7.6":
   version: 4.7.7
   resolution: "handlebars@npm:4.7.7"
   dependencies:
@@ -19241,12 +19206,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^3.0.6":
-  version: 3.0.8
-  resolution: "hosted-git-info@npm:3.0.8"
+"hosted-git-info@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "hosted-git-info@npm:4.0.0"
   dependencies:
     lru-cache: ^6.0.0
-  checksum: 686512459ccb7e7eac7833fc4e8e35a0533c0dda5f516025f276ecb620b316010b853c785439ac63702e044ab56b2485cf7e1b088c1f9a46675b9496f7a45683
+  checksum: 540b4a8bd08f9ac5713516862f313ce8843a8465e4ac80ba9328956ee09ba887ca9b0d4044be88b10a2091e4a5e463337f3db0f28f7dd33d4a0c9db18218b162
   languageName: node
   linkType: hard
 
@@ -20383,7 +20348,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-callable@npm:^1.1.4, is-callable@npm:^1.2.2, is-callable@npm:^1.2.3":
+"is-callable@npm:^1.1.4, is-callable@npm:^1.2.3":
   version: 1.2.3
   resolution: "is-callable@npm:1.2.3"
   checksum: 8180a1c4e227e204e199ff355c4f24a80f74536898e16716583aa6a09167f2cceecc188cea750a2f3ae3b163577691595ae8d22bf7bb94b4bbb9fbdfea1bc5c3
@@ -20781,9 +20746,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-path-inside@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "is-path-inside@npm:3.0.2"
-  checksum: 709ba85a713d25fb058a4c2f62e9e7160bcc1a3e48af2f201045cde027fc1efe61a6e1b5c1cf21b8329f764e3649e160976fde14317c1b848caa9c1f31d5beec
+  version: 3.0.3
+  resolution: "is-path-inside@npm:3.0.3"
+  checksum: b19a2937441131e68b9eb9931ec8933bc87743a8f5364f6f7e1b8fc6c1403386ecf305835fb781e3986332fada456d71ff95af77ccda5806b35aac58234f9080
   languageName: node
   linkType: hard
 
@@ -21286,7 +21251,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^26.0.0, jest-diff@npm:^26.6.2":
+"jest-diff@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-diff@npm:26.6.2"
   dependencies:
@@ -21921,41 +21886,41 @@ fsevents@^1.2.7:
   linkType: hard
 
 "jsdom@npm:^16.4.0":
-  version: 16.4.0
-  resolution: "jsdom@npm:16.4.0"
+  version: 16.5.0
+  resolution: "jsdom@npm:16.5.0"
   dependencies:
-    abab: ^2.0.3
-    acorn: ^7.1.1
+    abab: ^2.0.5
+    acorn: ^8.0.5
     acorn-globals: ^6.0.0
     cssom: ^0.4.4
-    cssstyle: ^2.2.0
+    cssstyle: ^2.3.0
     data-urls: ^2.0.0
-    decimal.js: ^10.2.0
+    decimal.js: ^10.2.1
     domexception: ^2.0.1
-    escodegen: ^1.14.1
+    escodegen: ^2.0.0
     html-encoding-sniffer: ^2.0.1
     is-potential-custom-element-name: ^1.0.0
     nwsapi: ^2.2.0
-    parse5: 5.1.1
+    parse5: 6.0.1
     request: ^2.88.2
-    request-promise-native: ^1.0.8
-    saxes: ^5.0.0
+    request-promise-native: ^1.0.9
+    saxes: ^5.0.1
     symbol-tree: ^3.2.4
-    tough-cookie: ^3.0.1
+    tough-cookie: ^4.0.0
     w3c-hr-time: ^1.0.2
     w3c-xmlserializer: ^2.0.0
     webidl-conversions: ^6.1.0
     whatwg-encoding: ^1.0.5
     whatwg-mimetype: ^2.3.0
     whatwg-url: ^8.0.0
-    ws: ^7.2.3
+    ws: ^7.4.4
     xml-name-validator: ^3.0.0
   peerDependencies:
     canvas: ^2.5.0
   peerDependenciesMeta:
     canvas:
       optional: true
-  checksum: adca681df01b62452970357bb941c5a0a67f784afbf32c57bb07d7b3799a853f161e4c7a1ccce75fd9089b5c5e5601acf9eab5fe440899d96c08b5bdc3d2cad5
+  checksum: 651e1f01ea322496f3e55210662195fc5aa9bae15dd7105f2404d8048532b2668f1194ba12f9e9df1c8947be9e1fdcf32393637d587b92b188ed9c40c4baf3ea
   languageName: node
   linkType: hard
 
@@ -22405,10 +22370,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"kleur@npm:4.1.3":
-  version: 4.1.3
-  resolution: "kleur@npm:4.1.3"
-  checksum: 2f7c8faa80c3581c8dad4d6b47a6790744b475a83a6815d05c5730fa3e87e65881be043455cebca99a89f7cab045bfa7eeb3c5f66c9f7c0385f4cb26a688e31b
+"kleur@npm:4.1.4":
+  version: 4.1.4
+  resolution: "kleur@npm:4.1.4"
+  checksum: 18e52c52a0138448dea0137d09ace853e096f1bbc32b99d8781254258b892214718f5f7c2bc25f25d5fb84b4086bca465a4c0b7562e27ae3a25116f77ea6436f
   languageName: node
   linkType: hard
 
@@ -23178,17 +23143,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lodash@npm:4.17.21, lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.0.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:~4.17.10, lodash@npm:~4.17.19":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468
+  languageName: node
+  linkType: hard
+
 "lodash@npm:4.17.5":
   version: 4.17.5
   resolution: "lodash@npm:4.17.5"
   checksum: d67bc6c35238d28c6ea2b7221894733d28a81ebdecb40876154a93ae656ede83f123dfe604c71f052a265437ea0b664bf238e3e282aca1839e9522ae7ee72fc7
-  languageName: node
-  linkType: hard
-
-"lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.0.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:~4.17.10, lodash@npm:~4.17.19":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468
   languageName: node
   linkType: hard
 
@@ -23520,9 +23485,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "map-obj@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "map-obj@npm:4.1.0"
-  checksum: 91827cab5aa21840605cb5e77c8cabd3089251f95f939419a7208c29fb6b1032006d8b2ad9d407c91b6e0a9e282105c1811eabd750df87f8b55ae758f87c2063
+  version: 4.2.0
+  resolution: "map-obj@npm:4.2.0"
+  checksum: 0ee5029e6d4482f378292565e3da1b70364f360e141295c6b3bd9164c916d31dcd43be126085dddd2f10d70846660728657d4ea5fa96baa5b40b03b135068600
   languageName: node
   linkType: hard
 
@@ -23554,21 +23519,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"marked@npm:1.1.1":
-  version: 1.1.1
-  resolution: "marked@npm:1.1.1"
+"marked@npm:2.0.1, marked@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "marked@npm:2.0.1"
   bin:
     marked: bin/marked
-  checksum: 4fb077a99ca6a6a4f389bbe2f27620509a332da6fac019560fc25e0e9636226cc86420ddbcfc6e8956920cbca68d64cd11d03954d22123a95ffc63c2e6c4e0ae
-  languageName: node
-  linkType: hard
-
-"marked@npm:1.2.7":
-  version: 1.2.7
-  resolution: "marked@npm:1.2.7"
-  bin:
-    marked: bin/marked
-  checksum: 52591bd9f0681b9ceb6f43b662078bef56e93510119986595c02f22a8eb5df3d2ce8bf19934de09caf8aac3ba0e7894fe03745a1ec6ffc90d62ab022d5299c1a
+  checksum: dd6f468a96ddfd6efbfdaa2f0fa61899b2ce1f8dac0a93c13d847d0fca6872d1f32362d7fe097932aeabc1dfbd83e33bb009a159860f60551d4c6adbdc5a0faf
   languageName: node
   linkType: hard
 
@@ -23972,16 +23928,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime@npm:2.5.0":
-  version: 2.5.0
-  resolution: "mime@npm:2.5.0"
-  bin:
-    mime: cli.js
-  checksum: 19f6f7046cea23d39fb75ee6b99caf1781303a5cbf189c0f209d5b70e4b467642b64106a9f9d3ffce08b6ddfdcfaa95fb60e449c12ae29fb979c229b978e420b
-  languageName: node
-  linkType: hard
-
-"mime@npm:^2.0.0, mime@npm:^2.4.2, mime@npm:^2.4.4":
+"mime@npm:2.5.2, mime@npm:^2.0.0, mime@npm:^2.4.2, mime@npm:^2.4.4":
   version: 2.5.2
   resolution: "mime@npm:2.5.2"
   bin:
@@ -24925,14 +24872,14 @@ fsevents@^1.2.7:
   linkType: hard
 
 "normalize-package-data@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "normalize-package-data@npm:3.0.0"
+  version: 3.0.1
+  resolution: "normalize-package-data@npm:3.0.1"
   dependencies:
-    hosted-git-info: ^3.0.6
+    hosted-git-info: ^4.0.0
     resolve: ^1.17.0
     semver: ^7.3.2
     validate-npm-package-license: ^3.0.1
-  checksum: 1a7d7a2f984a3627412e1838582e03267a35c0abc18eb2ab4a61354160308b59b03bad1856b7f2687eff02e73b8a26ef2f627accc4c81a50e6b2359e7fd5e35e
+  checksum: b17c234a06b5895e1b9ece172da15d0a21e0c2837e724ec20c948b320e9165d9e74126f4eeba70a4af78350a5f76780ba2f482caafa5fae3b3318069219a2285
   languageName: node
   linkType: hard
 
@@ -25245,7 +25192,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.8.0, object-inspect@npm:^1.9.0":
+"object-inspect@npm:^1.9.0":
   version: 1.9.0
   resolution: "object-inspect@npm:1.9.0"
   checksum: 63b412167d716e332b3233090a9e8cc7951479a6971629fb8a3d00135a2329136c697fbd2f56e48bb132928f01bd0f8c5fe2d7386222f217228ca697b8c3932a
@@ -25285,7 +25232,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.0, object.assign@npm:^4.1.1, object.assign@npm:^4.1.2":
+"object.assign@npm:^4.1.0, object.assign@npm:^4.1.2":
   version: 4.1.2
   resolution: "object.assign@npm:4.1.2"
   dependencies:
@@ -25653,9 +25600,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "p-cancelable@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "p-cancelable@npm:2.0.0"
-  checksum: 966065f056a116a1ca3b6c7064d4d27a65bc1740c25cc60729faa5deea385bbd0f2317aedabb8e64c0cfc3c6b2dafe7f3ea65c267373d6d9be1602af443b4f12
+  version: 2.1.0
+  resolution: "p-cancelable@npm:2.1.0"
+  checksum: 6031b388a3babef83bbfb25e70089f67e88db05968b8cc6ec2ba54e6bd71ebee113681ffaeee8dec807f9b913e1c6e1c2c15f5a3bff1436ec8947c4e81d420c6
   languageName: node
   linkType: hard
 
@@ -26083,10 +26030,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parse5@npm:5.1.1":
-  version: 5.1.1
-  resolution: "parse5@npm:5.1.1"
-  checksum: fad72ff5010ee8a6f0a38b83fc886b71a54d746d5c4ff5aad74d6ba1fe87b9606585bf32aa200b015ce329e0906f50f2851f29876abeacd5c13567c7a0455362
+"parse5@npm:6.0.1":
+  version: 6.0.1
+  resolution: "parse5@npm:6.0.1"
+  checksum: e312014edd76a6dc2eac35248ad53477b2594a7b92b7a00f66169483bb87c3d1d36660daddeb720457418dfe0893eb3ad1043085047fc3699167afa6834cb4c4
   languageName: node
   linkType: hard
 
@@ -27815,7 +27762,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.24, psl@npm:^1.1.28":
+"psl@npm:^1.1.24, psl@npm:^1.1.28, psl@npm:^1.1.33":
   version: 1.8.0
   resolution: "psl@npm:1.8.0"
   checksum: 92d47c6257456878bfa8190d76b84de69bcefdc129eeee3f9fe204c15fd08d35fe5b8627033f39b455e40a9375a1474b25ff4ab2c5448dd8c8f75da692d0f5b4
@@ -28603,18 +28550,18 @@ fsevents@^1.2.7:
   linkType: hard
 
 "react-helmet-async@npm:^1.0.2":
-  version: 1.0.7
-  resolution: "react-helmet-async@npm:1.0.7"
+  version: 1.0.9
+  resolution: "react-helmet-async@npm:1.0.9"
   dependencies:
-    "@babel/runtime": ^7.11.2
+    "@babel/runtime": ^7.12.5
     invariant: ^2.2.4
     prop-types: ^15.7.2
     react-fast-compare: ^3.2.0
     shallowequal: ^1.1.0
   peerDependencies:
-    react: ^16.6.0
-    react-dom: ^16.6.0
-  checksum: 4f42301e17bea201d1014caa526232727f3e2b09ea2acc6bade5f18b2c5c443d468332a862632faf0cd8b167fd73eb4076cf7064134763fbf6e269f8da6a085d
+    react: ^16.6.0 || ^17.0.0
+    react-dom: ^16.6.0 || ^17.0.0
+  checksum: 69d082670e7b09f2df1784d1d58f8361d7bd3f57f37f2f4155aaf4f6cace1c213bb25a4cea9e1bd4bfaeb56b1dc83f614f5f6e4713f9d2465cf3d716c0ec897b
   languageName: node
   linkType: hard
 
@@ -28794,18 +28741,19 @@ fsevents@^1.2.7:
   linkType: hard
 
 "react-popper@npm:^1.3.7":
-  version: 1.3.10
-  resolution: "react-popper@npm:1.3.10"
+  version: 1.3.11
+  resolution: "react-popper@npm:1.3.11"
   dependencies:
     "@babel/runtime": ^7.1.2
     "@hypnosphi/create-react-context": ^0.3.1
+    deep-equal: ^1.1.1
     popper.js: ^1.14.4
     prop-types: ^15.6.1
     typed-styles: ^0.0.7
     warning: ^4.0.2
   peerDependencies:
     react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: d1f6740cd1d70c31fddc9a47465bb78f53488cff6935d0c77ec40427014a6a44f3ab344ae5e5cca643a053dc3f04f8dee8e29ef1349a917673d4d74461919e56
+  checksum: bacaf0f75c71ef4de6d270d32f071e7890795a74def2dae9995bb1bbba5d2bf31945123f6e3d9abfa46929d720e34d37252b694d1a962a2c3472011eeabbddca
   languageName: node
   linkType: hard
 
@@ -29314,16 +29262,16 @@ fsevents@^1.2.7:
   linkType: hard
 
 "recoil@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "recoil@npm:0.1.2"
+  version: 0.1.3
+  resolution: "recoil@npm:0.1.3"
   peerDependencies:
-    react: ^16.13.1
+    react: ">=16.13.1"
   peerDependenciesMeta:
     react-dom:
       optional: true
     react-native:
       optional: true
-  checksum: c69105dd7da74430b2c58d17a9c690ebe6e6364c8a7e79e08ff732d4a3d6154a365dc698113ac29639948a6f0ddee05a34201375235f370fc9e3dc17234ed7b2
+  checksum: 7522cf89cf5f2829e166909912613b0e9db9fb385512eb5a6a7925730719cef47ff3fa398d1d9b62c3bec5fcbf68ef3cb000975e17b6b9e5934078abb3a1bed2
   languageName: node
   linkType: hard
 
@@ -29624,7 +29572,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"request-promise-native@npm:^1.0.7, request-promise-native@npm:^1.0.8":
+"request-promise-native@npm:^1.0.7, request-promise-native@npm:^1.0.9":
   version: 1.0.9
   resolution: "request-promise-native@npm:1.0.9"
   dependencies:
@@ -30397,7 +30345,7 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"saxes@npm:^5.0.0":
+"saxes@npm:^5.0.1":
   version: 5.0.1
   resolution: "saxes@npm:5.0.1"
   dependencies:
@@ -31618,7 +31566,7 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"string.prototype.trimend@npm:^1.0.1, string.prototype.trimend@npm:^1.0.4":
+"string.prototype.trimend@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimend@npm:1.0.4"
   dependencies:
@@ -31628,7 +31576,7 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"string.prototype.trimstart@npm:^1.0.1, string.prototype.trimstart@npm:^1.0.4":
+"string.prototype.trimstart@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimstart@npm:1.0.4"
   dependencies:
@@ -32628,6 +32576,17 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
+"tough-cookie@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "tough-cookie@npm:4.0.0"
+  dependencies:
+    psl: ^1.1.33
+    punycode: ^2.1.1
+    universalify: ^0.1.2
+  checksum: 161dc4728e2801c1bd3b32d4d14abd2762120d9ed0b96d892720440aa04ed0ad6c425c38195265c74366fe01d8aaf1cc0a31636cb18b82c9b6ce630743210235
+  languageName: node
+  linkType: hard
+
 "tough-cookie@npm:~2.4.3":
   version: 2.4.3
   resolution: "tough-cookie@npm:2.4.3"
@@ -32728,10 +32687,9 @@ resolve@1.12.2:
   linkType: hard
 
 "ts-jest@npm:^26.4.4":
-  version: 26.5.2
-  resolution: "ts-jest@npm:26.5.2"
+  version: 26.5.3
+  resolution: "ts-jest@npm:26.5.3"
   dependencies:
-    "@types/jest": 26.x
     bs-logger: 0.x
     buffer-from: 1.x
     fast-json-stable-stringify: 2.x
@@ -32747,7 +32705,7 @@ resolve@1.12.2:
     typescript: ">=3.8 <5.0"
   bin:
     ts-jest: cli.js
-  checksum: f9466241291bde18c6f6c5d61875d861983fa2a1b9b1a2164141418c129b874df2bc15bbc4fbde7fc2cb1fa9cae972d5fb292c79b4777afbe19f7ccf035e5d70
+  checksum: 6f429720812687c60b58464e40452687f8dfd958c7cbaf80c36b5af67d5c90b7a313bad05aa385a7f703b0607163f2e879ed719ea12334868d849175414111e7
   languageName: node
   linkType: hard
 
@@ -32837,13 +32795,13 @@ resolve@1.12.2:
   linkType: hard
 
 "tsutils@npm:^3.17.1":
-  version: 3.20.0
-  resolution: "tsutils@npm:3.20.0"
+  version: 3.21.0
+  resolution: "tsutils@npm:3.21.0"
   dependencies:
     tslib: ^1.8.1
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-  checksum: 9245072f9c0d511e3a30c52ec0bfd5ad91495f85d819426ad5283931d09bbdffe515c5c708ba99a4c2424e4576d37200d3e62df66f0027ca29fcfa76794e9610
+  checksum: a10e746258ca9c8e5cdd5e363259b4e353a6729b432f1b30455b9d84ff3fd2f12a44fedafd13872518b0e951fa8cdf56a5b35908bc91d5bf5e7d342548427f2e
   languageName: node
   linkType: hard
 
@@ -32955,9 +32913,9 @@ resolve@1.12.2:
   linkType: hard
 
 "type@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "type@npm:2.3.0"
-  checksum: e4976037e71df2550cbd84a5e3ff764f3706ebcb21b7c10deb671db5a2d58468cc6604633cf480b816d7649832d9d78a5edad40019b0fa48051e5f3d4bcc8038
+  version: 2.5.0
+  resolution: "type@npm:2.5.0"
+  checksum: 56dd61c60ed02dc75bae7029f95d1e457a9b174f60a75025ce9dc911a01e3918df29a9a29f0bc58d88a2baf18fa399f3898f2fa26d512d61cf9726c2c69920a0
   languageName: node
   linkType: hard
 
@@ -33180,7 +33138,7 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.1.0":
+"universalify@npm:^0.1.0, universalify@npm:^0.1.2":
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 420fc6547357782c700d53e9a92506a8e95345b13e97684c8f9ab75237912ec2ebb6af8ac10d4f7406b7b6bd21c58f6c5c0811414fb0b4091b78b4743fa6806e
@@ -33513,9 +33471,9 @@ resolve@1.12.2:
   linkType: hard
 
 "v8-compile-cache@npm:^2.0.3":
-  version: 2.2.0
-  resolution: "v8-compile-cache@npm:2.2.0"
-  checksum: 1efc9946401fcad7a67619b520d8d12e31c7138090ffd9f98af9b919461fa23d947ecef0eab89cca4037c01d29d25a389ab6c0fac70ee4ed030443b08cdf6cff
+  version: 2.3.0
+  resolution: "v8-compile-cache@npm:2.3.0"
+  checksum: b56f83d9ff14187562badc4955dadeef53ff3abde478ce60759539dd8d5472a91fce9db6083fc2450e54cef6f2110c1a28d8c12162dbf575a6cfcb846986904b
   languageName: node
   linkType: hard
 
@@ -33594,12 +33552,12 @@ resolve@1.12.2:
   linkType: hard
 
 "verdaccio@npm:^4.10.0":
-  version: 4.11.1
-  resolution: "verdaccio@npm:4.11.1"
+  version: 4.11.3
+  resolution: "verdaccio@npm:4.11.3"
   dependencies:
     "@verdaccio/commons-api": 9.7.1
-    "@verdaccio/local-storage": 9.7.4
-    "@verdaccio/readme": 9.7.3
+    "@verdaccio/local-storage": 9.7.5
+    "@verdaccio/readme": 9.7.5
     "@verdaccio/streams": 9.7.2
     "@verdaccio/ui-theme": 1.15.1
     JSONStream: 1.3.5
@@ -33610,18 +33568,18 @@ resolve@1.12.2:
     compression: 1.7.4
     cookies: 0.8.0
     cors: 2.8.5
-    dayjs: 1.10.3
-    envinfo: 7.7.3
+    dayjs: 1.10.4
+    envinfo: 7.7.4
     express: 4.17.1
-    handlebars: 4.7.6
+    handlebars: 4.7.7
     http-errors: 1.8.0
     js-yaml: 3.14.1
     jsonwebtoken: 8.5.1
-    kleur: 4.1.3
-    lodash: 4.17.20
+    kleur: 4.1.4
+    lodash: 4.17.21
     lunr-mutable-indexes: 2.3.2
-    marked: 1.2.7
-    mime: 2.5.0
+    marked: 2.0.1
+    mime: 2.5.2
     minimatch: 3.0.4
     mkdirp: 0.5.5
     mv: 2.1.1
@@ -33632,7 +33590,7 @@ resolve@1.12.2:
     verdaccio-htpasswd: 9.7.2
   bin:
     verdaccio: bin/verdaccio
-  checksum: ce3d6a0963d537e5ee651e1a5c433f6abcfb61fda03c403b5657eea54df278cf985f03181b39aa0fbffec66611cf71d8033ad6499f27404498b8c075aa1682e3
+  checksum: 97e5a578bd94bed063ed1ab3320f9356dea14c336aee52426f5aeae0fa7953abc68a9a883e8dec13123fca167394c33e7c2d9e2b8330b41bfee927e9553dfc8c
   languageName: node
   linkType: hard
 
@@ -34375,9 +34333,9 @@ resolve@1.12.2:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.0.0, ws@npm:^7.2.3":
-  version: 7.4.3
-  resolution: "ws@npm:7.4.3"
+"ws@npm:^7.0.0, ws@npm:^7.4.4":
+  version: 7.4.4
+  resolution: "ws@npm:7.4.4"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -34386,7 +34344,7 @@ resolve@1.12.2:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 493655b7c4589d09ff3c2b6e8870b9ad7f7aea0aff34034e2dbb9a2e13f6868a47b06b423bc2365aec6143500b04ad24fdaecfbd9a6752f8eab2d339182c9884
+  checksum: ad08761ed753cdd3f7172e9a9efc7d74e7e196623cace2380e5f74ff0abd16196e03223bd4148a34278dcbc653ee3841994635419281cbf303b3f22c589e2ec4
   languageName: node
   linkType: hard
 
@@ -34499,9 +34457,9 @@ resolve@1.12.2:
   linkType: hard
 
 "yargs-parser@npm:20.x, yargs-parser@npm:^20.2.3":
-  version: 20.2.6
-  resolution: "yargs-parser@npm:20.2.6"
-  checksum: ed21fc0f35290dc9ce1714e6a3e656ca1901ff59432f3dd43668244879b2cca6acff0bff66df9cfbcd934d4db6e98e57cae6def2700ca823e85449f2fb664660
+  version: 20.2.7
+  resolution: "yargs-parser@npm:20.2.7"
+  checksum: 124e7f1c24c9609d5d1c343f14b83289634e19bb43770708ebb6a19852647aaa0f89edcbf0e5b18a21bee77f54513ab5051518b2950cda69eb607a7c6251aa4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Related Issue
Along the way, in a real Webiny project, we discovered a couple of issues and improvements that can be made to the infrastructure-related Pulumi code, mainly in the production environment section.

1. The production configuration for ElasticSearch had an invalid configuration in the subnets section, causing the production deployment to fail. This has now been addressed (additional private subnet added).
2. We removed the accidental double slash (`//`) in a path of one of the functions.
3. We added the [`protected`](https://www.pulumi.com/docs/intro/concepts/resources/#protect) flag to mission-critical resources: DynamoDB and ElasticSearch databases, Cognito user pool, and important S3 buckets. This will protect users from performing the `yarn webiny destroy` command in the production environment.

## How Has This Been Tested?
Manual.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/110910010-12525380-8311-11eb-9dac-b4b82bae0ede.png)
