### PR TITLE
feat: add the ability to use ~ for import paths within packages

### DIFF
--- a/packages/cli-plugin-scaffold-admin-app-module/template/tsconfig.build.json
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/tsconfig.build.json
@@ -6,8 +6,11 @@
     "outDir": "dist",
     "rootDir": "src",
     "declarationDir": "dist",
-    "paths": {},
-    "noEmit": false
+    "noEmit": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "references": []
 }

--- a/packages/cli-plugin-scaffold-admin-app-module/template/tsconfig.json
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/tsconfig.json
@@ -3,6 +3,10 @@
   "include": ["src", "__tests__/**/*.ts"],
   "references": [],
   "compilerOptions": {
-    "noEmit": false
+    "noEmit": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   }
 }

--- a/packages/cli-plugin-scaffold-graphql-service/template/tsconfig.build.json
+++ b/packages/cli-plugin-scaffold-graphql-service/template/tsconfig.build.json
@@ -6,7 +6,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "declarationDir": "dist",
-    "paths": {}
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "references": []
 }

--- a/packages/cli-plugin-scaffold-graphql-service/template/tsconfig.json
+++ b/packages/cli-plugin-scaffold-graphql-service/template/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "PATH_TO_TSCONFIG",
   "include": ["src", "__tests__/**/*.ts"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
   "references": []
 }

--- a/packages/cwp-template-aws/template/dependencies.json
+++ b/packages/cwp-template-aws/template/dependencies.json
@@ -27,7 +27,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-lodash": "^3.3.4",
-    "babel-plugin-module-resolver": "^3.2.0",
+    "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-named-asset-import": "^1.0.0-next.154",
     "chalk": "^4.1.0",
     "eslint": "^7.18.0",

--- a/packages/cwp-template-aws/template/example.babel.node.js
+++ b/packages/cwp-template-aws/template/example.babel.node.js
@@ -1,10 +1,10 @@
-const babel = {
+module.exports = {
     presets: [
         [
             "@babel/preset-env",
             {
                 targets: {
-                    node: "10.14.0"
+                    node: "12"
                 }
             }
         ],
@@ -15,8 +15,14 @@ const babel = {
         ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
         ["@babel/plugin-transform-runtime", { useESModules: false }],
         ["babel-plugin-dynamic-import-node"],
-        ["babel-plugin-lodash"]
+        ["babel-plugin-lodash"],
+        [
+            "babel-plugin-module-resolver",
+            {
+                alias: {
+                    "~": "./src"
+                }
+            }
+        ]
     ].filter(Boolean)
 };
-
-module.exports = babel;

--- a/packages/cwp-template-aws/template/example.babel.react.js
+++ b/packages/cwp-template-aws/template/example.babel.react.js
@@ -21,6 +21,7 @@ module.exports = {
         ["@babel/preset-typescript", { isTSX: true, allExtensions: true }]
     ],
     plugins: [
+        "babel-plugin-macros",
         "babel-plugin-lodash",
         "@babel/plugin-proposal-class-properties",
         "@babel/plugin-proposal-throw-expressions",
@@ -49,6 +50,14 @@ module.exports = {
                     svg: {
                         ReactComponent: "@svgr/webpack![path]"
                     }
+                }
+            }
+        ],
+        [
+            "babel-plugin-module-resolver",
+            {
+                alias: {
+                    "~": "./src"
                 }
             }
         ]

--- a/packages/cwp-template-aws/template/jest.config.base.js
+++ b/packages/cwp-template-aws/template/jest.config.base.js
@@ -12,6 +12,9 @@ module.exports = ({ path }, presets = []) => {
         transform: {
             "^.+\\.(ts|tsx)$": "ts-jest"
         },
+        moduleNameMapper: {
+            "~/(.*)": `${path}/src/$1`
+        },
         moduleDirectories: ["node_modules"],
         moduleFileExtensions: ["ts", "js", "tsx"],
         modulePathIgnorePatterns: [],


### PR DESCRIPTION
## Related Issue
Import paths can get messy with all the `../../../../` going on.

## Your solution
Add `babel-plugin-module-resolver` and configs for TS and Jest to support `~` imports, which point to the `src` folder of each package.

## How Has This Been Tested?
Manually.

