### PR TITLE
Enable prefixing ES index with the "ELASTIC_SEARCH_INDEX_PREFIX" env variable

### DIFF
--- a/packages/api-file-manager/src/plugins/crud/utils/defaults.ts
+++ b/packages/api-file-manager/src/plugins/crud/utils/defaults.ts
@@ -27,12 +27,15 @@ export default {
     },
     es(context: Context<SecurityContext, TenancyContext>) {
         const tenant = context.security.getTenant();
-        if (tenant) {
-            return {
-                index: tenant.id + "-file-manager"
-            };
+        if (!tenant) {
+            throw new Error("Tenant missing.");
         }
 
-        throw new Error("Tenant missing.");
+        const index = tenant.id + "-file-manager";
+        const prefix = process.env.ELASTIC_SEARCH_INDEX_PREFIX;
+        if (prefix) {
+            return { index: prefix + index };
+        }
+        return { index };
     }
 };

--- a/packages/api-form-builder/src/plugins/crud/defaults.ts
+++ b/packages/api-form-builder/src/plugins/crud/defaults.ts
@@ -27,12 +27,15 @@ export default {
     },
     es(context: Context<SecurityContext, TenancyContext>) {
         const tenant = context.security.getTenant();
-        if (tenant) {
-            return {
-                index: tenant.id + "-form-builder"
-            };
+        if (!tenant) {
+            throw new Error("Tenant missing.");
         }
 
-        throw new Error("Tenant missing.");
+        const index = tenant.id + "-form-builder";
+        const prefix = process.env.ELASTIC_SEARCH_INDEX_PREFIX;
+        if (prefix) {
+            return { index: prefix + index };
+        }
+        return { index };
     }
 };

--- a/packages/api-headless-cms/src/utils.ts
+++ b/packages/api-headless-cms/src/utils.ts
@@ -54,10 +54,12 @@ export const defaults = {
         }
 
         const locale = context.cms.getLocale().code;
-
-        return {
-            index: `${tenant.id}-headless-cms-${locale}-${model.modelId}`.toLowerCase()
-        };
+        const index = `${tenant.id}-headless-cms-${locale}-${model.modelId}`.toLowerCase();
+        const prefix = process.env.ELASTIC_SEARCH_INDEX_PREFIX;
+        if (prefix) {
+            return { index: prefix + index };
+        }
+        return { index };
     }
 };
 

--- a/packages/api-page-builder/src/graphql/crud/utils/defaults.ts
+++ b/packages/api-page-builder/src/graphql/crud/utils/defaults.ts
@@ -1,4 +1,4 @@
-import { PbContext } from "../../../types";
+import { PbContext } from "../../types";
 
 export default {
     db: {
@@ -25,12 +25,15 @@ export default {
     },
     es(context: PbContext) {
         const tenant = context.security.getTenant();
-        if (tenant) {
-            return {
-                index: tenant.id + "-page-builder"
-            };
+        if (!tenant) {
+            throw new Error("Tenant missing.");
         }
 
-        throw new Error("Tenant missing.");
+        const index = tenant.id + "-page-builder";
+        const prefix = process.env.ELASTIC_SEARCH_INDEX_PREFIX;
+        if (prefix) {
+            return { index: prefix + index };
+        }
+        return { index };
     }
 };

--- a/packages/api-page-builder/src/utils/defaults.ts
+++ b/packages/api-page-builder/src/utils/defaults.ts
@@ -15,12 +15,15 @@ export default {
     },
     es(context: Context<TenancyContext>) {
         const tenant = context.security.getTenant();
-        if (tenant) {
-            return {
-                index: tenant.id + "-page-builder"
-            };
+        if (!tenant) {
+            throw new Error("Tenant missing.");
         }
 
-        throw new Error("Tenant missing.");
+        const index = tenant.id + "-page-builder";
+        const prefix = process.env.ELASTIC_SEARCH_INDEX_PREFIX;
+        if (prefix) {
+            return { index: prefix + index };
+        }
+        return { index };
     }
 };


### PR DESCRIPTION
With the `ELASTIC_SEARCH_INDEX_PREFIX` env variable, we can now affect the name of the ElasticSearch index, to which the data is stored by different Webiny applications (PB, FB, CMS, FM).

This is a minor feature, mainly to be used in CI environments.

## How Has This Been Tested?
Jest (existing tests passing).

## Screenshots (if relevant):
N/A