### PR TITLE
FileManager - ensure the default `application/octet-stream` MIME type is used, if none provided

### DIFF
--- a/packages/api-file-manager-s3/src/utils/getPresignedPostPayload.ts
+++ b/packages/api-file-manager-s3/src/utils/getPresignedPostPayload.ts
@@ -16,6 +16,12 @@ const sanitizeFileSizeValue = (value, defaultValue) => {
 };
 
 export default async (data, settings) => {
+    // If type is missing, let's use the default "application/octet-stream" type,
+    // which is also the default type that the Amazon S3 would use.
+    if (!data.type) {
+        data.type = "application/octet-stream";
+    }
+
     const contentType = data.type;
     if (!contentType) {
         throw Error(`File's content type could not be resolved.`);
@@ -25,6 +31,7 @@ export default async (data, settings) => {
     if (key) {
         key = uniqueId() + "-" + key;
     }
+
     if (data.keyPrefix) {
         key = `${sanitizeFilename(data.keyPrefix)}-${key}`;
     }

--- a/packages/app-admin/src/components/FileManager/FileManagerView.tsx
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.tsx
@@ -310,12 +310,6 @@ function FileManagerView(props: FileManagerViewProps) {
         const errors = [];
         await Promise.all(
             list.map(async file => {
-                // If type is missing, let's use the default "application/octet-stream" type,
-                // which is also the default type that the Amazon S3 would use.
-                if (!file.type) {
-                    file.type = "application/octet-stream";
-                }
-
                 try {
                     const response = await getFileUploader()(file, { apolloClient });
                     await createFile({ variables: { data: response } });

--- a/packages/app-admin/src/components/FileManager/FileManagerView.tsx
+++ b/packages/app-admin/src/components/FileManager/FileManagerView.tsx
@@ -310,6 +310,12 @@ function FileManagerView(props: FileManagerViewProps) {
         const errors = [];
         await Promise.all(
             list.map(async file => {
+                // If type is missing, let's use the default "application/octet-stream" type,
+                // which is also the default type that the Amazon S3 would use.
+                if (!file.type) {
+                    file.type = "application/octet-stream";
+                }
+
                 try {
                     const response = await getFileUploader()(file, { apolloClient });
                     await createFile({ variables: { data: response } });


### PR DESCRIPTION
## Changes
This PR fixes an issue with the File Manager application. Upon uploading a file, if the MIME type of a file wasn't detected properly, none would be provided, and the upload process would fail.

To fix this, we added a fallback MIME type - `application/octet-stream`, which is the same fallback MIME type that the Amazon S3 uses.

We added this logic to the `api-file-manager-s3` code.

## How Has This Been Tested?
Manual.

## Documentation
N/A