### PR TITLE
fix(app-page-builder): move test formatting styles to theme

### DIFF
--- a/apps/theme/pageBuilder/styles/elements/typography.scss
+++ b/apps/theme/pageBuilder/styles/elements/typography.scss
@@ -66,6 +66,20 @@ h6 {
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
+// Formatting styles for text
+.webiny-pb-page-element-text {
+  & b {
+    font-weight: bold;
+  }
+
+  & u {
+    text-decoration: underline;
+  }
+
+  & i {
+    font-style: italic;
+  }
+}
 
 // Blockquote default typography styles
 .webiny-pb-typography-quote {

--- a/packages/app-page-builder/src/editor/components/MediumEditor/index.ts
+++ b/packages/app-page-builder/src/editor/components/MediumEditor/index.ts
@@ -6,18 +6,6 @@ const editorClass = css({
     width: "100%",
     "&:focus": {
         outline: "none"
-    },
-    "& b": {
-        fontWeight: "bold"
-    },
-    "& u": {
-        textDecoration: "underline"
-    },
-    "& i": {
-        fontStyle: "italic"
-    },
-    "& h1,h2,h3,h4,h5,h6": {
-        fontSize: "unset"
     }
 });
 


### PR DESCRIPTION
## Changes
This PR fixes the Page Builder text element formatting not working in preview and website.

## How Has This Been Tested?
Manually using the admin app.
