### PR TITLE
fix(api-file-manager): update validators

### DIFF
--- a/packages/api-file-manager/src/plugins/crud/utils/createFileModel.ts
+++ b/packages/api-file-manager/src/plugins/crud/utils/createFileModel.ts
@@ -4,10 +4,12 @@ import { validation } from "@webiny/validation";
 
 export default (create = true) => {
     return withFields({
-        key: string({ validation: validation.create(`${create ? "required," : ""}maxLength:200`) }),
-        name: string({ validation: validation.create("maxLength:100") }),
+        key: string({
+            validation: validation.create(`${create ? "required," : ""}maxLength:1000`)
+        }),
+        name: string({ validation: validation.create("maxLength:1000") }),
         size: number(),
-        type: string({ validation: validation.create("maxLength:50") }),
+        type: string({ validation: validation.create("maxLength:255") }),
         meta: object({ value: { private: false } }),
         tags: onSet(value => {
             if (!Array.isArray(value)) {


### PR DESCRIPTION
## Changes
While uploading different types of files, I ran into a mime type that looks like this:
`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
It was a simple `.xlsx` file. That's 65 characters. Current file type validator limits the length to 50.

The changes introduced with this PR are:
- set mime type length to max 255 characters (as per [media type RFC](https://stackoverflow.com/questions/643690/maximum-mimetype-length-when-storing-type-in-db))
- increase `key` and `name` length limit to 1000 (S3 supports a max of 1024 bytes)

NOTE: in the future, we will move these validations into the storage driver itself, but that's a separate issue.

## How Has This Been Tested?
Manually.
