### PR TITLE
Fix: PB save element operation

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
@@ -104,7 +104,7 @@ const SaveAction: React.FunctionComponent = ({ children }) => {
             variables: formData.overwrite
                 ? {
                       id: element.source,
-                      data: pick(formData, ["content", "id"])
+                      data: pick(formData, ["content", "id", "preview"])
                   }
                 : { data: pick(formData, ["type", "category", "preview", "name", "content"]) }
         });

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog/domToImage.ts
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog/domToImage.ts
@@ -262,7 +262,7 @@ function makeSvgDataUri(node, width, height) {
         .then(function(xhtml) {
             return (
                 '<foreignObject x="0" y="0" width="100%" height="100%">' +
-                xhtml +
+                encodeURIComponent(xhtml) +
                 "</foreignObject>"
             );
         })


### PR DESCRIPTION
## Related Issue
Closes #1519 #1518 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->

- encode the `SVG` image URI using `encodeURIComponent`
- save `preview` on page element update
## How Has This Been Tested?
Manually, using the admin app.

## Screenshots (if relevant):
![save-block](https://user-images.githubusercontent.com/13612227/111637649-a5165500-881f-11eb-9286-7421eeb5535b.gif)
