### PR TITLE
fix: update `ImagesList` element type

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
@@ -24,7 +24,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
         }
     });
 
-    const elementType = kebabCase(args.elementType || "image-list");
+    const elementType = kebabCase(args.elementType || "images-list");
 
     const defaultToolbar = {
         title: "Image Gallery",
@@ -81,7 +81,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
         {
             name: "pb-editor-page-element-advanced-settings-images-list-filter",
             type: "pb-editor-page-element-advanced-settings",
-            elementType: "images-list",
+            elementType: elementType,
             render(props) {
                 return <ImagesListImagesSettings {...props} filter />;
             }
@@ -89,7 +89,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
         {
             name: "pb-editor-page-element-advanced-settings-images-list-design",
             type: "pb-editor-page-element-advanced-settings",
-            elementType: "images-list",
+            elementType: elementType,
             render(props) {
                 return <ImagesListDesignSettings {...props} />;
             }


### PR DESCRIPTION
## Changes
This PR includes the fix the `ImagesList` element settings not showing up in the Page Builder editor bug.

## How Has This Been Tested?
Manually using the admin app:

Before:
--
![image](https://user-images.githubusercontent.com/13612227/113391413-1eca4900-93b1-11eb-89b7-407429f32396.png)

After:
--
![image](https://user-images.githubusercontent.com/13612227/113391532-4ae5ca00-93b1-11eb-9304-826075eed8f0.png)


 