### PR TITLE
feat(api-plugin-elastic-search-client): enable connecting to multiple services

### DIFF
--- a/packages/api-plugin-elastic-search-client/src/index.ts
+++ b/packages/api-plugin-elastic-search-client/src/index.ts
@@ -1,21 +1,30 @@
-import { Client } from "@elastic/elasticsearch";
+import { Client, ClientOptions } from "@elastic/elasticsearch";
 import AWS from "aws-sdk";
 import createAwsElasticsearchConnector from "aws-elasticsearch-connector";
 import { ContextPlugin } from "@webiny/handler/types";
 
-interface Params {
-    endpoint: string;
+interface ElasticsearchClientOptions extends ClientOptions {
+    endpoint?: string;
 }
 
-export default ({ endpoint }: Params): ContextPlugin => {
+export default (options: ElasticsearchClientOptions): ContextPlugin => {
+    const { endpoint, node, ...rest } = options;
+
     return {
         type: "context",
         name: "context-elastic-search",
         async apply(context) {
-            context.elasticSearch = new Client({
-                ...createAwsElasticsearchConnector(AWS.config),
-                node: endpoint
-            });
+            const clientOptions: ClientOptions = {
+                node: endpoint || node,
+                ...rest
+            };
+
+            if (!clientOptions.auth) {
+                // If no `auth` configuration is present, we setup AWS connector.
+                Object.assign(clientOptions, createAwsElasticsearchConnector(AWS.config));
+            }
+
+            context.elasticSearch = new Client(clientOptions);
         }
     };
 };


### PR DESCRIPTION
## Changes
Enable connecting to different Elasticsearch services (currently only AWS)

## How Has This Been Tested?
Jest tests.