### PR TITLE
Headless CMS - Search Input Fixes

### DIFF
--- a/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import get from "lodash/get";
 import debounce from "lodash/debounce";
+import set from "lodash/set";
+import unset from "lodash/unset";
+import cloneDeep from "lodash/cloneDeep";
 import { css } from "emotion";
 import TimeAgo from "timeago-react";
 import pluralize from "pluralize";
@@ -76,10 +79,16 @@ const ContentDataList = ({
                 query.set("search", filter);
                 // We use the title field with the "contains" operator for doing basic searches.
                 const searchField = contentModel.titleFieldId + "_contains";
-                setListQueryVariables(prevState => ({
-                    ...prevState,
-                    where: { [searchField]: filter }
-                }));
+                setListQueryVariables(prev => {
+                    const next = cloneDeep(prev);
+                    if (filter) {
+                        set(next, `where.${searchField}`, filter);
+                    } else {
+                        unset(next, `where.${searchField}`);
+                    }
+
+                    return next;
+                });
                 history.push(`${baseUrl}?${query.toString()}`);
             }
         }, 250),

--- a/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
@@ -66,24 +66,23 @@ const ContentDataList = ({
     const query = new URLSearchParams(location.search);
     const entryId = query.get("id");
     const searchQuery = query.get("search");
-    const updateSearch = useMemo(
-        () =>
-            debounce(({ filter, query }) => {
-                const search = query.get("search");
-                if (typeof search !== "string" && !filter) {
-                    return;
-                }
-                if (filter !== search) {
-                    query.set("search", filter);
-                    // We use the title field with the "contains" operator for doing basic searches.
-                    const searchField = contentModel.titleFieldId + "_contains";
-                    setListQueryVariables(prevState => ({
-                        ...prevState,
-                        where: { [searchField]: filter }
-                    }));
-                    history.push(`${baseUrl}?${query.toString()}`);
-                }
-            }, 250),
+    const updateSearch = useCallback(
+        debounce(({ filter, query }) => {
+            const search = query.get("search");
+            if (typeof search !== "string" && !filter) {
+                return;
+            }
+            if (filter !== search) {
+                query.set("search", filter);
+                // We use the title field with the "contains" operator for doing basic searches.
+                const searchField = contentModel.titleFieldId + "_contains";
+                setListQueryVariables(prevState => ({
+                    ...prevState,
+                    where: { [searchField]: filter }
+                }));
+                history.push(`${baseUrl}?${query.toString()}`);
+            }
+        }, 250),
         [baseUrl]
     );
 

--- a/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/ContentEntries/ContentDataList.tsx
@@ -60,6 +60,7 @@ const ContentDataList = ({
     const [filter, setFilter] = useState("");
     const [formData, setFormData] = useState(listQueryVariables);
     const { history } = useRouter();
+    const baseUrl = `/cms/content-entries/${contentModel.modelId}`;
 
     // Get entry ID and search query (if any)
     const query = new URLSearchParams(location.search);
@@ -67,7 +68,7 @@ const ContentDataList = ({
     const searchQuery = query.get("search");
     const updateSearch = useMemo(
         () =>
-            debounce(({ filter, query, baseURL }) => {
+            debounce(({ filter, query }) => {
                 const search = query.get("search");
                 if (typeof search !== "string" && !filter) {
                     return;
@@ -80,22 +81,20 @@ const ContentDataList = ({
                         ...prevState,
                         where: { [searchField]: filter }
                     }));
-                    history.push(`${baseURL}?${query.toString()}`);
+                    history.push(`${baseUrl}?${query.toString()}`);
                 }
             }, 250),
-        [contentModel]
+        [baseUrl]
     );
+
     // Set "filter" from search "query" on page load.
     useEffect(() => {
-        if (!filter && searchQuery) {
+        if (searchQuery) {
             setFilter(searchQuery);
         }
-    }, []);
+    }, [baseUrl]);
 
-    useEffect(() => {
-        const baseURL = `/cms/content-entries/${contentModel.modelId}`;
-        updateSearch({ filter, query, baseURL });
-    }, [filter, query, contentModel.modelId]);
+    useEffect(() => updateSearch({ filter, query }), [baseUrl, filter]);
 
     // Generate a query based on current content model
     const LIST_QUERY = useMemo(() => createListQuery(contentModel), [contentModel.modelId]);


### PR DESCRIPTION
This PR resolves three issues.

## Infinite loop
When typing something into the search bar, and navigating to another content model, you end up in an infinite loop.

![infinite-loop](https://user-images.githubusercontent.com/5121148/112433377-70842b00-8d42-11eb-8fcd-dd6a453b4d6e.gif)

## Emptying the search input returns empty results

![no-results](https://user-images.githubusercontent.com/5121148/112433356-6a8e4a00-8d42-11eb-88e0-86896588c631.gif)

## Where Argument Not Correctly Updated
When setting, for example, **only-published** entries filter,  and clearing up the search input, that would also clear the applied **only-published** filter. We still need to have the **only-published** filter enabled if the user selected it.

## How Has This Been Tested?
Manual testing.
