### PR TITLE
fix(app-headless-cms): add selection to createdBy field

### DIFF
--- a/packages/app-headless-cms/src/admin/views/ContentModelGroups/graphql.ts
+++ b/packages/app-headless-cms/src/admin/views/ContentModelGroups/graphql.ts
@@ -7,7 +7,11 @@ const fields = `
     description
     icon
     createdOn
-    createdBy
+    createdBy {
+        id
+        displayName
+        type
+    }
 `;
 
 export const LIST_CONTENT_MODEL_GROUPS = gql`

--- a/packages/app-headless-cms/src/admin/viewsGraphql.ts
+++ b/packages/app-headless-cms/src/admin/viewsGraphql.ts
@@ -31,7 +31,11 @@ export const LIST_MENU_CONTENT_GROUPS_MODELS = gql`
                 contentModels {
                     name
                     modelId
-                    createdBy
+                    createdBy {
+                        id
+                        displayName
+                        type
+                    }
                 }
             }
         }
@@ -43,7 +47,11 @@ export const LIST_CONTENT_MODELS = gql`
         listContentModels {
             data {
                 ${BASE_CONTENT_MODEL_FIELDS}
-                createdBy
+                createdBy {
+                    id
+                    displayName
+                    type
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes
Fixe a bug where createdBy does not have selection of the subfields. This is due to GraphQL schema change on the Headless CMS API side.

## How Has This Been Tested?
Manual testing.
