### PR TITLE
Fix: update createHandler usage in headless cms

### DIFF
--- a/api/code/graphql/src/index.ts
+++ b/api/code/graphql/src/index.ts
@@ -17,10 +17,12 @@ import formBuilderPlugins from "@webiny/api-form-builder/plugins";
 import securityPlugins from "./security";
 import headlessCmsPlugins from "@webiny/api-headless-cms/plugins";
 
+const debug = process.env.DEBUG === "true";
+
 export const handler = createHandler({
     plugins: [
         logsPlugins(),
-        graphqlPlugins({ debug: process.env.DEBUG }),
+        graphqlPlugins({ debug }),
         elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
         dbPlugins({
             table: process.env.DB_TABLE,
@@ -51,7 +53,5 @@ export const handler = createHandler({
         formBuilderPlugins(),
         headlessCmsPlugins()
     ],
-    http: {
-        debug: process.env.DEBUG
-    }
+    http: { debug }
 });

--- a/api/code/headlessCMS/src/index.ts
+++ b/api/code/headlessCMS/src/index.ts
@@ -9,20 +9,25 @@ import headlessCmsPlugins from "@webiny/api-headless-cms/content";
 import securityPlugins from "./security";
 import logsPlugins from "@webiny/handler-logs";
 
-export const handler = createHandler(
-    logsPlugins(),
-    elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
-    dbPlugins({
-        table: process.env.DB_TABLE,
-        driver: new DynamoDbDriver({
-            documentClient: new DocumentClient({
-                convertEmptyValues: true,
-                region: process.env.AWS_REGION
+export const handler = createHandler({
+    plugins: [
+        logsPlugins(),
+        elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
+        dbPlugins({
+            table: process.env.DB_TABLE,
+            driver: new DynamoDbDriver({
+                documentClient: new DocumentClient({
+                    convertEmptyValues: true,
+                    region: process.env.AWS_REGION
+                })
             })
-        })
-    }),
-    securityPlugins(),
-    i18nPlugins(),
-    i18nContentPlugins(),
-    headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
-);
+        }),
+        securityPlugins(),
+        i18nPlugins(),
+        i18nContentPlugins(),
+        headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
+    ],
+    http: {
+        debug: process.env.DEBUG
+    }
+});

--- a/api/code/headlessCMS/src/index.ts
+++ b/api/code/headlessCMS/src/index.ts
@@ -9,6 +9,8 @@ import headlessCmsPlugins from "@webiny/api-headless-cms/content";
 import securityPlugins from "./security";
 import logsPlugins from "@webiny/handler-logs";
 
+const debug = process.env.DEBUG === "true";
+
 export const handler = createHandler({
     plugins: [
         logsPlugins(),
@@ -25,9 +27,7 @@ export const handler = createHandler({
         securityPlugins(),
         i18nPlugins(),
         i18nContentPlugins(),
-        headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
+        headlessCmsPlugins({ debug })
     ],
-    http: {
-        debug: process.env.DEBUG
-    }
+    http: { debug }
 });

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -4,7 +4,6 @@ import { makeExecutableSchema } from "@graphql-tools/schema";
 import { CmsContext } from "../types";
 import { I18NLocale } from "@webiny/api-i18n/types";
 import { NotAuthorizedError, NotAuthorizedResponse } from "@webiny/api-security";
-import { ErrorResponse } from "@webiny/handler-graphql";
 import { PluginCollection } from "@webiny/plugins/types";
 import debugPlugins from "@webiny/handler-graphql/debugPlugins";
 import processRequestBody from "@webiny/handler-graphql/processRequestBody";
@@ -143,49 +142,16 @@ export const graphQLHandlerFactory = (
                     return respond(http, new NotAuthorizedResponse(ex));
                 }
 
-                try {
-                    const schema = await getSchema({
-                        context,
-                        locale: context.cms.getLocale(),
-                        type: context.cms.type
-                    });
+                const schema = await getSchema({
+                    context,
+                    locale: context.cms.getLocale(),
+                    type: context.cms.type
+                });
 
-                    const body: ParsedBody | ParsedBody[] = JSON.parse(http.request.body);
+                const body: ParsedBody | ParsedBody[] = JSON.parse(http.request.body);
 
-                    const result = await processRequestBody(body, schema, context);
-                    return respond(http, result);
-                } catch (ex) {
-                    const report = {
-                        error: {
-                            name: ex.constructor.name,
-                            message: ex.message,
-                            data: ex.data || {},
-                            stack: ex.stack
-                        }
-                    };
-                    const body = JSON.stringify(report);
-                    console.log("[@webiny/api-headless-cms] An error occurred: ", body);
-
-                    if (boolean(options.debug)) {
-                        return context.http.response({
-                            statusCode: 500,
-                            body,
-                            headers: {
-                                ...DEFAULT_HEADERS,
-                                "Cache-Control": "no-store"
-                            }
-                        });
-                    }
-
-                    return respond(
-                        http,
-                        new ErrorResponse({
-                            message: ex.message,
-                            code: ex.code || "GENERAL_ERROR",
-                            data: ex.data || {}
-                        })
-                    );
-                }
+                const result = await processRequestBody(body, schema, context);
+                return respond(http, result);
             }
         }
     ];

--- a/packages/cwp-template-aws/template/api/code/graphql/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/graphql/src/index.ts
@@ -17,10 +17,12 @@ import formBuilderPlugins from "@webiny/api-form-builder/plugins";
 import securityPlugins from "./security";
 import headlessCmsPlugins from "@webiny/api-headless-cms/plugins";
 
+const debug = process.env.DEBUG === "true";
+
 export const handler = createHandler({
     plugins: [
         logsPlugins(),
-        graphqlPlugins({ debug: process.env.DEBUG }),
+        graphqlPlugins({ debug }),
         elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
         dbPlugins({
             table: process.env.DB_TABLE,
@@ -51,7 +53,5 @@ export const handler = createHandler({
         formBuilderPlugins(),
         headlessCmsPlugins()
     ],
-    http: {
-        debug: process.env.DEBUG
-    }
+    http: { debug }
 });

--- a/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
@@ -9,20 +9,25 @@ import headlessCmsPlugins from "@webiny/api-headless-cms/content";
 import securityPlugins from "./security";
 import logsPlugins from "@webiny/handler-logs";
 
-export const handler = createHandler(
-    logsPlugins(),
-    elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
-    dbPlugins({
-        table: process.env.DB_TABLE,
-        driver: new DynamoDbDriver({
-            documentClient: new DocumentClient({
-                convertEmptyValues: true,
-                region: process.env.AWS_REGION
+export const handler = createHandler({
+    plugins: [
+        logsPlugins(),
+        elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
+        dbPlugins({
+            table: process.env.DB_TABLE,
+            driver: new DynamoDbDriver({
+                documentClient: new DocumentClient({
+                    convertEmptyValues: true,
+                    region: process.env.AWS_REGION
+                })
             })
-        })
-    }),
-    securityPlugins(),
-    i18nPlugins(),
-    i18nContentPlugins(),
-    headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
-);
+        }),
+        securityPlugins(),
+        i18nPlugins(),
+        i18nContentPlugins(),
+        headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
+    ],
+    http: {
+        debug: process.env.DEBUG
+    }
+});

--- a/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
@@ -9,6 +9,8 @@ import headlessCmsPlugins from "@webiny/api-headless-cms/content";
 import securityPlugins from "./security";
 import logsPlugins from "@webiny/handler-logs";
 
+const debug = process.env.DEBUG === "true";
+
 export const handler = createHandler({
     plugins: [
         logsPlugins(),
@@ -25,9 +27,7 @@ export const handler = createHandler({
         securityPlugins(),
         i18nPlugins(),
         i18nContentPlugins(),
-        headlessCmsPlugins({ debug: Boolean(process.env.DEBUG) })
+        headlessCmsPlugins({ debug })
     ],
-    http: {
-        debug: process.env.DEBUG
-    }
+    http: { debug }
 });

--- a/packages/handler-http/src/index.ts
+++ b/packages/handler-http/src/index.ts
@@ -10,7 +10,7 @@ const DEFAULT_HEADERS = {
     "Access-Control-Allow-Methods": "OPTIONS,POST"
 };
 
-export default (options: HandlerHttpOptions) => [
+export default (options: HandlerHttpOptions = {}) => [
     {
         type: "context",
         apply(context) {
@@ -51,7 +51,7 @@ export default (options: HandlerHttpOptions) => [
             if (!context.http || typeof context.http.response !== "function") {
                 return error;
             }
-            const debug = boolean(options && options.debug);
+            const debug = boolean(options.debug);
 
             if (debug) {
                 return context.http.response({

--- a/packages/handler-http/src/types.ts
+++ b/packages/handler-http/src/types.ts
@@ -26,5 +26,5 @@ export type HttpContext = {
 };
 
 export type HandlerHttpOptions = {
-    debug?: boolean | string;
+    debug?: boolean;
 };

--- a/packages/handler-http/src/types.ts
+++ b/packages/handler-http/src/types.ts
@@ -26,5 +26,5 @@ export type HttpContext = {
 };
 
 export type HandlerHttpOptions = {
-    debug: boolean;
+    debug?: boolean | string;
 };


### PR DESCRIPTION
## Changes
This PR introduces the fix to update `createHandler` usage in `headless-cms`.

## How Has This Been Tested?
Manually.