### PR TITLE
fix(api-headless-cms): schema regeneration last changed date

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -38,7 +38,8 @@ const ids = {
     // bug
     field601: shortId.generate(),
     field602: shortId.generate(),
-    field603: shortId.generate()
+    field603: shortId.generate(),
+    field604: shortId.generate()
 };
 
 const models: CmsContentModel[] = [
@@ -46,6 +47,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "title",
         lockedFields: [],
         name: "Category",
@@ -116,6 +118,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "title",
         lockedFields: [],
         name: "Product",
@@ -412,6 +415,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "text",
         lockedFields: [],
         name: "Review",
@@ -512,6 +516,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "fullName",
         lockedFields: [],
         name: "Author",
@@ -552,6 +557,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "name",
         lockedFields: [],
         name: "Fruit",
@@ -950,6 +956,7 @@ const models: CmsContentModel[] = [
     {
         createdOn: new Date(),
         savedOn: new Date(),
+        locale: "en-US",
         titleFieldId: "name",
         lockedFields: [],
         name: "Bug",
@@ -959,7 +966,7 @@ const models: CmsContentModel[] = [
             id: contentModelGroup.id,
             name: contentModelGroup.name
         },
-        layout: [[ids.field601], [ids.field602], [ids.field603]],
+        layout: [[ids.field601], [ids.field602], [ids.field603], [ids.field604]],
         fields: [
             {
                 id: ids.field601,
@@ -1033,6 +1040,37 @@ const models: CmsContentModel[] = [
                         },
                         {
                             label: "High bug value",
+                            value: "3"
+                        }
+                    ]
+                },
+                renderer: {
+                    name: "renderer"
+                }
+            },
+            {
+                id: ids.field604,
+                multipleValues: false,
+                helpText: "",
+                label: "Bug fixed?",
+                type: "number",
+                fieldId: "bugFixed",
+                validation: [],
+                listValidation: [],
+                placeholderText: "A bug is fixed",
+                predefinedValues: {
+                    enabled: true,
+                    values: [
+                        {
+                            label: "No",
+                            value: "1"
+                        },
+                        {
+                            label: "Almost",
+                            value: "2"
+                        },
+                        {
+                            label: "Yes!",
                             value: "3"
                         }
                     ]

--- a/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
@@ -79,7 +79,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "critical",
-                bugValue: 2
+                bugValue: 2,
+                bugFixed: 1
             }
         });
 
@@ -105,7 +106,8 @@ describe("predefined values", () => {
                         },
                         name: "A hard debuggable bug",
                         bugType: "critical",
-                        bugValue: 2
+                        bugValue: 2,
+                        bugFixed: 1
                     },
                     error: null
                 }
@@ -125,7 +127,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "nonExistingBugType",
-                bugValue: 2
+                bugValue: 2,
+                bugFixed: 3
             }
         });
 
@@ -161,7 +164,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "critical",
-                bugValue: 4567
+                bugValue: 4567,
+                bugFixed: 3
             }
         });
 
@@ -197,7 +201,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "nonExistingBug",
-                bugValue: 4567
+                bugValue: 4567,
+                bugFixed: 3
             }
         });
 
@@ -240,7 +245,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "critical",
-                bugValue: 2
+                bugValue: 2,
+                bugFixed: 3
             }
         });
 
@@ -266,7 +272,8 @@ describe("predefined values", () => {
                         },
                         name: "A hard debuggable bug",
                         bugType: "critical",
-                        bugValue: 2
+                        bugValue: 2,
+                        bugFixed: 3
                     },
                     error: null
                 }
@@ -288,7 +295,8 @@ describe("predefined values", () => {
             data: {
                 name: "A hard debuggable bug",
                 bugType: "critical",
-                bugValue: 3
+                bugValue: 3,
+                bugFixed: 3
             }
         });
 
@@ -314,7 +322,8 @@ describe("predefined values", () => {
                         },
                         name: "A hard debuggable bug",
                         bugType: "critical",
-                        bugValue: 3
+                        bugValue: 3,
+                        bugFixed: 3
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/utils/useBugManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useBugManageHandler.ts
@@ -22,6 +22,7 @@ const bugFields = `
     name
     bugType
     bugValue
+    bugFixed
 `;
 
 const errorFields = `

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -1,7 +1,7 @@
 import { boolean } from "boolean";
 import { GraphQLSchema } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import { CmsContext, CmsSettings } from "../types";
+import { CmsContext } from "../types";
 import { I18NLocale } from "@webiny/api-i18n/types";
 import { NotAuthorizedError, NotAuthorizedResponse } from "@webiny/api-security";
 import { ErrorResponse } from "@webiny/handler-graphql";
@@ -44,23 +44,9 @@ const respond = (http, result: unknown) => {
 };
 const schemaList = new Map<string, SchemaCache>();
 
-const getLastModelChange = (settings?: CmsSettings): Date => {
-    if (!settings || !settings.contentModelLastChange) {
-        return new Date();
-    }
-    if (settings.contentModelLastChange instanceof Date) {
-        return settings.contentModelLastChange;
-    }
-    try {
-        return new Date(settings.contentModelLastChange);
-    } catch {
-        return new Date();
-    }
-};
 const generateCacheKey = async (args: Args): Promise<string> => {
     const { context, locale, type } = args;
-    const settings = await context.cms.settings.noAuth().get();
-    const lastModelChange = getLastModelChange(settings);
+    const lastModelChange = await context.cms.settings.getContentModelLastChange();
     return [locale.code, type, lastModelChange.toISOString()].join("#");
 };
 

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -202,10 +202,8 @@ export default (): ContextPlugin<CmsContext> => ({
                     ...model,
                     ...data
                 };
-
-                await afterUpdateHook({ context, model: combinedModel });
-
                 await updateManager(context, combinedModel);
+                await afterUpdateHook({ context, model: combinedModel });
             },
             async update(modelId, data) {
                 await checkPermissions("w");

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreate.hook.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreate.hook.ts
@@ -7,5 +7,7 @@ interface Args {
 }
 
 export const afterCreateHook = async (args: Args): Promise<void> => {
+    const { context } = args;
+    await context.cms.settings.updateContentModelLastChange();
     await runContentModelLifecycleHooks("afterCreate", args);
 };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -630,7 +630,7 @@ export interface CmsSettings {
     /**
      * Last content model change. Used to cache GraphQL schema.
      */
-    contentModelLastChange: Date;
+    contentModelLastChange: string;
 }
 
 /**
@@ -648,10 +648,6 @@ export interface CmsSettingsContext {
          */
         get: () => Promise<CmsSettings | null>;
     };
-    /**
-     * Last content model change. Used to cache GraphQL schema.
-     */
-    contentModelLastChange: Date;
     /**
      * Gets settings model from the database.
      */


### PR DESCRIPTION
## Issue
Headless CMS schema does not regenerate after some content model was changed.

## Your solution
There was settings record missing so it could not be updated.
Added some tests to make sure that schema is regenerated.

## How Has This Been Tested?
Jest tests for contentModel via querying for non-existing field and then updating the model with that field and querying again.
