### PR TITLE
Check for yarn blockers during CWP

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "chalk": "2.4.2",
     "dotenv": "8.2.0",
     "execa": "2.1.0",
-    "find-up": "4.1.0",
+    "find-up": "5.0.0",
     "fs-extra": "9.0.1",
     "load-json-file": "6.2.0",
     "ncp": "^2.0.0",

--- a/packages/create-webiny-project/package.json
+++ b/packages/create-webiny-project/package.json
@@ -16,6 +16,7 @@
     "@webiny/tracking": "^5.5.0",
     "chalk": "4.1.0",
     "execa": "^4.1.0",
+    "find-up": "^5.0.0",
     "fs-extra": "9.0.1",
     "js-yaml": "^3.0.0",
     "listr": "0.14.3",

--- a/packages/cwp-template-aws/setup.js
+++ b/packages/cwp-template-aws/setup.js
@@ -121,7 +121,7 @@ const setup = async args => {
                     "yarn webiny --help"
                 )} in your ${green(projectName)} directory.`,
                 "",
-                "Want to delve deeper into Webiny? Check out https://docs.webiny.com!",
+                "Want to dive deeper into Webiny? Check out https://webiny.com/docs/!",
                 "Like the project? Star us on https://github.com/webiny/webiny-js!",
                 "",
                 "Need help? Join our Slack community! https://www.webiny.com/slack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8586,7 +8586,7 @@ __metadata:
     chalk: 2.4.2
     dotenv: 8.2.0
     execa: 2.1.0
-    find-up: 4.1.0
+    find-up: 5.0.0
     fs-extra: 9.0.1
     load-json-file: 6.2.0
     ncp: ^2.0.0
@@ -13913,6 +13913,7 @@ __metadata:
     "@webiny/tracking": ^5.5.0
     chalk: 4.1.0
     execa: ^4.1.0
+    find-up: ^5.0.0
     fs-extra: 9.0.1
     js-yaml: ^3.0.0
     listr: 0.14.3
@@ -17684,6 +17685,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:5.0.0, find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: ^6.0.0
+    path-exists: ^4.0.0
+  checksum: cd0b77415bc59e5af31e4e1b29c6ff8d965d9ca3c60a4b74161f8f116c0d1ad8d35bc6e53bf8f92c69e704e98183f1628a363ed7d519eb28eff54378b8f167a7
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^1.0.0":
   version: 1.1.2
   resolution: "find-up@npm:1.1.2"
@@ -17700,16 +17711,6 @@ __metadata:
   dependencies:
     locate-path: ^2.0.0
   checksum: 9dedb89f936b572f7c9fda3f66ebe146b0000fe9ef16fad94a77c25ce9585962e910bb32c1e08bab9b423985ff20221d2af4b7e4130b27c0f5f60c1aad3f6a7f
-  languageName: node
-  linkType: hard
-
-"find-up@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "find-up@npm:5.0.0"
-  dependencies:
-    locate-path: ^6.0.0
-    path-exists: ^4.0.0
-  checksum: cd0b77415bc59e5af31e4e1b29c6ff8d965d9ca3c60a4b74161f8f116c0d1ad8d35bc6e53bf8f92c69e704e98183f1628a363ed7d519eb28eff54378b8f167a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
Yarn 2 will  complain if there are `yarn.lock` or `package.json` somewhere up in the hierarchy, as it breaks project root detection. I added a check for those files that is executed at the very beginning of `create-webiny-project` and it will print the exact file paths if found so it's easy to clean those up.

Also used this opportunity to update messages and link to docs.

![image](https://user-images.githubusercontent.com/3920893/116427694-89ea2c80-a844-11eb-9165-7d29eb631ac6.png)


## How Has This Been Tested?
Manually.
