### PR TITLE
Fix: UI improvements in new account form

### DIFF
--- a/apps/admin/code/src/plugins/security.ts
+++ b/apps/admin/code/src/plugins/security.ts
@@ -24,7 +24,11 @@ export default [
     /**
      * Add Cognito password field to user views.
      */
-    cognitoIdentityProvider(),
+    cognitoIdentityProvider({
+        passwordPolicy: {
+            minimumLength: 8
+        }
+    }),
     /**
      * User menu plugins
      */

--- a/apps/admin/code/src/plugins/security.ts
+++ b/apps/admin/code/src/plugins/security.ts
@@ -24,11 +24,7 @@ export default [
     /**
      * Add Cognito password field to user views.
      */
-    cognitoIdentityProvider({
-        passwordPolicy: {
-            minimumLength: 8
-        }
-    }),
+    cognitoIdentityProvider(),
     /**
      * User menu plugins
      */

--- a/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
+++ b/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
@@ -25,7 +25,7 @@ export const createCognitoPasswordValidator = (policy: PasswordPolicy) => (value
     }
 
     if (policy.requireUppercase && !requireUppercase.test(value)) {
-        throw new ValidationError("Value must contain a uppercase character.");
+        throw new ValidationError("Value must contain an uppercase character.");
     }
 
     if (policy.requireSymbols && !requireSymbols.test(value)) {

--- a/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
+++ b/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
@@ -1,24 +1,7 @@
-import { validation, ValidationError } from "@webiny/validation";
+import { ValidationError } from "@webiny/validation";
 import { PasswordPolicy } from "../types";
 
-const COGNITO_PASSWORD_POLICY = "cognitoPasswordPolicy";
-
-export const cognitoPasswordValidator = (policy: PasswordPolicy): string => {
-    // Create custom validator
-    const cognitoPasswordValidator = createCognitoPasswordValidator(policy);
-
-    validation.setValidator(COGNITO_PASSWORD_POLICY, cognitoPasswordValidator);
-
-    let validator = COGNITO_PASSWORD_POLICY;
-
-    if (policy.minimumLength !== undefined) {
-        validator += `,minLength:${policy.minimumLength}`;
-    }
-
-    return validator;
-};
-
-const createCognitoPasswordValidator = (policy: PasswordPolicy) => (value: any): void => {
+export const createCognitoPasswordValidator = (policy: PasswordPolicy) => (value: any): void => {
     if (!value) {
         return;
     }
@@ -28,6 +11,10 @@ const createCognitoPasswordValidator = (policy: PasswordPolicy) => (value: any):
     const requireNumber = /[0-9]/;
     const requireLowercase = /[a-z]/;
     const requireUppercase = /[A-Z]/;
+
+    if (policy.minimumLength !== undefined && value.length < policy.minimumLength) {
+        throw new ValidationError(`Value requires at least ${policy.minimumLength} characters.`);
+    }
 
     if (policy.requireLowercase && !requireLowercase.test(value)) {
         throw new ValidationError("Value must contain a lowercase character.");

--- a/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
+++ b/packages/app-plugin-security-cognito/src/identityProvider/cognitoPasswordValidator.ts
@@ -1,0 +1,49 @@
+import { validation, ValidationError } from "@webiny/validation";
+import { PasswordPolicy } from "../types";
+
+const COGNITO_PASSWORD_POLICY = "cognitoPasswordPolicy";
+
+export const cognitoPasswordValidator = (policy: PasswordPolicy): string => {
+    // Create custom validator
+    const cognitoPasswordValidator = createCognitoPasswordValidator(policy);
+
+    validation.setValidator(COGNITO_PASSWORD_POLICY, cognitoPasswordValidator);
+
+    let validator = COGNITO_PASSWORD_POLICY;
+
+    if (policy.minimumLength !== undefined) {
+        validator += `,minLength:${policy.minimumLength}`;
+    }
+
+    return validator;
+};
+
+const createCognitoPasswordValidator = (policy: PasswordPolicy) => (value: any): void => {
+    if (!value) {
+        return;
+    }
+    value = value + "";
+
+    const requireSymbols = /([=+\-^$*.\[\]{}()?"!@#%&/,><':;|_~`])+/;
+    const requireNumber = /[0-9]/;
+    const requireLowercase = /[a-z]/;
+    const requireUppercase = /[A-Z]/;
+
+    if (policy.requireLowercase && !requireLowercase.test(value)) {
+        throw new ValidationError("Value must contain a lowercase character.");
+    }
+
+    if (policy.requireNumbers && !requireNumber.test(value)) {
+        throw new ValidationError("Value must contain a number.");
+    }
+
+    if (policy.requireUppercase && !requireUppercase.test(value)) {
+        throw new ValidationError("Value must contain a uppercase character.");
+    }
+
+    if (policy.requireSymbols && !requireSymbols.test(value)) {
+        throw new ValidationError("Value must contain a special character.");
+    }
+
+    return;
+};

--- a/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
+++ b/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import isEmpty from "lodash/isEmpty";
 import { Cell } from "@webiny/ui/Grid";
 import { Input } from "@webiny/ui/Input";
 import { validation } from "@webiny/validation";
@@ -25,7 +24,7 @@ const defaultPasswordPolicy = {
     requireUppercase: false
 };
 
-export default (options?: CognitoIdentityProviderOptions): PluginCollection => [
+export default (options: CognitoIdentityProviderOptions = {}): PluginCollection => [
     {
         type: "security-installation-form",
         render({ Bind }) {
@@ -58,11 +57,9 @@ export default (options?: CognitoIdentityProviderOptions): PluginCollection => [
     {
         type: "security-user-form",
         render({ Bind, data }) {
-            const cognitoPasswordPolicy = !isEmpty(options && options.passwordPolicy)
-                ? options.passwordPolicy
-                : defaultPasswordPolicy;
+            const policy = Object.assign({}, defaultPasswordPolicy, options.passwordPolicy || {});
 
-            const passwordValidators = [createCognitoPasswordValidator(cognitoPasswordPolicy)];
+            const passwordValidators = [createCognitoPasswordValidator(policy)];
 
             if (!data.createdOn) {
                 passwordValidators.push(validation.create("required"));

--- a/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
+++ b/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
@@ -51,7 +51,11 @@ export default (): PluginCollection => [
                 <Cell span={12}>
                     <Bind
                         name="password"
-                        validators={data.createdOn ? undefined : validation.create("required")}
+                        validators={
+                            data.createdOn
+                                ? validation.create("minLength:8")
+                                : validation.create("required,minLength:8")
+                        }
                     >
                         <Input
                             autoComplete="off"

--- a/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
+++ b/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
@@ -10,13 +10,23 @@ import {
 } from "@webiny/app-security-tenancy/types";
 import { PluginCollection } from "@webiny/plugins/types";
 import { CognitoIdentityProviderArgs } from "../types";
-import { cognitoPasswordValidator } from "./cognitoPasswordValidator";
+import { createCognitoPasswordValidator } from "./cognitoPasswordValidator";
 
 const t1 = i18n.ns("cognito/user-management/installation-form");
 const t2 = i18n.ns("cognito/user-management/user-account-form");
 const t3 = i18n.ns("cognito/user-management/user-form");
 
-export default (options?: CognitoIdentityProviderArgs): PluginCollection => [
+const defaultArgs = {
+    passwordPolicy: {
+        minimumLength: 8,
+        requireLowercase: false,
+        requireNumbers: false,
+        requireSymbols: false,
+        requireUppercase: false
+    }
+};
+
+export default (options: CognitoIdentityProviderArgs = defaultArgs): PluginCollection => [
     {
         type: "security-installation-form",
         render({ Bind }) {
@@ -52,9 +62,7 @@ export default (options?: CognitoIdentityProviderArgs): PluginCollection => [
             const passwordValidators = [];
 
             if (options && options.passwordPolicy) {
-                passwordValidators.push(
-                    validation.create(cognitoPasswordValidator(options.passwordPolicy))
-                );
+                passwordValidators.push(createCognitoPasswordValidator(options.passwordPolicy));
             }
 
             if (!data.createdOn) {

--- a/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
+++ b/packages/app-plugin-security-cognito/src/identityProvider/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import isEmpty from "lodash/isEmpty";
 import { Cell } from "@webiny/ui/Grid";
 import { Input } from "@webiny/ui/Input";
 import { validation } from "@webiny/validation";
@@ -9,24 +10,22 @@ import {
     SecurityUserFormPlugin
 } from "@webiny/app-security-tenancy/types";
 import { PluginCollection } from "@webiny/plugins/types";
-import { CognitoIdentityProviderArgs } from "../types";
+import { CognitoIdentityProviderOptions } from "../types";
 import { createCognitoPasswordValidator } from "./cognitoPasswordValidator";
 
 const t1 = i18n.ns("cognito/user-management/installation-form");
 const t2 = i18n.ns("cognito/user-management/user-account-form");
 const t3 = i18n.ns("cognito/user-management/user-form");
 
-const defaultArgs = {
-    passwordPolicy: {
-        minimumLength: 8,
-        requireLowercase: false,
-        requireNumbers: false,
-        requireSymbols: false,
-        requireUppercase: false
-    }
+const defaultPasswordPolicy = {
+    minimumLength: 8,
+    requireLowercase: false,
+    requireNumbers: false,
+    requireSymbols: false,
+    requireUppercase: false
 };
 
-export default (options: CognitoIdentityProviderArgs = defaultArgs): PluginCollection => [
+export default (options?: CognitoIdentityProviderOptions): PluginCollection => [
     {
         type: "security-installation-form",
         render({ Bind }) {
@@ -59,11 +58,11 @@ export default (options: CognitoIdentityProviderArgs = defaultArgs): PluginColle
     {
         type: "security-user-form",
         render({ Bind, data }) {
-            const passwordValidators = [];
+            const cognitoPasswordPolicy = !isEmpty(options && options.passwordPolicy)
+                ? options.passwordPolicy
+                : defaultPasswordPolicy;
 
-            if (options && options.passwordPolicy) {
-                passwordValidators.push(createCognitoPasswordValidator(options.passwordPolicy));
-            }
+            const passwordValidators = [createCognitoPasswordValidator(cognitoPasswordPolicy)];
 
             if (!data.createdOn) {
                 passwordValidators.push(validation.create("required"));

--- a/packages/app-plugin-security-cognito/src/types.ts
+++ b/packages/app-plugin-security-cognito/src/types.ts
@@ -1,0 +1,11 @@
+export type PasswordPolicy = {
+    minimumLength?: number;
+    requireLowercase?: boolean;
+    requireNumbers?: boolean;
+    requireSymbols?: boolean;
+    requireUppercase?: boolean;
+};
+
+export type CognitoIdentityProviderArgs = {
+    passwordPolicy?: PasswordPolicy;
+};

--- a/packages/app-plugin-security-cognito/src/types.ts
+++ b/packages/app-plugin-security-cognito/src/types.ts
@@ -6,6 +6,6 @@ export type PasswordPolicy = {
     requireUppercase?: boolean;
 };
 
-export type CognitoIdentityProviderArgs = {
+export type CognitoIdentityProviderOptions = {
     passwordPolicy?: PasswordPolicy;
 };

--- a/packages/app-security-tenancy/src/views/Users/UsersForm.tsx
+++ b/packages/app-security-tenancy/src/views/Users/UsersForm.tsx
@@ -203,6 +203,7 @@ const UsersForm = () => {
                                         description="Assign to security group"
                                         title="Group"
                                         icon={<SecurityIcon />}
+                                        open
                                     >
                                         <Cell span={12} style={{ marginBottom: "8px" }}>
                                             <Bind


### PR DESCRIPTION
## Changes
This PR introduces the following two UI improvements in the new user account form:
- make the `group` accordion-item open by default so that the validation message is more accessible to user
- add `minLength:8` validator to password field

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually using the admin app:

![image](https://user-images.githubusercontent.com/13612227/112986371-08d54200-917f-11eb-98b3-7d5c848a6a05.png)


