### PR TITLE
fix: deny public access to ES domain

### DIFF
--- a/api/pulumi/dev/elasticSearch.ts
+++ b/api/pulumi/dev/elasticSearch.ts
@@ -27,21 +27,61 @@ class ElasticSearch {
             }
         });
 
+        /**
+         * Domain policy defines who can access your Elasticsearch Domain.
+         * For details on Elasticsearch security, read the official documentation:
+         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/security.html
+         */
         new aws.elasticsearch.DomainPolicy(`${domainName}-policy`, {
             domainName: this.domain.domainName.apply(v => `${v}`),
-            accessPolicies: {
-                Version: "2012-10-17",
-                Statement: [
-                    {
-                        Action: ["es:*"],
-                        Principal: {
-                            AWS: ["*"]
+            accessPolicies: Promise.all([aws.getCallerIdentity({})]).then(
+                ([currentCallerIdentity]) => ({
+                    Version: "2012-10-17",
+                    Statement: [
+                        /**
+                         * Allow requests signed with current account
+                         */
+                        {
+                            Effect: "Allow",
+                            Principal: {
+                                AWS: currentCallerIdentity.accountId
+                            },
+                            Action: "es:*",
+                            Resource: this.domain.arn.apply(v => `${v}/*`)
                         },
-                        Effect: "Allow",
-                        Resource: this.domain.arn.apply(v => `${v}/*`)
-                    }
-                ]
-            }
+                        /**
+                         * Deny all other requests
+                         */
+                        {
+                            Effect: "Deny",
+                            Principal: "*",
+                            Action: "es:*",
+                            Resource: this.domain.arn.apply(v => `${v}/*`)
+                        }
+                        /**
+                         * Replace the above `Deny` policy, with the following `Allow` policy to allow access
+                         * from specific IP address. This will be useful for development purposes, when you want
+                         * to access Kibana to inspect your data.
+                         *
+                         * If you need to setup proper user accounts for access to Kibana, you'll need to connect it to
+                         * Cognito User Pool. For instructions, see the official documentation:
+                         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html
+                         */
+
+                        // {
+                        //     Effect: "Allow",
+                        //     Principal: "*",
+                        //     Action: "es:*",
+                        //     Resource: this.domain.arn.apply(v => `${v}/!*`),
+                        //     Condition: {
+                        //         IpAddress: {
+                        //             "aws:SourceIp": "213.149.51.28/32"
+                        //         }
+                        //     }
+                        // }
+                    ]
+                })
+            )
         });
 
         /**

--- a/api/pulumi/dev/elasticSearch.ts
+++ b/api/pulumi/dev/elasticSearch.ts
@@ -48,20 +48,10 @@ class ElasticSearch {
                             },
                             Action: "es:*",
                             Resource: this.domain.arn.apply(v => `${v}/*`)
-                        },
-                        /**
-                         * Deny all other requests
-                         */
-                        {
-                            Effect: "Deny",
-                            Principal: "*",
-                            Action: "es:*",
-                            Resource: this.domain.arn.apply(v => `${v}/*`)
                         }
                         /**
-                         * Replace the above `Deny` policy, with the following `Allow` policy to allow access
-                         * from specific IP address. This will be useful for development purposes, when you want
-                         * to access Kibana to inspect your data.
+                         * Uncomment the following `Allow` policy to allow access from specific IP address.
+                         * This will be useful for development purposes, when you want to access Kibana to inspect your data.
                          *
                          * If you need to setup proper user accounts for access to Kibana, you'll need to connect it to
                          * Cognito User Pool. For instructions, see the official documentation:

--- a/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
@@ -27,21 +27,61 @@ class ElasticSearch {
             }
         });
 
+        /**
+         * Domain policy defines who can access your Elasticsearch Domain.
+         * For details on Elasticsearch security, read the official documentation:
+         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/security.html
+         */
         new aws.elasticsearch.DomainPolicy(`${domainName}-policy`, {
             domainName: this.domain.domainName.apply(v => `${v}`),
-            accessPolicies: {
-                Version: "2012-10-17",
-                Statement: [
-                    {
-                        Action: ["es:*"],
-                        Principal: {
-                            AWS: ["*"]
+            accessPolicies: Promise.all([aws.getCallerIdentity({})]).then(
+                ([currentCallerIdentity]) => ({
+                    Version: "2012-10-17",
+                    Statement: [
+                        /**
+                         * Allow requests signed with current account
+                         */
+                        {
+                            Effect: "Allow",
+                            Principal: {
+                                AWS: currentCallerIdentity.accountId
+                            },
+                            Action: "es:*",
+                            Resource: this.domain.arn.apply(v => `${v}/*`)
                         },
-                        Effect: "Allow",
-                        Resource: this.domain.arn.apply(v => `${v}/*`)
-                    }
-                ]
-            }
+                        /**
+                         * Deny all other requests
+                         */
+                        {
+                            Effect: "Deny",
+                            Principal: "*",
+                            Action: "es:*",
+                            Resource: this.domain.arn.apply(v => `${v}/*`)
+                        }
+                        /**
+                         * Replace the above `Deny` policy, with the following `Allow` policy to allow access
+                         * from specific IP address. This will be useful for development purposes, when you want
+                         * to access Kibana to inspect your data.
+                         *
+                         * If you need to setup proper user accounts for access to Kibana, you'll need to connect it to
+                         * Cognito User Pool. For instructions, see the official documentation:
+                         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html
+                         */
+
+                        // {
+                        //     Effect: "Allow",
+                        //     Principal: "*",
+                        //     Action: "es:*",
+                        //     Resource: this.domain.arn.apply(v => `${v}/!*`),
+                        //     Condition: {
+                        //         IpAddress: {
+                        //             "aws:SourceIp": "213.149.51.28/32"
+                        //         }
+                        //     }
+                        // }
+                    ]
+                })
+            )
         });
 
         /**

--- a/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
@@ -48,20 +48,10 @@ class ElasticSearch {
                             },
                             Action: "es:*",
                             Resource: this.domain.arn.apply(v => `${v}/*`)
-                        },
-                        /**
-                         * Deny all other requests
-                         */
-                        {
-                            Effect: "Deny",
-                            Principal: "*",
-                            Action: "es:*",
-                            Resource: this.domain.arn.apply(v => `${v}/*`)
                         }
                         /**
-                         * Replace the above `Deny` policy, with the following `Allow` policy to allow access
-                         * from specific IP address. This will be useful for development purposes, when you want
-                         * to access Kibana to inspect your data.
+                         * Uncomment the following `Allow` policy to allow access from specific IP address.
+                         * This will be useful for development purposes, when you want to access Kibana to inspect your data.
                          *
                          * If you need to setup proper user accounts for access to Kibana, you'll need to connect it to
                          * Cognito User Pool. For instructions, see the official documentation:

--- a/packages/cwp-template-aws/template/api/pulumi/prod/elasticSearch.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/elasticSearch.ts
@@ -41,23 +41,33 @@ class ElasticSearch {
             { protect: protectedEnvironment }
         );
 
+        /**
+         * Domain policy defines who can access your Elasticsearch Domain.
+         * For details on Elasticsearch security, read the official documentation:
+         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/security.html
+         */
         new aws.elasticsearch.DomainPolicy(
             `${domainName}-policy`,
             {
                 domainName: this.domain.domainName.apply(v => `${v}`),
-                accessPolicies: {
-                    Version: "2012-10-17",
-                    Statement: [
-                        {
-                            Action: ["es:*"],
-                            Principal: {
-                                AWS: ["*"]
-                            },
-                            Effect: "Allow",
-                            Resource: this.domain.arn.apply(v => `${v}/*`)
-                        }
-                    ]
-                }
+                accessPolicies: Promise.all([aws.getCallerIdentity({})]).then(
+                    ([currentCallerIdentity]) => ({
+                        Version: "2012-10-17",
+                        Statement: [
+                            /**
+                             * Allow requests signed with current account
+                             */
+                            {
+                                Effect: "Allow",
+                                Principal: {
+                                    AWS: currentCallerIdentity.accountId
+                                },
+                                Action: "es:*",
+                                Resource: this.domain.arn.apply(v => `${v}/*`)
+                            }
+                        ]
+                    })
+                )
             },
             { protect: protectedEnvironment }
         );


### PR DESCRIPTION
## Related Issue
Currently our `dev` pulumi config deploys a `DomainPolicy` which allows public access to ES Kibana; not the best approach.

## Your solution
Only allow access to ES from current AWS account. All other requests will be blocked. Also add a policy which a developer can uncomment to allow access from a given IP address.

## How Has This Been Tested?
Manually. From now on, when you try to access Kibana, this is what you'll see:
```json
{"Message":"User: anonymous is not authorized to perform: es:ESHttpGet"}
```
