### PR TITLE
feat(api-headless-cms): search via ref field id

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -83,6 +83,11 @@ export default /* GraphQL */ `
         title_not_in: [String]
         title_contains: String
         title_not_contains: String
+        
+        category: String
+        category_in: [String!]
+        category_not: String
+        category_not_in: [String!]
 
         price: Number
         price_not: Number

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -57,6 +57,11 @@ export default /* GraphQL */ `
         title_contains: String
         title_not_contains: String
 
+        category: String
+        category_in: [String!]
+        category_not: String
+        category_not_in: [String!]
+
         price: Number
         price_not: Number
         price_in: [Number]

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -66,6 +66,11 @@ export default /* GraphQL */ `
         text_not_in: [String]
         text_contains: String
         text_not_contains: String
+        
+        product: String
+        product_in: [String!]
+        product_not: String
+        product_not_in: [String!]
 
         rating: Number
         rating_not: Number
@@ -75,6 +80,11 @@ export default /* GraphQL */ `
         rating_lte: Number
         rating_gt: Number
         rating_gte: Number
+        
+        author: String
+        author_in: [String!]
+        author_not: String
+        author_not_in: [String!]
     }
 
     type ReviewResponse {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.read.ts
@@ -46,6 +46,11 @@ export default /* GraphQL */ `
         text_contains: String
         text_not_contains: String
 
+        product: String
+        product_in: [String!]
+        product_not: String
+        product_not_in: [String!]
+
         rating: Number
         rating_not: Number
         rating_in: [Number]
@@ -54,6 +59,11 @@ export default /* GraphQL */ `
         rating_lte: Number
         rating_gt: Number
         rating_gte: Number
+
+        author: String
+        author_in: [String!]
+        author_not: String
+        author_not_in: [String!]
     }
 
     enum ReviewListSorter {

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry/es/createElasticsearchQueryBody.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry/es/createElasticsearchQueryBody.ts
@@ -197,13 +197,22 @@ const execElasticsearchBuildQueryPlugins = (
                 operator: op
             });
         }
+        const fieldSearchPlugin = searchPlugins[modelFieldOptions.type];
         const value = transformValueForSearch({
             plugins: searchPlugins,
             field: cmsField,
             value: where[key],
             context
         });
-        const fieldWithParent = isSystemField ? null : withParentObject(field);
+        // A possibility to build field custom path in the elasticsearch
+        const customFieldPath =
+            fieldSearchPlugin && typeof fieldSearchPlugin.createPath === "function"
+                ? fieldSearchPlugin.createPath({
+                      field: modelFieldOptions.field,
+                      context
+                  })
+                : null;
+        const fieldWithParent = isSystemField ? null : customFieldPath || withParentObject(field);
         plugin.apply(query, {
             field: fieldWithParent || field,
             value,

--- a/packages/api-headless-cms/src/content/plugins/es/search/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/es/search/index.ts
@@ -1,4 +1,5 @@
 import { ElasticsearchQueryBuilderValueSearchPlugin } from "../../../../types";
 import timeSearch from "./timeSearch";
+import refSearch from "./refSearch";
 
-export default (): ElasticsearchQueryBuilderValueSearchPlugin[] => [timeSearch()];
+export default (): ElasticsearchQueryBuilderValueSearchPlugin[] => [timeSearch(), refSearch()];

--- a/packages/api-headless-cms/src/content/plugins/es/search/refSearch.ts
+++ b/packages/api-headless-cms/src/content/plugins/es/search/refSearch.ts
@@ -1,0 +1,13 @@
+import { ElasticsearchQueryBuilderValueSearchPlugin } from "../../../../types";
+
+export default (): ElasticsearchQueryBuilderValueSearchPlugin => ({
+    type: "cms-elastic-search-query-builder-value-search",
+    name: "cms-elastic-search-query-builder-value-search-ref-field",
+    fieldType: "ref",
+    transform: ({ value }) => {
+        return value;
+    },
+    createPath: ({ field }) => {
+        return `values.${field.fieldId}.entryId`;
+    }
+});

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -1,6 +1,15 @@
 import { CmsContext, CmsModelFieldToGraphQLPlugin } from "../../../types";
 import { createReadTypeName } from "../utils/createTypeName";
 
+const createListFilters = ({ field }) => {
+    return `
+        ${field.fieldId}: String
+        ${field.fieldId}_in: [String!]
+        ${field.fieldId}_not: String
+        ${field.fieldId}_not_in: [String!]
+    `;
+};
+
 const plugin: CmsModelFieldToGraphQLPlugin = {
     name: "cms-model-field-to-graphql-ref",
     type: "cms-model-field-to-graphql",
@@ -52,7 +61,8 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
 
                 return revisions[0];
             };
-        }
+        },
+        createListFilters
     },
     manage: {
         createSchema() {
@@ -84,7 +94,8 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             }
 
             return field.fieldId + ": RefFieldInput";
-        }
+        },
+        createListFilters
     }
 };
 

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1589,6 +1589,10 @@ export interface ElasticsearchQueryBuilderValueSearchPlugin extends Plugin {
      * Transform value that is going to be searched for in the Elasticsearch.
      */
     transform: (args: ElasticsearchQueryBuilderValueSearchPluginArgs) => any;
+    /**
+     * Create a path to search in the Elasticsearch. Default one is values.fieldId.
+     */
+    createPath?: (args: Omit<ElasticsearchQueryBuilderValueSearchPluginArgs, "value">) => string;
 }
 
 /**


### PR DESCRIPTION
## Changes
Added a possibility to find a record with certain ref field id. You can compare by equal, not equal, in and not in operators.

For example:
```graphql
author: "author-id"
author_not: "author-id"
author_in: ["author-id", "another-author-id"]
author_not_in: ["author-id", "another-author-id"]
```

## How Has This Been Tested?
Jest tests on manage and read APis.
