### PR TITLE
fix(api-headless-cms-ddb-es): get previous entry

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/CmsContentEntryDynamoElastic.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/CmsContentEntryDynamoElastic.ts
@@ -272,7 +272,7 @@ export default class CmsContentEntryDynamoElastic implements CmsContentEntryStor
         /**
          * Load ES entries to delete
          */
-        const [esDbItems] = await db.read({
+        const [esDbItems] = await db.read<CmsContentEntry>({
             ...configurations.esDb(),
             query: {
                 PK: primaryKey,
@@ -1105,7 +1105,7 @@ export default class CmsContentEntryDynamoElastic implements CmsContentEntryStor
         entryId: string,
         version: number
     ): Promise<CmsContentEntry | null> {
-        return this.getSingleDynamoDbItem(
+        const entry = await this.getSingleDynamoDbItem(
             {
                 PK: this.getPrimaryKey(entryId),
                 SK: {
@@ -1116,6 +1116,13 @@ export default class CmsContentEntryDynamoElastic implements CmsContentEntryStor
                 SK: -1
             }
         );
+        /**
+         * We need this due to possibly getting latest or published if given revision does not exist
+         */
+        if ((entry as any).TYPE !== TYPE_ENTRY) {
+            return null;
+        }
+        return entry;
     }
 
     private async getSingleDynamoDbItem(

--- a/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
@@ -966,12 +966,16 @@ export class CmsContentEntryDynamo implements CmsContentEntryStorageOperations {
         entryId: string,
         version: number
     ): Promise<CmsContentEntry | null> {
-        return this.getSingleDynamoDbItem({
+        const entry = await this.getSingleDynamoDbItem({
             partitionKey: this.getPartitionKey(entryId),
             op: "lt",
             value: this.getSortKeyRevision(version),
             order: "DESC"
         });
+        if ((entry as any).TYPE !== TYPE_ENTRY) {
+            return null;
+        }
+        return entry;
     }
 
     private async getSingleDynamoDbItem(

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntryHooks.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntryHooks.test.ts
@@ -198,9 +198,12 @@ describe("contentEntryHooks", () => {
     });
 
     test("should execute hooks on delete revision", async () => {
-        const { createCategory, deleteCategory, sleep } = useCategoryManageHandler(manageOpts, [
-            contentEntryHooks()
-        ]);
+        const {
+            createCategory,
+            createCategoryFrom,
+            deleteCategory,
+            sleep
+        } = useCategoryManageHandler(manageOpts, [contentEntryHooks()]);
 
         const [createResponse] = await createCategory({
             data: {
@@ -209,10 +212,15 @@ describe("contentEntryHooks", () => {
             }
         });
 
+        const { id } = createResponse.data.createCategory.data;
+
+        // create another category
+        await createCategoryFrom({
+            revision: id
+        });
+
         // wait for data to be come available
         await sleep(1000);
-
-        const { id } = createResponse.data.createCategory.data;
 
         hooksTracker.reset();
 


### PR DESCRIPTION
## Issue
Previous entry was resolved as latest in the case SK with a REV#VERSION did not exist.

## Changes
Added a check that entry that was read really is a regular entry.
Added a test that verifies that there are no records left after entry was deleted. Checked on both MANAGE and READ APIs.

## How Has This Been Tested?
Jest tests.
