### PR TITLE
Add before-handler plugin

### DIFF
--- a/packages/api-i18n/src/graphql/context.ts
+++ b/packages/api-i18n/src/graphql/context.ts
@@ -1,4 +1,4 @@
-import { ContextPluginInterface } from "@webiny/handler/types";
+import { ContextPlugin } from "@webiny/handler/types";
 import acceptLanguageParser from "accept-language-parser";
 import {
     ContextI18NGetLocales,
@@ -56,7 +56,7 @@ const getLocaleFromHeaders = (http, localeContext = "default") => {
     return { acceptLanguageHeader, contextLocaleHeader };
 };
 
-export default (): ContextPluginInterface<I18NContext & TenancyContext> => ({
+export default (): ContextPlugin<I18NContext, TenancyContext> => ({
     type: "context",
     apply: async context => {
         context.i18n = {

--- a/packages/api-security-tenancy/src/context.ts
+++ b/packages/api-security-tenancy/src/context.ts
@@ -1,4 +1,4 @@
-import { ContextPluginInterface } from "@webiny/handler/types";
+import { ContextPlugin } from "@webiny/handler/types";
 import { TenancyContext, Tenant } from "./types";
 import tenantCrud from "./crud/tenants.crud";
 import userCrud from "./crud/users.crud";
@@ -20,7 +20,7 @@ const getCurrentTenant = async (context: TenancyContext): Promise<Tenant> => {
     return tenantCache[tenantId];
 };
 
-export default (): ContextPluginInterface<TenancyContext> => ({
+export default (): ContextPlugin<TenancyContext> => ({
     type: "context",
     apply: async context => {
         let __tenant = null;

--- a/packages/handler-graphql/src/debugPlugins.ts
+++ b/packages/handler-graphql/src/debugPlugins.ts
@@ -1,4 +1,12 @@
 import { interceptConsole } from "./interceptConsole";
+import { GraphQLAfterQueryPlugin, GraphQLBeforeQueryPlugin } from "./types";
+import { ContextInterface, ContextPlugin } from "@webiny/handler/types";
+
+interface DebugContext extends ContextInterface {
+    debug: {
+        logs?: { method: string; args: any }[];
+    };
+}
 
 export default () => [
     {
@@ -10,18 +18,18 @@ export default () => [
                 context.debug.logs.push({ method, args });
             });
         }
-    },
+    } as ContextPlugin<DebugContext>,
     {
-        type: "handler-graphql-before-query",
-        apply(context) {
+        type: "graphql-before-query",
+        apply({ context }) {
             // Empty logs
             context.debug.logs = [];
         }
-    },
+    } as GraphQLBeforeQueryPlugin<DebugContext>,
     {
-        type: "handler-graphql-after-query",
-        apply(result, context) {
+        type: "graphql-after-query",
+        apply({ result, context }) {
             result["extensions"] = { console: context.debug.logs || [] };
         }
-    }
+    } as GraphQLAfterQueryPlugin<DebugContext>
 ];

--- a/packages/handler-graphql/src/types.ts
+++ b/packages/handler-graphql/src/types.ts
@@ -1,11 +1,15 @@
-import { GraphQLScalarType, GraphQLFieldResolver as BaseGraphQLFieldResolver } from "graphql";
+import {
+    GraphQLScalarType,
+    GraphQLFieldResolver as BaseGraphQLFieldResolver,
+    GraphQLSchema
+} from "graphql";
 import { Plugin } from "@webiny/plugins/types";
 import { ContextInterface } from "@webiny/handler/types";
 
-export type GraphQLScalarPlugin = Plugin & {
+export interface GraphQLScalarPlugin extends Plugin {
     type: "graphql-scalar";
     scalar: GraphQLScalarType;
-};
+}
 
 export interface HandlerGraphQLOptions {
     debug?: boolean | string;
@@ -20,23 +24,47 @@ export type GraphQLFieldResolver<
 // `GraphQLSchemaPlugin` types.
 export type Types = string | (() => string | Promise<string>);
 
-export type GraphQLSchemaPluginTypeArgs = {
+export interface GraphQLSchemaPluginTypeArgs {
     context?: any;
     args?: any;
     source?: any;
-};
+}
 
 export type Resolvers<TContext> =
     | GraphQLScalarType
     | GraphQLFieldResolver<any, Record<string, any>, TContext>
     | { [property: string]: Resolvers<TContext> };
 
-export type GraphQLSchemaDefinition<TContext> = {
+export interface GraphQLSchemaDefinition<TContext> {
     typeDefs: Types;
     resolvers?: Resolvers<TContext>;
-};
+}
 
-export type GraphQLSchemaPlugin<TContext extends ContextInterface = ContextInterface> = Plugin<{
+export interface GraphQLSchemaPlugin<TContext extends ContextInterface = ContextInterface>
+    extends Plugin {
     type: "graphql-schema";
     schema: GraphQLSchemaDefinition<TContext>;
-}>;
+}
+
+export interface GraphQLRequestBody {
+    query: string;
+    variables: Record<string, any>;
+    operationName: string;
+}
+
+export interface GraphQLBeforeQueryPlugin<TContext extends ContextInterface = ContextInterface>
+    extends Plugin {
+    type: "graphql-before-query";
+    apply(params: { body: GraphQLRequestBody; schema: GraphQLSchema; context: TContext }): void;
+}
+
+export interface GraphQLAfterQueryPlugin<TContext extends ContextInterface = ContextInterface>
+    extends Plugin {
+    type: "graphql-after-query";
+    apply(params: {
+        result: any;
+        body: GraphQLRequestBody;
+        schema: GraphQLSchema;
+        context: TContext;
+    }): void;
+}

--- a/packages/handler/src/createHandler.ts
+++ b/packages/handler/src/createHandler.ts
@@ -1,5 +1,5 @@
 import { PluginsContainer } from "@webiny/plugins";
-import { ContextPlugin, HandlerPlugin, HandlerErrorPlugin } from "./types";
+import { ContextPlugin, HandlerPlugin, HandlerErrorPlugin, BeforeHandlerPlugin } from "./types";
 import middleware from "./middleware";
 
 export default (...plugins) => async (...args) => {
@@ -16,6 +16,13 @@ export default (...plugins) => async (...args) => {
         for (let i = 0; i < contextPlugins.length; i++) {
             if (contextPlugins[i].apply) {
                 await contextPlugins[i].apply(context);
+            }
+        }
+
+        const beforeHandlerPlugins = context.plugins.byType<BeforeHandlerPlugin>("before-handler");
+        for (let i = 0; i < beforeHandlerPlugins.length; i++) {
+            if (beforeHandlerPlugins[i].apply) {
+                await beforeHandlerPlugins[i].apply(context);
             }
         }
 

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -34,9 +34,8 @@ export type Context<
     C8 &
     C9;
 
-export interface ContextPluginInterface<T extends ContextInterface = ContextInterface>
-    extends Plugin {
-    type: "context";
+export interface BeforeHandlerPlugin<T extends ContextInterface = ContextInterface> extends Plugin {
+    type: "before-handler";
     apply: (context: T) => Promise<void>;
 }
 


### PR DESCRIPTION
## Changes
During a request lifecycle, we only processed `context` plugins. This posed a problem for authentication plugins, because authentication was executing different DB queries as soon as the `context` plugin was applied - which is too early. Some plugins required the use of CRUD operations, which were not yet present on the `context` object.

I added a `before-handler` plugin to mitigate this. `context` plugins are now only used to populate the `context` object, and authentication is now executed using `before-handler` plugin. At this point the entire `context` is populated and we can safely execute different CRUD operations.

### Other changes
Along the way I also renamed `handler-graphql-before/after-query` plugins to `graphql-before/after-query` to match with other plugins in the `handler-graphql` package. I also added the appropriate TS types for these plugins, and expanded the parameters that get passed to these plugins.

For example, you can now modify the schema in the `graphql-before-query` plugin, and wrap resolvers to measure their execution time.

## How Has This Been Tested?
Unit tests are passing + manual testing.

## Documentation
Documentation of this is coming as part of the security and API development key-topics.

Source of inspiration for this upgrade was this diagram:
![image](https://user-images.githubusercontent.com/3920893/114900211-f3fddd00-9e13-11eb-9fa5-61e3a528cccc.png)
