### PR TITLE
Headless CMS - normalize values before querying with `contains` operator

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/normalizeContainsOperatorQuery.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/normalizeContainsOperatorQuery.test.ts
@@ -1,0 +1,15 @@
+import { normalizeValue } from "../../src/content/plugins/es/elasticSearchQueryBuilderContainsPlugin";
+
+describe(`GraphQL "contains" operator - query normalization`, () => {
+    test("must properly escape ES reserved characters", async () => {
+        expect(normalizeValue("Sembach Germany")).toBe("*Sembach Germany*");
+        expect(normalizeValue("Sembach\\Germany")).toBe("*Sembach Germany*");
+        expect(normalizeValue("AE0003 - VFW Post 12139 Donnersberg, Sembach-Germany")).toBe(
+            "*AE0003   VFW Post 12139 Donnersberg, Sembach Germany*"
+        );
+
+        expect(normalizeValue('+ 1 - = && || > < ! ( A ) { } [ ] ^ " ~ * ? : \\ 2 /')).toBe(
+            "*  1                 A                         2  *"
+        );
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
@@ -544,7 +544,7 @@ describe("READ - Resolvers", () => {
             () =>
                 listCategories({
                     where: {
-                        title_contains: "*NIMal*"
+                        title_contains: "NIMal"
                     }
                 }).then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === animals.id

--- a/packages/api-headless-cms/__tests__/plugins/es/elasticSearchQueryBuilderContainsPlugin.test.ts
+++ b/packages/api-headless-cms/__tests__/plugins/es/elasticSearchQueryBuilderContainsPlugin.test.ts
@@ -27,6 +27,8 @@ describe("elasticSearchQueryBuilderContainsPlugin", () => {
                 {
                     query_string: {
                         allow_leading_wildcard: true,
+                        // @ts-ignore
+                        default_operator: "AND",
                         fields: ["name"],
                         query: "*John*"
                     }
@@ -34,6 +36,8 @@ describe("elasticSearchQueryBuilderContainsPlugin", () => {
                 {
                     query_string: {
                         allow_leading_wildcard: true,
+                        // @ts-ignore
+                        default_operator: "AND",
                         fields: ["name"],
                         query: "*Doe*"
                     }


### PR DESCRIPTION
## Related Issue

This PR tries to resolve two issues, both related to the `contains` GraphQL operator.

### Escaping of ElasticSearch operators
Using characters like `-`, on the ES side, is interpreted as `not` operator. There are a lot of other operators that can be used, and so, in order to not confuse the user with unexpected results, we are escaping all ES operators.

Note that the user can always tweak this behavior further via the `elastic-search-query-builder-contains` plugin.

#### We are not escaping, we are replacing with " "
I tried just escaping the special characters with `\\`, as per ES docs. After more than an hour (probably two) of fiddling with it and reading different articles, I couldn't get it to work. So in the end, together with @Pavel910, we decided to just replace special characters with " ".

I don't know what's the reason it doesn't work, but it could be something related to how the `*headless-cms*` indices are created. Maybe we need a different `word_separator` there, but seeing how doing that can introduce new problems, I decided not to do it.  Maybe it's because we're using wildcard (`*`) operators when performing the query. I even saw a couple of reports of "can't escape hyphen character" in one of the GitHub issues. 

All in all, we'll have to revisit this in the near future anyhow. For now, I believe this will still return the most expected results to the user, while still not impacting the performance with this change.

### Using `default operator: AND`

We added the `default_operator: "AND"` when performing the `contains` query via ES. This is because, without it, the ES will return all results that contain any of the provided words, which, as we've seen, can return incorrect or unexpected results. Setting the default operator to `AND` will ensure that we only return matches that contain all given words.

## How Has This Been Tested?
Added a Jest test for the ES-characters escape function.

## Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/5121148/112423707-70306380-8d33-11eb-9a02-8cb4e1d090f6.png)

![search-new](https://user-images.githubusercontent.com/5121148/112435478-146ed600-8d45-11eb-8abd-40f754bba144.gif)
