### PR TITLE
fix(api-headless-cms): content model group schema required variables

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModelGroup.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModelGroup.crud.test.ts
@@ -198,7 +198,10 @@ describe("Content model group crud test", () => {
     test("error when trying to update non-existing content model group", async () => {
         const [response] = await updateContentModelGroupMutation({
             id: "nonExistingIdUpdate",
-            data: {}
+            data: {
+                name: "test",
+                icon: "test"
+            }
         });
         expect(response).toEqual({
             data: {
@@ -235,6 +238,7 @@ describe("Content model group crud test", () => {
     test("error when trying to create a content model group with incomplete data", async () => {
         const [nameResponse] = await createContentModelGroupMutation({
             data: {
+                name: "",
                 slug: "slug",
                 description: `description`,
                 icon: `icon`
@@ -257,7 +261,8 @@ describe("Content model group crud test", () => {
             data: {
                 name: "name",
                 slug: "slug",
-                description: `description`
+                description: `description`,
+                icon: ""
             }
         });
 
@@ -278,7 +283,9 @@ describe("Content model group crud test", () => {
     test("error when trying to create a new content model group with no name or slug", async () => {
         const [response] = await createContentModelGroupMutation({
             data: {
-                description: "description"
+                name: "",
+                description: "description",
+                icon: ""
             }
         });
         expect(response).toEqual({

--- a/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
@@ -28,10 +28,10 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
     if (context.cms.MANAGE) {
         manageSchema = /* GraphQL */ `
             input CmsContentModelGroupInput {
-                name: String
+                name: String!
                 slug: String
                 description: String
-                icon: String
+                icon: String!
             }
 
             type CmsContentModelGroupResponse {


### PR DESCRIPTION
## Changes
Schema for content model group was missing name and icon exclamation mark (required), now they are added so group input cannot be empty.

## How Has This Been Tested?
Jest tests.