### PR TITLE
fix: Broken 'Configure AWS Credentials' doc link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -69,7 +69,7 @@ The setup of our Github repo is identical to the one created by `create-webiny-p
 2. `yarn 1.22.*` or higher (because our project setup uses workspaces). We prefer using `yarn 2` as it's a lot faster and some issues from `yarn 1` are finally fixed. 
    If you don't already have `yarn`, visit https://yarnpkg.com/ to install it.
 
-3. A verified AWS account with an [IAM user for programmatic usage](https://docs.webiny.com/docs/how-to-guides/deployment/configure-aws-credentials)
+3. A verified AWS account with an [IAM user for programmatic usage](https://www.webiny.com/docs/how-to-guides/deployment/aws/configure-aws-credentials)
 
 ## Local setup
 


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
Fixed the broken link of the 'Configure AWS Credentials' document. 
It seems that the document directory structure is updated, so the older link is no longer accessible. 

<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested new link [IAM user for programmatic usage](https://www.webiny.com/docs/how-to-guides/deployment/aws/configure-aws-credentials), it is working as expected. 


## Documentation
None
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
