### PR TITLE
refactor(api-plugin-elastic-search-client): use elastic-ts package for ES types

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/helpers.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/helpers.ts
@@ -1,7 +1,7 @@
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
-export const createBlankQuery = (): ElasticsearchQuery => ({
-    mustNot: [],
+export const createBlankQuery = (): ElasticsearchBoolQueryConfig => ({
+    must_not: [],
     must: [],
     filter: [],
     should: []

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/between.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/between.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorBetweenPlugin } from "../../../../src/elasticsearch/operators/between";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorBetweenPlugin", () => {
     const plugin = elasticsearchOperatorBetweenPlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorBetweenPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -50,8 +50,8 @@ describe("elasticsearchOperatorBetweenPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -64,8 +64,8 @@ describe("elasticsearchOperatorBetweenPlugin", () => {
                 {
                     range: {
                         date: {
-                            lte: to,
-                            gte: from
+                            lte: to as any,
+                            gte: from as any
                         }
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/contains.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/contains.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorContainsPlugin } from "../../../../src/elasticsearch/operators/contains";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorContainsPlugin", () => {
     const plugin = elasticsearchOperatorContainsPlugin();
@@ -21,8 +21,8 @@ describe("elasticsearchOperatorContainsPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     query_string: {

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/equal.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/equal.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorEqualPlugin } from "../../../../src/elasticsearch/operators/equal";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorEqualPlugin", () => {
     const plugin = elasticsearchOperatorEqualPlugin();
@@ -21,8 +21,8 @@ describe("elasticsearchOperatorEqualPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     term: {

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/gt.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/gt.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorGtPlugin } from "../../../../src/elasticsearch/operators/gt";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorGtPlugin", () => {
     const plugin = elasticsearchOperatorGtPlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorGtPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -47,8 +47,8 @@ describe("elasticsearchOperatorGtPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -60,7 +60,7 @@ describe("elasticsearchOperatorGtPlugin", () => {
                 {
                     range: {
                         date: {
-                            gt: from
+                            gt: from as any
                         }
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/gte.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/gte.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorGtePlugin } from "../../../../src/elasticsearch/operators/gte";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorGtePlugin", () => {
     const plugin = elasticsearchOperatorGtePlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorGtePlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -47,8 +47,8 @@ describe("elasticsearchOperatorGtePlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -60,7 +60,7 @@ describe("elasticsearchOperatorGtePlugin", () => {
                 {
                     range: {
                         date: {
-                            gte: from
+                            gte: from as any
                         }
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/in.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/in.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorInPlugin } from "../../../../src/elasticsearch/operators/in";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorInPlugin", () => {
     const plugin = elasticsearchOperatorInPlugin();
@@ -15,8 +15,8 @@ describe("elasticsearchOperatorInPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     terms: {

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/lt.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/lt.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorLtPlugin } from "../../../../src/elasticsearch/operators/lt";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorLtPlugin", () => {
     const plugin = elasticsearchOperatorLtPlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorLtPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -47,8 +47,8 @@ describe("elasticsearchOperatorLtPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -60,7 +60,7 @@ describe("elasticsearchOperatorLtPlugin", () => {
                 {
                     range: {
                         date: {
-                            lt: to
+                            lt: to as any
                         }
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/lte.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/lte.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorLtePlugin } from "../../../../src/elasticsearch/operators/lte";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorLtePlugin", () => {
     const plugin = elasticsearchOperatorLtePlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorLtePlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -47,8 +47,8 @@ describe("elasticsearchOperatorLtePlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [],
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [],
             must: [
                 {
                     range: {
@@ -60,7 +60,7 @@ describe("elasticsearchOperatorLtePlugin", () => {
                 {
                     range: {
                         date: {
-                            lte: to
+                            lte: to as any
                         }
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/not.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/not.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorNotPlugin } from "../../../../src/elasticsearch/operators/not";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorNotPlugin", () => {
     const plugin = elasticsearchOperatorNotPlugin();
@@ -15,8 +15,8 @@ describe("elasticsearchOperatorNotPlugin", () => {
             value: "John",
             context
         });
-        const expected: ElasticsearchQuery = {
-            mustNot: [
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [
                 {
                     term: {
                         "name.keyword": "John"

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notBetween.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notBetween.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorNotBetweenPlugin } from "../../../../src/elasticsearch/operators/notBetween";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorNotBetweenPlugin", () => {
     const plugin = elasticsearchOperatorNotBetweenPlugin();
@@ -15,8 +15,8 @@ describe("elasticsearchOperatorNotBetweenPlugin", () => {
             context
         });
 
-        const expected: ElasticsearchQuery = {
-            mustNot: [
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [
                 {
                     range: {
                         id: {

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notContains.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notContains.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorNotContainsPlugin } from "../../../../src/elasticsearch/operators/notContains";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorNotContainsPlugin", () => {
     const plugin = elasticsearchOperatorNotContainsPlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorNotContainsPlugin", () => {
             value: "John",
             context
         });
-        const expected: ElasticsearchQuery = {
-            mustNot: [
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [
                 {
                     query_string: {
                         allow_leading_wildcard: true,

--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notIn.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/operators/notIn.test.ts
@@ -1,6 +1,6 @@
 import { elasticsearchOperatorNotInPlugin } from "../../../../src/elasticsearch/operators/notIn";
 import { createBlankQuery } from "../helpers";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 describe("elasticsearchOperatorNotInPlugin", () => {
     const plugin = elasticsearchOperatorNotInPlugin();
@@ -14,8 +14,8 @@ describe("elasticsearchOperatorNotInPlugin", () => {
             value: ["John", "Doe", "P."],
             context
         });
-        const expected: ElasticsearchQuery = {
-            mustNot: [
+        const expected: ElasticsearchBoolQueryConfig = {
+            must_not: [
                 {
                     terms: {
                         "name.keyword": ["John", "Doe", "P."]

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/not.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/not.ts
@@ -6,13 +6,13 @@ export const elasticsearchOperatorNotPlugin = (): ElasticsearchQueryBuilderPlugi
     operator: "not",
     apply(query, { field, value }) {
         if (typeof value === "string") {
-            query.mustNot.push({
+            query.must_not.push({
                 term: {
                     [`${field}.keyword`]: value
                 }
             });
         } else {
-            query.mustNot.push({
+            query.must_not.push({
                 term: {
                     [`${field}`]: value
                 }

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notBetween.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notBetween.ts
@@ -15,7 +15,7 @@ export const elasticsearchOperatorNotBetweenPlugin = (): ElasticsearchQueryBuild
         // we take gte first because it should be a lesser value than lte, eg [5, 10]
         // 6 >= gte && 6 <= lte === true which in this case it means that record will not match
         const [gte, lte] = value;
-        query.mustNot.push({
+        query.must_not.push({
             range: {
                 [field]: {
                     lte,

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notContains.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notContains.ts
@@ -5,7 +5,7 @@ export const elasticsearchOperatorNotContainsPlugin = (): ElasticsearchQueryBuil
     name: "elastic-search-query-builder-not-contains",
     operator: "not_contains",
     apply(query, { field, value }) {
-        query.mustNot.push({
+        query.must_not.push({
             query_string: {
                 allow_leading_wildcard: true,
                 fields: [field],

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notIn.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/operators/notIn.ts
@@ -15,7 +15,7 @@ export const elasticsearchOperatorNotInPlugin = (): ElasticsearchQueryBuilderPlu
         for (let i = 0; i < values.length; i++) {
             const value = values[i];
             if (typeof value !== "string") {
-                query.mustNot.push({
+                query.must_not.push({
                     terms: {
                         [field]: values
                     }
@@ -24,7 +24,7 @@ export const elasticsearchOperatorNotInPlugin = (): ElasticsearchQueryBuilderPlu
             }
         }
 
-        query.mustNot.push({
+        query.must_not.push({
             terms: {
                 [`${field}.keyword`]: values
             }

--- a/packages/api-headless-cms-ddb-es/src/types.ts
+++ b/packages/api-headless-cms-ddb-es/src/types.ts
@@ -7,7 +7,7 @@ import {
     CmsContext
 } from "@webiny/api-headless-cms/types";
 import {
-    ElasticsearchQuery,
+    ElasticsearchBoolQueryConfig,
     ElasticsearchQueryOperator
 } from "@webiny/api-plugin-elastic-search-client/types";
 
@@ -33,7 +33,7 @@ export interface ElasticsearchQueryBuilderArgsPlugin {
  * @see ElasticsearchQueryPlugin.modify
  */
 interface ElasticsearchQueryPluginArgs {
-    query: ElasticsearchQuery;
+    query: ElasticsearchBoolQueryConfig;
     model: CmsContentModel;
     context: CmsContext;
 }
@@ -72,7 +72,7 @@ export interface ElasticsearchQueryBuilderPlugin extends Plugin {
      * Method used to modify received query object.
      * Has access to whole query object so it can remove something added by other plugins.
      */
-    apply: (query: ElasticsearchQuery, args: ElasticsearchQueryBuilderArgsPlugin) => void;
+    apply: (query: ElasticsearchBoolQueryConfig, args: ElasticsearchQueryBuilderArgsPlugin) => void;
 }
 
 /**

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -257,7 +257,8 @@ const plugin: ContextPlugin<PbContext> = {
                             query: {
                                 bool: {
                                     must: query.must.length > 0 ? query.must : undefined,
-                                    must_not: query.mustNot.length > 0 ? query.mustNot : undefined,
+                                    must_not:
+                                        query.must_not.length > 0 ? query.must_not : undefined,
                                     filter: query.filter.length > 0 ? query.filter : undefined
                                 }
                             },
@@ -306,7 +307,8 @@ const plugin: ContextPlugin<PbContext> = {
                             query: {
                                 bool: {
                                     must: query.must.length > 0 ? query.must : undefined,
-                                    must_not: query.mustNot.length > 0 ? query.mustNot : undefined,
+                                    must_not:
+                                        query.must_not.length > 0 ? query.must_not : undefined,
                                     filter: query.filter.length > 0 ? query.filter : undefined
                                 }
                             },

--- a/packages/api-page-builder/src/graphql/crud/utils/getNormalizedListPagesArgs.ts
+++ b/packages/api-page-builder/src/graphql/crud/utils/getNormalizedListPagesArgs.ts
@@ -1,5 +1,5 @@
 import { ListPagesArgs, PbContext } from "../../types";
-import { ElasticsearchQuery } from "@webiny/api-plugin-elastic-search-client/types";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-plugin-elastic-search-client/types";
 
 /**
  * Returns arguments suited to be sent to ElasticSearch's `search` method.
@@ -17,12 +17,12 @@ export default (args: ListPagesArgs, context: PbContext) => {
     return normalized;
 };
 
-const getQuery = (args: ListPagesArgs, context: PbContext): ElasticsearchQuery => {
+const getQuery = (args: ListPagesArgs, context: PbContext): ElasticsearchBoolQueryConfig => {
     const { where, search, exclude } = args;
-    const query: ElasticsearchQuery = {
+    const query: ElasticsearchBoolQueryConfig = {
         filter: [],
         must: [],
-        mustNot: [],
+        must_not: [],
         should: []
     };
 
@@ -84,7 +84,7 @@ const getQuery = (args: ListPagesArgs, context: PbContext): ElasticsearchQuery =
         });
 
         if (paths.length) {
-            query.mustNot.push({
+            query.must_not.push({
                 terms: {
                     "path.keyword": paths
                 }
@@ -92,7 +92,7 @@ const getQuery = (args: ListPagesArgs, context: PbContext): ElasticsearchQuery =
         }
 
         if (pageIds.length) {
-            query.mustNot.push({
+            query.must_not.push({
                 terms: {
                     pid: pageIds
                 }

--- a/packages/api-page-builder/src/plugins/SearchPagesPlugin.ts
+++ b/packages/api-page-builder/src/plugins/SearchPagesPlugin.ts
@@ -1,18 +1,18 @@
 import { Plugin } from "@webiny/plugins";
 import {
-    ElasticsearchQuery,
-    ElasticsearchSort
+    ElasticsearchBoolQueryConfig,
+    Sort as esSort
 } from "@webiny/api-plugin-elastic-search-client/types";
 import { PbContext } from "~/graphql/types";
 
 interface ModifyQueryArgs {
-    query: ElasticsearchQuery;
+    query: ElasticsearchBoolQueryConfig;
     args: Record<string, any>;
     context: PbContext;
 }
 
 interface ModifySortArgs {
-    sort: ElasticsearchSort;
+    sort: esSort;
     args: Record<string, any>;
     context: PbContext;
 }

--- a/packages/api-plugin-elastic-search-client/package.json
+++ b/packages/api-plugin-elastic-search-client/package.json
@@ -15,7 +15,8 @@
     "@elastic/elasticsearch": "^7.9.1",
     "@webiny/handler": "^5.7.0",
     "aws-elasticsearch-connector": "^9.0.0",
-    "aws-sdk": "^2.539.0"
+    "aws-sdk": "^2.539.0",
+    "elastic-ts": "^0.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/api-plugin-elastic-search-client/src/types.ts
+++ b/packages/api-plugin-elastic-search-client/src/types.ts
@@ -1,8 +1,21 @@
 import { Client } from "@elastic/elasticsearch";
+import { BoolQueryConfig as esBoolQueryConfig, Query as esQuery } from "elastic-ts";
+export * from "elastic-ts";
 
 export type ElasticSearchClientContext = {
     elasticSearch: Client;
 };
+
+/**
+ * To simplify our plugins, we say that query contains arrays of objects, not single objects.
+ * And that they all are defined as empty arrays at the start.
+ */
+export interface ElasticsearchBoolQueryConfig extends esBoolQueryConfig {
+    must: esQuery[];
+    filter: esQuery[];
+    should: esQuery[];
+    must_not: esQuery[];
+}
 
 /**
  * Definitions of possible Elasticsearch operators.
@@ -22,142 +35,3 @@ export type ElasticsearchQueryOperator =
     | "gte"
     | "lt"
     | "lte";
-/**
- * definition for Elasticsearch range keyword.
- *
- * @category Elasticsearch
- */
-type ElasticsearchQueryRange = {
-    [key: string]: {
-        gt?: string | number | Date;
-        gte?: string | number | Date;
-        lt?: string | number | Date;
-        lte?: string | number | Date;
-    };
-};
-/**
- * definition for Elasticsearch query string.
- *
- * @category Elasticsearch
- */
-type ElasticsearchQueryString = {
-    allow_leading_wildcard?: boolean;
-    fields: string[];
-    query: string;
-    /**
-     * Keep it loose.
-     */
-    [key: string]: any;
-};
-/**
- * definition for Elasticsearch simple query string.
- *
- * @category Elasticsearch
- */
-type ElasticsearchSimpleQueryString = {
-    fields: string[];
-    query: string;
-    /**
-     * Keep it loose.
-     */
-    [key: string]: any;
-};
-/**
- * definition for Elasticsearch must keyword.
- *
- * @category Elasticsearch
- */
-type ElasticsearchQueryMust = {
-    term?: {
-        [key: string]: any;
-    };
-    terms?: {
-        [key: string]: any[];
-    };
-    range?: ElasticsearchQueryRange;
-    query_string?: ElasticsearchQueryString;
-    simple_query_string?: ElasticsearchSimpleQueryString;
-};
-/**
- * definition for Elasticsearch must_not keyword.
- *
- * @category Elasticsearch
- */
-type ElasticsearchQueryMustNot = {
-    term?: {
-        [key: string]: any;
-    };
-    terms?: {
-        [key: string]: any[];
-    };
-    range?: ElasticsearchQueryRange;
-    query_string?: ElasticsearchQueryString;
-    simple_query_string?: ElasticsearchSimpleQueryString;
-};
-
-/**
- * definition for Elasticsearch match keyword.
- *
- * @category Elasticsearch
- */
-export interface ElasticsearchQueryMatch {
-    [key: string]: {
-        query: string;
-        // OR is default one in ES
-        operator?: "AND" | "OR";
-    };
-}
-
-export interface ElasticsearchSort {
-    [key: string]: {
-        order: "asc" | "desc";
-        unmapped_type?: string;
-    };
-}
-
-/**
- * definition for Elasticsearch "filter" keyword.
- *
- * @category Elasticsearch
- */
-type ElasticsearchQueryFilter = {
-    term?: {
-        [key: string]: any;
-    };
-    terms?: {
-        [key: string]: any[];
-    };
-    bool?: ElasticsearchBoolQuery;
-};
-
-type ElasticsearchQueryShould = {
-    term: {
-        [key: string]: any;
-    };
-};
-
-/**
- * Definition for Elasticsearch bool query with no required properties.
- *
- * @category Elasticsearch
- */
-export interface ElasticsearchBoolQuery {
-    /**
-     * "must" part of the query.
-     */
-    must?: ElasticsearchQueryMust[];
-    /**
-     * "mustNot" part of the query.
-     */
-    mustNot?: ElasticsearchQueryMustNot[];
-    /**
-     * "filter" part of the query.
-     */
-    filter?: ElasticsearchQueryFilter[];
-    /**
-     * "should" part of the query.
-     */
-    should?: ElasticsearchQueryShould[];
-}
-
-export type ElasticsearchQuery = ElasticsearchBoolQuery;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7949,6 +7949,7 @@ __metadata:
     "@webiny/project-utils": ^5.7.0
     aws-elasticsearch-connector: ^9.0.0
     aws-sdk: ^2.539.0
+    elastic-ts: ^0.6.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
@@ -8154,6 +8155,7 @@ __metadata:
     invariant: ^2.2.4
     lodash: ^4.17.11
     mime: ^2.4.2
+    minimatch: ^3.0.4
     prop-types: ^15.7.2
     react: ^16.14.0
     react-butterfiles: ^1.3.1
@@ -16253,6 +16255,15 @@ __metadata:
   version: 2.7.4
   resolution: "ejs@npm:2.7.4"
   checksum: f066d9a932fb921bdb6e87133d747d5e3408a1c1303f9a15e5a7a3973afdf444a672c98c2f6d97b9a1a76363bd8ae6d05286f26c6b6b7b9674dfc5802fc8546d
+  languageName: node
+  linkType: hard
+
+"elastic-ts@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "elastic-ts@npm:0.6.0"
+  dependencies:
+    "@sindresorhus/is": ^4.0.0
+  checksum: 3d7e2940da3999be328b5ae621db2435fd8f4880a7bd483ee0a28721a9925caa778847b0cf508937c8a2906fe9958a0a8a92682622c37c130cd258211ec67dcb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
Use Elasticsearch types from the elastic-ts package instead of our own written ones.

## How Has This Been Tested?
Build and jest tests.

## Documentation
There will be a upgrade guide for the users Elasticsearch plugins. There are minor changes.
