### PR TITLE
fix(cli-plugin-scaffold-graphql-service): graphql types naming

### DIFF
--- a/packages/cli-plugin-scaffold-admin-app-module/src/index.ts
+++ b/packages/cli-plugin-scaffold-admin-app-module/src/index.ts
@@ -367,7 +367,7 @@ ${entity.singular}Plugin()
             );
 
             console.log(
-                "Learn more about app development at https://docs.webiny.com/docs/app-development/introduction."
+                "Learn more about app development at https://www.webiny.com/docs/tutorials/create-an-application/admin-area-package."
             );
         }
     }

--- a/packages/cli-plugin-scaffold-graphql-service/src/index.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/src/index.ts
@@ -483,9 +483,7 @@ in the API playground.`,
             );
 
             console.log(
-                `
-Learn more about scaffolding at https://docs.webiny.com/docs/tutorials/create-an-application/introduction
-`
+                "Learn more about API development at https://www.webiny.com/docs/tutorials/create-an-application/api-package."
             );
         }
     }

--- a/packages/cli-plugin-scaffold-graphql-service/template/src/graphql.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/src/graphql.ts
@@ -119,11 +119,11 @@ const graphql = /* GraphQL */ `
 
         uninstall: TargetUninstallResponse!
     }
-    # we need to extend the original Query with targets so we can write a query like { targets: { listTargets {...} } }
+    # We need to extend the original Query with targets so we can write a query like { targets: { listTargets {...} } }
     extend type Query {
         targets: TargetQuery
     }
-    # we need to extend the original Mutation with targets so we can write a mutation like { targets: { createTarget {...} } }
+    # We need to extend the original Mutation with targets so we can write a mutation like { targets: { createTarget {...} } }
     extend type Mutation {
         targets: TargetMutation
     }

--- a/packages/cli-plugin-scaffold-graphql-service/template/src/graphql.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/src/graphql.ts
@@ -20,7 +20,7 @@ const graphql = /* GraphQL */ `
         data: JSON
     }
     # target is created by whom?
-    type CreatedByResponse {
+    type TargetCreatedByResponse {
         id: String!
         displayName: String!
         type: String!
@@ -30,7 +30,7 @@ const graphql = /* GraphQL */ `
         id: ID!
         createdOn: DateTime!
         savedOn: DateTime!
-        createdBy: CreatedByResponse!
+        createdBy: TargetCreatedByResponse!
         title: String!
         description: String
         isNice: Boolean!
@@ -85,12 +85,12 @@ const graphql = /* GraphQL */ `
         error: TargetError
     }
     # A type definition to add the Elasticsearch index
-    type InstallResponse {
+    type TargetInstallResponse {
         data: Boolean
         error: TargetError
     }
     # A type definition to remove the Elasticsearch index
-    type UninstallResponse {
+    type TargetUninstallResponse {
         data: Boolean
         error: TargetError
     }
@@ -105,7 +105,7 @@ const graphql = /* GraphQL */ `
             after: String
         ): TargetListResponse!
 
-        isInstalled: InstallResponse!
+        isInstalled: TargetInstallResponse!
     }
 
     type TargetMutation {
@@ -115,9 +115,9 @@ const graphql = /* GraphQL */ `
 
         deleteTarget(id: ID!): TargetDeleteResponse!
 
-        install: InstallResponse!
+        install: TargetInstallResponse!
 
-        uninstall: UninstallResponse!
+        uninstall: TargetUninstallResponse!
     }
     # we need to extend the original Query with targets so we can write a query like { targets: { listTargets {...} } }
     extend type Query {


### PR DESCRIPTION
## Related Issue
The problem when using graphql scaffold multiple times is that CreatedByResponse, InstallResponse and UninstallResponse are not prefixed with the created model name (Target) so graphql breaks due to multiple definitions.

## Your solution
Prefix the responses with Target (model name).

## How Has This Been Tested?
Created Toy, Car and Beer APIs and deployed them. Ran the InstallMutation and UninstallMutation.
