### PR TITLE
feat(api-security-tenancy): cache permissions and users

### DIFF
--- a/packages/api-security-tenancy/package.json
+++ b/packages/api-security-tenancy/package.json
@@ -13,6 +13,7 @@
     "@commodo/fields": "1.1.2-beta.20",
     "@webiny/api-security": "^5.3.0",
     "@webiny/db-dynamodb": "^5.3.0",
+    "@webiny/error": "^5.3.0",
     "@webiny/handler": "^5.3.0",
     "@webiny/handler-aws": "^5.3.0",
     "@webiny/handler-db": "^5.3.0",
@@ -21,6 +22,7 @@
     "@webiny/plugins": "^5.3.0",
     "@webiny/validation": "^5.3.0",
     "commodo-fields-object": "^1.0.6",
+    "dataloader": "^2.0.0",
     "deep-equal": "^2.0.4",
     "md5": "^2.3.0",
     "mdbid": "^1.0.0"

--- a/packages/api-security-tenancy/src/authorization/anonymous.ts
+++ b/packages/api-security-tenancy/src/authorization/anonymous.ts
@@ -21,7 +21,7 @@ export default () => {
             // and we need to load permissions from the "anonymous" group.
             const group = await security.groups.getGroup(tenant, "anonymous");
 
-            const permissions = group?.permissions || [];
+            const permissions = group ? group.permissions || [] : [];
             permissionCache.set(tenant.id, permissions);
 
             return permissions;

--- a/packages/api-security-tenancy/src/authorization/anonymous.ts
+++ b/packages/api-security-tenancy/src/authorization/anonymous.ts
@@ -1,24 +1,30 @@
 import { TenancyContext } from "../types";
-import { SecurityContext } from "@webiny/api-security/types";
+import { SecurityContext, SecurityPermission } from "@webiny/api-security/types";
 
-export default () => ({
-    type: "security-authorization",
-    name: "security-authorization-anonymous",
-    async getPermissions({ security }: SecurityContext & TenancyContext) {
-        const tenant = security.getTenant();
-        if (!tenant) {
-            return [];
+export default () => {
+    const permissionCache = new Map<string, SecurityPermission[] | null>();
+    return {
+        type: "security-authorization",
+        name: "security-authorization-anonymous",
+        async getPermissions({ security }: SecurityContext & TenancyContext) {
+            const tenant = security.getTenant();
+            if (!tenant) {
+                return [];
+            }
+
+            if (permissionCache.has(tenant.id)) {
+                return permissionCache.get(tenant.id);
+            }
+
+            // We assume that all other authorization plugins have already been executed.
+            // If we've reached this far, it means that we have an anonymous user
+            // and we need to load permissions from the "anonymous" group.
+            const group = await security.groups.getGroup(tenant, "anonymous");
+
+            const permissions = group?.permissions || [];
+            permissionCache.set(tenant.id, permissions);
+
+            return permissions;
         }
-
-        // We assume that all other authorization plugins have already been executed.
-        // If we've reached this far, it means that we have an anonymous user
-        // and we need to load permissions from the "anonymous" group.
-        const group = await security.groups.getGroup(tenant, "anonymous");
-
-        if (!group) {
-            return [];
-        }
-
-        return group?.permissions;
-    }
-});
+    };
+};

--- a/packages/api-security-tenancy/src/authorization/apiKey.ts
+++ b/packages/api-security-tenancy/src/authorization/apiKey.ts
@@ -1,22 +1,32 @@
-import { SecurityAuthorizationPlugin } from "@webiny/api-security/types";
+import { SecurityAuthorizationPlugin, SecurityPermission } from "@webiny/api-security/types";
 
 type APIKeyAuthorization = {
     identityType?: string;
 };
 
-export default (config: APIKeyAuthorization = {}): SecurityAuthorizationPlugin => ({
-    type: "security-authorization",
-    name: "security-authorization-api-key",
-    async getPermissions({ security }) {
-        const identityType = config.identityType || "api-key";
+export default (config: APIKeyAuthorization = {}): SecurityAuthorizationPlugin => {
+    const permissionCache = new Map<string, SecurityPermission[] | null>();
+    return {
+        type: "security-authorization",
+        name: "security-authorization-api-key",
+        async getPermissions({ security }) {
+            const identityType = config.identityType || "api-key";
 
-        const identity = security.getIdentity();
+            const identity = security.getIdentity();
 
-        if (!identity || identity.type !== identityType) {
-            return;
+            if (!identity || identity.type !== identityType) {
+                return;
+            }
+            if (permissionCache.has(identity.id)) {
+                return permissionCache.get(identity.id);
+            }
+            // We can expect `permissions` to exist on the identity, because api-key authentication
+            // plugin sets them on the identity instance to avoid loading them from DB here.
+            const permissions = Array.isArray(identity.permissions) ? identity.permissions : [];
+
+            permissionCache.set(identity.id, permissions);
+
+            return permissions;
         }
-        // We can expect `permissions` to exist on the identity, because api-key authentication
-        // plugin sets them on the identity instance to avoid loading them from DB here.
-        return Array.isArray(identity.permissions) ? identity.permissions : [];
-    }
-});
+    };
+};

--- a/packages/api-security-tenancy/src/authorization/user.ts
+++ b/packages/api-security-tenancy/src/authorization/user.ts
@@ -1,24 +1,37 @@
 import { TenancyContext } from "../types";
-import { SecurityContext } from "@webiny/api-security/types";
+import { SecurityContext, SecurityPermission } from "@webiny/api-security/types";
+import WebinyError from "@webiny/error";
 
-export default ({ identityType }) => ({
-    type: "security-authorization",
-    name: "security-authorization-user",
-    async getPermissions({ security }: SecurityContext & TenancyContext) {
-        const identity = security.getIdentity();
-        const tenant = security.getTenant();
+export default ({ identityType }) => {
+    const permissionCache = new Map<string, SecurityPermission[] | null>();
+    return {
+        type: "security-authorization",
+        name: "security-authorization-user",
+        async getPermissions({ security }: SecurityContext & TenancyContext) {
+            const identity = security.getIdentity();
+            if (!identity || identity.type !== identityType) {
+                return null;
+            }
+            if (permissionCache.has(identity.id)) {
+                return permissionCache.get(identity.id);
+            }
 
-        if (identity && identity.type === identityType) {
-            // TODO: implement via DataLoader to cache User data
             const user = await security.users.getUser(identity.id);
 
             if (!user) {
-                throw Error(`User "${identity.id}" was not found!`);
+                throw WebinyError(`User "${identity.id}" was not found!`, "USER_NOT_FOUND", {
+                    id: identity.id
+                });
             }
 
+            const tenant = security.getTenant();
             const permissions = await security.users.getUserAccess(user.login);
             const tenantAccess = permissions.find(set => set.tenant.id === tenant.id);
-            return tenantAccess.group.permissions ?? null;
+            const value = tenantAccess.group.permissions ?? null;
+
+            permissionCache.set(identity.id, value);
+
+            return value;
         }
-    }
-});
+    };
+};

--- a/packages/api-security-tenancy/src/authorization/user.ts
+++ b/packages/api-security-tenancy/src/authorization/user.ts
@@ -19,7 +19,7 @@ export default ({ identityType }) => {
             const user = await security.users.getUser(identity.id);
 
             if (!user) {
-                throw WebinyError(`User "${identity.id}" was not found!`, "USER_NOT_FOUND", {
+                throw new WebinyError(`User "${identity.id}" was not found!`, "USER_NOT_FOUND", {
                     id: identity.id
                 });
             }

--- a/packages/api-security-tenancy/src/authorization/user.ts
+++ b/packages/api-security-tenancy/src/authorization/user.ts
@@ -1,6 +1,13 @@
-import { TenancyContext } from "../types";
+import { TenancyContext, TenantAccess } from "../types";
 import { SecurityContext, SecurityPermission } from "@webiny/api-security/types";
 import WebinyError from "@webiny/error";
+
+const extractPermissions = (tenantAccess?: TenantAccess): SecurityPermission[] | null => {
+    if (!tenantAccess || !tenantAccess.group || !tenantAccess.group.permissions) {
+        return null;
+    }
+    return tenantAccess.group.permissions;
+};
 
 export default ({ identityType }) => {
     const permissionCache = new Map<string, SecurityPermission[] | null>();
@@ -27,7 +34,7 @@ export default ({ identityType }) => {
             const tenant = security.getTenant();
             const permissions = await security.users.getUserAccess(user.login);
             const tenantAccess = permissions.find(set => set.tenant.id === tenant.id);
-            const value = tenantAccess.group.permissions ?? null;
+            const value = extractPermissions(tenantAccess);
 
             permissionCache.set(identity.id, value);
 

--- a/packages/api-security-tenancy/src/crud/users.crud.ts
+++ b/packages/api-security-tenancy/src/crud/users.crud.ts
@@ -287,10 +287,7 @@ export default (context: DbContext & SecurityContext & TenancyContext): UsersCRU
                     ...data
                 }
             });
-            // loaders.getUser.clear(login);
-            // loaders.getUserAccess.clear(login);
             await addDataLoaderAccessCache(login, data);
-            // await clearDataLoaderAccessCache(login);
         },
         async unlinkUserFromTenant(login, tenant) {
             const [[link]] = await db.read<DbItemSecurityUser2Tenant>({
@@ -309,7 +306,6 @@ export default (context: DbContext & SecurityContext & TenancyContext): UsersCRU
                     SK: link.SK
                 }
             });
-
             await deleteDataLoaderAccessCache(login, tenant);
         },
         async getUserAccess(login) {

--- a/packages/api-security-tenancy/tsconfig.build.json
+++ b/packages/api-security-tenancy/tsconfig.build.json
@@ -5,6 +5,7 @@
     "node_modules",
     "dist",
     "../db-dynamodb",
+    "../error",
     "../handler",
     "../handler-http",
     "../handler-db",

--- a/packages/api-security-tenancy/tsconfig.json
+++ b/packages/api-security-tenancy/tsconfig.json
@@ -9,6 +9,9 @@
       "path": "../db-dynamodb"
     },
     {
+      "path": "../error"
+    },
+    {
       "path": "../handler"
     },
     {
@@ -36,6 +39,8 @@
       "@webiny/api-security": ["../api-security/src"],
       "@webiny/db-dynamodb/*": ["../db-dynamodb/src/*"],
       "@webiny/db-dynamodb": ["../db-dynamodb/src"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
       "@webiny/handler/*": ["../handler/src/*"],
       "@webiny/handler": ["../handler/src"],
       "@webiny/handler-aws/*": ["../handler-aws/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7675,6 +7675,7 @@ __metadata:
     "@commodo/fields": 1.1.2-beta.20
     "@webiny/api-security": ^5.3.0
     "@webiny/db-dynamodb": ^5.3.0
+    "@webiny/error": ^5.3.0
     "@webiny/handler": ^5.3.0
     "@webiny/handler-aws": ^5.3.0
     "@webiny/handler-db": ^5.3.0
@@ -7683,6 +7684,7 @@ __metadata:
     "@webiny/plugins": ^5.3.0
     "@webiny/validation": ^5.3.0
     commodo-fields-object: ^1.0.6
+    dataloader: ^2.0.0
     deep-equal: ^2.0.4
     jest: ^26.6.3
     jest-dynalite: ^3.2.0


### PR DESCRIPTION
## Changes
Add dataloaders to cache getUser and getUserAccess method responses.
Add local variable caching in [user](https://github.com/webiny/webiny-js/blob/d1e3f1ce9ab0839172a76796315933e6972406ef/packages/api-security-tenancy/src/authorization/user.ts) and [anonymous](https://github.com/webiny/webiny-js/blob/d1e3f1ce9ab0839172a76796315933e6972406ef/packages/api-security-tenancy/src/authorization/anonymous.ts) authorization plugins.

## How Has This Been Tested?
Jest tests.
