### PR TITLE
fix: tooltip hover type of file

### DIFF
--- a/packages/app-admin/src/components/FileManager/FileDetails.tsx
+++ b/packages/app-admin/src/components/FileManager/FileDetails.tsx
@@ -148,18 +148,19 @@ type FileDetailsProps = {
     };
     [key: string]: any;
 };
+
+const isImage = file => {
+    const fileType = mime.getType(file && file.name);
+
+    if (fileType && typeof fileType === "string") {
+        return fileType.includes("image");
+    }
+
+    return false;
+};
+
 export default function FileDetails(props: FileDetailsProps) {
     const { file, uploadFile, validateFiles } = props;
-
-    const isImage = file => {
-        const fileType = mime.getType(file && file.name);
-
-        if (fileType && typeof fileType === "string") {
-            return fileType.includes("image");
-        }
-
-        return false;
-    };
 
     const filePlugin = getFileTypePlugin(file);
     const actions = get(filePlugin, "fileDetails.actions") || [];

--- a/packages/app-admin/src/components/FileManager/FileDetails.tsx
+++ b/packages/app-admin/src/components/FileManager/FileDetails.tsx
@@ -28,6 +28,7 @@ import { useSecurity } from "@webiny/app-security";
 import { ConfirmationDialog } from "@webiny/ui/ConfirmationDialog";
 import { DELETE_FILE, LIST_FILES, LIST_TAGS } from "./graphql";
 import { i18n } from "@webiny/app/i18n";
+import mime from "mime";
 
 const t = i18n.ns("app-admin/file-manager/file-details");
 
@@ -149,7 +150,17 @@ type FileDetailsProps = {
 };
 export default function FileDetails(props: FileDetailsProps) {
     const { file, uploadFile, validateFiles } = props;
-    const isImage = file.name.match(/.(jpg|jpeg|png|gif)$/i)
+
+    const isImage = file => {
+        const fileType = mime.getType(file && file.name);
+
+        if (fileType && typeof fileType === "string") {
+            return fileType.includes("image");
+        }
+
+        return false;
+    };
+
     const filePlugin = getFileTypePlugin(file);
     const actions = get(filePlugin, "fileDetails.actions") || [];
 
@@ -265,7 +276,16 @@ export default function FileDetails(props: FileDetailsProps) {
             >
                 {({ showConfirmation }) => {
                     return (
-                        <Tooltip content={isImage ? <span>{t`Delete image`}</span> : <span>{t`Delete file`}</span>} placement={"bottom"}>
+                        <Tooltip
+                            content={
+                                isImage ? (
+                                    <span>{t`Delete image`}</span>
+                                ) : (
+                                    <span>{t`Delete file`}</span>
+                                )
+                            }
+                            placement={"bottom"}
+                        >
                             <IconButton
                                 data-testid={"fm-delete-file-button"}
                                 icon={<DeleteIcon style={{ margin: "0 8px 0 0" }} />}

--- a/packages/app-admin/src/components/FileManager/FileDetails.tsx
+++ b/packages/app-admin/src/components/FileManager/FileDetails.tsx
@@ -149,6 +149,7 @@ type FileDetailsProps = {
 };
 export default function FileDetails(props: FileDetailsProps) {
     const { file, uploadFile, validateFiles } = props;
+    const isImage = file.name.match(/.(jpg|jpeg|png|gif)$/i)
     const filePlugin = getFileTypePlugin(file);
     const actions = get(filePlugin, "fileDetails.actions") || [];
 
@@ -264,7 +265,7 @@ export default function FileDetails(props: FileDetailsProps) {
             >
                 {({ showConfirmation }) => {
                     return (
-                        <Tooltip content={<span>{t`Delete image`}</span>} placement={"bottom"}>
+                        <Tooltip content={isImage ? <span>{t`Delete image`}</span> : <span>{t`Delete file`}</span>} placement={"bottom"}>
                             <IconButton
                                 data-testid={"fm-delete-file-button"}
                                 icon={<DeleteIcon style={{ margin: "0 8px 0 0" }} />}


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #1604 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Hovered over different files and tested.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
This checks if the file is of any of the type jpeg, png, gif or jpg then the hover shows `Delete image` otherwise `Delete file`