### PR TITLE
Introduce FileManagerFileType plugin

### DIFF
--- a/api/pulumi/dev/elasticSearch.ts
+++ b/api/pulumi/dev/elasticSearch.ts
@@ -62,7 +62,7 @@ class ElasticSearch {
                         //     Effect: "Allow",
                         //     Principal: "*",
                         //     Action: "es:*",
-                        //     Resource: this.domain.arn.apply(v => `${v}/!*`),
+                        //     Resource: this.domain.arn.apply(v => `${v}/*`),
                         //     Condition: {
                         //         IpAddress: {
                         //             "aws:SourceIp": "213.149.51.28/32"

--- a/packages/api-plugin-elastic-search-client/src/types.ts
+++ b/packages/api-plugin-elastic-search-client/src/types.ts
@@ -160,24 +160,4 @@ export interface ElasticsearchBoolQuery {
     should?: ElasticsearchQueryShould[];
 }
 
-/**
- *
- */
-export interface ElasticsearchQuery {
-    /**
-     * A must part of the query.
-     */
-    must: ElasticsearchQueryMust[];
-    /**
-     * A mustNot part of the query.
-     */
-    mustNot: ElasticsearchQueryMustNot[];
-    /**
-     * A match part of the query.
-     */
-    filter: ElasticsearchQueryFilter[];
-    /**
-     * A should part of the query.
-     */
-    should: ElasticsearchQueryShould[];
-}
+export type ElasticsearchQuery = ElasticsearchBoolQuery;

--- a/packages/app-admin/package.json
+++ b/packages/app-admin/package.json
@@ -42,6 +42,7 @@
     "invariant": "^2.2.4",
     "lodash": "^4.17.11",
     "mime": "^2.4.2",
+    "minimatch": "^3.0.4",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-butterfiles": "^1.3.1",

--- a/packages/app-admin/src/components/FileManager/FileDetails.tsx
+++ b/packages/app-admin/src/components/FileManager/FileDetails.tsx
@@ -163,7 +163,7 @@ export default function FileDetails(props: FileDetailsProps) {
     const { file, uploadFile, validateFiles } = props;
 
     const filePlugin = getFileTypePlugin(file);
-    const actions = get(filePlugin, "fileDetails.actions") || [];
+    const actions = get(filePlugin, "fileDetails.actions") || get(filePlugin, "actions") || [];
 
     const { hideFileDetails, queryParams } = useFileManager();
     const [darkImageBackground, setDarkImageBackground] = useState(false);

--- a/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
+++ b/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
@@ -1,5 +1,6 @@
-import { plugins } from "@webiny/plugins";
 import invariant from "invariant";
+import minimatch from "minimatch";
+import { plugins } from "@webiny/plugins";
 import { AdminFileManagerFileTypePlugin } from "../../types";
 import { FileManagerFileTypePlugin } from "../../plugins/FileManagerFileTypePlugin";
 
@@ -15,16 +16,14 @@ export default function getFileTypePlugin(file) {
 
     let plugin = null;
     for (let i = 0; i < fileTypePlugins.length; i++) {
-        const current = fileTypePlugins[i];
-        if (Array.isArray(current.types) && current.types.includes(file.type)) {
-            plugin = current;
+        // We don't want to include the global wildcard in this check.
+        const types = fileTypePlugins[i].types;
+        if (types.find(t => minimatch(file.type, t))) {
+            plugin = fileTypePlugins[i];
         }
     }
 
-    if (!plugin) {
-        plugin = plugins.byName("file-manager-file-type-default");
-        invariant(plugin, `Missing default "file-manager-file-type" plugin.`);
-    }
+    invariant(plugin, `Missing plugin to handle "${file.type}"!`);
 
     return plugin;
 }

--- a/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
+++ b/packages/app-admin/src/components/FileManager/getFileTypePlugin.ts
@@ -1,19 +1,21 @@
 import { plugins } from "@webiny/plugins";
 import invariant from "invariant";
 import { AdminFileManagerFileTypePlugin } from "../../types";
+import { FileManagerFileTypePlugin } from "../../plugins/FileManagerFileTypePlugin";
 
 export default function getFileTypePlugin(file) {
     if (!file) {
         return null;
     }
 
-    const pluginsByType = plugins.byType<AdminFileManagerFileTypePlugin>(
-        "admin-file-manager-file-type"
-    );
+    const fileTypePlugins = [
+        ...plugins.byType<AdminFileManagerFileTypePlugin>("admin-file-manager-file-type"),
+        ...plugins.byType<FileManagerFileTypePlugin>(FileManagerFileTypePlugin.type)
+    ];
 
     let plugin = null;
-    for (let i = 0; i < pluginsByType.length; i++) {
-        const current = pluginsByType[i];
+    for (let i = 0; i < fileTypePlugins.length; i++) {
+        const current = fileTypePlugins[i];
         if (Array.isArray(current.types) && current.types.includes(file.type)) {
             plugin = current;
         }

--- a/packages/app-admin/src/plugins/FileManagerFileTypePlugin.tsx
+++ b/packages/app-admin/src/plugins/FileManagerFileTypePlugin.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Plugin } from "@webiny/plugins";
+
+interface File {
+    id: string;
+    name: string;
+    key: string;
+    src: string;
+    size: number;
+    type: string;
+    tags: string[];
+    createdOn: string;
+    createdBy: {
+        id: string;
+    };
+    [key: string]: any;
+}
+
+export interface RenderParams {
+    file: File;
+}
+
+interface Config {
+    types: string[];
+    actions?: React.ComponentType<any>[];
+    render(params: RenderParams): React.ReactNode;
+}
+
+interface FileDetails {
+    actions: React.ComponentType<any>[];
+}
+
+export class FileManagerFileTypePlugin extends Plugin {
+    public static readonly type = "admin-file-manager-file-type";
+    private config: Partial<Config>;
+
+    constructor(config?: Config) {
+        super();
+        this.config = config || {};
+    }
+
+    get types() {
+        return this.config.types || [];
+    }
+
+    get fileDetails(): FileDetails {
+        return {
+            actions: this.config.actions || []
+        };
+    }
+
+    render(params: RenderParams): React.ReactNode {
+        return this.config.render(params);
+    }
+}

--- a/packages/app-admin/src/plugins/FileManagerFileTypePlugin.tsx
+++ b/packages/app-admin/src/plugins/FileManagerFileTypePlugin.tsx
@@ -26,10 +26,6 @@ interface Config {
     render(params: RenderParams): React.ReactNode;
 }
 
-interface FileDetails {
-    actions: React.ComponentType<any>[];
-}
-
 export class FileManagerFileTypePlugin extends Plugin {
     public static readonly type = "admin-file-manager-file-type";
     private config: Partial<Config>;
@@ -43,10 +39,8 @@ export class FileManagerFileTypePlugin extends Plugin {
         return this.config.types || [];
     }
 
-    get fileDetails(): FileDetails {
-        return {
-            actions: this.config.actions || []
-        };
+    get actions() {
+        return this.config.actions || [];
     }
 
     render(params: RenderParams): React.ReactNode {

--- a/packages/app-admin/src/plugins/fileManager/fileDefault.tsx
+++ b/packages/app-admin/src/plugins/fileManager/fileDefault.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { AdminFileManagerFileTypePlugin } from "../../types";
 import { ReactComponent as FileIcon } from "./icons/round-description-24px.svg";
-
 import { css } from "emotion";
+import { FileManagerFileTypePlugin } from "../FileManagerFileTypePlugin";
+
 const style = {
     centering: css({
         display: "flex",
@@ -12,9 +12,8 @@ const style = {
     })
 };
 
-const plugin: AdminFileManagerFileTypePlugin = {
-    name: "file-manager-file-type-default",
-    type: "admin-file-manager-file-type",
+export default new FileManagerFileTypePlugin({
+    types: ["*/*"],
     render() {
         return (
             <div className={style.centering}>
@@ -22,6 +21,4 @@ const plugin: AdminFileManagerFileTypePlugin = {
             </div>
         );
     }
-};
-
-export default plugin;
+});

--- a/packages/app-admin/src/plugins/fileManager/fileImage/index.tsx
+++ b/packages/app-admin/src/plugins/fileManager/fileImage/index.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { css } from "emotion";
 import { Image } from "@webiny/app/components";
-import { AdminFileManagerFileTypePlugin } from "../../../types";
 
 import EditAction from "./EditAction";
+import { FileManagerFileTypePlugin } from "../../FileManagerFileTypePlugin";
 
 const styles = css({
     maxHeight: 200,
@@ -15,26 +15,12 @@ const styles = css({
     transform: "translateX(-50%) translateY(-50%)"
 });
 
-const imageFilePlugin: AdminFileManagerFileTypePlugin = {
-    name: "file-manager-file-type-image",
-    type: "admin-file-manager-file-type",
-    types: [
-        "image/jpeg",
-        "image/jpg",
-        "image/gif",
-        "image/png",
-        "image/svg+xml",
-        "image/x-icon",
-        "image/vnd.microsoft.icon"
-    ],
+export default new FileManagerFileTypePlugin({
+    types: ["image/*"],
     render({ file }) {
         return (
             <Image className={styles} src={file.src} alt={file.name} transform={{ width: 300 }} />
         );
     },
-    fileDetails: {
-        actions: [EditAction]
-    }
-};
-
-export default imageFilePlugin;
+    actions: [EditAction]
+});

--- a/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/elasticSearch.ts
@@ -62,7 +62,7 @@ class ElasticSearch {
                         //     Effect: "Allow",
                         //     Principal: "*",
                         //     Action: "es:*",
-                        //     Resource: this.domain.arn.apply(v => `${v}/!*`),
+                        //     Resource: this.domain.arn.apply(v => `${v}/*`),
                         //     Condition: {
                         //         IpAddress: {
                         //             "aws:SourceIp": "213.149.51.28/32"

--- a/packages/plugins/src/Plugin.ts
+++ b/packages/plugins/src/Plugin.ts
@@ -1,19 +1,11 @@
 export abstract class Plugin {
     public static readonly type: string;
-    private _name: string;
+    public name: string;
 
     constructor() {
         if (!this.type) {
             throw Error(`Missing "type" definition in "${this.constructor.name}"!`);
         }
-    }
-
-    get name() {
-        return this._name;
-    }
-
-    set name(value) {
-        this._name = value;
     }
 
     get type() {


### PR DESCRIPTION
## Changes
This PR is inspired by @AndriiUhryn. He wanted to customize rendering of specific file types in the File Manager, and although it was possible using plugins, it wasn't that user-friendly.

With this PR we're introducing a new class plugin to make customizations really easy and straightforward.

## How Has This Been Tested?
Manually, by implementing custom renderers and actions using the `admin` app.

## Documentation
There's a new [Create a File Type Plugin](https://deploy-preview-292--webiny-docs.netlify.app/docs/how-to-guides/webiny-applications/file-manager/create-a-file-type-plugin/) guide describing the added functionality in details.