### PR TITLE
fix(api-security-tenancy): check both upper case and lower case header

### DIFF
--- a/packages/api-security-tenancy/src/context.ts
+++ b/packages/api-security-tenancy/src/context.ts
@@ -11,7 +11,7 @@ const tenantCache = {};
 const getCurrentTenant = async (context: TenancyContext): Promise<Tenant> => {
     const { headers = {} } = context.http.request;
 
-    const tenantId = headers["X-Tenant"] ?? "root";
+    const tenantId = headers["X-Tenant"] || headers["x-tenant"] || "root";
 
     if (!tenantCache[tenantId]) {
         tenantCache[tenantId] = await context.security.tenants.getTenant(tenantId);


### PR DESCRIPTION
## Changes
Fixed tenant loading, by checking both `X-Tenant` and `x-tenant` headers.

## How Has This Been Tested?
Manually, in a demo app that uses multi-tenancy.
