### PR TITLE
fix(cli): use uuid instead of public-ip

### DIFF
--- a/api/code/dynamoToElastic/package.json
+++ b/api/code/dynamoToElastic/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "api-dynamo-to-elastic",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-dynamodb-to-elasticsearch": "^5.5.0-beta.0",
-    "@webiny/api-plugin-elastic-search-client": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-dynamo-to-elastic",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-dynamodb-to-elasticsearch": "^5.8.0-beta.0",
+		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/dynamoToElastic/package.json
+++ b/api/code/dynamoToElastic/package.json
@@ -1,16 +1,16 @@
 {
-	"name": "api-dynamo-to-elastic",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-dynamodb-to-elasticsearch": "^5.8.0-beta.0",
-		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-dynamo-to-elastic",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-dynamodb-to-elasticsearch": "^5.8.0-beta.0",
+    "@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/fileManager/download/package.json
+++ b/api/code/fileManager/download/package.json
@@ -1,15 +1,15 @@
 {
-	"name": "api-file-manager-download",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-file-manager": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-file-manager-download",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-file-manager": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/fileManager/download/package.json
+++ b/api/code/fileManager/download/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "api-file-manager-download",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-file-manager": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-file-manager-download",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-file-manager": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/fileManager/manage/package.json
+++ b/api/code/fileManager/manage/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "api-file-manager-manage",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-file-manager": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-file-manager-manage",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-file-manager": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/fileManager/manage/package.json
+++ b/api/code/fileManager/manage/package.json
@@ -1,15 +1,15 @@
 {
-	"name": "api-file-manager-manage",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-file-manager": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-file-manager-manage",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-file-manager": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/fileManager/transform/package.json
+++ b/api/code/fileManager/transform/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "api-file-manager-transform",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-file-manager": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-file-manager-transform",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-file-manager": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/fileManager/transform/package.json
+++ b/api/code/fileManager/transform/package.json
@@ -1,15 +1,15 @@
 {
-	"name": "api-file-manager-transform",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-file-manager": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-file-manager-transform",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-file-manager": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/graphql/package.json
+++ b/api/code/graphql/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "api-graphql",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-file-manager": "^5.8.0-beta.0",
-		"@webiny/api-file-manager-s3": "^5.8.0-beta.0",
-		"@webiny/api-form-builder": "^5.8.0-beta.0",
-		"@webiny/api-headless-cms": "^5.8.0-beta.0",
-		"@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
-		"@webiny/api-i18n": "^5.8.0-beta.0",
-		"@webiny/api-i18n-content": "^5.8.0-beta.0",
-		"@webiny/api-page-builder": "^5.8.0-beta.0",
-		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
-		"@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
-		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
-		"@webiny/api-security": "^5.8.0-beta.0",
-		"@webiny/api-security-tenancy": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-graphql": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-graphql",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-file-manager": "^5.8.0-beta.0",
+    "@webiny/api-file-manager-s3": "^5.8.0-beta.0",
+    "@webiny/api-form-builder": "^5.8.0-beta.0",
+    "@webiny/api-headless-cms": "^5.8.0-beta.0",
+    "@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
+    "@webiny/api-i18n": "^5.8.0-beta.0",
+    "@webiny/api-i18n-content": "^5.8.0-beta.0",
+    "@webiny/api-page-builder": "^5.8.0-beta.0",
+    "@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+    "@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
+    "@webiny/api-prerendering-service": "^5.8.0-beta.0",
+    "@webiny/api-security": "^5.8.0-beta.0",
+    "@webiny/api-security-tenancy": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-graphql": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/graphql/package.json
+++ b/api/code/graphql/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "api-graphql",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-file-manager": "^5.5.0-beta.0",
-    "@webiny/api-file-manager-s3": "^5.5.0-beta.0",
-    "@webiny/api-form-builder": "^5.5.0-beta.0",
-    "@webiny/api-headless-cms": "^5.5.0-beta.0",
-    "@webiny/api-headless-cms-ddb-es": "^5.6.0",
-    "@webiny/api-i18n": "^5.5.0-beta.0",
-    "@webiny/api-i18n-content": "^5.5.0-beta.0",
-    "@webiny/api-page-builder": "^5.5.0-beta.0",
-    "@webiny/api-plugin-elastic-search-client": "^5.5.0-beta.0",
-    "@webiny/api-plugin-security-cognito": "^5.5.0-beta.0",
-    "@webiny/api-prerendering-service": "^5.5.0-beta.0",
-    "@webiny/api-security": "^5.5.0-beta.0",
-    "@webiny/api-security-tenancy": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-graphql": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-graphql",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-file-manager": "^5.8.0-beta.0",
+		"@webiny/api-file-manager-s3": "^5.8.0-beta.0",
+		"@webiny/api-form-builder": "^5.8.0-beta.0",
+		"@webiny/api-headless-cms": "^5.8.0-beta.0",
+		"@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
+		"@webiny/api-i18n": "^5.8.0-beta.0",
+		"@webiny/api-i18n-content": "^5.8.0-beta.0",
+		"@webiny/api-page-builder": "^5.8.0-beta.0",
+		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+		"@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
+		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
+		"@webiny/api-security": "^5.8.0-beta.0",
+		"@webiny/api-security-tenancy": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-graphql": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/headlessCMS/package.json
+++ b/api/code/headlessCMS/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "api-headless-cms",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-headless-cms": "^5.8.0-beta.0",
-		"@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
-		"@webiny/api-i18n": "^5.8.0-beta.0",
-		"@webiny/api-i18n-content": "^5.8.0-beta.0",
-		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
-		"@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
-		"@webiny/api-security": "^5.8.0-beta.0",
-		"@webiny/api-security-tenancy": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-headless-cms",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-headless-cms": "^5.8.0-beta.0",
+    "@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
+    "@webiny/api-i18n": "^5.8.0-beta.0",
+    "@webiny/api-i18n-content": "^5.8.0-beta.0",
+    "@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+    "@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
+    "@webiny/api-security": "^5.8.0-beta.0",
+    "@webiny/api-security-tenancy": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/headlessCMS/package.json
+++ b/api/code/headlessCMS/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "api-headless-cms",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-headless-cms": "^5.5.0-beta.0",
-    "@webiny/api-headless-cms-ddb-es": "^5.6.0",
-    "@webiny/api-i18n": "^5.5.0-beta.0",
-    "@webiny/api-i18n-content": "^5.5.0-beta.0",
-    "@webiny/api-plugin-elastic-search-client": "^5.5.0-beta.0",
-    "@webiny/api-plugin-security-cognito": "^5.5.0-beta.0",
-    "@webiny/api-security": "^5.5.0-beta.0",
-    "@webiny/api-security-tenancy": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-headless-cms",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-headless-cms": "^5.8.0-beta.0",
+		"@webiny/api-headless-cms-ddb-es": "^5.8.0-beta.0",
+		"@webiny/api-i18n": "^5.8.0-beta.0",
+		"@webiny/api-i18n-content": "^5.8.0-beta.0",
+		"@webiny/api-plugin-elastic-search-client": "^5.8.0-beta.0",
+		"@webiny/api-plugin-security-cognito": "^5.8.0-beta.0",
+		"@webiny/api-security": "^5.8.0-beta.0",
+		"@webiny/api-security-tenancy": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/pageBuilder/updateSettings/package.json
+++ b/api/code/pageBuilder/updateSettings/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "api-page-builder-update-settings",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-page-builder": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-page-builder-update-settings",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-page-builder": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/pageBuilder/updateSettings/package.json
+++ b/api/code/pageBuilder/updateSettings/package.json
@@ -1,17 +1,17 @@
 {
-	"name": "api-page-builder-update-settings",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-page-builder": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-page-builder-update-settings",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-page-builder": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/prerenderingService/flush/package.json
+++ b/api/code/prerenderingService/flush/package.json
@@ -1,18 +1,18 @@
 {
-	"name": "api-page-builder-flush",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
-		"@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-page-builder-flush",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-prerendering-service": "^5.8.0-beta.0",
+    "@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/prerenderingService/flush/package.json
+++ b/api/code/prerenderingService/flush/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "api-page-builder-flush",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-prerendering-service": "^5.5.0-beta.0",
-    "@webiny/api-prerendering-service-aws": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-page-builder-flush",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
+		"@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/prerenderingService/queue/add/package.json
+++ b/api/code/prerenderingService/queue/add/package.json
@@ -1,17 +1,17 @@
 {
-	"name": "api-prerendering-service-queue-add",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-prerendering-service-queue-add",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-prerendering-service": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/prerenderingService/queue/add/package.json
+++ b/api/code/prerenderingService/queue/add/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "api-prerendering-service-queue-add",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-prerendering-service": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-prerendering-service-queue-add",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/prerenderingService/queue/process/package.json
+++ b/api/code/prerenderingService/queue/process/package.json
@@ -1,17 +1,17 @@
 {
-	"name": "api-prerendering-service-queue-process",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-prerendering-service-queue-process",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-prerendering-service": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/prerenderingService/queue/process/package.json
+++ b/api/code/prerenderingService/queue/process/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "api-prerendering-service-queue-process",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-prerendering-service": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-prerendering-service-queue-process",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/api/code/prerenderingService/render/package.json
+++ b/api/code/prerenderingService/render/package.json
@@ -1,18 +1,18 @@
 {
-	"name": "api-page-builder-render",
-	"version": "0.1.0",
-	"scripts": {
-		"build": "yarn webiny run build",
-		"watch": "yarn webiny run watch"
-	},
-	"dependencies": {
-		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
-		"@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/db-dynamodb": "^5.8.0-beta.0",
-		"@webiny/handler-aws": "^5.8.0-beta.0",
-		"@webiny/handler-db": "^5.8.0-beta.0",
-		"@webiny/handler-logs": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0"
-	}
+  "name": "api-page-builder-render",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "dependencies": {
+    "@webiny/api-prerendering-service": "^5.8.0-beta.0",
+    "@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/db-dynamodb": "^5.8.0-beta.0",
+    "@webiny/handler-aws": "^5.8.0-beta.0",
+    "@webiny/handler-db": "^5.8.0-beta.0",
+    "@webiny/handler-logs": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0"
+  }
 }

--- a/api/code/prerenderingService/render/package.json
+++ b/api/code/prerenderingService/render/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "api-page-builder-render",
-  "version": "0.1.0",
-  "scripts": {
-    "build": "yarn webiny run build",
-    "watch": "yarn webiny run watch"
-  },
-  "dependencies": {
-    "@webiny/api-prerendering-service": "^5.5.0-beta.0",
-    "@webiny/api-prerendering-service-aws": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/db-dynamodb": "^5.5.0-beta.0",
-    "@webiny/handler-aws": "^5.5.0-beta.0",
-    "@webiny/handler-db": "^5.5.0-beta.0",
-    "@webiny/handler-logs": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0"
-  }
+	"name": "api-page-builder-render",
+	"version": "0.1.0",
+	"scripts": {
+		"build": "yarn webiny run build",
+		"watch": "yarn webiny run watch"
+	},
+	"dependencies": {
+		"@webiny/api-prerendering-service": "^5.8.0-beta.0",
+		"@webiny/api-prerendering-service-aws": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/db-dynamodb": "^5.8.0-beta.0",
+		"@webiny/handler-aws": "^5.8.0-beta.0",
+		"@webiny/handler-db": "^5.8.0-beta.0",
+		"@webiny/handler-logs": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0"
+	}
 }

--- a/apps/admin/code/package.json
+++ b/apps/admin/code/package.json
@@ -1,81 +1,81 @@
 {
-	"name": "admin",
-	"version": "0.1.0",
-	"private": true,
-	"dependencies": {
-		"@apollo/react-components": "^3.1.5",
-		"@editorjs/delimiter": "^1.2.0",
-		"@editorjs/list": "^1.6.0",
-		"@editorjs/quote": "^2.4.0",
-		"@editorjs/underline": "^1.0.0",
-		"@types/react": "^16.14.2",
-		"@webiny/app": "^5.8.0-beta.0",
-		"@webiny/app-admin": "^5.8.0-beta.0",
-		"@webiny/app-file-manager": "^5.8.0-beta.0",
-		"@webiny/app-file-manager-s3": "^5.8.0-beta.0",
-		"@webiny/app-form-builder": "^5.8.0-beta.0",
-		"@webiny/app-graphql-playground": "^5.8.0-beta.0",
-		"@webiny/app-headless-cms": "^5.8.0-beta.0",
-		"@webiny/app-i18n": "^5.8.0-beta.0",
-		"@webiny/app-i18n-content": "^5.8.0-beta.0",
-		"@webiny/app-page-builder": "^5.8.0-beta.0",
-		"@webiny/app-plugin-admin-welcome-screen": "^5.8.0-beta.0",
-		"@webiny/app-plugin-security-cognito": "^5.8.0-beta.0",
-		"@webiny/app-security": "^5.8.0-beta.0",
-		"@webiny/app-security-tenancy": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
-		"@webiny/plugins": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0",
-		"@webiny/react-router": "^5.8.0-beta.0",
-		"@webiny/tracking": "^5.8.0-beta.0",
-		"@webiny/ui": "^5.8.0-beta.0",
-		"apollo-cache": "^1.3.5",
-		"apollo-cache-inmemory": "^1.6.6",
-		"apollo-client": "^2.2.8",
-		"apollo-link": "^1.2.14",
-		"apollo-link-batch-http": "^1.2.14",
-		"apollo-utilities": "^1.3.4",
-		"core-js": "^3.0.1",
-		"cross-fetch": "^3.0.4",
-		"invariant": "^2.2.4",
-		"prop-types": "^15.7.2",
-		"react": "^16.14.0",
-		"react-dom": "^16.14.0",
-		"regenerator-runtime": "^0.13.5",
-		"theme": "^0.1.0"
-	},
-	"devDependencies": {
-		"cross-env": "^5.0.2"
-	},
-	"scripts": {
-		"analyze": "source-map-explorer build/static/js/main.*",
-		"start": "cross-env PORT=3001 yarn webiny run start",
-		"watch": "cross-env PORT=3001 yarn webiny run start",
-		"build": "yarn webiny run build"
-	},
-	"browserslist": {
-		"development": [
-			"last 2 chrome versions",
-			"last 2 firefox versions",
-			"last 2 edge versions"
-		],
-		"production": [
-			">0.25%",
-			"not op_mini all",
-			"ie 11"
-		]
-	},
-	"svgo": {
-		"plugins": {
-			"removeViewBox": false
-		}
-	},
-	"adio": {
-		"ignore": {
-			"dependencies": [
-				"@webiny/cli"
-			]
-		}
-	}
+  "name": "admin",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@apollo/react-components": "^3.1.5",
+    "@editorjs/delimiter": "^1.2.0",
+    "@editorjs/list": "^1.6.0",
+    "@editorjs/quote": "^2.4.0",
+    "@editorjs/underline": "^1.0.0",
+    "@types/react": "^16.14.2",
+    "@webiny/app": "^5.8.0-beta.0",
+    "@webiny/app-admin": "^5.8.0-beta.0",
+    "@webiny/app-file-manager": "^5.8.0-beta.0",
+    "@webiny/app-file-manager-s3": "^5.8.0-beta.0",
+    "@webiny/app-form-builder": "^5.8.0-beta.0",
+    "@webiny/app-graphql-playground": "^5.8.0-beta.0",
+    "@webiny/app-headless-cms": "^5.8.0-beta.0",
+    "@webiny/app-i18n": "^5.8.0-beta.0",
+    "@webiny/app-i18n-content": "^5.8.0-beta.0",
+    "@webiny/app-page-builder": "^5.8.0-beta.0",
+    "@webiny/app-plugin-admin-welcome-screen": "^5.8.0-beta.0",
+    "@webiny/app-plugin-security-cognito": "^5.8.0-beta.0",
+    "@webiny/app-security": "^5.8.0-beta.0",
+    "@webiny/app-security-tenancy": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
+    "@webiny/plugins": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0",
+    "@webiny/react-router": "^5.8.0-beta.0",
+    "@webiny/tracking": "^5.8.0-beta.0",
+    "@webiny/ui": "^5.8.0-beta.0",
+    "apollo-cache": "^1.3.5",
+    "apollo-cache-inmemory": "^1.6.6",
+    "apollo-client": "^2.2.8",
+    "apollo-link": "^1.2.14",
+    "apollo-link-batch-http": "^1.2.14",
+    "apollo-utilities": "^1.3.4",
+    "core-js": "^3.0.1",
+    "cross-fetch": "^3.0.4",
+    "invariant": "^2.2.4",
+    "prop-types": "^15.7.2",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
+    "regenerator-runtime": "^0.13.5",
+    "theme": "^0.1.0"
+  },
+  "devDependencies": {
+    "cross-env": "^5.0.2"
+  },
+  "scripts": {
+    "analyze": "source-map-explorer build/static/js/main.*",
+    "start": "cross-env PORT=3001 yarn webiny run start",
+    "watch": "cross-env PORT=3001 yarn webiny run start",
+    "build": "yarn webiny run build"
+  },
+  "browserslist": {
+    "development": [
+      "last 2 chrome versions",
+      "last 2 firefox versions",
+      "last 2 edge versions"
+    ],
+    "production": [
+      ">0.25%",
+      "not op_mini all",
+      "ie 11"
+    ]
+  },
+  "svgo": {
+    "plugins": {
+      "removeViewBox": false
+    }
+  },
+  "adio": {
+    "ignore": {
+      "dependencies": [
+        "@webiny/cli"
+      ]
+    }
+  }
 }

--- a/apps/admin/code/package.json
+++ b/apps/admin/code/package.json
@@ -1,81 +1,81 @@
 {
-  "name": "admin",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@apollo/react-components": "^3.1.5",
-    "@editorjs/delimiter": "^1.2.0",
-    "@editorjs/list": "^1.6.0",
-    "@editorjs/quote": "^2.4.0",
-    "@editorjs/underline": "^1.0.0",
-    "@types/react": "^16.14.2",
-    "@webiny/app": "^5.5.0-beta.0",
-    "@webiny/app-admin": "^5.5.0-beta.0",
-    "@webiny/app-file-manager": "^5.5.0-beta.0",
-    "@webiny/app-file-manager-s3": "^5.5.0-beta.0",
-    "@webiny/app-form-builder": "^5.5.0-beta.0",
-    "@webiny/app-graphql-playground": "^5.5.0-beta.0",
-    "@webiny/app-headless-cms": "^5.5.0-beta.0",
-    "@webiny/app-i18n": "^5.5.0-beta.0",
-    "@webiny/app-i18n-content": "^5.5.0-beta.0",
-    "@webiny/app-page-builder": "^5.5.0-beta.0",
-    "@webiny/app-plugin-admin-welcome-screen": "^5.5.0-beta.0",
-    "@webiny/app-plugin-security-cognito": "^5.5.0-beta.0",
-    "@webiny/app-security": "^5.5.0-beta.0",
-    "@webiny/app-security-tenancy": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/cli-plugin-deploy-pulumi": "^5.5.0-beta.0",
-    "@webiny/plugins": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0",
-    "@webiny/react-router": "^5.5.0-beta.0",
-    "@webiny/tracking": "^5.5.0-beta.0",
-    "@webiny/ui": "^5.5.0-beta.0",
-    "apollo-cache": "^1.3.5",
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.2.8",
-    "apollo-link": "^1.2.14",
-    "apollo-link-batch-http": "^1.2.14",
-    "apollo-utilities": "^1.3.4",
-    "core-js": "^3.0.1",
-    "cross-fetch": "^3.0.4",
-    "invariant": "^2.2.4",
-    "prop-types": "^15.7.2",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
-    "regenerator-runtime": "^0.13.5",
-    "theme": "^0.1.0"
-  },
-  "devDependencies": {
-    "cross-env": "^5.0.2"
-  },
-  "scripts": {
-    "analyze": "source-map-explorer build/static/js/main.*",
-    "start": "cross-env PORT=3001 yarn webiny run start",
-    "watch": "cross-env PORT=3001 yarn webiny run start",
-    "build": "yarn webiny run build"
-  },
-  "browserslist": {
-    "development": [
-      "last 2 chrome versions",
-      "last 2 firefox versions",
-      "last 2 edge versions"
-    ],
-    "production": [
-      ">0.25%",
-      "not op_mini all",
-      "ie 11"
-    ]
-  },
-  "svgo": {
-    "plugins": {
-      "removeViewBox": false
-    }
-  },
-  "adio": {
-    "ignore": {
-      "dependencies": [
-        "@webiny/cli"
-      ]
-    }
-  }
+	"name": "admin",
+	"version": "0.1.0",
+	"private": true,
+	"dependencies": {
+		"@apollo/react-components": "^3.1.5",
+		"@editorjs/delimiter": "^1.2.0",
+		"@editorjs/list": "^1.6.0",
+		"@editorjs/quote": "^2.4.0",
+		"@editorjs/underline": "^1.0.0",
+		"@types/react": "^16.14.2",
+		"@webiny/app": "^5.8.0-beta.0",
+		"@webiny/app-admin": "^5.8.0-beta.0",
+		"@webiny/app-file-manager": "^5.8.0-beta.0",
+		"@webiny/app-file-manager-s3": "^5.8.0-beta.0",
+		"@webiny/app-form-builder": "^5.8.0-beta.0",
+		"@webiny/app-graphql-playground": "^5.8.0-beta.0",
+		"@webiny/app-headless-cms": "^5.8.0-beta.0",
+		"@webiny/app-i18n": "^5.8.0-beta.0",
+		"@webiny/app-i18n-content": "^5.8.0-beta.0",
+		"@webiny/app-page-builder": "^5.8.0-beta.0",
+		"@webiny/app-plugin-admin-welcome-screen": "^5.8.0-beta.0",
+		"@webiny/app-plugin-security-cognito": "^5.8.0-beta.0",
+		"@webiny/app-security": "^5.8.0-beta.0",
+		"@webiny/app-security-tenancy": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
+		"@webiny/plugins": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0",
+		"@webiny/react-router": "^5.8.0-beta.0",
+		"@webiny/tracking": "^5.8.0-beta.0",
+		"@webiny/ui": "^5.8.0-beta.0",
+		"apollo-cache": "^1.3.5",
+		"apollo-cache-inmemory": "^1.6.6",
+		"apollo-client": "^2.2.8",
+		"apollo-link": "^1.2.14",
+		"apollo-link-batch-http": "^1.2.14",
+		"apollo-utilities": "^1.3.4",
+		"core-js": "^3.0.1",
+		"cross-fetch": "^3.0.4",
+		"invariant": "^2.2.4",
+		"prop-types": "^15.7.2",
+		"react": "^16.14.0",
+		"react-dom": "^16.14.0",
+		"regenerator-runtime": "^0.13.5",
+		"theme": "^0.1.0"
+	},
+	"devDependencies": {
+		"cross-env": "^5.0.2"
+	},
+	"scripts": {
+		"analyze": "source-map-explorer build/static/js/main.*",
+		"start": "cross-env PORT=3001 yarn webiny run start",
+		"watch": "cross-env PORT=3001 yarn webiny run start",
+		"build": "yarn webiny run build"
+	},
+	"browserslist": {
+		"development": [
+			"last 2 chrome versions",
+			"last 2 firefox versions",
+			"last 2 edge versions"
+		],
+		"production": [
+			">0.25%",
+			"not op_mini all",
+			"ie 11"
+		]
+	},
+	"svgo": {
+		"plugins": {
+			"removeViewBox": false
+		}
+	},
+	"adio": {
+		"ignore": {
+			"dependencies": [
+				"@webiny/cli"
+			]
+		}
+	}
 }

--- a/apps/theme/package.json
+++ b/apps/theme/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "theme",
-  "version": "0.1.0",
-  "main": "index.js",
-  "license": "MIT",
-  "dependencies": {
-    "@apollo/react-components": "^3.1.5",
-    "@webiny/app-form-builder": "^5.5.0-beta.0",
-    "@webiny/app-page-builder": "^5.5.0-beta.0",
-    "@webiny/form": "^5.5.0-beta.0",
-    "@webiny/react-rich-text-renderer": "^5.5.0-beta.0",
-    "@webiny/react-router": "^5.5.0-beta.0",
-    "@webiny/validation": "^5.5.0-beta.0",
-    "classnames": "^2.2.6",
-    "emotion": "^10.0.17",
-    "graphql": "^14.7.0",
-    "graphql-tag": "2.10.1",
-    "invariant": "^2.2.4",
-    "lodash.get": "^4.4.2",
-    "react": "^16.14.0",
-    "react-hamburger-menu": "^1.1.1",
-    "react-helmet": "^5.2.0"
-  }
+	"name": "theme",
+	"version": "0.1.0",
+	"main": "index.js",
+	"license": "MIT",
+	"dependencies": {
+		"@apollo/react-components": "^3.1.5",
+		"@webiny/app-form-builder": "^5.8.0-beta.0",
+		"@webiny/app-page-builder": "^5.8.0-beta.0",
+		"@webiny/form": "^5.8.0-beta.0",
+		"@webiny/react-rich-text-renderer": "^5.8.0-beta.0",
+		"@webiny/react-router": "^5.8.0-beta.0",
+		"@webiny/validation": "^5.8.0-beta.0",
+		"classnames": "^2.2.6",
+		"emotion": "^10.0.17",
+		"graphql": "^14.7.0",
+		"graphql-tag": "2.10.1",
+		"invariant": "^2.2.4",
+		"lodash.get": "^4.4.2",
+		"react": "^16.14.0",
+		"react-hamburger-menu": "^1.1.1",
+		"react-helmet": "^5.2.0"
+	}
 }

--- a/apps/theme/package.json
+++ b/apps/theme/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "theme",
-	"version": "0.1.0",
-	"main": "index.js",
-	"license": "MIT",
-	"dependencies": {
-		"@apollo/react-components": "^3.1.5",
-		"@webiny/app-form-builder": "^5.8.0-beta.0",
-		"@webiny/app-page-builder": "^5.8.0-beta.0",
-		"@webiny/form": "^5.8.0-beta.0",
-		"@webiny/react-rich-text-renderer": "^5.8.0-beta.0",
-		"@webiny/react-router": "^5.8.0-beta.0",
-		"@webiny/validation": "^5.8.0-beta.0",
-		"classnames": "^2.2.6",
-		"emotion": "^10.0.17",
-		"graphql": "^14.7.0",
-		"graphql-tag": "2.10.1",
-		"invariant": "^2.2.4",
-		"lodash.get": "^4.4.2",
-		"react": "^16.14.0",
-		"react-hamburger-menu": "^1.1.1",
-		"react-helmet": "^5.2.0"
-	}
+  "name": "theme",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@apollo/react-components": "^3.1.5",
+    "@webiny/app-form-builder": "^5.8.0-beta.0",
+    "@webiny/app-page-builder": "^5.8.0-beta.0",
+    "@webiny/form": "^5.8.0-beta.0",
+    "@webiny/react-rich-text-renderer": "^5.8.0-beta.0",
+    "@webiny/react-router": "^5.8.0-beta.0",
+    "@webiny/validation": "^5.8.0-beta.0",
+    "classnames": "^2.2.6",
+    "emotion": "^10.0.17",
+    "graphql": "^14.7.0",
+    "graphql-tag": "2.10.1",
+    "invariant": "^2.2.4",
+    "lodash.get": "^4.4.2",
+    "react": "^16.14.0",
+    "react-hamburger-menu": "^1.1.1",
+    "react-helmet": "^5.2.0"
+  }
 }

--- a/apps/website/code/package.json
+++ b/apps/website/code/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "website",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@apollo/react-components": "^3.1.5",
-    "@apollo/react-hooks": "^3.1.5",
-    "@types/react": "^16.14.2",
-    "@webiny/app": "^5.5.0-beta.0",
-    "@webiny/app-form-builder": "^5.5.0-beta.0",
-    "@webiny/app-page-builder": "^5.5.0-beta.0",
-    "@webiny/cli": "^5.5.0-beta.0",
-    "@webiny/cli-plugin-deploy-pulumi": "^5.5.0-beta.0",
-    "@webiny/plugins": "^5.5.0-beta.0",
-    "@webiny/project-utils": "^5.5.0-beta.0",
-    "@webiny/react-router": "^5.5.0-beta.0",
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.2.8",
-    "apollo-link": "^1.2.14",
-    "apollo-link-batch-http": "^1.2.14",
-    "core-js": "^3.0.1",
-    "cross-fetch": "^3.0.4",
-    "graphql": "^14.7.0",
-    "graphql-tag": "^2.11.0",
-    "invariant": "^2.2.4",
-    "lodash.trim": "^4.4.2",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
-    "react-helmet": "^6.1.0",
-    "regenerator-runtime": "^0.13.5",
-    "theme": "^0.1.0"
-  },
-  "devDependencies": {
-    "cross-env": "^5.0.2"
-  },
-  "scripts": {
-    "analyze": "source-map-explorer build/static/js/main.*",
-    "start": "cross-env PORT=3000 yarn webiny run start",
-    "watch": "cross-env PORT=3000 yarn webiny run start",
-    "build": "yarn webiny run build"
-  },
-  "browserslist": {
-    "development": [
-      "last 2 chrome versions",
-      "last 2 firefox versions",
-      "last 2 edge versions"
-    ],
-    "production": [
-      ">0.25%",
-      "not op_mini all",
-      "ie 11"
-    ]
-  },
-  "svgo": {
-    "plugins": {
-      "removeViewBox": false
-    }
-  },
-  "adio": {
-    "ignore": {
-      "dependencies": [
-        "@webiny/cli"
-      ]
-    }
-  }
+	"name": "website",
+	"version": "0.1.0",
+	"private": true,
+	"dependencies": {
+		"@apollo/react-components": "^3.1.5",
+		"@apollo/react-hooks": "^3.1.5",
+		"@types/react": "^16.14.2",
+		"@webiny/app": "^5.8.0-beta.0",
+		"@webiny/app-form-builder": "^5.8.0-beta.0",
+		"@webiny/app-page-builder": "^5.8.0-beta.0",
+		"@webiny/cli": "^5.8.0-beta.0",
+		"@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
+		"@webiny/plugins": "^5.8.0-beta.0",
+		"@webiny/project-utils": "^5.8.0-beta.0",
+		"@webiny/react-router": "^5.8.0-beta.0",
+		"apollo-cache-inmemory": "^1.6.6",
+		"apollo-client": "^2.2.8",
+		"apollo-link": "^1.2.14",
+		"apollo-link-batch-http": "^1.2.14",
+		"core-js": "^3.0.1",
+		"cross-fetch": "^3.0.4",
+		"graphql": "^14.7.0",
+		"graphql-tag": "^2.11.0",
+		"invariant": "^2.2.4",
+		"lodash.trim": "^4.4.2",
+		"react": "^16.14.0",
+		"react-dom": "^16.14.0",
+		"react-helmet": "^6.1.0",
+		"regenerator-runtime": "^0.13.5",
+		"theme": "^0.1.0"
+	},
+	"devDependencies": {
+		"cross-env": "^5.0.2"
+	},
+	"scripts": {
+		"analyze": "source-map-explorer build/static/js/main.*",
+		"start": "cross-env PORT=3000 yarn webiny run start",
+		"watch": "cross-env PORT=3000 yarn webiny run start",
+		"build": "yarn webiny run build"
+	},
+	"browserslist": {
+		"development": [
+			"last 2 chrome versions",
+			"last 2 firefox versions",
+			"last 2 edge versions"
+		],
+		"production": [
+			">0.25%",
+			"not op_mini all",
+			"ie 11"
+		]
+	},
+	"svgo": {
+		"plugins": {
+			"removeViewBox": false
+		}
+	},
+	"adio": {
+		"ignore": {
+			"dependencies": [
+				"@webiny/cli"
+			]
+		}
+	}
 }

--- a/apps/website/code/package.json
+++ b/apps/website/code/package.json
@@ -1,66 +1,66 @@
 {
-	"name": "website",
-	"version": "0.1.0",
-	"private": true,
-	"dependencies": {
-		"@apollo/react-components": "^3.1.5",
-		"@apollo/react-hooks": "^3.1.5",
-		"@types/react": "^16.14.2",
-		"@webiny/app": "^5.8.0-beta.0",
-		"@webiny/app-form-builder": "^5.8.0-beta.0",
-		"@webiny/app-page-builder": "^5.8.0-beta.0",
-		"@webiny/cli": "^5.8.0-beta.0",
-		"@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
-		"@webiny/plugins": "^5.8.0-beta.0",
-		"@webiny/project-utils": "^5.8.0-beta.0",
-		"@webiny/react-router": "^5.8.0-beta.0",
-		"apollo-cache-inmemory": "^1.6.6",
-		"apollo-client": "^2.2.8",
-		"apollo-link": "^1.2.14",
-		"apollo-link-batch-http": "^1.2.14",
-		"core-js": "^3.0.1",
-		"cross-fetch": "^3.0.4",
-		"graphql": "^14.7.0",
-		"graphql-tag": "^2.11.0",
-		"invariant": "^2.2.4",
-		"lodash.trim": "^4.4.2",
-		"react": "^16.14.0",
-		"react-dom": "^16.14.0",
-		"react-helmet": "^6.1.0",
-		"regenerator-runtime": "^0.13.5",
-		"theme": "^0.1.0"
-	},
-	"devDependencies": {
-		"cross-env": "^5.0.2"
-	},
-	"scripts": {
-		"analyze": "source-map-explorer build/static/js/main.*",
-		"start": "cross-env PORT=3000 yarn webiny run start",
-		"watch": "cross-env PORT=3000 yarn webiny run start",
-		"build": "yarn webiny run build"
-	},
-	"browserslist": {
-		"development": [
-			"last 2 chrome versions",
-			"last 2 firefox versions",
-			"last 2 edge versions"
-		],
-		"production": [
-			">0.25%",
-			"not op_mini all",
-			"ie 11"
-		]
-	},
-	"svgo": {
-		"plugins": {
-			"removeViewBox": false
-		}
-	},
-	"adio": {
-		"ignore": {
-			"dependencies": [
-				"@webiny/cli"
-			]
-		}
-	}
+  "name": "website",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@apollo/react-components": "^3.1.5",
+    "@apollo/react-hooks": "^3.1.5",
+    "@types/react": "^16.14.2",
+    "@webiny/app": "^5.8.0-beta.0",
+    "@webiny/app-form-builder": "^5.8.0-beta.0",
+    "@webiny/app-page-builder": "^5.8.0-beta.0",
+    "@webiny/cli": "^5.8.0-beta.0",
+    "@webiny/cli-plugin-deploy-pulumi": "^5.8.0-beta.0",
+    "@webiny/plugins": "^5.8.0-beta.0",
+    "@webiny/project-utils": "^5.8.0-beta.0",
+    "@webiny/react-router": "^5.8.0-beta.0",
+    "apollo-cache-inmemory": "^1.6.6",
+    "apollo-client": "^2.2.8",
+    "apollo-link": "^1.2.14",
+    "apollo-link-batch-http": "^1.2.14",
+    "core-js": "^3.0.1",
+    "cross-fetch": "^3.0.4",
+    "graphql": "^14.7.0",
+    "graphql-tag": "^2.11.0",
+    "invariant": "^2.2.4",
+    "lodash.trim": "^4.4.2",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
+    "react-helmet": "^6.1.0",
+    "regenerator-runtime": "^0.13.5",
+    "theme": "^0.1.0"
+  },
+  "devDependencies": {
+    "cross-env": "^5.0.2"
+  },
+  "scripts": {
+    "analyze": "source-map-explorer build/static/js/main.*",
+    "start": "cross-env PORT=3000 yarn webiny run start",
+    "watch": "cross-env PORT=3000 yarn webiny run start",
+    "build": "yarn webiny run build"
+  },
+  "browserslist": {
+    "development": [
+      "last 2 chrome versions",
+      "last 2 firefox versions",
+      "last 2 edge versions"
+    ],
+    "production": [
+      ">0.25%",
+      "not op_mini all",
+      "ie 11"
+    ]
+  },
+  "svgo": {
+    "plugins": {
+      "removeViewBox": false
+    }
+  },
+  "adio": {
+    "ignore": {
+      "dependencies": [
+        "@webiny/cli"
+      ]
+    }
+  }
 }

--- a/packages/api-page-builder/__tests__/graphql/categoriesSecurity.test.js
+++ b/packages/api-page-builder/__tests__/graphql/categoriesSecurity.test.js
@@ -37,14 +37,25 @@ const identityB = new SecurityIdentity({
     displayName: "Bb"
 });
 
-const defaultHandler = useGqlHandler({
+const { createCategory, createElasticSearchIndex, deleteElasticSearchIndex } = useGqlHandler({
     permissions: [{ name: "content.i18n" }, { name: "pb.*" }],
     identity: identityA
 });
 
 describe("Categories Security Test", () => {
+    beforeAll(async () => {
+        await deleteElasticSearchIndex();
+    });
+
+    beforeEach(async () => {
+        await createElasticSearchIndex();
+    });
+
+    afterEach(async () => {
+        await deleteElasticSearchIndex();
+    });
+
     test(`"listCategories" only returns entries to which the identity has access to`, async () => {
-        const { createCategory } = defaultHandler;
         await createCategory({ data: new Mock("list-categories-1-") });
         await createCategory({ data: new Mock("list-categories-2-") });
 
@@ -274,7 +285,6 @@ describe("Categories Security Test", () => {
     });
 
     test(`allow "updateCategory" if identity has sufficient permissions`, async () => {
-        const { createCategory } = defaultHandler;
         const mock = new Mock("update-category-");
 
         await createCategory({ data: mock });
@@ -326,7 +336,6 @@ describe("Categories Security Test", () => {
     });
 
     test(`allow "deleteCategory" if identity has sufficient permissions`, async () => {
-        const { createCategory } = defaultHandler;
         const mock = new Mock("delete-category-");
 
         await createCategory({ data: mock });
@@ -388,7 +397,6 @@ describe("Categories Security Test", () => {
     });
 
     test(`allow "getCategory" if identity has sufficient permissions`, async () => {
-        const { createCategory } = defaultHandler;
         const mock = new Mock("get-category-");
 
         await createCategory({ data: mock });

--- a/packages/cli/config/index.js
+++ b/packages/cli/config/index.js
@@ -2,7 +2,7 @@ const os = require("os");
 const path = require("path");
 const readJson = require("load-json-file");
 const writeJson = require("write-json-file");
-const publicIp = require("public-ip");
+const { v4: uuidv4 } = require("uuid");
 
 const configPath = path.join(os.homedir(), ".webiny", "config");
 
@@ -17,7 +17,7 @@ const verifyConfig = async () => {
         }
     } catch (e) {
         // A new config file is written if it doesn't exist or is invalid.
-        config = { id: await publicIp.v4() };
+        config = { id: uuidv4() };
         await writeJson(configPath, config);
     }
 
@@ -32,13 +32,13 @@ const setTracking = async enabled => {
     try {
         const config = readJson.sync(configPath);
         if (!config.id) {
-            config.id = await publicIp.v4();
+            config.id = uuidv4();
         }
         config.tracking = enabled;
         writeJson.sync(configPath, config);
     } catch (e) {
         // A new config file is written if it doesn't exist.
-        writeJson.sync(configPath, { id: await publicIp.v4(), tracking: enabled });
+        writeJson.sync(configPath, { id: uuidv4(), tracking: enabled });
     }
 };
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,12 +23,12 @@
     "ncp": "^2.0.0",
     "pirates": "^4.0.1",
     "prettier": "^1.14.2",
-    "public-ip": "4.0.3",
     "rimraf": "^3.0.2",
     "semver": "7.3.4",
     "ts-morph": "^11.0.0",
     "typescript": "4.1.3",
     "uniqid": "^5.3.0",
+    "uuid": "^8.3.2",
     "write-json-file": "4.3.0",
     "yargs": "14.2.3"
   },

--- a/packages/create-webiny-project/package.json
+++ b/packages/create-webiny-project/package.json
@@ -24,9 +24,9 @@
     "node-fetch": "2.6.1",
     "os": "0.1.1",
     "p-retry": "4.2.0",
-    "public-ip": "4.0.3",
     "rimraf": "3.0.2",
     "semver": "7.3.4",
+    "uuid": "^8.3.2",
     "validate-npm-package-name": "3.0.0",
     "write-json-file": "4.3.0",
     "yargs": "15.4.1"

--- a/packages/create-webiny-project/utils/verifyConfig.js
+++ b/packages/create-webiny-project/utils/verifyConfig.js
@@ -13,8 +13,8 @@ module.exports = async () => {
             throw Error("Invalid Webiny config!");
         }
     } catch (e) {
-        const publicIp = require("public-ip");
+        const { v4: uuidv4 } = require("uuid");
         // A new config file is written if it doesn't exist or is invalid.
-        writeJson.sync(configPath, { id: await publicIp.v4() });
+        writeJson.sync(configPath, { id: uuidv4() });
     }
 };

--- a/packages/project-utils/testing/presets/index.js
+++ b/packages/project-utils/testing/presets/index.js
@@ -9,7 +9,7 @@ const getYarnWorkspaces = require("get-yarn-workspaces");
 
 const getAllPackages = targetKeywords => {
     const packages = getYarnWorkspaces(process.cwd())
-        .map(pkg => pkg.replace(/\//g, path.sep))
+        .map(pkg => pkg.replace(/\//g, "/"))
         .filter(pkg => {
             return pkg.match(/\/packages\//) !== null;
         });
@@ -60,9 +60,7 @@ const getPackagesPresets = (targetKeywords, nameSuffix) => {
     }
     const packages = getAllPackages(targetKeywords);
     if (packages.length === 0) {
-        throw new Error(
-            `There are no storage operations packages with keywords ${targetKeywords.join(", ")}.`
-        );
+        return [];
     }
     const items = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/react-components@npm:^3.1.5":
+"@apollo/react-components@npm:3.1.5, @apollo/react-components@npm:^3.1.5":
   version: 3.1.5
   resolution: "@apollo/react-components@npm:3.1.5"
   dependencies:
@@ -52,7 +52,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/react-hooks@npm:^3.1.5":
+"@apollo/react-hooks@npm:3.1.5, @apollo/react-hooks@npm:^3.1.5":
   version: 3.1.5
   resolution: "@apollo/react-hooks@npm:3.1.5"
   dependencies:
@@ -79,7 +79,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/auth@npm:^1.3.3":
+"@aws-amplify/auth@npm:1.6.3, @aws-amplify/auth@npm:^1.3.3":
   version: 1.6.3
   resolution: "@aws-amplify/auth@npm:1.6.3"
   dependencies:
@@ -184,10 +184,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.12.7, @babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.13.15, @babel/compat-data@npm:^7.14.0, @babel/compat-data@npm:^7.9.0":
-  version: 7.14.0
-  resolution: "@babel/compat-data@npm:7.14.0"
-  checksum: d2d9de745e7a6f83ddf699865656e9298025bda5d350497845c57af440685723de28e7c1f34315e0028c6ad08bca0173436252ada7ac38eb2227c069d40916dd
+"@babel/compat-data@npm:^7.12.7, @babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.14.4, @babel/compat-data@npm:^7.9.0":
+  version: 7.14.4
+  resolution: "@babel/compat-data@npm:7.14.4"
+  checksum: 35c1152702c158814260944836f4c21b94acc6397d9e64129077b10c0f1c0b887786760d8366cf91621fb9dda1ed5ae9a5ba50c44d3e6b92b51ccd0276346794
   languageName: node
   linkType: hard
 
@@ -291,33 +291,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.13.16, @babel/helper-compilation-targets@npm:^7.8.7":
-  version: 7.13.16
-  resolution: "@babel/helper-compilation-targets@npm:7.13.16"
+"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.13.16, @babel/helper-compilation-targets@npm:^7.14.4, @babel/helper-compilation-targets@npm:^7.8.7":
+  version: 7.14.4
+  resolution: "@babel/helper-compilation-targets@npm:7.14.4"
   dependencies:
-    "@babel/compat-data": ^7.13.15
+    "@babel/compat-data": ^7.14.4
     "@babel/helper-validator-option": ^7.12.17
-    browserslist: ^4.14.5
+    browserslist: ^4.16.6
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: baa1e4cdd562996c6af0a8cedb097cd72f67c44577faf4b657015f477d4930ebcc40ca21dc1e5fcffe91a1517de6e4114bc21f805ca701dfac2ddd2e9b006228
+  checksum: d4725417dcb5f63a71f50038802a57c3ef5ef6f7830f563210b672c684583ddfbd03b542fd3c322aa32c8ada3ac4c1c5676971dfee28e63fd2886379300c6b31
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.13.0, @babel/helper-create-class-features-plugin@npm:^7.14.0, @babel/helper-create-class-features-plugin@npm:^7.14.3, @babel/helper-create-class-features-plugin@npm:^7.8.3":
-  version: 7.14.3
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.14.3"
+"@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.13.0, @babel/helper-create-class-features-plugin@npm:^7.14.0, @babel/helper-create-class-features-plugin@npm:^7.14.3, @babel/helper-create-class-features-plugin@npm:^7.14.4, @babel/helper-create-class-features-plugin@npm:^7.8.3":
+  version: 7.14.4
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.14.4"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.12.13
     "@babel/helper-function-name": ^7.14.2
     "@babel/helper-member-expression-to-functions": ^7.13.12
     "@babel/helper-optimise-call-expression": ^7.12.13
-    "@babel/helper-replace-supers": ^7.14.3
+    "@babel/helper-replace-supers": ^7.14.4
     "@babel/helper-split-export-declaration": ^7.12.13
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 9293683d388edaeb321bf9c4be64a5d4df1fc60aa8f66f0801bb87418dd57466b78aa5bccf3dea395ebed3e69226e6e0c8e365b202a554e39bb1d65f4d492078
+  checksum: f1b1092f75c3fbc5c2dfc339024a8c131ce80769408cfd96bb0a1461b421c09b2ffa3f02273a02085bd820178bcb38088998064a04f6fb1397d2aa40687f3bb7
   languageName: node
   linkType: hard
 
@@ -451,15 +451,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.12.13, @babel/helper-replace-supers@npm:^7.13.12, @babel/helper-replace-supers@npm:^7.14.3":
-  version: 7.14.3
-  resolution: "@babel/helper-replace-supers@npm:7.14.3"
+"@babel/helper-replace-supers@npm:^7.12.13, @babel/helper-replace-supers@npm:^7.13.12, @babel/helper-replace-supers@npm:^7.14.4":
+  version: 7.14.4
+  resolution: "@babel/helper-replace-supers@npm:7.14.4"
   dependencies:
     "@babel/helper-member-expression-to-functions": ^7.13.12
     "@babel/helper-optimise-call-expression": ^7.12.13
     "@babel/traverse": ^7.14.2
-    "@babel/types": ^7.14.2
-  checksum: 9c7de51e890dc92b011cd9a4cdc64399b66a473b2341360e1ffa143fbd5bb7a1f8ce6f3a68f67480da07e2940b0ceeb8f5bed5543cbbc7850d4cd6e20f4bd465
+    "@babel/types": ^7.14.4
+  checksum: 00d08b8489daf9a2973d54c36b41de1a2aa45178b05de4cfaaee5c5ed0945523f50a13360f262ab6bb5b49b358edb9d397a5b23416a23b6fa602dc1589c2f0e6
   languageName: node
   linkType: hard
 
@@ -539,11 +539,11 @@ __metadata:
   linkType: hard
 
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.10, @babel/parser@npm:^7.12.13, @babel/parser@npm:^7.14.2, @babel/parser@npm:^7.14.3, @babel/parser@npm:^7.6.4, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.9.0":
-  version: 7.14.3
-  resolution: "@babel/parser@npm:7.14.3"
+  version: 7.14.4
+  resolution: "@babel/parser@npm:7.14.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 5e8d1b2bfc53b59c7476c32adee20c8a4d19fdab58b04b6b177d89319bd76526219dad2f6ab6f51a80a518d0cbcdc3980b73c18bde16017aeee2dd8a50687fe3
+  checksum: 3bc067c1ee0e0178d365e1b2988ea1a0d6d37af37870ea1a7e80729b3bdc40acda083cac44ce72f63a5b31a489e35120f617bd41f312dec4c86cf814cff8e64a
   languageName: node
   linkType: hard
 
@@ -609,7 +609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-static-block@npm:^7.13.11":
+"@babel/plugin-proposal-class-static-block@npm:^7.14.3":
   version: 7.14.3
   resolution: "@babel/plugin-proposal-class-static-block@npm:7.14.3"
   dependencies:
@@ -743,18 +743,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.12.1, @babel/plugin-proposal-object-rest-spread@npm:^7.14.2, @babel/plugin-proposal-object-rest-spread@npm:^7.5.5, @babel/plugin-proposal-object-rest-spread@npm:^7.6.2, @babel/plugin-proposal-object-rest-spread@npm:^7.9.0":
-  version: 7.14.2
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.14.2"
+"@babel/plugin-proposal-object-rest-spread@npm:^7.12.1, @babel/plugin-proposal-object-rest-spread@npm:^7.14.4, @babel/plugin-proposal-object-rest-spread@npm:^7.5.5, @babel/plugin-proposal-object-rest-spread@npm:^7.6.2, @babel/plugin-proposal-object-rest-spread@npm:^7.9.0":
+  version: 7.14.4
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.14.4"
   dependencies:
-    "@babel/compat-data": ^7.14.0
-    "@babel/helper-compilation-targets": ^7.13.16
+    "@babel/compat-data": ^7.14.4
+    "@babel/helper-compilation-targets": ^7.14.4
     "@babel/helper-plugin-utils": ^7.13.0
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@babel/plugin-transform-parameters": ^7.14.2
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 787075655ea6a124bc0f4988f642cb285d32be4607a67373ab86bbb992a29be109f8726670e6bd0a2440180b3dd8f64c376dd54901934f93d72cac5df332b575
+  checksum: 460196a61d1f11bf864619c78df8536950e10ef02b13cd39c0fa81d73ff614b11c005da942505d40df63885594dc92d49d39cb88c659d1d02225d5888c8f1ceb
   languageName: node
   linkType: hard
 
@@ -1122,31 +1122,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.12.11, @babel/plugin-transform-block-scoping@npm:^7.14.2, @babel/plugin-transform-block-scoping@npm:^7.8.3":
-  version: 7.14.2
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.14.2"
+"@babel/plugin-transform-block-scoping@npm:^7.12.11, @babel/plugin-transform-block-scoping@npm:^7.14.4, @babel/plugin-transform-block-scoping@npm:^7.8.3":
+  version: 7.14.4
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.14.4"
   dependencies:
     "@babel/helper-plugin-utils": ^7.13.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: fb726d0ead02aaaf04076c26b476fe78bc5f698b763ff27135ab1bfbc9086bc49e7e50d09c61e661fb74b7ccb6f4184f70cb396e6dd495bc5806b20543b2280f
+  checksum: a2180f1a4948a0c7a28d5d772e40bb9ca1b1358aab5a2507f317f92829b088645a98cab8e15ec7bcea78a8d2e2c49db57cf4bc63903d2805a46a0d78541a347e
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.12.1, @babel/plugin-transform-classes@npm:^7.14.2, @babel/plugin-transform-classes@npm:^7.9.0":
-  version: 7.14.2
-  resolution: "@babel/plugin-transform-classes@npm:7.14.2"
+"@babel/plugin-transform-classes@npm:^7.12.1, @babel/plugin-transform-classes@npm:^7.14.4, @babel/plugin-transform-classes@npm:^7.9.0":
+  version: 7.14.4
+  resolution: "@babel/plugin-transform-classes@npm:7.14.4"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.12.13
     "@babel/helper-function-name": ^7.14.2
     "@babel/helper-optimise-call-expression": ^7.12.13
     "@babel/helper-plugin-utils": ^7.13.0
-    "@babel/helper-replace-supers": ^7.13.12
+    "@babel/helper-replace-supers": ^7.14.4
     "@babel/helper-split-export-declaration": ^7.12.13
     globals: ^11.1.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: a184a2d98868e9096db9c46c8a201976ece422350ce7834001ebd828a3df774fd21f2285a01c45c5dc5d238336422ea1ba8889d555e02b977243b1484215a115
+  checksum: bd99da94e59f1617a14ea7fe1dac9a2f9dca20bdf969fb34616771f6501a73c75401009565d5f8b2a7ac2defc22f90e88f649391c9bb4fb4b79e21f745c781ce
   languageName: node
   linkType: hard
 
@@ -1161,14 +1161,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.12.1, @babel/plugin-transform-destructuring@npm:^7.13.17, @babel/plugin-transform-destructuring@npm:^7.8.3":
-  version: 7.13.17
-  resolution: "@babel/plugin-transform-destructuring@npm:7.13.17"
+"@babel/plugin-transform-destructuring@npm:^7.12.1, @babel/plugin-transform-destructuring@npm:^7.14.4, @babel/plugin-transform-destructuring@npm:^7.8.3":
+  version: 7.14.4
+  resolution: "@babel/plugin-transform-destructuring@npm:7.14.4"
   dependencies:
     "@babel/helper-plugin-utils": ^7.13.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 16c08ecaf55d02754a5e0a33a766798362b5489c1632ce62bbef0624c0227f6cfa6b4066bf51efad0fac5655f34c1c9e7b06c631b31c13c1c55c3bfe39490d7c
+  checksum: 3743cee3743bbbfdc5225635a93a33a1a1b4be7e1b154ef7cf2fbabb83c46056d88ecb5b5967d233a5f64b4f840aabfea11ed84829e461b8e109a9b3f0025310
   languageName: node
   linkType: hard
 
@@ -1588,15 +1588,15 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-typescript@npm:^7.12.1, @babel/plugin-transform-typescript@npm:^7.13.0, @babel/plugin-transform-typescript@npm:^7.9.0":
-  version: 7.14.3
-  resolution: "@babel/plugin-transform-typescript@npm:7.14.3"
+  version: 7.14.4
+  resolution: "@babel/plugin-transform-typescript@npm:7.14.4"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.14.3
+    "@babel/helper-create-class-features-plugin": ^7.14.4
     "@babel/helper-plugin-utils": ^7.13.0
     "@babel/plugin-syntax-typescript": ^7.12.13
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 9fa070792c7742463665ae33cc1612941264f11909b2016351e119b36b545c3b0b47de96f0c4ad91cf5e19a2135edbfcb96f975abff1cd8e04fcd410847c55d7
+  checksum: 5850a0f88d6536ac22c41d02c5f79a1258ded5af444a19ec9342da1ea560a7b8e335f29fb1fdb3da1c4f06a60c1e8d8628d842014f5aae14e5ce27d367f2cece
   languageName: node
   linkType: hard
 
@@ -1780,24 +1780,24 @@ __metadata:
   linkType: hard
 
 "@babel/preset-env@npm:^7.4.5, @babel/preset-env@npm:^7.5.5":
-  version: 7.14.2
-  resolution: "@babel/preset-env@npm:7.14.2"
+  version: 7.14.4
+  resolution: "@babel/preset-env@npm:7.14.4"
   dependencies:
-    "@babel/compat-data": ^7.14.0
-    "@babel/helper-compilation-targets": ^7.13.16
+    "@babel/compat-data": ^7.14.4
+    "@babel/helper-compilation-targets": ^7.14.4
     "@babel/helper-plugin-utils": ^7.13.0
     "@babel/helper-validator-option": ^7.12.17
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.13.12
     "@babel/plugin-proposal-async-generator-functions": ^7.14.2
     "@babel/plugin-proposal-class-properties": ^7.13.0
-    "@babel/plugin-proposal-class-static-block": ^7.13.11
+    "@babel/plugin-proposal-class-static-block": ^7.14.3
     "@babel/plugin-proposal-dynamic-import": ^7.14.2
     "@babel/plugin-proposal-export-namespace-from": ^7.14.2
     "@babel/plugin-proposal-json-strings": ^7.14.2
     "@babel/plugin-proposal-logical-assignment-operators": ^7.14.2
     "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.2
     "@babel/plugin-proposal-numeric-separator": ^7.14.2
-    "@babel/plugin-proposal-object-rest-spread": ^7.14.2
+    "@babel/plugin-proposal-object-rest-spread": ^7.14.4
     "@babel/plugin-proposal-optional-catch-binding": ^7.14.2
     "@babel/plugin-proposal-optional-chaining": ^7.14.2
     "@babel/plugin-proposal-private-methods": ^7.13.0
@@ -1820,10 +1820,10 @@ __metadata:
     "@babel/plugin-transform-arrow-functions": ^7.13.0
     "@babel/plugin-transform-async-to-generator": ^7.13.0
     "@babel/plugin-transform-block-scoped-functions": ^7.12.13
-    "@babel/plugin-transform-block-scoping": ^7.14.2
-    "@babel/plugin-transform-classes": ^7.14.2
+    "@babel/plugin-transform-block-scoping": ^7.14.4
+    "@babel/plugin-transform-classes": ^7.14.4
     "@babel/plugin-transform-computed-properties": ^7.13.0
-    "@babel/plugin-transform-destructuring": ^7.13.17
+    "@babel/plugin-transform-destructuring": ^7.14.4
     "@babel/plugin-transform-dotall-regex": ^7.12.13
     "@babel/plugin-transform-duplicate-keys": ^7.12.13
     "@babel/plugin-transform-exponentiation-operator": ^7.12.13
@@ -1850,7 +1850,7 @@ __metadata:
     "@babel/plugin-transform-unicode-escapes": ^7.12.13
     "@babel/plugin-transform-unicode-regex": ^7.12.13
     "@babel/preset-modules": ^0.1.4
-    "@babel/types": ^7.14.2
+    "@babel/types": ^7.14.4
     babel-plugin-polyfill-corejs2: ^0.2.0
     babel-plugin-polyfill-corejs3: ^0.2.0
     babel-plugin-polyfill-regenerator: ^0.2.0
@@ -1858,7 +1858,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: a604b3ce5ba65dce1f9a7943060f0aab992bea9cf7b38fc2620cbda4cd849b87047a742537f2b123e6597a5959d2267b922789c77b702c17aa42f5dd9bc0d04a
+  checksum: 2620edcca3004a43af2a235a9299419484347dbadf8809f49d51083cdf3ed7da0d72340939d186c7e9c5db616ebe92a92a03cf11f7294c324341a67756c26e79
   languageName: node
   linkType: hard
 
@@ -2000,6 +2000,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:7.14.0, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.14.0
+  resolution: "@babel/runtime@npm:7.14.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:7.9.0":
   version: 7.9.0
   resolution: "@babel/runtime@npm:7.9.0"
@@ -2009,19 +2018,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.14.0
-  resolution: "@babel/runtime@npm:7.14.0"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
-  languageName: node
-  linkType: hard
-
 "@babel/standalone@npm:^7.4.5":
-  version: 7.14.3
-  resolution: "@babel/standalone@npm:7.14.3"
-  checksum: 35a40ff7bc3d6960dfdd19a6edbc240e7eafc17d84adfcbfbe2dad7d265daa5a058d2ef1ffe08e80798a1e34d18bf0aaa6c04fa3924f2ff74029dffc1d479ecc
+  version: 7.14.4
+  resolution: "@babel/standalone@npm:7.14.4"
+  checksum: 39ac6da8f243d6b3095fccec39133ff153911800f34dcb6b8006c1cc95bf81e1c42959532b26bd2898c109fd27849778a8692501025a15c06d61e5604da020e4
   languageName: node
   linkType: hard
 
@@ -2052,13 +2052,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.49, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.13, @babel/types@npm:^7.13.0, @babel/types@npm:^7.13.12, @babel/types@npm:^7.13.16, @babel/types@npm:^7.14.0, @babel/types@npm:^7.14.2, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3, @babel/types@npm:^7.9.0":
-  version: 7.14.2
-  resolution: "@babel/types@npm:7.14.2"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.49, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.13, @babel/types@npm:^7.13.0, @babel/types@npm:^7.13.12, @babel/types@npm:^7.13.16, @babel/types@npm:^7.14.0, @babel/types@npm:^7.14.2, @babel/types@npm:^7.14.4, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3, @babel/types@npm:^7.9.0":
+  version: 7.14.4
+  resolution: "@babel/types@npm:7.14.4"
   dependencies:
     "@babel/helper-validator-identifier": ^7.14.0
     to-fast-properties: ^2.0.0
-  checksum: 34893ac415826cd2ddead0511be9c3cb876bf626148b00b0a471c4630b193939ba46a9bf9d8b2be88e46fceb3ae9204ed7488ceb6a08a67550211d40df65a7c7
+  checksum: aadd11ec93c4ed1405ff85f8418c24a00d118750beffbc73cb662fd388ff2a89c8b763cccef5595015f2ff668bfa2fb6d63906296226f4f219554ce9e428aeb6
   languageName: node
   linkType: hard
 
@@ -2367,6 +2367,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@editorjs/editorjs@npm:2.21.0":
+  version: 2.21.0
+  resolution: "@editorjs/editorjs@npm:2.21.0"
+  dependencies:
+    codex-notifier: ^1.1.2
+    codex-tooltip: ^1.0.2
+    nanoid: ^3.1.22
+  checksum: b7afd0e53dcd9eff9b1fc528502fe59f8e7ff128865aebdac7b6d53eff1a8501672212fca922ecdbefa15585073e683342f28b6341b1eb12a3ab7eee77b2e870
+  languageName: node
+  linkType: hard
+
 "@editorjs/editorjs@npm:^2.19.0, @editorjs/editorjs@npm:^2.19.3, @editorjs/editorjs@npm:^2.20.1":
   version: 2.22.0
   resolution: "@editorjs/editorjs@npm:2.22.0"
@@ -2410,7 +2421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@elastic/elasticsearch@npm:^7.9.1":
+"@elastic/elasticsearch@npm:7.12.0":
   version: 7.12.0
   resolution: "@elastic/elasticsearch@npm:7.12.0"
   dependencies:
@@ -2420,6 +2431,18 @@ __metadata:
     pump: ^3.0.0
     secure-json-parse: ^2.3.1
   checksum: ec823ea4f237b10d7c2ac09b0213702c0f92cbf410103bb1a7b007a9ff3daee6759888bf045204596e2533335e777e7bc4ea112d1ec24a246e3a61e45798612f
+  languageName: node
+  linkType: hard
+
+"@elastic/elasticsearch@npm:^7.9.1":
+  version: 7.13.0
+  resolution: "@elastic/elasticsearch@npm:7.13.0"
+  dependencies:
+    debug: ^4.3.1
+    hpagent: ^0.1.1
+    ms: ^2.1.3
+    secure-json-parse: ^2.4.0
+  checksum: 9881b32643540512947ed55253005fb2c42ad41a4f4cb304c643a2ffa58fef3f23eb4eacd3c35e2a7bb16c4ce6837fff7668b974bed088a4f734507514cdaa1f
   languageName: node
   linkType: hard
 
@@ -2449,7 +2472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/core@npm:^10.0.17, @emotion/core@npm:^10.0.20, @emotion/core@npm:^10.0.27, @emotion/core@npm:^10.0.9":
+"@emotion/core@npm:10.1.1, @emotion/core@npm:^10.0.17, @emotion/core@npm:^10.0.20, @emotion/core@npm:^10.0.27, @emotion/core@npm:^10.0.9":
   version: 10.1.1
   resolution: "@emotion/core@npm:10.1.1"
   dependencies:
@@ -2560,7 +2583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:^10.0.17, @emotion/styled@npm:^10.0.27":
+"@emotion/styled@npm:10.0.27, @emotion/styled@npm:^10.0.17, @emotion/styled@npm:^10.0.27":
   version: 10.0.27
   resolution: "@emotion/styled@npm:10.0.27"
   dependencies:
@@ -2728,7 +2751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-svg-core@npm:^1.2.8":
+"@fortawesome/fontawesome-svg-core@npm:1.2.35, @fortawesome/fontawesome-svg-core@npm:^1.2.8":
   version: 1.2.35
   resolution: "@fortawesome/fontawesome-svg-core@npm:1.2.35"
   dependencies:
@@ -2737,7 +2760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-brands-svg-icons@npm:^5.5.0":
+"@fortawesome/free-brands-svg-icons@npm:5.15.3, @fortawesome/free-brands-svg-icons@npm:^5.5.0":
   version: 5.15.3
   resolution: "@fortawesome/free-brands-svg-icons@npm:5.15.3"
   dependencies:
@@ -2746,7 +2769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-regular-svg-icons@npm:^5.6.0":
+"@fortawesome/free-regular-svg-icons@npm:5.15.3, @fortawesome/free-regular-svg-icons@npm:^5.6.0":
   version: 5.15.3
   resolution: "@fortawesome/free-regular-svg-icons@npm:5.15.3"
   dependencies:
@@ -2755,7 +2778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-solid-svg-icons@npm:^5.5.0":
+"@fortawesome/free-solid-svg-icons@npm:5.15.3, @fortawesome/free-solid-svg-icons@npm:^5.5.0":
   version: 5.15.3
   resolution: "@fortawesome/free-solid-svg-icons@npm:5.15.3"
   dependencies:
@@ -2764,7 +2787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/react-fontawesome@npm:^0.1.3":
+"@fortawesome/react-fontawesome@npm:0.1.14, @fortawesome/react-fontawesome@npm:^0.1.3":
   version: 0.1.14
   resolution: "@fortawesome/react-fontawesome@npm:0.1.14"
   dependencies:
@@ -2776,7 +2799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/schema@npm:^7.0.0, @graphql-tools/schema@npm:^7.1.2":
+"@graphql-tools/schema@npm:7.1.5, @graphql-tools/schema@npm:^7.0.0, @graphql-tools/schema@npm:^7.1.2":
   version: 7.1.5
   resolution: "@graphql-tools/schema@npm:7.1.5"
   dependencies:
@@ -3922,9 +3945,9 @@ __metadata:
   linkType: hard
 
 "@logdna/tail-file@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@logdna/tail-file@npm:2.0.6"
-  checksum: 63464140f0997603899e2be71aaace859c67a5bdeb81f87ad3b20396c7354912d9816954c96c100a834c3a9629913612bc2ed99dde270926262b4f4ce46640fa
+  version: 2.0.7
+  resolution: "@logdna/tail-file@npm:2.0.7"
+  checksum: 83fbf1e14af7a8415200d331307022ffae449deb7ad5e00583eeda5a312d564b8f35ea83010c4af3f230a0e48c3e63ee460582a85bb0b039113bc1cb3678a719
   languageName: node
   linkType: hard
 
@@ -3947,7 +3970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material/base@npm:^3.1.0":
+"@material/base@npm:3.1.0, @material/base@npm:^3.1.0":
   version: 3.1.0
   resolution: "@material/base@npm:3.1.0"
   dependencies:
@@ -4462,7 +4485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material/textfield@npm:^3.2.0":
+"@material/textfield@npm:3.2.0, @material/textfield@npm:^3.2.0":
   version: 3.2.0
   resolution: "@material/textfield@npm:3.2.0"
   dependencies:
@@ -4547,20 +4570,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.scandir@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@nodelib/fs.scandir@npm:2.1.4"
+"@nodelib/fs.scandir@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@nodelib/fs.scandir@npm:2.1.5"
   dependencies:
-    "@nodelib/fs.stat": 2.0.4
+    "@nodelib/fs.stat": 2.0.5
     run-parallel: ^1.1.9
-  checksum: 30b3102ee37e1c1a0cb939a8e93f9a58b1637e2b4b546bb9143b3fb5efacd2abde3237a5313d5329bf1bc4231c418a77c3cb7f5434ce410e61a91ff4051cf215
+  checksum: 91b3de88d9ba843b74057ebec53d97bb1ca006fcb794f1eb2becfe6faf114cb575c90b10fc20f7390358106ffa5e6bbc493506c24f2263a33aa69f90c1e77f74
   languageName: node
   linkType: hard
 
-"@nodelib/fs.stat@npm:2.0.4, @nodelib/fs.stat@npm:^2.0.2":
-  version: 2.0.4
-  resolution: "@nodelib/fs.stat@npm:2.0.4"
-  checksum: 6454a79e945dd55102b5c2e158813804ed349f9c1cc806f8754fca4587688a5d8e4115fc3eedbdf3d8a6b343169a6b664ecd8a7a42289eed210c686a4d0897c4
+"@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
+  version: 2.0.5
+  resolution: "@nodelib/fs.stat@npm:2.0.5"
+  checksum: a4fcf7408f2a1e11737856629b1259fb9ed658c464fabb17f77db1069fea5dd47abd5e92325b217617dbc116138d82ea6d33ffc07a426de940c5f6e08603da88
   languageName: node
   linkType: hard
 
@@ -4572,12 +4595,12 @@ __metadata:
   linkType: hard
 
 "@nodelib/fs.walk@npm:^1.2.3":
-  version: 1.2.6
-  resolution: "@nodelib/fs.walk@npm:1.2.6"
+  version: 1.2.7
+  resolution: "@nodelib/fs.walk@npm:1.2.7"
   dependencies:
-    "@nodelib/fs.scandir": 2.1.4
+    "@nodelib/fs.scandir": 2.1.5
     fastq: ^1.6.0
-  checksum: d0503ffd0bb4172d5ac5d23993b14665f5f6d42a460a719ad97743ce71e60588d134cc60df12ca76be0e5e3a93c9a3156904d9296b78a8cdf19425c3423c0b58
+  checksum: ac8e2d9ca000b9f7fca2a7b005b9e476ba7b2f416d2873f64b94b207ed1854bd30f63ced4c221969c5e470ec82fbeb353c97504a86c3838cda11f98660fac284
   languageName: node
   linkType: hard
 
@@ -4607,10 +4630,10 @@ __metadata:
   linkType: hard
 
 "@octokit/auth-app@npm:^3.3.0":
-  version: 3.4.0
-  resolution: "@octokit/auth-app@npm:3.4.0"
+  version: 3.4.1
+  resolution: "@octokit/auth-app@npm:3.4.1"
   dependencies:
-    "@octokit/auth-oauth-app": ^4.1.0
+    "@octokit/auth-oauth-app": ^4.3.0
     "@octokit/auth-oauth-user": ^1.2.3
     "@octokit/request": ^5.4.11
     "@octokit/request-error": ^2.0.0
@@ -4620,13 +4643,13 @@ __metadata:
     lru-cache: ^6.0.0
     universal-github-app-jwt: ^1.0.1
     universal-user-agent: ^6.0.0
-  checksum: ff2f1acff1ac977f9e8d36a4ef1b9db16ee5fa20b7b059072c77a1f3a410ce36e764d4c41ec9dee555b98b7f614d4087ba5a60c8d8129a72b7d3ac4d50ac6efd
+  checksum: e81ed64403b4313c8e00e3cc9c374283a19f5d4b2c8e2055c0ad7ce236d1c70ca6e8ed96557463bcd34c14488b278bd74b8940e3e7ae1c2f20a2e3caae4fab41
   languageName: node
   linkType: hard
 
-"@octokit/auth-oauth-app@npm:^4.0.0, @octokit/auth-oauth-app@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "@octokit/auth-oauth-app@npm:4.2.0"
+"@octokit/auth-oauth-app@npm:^4.0.0, @octokit/auth-oauth-app@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@octokit/auth-oauth-app@npm:4.3.0"
   dependencies:
     "@octokit/auth-oauth-device": ^3.1.1
     "@octokit/auth-oauth-user": ^1.2.1
@@ -4635,7 +4658,7 @@ __metadata:
     "@types/btoa-lite": ^1.0.0
     btoa-lite: ^1.0.0
     universal-user-agent: ^6.0.0
-  checksum: cfe5a87cf4844b3fbab50fbc9d5d6dcdbd9e9232e3143874aee6f7248849d8048d97286882e60dec95194670e5297ee56aac191bcb4eba2e0f71a79f372eccc8
+  checksum: 21cec2f23fa82a0f4c45aac50eb46be37366e45a9605062c46c7a686d01158408655e9d223053788faaa0333338859ba3a3951ce0ad7925b04ceedd6ff12f43f
   languageName: node
   linkType: hard
 
@@ -4833,14 +4856,14 @@ __metadata:
   linkType: hard
 
 "@octokit/plugin-throttling@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "@octokit/plugin-throttling@npm:3.4.1"
+  version: 3.4.2
+  resolution: "@octokit/plugin-throttling@npm:3.4.2"
   dependencies:
     "@octokit/types": ^6.0.1
     bottleneck: ^2.15.3
   peerDependencies:
     "@octokit/core": ^3.0.0
-  checksum: d5411fcab6e4ad7dd8834852aab7d245ba91403d36c12230ec48e65d79deae13685359130061b4c0d459083859536890e11a0846e72abd0172017d14baf301df
+  checksum: df57449470cf568d5a06469f528124fcb05ece853d3967c649e402f1b0fc54653dac20c67450be17b64ebd843e8405692ee64923ed0c87042e54a88d40dbd979
   languageName: node
   linkType: hard
 
@@ -4929,22 +4952,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/webhooks-types@npm:3.75.1":
-  version: 3.75.1
-  resolution: "@octokit/webhooks-types@npm:3.75.1"
-  checksum: b5bc25a696dfc9f9cc092eecf47a8619bb9facbda65a284bf5b3b96720c9a44f08ed7ce92d4034440d3886bdc86e2fa286ef7291c4b64283802c48f2b3193601
+"@octokit/webhooks-types@npm:3.75.2":
+  version: 3.75.2
+  resolution: "@octokit/webhooks-types@npm:3.75.2"
+  checksum: aaeb17a4828766d42be5363cd994405c1185bc97d47559965b625552eaaa9d2b5bd91f8de69ede4359becfa7490fbf721b158c90edf691c4c86cad97d06faaf0
   languageName: node
   linkType: hard
 
 "@octokit/webhooks@npm:^9.0.1":
-  version: 9.6.2
-  resolution: "@octokit/webhooks@npm:9.6.2"
+  version: 9.6.3
+  resolution: "@octokit/webhooks@npm:9.6.3"
   dependencies:
     "@octokit/request-error": ^2.0.2
     "@octokit/webhooks-methods": ^1.0.0
-    "@octokit/webhooks-types": 3.75.1
+    "@octokit/webhooks-types": 3.75.2
     aggregate-error: ^3.1.0
-  checksum: e5a23fae74a8978327545d6c80b27f8688f437dadb042b98ab8431ab366fdac7e653ecbcbd0fc2608e35c57498c7bad23aec391b17350385a0894e48da6b13d7
+  checksum: cb9a5106efe144606ea2f7527506a1da4e76f09fcfceceb47da0578a748f0648206d08f231dbbee21ee4cba7c6ee773cb424a88b4d5a55995f60bf5e1b1279ef
   languageName: node
   linkType: hard
 
@@ -5117,7 +5140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/aws@npm:^3.22.0":
+"@pulumi/aws@npm:^3.22.0, @pulumi/aws@npm:v3.38.1":
   version: 3.38.1
   resolution: "@pulumi/aws@npm:3.38.1"
   dependencies:
@@ -5131,7 +5154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/pulumi@npm:^2.17.0, @pulumi/pulumi@npm:^2.21.2":
+"@pulumi/pulumi@npm:2.25.2+dirty, @pulumi/pulumi@npm:^2.17.0, @pulumi/pulumi@npm:^2.21.2":
   version: 2.25.2
   resolution: "@pulumi/pulumi@npm:2.25.2"
   dependencies:
@@ -5198,7 +5221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/base@npm:^5.6.0, @rmwc/base@npm:^5.7.2":
+"@rmwc/base@npm:5.7.2, @rmwc/base@npm:^5.6.0, @rmwc/base@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/base@npm:5.7.2"
   dependencies:
@@ -5214,7 +5237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/button@npm:^5.6.0, @rmwc/button@npm:^5.7.2":
+"@rmwc/button@npm:5.7.2, @rmwc/button@npm:^5.6.0, @rmwc/button@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/button@npm:5.7.2"
   dependencies:
@@ -5231,7 +5254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/checkbox@npm:^5.6.0":
+"@rmwc/checkbox@npm:5.7.2, @rmwc/checkbox@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/checkbox@npm:5.7.2"
   dependencies:
@@ -5249,7 +5272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/chip@npm:^5.6.0":
+"@rmwc/chip@npm:5.7.2, @rmwc/chip@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/chip@npm:5.7.2"
   dependencies:
@@ -5265,7 +5288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/dialog@npm:^5.6.0":
+"@rmwc/dialog@npm:5.7.2, @rmwc/dialog@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/dialog@npm:5.7.2"
   dependencies:
@@ -5281,7 +5304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/drawer@npm:^5.6.0":
+"@rmwc/drawer@npm:5.7.2, @rmwc/drawer@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/drawer@npm:5.7.2"
   dependencies:
@@ -5295,7 +5318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/elevation@npm:^5.6.0":
+"@rmwc/elevation@npm:5.7.2, @rmwc/elevation@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/elevation@npm:5.7.2"
   dependencies:
@@ -5309,7 +5332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/fab@npm:^5.6.0":
+"@rmwc/fab@npm:5.7.2, @rmwc/fab@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/fab@npm:5.7.2"
   dependencies:
@@ -5326,7 +5349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/floating-label@npm:^5.6.0, @rmwc/floating-label@npm:^5.7.2":
+"@rmwc/floating-label@npm:5.7.2, @rmwc/floating-label@npm:^5.6.0, @rmwc/floating-label@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/floating-label@npm:5.7.2"
   dependencies:
@@ -5354,7 +5377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/grid@npm:^5.6.0":
+"@rmwc/grid@npm:5.7.2, @rmwc/grid@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/grid@npm:5.7.2"
   dependencies:
@@ -5368,7 +5391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/icon-button@npm:^5.6.0, @rmwc/icon-button@npm:^5.7.2":
+"@rmwc/icon-button@npm:5.7.2, @rmwc/icon-button@npm:^5.6.0, @rmwc/icon-button@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/icon-button@npm:5.7.2"
   dependencies:
@@ -5384,7 +5407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/icon@npm:^5.6.0, @rmwc/icon@npm:^5.7.2":
+"@rmwc/icon@npm:5.7.2, @rmwc/icon@npm:^5.6.0, @rmwc/icon@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/icon@npm:5.7.2"
   dependencies:
@@ -5398,7 +5421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/line-ripple@npm:^5.6.0, @rmwc/line-ripple@npm:^5.7.2":
+"@rmwc/line-ripple@npm:5.7.2, @rmwc/line-ripple@npm:^5.6.0, @rmwc/line-ripple@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/line-ripple@npm:5.7.2"
   dependencies:
@@ -5412,7 +5435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/list@npm:^5.6.0, @rmwc/list@npm:^5.7.2":
+"@rmwc/list@npm:5.7.2, @rmwc/list@npm:^5.6.0, @rmwc/list@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/list@npm:5.7.2"
   dependencies:
@@ -5429,7 +5452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/menu@npm:^5.6.0, @rmwc/menu@npm:^5.7.2":
+"@rmwc/menu@npm:5.7.2, @rmwc/menu@npm:^5.6.0, @rmwc/menu@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/menu@npm:5.7.2"
   dependencies:
@@ -5445,7 +5468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/notched-outline@npm:^5.6.0, @rmwc/notched-outline@npm:^5.7.2":
+"@rmwc/notched-outline@npm:5.7.2, @rmwc/notched-outline@npm:^5.6.0, @rmwc/notched-outline@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/notched-outline@npm:5.7.2"
   dependencies:
@@ -5472,7 +5495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/radio@npm:^5.6.0":
+"@rmwc/radio@npm:5.7.2, @rmwc/radio@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/radio@npm:5.7.2"
   dependencies:
@@ -5489,7 +5512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/ripple@npm:^5.6.0, @rmwc/ripple@npm:^5.7.2":
+"@rmwc/ripple@npm:5.7.2, @rmwc/ripple@npm:^5.6.0, @rmwc/ripple@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/ripple@npm:5.7.2"
   dependencies:
@@ -5504,7 +5527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/select@npm:^5.6.0":
+"@rmwc/select@npm:5.7.2, @rmwc/select@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/select@npm:5.7.2"
   dependencies:
@@ -5525,7 +5548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/slider@npm:^5.6.0":
+"@rmwc/slider@npm:5.7.2, @rmwc/slider@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/slider@npm:5.7.2"
   dependencies:
@@ -5539,7 +5562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/snackbar@npm:^5.6.0":
+"@rmwc/snackbar@npm:5.7.2, @rmwc/snackbar@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/snackbar@npm:5.7.2"
   dependencies:
@@ -5556,7 +5579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/switch@npm:^5.6.0":
+"@rmwc/switch@npm:5.7.2, @rmwc/switch@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/switch@npm:5.7.2"
   dependencies:
@@ -5573,7 +5596,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/tabs@npm:^5.6.0":
+"@rmwc/tabs@npm:5.7.2, @rmwc/tabs@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/tabs@npm:5.7.2"
   dependencies:
@@ -5612,7 +5635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/top-app-bar@npm:^5.6.0":
+"@rmwc/top-app-bar@npm:5.7.2, @rmwc/top-app-bar@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/top-app-bar@npm:5.7.2"
   dependencies:
@@ -5628,14 +5651,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/types@npm:^5.6.0":
+"@rmwc/types@npm:5.6.0, @rmwc/types@npm:^5.6.0":
   version: 5.6.0
   resolution: "@rmwc/types@npm:5.6.0"
   checksum: 1096bba42087d4581728c7d1ec6279953f942a4d623b02add9e2a44486e4d9620d19e35e8d3d6fb6404d24222969b4a6a7ed5c503900ed1398af7ac82ac2a5e0
   languageName: node
   linkType: hard
 
-"@rmwc/typography@npm:^5.6.0":
+"@rmwc/typography@npm:5.7.2, @rmwc/typography@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/typography@npm:5.7.2"
   dependencies:
@@ -6351,18 +6374,18 @@ __metadata:
   linkType: hard
 
 "@testing-library/dom@npm:^7.28.1":
-  version: 7.31.0
-  resolution: "@testing-library/dom@npm:7.31.0"
+  version: 7.31.2
+  resolution: "@testing-library/dom@npm:7.31.2"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
     "@types/aria-query": ^4.2.0
     aria-query: ^4.2.2
     chalk: ^4.1.0
-    dom-accessibility-api: ^0.5.4
+    dom-accessibility-api: ^0.5.6
     lz-string: ^1.4.4
     pretty-format: ^26.6.2
-  checksum: 84c4bf5d33091b2eb668d8305591362bf9e3037eaca636bc97469622feaa3407ce1cc2af6d5f1a81b66b3e566cebef5b2c01d3ee47bc4c92abca38969f0f155d
+  checksum: f930b4797fd41e515e645427027574fb82a46d90edde20523c2269916be88aeb302f2a4eb982d7c41afbe2de4ed3129e6b269424db2a90974ea76bdb9f26e3ed
   languageName: node
   linkType: hard
 
@@ -6569,11 +6592,11 @@ __metadata:
   linkType: hard
 
 "@types/istanbul-reports@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/istanbul-reports@npm:3.0.0"
+  version: 3.0.1
+  resolution: "@types/istanbul-reports@npm:3.0.1"
   dependencies:
     "@types/istanbul-lib-report": "*"
-  checksum: 8aee794ea2e8065aa83e0a1017420068d10110f5e67f8473f5751e74462509306c451f79db3856e6848507519bf1d4de7d101daede6539701cc4d74b4646acd9
+  checksum: 398cc6bea308522f70829875c983cb26a19f2e420859a629d57713e3bfad64a02cf1c505575b29b5c3a1816397ad523135ae43a67eaeeae3b054f75233f4e7c4
   languageName: node
   linkType: hard
 
@@ -6595,7 +6618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6":
+"@types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7":
   version: 7.0.7
   resolution: "@types/json-schema@npm:7.0.7"
   checksum: b9d2c509fa4e0b82f58e73f5e6ab76c60ff1884ba41bb82f37fb1cece226d4a3e5a62fedf78a43da0005373a6713d9abe61c1e592906402c41c08ad6ab26d52b
@@ -6655,7 +6678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime@npm:^2.0.3":
+"@types/mime@npm:2.0.3, @types/mime@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/mime@npm:2.0.3"
   checksum: 6df548a912494f8579d548cd883be0425f30eaa2922283335c405e270600f49045a06d766460c0f0edabb41dff570c614d174d3c52215de3bddd11f190ec9ae9
@@ -6696,9 +6719,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:>=6":
-  version: 15.6.1
-  resolution: "@types/node@npm:15.6.1"
-  checksum: 07b3855bc0a1ba2215455a3ef4ed5e88711321b3cdc0ba1ea0286f6facbdf61530970b9fa7eec79eb1d46231f986c21ef3b7c1f1e0c365cf1b887d76b0addb86
+  version: 15.12.1
+  resolution: "@types/node@npm:15.12.1"
+  checksum: 8a111dc99281e07b1a6408437a09eafb081760aa8bd73d481793345b302a565772c45f2be7fdd7386a8a7ce589a999ccfb513dba15a0b3320dba03c94308253f
   languageName: node
   linkType: hard
 
@@ -6717,9 +6740,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^12.12.22":
-  version: 12.20.13
-  resolution: "@types/node@npm:12.20.13"
-  checksum: 4e0f02ec78b8d911595b20b9a7c3ac6c8e5f77ab5c57d0c14197fa021dec2c791469e1597b890f0d443f3809c908952e9ea56a2866d3cccf6076ff8a4579d969
+  version: 12.20.14
+  resolution: "@types/node@npm:12.20.14"
+  checksum: 2047f32e4a5a7f5be80745bdfd834635de673b2ee23259cf1dd2023513c33af7f165387a5ebb0f0aab605fe078b4840e4e810152266e5611aa755538d9bf77df
   languageName: node
   linkType: hard
 
@@ -6782,11 +6805,11 @@ __metadata:
   linkType: hard
 
 "@types/reach__router@npm:^1.2.3":
-  version: 1.3.7
-  resolution: "@types/reach__router@npm:1.3.7"
+  version: 1.3.8
+  resolution: "@types/reach__router@npm:1.3.8"
   dependencies:
     "@types/react": "*"
-  checksum: a17679f85c6f39a94cacbac62fff7b976adadd660ee9a8e2c5ab58036520869d4875b2707f7dd097f9eb14756b2041462d3615dfbb1efa61b37327f377866c61
+  checksum: 52cdde63e520101179a2f83f504906a8eb389220b9e0e9de2330d806230f83a7ca17889f8f69aa2ee3f4800727c1f236de59ef55e1b52b307d62487f937aba43
   languageName: node
   linkType: hard
 
@@ -6801,15 +6824,15 @@ __metadata:
   linkType: hard
 
 "@types/react-dom@npm:^17.0.0":
-  version: 17.0.5
-  resolution: "@types/react-dom@npm:17.0.5"
+  version: 17.0.6
+  resolution: "@types/react-dom@npm:17.0.6"
   dependencies:
     "@types/react": "*"
-  checksum: b3e23acb7be9405050abb4bcd443d14b16b2f3ded2d1853528199e4307b17b25186f905ddd236c27b6ef0297e6779b7fedd11fd24ee9170771be45a7e8e70f4b
+  checksum: baf0e2ea405768ccfe30399c1d2d5bc35d48023c6d67394b0c9a8179e51ff3d5e0363e7166114195ea275f97611aae9d8d0163a2813c7a3f1e95ef99f8070390
   languageName: node
   linkType: hard
 
-"@types/react-router-dom@npm:^5.1.5":
+"@types/react-router-dom@npm:5.1.7, @types/react-router-dom@npm:^5.1.5":
   version: 5.1.7
   resolution: "@types/react-router-dom@npm:5.1.7"
   dependencies:
@@ -7036,40 +7059,40 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^4.14.1":
-  version: 4.25.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.25.0"
+  version: 4.26.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.26.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.25.0
-    "@typescript-eslint/scope-manager": 4.25.0
-    debug: ^4.1.1
+    "@typescript-eslint/experimental-utils": 4.26.0
+    "@typescript-eslint/scope-manager": 4.26.0
+    debug: ^4.3.1
     functional-red-black-tree: ^1.0.1
-    lodash: ^4.17.15
-    regexpp: ^3.0.0
-    semver: ^7.3.2
-    tsutils: ^3.17.1
+    lodash: ^4.17.21
+    regexpp: ^3.1.0
+    semver: ^7.3.5
+    tsutils: ^3.21.0
   peerDependencies:
     "@typescript-eslint/parser": ^4.0.0
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3bab84b7770485ed0c56d315c0052758908293724b477f4e4a5546c1e1ce17dc2759af0ea5756b09edbf42d82a13436f9a24d563b1222653ec96a79eccb916f9
+  checksum: ccbe9e7cbb084cf0f35546de620e220d310a913805d3b428544a647b8d1e2a67a8c3f64b1656119c1beb734302bd83563bc1425b76a3c076178e5716ffe4f99a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.25.0":
-  version: 4.25.0
-  resolution: "@typescript-eslint/experimental-utils@npm:4.25.0"
+"@typescript-eslint/experimental-utils@npm:4.26.0":
+  version: 4.26.0
+  resolution: "@typescript-eslint/experimental-utils@npm:4.26.0"
   dependencies:
-    "@types/json-schema": ^7.0.3
-    "@typescript-eslint/scope-manager": 4.25.0
-    "@typescript-eslint/types": 4.25.0
-    "@typescript-eslint/typescript-estree": 4.25.0
-    eslint-scope: ^5.0.0
-    eslint-utils: ^2.0.0
+    "@types/json-schema": ^7.0.7
+    "@typescript-eslint/scope-manager": 4.26.0
+    "@typescript-eslint/types": 4.26.0
+    "@typescript-eslint/typescript-estree": 4.26.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 4b83a4cadbf6dbad9d822748e90403f40a749a8f213c92a26f29ce7deab10ee4adc1066f58ec49050a5fafc6fda593f3d672512b787872fae263de81b5ee4faa
+  checksum: 36048190f384a36fa376cba19a65066738db081c2bdecc5419fed0088a681671d2fa4e71047b715f7730a27b5235c7b46be5fdd8db4988cbc3fc43febc6a2893
   languageName: node
   linkType: hard
 
@@ -7088,36 +7111,36 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^4.14.1":
-  version: 4.25.0
-  resolution: "@typescript-eslint/parser@npm:4.25.0"
+  version: 4.26.0
+  resolution: "@typescript-eslint/parser@npm:4.26.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.25.0
-    "@typescript-eslint/types": 4.25.0
-    "@typescript-eslint/typescript-estree": 4.25.0
-    debug: ^4.1.1
+    "@typescript-eslint/scope-manager": 4.26.0
+    "@typescript-eslint/types": 4.26.0
+    "@typescript-eslint/typescript-estree": 4.26.0
+    debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: deab7d5edb21e267bc5db41dbfcd7cce5c779d639c5cbc1f2ecc2e9fc08a9d35b66697f090d01d17d2e82dd75ebe0385aef1ed90916ae5051b5541453d9407fa
+  checksum: afbcbf0ca3f82e94a50877e1389265b1d6e344dadc1a1f28d9f0e58b4bacd1c79acf82228b12a9a172827128952ce5f87b5162b70ca0acdb7a58263a108252e0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.25.0":
-  version: 4.25.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.25.0"
+"@typescript-eslint/scope-manager@npm:4.26.0":
+  version: 4.26.0
+  resolution: "@typescript-eslint/scope-manager@npm:4.26.0"
   dependencies:
-    "@typescript-eslint/types": 4.25.0
-    "@typescript-eslint/visitor-keys": 4.25.0
-  checksum: 26b41cf95eb6e0de7dc409bef6b78ad16c44e5f3c1fe727769093cd0cd41ca1f86b3f1755710e2a72c2b823adfbdd78cdac2427911b80ca0c7aabbbf6a6caccf
+    "@typescript-eslint/types": 4.26.0
+    "@typescript-eslint/visitor-keys": 4.26.0
+  checksum: cda031b525af0400cb5d30e6d4bdec5b0f52a4f3557e845ab91194029be119be4a0c7b560cd63c15dfd32ab25f1be64020b9a6b85c2d0df15e2493c5cdb6509f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.25.0":
-  version: 4.25.0
-  resolution: "@typescript-eslint/types@npm:4.25.0"
-  checksum: b40d8bcbfcd862b0c857ecb899e6933fdadafc95633aa1ea94dd9c2b2960d6d1abcbf0662ba8d4a36307f76123f964949a00c429901f8ac523f1520cc2a5e05f
+"@typescript-eslint/types@npm:4.26.0":
+  version: 4.26.0
+  resolution: "@typescript-eslint/types@npm:4.26.0"
+  checksum: 011fe4cc886449659e7ba623aaeb7af34bcf2a35b4749de01a707ba92d3c232d9167533ad5008dedeb01f13f67e8d04b7b2d0d316f403173280c520656ce0c2f
   languageName: node
   linkType: hard
 
@@ -7139,31 +7162,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.25.0":
-  version: 4.25.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.25.0"
+"@typescript-eslint/typescript-estree@npm:4.26.0":
+  version: 4.26.0
+  resolution: "@typescript-eslint/typescript-estree@npm:4.26.0"
   dependencies:
-    "@typescript-eslint/types": 4.25.0
-    "@typescript-eslint/visitor-keys": 4.25.0
-    debug: ^4.1.1
-    globby: ^11.0.1
+    "@typescript-eslint/types": 4.26.0
+    "@typescript-eslint/visitor-keys": 4.26.0
+    debug: ^4.3.1
+    globby: ^11.0.3
     is-glob: ^4.0.1
-    semver: ^7.3.2
-    tsutils: ^3.17.1
+    semver: ^7.3.5
+    tsutils: ^3.21.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 89c5fa4362636eff8a003414fe9c4c8f84f0f927593e779035535ea3518c45f0145fcb3eb02c2df171b8d3ab046bd0e17ada70ff566fc163b66a55c3dfa6ca51
+  checksum: 9f55637979d22f67f03936aac89f167d7a3cee9f9a81129ea23cba4f956894358a543c70a7a0063f6f306510d385cc965b2cde24231548607e42ed4b680b39bc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.25.0":
-  version: 4.25.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.25.0"
+"@typescript-eslint/visitor-keys@npm:4.26.0":
+  version: 4.26.0
+  resolution: "@typescript-eslint/visitor-keys@npm:4.26.0"
   dependencies:
-    "@typescript-eslint/types": 4.25.0
+    "@typescript-eslint/types": 4.26.0
     eslint-visitor-keys: ^2.0.0
-  checksum: 53369ad5faa8f9f597ef1cdbe87cdaf078065ff0c488c2f31324605cce952aa4ef54cd643ed76c78502964ac84b8e910191924bde5bf7273a12ec67437de69c9
+  checksum: 22f6327eaabc6bb9f57ee0682f57a6066c652f174c014cd9ee251c773ce213c5177faa141a4cc777272df349a71c5464e0ca282cf6667692c3a7a8175b919a24
   languageName: node
   linkType: hard
 
@@ -7589,7 +7612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webiny/api-dynamodb-to-elasticsearch@^5.3.0, @webiny/api-dynamodb-to-elasticsearch@^5.5.0-beta.0, @webiny/api-dynamodb-to-elasticsearch@^5.7.0, @webiny/api-dynamodb-to-elasticsearch@workspace:packages/api-dynamodb-to-elasticsearch":
+"@webiny/api-dynamodb-to-elasticsearch@^5.8.0-beta.0, @webiny/api-dynamodb-to-elasticsearch@workspace:packages/api-dynamodb-to-elasticsearch":
   version: 0.0.0-use.local
   resolution: "@webiny/api-dynamodb-to-elasticsearch@workspace:packages/api-dynamodb-to-elasticsearch"
   dependencies:
@@ -7600,28 +7623,57 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.0.0
     "@babel/runtime": ^7.5.5
-    "@webiny/api-plugin-elastic-search-client": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     aws-sdk: ^2.539.0
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/api-file-manager-s3@^5.5.0-beta.0, @webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3":
+"@webiny/api-dynamodb-to-elasticsearch@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-dynamodb-to-elasticsearch@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/api-plugin-elastic-search-client": 5.7.0
+    "@webiny/handler": 5.7.0
+    aws-sdk: 2.911.0
+  checksum: c9079c0e391001a39a80584fd61230a92a7e215dacc2d693ce1e99e5b2979349700610d0046167e060c95f71e242f98352d1b1b24e95461a26062e672a41c2de
+  languageName: node
+  linkType: hard
+
+"@webiny/api-file-manager-s3@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-file-manager-s3@npm:5.7.0"
+  dependencies:
+    "@webiny/api-file-manager": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/validation": 5.7.0
+    form-data: 3.0.1
+    node-fetch: 2.6.1
+    sanitize-filename: 1.6.3
+    uniqid: 5.3.0
+  checksum: c2f35a75ad6033dd4f6e0731c0d68ea4cb98c7f21bd674419d0c0d528f6e06851343b4e11f7e1ba4a512d40cdb9601576112dc41829939ffa0de6c3ba893082d
+  languageName: node
+  linkType: hard
+
+"@webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3":
   version: 0.0.0-use.local
   resolution: "@webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
-    "@webiny/api-file-manager": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     form-data: ^3.0.0
     node-fetch: ^2.6.1
     rimraf: ^3.0.2
@@ -7631,7 +7683,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-file-manager@^5.5.0-beta.0, @webiny/api-file-manager@^5.7.0, @webiny/api-file-manager@workspace:packages/api-file-manager":
+"@webiny/api-file-manager@^5.8.0-beta.0, @webiny/api-file-manager@workspace:packages/api-file-manager":
   version: 0.0.0-use.local
   resolution: "@webiny/api-file-manager@workspace:packages/api-file-manager"
   dependencies:
@@ -7646,19 +7698,19 @@ __metadata:
     "@elastic/elasticsearch": ^7.9.1
     "@elastic/elasticsearch-mock": 0.3.0
     "@shelf/jest-elasticsearch": ^1.0.0
-    "@webiny/api-dynamodb-to-elasticsearch": ^5.7.0
-    "@webiny/api-i18n-content": ^5.7.0
-    "@webiny/api-plugin-elastic-search-client": ^5.7.0
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/api-upgrade": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-client": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-dynamodb-to-elasticsearch": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/api-upgrade": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-client": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     aws-sdk: ^2.539.0
     commodo-fields-object: ^1.0.6
     execa: ^5.0.0
@@ -7673,7 +7725,65 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-form-builder@^5.5.0-beta.0, @webiny/api-form-builder@workspace:packages/api-form-builder":
+"@webiny/api-file-manager@npm:5.7.0, @webiny/api-file-manager@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-file-manager@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@commodo/fields": 1.1.2-beta.20
+    "@webiny/api-i18n-content": 5.7.0
+    "@webiny/api-plugin-elastic-search-client": 5.7.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/api-upgrade": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-client": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/project-utils": 5.7.0
+    "@webiny/validation": 5.7.0
+    aws-sdk: 2.911.0
+    commodo-fields-object: 1.0.6
+    mdbid: 1.0.0
+    object-hash: 1.3.1
+    sanitize-filename: 1.6.3
+  checksum: 4fef6c464913c9ac58a75ad6b3fe53836ac0572d2833f7121d5c11fc3b8d5ab59453c009497cd29189c895de6ea34aca1495e57f5d05b1091253259475d61b3b
+  languageName: node
+  linkType: hard
+
+"@webiny/api-form-builder@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-form-builder@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@commodo/fields": 1.1.2-beta.20
+    "@webiny/api-file-manager": 5.7.0
+    "@webiny/api-i18n": 5.7.0
+    "@webiny/api-i18n-content": 5.7.0
+    "@webiny/api-plugin-elastic-search-client": 5.7.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/api-upgrade": 5.7.0
+    "@webiny/db-dynamodb": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-aws": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/validation": 5.7.0
+    commodo-fields-object: 1.0.6
+    got: 9.6.0
+    json2csv: 4.5.4
+    lodash: 4.17.21
+    mdbid: 1.0.0
+    node-fetch: 2.6.1
+    slugify: 1.5.3
+  checksum: f2c541cce995e03b91486b549ae8e356f8a43e0850fcd438c55ec4ecb0eb630957fb93bd8164d224f03c1da8e9d1794ba7430ce2c516dc3a0595c3fa5758612b
+  languageName: node
+  linkType: hard
+
+"@webiny/api-form-builder@workspace:packages/api-form-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/api-form-builder@workspace:packages/api-form-builder"
   dependencies:
@@ -7685,24 +7795,24 @@ __metadata:
     "@commodo/fields": 1.1.2-beta.20
     "@elastic/elasticsearch": ^7.9.1
     "@shelf/jest-elasticsearch": ^1.0.0
-    "@webiny/api-dynamodb-to-elasticsearch": ^5.7.0
-    "@webiny/api-file-manager": ^5.7.0
-    "@webiny/api-i18n": ^5.7.0
-    "@webiny/api-i18n-content": ^5.7.0
-    "@webiny/api-plugin-elastic-search-client": ^5.7.0
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/api-upgrade": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/db-dynamodb": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-dynamodb-to-elasticsearch": ^5.8.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/api-upgrade": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     commodo-fields-object: ^1.0.6
     csvtojson: ^2.0.10
     got: ^9.6.0
@@ -7718,7 +7828,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-headless-cms-ddb-es@^5.6.0, @webiny/api-headless-cms-ddb-es@workspace:packages/api-headless-cms-ddb-es":
+"@webiny/api-headless-cms-ddb-es@^5.8.0-beta.0, @webiny/api-headless-cms-ddb-es@workspace:packages/api-headless-cms-ddb-es":
   version: 0.0.0-use.local
   resolution: "@webiny/api-headless-cms-ddb-es@workspace:packages/api-headless-cms-ddb-es"
   dependencies:
@@ -7730,17 +7840,17 @@ __metadata:
     "@elastic/elasticsearch": ^7.9.1
     "@shelf/jest-elasticsearch": ^1.0.0
     "@types/jsonpack": ^1.1.0
-    "@webiny/api-dynamodb-to-elasticsearch": ^5.3.0
-    "@webiny/api-headless-cms": ^5.3.0
-    "@webiny/api-plugin-elastic-search-client": ^5.3.0
-    "@webiny/api-upgrade": ^5.3.0
-    "@webiny/cli": ^5.6.0
-    "@webiny/db-dynamodb": ^5.3.0
-    "@webiny/error": ^5.3.0
-    "@webiny/handler-aws": ^5.3.0
-    "@webiny/handler-db": ^5.3.0
-    "@webiny/plugins": ^5.3.0
-    "@webiny/project-utils": ^5.3.0
+    "@webiny/api-dynamodb-to-elasticsearch": ^5.8.0-beta.0
+    "@webiny/api-headless-cms": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-upgrade": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     dataloader: ^2.0.0
     dynamodb-toolbox: ^0.3.4
     jest: ^26.6.3
@@ -7768,13 +7878,13 @@ __metadata:
     "@babel/preset-flow": ^7.0.0
     "@babel/runtime": ^7.5.5
     "@types/jsonpack": ^1.1.0
-    "@webiny/api-headless-cms": ^5.3.0
-    "@webiny/cli": ^5.6.0
-    "@webiny/db-dynamodb": ^5.3.0
-    "@webiny/error": ^5.3.0
-    "@webiny/handler-db": ^5.3.0
-    "@webiny/plugins": ^5.3.0
-    "@webiny/project-utils": ^5.3.0
+    "@webiny/api-headless-cms": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     aws-sdk: 2.868.0
     dataloader: ^2.0.0
     date-fns: ^2.21.1
@@ -7795,7 +7905,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-headless-cms@^5.3.0, @webiny/api-headless-cms@^5.5.0-beta.0, @webiny/api-headless-cms@workspace:packages/api-headless-cms":
+"@webiny/api-headless-cms@^5.8.0-beta.0, @webiny/api-headless-cms@workspace:packages/api-headless-cms":
   version: 0.0.0-use.local
   resolution: "@webiny/api-headless-cms@workspace:packages/api-headless-cms"
   dependencies:
@@ -7806,22 +7916,22 @@ __metadata:
     "@babel/runtime": ^7.5.5
     "@commodo/fields": beta
     "@graphql-tools/schema": ^7.1.2
-    "@webiny/api-file-manager": ^5.7.0
-    "@webiny/api-i18n": ^5.7.0
-    "@webiny/api-i18n-content": ^5.7.0
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/api-upgrade": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/handler-http": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/api-upgrade": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/handler-http": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-graphql: ^0.4.1
     boolean: ^3.0.2
     commodo-fields-object: ^1.0.6
@@ -7842,25 +7952,73 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-i18n-content@^5.5.0-beta.0, @webiny/api-i18n-content@^5.7.0, @webiny/api-i18n-content@workspace:packages/api-i18n-content":
+"@webiny/api-headless-cms@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-headless-cms@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@commodo/fields": 1.1.2-beta.20
+    "@graphql-tools/schema": 7.1.5
+    "@webiny/api-file-manager": 5.7.0
+    "@webiny/api-i18n": 5.7.0
+    "@webiny/api-i18n-content": 5.7.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/api-upgrade": 5.7.0
+    "@webiny/db-dynamodb": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-aws": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/handler-http": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/validation": 5.7.0
+    boolean: 3.0.4
+    commodo-fields-object: 1.0.6
+    dataloader: 2.0.0
+    dot-prop-immutable: 1.6.0
+    jsonpack: 1.1.5
+    lodash: 4.17.21
+    pluralize: 8.0.0
+    shortid: 2.2.16
+    slugify: 1.5.3
+  checksum: cdd89a3fbfbfb72dc0ebd56a1cac5483f16ac5f1a719a3436ec1e29974ed04b7a8d1b66072ba484edf04b2a18637d69e2f5942f6cdc989c5ccc0cfd3231abb9b
+  languageName: node
+  linkType: hard
+
+"@webiny/api-i18n-content@^5.8.0-beta.0, @webiny/api-i18n-content@workspace:packages/api-i18n-content":
   version: 0.0.0-use.local
   resolution: "@webiny/api-i18n-content@workspace:packages/api-i18n-content"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/api-i18n": ^5.7.0
-    "@webiny/api-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/api-i18n@^5.5.0-beta.0, @webiny/api-i18n@^5.7.0, @webiny/api-i18n@workspace:packages/api-i18n":
+"@webiny/api-i18n-content@npm:5.7.0, @webiny/api-i18n-content@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-i18n-content@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/api-i18n": 5.7.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+  checksum: bd12e8c8f7e229aac1e62615555b62dbcbfb4b35d748eb33f50c7f23b83419435aa7d18e804a23936935b99419181ea9c7715e4ef03c2845b0b8cb6bbb12c044
+  languageName: node
+  linkType: hard
+
+"@webiny/api-i18n@^5.8.0-beta.0, @webiny/api-i18n@workspace:packages/api-i18n":
   version: 0.0.0-use.local
   resolution: "@webiny/api-i18n@workspace:packages/api-i18n"
   dependencies:
@@ -7869,17 +8027,17 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/db-dynamodb": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-client": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-client": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     accept-language-parser: ^1.5.0
     execa: ^5.0.0
     i18n-locales: ^0.0.2
@@ -7891,7 +8049,69 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-page-builder@^5.5.0-beta.0, @webiny/api-page-builder@workspace:packages/api-page-builder":
+"@webiny/api-i18n@npm:5.7.0, @webiny/api-i18n@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-i18n@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/db-dynamodb": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-aws": 5.7.0
+    "@webiny/handler-client": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/plugins": 5.7.0
+    accept-language-parser: 1.5.0
+    i18n-locales: 0.0.2
+  checksum: 6ef62d7fb4f792ec13bc7423bfa0f18f85d67a6b4af91a4b3d40d6f2335caea28ad5f234aa3095bd07f8b4f73e9da771de2a6299799d29a5edfbce64ffb9af16
+  languageName: node
+  linkType: hard
+
+"@webiny/api-page-builder@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-page-builder@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@commodo/fields": 1.1.2-beta.20
+    "@webiny/api-file-manager": 5.7.0
+    "@webiny/api-i18n": 5.7.0
+    "@webiny/api-i18n-content": 5.7.0
+    "@webiny/api-prerendering-service": 5.7.0
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/api-upgrade": 5.7.0
+    "@webiny/cli-plugin-deploy-pulumi": 5.7.0
+    "@webiny/db-dynamodb": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-args": 5.7.0
+    "@webiny/handler-aws": 5.7.0
+    "@webiny/handler-client": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/validation": 5.7.0
+    commodo-fields-object: 1.0.6
+    dataloader: 2.0.0
+    extract-zip: 1.7.0
+    fs-extra: 7.0.1
+    jsonpack: 1.1.5
+    load-json-file: 6.2.0
+    lodash: 4.17.21
+    mdbid: 1.0.0
+    mime: 2.5.2
+    node-fetch: 2.6.1
+    rimraf: 3.0.2
+    stream: 0.0.2
+    uniqid: 5.3.0
+    zip-local: 0.3.4
+  checksum: 489a0906e64d8e2b8a904e1d722f04c69107234d746efae603426b1c5ee745681e4d45bed9b69fca3e4825cfa21bf201914905cd9670d1eabcfb79e785f45995
+  languageName: node
+  linkType: hard
+
+"@webiny/api-page-builder@workspace:packages/api-page-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/api-page-builder@workspace:packages/api-page-builder"
   dependencies:
@@ -7905,29 +8125,29 @@ __metadata:
     "@elastic/elasticsearch": ^7.9.1
     "@shelf/jest-elasticsearch": ^1.0.0
     "@types/puppeteer": ^5.4.2
-    "@webiny/api-dynamodb-to-elasticsearch": ^5.7.0
-    "@webiny/api-file-manager": ^5.7.0
-    "@webiny/api-i18n": ^5.7.0
-    "@webiny/api-i18n-content": ^5.7.0
-    "@webiny/api-plugin-elastic-search-client": ^5.7.0
-    "@webiny/api-prerendering-service": ^5.7.0
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/api-upgrade": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-deploy-pulumi": ^5.7.0
-    "@webiny/db": ^5.7.0
-    "@webiny/db-dynamodb": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-args": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-client": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-dynamodb-to-elasticsearch": ^5.8.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/api-upgrade": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-deploy-pulumi": ^5.8.0-beta.0
+    "@webiny/db": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-args": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-client": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     commodo-fields-object: ^1.0.6
     dataloader: ^2.0.0
     extract-zip: ^1.6.7
@@ -7948,16 +8168,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-plugin-elastic-search-client@^5.3.0, @webiny/api-plugin-elastic-search-client@^5.5.0-beta.0, @webiny/api-plugin-elastic-search-client@^5.7.0, @webiny/api-plugin-elastic-search-client@workspace:packages/api-plugin-elastic-search-client":
+"@webiny/api-plugin-elastic-search-client@^5.8.0-beta.0, @webiny/api-plugin-elastic-search-client@workspace:packages/api-plugin-elastic-search-client":
   version: 0.0.0-use.local
   resolution: "@webiny/api-plugin-elastic-search-client@workspace:packages/api-plugin-elastic-search-client"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@elastic/elasticsearch": ^7.9.1
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     aws-elasticsearch-connector: ^9.0.0
     aws-sdk: ^2.539.0
     elastic-ts: ^0.6.0
@@ -7966,20 +8186,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-plugin-security-cognito@^5.5.0-beta.0, @webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito":
+"@webiny/api-plugin-elastic-search-client@npm:5.7.0, @webiny/api-plugin-elastic-search-client@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-plugin-elastic-search-client@npm:5.7.0"
+  dependencies:
+    "@elastic/elasticsearch": 7.12.0
+    "@webiny/handler": 5.7.0
+    aws-elasticsearch-connector: 9.0.3
+    aws-sdk: 2.911.0
+  checksum: 85d6cea6325938153f2361f92b1e65cfe66962cca6bdcbaa0a893a9787b550f598f94f46c9bdcd17cc91bd315f533d940d7a08ca8cf54435f2432a50874c7a96
+  languageName: node
+  linkType: hard
+
+"@webiny/api-plugin-security-cognito@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-plugin-security-cognito@npm:5.7.0"
+  dependencies:
+    "@webiny/api-security": 5.7.0
+    "@webiny/api-security-tenancy": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/handler-http": 5.7.0
+    jsonwebtoken: 8.5.1
+    jwk-to-pem: 2.0.5
+    node-fetch: 2.6.1
+  checksum: 3ea2a9eda78fbaea4126bf817789df4a8d291c26891a0b93b4ffee8204b956229bcadb12a0820a01a701d9467548fd735608e8091d953af970de441cecc4a899
+  languageName: node
+  linkType: hard
+
+"@webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito":
   version: 0.0.0-use.local
   resolution: "@webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@types/jsonwebtoken": ^8.5.1
-    "@webiny/api-security": ^5.7.0
-    "@webiny/api-security-tenancy": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/handler-http": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/handler-http": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     jsonwebtoken: ^8.5.1
     jwk-to-pem: ^2.0.1
     node-fetch: ^2.6.1
@@ -7988,7 +8236,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-prerendering-service-aws@^5.5.0-beta.0, @webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws":
+"@webiny/api-prerendering-service-aws@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-prerendering-service-aws@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/api-prerendering-service": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-args": 5.7.0
+    "@webiny/plugins": 5.7.0
+  checksum: b6c84e46ff660793cbd76172efee0919d4d2486ee055871e8827b8818d9181578ef8293c4c50dc8d55ec177043c224b5a787e205fd7ce0b0257d7d930e15dcce
+  languageName: node
+  linkType: hard
+
+"@webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws":
   version: 0.0.0-use.local
   resolution: "@webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws"
   dependencies:
@@ -7998,18 +8259,18 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/api-prerendering-service": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-args": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-args": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/api-prerendering-service@^5.5.0-beta.0, @webiny/api-prerendering-service@^5.7.0, @webiny/api-prerendering-service@workspace:packages/api-prerendering-service":
+"@webiny/api-prerendering-service@^5.8.0-beta.0, @webiny/api-prerendering-service@workspace:packages/api-prerendering-service":
   version: 0.0.0-use.local
   resolution: "@webiny/api-prerendering-service@workspace:packages/api-prerendering-service"
   dependencies:
@@ -8019,17 +8280,17 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/db": ^5.7.0
-    "@webiny/db-dynamodb": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-args": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-client": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-args": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-client": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     chrome-aws-lambda: ^5.5.0
     jest-dynalite: ^3.3.1
     lodash: ^4.17.20
@@ -8045,25 +8306,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-security-tenancy@^5.5.0-beta.0, @webiny/api-security-tenancy@^5.7.0, @webiny/api-security-tenancy@workspace:packages/api-security-tenancy":
+"@webiny/api-prerendering-service@npm:5.7.0, @webiny/api-prerendering-service@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-prerendering-service@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-args": 5.7.0
+    "@webiny/handler-client": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/plugins": 5.7.0
+    chrome-aws-lambda: 5.5.0
+    lodash: 4.17.21
+    mdbid: 1.0.0
+    object-hash: 2.1.1
+    pluralize: 8.0.0
+    posthtml: 0.15.2
+    posthtml-noopener: 1.0.5
+    shortid: 2.2.16
+  checksum: 15fa85d3fcf816b743263dbf00da862847e55084a82a500130f47bc0d49711c6fb9c90746384e0acce8e8671a60c38caf5fe36bfadba8a95e1ecaa92149ecb78
+  languageName: node
+  linkType: hard
+
+"@webiny/api-security-tenancy@^5.8.0-beta.0, @webiny/api-security-tenancy@workspace:packages/api-security-tenancy":
   version: 0.0.0-use.local
   resolution: "@webiny/api-security-tenancy@workspace:packages/api-security-tenancy"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@commodo/fields": 1.1.2-beta.20
-    "@webiny/api-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/db-dynamodb": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-aws": ^5.7.0
-    "@webiny/handler-db": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/handler-http": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/handler-http": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     commodo-fields-object: ^1.0.6
     dataloader: ^2.0.0
     deep-equal: ^2.0.4
@@ -8076,7 +8360,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-security@^5.5.0-beta.0, @webiny/api-security@^5.7.0, @webiny/api-security@workspace:packages/api-security":
+"@webiny/api-security-tenancy@npm:5.7.0, @webiny/api-security-tenancy@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-security-tenancy@npm:5.7.0"
+  dependencies:
+    "@commodo/fields": 1.1.2-beta.20
+    "@webiny/api-security": 5.7.0
+    "@webiny/db-dynamodb": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-aws": 5.7.0
+    "@webiny/handler-db": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/handler-http": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/validation": 5.7.0
+    commodo-fields-object: 1.0.6
+    dataloader: 2.0.0
+    deep-equal: 2.0.5
+    md5: 2.3.0
+    mdbid: 1.0.0
+  checksum: 70e8cbab712a24c1bf50de51fe05c55973f30582be4bfc5f4a09cacb2e1eebbdc18b9a4ad9719502f40191a338436157e60937d2d3e79d9783ae61e7d2bcf37d
+  languageName: node
+  linkType: hard
+
+"@webiny/api-security@^5.8.0-beta.0, @webiny/api-security@workspace:packages/api-security":
   version: 0.0.0-use.local
   resolution: "@webiny/api-security@workspace:packages/api-security"
   dependencies:
@@ -8085,19 +8393,33 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-graphql": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     minimatch: ^3.0.4
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/api-upgrade@^5.3.0, @webiny/api-upgrade@^5.7.0, @webiny/api-upgrade@workspace:packages/api-upgrade":
+"@webiny/api-security@npm:5.7.0, @webiny/api-security@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/api-security@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-graphql": 5.7.0
+    "@webiny/plugins": 5.7.0
+    minimatch: 3.0.4
+  checksum: 934d71709ee80972b2efeb740484f96508fd6640c851de4eb4b28689db734b70d72369eaa8630661ae1f597eda6633ad7cd27968639088c75a55fd1dddf10ccc
+  languageName: node
+  linkType: hard
+
+"@webiny/api-upgrade@^5.8.0-beta.0, @webiny/api-upgrade@workspace:packages/api-upgrade":
   version: 0.0.0-use.local
   resolution: "@webiny/api-upgrade@workspace:packages/api-upgrade"
   dependencies:
@@ -8106,11 +8428,11 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/runtime": ^7.5.5
     "@types/semver": ^7.3.4
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     jest: ^26.6.3
     jest-mock-console: ^1.0.0
     rimraf: ^3.0.2
@@ -8119,7 +8441,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-admin@^5.5.0-beta.0, @webiny/app-admin@^5.7.0, @webiny/app-admin@workspace:packages/app-admin":
+"@webiny/api-upgrade@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/api-upgrade@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/plugins": 5.7.0
+    semver: 7.3.5
+  checksum: 912d9bcbc724808e05671bf899716ff9a7d3a5291b7f182d56534be896fc9c0fe2c9f695b0b0b50f452558f18b04f8794ed2085c609d6d56bcfed32ea3cb93b2
+  languageName: node
+  linkType: hard
+
+"@webiny/app-admin@^5.8.0-beta.0, @webiny/app-admin@workspace:packages/app-admin":
   version: 0.0.0-use.local
   resolution: "@webiny/app-admin@workspace:packages/app-admin"
   dependencies:
@@ -8137,15 +8472,15 @@ __metadata:
     "@svgr/webpack": ^4.3.2
     "@types/mime": ^2.0.3
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.8
     apollo-link: ^1.2.14
@@ -8182,15 +8517,77 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-file-manager-s3@^5.5.0-beta.0, @webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3":
+"@webiny/app-admin@npm:5.7.0, @webiny/app-admin@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-admin@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@editorjs/editorjs": 2.21.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@svgr/webpack": 4.3.3
+    "@types/mime": 2.0.3
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-utilities: 1.3.4
+    bytes: 3.1.0
+    classnames: 2.3.1
+    dataurl-to-blob: 0.0.1
+    dayjs: 1.10.4
+    dot-prop-immutable: 1.6.0
+    downshift: 3.4.8
+    emotion: 10.0.27
+    graphlib: 2.1.8
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    invariant: 2.2.4
+    lodash: 4.17.21
+    mime: 2.5.2
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-butterfiles: 1.3.3
+    react-dom: 16.14.0
+    react-hotkeyz: 1.0.4
+    react-lazy-load: 3.1.13
+    react-transition-group: 4.4.1
+    semver: 7.3.5
+    shortid: 2.2.16
+    store: 2.0.12
+  checksum: 54d2cf1ba3ae0a47a9282315c9f26a19c976902199353903bd1792e880c436cb8ad78a739d2529fe8db6e8736fab519ebe0e484d84ebfba21a18188ed7f1a430
+  languageName: node
+  linkType: hard
+
+"@webiny/app-file-manager-s3@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-file-manager-s3@npm:5.7.0"
+  dependencies:
+    "@webiny/plugins": 5.7.0
+    apollo-client: 2.6.10
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+  checksum: 779114594af2398824b7b4e98871b4afdc1d4ac7a5b0058f8abff8071d6d0c8636ba1f69ce9a1c2dbdb00cd96ef24ca11441ce79aab0e546d26a7c907caf050b
+  languageName: node
+  linkType: hard
+
+"@webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3":
   version: 0.0.0-use.local
   resolution: "@webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     apollo-client: ^2.6.10
     graphql: ^14.7.0
     graphql-tag: ^2.11.0
@@ -8199,7 +8596,39 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-file-manager@^5.5.0-beta.0, @webiny/app-file-manager@workspace:packages/app-file-manager":
+"@webiny/app-file-manager@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-file-manager@npm:5.7.0"
+  dependencies:
+    "@apollo/react-components": 3.1.5
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-utilities: 1.3.4
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    lodash.get: 4.4.2
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+  checksum: ab6d6cd0eac02a1b64a9202c508ec5244e222425664fa055e6915a816d0ade114bfcb9ccccb5f86a357a29ed46891386502eed3299645a0b995500f92c1509fe
+  languageName: node
+  linkType: hard
+
+"@webiny/app-file-manager@workspace:packages/app-file-manager":
   version: 0.0.0-use.local
   resolution: "@webiny/app-file-manager@workspace:packages/app-file-manager"
   dependencies:
@@ -8215,15 +8644,15 @@ __metadata:
     "@emotion/styled": ^10.0.27
     "@svgr/webpack": ^4.3.2
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8241,7 +8670,53 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-form-builder@^5.5.0-beta.0, @webiny/app-form-builder@workspace:packages/app-form-builder":
+"@webiny/app-form-builder@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-form-builder@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@editorjs/editorjs": 2.21.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@rmwc/menu": 5.7.2
+    "@svgr/webpack": 4.3.3
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-page-builder": 5.7.0
+    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-utilities: 1.3.4
+    dot-prop-immutable: 2.1.0
+    emotion: 10.0.27
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    lodash: 4.17.21
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-dnd: 9.5.1
+    react-dnd-html5-backend: 9.5.1
+    react-dom: 16.14.0
+    react-google-recaptcha: 1.1.0
+    react-helmet: 5.2.1
+    react-hotkeyz: 1.0.4
+    react-router: 5.2.0
+    react-sortable-hoc: 1.11.0
+    shortid: 2.2.16
+    timeago-react: 2.0.1
+  checksum: e7d4047a716ccb9b98a461e9e4539a955b874f89fca4d1c743554c9a8c6db5d2a2ec7bf9d26e21c4087f3514d97d10194ec0ae4d8725abd4f3f0569583fd38d4
+  languageName: node
+  linkType: hard
+
+"@webiny/app-form-builder@workspace:packages/app-form-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/app-form-builder@workspace:packages/app-form-builder"
   dependencies:
@@ -8258,18 +8733,18 @@ __metadata:
     "@rmwc/menu": ^5.6.0
     "@svgr/webpack": ^4.3.2
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-page-builder": ^5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-page-builder": ^5.8.0-beta.0
+    "@webiny/app-plugin-admin-welcome-screen": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.2.8
     apollo-utilities: ^1.3.4
@@ -8298,7 +8773,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-graphql-playground@^5.5.0-beta.0, @webiny/app-graphql-playground@^5.7.0, @webiny/app-graphql-playground@workspace:packages/app-graphql-playground":
+"@webiny/app-graphql-playground@^5.8.0-beta.0, @webiny/app-graphql-playground@workspace:packages/app-graphql-playground":
   version: 0.0.0-use.local
   resolution: "@webiny/app-graphql-playground@workspace:packages/app-graphql-playground"
   dependencies:
@@ -8310,15 +8785,15 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@emotion/core": ^10.0.17
     "@emotion/styled": ^10.0.27
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-i18n": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-i18n": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8337,7 +8812,89 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-headless-cms@^5.5.0-beta.0, @webiny/app-headless-cms@workspace:packages/app-headless-cms":
+"@webiny/app-graphql-playground@npm:5.7.0, @webiny/app-graphql-playground@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-graphql-playground@npm:5.7.0"
+  dependencies:
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-i18n": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-link-context: 1.0.20
+    apollo-utilities: 1.3.4
+    graphql: 14.7.0
+    load-script: 1.0.0
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+  checksum: e94b4f2eb5112d9fb01d87b50d38df996f8412f9a398190a929a1f2dcbf8610609a2b9ae36150a1c9b2c83c5dd5200efe5a9a11fa7e4b36de54862b7b2a44427
+  languageName: node
+  linkType: hard
+
+"@webiny/app-headless-cms@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-headless-cms@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@fortawesome/fontawesome-svg-core": 1.2.35
+    "@fortawesome/free-brands-svg-icons": 5.15.3
+    "@fortawesome/free-regular-svg-icons": 5.15.3
+    "@fortawesome/free-solid-svg-icons": 5.15.3
+    "@fortawesome/react-fontawesome": 0.1.14
+    "@svgr/webpack": 4.3.3
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-graphql-playground": 5.7.0
+    "@webiny/app-i18n": 5.7.0
+    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/error": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-utilities: 1.3.4
+    classnames: 2.3.1
+    dot-prop-immutable: 2.1.0
+    emotion: 10.0.27
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    lodash: 4.17.21
+    pluralize: 8.0.0
+    prop-types: 15.7.2
+    raw.macro: 0.4.2
+    react: 16.14.0
+    react-dnd: 9.5.1
+    react-dnd-html5-backend: 9.5.1
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+    react-hotkeyz: 1.0.4
+    react-router: 5.2.0
+    react-virtualized: 9.22.3
+    shortid: 2.2.16
+    timeago-react: 2.0.1
+  checksum: fee25c5045003b62a308d6da589ac031f69e0ac4944a72e925c3b629e079f3d6f5bfc18e3556efa57d4c38f948bfd00f676f4ada6cf7afd9458da78382f6535a
+  languageName: node
+  linkType: hard
+
+"@webiny/app-headless-cms@workspace:packages/app-headless-cms":
   version: 0.0.0-use.local
   resolution: "@webiny/app-headless-cms@workspace:packages/app-headless-cms"
   dependencies:
@@ -8357,20 +8914,20 @@ __metadata:
     "@fortawesome/react-fontawesome": ^0.1.3
     "@svgr/webpack": ^4.3.2
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-graphql-playground": ^5.7.0
-    "@webiny/app-i18n": ^5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-graphql-playground": ^5.8.0-beta.0
+    "@webiny/app-i18n": ^5.8.0-beta.0
+    "@webiny/app-plugin-admin-welcome-screen": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8405,7 +8962,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-i18n-content@^5.5.0-beta.0, @webiny/app-i18n-content@workspace:packages/app-i18n-content":
+"@webiny/app-i18n-content@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-i18n-content@npm:5.7.0"
+  dependencies:
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-i18n": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/ui": 5.7.0
+    emotion: 10.0.27
+    react: 16.14.0
+    react-dom: 16.14.0
+  checksum: 7fed1221b43108ceebb4f630bf62eb6b01785f3f1d7ff3d68ffff7140ecb536d15c785f377515616ff3aba645941945a9610bb90dfe2f0eec37d57cea39151d4
+  languageName: node
+  linkType: hard
+
+"@webiny/app-i18n-content@workspace:packages/app-i18n-content":
   version: 0.0.0-use.local
   resolution: "@webiny/app-i18n-content@workspace:packages/app-i18n-content"
   dependencies:
@@ -8415,14 +8989,14 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.8.3
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-i18n": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/ui": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-i18n": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     babel-plugin-emotion: ^9.2.8
     babel-plugin-lodash: ^3.3.4
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
@@ -8434,7 +9008,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-i18n@^5.5.0-beta.0, @webiny/app-i18n@^5.7.0, @webiny/app-i18n@workspace:packages/app-i18n":
+"@webiny/app-i18n@^5.8.0-beta.0, @webiny/app-i18n@workspace:packages/app-i18n":
   version: 0.0.0-use.local
   resolution: "@webiny/app-i18n@workspace:packages/app-i18n"
   dependencies:
@@ -8448,15 +9022,15 @@ __metadata:
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.27
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8477,7 +9051,39 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-page-builder@^5.5.0-beta.0, @webiny/app-page-builder@^5.7.0, @webiny/app-page-builder@workspace:packages/app-page-builder":
+"@webiny/app-i18n@npm:5.7.0, @webiny/app-i18n@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-i18n@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-link-context: 1.0.20
+    apollo-utilities: 1.3.4
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    lodash: 4.17.21
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+  checksum: 4a1362cbc0f2096d70a8a708b86535be37c49203dd9548f0468d4075c848ebe92d4ad2cf6739f6e1ba88212ffe8b5b2a2c97c7712bf677691c893cba4c83daca
+  languageName: node
+  linkType: hard
+
+"@webiny/app-page-builder@^5.8.0-beta.0, @webiny/app-page-builder@workspace:packages/app-page-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/app-page-builder@workspace:packages/app-page-builder"
   dependencies:
@@ -8502,20 +9108,20 @@ __metadata:
     "@types/medium-editor": ^5.0.3
     "@types/react": ^16.9.56
     "@types/resize-observer-browser": ^0.1.4
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-i18n": ^5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/app-security-tenancy": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/tracking": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-i18n": ^5.8.0-beta.0
+    "@webiny/app-plugin-admin-welcome-screen": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/app-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/tracking": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     aos: ^2.3.4
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
@@ -8563,7 +9169,77 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-plugin-admin-welcome-screen@^5.5.0-beta.0, @webiny/app-plugin-admin-welcome-screen@^5.7.0, @webiny/app-plugin-admin-welcome-screen@workspace:packages/app-plugin-admin-welcome-screen":
+"@webiny/app-page-builder@npm:5.7.0, @webiny/app-page-builder@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-page-builder@npm:5.7.0"
+  dependencies:
+    "@apollo/react-components": 3.1.5
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@fortawesome/fontawesome-svg-core": 1.2.35
+    "@fortawesome/free-brands-svg-icons": 5.15.3
+    "@fortawesome/free-regular-svg-icons": 5.15.3
+    "@fortawesome/free-solid-svg-icons": 5.15.3
+    "@fortawesome/react-fontawesome": 0.1.14
+    "@rmwc/menu": 5.7.2
+    "@svgr/webpack": 4.3.3
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-i18n": 5.7.0
+    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/app-security-tenancy": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/tracking": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    aos: 2.3.4
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-utilities: 1.3.4
+    classnames: 2.3.1
+    dataurl-to-blob: 0.0.1
+    dot-prop-immutable: 1.6.0
+    emotion: 10.0.27
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    invariant: 2.2.4
+    is-hotkey: 0.1.8
+    lodash: 4.17.21
+    lodash.pick: 4.4.0
+    medium-editor: 5.23.3
+    nanoid: 3.1.23
+    object.pick: 1.3.0
+    platform: 1.3.6
+    prop-types: 15.7.2
+    react: 16.14.0
+    react-color: 2.19.3
+    react-dnd: 9.5.1
+    react-dnd-html5-backend: 9.5.1
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+    react-images: 0.5.19
+    react-sortable: 2.0.0
+    react-sortable-tree: 2.8.0
+    react-transition-group: 4.4.1
+    react-virtualized: 9.22.3
+    recoil: 0.1.3
+    slugify: 1.5.3
+    store: 2.0.12
+    timeago-react: 2.0.1
+    uniqid: 5.3.0
+    warning: 4.0.3
+  checksum: 104d346f575d2d39f6c4f20f5e55eda8afe2507796a11a9755a925b39f3c9f952aed766cec4dbed7a750b251766093d4d8132c30649b169b3fdd1a3aad4f86af
+  languageName: node
+  linkType: hard
+
+"@webiny/app-plugin-admin-welcome-screen@^5.8.0-beta.0, @webiny/app-plugin-admin-welcome-screen@workspace:packages/app-plugin-admin-welcome-screen":
   version: 0.0.0-use.local
   resolution: "@webiny/app-plugin-admin-welcome-screen@workspace:packages/app-plugin-admin-welcome-screen"
   dependencies:
@@ -8574,13 +9250,13 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.27
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     emotion: ^10.0.27
     react: ^16.14.0
     react-dom: ^16.14.0
@@ -8590,7 +9266,56 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-plugin-security-cognito@^5.5.0-beta.0, @webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito":
+"@webiny/app-plugin-admin-welcome-screen@npm:5.7.0, @webiny/app-plugin-admin-welcome-screen@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-plugin-admin-welcome-screen@npm:5.7.0"
+  dependencies:
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    emotion: 10.0.27
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-helmet: 6.1.0
+  checksum: 68291f2f53ab7bb5625e1e18ad07f5132acec90407850d19b821b1a3c93e640867f860c943808e88ac479356b57715b2863907720a641d69f24b0dd6ed5e04ec
+  languageName: node
+  linkType: hard
+
+"@webiny/app-plugin-security-cognito@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-plugin-security-cognito@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@aws-amplify/auth": 1.6.3
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/app-security-tenancy": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-link-context: 1.0.20
+    apollo-utilities: 1.3.4
+    emotion: 10.0.27
+    graphql: 14.7.0
+    lodash: 4.17.21
+    react: 16.14.0
+    react-dom: 16.14.0
+  checksum: e5ec8624aca4ba6e7447ccf9e27152c69d7eb15be5d4bc94772fa2926adabb55fc7549e087c5caf908ae26c60afdae5063ed567503f6b7350c028b76a737a601
+  languageName: node
+  linkType: hard
+
+"@webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito":
   version: 0.0.0-use.local
   resolution: "@webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito"
   dependencies:
@@ -8606,15 +9331,15 @@ __metadata:
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.27
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/app-security-tenancy": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/app-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8631,7 +9356,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-security-tenancy@^5.5.0-beta.0, @webiny/app-security-tenancy@^5.7.0, @webiny/app-security-tenancy@workspace:packages/app-security-tenancy":
+"@webiny/app-security-tenancy@^5.8.0-beta.0, @webiny/app-security-tenancy@workspace:packages/app-security-tenancy":
   version: 0.0.0-use.local
   resolution: "@webiny/app-security-tenancy@workspace:packages/app-security-tenancy"
   dependencies:
@@ -8646,16 +9371,16 @@ __metadata:
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.27
     "@types/react": ^16.9.56
-    "@webiny/app": ^5.7.0
-    "@webiny/app-admin": ^5.7.0
-    "@webiny/app-security": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
@@ -8676,7 +9401,40 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-security@^5.5.0-beta.0, @webiny/app-security@^5.7.0, @webiny/app-security@workspace:packages/app-security":
+"@webiny/app-security-tenancy@npm:5.7.0, @webiny/app-security-tenancy@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-security-tenancy@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@types/react": 16.14.2
+    "@webiny/app": 5.7.0
+    "@webiny/app-admin": 5.7.0
+    "@webiny/app-security": 5.7.0
+    "@webiny/form": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    "@webiny/validation": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-utilities: 1.3.4
+    dot-prop-immutable: 1.6.0
+    emotion: 10.0.17
+    graphql: 14.7.0
+    graphql-tag: 2.12.4
+    lodash: 4.17.21
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-helmet: 5.2.1
+  checksum: ba4e67b6a1119eb1d617fafbbd5d2598bb898c04f46173b75a65763e1d68245a15c80d887e9a2288c8221d0db8ea1009056783fcdbabcde414948debf4f87ecc
+  languageName: node
+  linkType: hard
+
+"@webiny/app-security@^5.8.0-beta.0, @webiny/app-security@workspace:packages/app-security":
   version: 0.0.0-use.local
   resolution: "@webiny/app-security@workspace:packages/app-security"
   dependencies:
@@ -8686,10 +9444,10 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.8.3
-    "@webiny/app": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-emotion: ^9.2.8
     babel-plugin-lodash: ^3.3.4
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
@@ -8700,6 +9458,19 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
+
+"@webiny/app-security@npm:5.7.0, @webiny/app-security@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app-security@npm:5.7.0"
+  dependencies:
+    "@webiny/app": 5.7.0
+    "@webiny/plugins": 5.7.0
+    minimatch: 3.0.4
+    react: 16.14.0
+    react-dom: 16.14.0
+  checksum: 6aca51ecab39ba705a715cc78545ba2663be90ed9a967cd61330a17b7fa73643f48d71c079065e6f17206dbcd37ae27fea35c457a9e5153efce676b3b8d564bc
+  languageName: node
+  linkType: hard
 
 "@webiny/app-typeform@workspace:packages/app-typeform":
   version: 0.0.0-use.local
@@ -8714,11 +9485,11 @@ __metadata:
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.17
     "@svgr/webpack": ^4.3.2
-    "@webiny/app": ^5.7.0
-    "@webiny/app-page-builder": ^5.7.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-page-builder": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     babel-plugin-emotion: ^9.2.8
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
     lodash: ^4.17.4
@@ -8730,7 +9501,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app@^5.5.0-beta.0, @webiny/app@^5.7.0, @webiny/app@workspace:packages/app":
+"@webiny/app@^5.8.0-beta.0, @webiny/app@workspace:packages/app":
   version: 0.0.0-use.local
   resolution: "@webiny/app@workspace:packages/app"
   dependencies:
@@ -8744,13 +9515,13 @@ __metadata:
     "@babel/runtime": ^7.5.5
     "@emotion/styled": ^10.0.17
     "@types/react": ^16.9.56
-    "@webiny/cli": ^5.7.0
-    "@webiny/i18n": ^5.7.0
-    "@webiny/i18n-react": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/react-router": ^5.7.0
-    "@webiny/ui": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/i18n": ^5.8.0-beta.0
+    "@webiny/i18n-react": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.8
     apollo-link: ^1.2.14
@@ -8770,6 +9541,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/app@npm:5.7.0, @webiny/app@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/app@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@emotion/styled": 10.0.27
+    "@types/react": 16.14.2
+    "@webiny/i18n": 5.7.0
+    "@webiny/i18n-react": 5.7.0
+    "@webiny/plugins": 5.7.0
+    "@webiny/react-router": 5.7.0
+    "@webiny/ui": 5.7.0
+    apollo-cache: 1.3.5
+    apollo-client: 2.6.10
+    apollo-link: 1.2.14
+    apollo-link-context: 1.0.20
+    apollo-link-error: 1.1.13
+    apollo-utilities: 1.3.4
+    boolean: 3.0.4
+    graphql: 14.7.0
+    invariant: 2.2.4
+    lodash: 4.17.21
+    react: 16.14.0
+    react-dom: 16.14.0
+    warning: 4.0.3
+  checksum: efafd8faf0e661be5dd2987e51c14f8c5d6cff80d4546dbca7d34d2c3c970175d5f83bb4ae1500e8af2bce45ea223a1378fcd6ad21caf750f0c5d2f07c011c0f
+  languageName: node
+  linkType: hard
+
 "@webiny/aws-layers@workspace:packages/aws-layers":
   version: 0.0.0-use.local
   resolution: "@webiny/aws-layers@workspace:packages/aws-layers"
@@ -8778,13 +9579,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli-plugin-deploy-pulumi@^5.5.0-beta.0, @webiny/cli-plugin-deploy-pulumi@^5.7.0, @webiny/cli-plugin-deploy-pulumi@workspace:packages/cli-plugin-deploy-pulumi":
+"@webiny/cli-plugin-deploy-pulumi@^5.8.0-beta.0, @webiny/cli-plugin-deploy-pulumi@workspace:packages/cli-plugin-deploy-pulumi":
   version: 0.0.0-use.local
   resolution: "@webiny/cli-plugin-deploy-pulumi@workspace:packages/cli-plugin-deploy-pulumi"
   dependencies:
     "@pulumi/pulumi": ^2.21.2
-    "@webiny/cli": ^5.7.0
-    "@webiny/pulumi-sdk": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/pulumi-sdk": ^5.8.0-beta.0
     ansi-to-html: ^0.6.14
     blessed: ^0.1.81
     blessed-contrib: ^4.8.21
@@ -8807,6 +9608,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/cli-plugin-deploy-pulumi@npm:5.7.0, @webiny/cli-plugin-deploy-pulumi@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/cli-plugin-deploy-pulumi@npm:5.7.0"
+  dependencies:
+    "@pulumi/pulumi": 2.25.2+dirty
+    "@webiny/cli": 5.7.0
+    "@webiny/pulumi-sdk": 5.7.0
+    ansi-to-html: 0.6.15
+    blessed: 0.1.81
+    blessed-contrib: 4.8.21
+    body-parser: 1.19.0
+    chalk: 4.1.0
+    execa: 5.0.0
+    express: 4.17.1
+    handlebars: 4.7.7
+    localtunnel: 2.0.1
+    lodash: 4.17.20
+    minimatch: 3.0.4
+    ncp: 2.0.0
+    node-notifier: 7.0.2
+    open: 8.0.9
+    ora: 4.1.1
+    rimraf: 3.0.2
+    tree-kill: 1.2.2
+    ws: 7.4.5
+  checksum: 206e18b1e665d3ea9c68929fb008dfbf89a4105b48805406b84359462f2800c4a1655c8ceb3aa77729f401d0667317b4cf21908396dd348acbc38bd056cc634e
+  languageName: node
+  linkType: hard
+
 "@webiny/cli-plugin-scaffold-admin-app-module@workspace:packages/cli-plugin-scaffold-admin-app-module":
   version: 0.0.0-use.local
   resolution: "@webiny/cli-plugin-scaffold-admin-app-module@workspace:packages/cli-plugin-scaffold-admin-app-module"
@@ -8818,12 +9648,12 @@ __metadata:
     "@types/inquirer": ^7.3.1
     "@types/ncp": ^2.0.4
     "@types/pluralize": ^0.0.29
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-scaffold": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-scaffold": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     case: ^1.6.3
     chalk: ^4.1.0
     execa: ^5.0.0
@@ -8849,10 +9679,10 @@ __metadata:
     "@types/inquirer": ^7.3.1
     "@types/ncp": ^2.0.4
     "@types/pluralize": ^0.0.29
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-scaffold": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-scaffold": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     chalk: ^4.1.0
     js-base64: ^3.6.0
     octokit: ^1.0.4
@@ -8874,12 +9704,12 @@ __metadata:
     "@types/inquirer": ^7.3.1
     "@types/ncp": ^2.0.4
     "@types/pluralize": ^0.0.29
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-scaffold": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-scaffold": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     case: ^1.6.3
     chalk: ^4.1.0
     execa: ^5.0.0
@@ -8906,10 +9736,10 @@ __metadata:
     "@types/inquirer": ^7.3.1
     "@types/ncp": ^2.0.4
     "@types/pluralize": ^0.0.29
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-scaffold": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-scaffold": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     case: ^1.6.3
     chalk: ^4.1.0
     execa: ^5.0.0
@@ -8925,7 +9755,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli-plugin-scaffold@^5.7.0, @webiny/cli-plugin-scaffold@workspace:packages/cli-plugin-scaffold":
+"@webiny/cli-plugin-scaffold@^5.8.0-beta.0, @webiny/cli-plugin-scaffold@workspace:packages/cli-plugin-scaffold":
   version: 0.0.0-use.local
   resolution: "@webiny/cli-plugin-scaffold@workspace:packages/cli-plugin-scaffold"
   dependencies:
@@ -8935,10 +9765,10 @@ __metadata:
     "@babel/preset-flow": ^7.0.0
     "@babel/runtime": ^7.5.5
     "@types/inquirer": ^7.3.1
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     inquirer: ^7.3.3
     ora: 4.1.1
     rimraf: ^3.0.2
@@ -8950,7 +9780,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/cli-plugin-workspaces@workspace:packages/cli-plugin-workspaces"
   dependencies:
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     archy: ^1.0.0
     chalk: 4.1.0
     execa: 5.0.0
@@ -8961,13 +9791,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli@^5.5.0-beta.0, @webiny/cli@^5.6.0, @webiny/cli@^5.7.0, @webiny/cli@workspace:packages/cli":
+"@webiny/cli@^5.8.0-beta.0, @webiny/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@webiny/cli@workspace:packages/cli"
   dependencies:
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/tracking": ^5.7.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/tracking": ^5.8.0-beta.0
     camelcase: 5.3.1
     chalk: 2.4.2
     dotenv: 8.2.0
@@ -8977,18 +9807,45 @@ __metadata:
     ncp: ^2.0.0
     pirates: ^4.0.1
     prettier: ^1.14.2
-    public-ip: 4.0.3
     rimraf: ^3.0.2
     semver: 7.3.4
     ts-morph: ^11.0.0
     typescript: 4.1.3
     uniqid: ^5.3.0
+    uuid: ^8.3.2
     write-json-file: 4.3.0
     yargs: 14.2.3
   bin:
     webiny: ./bin.js
   languageName: unknown
   linkType: soft
+
+"@webiny/cli@npm:5.7.0, @webiny/cli@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/cli@npm:5.7.0"
+  dependencies:
+    "@webiny/tracking": 5.7.0
+    camelcase: 5.3.1
+    chalk: 2.4.2
+    dotenv: 8.2.0
+    execa: 2.1.0
+    find-up: 5.0.0
+    load-json-file: 6.2.0
+    ncp: 2.0.0
+    pirates: 4.0.1
+    prettier: 1.19.1
+    public-ip: 4.0.3
+    rimraf: 3.0.2
+    semver: 7.3.4
+    typescript: 4.1.3
+    uniqid: 5.3.0
+    write-json-file: 4.3.0
+    yargs: 14.2.3
+  bin:
+    webiny: bin.js
+  checksum: 9e175ee0fb60e2e38e658bd1a906e404fd8fd3e837afb8334f5b442c9de49867116e58a8f8cc0315437206949072c0f46ac4ddcacb326fe7f7dbd29f75300b31
+  languageName: node
+  linkType: hard
 
 "@webiny/commodo@workspace:packages/commodo":
   version: 0.0.0-use.local
@@ -8999,8 +9856,8 @@ __metadata:
     "@commodo/fields": ^1.2.1
     "@commodo/hooks": ^1.2.1
     "@commodo/name": ^1.3.1
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     commodo-fields-date: ^1.0.3
     commodo-fields-float: ^1.0.2
     commodo-fields-int: ^1.0.1
@@ -9016,9 +9873,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/cwp-template-aws@workspace:packages/cwp-template-aws"
   dependencies:
-    "@webiny/cli": ^5.7.0
-    "@webiny/cli-plugin-deploy-pulumi": ^5.7.0
-    "@webiny/tracking": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-deploy-pulumi": ^5.8.0-beta.0
+    "@webiny/tracking": ^5.8.0-beta.0
     chalk: 4.1.0
     dotenv: ^8.2.0
     execa: 4.1.0
@@ -9033,15 +9890,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/db-dynamodb@^5.3.0, @webiny/db-dynamodb@^5.5.0-beta.0, @webiny/db-dynamodb@^5.7.0, @webiny/db-dynamodb@workspace:packages/db-dynamodb":
+"@webiny/db-dynamodb@^5.8.0-beta.0, @webiny/db-dynamodb@workspace:packages/db-dynamodb":
   version: 0.0.0-use.local
   resolution: "@webiny/db-dynamodb@workspace:packages/db-dynamodb"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/db": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     jest: ^26.6.3
     jest-dynalite: ^3.2.0
     rimraf: ^3.0.2
@@ -9049,33 +9906,56 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/db@^5.7.0, @webiny/db@workspace:packages/db":
+"@webiny/db-dynamodb@npm:5.7.0, @webiny/db-dynamodb@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/db-dynamodb@npm:5.7.0"
+  dependencies:
+    "@webiny/db": 5.7.0
+  checksum: 7fcc5185f607133305f9a3c57de539739a6b042479a14f52fbf5249926e2c34c15ca53c9ddc0da38833916b6beb9dee9444fbf48ff772125675cd33fd51dbcd2
+  languageName: node
+  linkType: hard
+
+"@webiny/db@^5.8.0-beta.0, @webiny/db@workspace:packages/db":
   version: 0.0.0-use.local
   resolution: "@webiny/db@workspace:packages/db"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/error@^5.3.0, @webiny/error@^5.7.0, @webiny/error@workspace:packages/error":
+"@webiny/db@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/db@npm:5.7.0"
+  checksum: bbe75040ceacc26ccd055f7be1de3241454e14f5d2c20b5cf9d3cf92e3b6e70cbf33913e2a7c889d7e34abffaaf815313c97527adca0be9c0bb7838bcfcccbef
+  languageName: node
+  linkType: hard
+
+"@webiny/error@^5.8.0-beta.0, @webiny/error@workspace:packages/error":
   version: 0.0.0-use.local
   resolution: "@webiny/error@workspace:packages/error"
   dependencies:
     "@babel/cli": ^7.12.10
     "@babel/core": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/form@^5.5.0-beta.0, @webiny/form@^5.7.0, @webiny/form@workspace:packages/form":
+"@webiny/error@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/error@npm:5.7.0"
+  checksum: f0029cefc2422b1e083391a8e3cc51a9c170aea6000db350ec321841e6b4cc839a3b914ccd54e7b9ee35f2da269aa1b1bfc9054fcdcf7403f5cb42cc2e2f131b
+  languageName: node
+  linkType: hard
+
+"@webiny/form@^5.8.0-beta.0, @webiny/form@workspace:packages/form":
   version: 0.0.0-use.local
   resolution: "@webiny/form@workspace:packages/form"
   dependencies:
@@ -9085,8 +9965,8 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-lodash: ^3.3.4
     invariant: ^2.2.4
     lodash: ^4.17.5
@@ -9097,7 +9977,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-args@^5.7.0, @webiny/handler-args@workspace:packages/handler-args":
+"@webiny/form@npm:5.7.0, @webiny/form@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/form@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    invariant: 2.2.4
+    lodash: 4.17.21
+  peerDependencies:
+    react: 16.14.0
+  checksum: e4efd401bc1255fd633aa8aa7890be9882551be19591e961ff714044782805be342671c81f56f23c350f8e2e4311bc2dc3a191fe881e80e2b60d482a4f3ab135
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-args@^5.8.0-beta.0, @webiny/handler-args@workspace:packages/handler-args":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-args@workspace:packages/handler-args"
   dependencies:
@@ -9106,14 +9999,23 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-aws@^5.3.0, @webiny/handler-aws@^5.5.0-beta.0, @webiny/handler-aws@^5.7.0, @webiny/handler-aws@workspace:packages/handler-aws":
+"@webiny/handler-args@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-args@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+  checksum: 8b043749c94367aa9b47664f014319d006063cbc416002180d386d6891868c624f221a6d24c718802a9980b7351f41d475f9890dfd9989b0c38dd29034ff051f
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-aws@^5.8.0-beta.0, @webiny/handler-aws@workspace:packages/handler-aws":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-aws@workspace:packages/handler-aws"
   dependencies:
@@ -9122,13 +10024,13 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-args": ^5.7.0
-    "@webiny/handler-client": ^5.7.0
-    "@webiny/handler-http": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-args": ^5.8.0-beta.0
+    "@webiny/handler-client": ^5.8.0-beta.0
+    "@webiny/handler-http": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-lodash: ^3.3.4
     merge: ^1.2.1
     rimraf: ^3.0.2
@@ -9136,7 +10038,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-client@^5.7.0, @webiny/handler-client@workspace:packages/handler-client":
+"@webiny/handler-aws@npm:5.7.0, @webiny/handler-aws@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-aws@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-args": 5.7.0
+    "@webiny/handler-client": 5.7.0
+    "@webiny/handler-http": 5.7.0
+    "@webiny/plugins": 5.7.0
+  checksum: dc9252c0387d8d65a8c7d81e59e324d692e68ac78db7de48477dd42921a4412b98240ff2db87747b7f50b51f626e33024dec3eaf41f0b9d660ab829d13cf628b
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-client@^5.8.0-beta.0, @webiny/handler-client@workspace:packages/handler-client":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-client@workspace:packages/handler-client"
   dependencies:
@@ -9145,11 +10061,11 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-lodash: ^3.3.4
     jest: ^26.6.3
     merge: ^1.2.1
@@ -9158,7 +10074,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-db@^5.3.0, @webiny/handler-db@^5.5.0-beta.0, @webiny/handler-db@^5.7.0, @webiny/handler-db@workspace:packages/handler-db":
+"@webiny/handler-client@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-client@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/plugins": 5.7.0
+  checksum: fc5cf5a0d7ee5f08569a2596b54de01694be0b1994d9feb8bfecba0cc6b58c195f014d118ff3605f7a4ba2e3da5279d679e0457fa9db4eb2ed1b41ab7e408ebf
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-db@^5.8.0-beta.0, @webiny/handler-db@workspace:packages/handler-db":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-db@workspace:packages/handler-db"
   dependencies:
@@ -9166,16 +10094,27 @@ __metadata:
     "@babel/core": ^7.5.5
     "@babel/preset-env": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/db": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-graphql@^5.5.0-beta.0, @webiny/handler-graphql@^5.7.0, @webiny/handler-graphql@workspace:packages/handler-graphql":
+"@webiny/handler-db@npm:5.7.0, @webiny/handler-db@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-db@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/db": 5.7.0
+    "@webiny/handler": 5.7.0
+  checksum: 8236e9d4d40770b06c695e9a24ecfc76a64ce920fc9f797be994ead840003bd22d2729c7c61d1cc908cdb7f98d42df91320209feadf647c8391f9b9ad2d0d08e
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-graphql@^5.8.0-beta.0, @webiny/handler-graphql@workspace:packages/handler-graphql":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-graphql@workspace:packages/handler-graphql"
   dependencies:
@@ -9184,13 +10123,13 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/runtime": ^7.5.5
     "@graphql-tools/schema": ^7.0.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/handler-args": ^5.7.0
-    "@webiny/handler-http": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/handler-args": ^5.8.0-beta.0
+    "@webiny/handler-http": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     boolean: ^3.0.1
     graphql: ^14.4.2
     graphql-scalars: ^1.7.0
@@ -9202,16 +10141,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-http@^5.7.0, @webiny/handler-http@workspace:packages/handler-http":
+"@webiny/handler-graphql@npm:5.7.0, @webiny/handler-graphql@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-graphql@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@graphql-tools/schema": 7.1.5
+    "@webiny/error": 5.7.0
+    "@webiny/handler": 5.7.0
+    "@webiny/handler-http": 5.7.0
+    "@webiny/plugins": 5.7.0
+    boolean: 3.0.4
+    graphql: 14.7.0
+    graphql-scalars: 1.9.3
+    graphql-tag: 2.12.4
+  checksum: 396f70e73408dbe02538c17778e89d63583284e0b1c46717e01c370dfc1d8eea0c9c391dedc11a66560cda279434c64bef65fbd8cf2b4e69d5239e071c4856d3
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-http@^5.8.0-beta.0, @webiny/handler-http@workspace:packages/handler-http":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-http@workspace:packages/handler-http"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/handler": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     boolean: ^3.0.1
     merge: ^1.2.1
     rimraf: ^3.0.2
@@ -9219,7 +10176,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-logs@^5.5.0-beta.0, @webiny/handler-logs@workspace:packages/handler-logs":
+"@webiny/handler-http@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-http@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/handler": 5.7.0
+    boolean: 3.0.4
+  checksum: fdc37236e7be265a144329032021775b3b67f79e8a29d221857b9288c88dd458ec09200b0bf216a57d3321244ffbcc653bcab643cb2d27a90b6292d18ac06fbf
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-logs@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/handler-logs@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    node-fetch: 2.6.1
+  checksum: f2a4ea7d935f2637739e0f9247c04a161e70ba76b72803c221928b0eeb7530f4d5b8c6ea02108bdae1ff39d68c9dc3c9b1a9bb9754314fa3201e75927579e77c
+  languageName: node
+  linkType: hard
+
+"@webiny/handler-logs@workspace:packages/handler-logs":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-logs@workspace:packages/handler-logs"
   dependencies:
@@ -9228,15 +10206,15 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     node-fetch: ^2.6.1
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/handler@^5.7.0, @webiny/handler@workspace:packages/handler":
+"@webiny/handler@^5.8.0-beta.0, @webiny/handler@workspace:packages/handler":
   version: 0.0.0-use.local
   resolution: "@webiny/handler@workspace:packages/handler"
   dependencies:
@@ -9244,15 +10222,25 @@ __metadata:
     "@babel/core": ^7.5.5
     "@babel/preset-env": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
 
-"@webiny/i18n-react@^5.7.0, @webiny/i18n-react@workspace:packages/i18n-react":
+"@webiny/handler@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/handler@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/plugins": 5.7.0
+  checksum: 09df0fdbb59f591ddbb76ea36a3c34c2366b80230efd5ac876d1668d5c35e47a7781bf98e447faf4650ea2b36ebca33508bb62d87a28f98aba708cec9217553f
+  languageName: node
+  linkType: hard
+
+"@webiny/i18n-react@^5.8.0-beta.0, @webiny/i18n-react@workspace:packages/i18n-react":
   version: 0.0.0-use.local
   resolution: "@webiny/i18n-react@workspace:packages/i18n-react"
   dependencies:
@@ -9262,9 +10250,9 @@ __metadata:
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/i18n": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/i18n": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-lodash: ^3.3.4
     lodash: ^4.17.4
     rimraf: ^3.0.2
@@ -9274,7 +10262,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/i18n@^5.7.0, @webiny/i18n@workspace:packages/i18n":
+"@webiny/i18n-react@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/i18n-react@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@webiny/i18n": 5.7.0
+    lodash: 4.17.21
+  peerDependencies:
+    react: 16.14.0
+  checksum: 2903b0df5e934c36585f84f6ba763f971aaa44738a9e7d6d83dc70aa738d87a2e822c38d5570245883d700e62353429e075f6e5db30aacccef39d493b4c3a76f
+  languageName: node
+  linkType: hard
+
+"@webiny/i18n@^5.8.0-beta.0, @webiny/i18n@workspace:packages/i18n":
   version: 0.0.0-use.local
   resolution: "@webiny/i18n@workspace:packages/i18n"
   dependencies:
@@ -9284,8 +10285,8 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@babel/register": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     accounting: ^0.4.1
     babel-plugin-lodash: ^3.3.4
     fecha: ^2.3.3
@@ -9300,22 +10301,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/plugins@^5.3.0, @webiny/plugins@^5.5.0-beta.0, @webiny/plugins@^5.7.0, @webiny/plugins@workspace:packages/plugins":
+"@webiny/i18n@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/i18n@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    accounting: 0.4.1
+    fecha: 2.3.3
+    lodash: 4.17.21
+    short-hash: 1.0.0
+    yargs: 12.0.5
+  peerDependencies:
+    react: 16.14.0
+  checksum: f429da658dd128b4b9d3b3cb61a458166951185cc5c37de07d6f76e706587cebdbcc27d3c9dcc52fdddaa213911fb66ccbc4ecf9cc8261c11183a3627bccdf09
+  languageName: node
+  linkType: hard
+
+"@webiny/plugins@^5.8.0-beta.0, @webiny/plugins@workspace:packages/plugins":
   version: 0.0.0-use.local
   resolution: "@webiny/plugins@workspace:packages/plugins"
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     rimraf: ^3.0.2
     typescript: ^4.1.3
     uniqid: ^5.2.0
   languageName: unknown
   linkType: soft
 
-"@webiny/project-utils@^5.3.0, @webiny/project-utils@^5.5.0-beta.0, @webiny/project-utils@^5.7.0, @webiny/project-utils@workspace:packages/project-utils":
+"@webiny/plugins@npm:5.7.0, @webiny/plugins@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/plugins@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    uniqid: 5.3.0
+  checksum: 5aebd133c09c16f92d16daf921481722c95ad3f358720d9bacb38af27f187552e83d13d8c0172630b8fa20769dd7b43f380436691daa5b7ee1bc08ba6167caa9
+  languageName: node
+  linkType: hard
+
+"@webiny/project-utils@^5.8.0-beta.0, @webiny/project-utils@workspace:packages/project-utils":
   version: 0.0.0-use.local
   resolution: "@webiny/project-utils@workspace:packages/project-utils"
   dependencies:
@@ -9328,7 +10355,7 @@ __metadata:
     "@hot-loader/react-dom": 16.14.0+4.13.0
     "@svgr/webpack": 4.3.3
     "@types/webpack-env": 1.15.2
-    "@webiny/cli": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
     babel-loader: 8.0.6
     babel-plugin-lodash: 3.3.4
     babel-plugin-named-asset-import: 0.3.7
@@ -9378,7 +10405,71 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/pulumi-sdk@^5.7.0, @webiny/pulumi-sdk@workspace:packages/pulumi-sdk":
+"@webiny/project-utils@npm:5.7.0, @webiny/project-utils@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/project-utils@npm:5.7.0"
+  dependencies:
+    "@babel/core": 7.12.10
+    "@babel/plugin-proposal-class-properties": 7.12.1
+    "@babel/plugin-syntax-object-rest-spread": 7.8.3
+    "@babel/preset-env": 7.12.11
+    "@babel/preset-react": 7.12.10
+    "@babel/preset-typescript": 7.12.7
+    "@hot-loader/react-dom": 16.14.0+4.13.0
+    "@svgr/webpack": 4.3.3
+    "@types/webpack-env": 1.15.2
+    "@webiny/cli": 5.7.0
+    babel-loader: 8.0.6
+    babel-plugin-lodash: 3.3.4
+    babel-plugin-named-asset-import: 0.3.7
+    babel-preset-react-app: 9.1.2
+    boolean: 3.0.2
+    camelcase: 5.3.1
+    case-sensitive-paths-webpack-plugin: 2.2.0
+    chalk: 3.0.0
+    css-loader: 3.2.0
+    eslint: 6.8.0
+    eslint-loader: 3.0.2
+    execa: 5.0.0
+    file-loader: 4.3.0
+    fs-extra: 8.1.0
+    get-yarn-workspaces: 1.0.2
+    html-webpack-plugin: 4.0.0-beta.5
+    lodash.get: 4.4.2
+    mini-css-extract-plugin: 0.9.0
+    node-sass: 4.14.1
+    optimize-css-assets-webpack-plugin: 5.0.3
+    pnp-webpack-plugin: 1.5.0
+    postcss-flexbugs-fixes: 4.1.0
+    postcss-loader: 3.0.0
+    postcss-normalize: 8.0.1
+    postcss-preset-env: 6.7.0
+    postcss-safe-parser: 4.0.1
+    raw-loader: 4.0.2
+    react: 16.14.0
+    react-dev-utils: 10.2.1
+    react-dom: 16.14.0
+    react-native-web: 0.12.3
+    read-json-sync: 2.0.1
+    resolve: 1.12.2
+    resolve-url-loader: 3.1.1
+    rimraf: 3.0.2
+    sass-loader: 8.0.0
+    scheduler: 0.19.1
+    style-loader: 1.0.0
+    terser-webpack-plugin: 2.2.1
+    ts-pnp: 1.1.5
+    url: 0.11.0
+    url-loader: 2.3.0
+    webpack: 4.41.2
+    webpack-dev-server: 3.9.0
+    webpack-manifest-plugin: 2.2.0
+    webpackbar: 4.0.0
+  checksum: e5140d37deffecc2bb8ab834fc9bca00d084e1ad1438394a2e9f8450365b02eab524b082a1280f665dbeb48d575eb62612a07e79d3616ce756c8d86354d810b3
+  languageName: node
+  linkType: hard
+
+"@webiny/pulumi-sdk@^5.8.0-beta.0, @webiny/pulumi-sdk@workspace:packages/pulumi-sdk":
   version: 0.0.0-use.local
   resolution: "@webiny/pulumi-sdk@workspace:packages/pulumi-sdk"
   dependencies:
@@ -9387,8 +10478,8 @@ __metadata:
     "@pulumi/aws": ^3.22.0
     "@pulumi/pulumi": ^2.21.2
     "@types/node": ^10.0.0
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     decompress: ^4.2.1
     download: ^5.0.3
     execa: ^4.0.3
@@ -9400,7 +10491,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/react-rich-text-renderer@^5.5.0-beta.0, @webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
+"@webiny/pulumi-sdk@npm:5.7.0":
+  version: 5.7.0
+  resolution: "@webiny/pulumi-sdk@npm:5.7.0"
+  dependencies:
+    "@pulumi/aws": v3.38.1
+    "@pulumi/pulumi": 2.25.2+dirty
+    decompress: 4.2.1
+    download: 5.0.3
+    execa: 4.1.0
+    lodash: 4.17.21
+    semver: 7.3.5
+    tar: 6.1.0
+  checksum: ded48b574d004c223e8337d78cf5e64ddd63e63b3fd39513b18835c6633996063934ec20a772f3b31c70f887ef23b4d31e717857b02c0f3265607ad77f8a1f59
+  languageName: node
+  linkType: hard
+
+"@webiny/react-rich-text-renderer@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/react-rich-text-renderer@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@editorjs/editorjs": 2.21.0
+    "@types/react": 16.14.2
+    classnames: 2.3.1
+    react: 16.14.0
+  checksum: eb3468403773506fe377b37b544b0ab03961ef7dbd75dfc16c556cb3207e1c324e0ce0b98781e3800b6a074d34289d353cc196be665f4eb7023faa2e6d921016
+  languageName: node
+  linkType: hard
+
+"@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
   version: 0.0.0-use.local
   resolution: "@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer"
   dependencies:
@@ -9412,8 +10532,8 @@ __metadata:
     "@babel/runtime": ^7.5.5
     "@editorjs/editorjs": ^2.20.1
     "@types/react": ^16.9.56
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
     classnames: ^2.3.1
     react: ^16.14.0
@@ -9422,7 +10542,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/react-router@^5.5.0-beta.0, @webiny/react-router@^5.7.0, @webiny/react-router@workspace:packages/react-router":
+"@webiny/react-router@^5.8.0-beta.0, @webiny/react-router@workspace:packages/react-router":
   version: 0.0.0-use.local
   resolution: "@webiny/react-router@workspace:packages/react-router"
   dependencies:
@@ -9432,9 +10552,9 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/runtime": ^7.5.5
     "@types/react-router-dom": ^5.1.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/plugins": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     apollo-client: ^2.6.8
     graphql: ^14.7.0
     react: ^16.14.0
@@ -9448,7 +10568,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/storybook-utils@^5.7.0, @webiny/storybook-utils@workspace:packages/storybook-utils":
+"@webiny/react-router@npm:5.7.0, @webiny/react-router@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/react-router@npm:5.7.0"
+  dependencies:
+    "@apollo/react-hooks": 3.1.5
+    "@babel/runtime": 7.14.0
+    "@types/react-router-dom": 5.1.7
+    "@webiny/plugins": 5.7.0
+    apollo-client: 2.6.10
+    graphql: 14.7.0
+    react: 16.14.0
+    react-dom: 16.14.0
+    react-router: 5.2.0
+    react-router-dom: 5.2.0
+  peerDependencies:
+    react: 16.14.0
+  checksum: 4098c0852fc2f05a6ac95f6237632c2aed22c58be3f59ddb53cb4ac440fbfe47bd5b7ffe721f9dd354e823577e98f7f411b2732b88cbc90be71c5fcae1411919
+  languageName: node
+  linkType: hard
+
+"@webiny/storybook-utils@^5.8.0-beta.0, @webiny/storybook-utils@workspace:packages/storybook-utils":
   version: 0.0.0-use.local
   resolution: "@webiny/storybook-utils@workspace:packages/storybook-utils"
   dependencies:
@@ -9462,8 +10602,8 @@ __metadata:
     "@babel/runtime": ^7.5.5
     "@emotion/core": ^10.0.27
     "@emotion/styled": ^10.0.17
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     copy-to-clipboard: ^3.0.8
     execa: ^5.0.0
     highlight.js: ^9.12.0
@@ -9478,7 +10618,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/tracking@^5.5.0-beta.0, @webiny/tracking@^5.7.0, @webiny/tracking@workspace:packages/tracking":
+"@webiny/tracking@^5.8.0-beta.0, @webiny/tracking@workspace:packages/tracking":
   version: 0.0.0-use.local
   resolution: "@webiny/tracking@workspace:packages/tracking"
   dependencies:
@@ -9488,7 +10628,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/ui@^5.5.0-beta.0, @webiny/ui@^5.7.0, @webiny/ui@workspace:packages/ui":
+"@webiny/tracking@npm:5.7.0, @webiny/tracking@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/tracking@npm:5.7.0"
+  dependencies:
+    form-data: 3.0.0
+    load-json-file: 6.2.0
+    node-fetch: 2.6.1
+  checksum: 0defd19d9491d1833fb7a0d20e9f38eb04fd87c724a0cdb443ce3ad48667f5e20c240aa2e358a8123814524684f3ebf8f23d4f19495bdadd7f49cb791bdd8567
+  languageName: node
+  linkType: hard
+
+"@webiny/ui@^5.8.0-beta.0, @webiny/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@webiny/ui@workspace:packages/ui"
   dependencies:
@@ -9535,11 +10686,11 @@ __metadata:
     "@storybook/addon-links": ^5.0.5
     "@storybook/react": ^5.2.8
     "@svgr/webpack": ^4.3.2
-    "@webiny/cli": ^5.7.0
-    "@webiny/form": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
-    "@webiny/storybook-utils": ^5.7.0
-    "@webiny/validation": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/storybook-utils": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     babel-loader: ^8.0.0-beta.6
     babel-plugin-emotion: ^9.2.8
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
@@ -9584,7 +10735,74 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/validation@^5.5.0-beta.0, @webiny/validation@^5.7.0, @webiny/validation@workspace:packages/validation":
+"@webiny/ui@npm:5.7.0, @webiny/ui@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/ui@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    "@editorjs/editorjs": 2.21.0
+    "@emotion/core": 10.1.1
+    "@emotion/styled": 10.0.27
+    "@material/base": 3.1.0
+    "@material/textfield": 3.2.0
+    "@rmwc/base": 5.7.2
+    "@rmwc/button": 5.7.2
+    "@rmwc/checkbox": 5.7.2
+    "@rmwc/chip": 5.7.2
+    "@rmwc/dialog": 5.7.2
+    "@rmwc/drawer": 5.7.2
+    "@rmwc/elevation": 5.7.2
+    "@rmwc/fab": 5.7.2
+    "@rmwc/floating-label": 5.7.2
+    "@rmwc/grid": 5.7.2
+    "@rmwc/icon": 5.7.2
+    "@rmwc/icon-button": 5.7.2
+    "@rmwc/line-ripple": 5.7.2
+    "@rmwc/list": 5.7.2
+    "@rmwc/menu": 5.7.2
+    "@rmwc/notched-outline": 5.7.2
+    "@rmwc/radio": 5.7.2
+    "@rmwc/ripple": 5.7.2
+    "@rmwc/select": 5.7.2
+    "@rmwc/slider": 5.7.2
+    "@rmwc/snackbar": 5.7.2
+    "@rmwc/switch": 5.7.2
+    "@rmwc/tabs": 5.7.2
+    "@rmwc/textfield": "file:./rmwc/textfield"
+    "@rmwc/top-app-bar": 5.7.2
+    "@rmwc/types": 5.6.0
+    "@rmwc/typography": 5.7.2
+    "@svgr/webpack": 4.3.3
+    brace: 0.11.1
+    classnames: 2.3.1
+    cropperjs: 1.5.11
+    dot-prop-immutable: 1.6.0
+    downshift: 2.2.3
+    emotion: 10.0.17
+    keycode: 2.2.0
+    load-script: 1.0.0
+    lodash: 4.17.21
+    material-components-web: 3.2.0
+    nprogress: 0.2.0
+    nuka-carousel: 4.7.1
+    rc-tooltip: 3.7.3
+    react-ace: 6.6.0
+    react-butterfiles: 1.3.3
+    react-color: 2.19.3
+    react-columned: 1.1.3
+    react-custom-scrollbars: 4.2.1
+    react-loading-skeleton: 0.5.0
+    react-spinner-material: 1.1.4
+    react-transition-group: 4.4.1
+    shortid: 2.2.16
+  peerDependencies:
+    react: 16.14.0
+    react-dom: 16.14.0
+  checksum: 10c6b701805c5b90bc895417099c06a393656e108df917554f5e5f45f463d3d5c2b8acf172f6e3bd04c2bf7757e2be7e1752e37795096ca71a6fbd328fa6e213
+  languageName: node
+  linkType: hard
+
+"@webiny/validation@^5.8.0-beta.0, @webiny/validation@workspace:packages/validation":
   version: 0.0.0-use.local
   resolution: "@webiny/validation@workspace:packages/validation"
   dependencies:
@@ -9593,8 +10811,8 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     babel-plugin-lodash: ^3.3.4
     isnumeric: ^0.3.3
     jest: ^26.6.3
@@ -9605,6 +10823,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/validation@npm:5.7.0, @webiny/validation@npm:^5.5.0-beta.0":
+  version: 5.7.0
+  resolution: "@webiny/validation@npm:5.7.0"
+  dependencies:
+    "@babel/runtime": 7.14.0
+    isnumeric: 0.3.3
+    lodash: 4.17.21
+  checksum: 481d6731e39bdd646b278973a36dae1d4e7a7bb4f6fd381a6302e0d5a0ba80e00abadbd868c796eabb175c57d4980d11cb8b0b9384d37923e64225edce3847a6
+  languageName: node
+  linkType: hard
+
 "@webiny/where-parser@workspace:packages/where-parser":
   version: 0.0.0-use.local
   resolution: "@webiny/where-parser@workspace:packages/where-parser"
@@ -9614,9 +10843,9 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-flow": ^7.0.0
     "@babel/runtime": ^7.5.5
-    "@webiny/cli": ^5.7.0
-    "@webiny/error": ^5.7.0
-    "@webiny/project-utils": ^5.7.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/error": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
     jest: ^26.6.3
     prettier: ^1.19.1
     rimraf: ^3.0.2
@@ -9747,7 +10976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accept-language-parser@npm:^1.5.0":
+"accept-language-parser@npm:1.5.0, accept-language-parser@npm:^1.5.0":
   version: 1.5.0
   resolution: "accept-language-parser@npm:1.5.0"
   checksum: 598934ae1cf551a81d7adc4620a22596993a84db259f6f8bdd7516f95983018e9bbaaaa22cb87aefd045ca78b4d289e95db058353a655c63949d75f24bbdfaa9
@@ -9764,7 +10993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accounting@npm:^0.4.1":
+"accounting@npm:0.4.1, accounting@npm:^0.4.1":
   version: 0.4.1
   resolution: "accounting@npm:0.4.1"
   checksum: df31f784a2013c9e5c83fc1867e2cc26382be1a1e40db5cfc9181bcef68c606c908fabfef3cf4b8fa7662a827ee33196531447c01f4480be1eded0000dba9d00
@@ -9842,11 +11071,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.2.4":
-  version: 8.2.4
-  resolution: "acorn@npm:8.2.4"
+  version: 8.3.0
+  resolution: "acorn@npm:8.3.0"
   bin:
     acorn: bin/acorn
-  checksum: 6879266ea9ba4ece99afb4ab4f3ac6eaa3cf866cee40651ca90cde0b1fd5c6954d2006c54877c83287d5d38700327cbd6bda028b6fbb1daa346c7034f18147c2
+  checksum: e535e9ac85daf28a138611a4ad87b34bacd76733c0fd768b42e8b32a02c18bf34723e4aa70db38a052e6c93172abb106016795fe1d2e509647832a54a4250cb2
   languageName: node
   linkType: hard
 
@@ -10246,7 +11475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-to-html@npm:^0.6.11, ansi-to-html@npm:^0.6.14":
+"ansi-to-html@npm:0.6.15, ansi-to-html@npm:^0.6.11, ansi-to-html@npm:^0.6.14":
   version: 0.6.15
   resolution: "ansi-to-html@npm:0.6.15"
   dependencies:
@@ -10298,7 +11527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aos@npm:^2.3.4":
+"aos@npm:2.3.4, aos@npm:^2.3.4":
   version: 2.3.4
   resolution: "aos@npm:2.3.4"
   dependencies:
@@ -10383,7 +11612,7 @@ __metadata:
     "@webiny/api-file-manager-s3": ^5.5.0-beta.0
     "@webiny/api-form-builder": ^5.5.0-beta.0
     "@webiny/api-headless-cms": ^5.5.0-beta.0
-    "@webiny/api-headless-cms-ddb-es": ^5.6.0
+    "@webiny/api-headless-cms-ddb-es": ^5.8.0-beta.0
     "@webiny/api-i18n": ^5.5.0-beta.0
     "@webiny/api-i18n-content": ^5.5.0-beta.0
     "@webiny/api-page-builder": ^5.5.0-beta.0
@@ -10407,7 +11636,7 @@ __metadata:
   resolution: "api-headless-cms@workspace:api/code/headlessCMS"
   dependencies:
     "@webiny/api-headless-cms": ^5.5.0-beta.0
-    "@webiny/api-headless-cms-ddb-es": ^5.6.0
+    "@webiny/api-headless-cms-ddb-es": ^5.8.0-beta.0
     "@webiny/api-i18n": ^5.5.0-beta.0
     "@webiny/api-i18n-content": ^5.5.0-beta.0
     "@webiny/api-plugin-elastic-search-client": ^5.5.0-beta.0
@@ -10522,7 +11751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-client@npm:^2.2.8, apollo-client@npm:^2.6.10, apollo-client@npm:^2.6.8":
+"apollo-client@npm:2.6.10, apollo-client@npm:^2.2.8, apollo-client@npm:^2.6.10, apollo-client@npm:^2.6.8":
   version: 2.6.10
   resolution: "apollo-client@npm:2.6.10"
   dependencies:
@@ -10588,7 +11817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link-context@npm:^1.0.20":
+"apollo-link-context@npm:1.0.20, apollo-link-context@npm:^1.0.20":
   version: 1.0.20
   resolution: "apollo-link-context@npm:1.0.20"
   dependencies:
@@ -10598,7 +11827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link-error@npm:^1.1.13":
+"apollo-link-error@npm:1.1.13, apollo-link-error@npm:^1.1.13":
   version: 1.1.13
   resolution: "apollo-link-error@npm:1.1.13"
   dependencies:
@@ -10622,7 +11851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link@npm:^1.0.0, apollo-link@npm:^1.2.14":
+"apollo-link@npm:1.2.14, apollo-link@npm:^1.0.0, apollo-link@npm:^1.2.14":
   version: 1.2.14
   resolution: "apollo-link@npm:1.2.14"
   dependencies:
@@ -11117,7 +12346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-elasticsearch-connector@npm:^9.0.0":
+"aws-elasticsearch-connector@npm:9.0.3, aws-elasticsearch-connector@npm:^9.0.0":
   version: 9.0.3
   resolution: "aws-elasticsearch-connector@npm:9.0.3"
   dependencies:
@@ -11163,9 +12392,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.0.0, aws-sdk@npm:^2.539.0":
-  version: 2.917.0
-  resolution: "aws-sdk@npm:2.917.0"
+"aws-sdk@npm:2.911.0":
+  version: 2.911.0
+  resolution: "aws-sdk@npm:2.911.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -11176,7 +12405,24 @@ __metadata:
     url: 0.10.3
     uuid: 3.3.2
     xml2js: 0.4.19
-  checksum: 5e6b477003986acd46644d818c039d0bb3b195d211daf2efc240bdd5404d3c5cfca04150fe37049386d0b3173c8506d046e5cfdd321c7cb0850118f58b395f6e
+  checksum: 3453496d407dea6e0af3610b1ff303f151ebf3d207b6479c0fa2131523ee7b3593db3003030fc9fb23f50a4b35eaa4a5f80cae7a8fc7e2f29105256c4a759ddd
+  languageName: node
+  linkType: hard
+
+"aws-sdk@npm:^2.0.0, aws-sdk@npm:^2.539.0":
+  version: 2.921.0
+  resolution: "aws-sdk@npm:2.921.0"
+  dependencies:
+    buffer: 4.9.2
+    events: 1.1.1
+    ieee754: 1.1.13
+    jmespath: 0.15.0
+    querystring: 0.2.0
+    sax: 1.2.1
+    url: 0.10.3
+    uuid: 3.3.2
+    xml2js: 0.4.19
+  checksum: 3c321006767e5c3b132eaf9969c2e63d41608b5b938ddb762890e8cf6e1a7d2d962626d6f5785af1c8fc2e5f61fd76645bbb54bee02567a6cc011061dcb7b183
   languageName: node
   linkType: hard
 
@@ -11954,7 +13200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blessed-contrib@npm:^4.8.21":
+"blessed-contrib@npm:4.8.21, blessed-contrib@npm:^4.8.21":
   version: 4.8.21
   resolution: "blessed-contrib@npm:4.8.21"
   dependencies:
@@ -12075,10 +13321,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boolean@npm:^3.0.1, boolean@npm:^3.0.2":
+"boolean@npm:3.0.4":
   version: 3.0.4
   resolution: "boolean@npm:3.0.4"
   checksum: 5ba56fa07e73f6e30c6fc39a922c31710f9d428cc7f468b04a552fc74c39ad0649d640425072bc2fd935ecae3e27bfb4ccbab407d78983a64bcd1c2a72a51499
+  languageName: node
+  linkType: hard
+
+"boolean@npm:^3.0.1, boolean@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "boolean@npm:3.1.0"
+  checksum: 8959d0fbed12bc43a39ac48be97aae5e2c5271d3cb4551e3421fabc2ea872ba7ee06bf286a06b2d4666f6c6091fd7a7453f2b2d4a5beecc1bb1f93378944ee3f
   languageName: node
   linkType: hard
 
@@ -12122,7 +13375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace@npm:^0.11.1":
+"brace@npm:0.11.1, brace@npm:^0.11.1":
   version: 0.11.1
   resolution: "brace@npm:0.11.1"
   checksum: 7438fc7d700b0edaeafe5b2943eb2c79ecdafb04558fc504ac4e62973e63597b5d64f9743d115e32779e9c4216fed477a4cbd4009dc6c9050e6040b5226afab5
@@ -12297,7 +13550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.14.5, browserslist@npm:^4.16.6, browserslist@npm:^4.6.2, browserslist@npm:^4.6.4, browserslist@npm:^4.9.1":
+"browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.16.6, browserslist@npm:^4.6.2, browserslist@npm:^4.6.4, browserslist@npm:^4.9.1":
   version: 4.16.6
   resolution: "browserslist@npm:4.16.6"
   dependencies:
@@ -12854,9 +14107,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30000989, caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001219":
-  version: 1.0.30001230
-  resolution: "caniuse-lite@npm:1.0.30001230"
-  checksum: bb319bedf33722a2d16e28a7e0d13fabde59be4fccd48d80939254228c7a49059b74bd99b313596f75c997480f9097cc3e7cda7c7687e5a096bb9c75260c145d
+  version: 1.0.30001234
+  resolution: "caniuse-lite@npm:1.0.30001234"
+  checksum: 0c8e2b68e227eb47121ca0c93bda530bbe8475a3e2ab14138a3d751258817c1a16c8a86a0809637fb90d48f92b63e47740f863c806f3e6de012e417dc3cb54c4
   languageName: node
   linkType: hard
 
@@ -13101,7 +14354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrome-aws-lambda@npm:^5.5.0":
+"chrome-aws-lambda@npm:5.5.0, chrome-aws-lambda@npm:^5.5.0":
   version: 5.5.0
   resolution: "chrome-aws-lambda@npm:5.5.0"
   dependencies:
@@ -13169,7 +14422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
+"classnames@npm:2.3.1, classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
   checksum: 57d536edede609f81425d24b062d8d720a466565faf1e38d32c881e883920baa71519ac70c7b565e9cd39201fb1c1ff9bdf8aabf8e26544bac481e7924867c83
@@ -13703,7 +14956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commodo-fields-object@npm:^1.0.3, commodo-fields-object@npm:^1.0.6":
+"commodo-fields-object@npm:1.0.6, commodo-fields-object@npm:^1.0.3, commodo-fields-object@npm:^1.0.6":
   version: 1.0.6
   resolution: "commodo-fields-object@npm:1.0.6"
   dependencies:
@@ -13866,12 +15119,12 @@ __metadata:
   linkType: hard
 
 "config-chain@npm:^1.1.11":
-  version: 1.1.12
-  resolution: "config-chain@npm:1.1.12"
+  version: 1.1.13
+  resolution: "config-chain@npm:1.1.13"
   dependencies:
     ini: ^1.3.4
     proto-list: ~1.2.1
-  checksum: caf4b96491c2ea6fc5e6e23cebc526040cf21779ffc544c705a21b788f7dc3d34bc439878dcdfae8c15830052be55d62b26acada13da1236142d3efc5b4329be
+  checksum: 047fb0971ba48cf242aa390e8e404ced375e136e2e4a8b753d2ce2b83928d62ef6b3ec74ee35e8f5b2d7cd9cb38fedd7962a83d64422c10afd7e9acfa83ecbb1
   languageName: node
   linkType: hard
 
@@ -14153,19 +15406,19 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.6.2, core-js-compat@npm:^3.8.0, core-js-compat@npm:^3.9.0, core-js-compat@npm:^3.9.1":
-  version: 3.13.0
-  resolution: "core-js-compat@npm:3.13.0"
+  version: 3.13.1
+  resolution: "core-js-compat@npm:3.13.1"
   dependencies:
     browserslist: ^4.16.6
     semver: 7.0.0
-  checksum: 242aac66cfeb2c5c0b646518c45517e5a12f98dd0161f1a10769b9419ba323985aa7feb0cb90bad27e3d249dfc9378b0dda209ff6bfc1fb4f4ca1a790c17995f
+  checksum: c04bc43c6ac189710dda37e8c31a5854dfd13c552392792437afb93196bfad86f6706f8968c2fe8536d28573d1f4e889a7f5bae9d7a351d96f157325711e414c
   languageName: node
   linkType: hard
 
 "core-js-pure@npm:^3.0.0, core-js-pure@npm:^3.0.1":
-  version: 3.13.0
-  resolution: "core-js-pure@npm:3.13.0"
-  checksum: 0304b523c29258ddd3b624f31f413d0f900415aa19156d3b9dc8ad681ef53cfa4afe7b47cda61bc24a14bcabb6db4f14e2fd7c290c718a54c9d1fecdd8b57974
+  version: 3.13.1
+  resolution: "core-js-pure@npm:3.13.1"
+  checksum: 12f0509d4bca05a221a81a6253dea8a75fa8fe0f9c81ee2db2f655f0a6acc0eea0237ac6d00815f37abf492b2ab543aceb514d8fa847f51faa9086bcf646d1e7
   languageName: node
   linkType: hard
 
@@ -14184,9 +15437,9 @@ __metadata:
   linkType: hard
 
 "core-js@npm:^3.0.1, core-js@npm:^3.0.4, core-js@npm:^3.6.1":
-  version: 3.13.0
-  resolution: "core-js@npm:3.13.0"
-  checksum: ec1fb8ee6692353c1c4eec0ac6cf58010e927458a373a33f1a4a9cc89391130dd378de4ad6e4e51b68ee6ea9bc622ae7ed82eeac6cea6076f2115e7ec632c6e5
+  version: 3.13.1
+  resolution: "core-js@npm:3.13.1"
+  checksum: 9138463ed7e6489a0b7f7e8a13cb345fde22866ab23d35f0e0e0ddc13e0374dfc7542d7316762a7dc2a5074efe22f8ff692e26ccc22860d8179de5eedf922e98
   languageName: node
   linkType: hard
 
@@ -14340,7 +15593,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-webiny-project@workspace:packages/create-webiny-project"
   dependencies:
-    "@webiny/tracking": ^5.7.0
+    "@webiny/tracking": ^5.8.0-beta.0
     chalk: 4.1.0
     execa: ^4.1.0
     find-up: ^5.0.0
@@ -14351,9 +15604,9 @@ __metadata:
     node-fetch: 2.6.1
     os: 0.1.1
     p-retry: 4.2.0
-    public-ip: 4.0.3
     rimraf: 3.0.2
     semver: 7.3.4
+    uuid: ^8.3.2
     validate-npm-package-name: 3.0.0
     write-json-file: 4.3.0
     yargs: 15.4.1
@@ -14371,7 +15624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cropperjs@npm:^1.4.3":
+"cropperjs@npm:1.5.11, cropperjs@npm:^1.4.3":
   version: 1.5.11
   resolution: "cropperjs@npm:1.5.11"
   checksum: 450b5cbeba4ce482b9f7aacdd359281099dc883b1189e34ccec0db5bbc731ec9be206cfcf9c03067d96e8c227547407db629b7203189446877196bfa2ce6c948
@@ -15029,14 +16282,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:^2.0.0":
+"dataloader@npm:2.0.0, dataloader@npm:^2.0.0":
   version: 2.0.0
   resolution: "dataloader@npm:2.0.0"
   checksum: 0165c2e80751d269c33d2a14b0078a4f3853cb010e2531e7aa99523aba8d0cdc922b9ad67e4c2bb9074c90e0ee0a41b6e7f5f63c40d31224a71c8a0b703f4be3
   languageName: node
   linkType: hard
 
-"dataurl-to-blob@npm:^0.0.1":
+"dataurl-to-blob@npm:0.0.1, dataurl-to-blob@npm:^0.0.1":
   version: 0.0.1
   resolution: "dataurl-to-blob@npm:0.0.1"
   dependencies:
@@ -15264,7 +16517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress@npm:^4.0.0, decompress@npm:^4.2.1":
+"decompress@npm:4.2.1, decompress@npm:^4.0.0, decompress@npm:^4.2.1":
   version: 4.2.1
   resolution: "decompress@npm:4.2.1"
   dependencies:
@@ -15303,21 +16556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:^1.0.1, deep-equal@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "deep-equal@npm:1.1.1"
-  dependencies:
-    is-arguments: ^1.0.4
-    is-date-object: ^1.0.1
-    is-regex: ^1.0.4
-    object-is: ^1.0.1
-    object-keys: ^1.1.1
-    regexp.prototype.flags: ^1.2.0
-  checksum: cc6a0009ce73a10230758d50795211fb3ceb7eb7f2cf8baed1c4a4cb2a06dc28857ce11e641c95ca9abb5edc1f1e86a4bb6bcffaadf9fe9d310c102d346d043b
-  languageName: node
-  linkType: hard
-
-"deep-equal@npm:^2.0.4":
+"deep-equal@npm:2.0.5, deep-equal@npm:^2.0.4":
   version: 2.0.5
   resolution: "deep-equal@npm:2.0.5"
   dependencies:
@@ -15337,6 +16576,20 @@ __metadata:
     which-collection: ^1.0.1
     which-typed-array: ^1.1.2
   checksum: bf99bc27fa34dc229829126b9d18d509fd54e8ac92941c7c9d2be5dddff66fdbce35e9b39026ab12b4d2235491cdcc56cb50317da41230ab558d3b57f48ec454
+  languageName: node
+  linkType: hard
+
+"deep-equal@npm:^1.0.1, deep-equal@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "deep-equal@npm:1.1.1"
+  dependencies:
+    is-arguments: ^1.0.4
+    is-date-object: ^1.0.1
+    is-regex: ^1.0.4
+    object-is: ^1.0.1
+    object-keys: ^1.1.1
+    regexp.prototype.flags: ^1.2.0
+  checksum: cc6a0009ce73a10230758d50795211fb3ceb7eb7f2cf8baed1c4a4cb2a06dc28857ce11e641c95ca9abb5edc1f1e86a4bb6bcffaadf9fe9d310c102d346d043b
   languageName: node
   linkType: hard
 
@@ -15761,7 +17014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dns-packet@npm:^5.1.2":
+"dns-packet@npm:^5.2.4":
   version: 5.2.4
   resolution: "dns-packet@npm:5.2.4"
   dependencies:
@@ -15771,11 +17024,11 @@ __metadata:
   linkType: hard
 
 "dns-socket@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "dns-socket@npm:4.2.1"
+  version: 4.2.2
+  resolution: "dns-socket@npm:4.2.2"
   dependencies:
-    dns-packet: ^5.1.2
-  checksum: a34d3e2bfce6f83f3d774bd4862812cae043048068fd08a2e3758c202ff1a4f8cb682d1c3920eaed41e2a38e49a0c611610d11076f032c0192415d03e3cc2587
+    dns-packet: ^5.2.4
+  checksum: 34f7509c4dd26e3f158e31d2286af387dd33d7f71c64447263dd03279b2712fd92b94295dff731cb313896ead93efcee501f2ba02bf09c536a5bdcb592091082
   languageName: node
   linkType: hard
 
@@ -15806,10 +17059,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "dom-accessibility-api@npm:0.5.4"
-  checksum: 39351d26a3732312f14411effef698204bf6c79a7d5eb0664441897541243f2cdf2e508aca52684ccf3b10df6708a6c265d1fde323eebcb8363a1093f5927b10
+"dom-accessibility-api@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "dom-accessibility-api@npm:0.5.6"
+  checksum: b579681083e683291df022bdf094dae2c7e39db0ff28f70ed2c8368eda203fe4c45bcf92f1c623ce4b746cb245f9a5dc9d176f1781d600b9218728d3a1d1580f
   languageName: node
   linkType: hard
 
@@ -15954,9 +17207,9 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^2.2.6":
-  version: 2.2.8
-  resolution: "dompurify@npm:2.2.8"
-  checksum: c8498b4dc81c5b61f84c09836da7ed1ab61fce3f349bbcf669b28a44047d85f795141c4a1daa66879481560b955bfbd1dc9dae04ad554f52d727739ecb6ea545
+  version: 2.2.9
+  resolution: "dompurify@npm:2.2.9"
+  checksum: 8673be49aed95d5be99f6b92fe1f9edd70d209e8842853ccad9dd986460b03f6621d38c9e3cf63a525247c3e2be45456ce03c87d2ab1b83bd2a9617dff904069
   languageName: node
   linkType: hard
 
@@ -16001,14 +17254,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop-immutable@npm:^1.4.0":
+"dot-prop-immutable@npm:1.6.0, dot-prop-immutable@npm:^1.4.0":
   version: 1.6.0
   resolution: "dot-prop-immutable@npm:1.6.0"
   checksum: 32f0123e23a21a03b8e1f4b94aff87ed066c368c82ca90fa2846c7fa109ac1620c8ba0fd64765eef36e7574f897bd0b7c5590c8cad13186973f2b21626235838
   languageName: node
   linkType: hard
 
-"dot-prop-immutable@npm:^2.1.0":
+"dot-prop-immutable@npm:2.1.0, dot-prop-immutable@npm:^2.1.0":
   version: 2.1.0
   resolution: "dot-prop-immutable@npm:2.1.0"
   checksum: 5297a7bb2e63eb67b3c600391492ddacc06b077a652b79fc15dc2527dc6deb182f5a51c495b891ed2343f03ea65cc3bba5b482448e8bbc4f5d716dababc6654e
@@ -16095,7 +17348,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"download@npm:^5.0.3":
+"download@npm:5.0.3, download@npm:^5.0.3":
   version: 5.0.3
   resolution: "download@npm:5.0.3"
   dependencies:
@@ -16110,7 +17363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:^2.1.5":
+"downshift@npm:2.2.3, downshift@npm:^2.1.5":
   version: 2.2.3
   resolution: "downshift@npm:2.2.3"
   dependencies:
@@ -16122,7 +17375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:^3.1.2":
+"downshift@npm:3.4.8, downshift@npm:^3.1.2":
   version: 3.4.8
   resolution: "downshift@npm:3.4.8"
   dependencies:
@@ -16273,9 +17526,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.3.247, electron-to-chromium@npm:^1.3.378, electron-to-chromium@npm:^1.3.723":
-  version: 1.3.741
-  resolution: "electron-to-chromium@npm:1.3.741"
-  checksum: 1179e03b383ea0740abd628f7eac92fca242326e7a1a451f43df24f4df95d870b323708190d1e6d97a972147bc58a593f33e53699fa4d8ea63f5db55176280ef
+  version: 1.3.748
+  resolution: "electron-to-chromium@npm:1.3.748"
+  checksum: 748b43a7699cea081735d2b1cdfc092b98ff9d7fce5f4609270eb0dac91eb0a5fc4f61738b58fe260347a2f0462ea740c0743a10bb1a112c3a8ed6ed3682fcdc
   languageName: node
   linkType: hard
 
@@ -16385,7 +17638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emotion@npm:^10.0.17, emotion@npm:^10.0.27":
+"emotion@npm:10.0.27, emotion@npm:^10.0.17, emotion@npm:^10.0.27":
   version: 10.0.27
   resolution: "emotion@npm:10.0.27"
   dependencies:
@@ -16830,8 +18083,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-import@npm:^2.22.1":
-  version: 2.23.3
-  resolution: "eslint-plugin-import@npm:2.23.3"
+  version: 2.23.4
+  resolution: "eslint-plugin-import@npm:2.23.4"
   dependencies:
     array-includes: ^3.1.3
     array.prototype.flat: ^1.2.4
@@ -16850,7 +18103,7 @@ __metadata:
     tsconfig-paths: ^3.9.0
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-  checksum: 25f2ec03f1a3b12b98e4e9787dca9023fffd7e7df6c3a08d514476a861a028d9299546f6b09e3d80cfa370aaffd52179cbb6ef397c6397a321a94525d4e009df
+  checksum: d15a470088381cb14821480f35fe23258f6365d704ea9fc724b87e1ccf9eb45f4bb048ff033784af0cacff368ae1542c2b1dfbe6cd4dbec7138f8f6dca090a57
   languageName: node
   linkType: hard
 
@@ -16889,8 +18142,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react@npm:^7.22.0":
-  version: 7.23.2
-  resolution: "eslint-plugin-react@npm:7.23.2"
+  version: 7.24.0
+  resolution: "eslint-plugin-react@npm:7.24.0"
   dependencies:
     array-includes: ^3.1.3
     array.prototype.flatmap: ^1.2.4
@@ -16898,15 +18151,15 @@ __metadata:
     has: ^1.0.3
     jsx-ast-utils: ^2.4.1 || ^3.0.0
     minimatch: ^3.0.4
-    object.entries: ^1.1.3
+    object.entries: ^1.1.4
     object.fromentries: ^2.0.4
-    object.values: ^1.1.3
+    object.values: ^1.1.4
     prop-types: ^15.7.2
     resolve: ^2.0.0-next.3
-    string.prototype.matchall: ^4.0.4
+    string.prototype.matchall: ^4.0.5
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7
-  checksum: 0607db70fe5dd8366f046fee0bb8213b72a5f801fced1b82a7c85d5e88eac5cee43c221a0a20b032925210cbd52e2669a10ae03f1bd58e03485e2c18070cbb57
+  checksum: 256e25dc8dde4664361b4a47ee452065444491fb5e694b52f9c5f56b8d8bd25c6e7ac660d722b234c7fdc7d29a1dffebdc30c9b7eee4f840d883da922882460a
   languageName: node
   linkType: hard
 
@@ -16960,6 +18213,17 @@ __metadata:
   dependencies:
     eslint-visitor-keys: ^1.1.0
   checksum: a43892372a4205374982ac9d4c8edc5fe180cba76535ab9184c48f18a3d931b7ffdd6862cb2f8ca4305c47eface0e614e39884a75fbf169fcc55a6131af2ec48
+  languageName: node
+  linkType: hard
+
+"eslint-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eslint-utils@npm:3.0.0"
+  dependencies:
+    eslint-visitor-keys: ^2.0.0
+  peerDependencies:
+    eslint: ">=5"
+  checksum: 035451529f016e28edd26e8951f15e28a6a4e58adff67bd0cb494879f360080750b9c779e46561369aec0657ac2b89dd8b0aa38476e8cdf50e635aa872fa27b6
   languageName: node
   linkType: hard
 
@@ -17308,7 +18572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:5.0.0, execa@npm:^5.0.0":
+"execa@npm:5.0.0":
   version: 5.0.0
   resolution: "execa@npm:5.0.0"
   dependencies:
@@ -17367,6 +18631,23 @@ __metadata:
     signal-exit: ^3.0.0
     strip-eof: ^1.0.0
   checksum: 39714ea24e349403f9fc92b450f0e6823cdd4573e15b17c0fba6d95f2eecd46dc32624bbf15071d91e2c64a4402c74ce7a362671126964100ad34e2d6210adf9
+  languageName: node
+  linkType: hard
+
+"execa@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.0
+    human-signals: ^2.1.0
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.1
+    onetime: ^5.1.2
+    signal-exit: ^3.0.3
+    strip-final-newline: ^2.0.0
+  checksum: 4286ade8cdb267bfb982bddbf894a58df29ff4f3bb871252a4832c4608e485dd71e5a8bbfde9f95d7db4af864f5de1aa6a1780017217bd946a16409b8e022987
   languageName: node
   linkType: hard
 
@@ -17608,7 +18889,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:^1.6.7, extract-zip@npm:^1.7.0":
+"extract-zip@npm:1.7.0, extract-zip@npm:^1.6.7, extract-zip@npm:^1.7.0":
   version: 1.7.0
   resolution: "extract-zip@npm:1.7.0"
   dependencies:
@@ -17805,7 +19086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fecha@npm:^2.3.3":
+"fecha@npm:2.3.3, fecha@npm:^2.3.3":
   version: 2.3.3
   resolution: "fecha@npm:2.3.3"
   checksum: 1761ec8cd88dc165bad8d726e5bc38c933de6cc7ae479eea83260bcbadd3dd285f67b7605db6d2d5e2f8cb92ab5fe7f7634fe09229f0746bdc032a84d824dedb
@@ -18384,7 +19665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^3.0.0":
+"form-data@npm:3.0.1, form-data@npm:^3.0.0":
   version: 3.0.1
   resolution: "form-data@npm:3.0.1"
   dependencies:
@@ -18413,10 +19694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"forwarded@npm:~0.1.2":
-  version: 0.1.2
-  resolution: "forwarded@npm:0.1.2"
-  checksum: 568d862ad1c514813fc62dc1bd58b8669b16d4ee2e634a6fc71f4849df798883ab94e63d8e1b35a17af51b2b39ca869e672c7310efe42fc7b9bad43a80b5ff87
+"forwarded@npm:0.2.0":
+  version: 0.2.0
+  resolution: "forwarded@npm:0.2.0"
+  checksum: 1e84548d8ffb072d7edd4c5375ce71e2631c28efcd1084c4578f1a71dd6c4b0d58a6ddcdc923514766030cf38068258971a919e91ffa472460ec0f6dac7209ea
   languageName: node
   linkType: hard
 
@@ -18484,6 +19765,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:7.0.1, fs-extra@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "fs-extra@npm:7.0.1"
+  dependencies:
+    graceful-fs: ^4.1.2
+    jsonfile: ^4.0.0
+    universalify: ^0.1.0
+  checksum: 0de3773953a13b517f053dbfa291166da076cc563cdd8f0ecefc64018ab15d2614f1707860b82e6b0e41695f613c1855f410749bd01bcb585f0243b1018a6595
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
@@ -18528,17 +19820,6 @@ __metadata:
     jsonfile: ^2.1.0
     klaw: ^1.0.0
   checksum: b07d107d48524fcb6f055303dcd0546098e7c2f1e02548734abfabc5353a14232bec77738c0acfff670ac41c36e25460af7afda516bac6d647d814df102c9023
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "fs-extra@npm:7.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: 0de3773953a13b517f053dbfa291166da076cc563cdd8f0ecefc64018ab15d2614f1707860b82e6b0e41695f613c1855f410749bd01bcb585f0243b1018a6595
   languageName: node
   linkType: hard
 
@@ -19242,7 +20523,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.1":
+"globby@npm:^11.0.1, globby@npm:^11.0.3":
   version: 11.0.3
   resolution: "globby@npm:11.0.3"
   dependencies:
@@ -19306,9 +20587,28 @@ fsevents@^1.2.7:
   linkType: hard
 
 "google-protobuf@npm:^3.5.0":
-  version: 3.17.1
-  resolution: "google-protobuf@npm:3.17.1"
-  checksum: c74efa290057956a29335428223e7e6ea678bc48f39a1600d63ef8bf1ea6e6cc5b953b616a5b66000cba1ffde50f96cd4d0ab4ad883b0fd7ca84f01f950b5493
+  version: 3.17.2
+  resolution: "google-protobuf@npm:3.17.2"
+  checksum: 1ae6f76d78f01e7074fbdb8f8b6a3b3d42d6c91d670b56c8523c317c053a9388588c60284e8e6333163de9f7177553a75ed2d4487b4b930ae4784a3b3210487e
+  languageName: node
+  linkType: hard
+
+"got@npm:9.6.0, got@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "got@npm:9.6.0"
+  dependencies:
+    "@sindresorhus/is": ^0.14.0
+    "@szmarczak/http-timer": ^1.1.2
+    cacheable-request: ^6.0.0
+    decompress-response: ^3.3.0
+    duplexer3: ^0.1.4
+    get-stream: ^4.1.0
+    lowercase-keys: ^1.0.1
+    mimic-response: ^1.0.1
+    p-cancelable: ^1.0.0
+    to-readable-stream: ^1.0.0
+    url-parse-lax: ^3.0.0
+  checksum: 4cfb862eb7e2d023f486efbd9ad5ab199ea44f957dc72be9518bf54d832ad4281ef3b63eac4d861b189690c3b7674eef3e1cb4f41285a83fa43293431ab879bd
   languageName: node
   linkType: hard
 
@@ -19375,25 +20675,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"got@npm:^9.6.0":
-  version: 9.6.0
-  resolution: "got@npm:9.6.0"
-  dependencies:
-    "@sindresorhus/is": ^0.14.0
-    "@szmarczak/http-timer": ^1.1.2
-    cacheable-request: ^6.0.0
-    decompress-response: ^3.3.0
-    duplexer3: ^0.1.4
-    get-stream: ^4.1.0
-    lowercase-keys: ^1.0.1
-    mimic-response: ^1.0.1
-    p-cancelable: ^1.0.0
-    to-readable-stream: ^1.0.0
-    url-parse-lax: ^3.0.0
-  checksum: 4cfb862eb7e2d023f486efbd9ad5ab199ea44f957dc72be9518bf54d832ad4281ef3b63eac4d861b189690c3b7674eef3e1cb4f41285a83fa43293431ab879bd
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.1.10, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:~4.2.0":
   version: 4.2.6
   resolution: "graceful-fs@npm:4.2.6"
@@ -19423,7 +20704,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-scalars@npm:^1.7.0":
+"graphql-scalars@npm:1.9.3, graphql-scalars@npm:^1.7.0":
   version: 1.9.3
   resolution: "graphql-scalars@npm:1.9.3"
   dependencies:
@@ -19443,7 +20724,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:^2.10.1, graphql-tag@npm:^2.10.3, graphql-tag@npm:^2.11.0":
+"graphql-tag@npm:2.12.4, graphql-tag@npm:^2.10.1, graphql-tag@npm:^2.10.3, graphql-tag@npm:^2.11.0":
   version: 2.12.4
   resolution: "graphql-tag@npm:2.12.4"
   dependencies:
@@ -19454,7 +20735,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql@npm:^14.4.2, graphql@npm:^14.5.8, graphql@npm:^14.6.0, graphql@npm:^14.7.0":
+"graphql@npm:14.7.0, graphql@npm:^14.4.2, graphql@npm:^14.5.8, graphql@npm:^14.6.0, graphql@npm:^14.7.0":
   version: 14.7.0
   resolution: "graphql@npm:14.7.0"
   dependencies:
@@ -20223,7 +21504,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"i18n-locales@npm:^0.0.2":
+"i18n-locales@npm:0.0.2, i18n-locales@npm:^0.0.2":
   version: 0.0.2
   resolution: "i18n-locales@npm:0.0.2"
   checksum: 6f69fa000728cf89a1b100805b431e193ae405067f76e6dc1cf95dd01ae1e2c6dd3939799d0811b859992dfb226750a10278a9ed16c0ffbfe7cbb064a19edb5a
@@ -20777,7 +22058,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.2, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
+"invariant@npm:2.2.4, invariant@npm:^2.2.2, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -21183,7 +22464,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-hotkey@npm:^0.1.3, is-hotkey@npm:^0.1.4":
+"is-hotkey@npm:0.1.8, is-hotkey@npm:^0.1.3, is-hotkey@npm:^0.1.4":
   version: 0.1.8
   resolution: "is-hotkey@npm:0.1.8"
   checksum: 711e7e4e7d59738dda34951a3d63c03519de5d1b36b4e45aa264b94ac539c4f57531e1896d655e5c6739f8393bdecacaa73e02ad6711a1b13db407b22e10494d
@@ -21616,7 +22897,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"isnumeric@npm:^0.3.3":
+"isnumeric@npm:0.3.3, isnumeric@npm:^0.3.3":
   version: 0.3.3
   resolution: "isnumeric@npm:0.3.3"
   checksum: fad036098954ac61c4e5497e7e2a96d83500ae11025d9348a2ef57fec43885704b14dc9ac1e5fecc984008e3507bcf25c9f3650edd4d4130d58c10ea0052a26d
@@ -22542,20 +23823,20 @@ fsevents@^1.2.7:
   linkType: hard
 
 "jshint@npm:^2.9.2":
-  version: 2.12.0
-  resolution: "jshint@npm:2.12.0"
+  version: 2.13.0
+  resolution: "jshint@npm:2.13.0"
   dependencies:
     cli: ~1.0.0
     console-browserify: 1.1.x
     exit: 0.1.x
     htmlparser2: 3.8.x
-    lodash: ~4.17.19
+    lodash: ~4.17.21
     minimatch: ~3.0.2
     shelljs: 0.3.x
     strip-json-comments: 1.0.x
   bin:
     jshint: bin/jshint
-  checksum: 13b98ec84f688f38df731aa7ec7891cc855731470173a96c6f318ab330b20d940f1e2ce9be79b14f5d7e6f62a490f68b90a496b992ca7aaf716638b5442c5ba2
+  checksum: e2fe6410a678aeccbe35efecd9eefed8b7ea41f24cd0c6f752e980dc86a6501e04c391e7724cbb4f272cefafe4f77365a796249196c2b0e2dabf03bc238dd8bb
   languageName: node
   linkType: hard
 
@@ -22622,7 +23903,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json2csv@npm:^4.5.2":
+"json2csv@npm:4.5.4, json2csv@npm:^4.5.2":
   version: 4.5.4
   resolution: "json2csv@npm:4.5.4"
   dependencies:
@@ -22710,7 +23991,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jsonpack@npm:^1.1.5":
+"jsonpack@npm:1.1.5, jsonpack@npm:^1.1.5":
   version: 1.1.5
   resolution: "jsonpack@npm:1.1.5"
   checksum: 764a36d7f0c7780c5cb5ebaad3ce1bb68e792c4ba22b92b86e96fb170c93b3d9c21a6699cf6b8054864e631eee8ccd8ae174710e83dd097a9b6b9d67ce035e8d
@@ -22806,7 +24087,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jwk-to-pem@npm:^2.0.1":
+"jwk-to-pem@npm:2.0.5, jwk-to-pem@npm:^2.0.1":
   version: 2.0.5
   resolution: "jwk-to-pem@npm:2.0.5"
   dependencies:
@@ -22836,7 +24117,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"keycode@npm:^2.2.0":
+"keycode@npm:2.2.0, keycode@npm:^2.2.0":
   version: 2.2.0
   resolution: "keycode@npm:2.2.0"
   checksum: f417ba53db8eee6dde1b01d0dae4658b3a07cfbff7e6ce0a74e5a2346b088b98daf13d979fec6f05eba2c6fc169c8799bfdcf73049a9db5036a566f465796f70
@@ -23352,7 +24633,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"load-script@npm:^1.0.0":
+"load-script@npm:1.0.0, load-script@npm:^1.0.0":
   version: 1.0.0
   resolution: "load-script@npm:1.0.0"
   checksum: 9f907ee20dfe8068af210be73a072dd61a287566a23b5666b9c6b9957e66eb33cc7c6a790308cf307c373d7ff75265ab1dde779c3fff90d65535fb3a1c0a167a
@@ -23409,7 +24690,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"localtunnel@npm:^2.0.1":
+"localtunnel@npm:2.0.1, localtunnel@npm:^2.0.1":
   version: 2.0.1
   resolution: "localtunnel@npm:2.0.1"
   dependencies:
@@ -23631,7 +24912,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.pick@npm:^4.4.0":
+"lodash.pick@npm:4.4.0, lodash.pick@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.pick@npm:4.4.0"
   checksum: 3cf24484b1bd36652bfbe1e925e6955ee0332f1612919331a2d6115d5617bcaaf559e4fb21f4160d51eb2359f7a8dc0e478773da516b4ccc15ef261327064aab
@@ -23713,7 +24994,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.0.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:^4.7.0, lodash@npm:~4.17.10, lodash@npm:~4.17.19, lodash@npm:~>=4.17.11":
+"lodash@npm:4.17.21, lodash@npm:4.x, lodash@npm:>=3.5 <5, lodash@npm:^4.0.0, lodash@npm:^4.0.1, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.2.1, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:^4.7.0, lodash@npm:~4.17.10, lodash@npm:~4.17.21, lodash@npm:~>=4.17.11":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468
@@ -24167,11 +25448,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "marked@npm:^2.0.1":
-  version: 2.0.6
-  resolution: "marked@npm:2.0.6"
+  version: 2.0.7
+  resolution: "marked@npm:2.0.7"
   bin:
     marked: bin/marked
-  checksum: 73c10b8531521f16ba79b4f9cfd6d35a9e454ab795586aaff004a5f88c2db8e669c7db4e4079123823baf596df2a5a5aa39e50663eb8b86b25a59bc0d5f4b5b3
+  checksum: f2df7d761530ec0794f6a4cdac052f2bdb4a4cdbad3578d019cf665a35cf29688f1c0d3885a8abd80de76451b780418048bfcb43999e4a7c5a9fa5f1264f2168
   languageName: node
   linkType: hard
 
@@ -24193,7 +25474,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"material-components-web@npm:^3.1.1":
+"material-components-web@npm:3.2.0, material-components-web@npm:^3.1.1":
   version: 3.2.0
   resolution: "material-components-web@npm:3.2.0"
   dependencies:
@@ -24261,7 +25542,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"md5@npm:^2.3.0":
+"md5@npm:2.3.0, md5@npm:^2.3.0":
   version: 2.3.0
   resolution: "md5@npm:2.3.0"
   dependencies:
@@ -24272,7 +25553,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mdbid@npm:^1.0.0":
+"mdbid@npm:1.0.0, mdbid@npm:^1.0.0":
   version: 1.0.0
   resolution: "mdbid@npm:1.0.0"
   dependencies:
@@ -24302,7 +25583,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"medium-editor@npm:^5.23.3":
+"medium-editor@npm:5.23.3, medium-editor@npm:^5.23.3":
   version: 5.23.3
   resolution: "medium-editor@npm:5.23.3"
   checksum: 6a5ac634942d75da20c3c3d51ffd59a9dff3c891f3e5320ff3b8c505fe81c55b6cac8d02988f889840bab0acb1530893ec1cabac4d88b673d6111278f9b33c41
@@ -24557,19 +25838,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.47.0, mime-db@npm:>= 1.43.0 < 2":
-  version: 1.47.0
-  resolution: "mime-db@npm:1.47.0"
-  checksum: f5f9220dd53c240c9234323571f632486c663e36676ebfdca9963fb9a92d1dd28b16124bceff60868fb70743764ade8466dd5e6a1a833decde89ae6d15211503
+"mime-db@npm:1.48.0, mime-db@npm:>= 1.43.0 < 2":
+  version: 1.48.0
+  resolution: "mime-db@npm:1.48.0"
+  checksum: 346d5df2ff2f501bdeff07e88a28d205f9cd27bccd3b8604847d3aee6ce73d4ecf88e943bbbce46c167d404487f46cdf09d57354c51b6f08a4d5833bcaafa59f
   languageName: node
   linkType: hard
 
 "mime-types@npm:^2.1.12, mime-types@npm:~2.1.17, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
-  version: 2.1.30
-  resolution: "mime-types@npm:2.1.30"
+  version: 2.1.31
+  resolution: "mime-types@npm:2.1.31"
   dependencies:
-    mime-db: 1.47.0
-  checksum: c7ca8a9980bdae0b760820aded39ea9541a8236f4abc105df645ea5b09a9c4a5299e28667c0c9596ab8e4ca84b219fd8b94b5c68e32b59891ca1f57a7e848c02
+    mime-db: 1.48.0
+  checksum: 0373e58e3826802e462cf0c180ca5556fd0990acaf123d421d5f8643f0ca61d2126ea57eb6f4ba96f9ef07d3e627c06261825418a6549b0671261cc1bb4219b4
   languageName: node
   linkType: hard
 
@@ -25072,19 +26353,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^2.1.0":
-  version: 2.1.11
-  resolution: "nanoid@npm:2.1.11"
-  checksum: 41453e344e3abb189cd3baa3ab52685601d7220f86ce73f6a1d9594ebae286c2acf47a20b5aa9cf11933b587b69c6007e88f190ca266450c2fbe20be6db43a29
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.1.20, nanoid@npm:^3.1.22":
+"nanoid@npm:3.1.23, nanoid@npm:^3.1.20, nanoid@npm:^3.1.22":
   version: 3.1.23
   resolution: "nanoid@npm:3.1.23"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: e6dea1da5a593ffdc8cf2676d1d02f0626f07a54a5947a7a1f5ff1fd07901b2f53044c285e98b87eb367f016fde285fd8785d54a2dceeab9c3721f4e618f8326
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^2.1.0":
+  version: 2.1.11
+  resolution: "nanoid@npm:2.1.11"
+  checksum: 41453e344e3abb189cd3baa3ab52685601d7220f86ce73f6a1d9594ebae286c2acf47a20b5aa9cf11933b587b69c6007e88f190ca266450c2fbe20be6db43a29
   languageName: node
   linkType: hard
 
@@ -25121,7 +26402,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"ncp@npm:^2.0.0, ncp@npm:~2.0.0":
+"ncp@npm:2.0.0, ncp@npm:^2.0.0, ncp@npm:~2.0.0":
   version: 2.0.0
   resolution: "ncp@npm:2.0.0"
   bin:
@@ -25605,7 +26886,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^3.0.0, normalize-url@npm:^3.3.0":
+"normalize-url@npm:^3.0.0":
   version: 3.3.0
   resolution: "normalize-url@npm:3.3.0"
   checksum: 5704115f74833cf157a5f104477d9c8e8b4e2c00275624159bcd3c65dbdac93db4f6f008f91364d0f20f93655bd2b643afa9e8875c67b4ab8673cd1dd0fb7a5c
@@ -25616,6 +26897,13 @@ fsevents@^1.2.7:
   version: 4.5.1
   resolution: "normalize-url@npm:4.5.1"
   checksum: 31dd05ad33cc649d5c1cd390f1e494d36bdcd3c0a440fd873290ffc5d4f838e2d0c1f4e9c29c9395d4907318cd8c0aaa759af336ac04ec0bd6fecb62ef1f4556
+  languageName: node
+  linkType: hard
+
+"normalize-url@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "normalize-url@npm:6.0.1"
+  checksum: 63fe38bbc1c1b41fcc4ba9f54411755ce75aaeb25624d3c95f6d84501ea7a0e4ddd79fbcfcf9e497de7952e3c4856cba8719e9417cfbdd8e082aea5c900f3de4
   languageName: node
   linkType: hard
 
@@ -25758,7 +27046,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nprogress@npm:^0.2.0":
+"nprogress@npm:0.2.0, nprogress@npm:^0.2.0":
   version: 0.2.0
   resolution: "nprogress@npm:0.2.0"
   checksum: 652dfcfea776f9d9a2c3ad1f79b4cbd3056a03e7c6884966eab70fb184e8e70bfca9e0343ba89d11aa1ed95370d648fb638fab91b5dc027bdad54c8d37c96478
@@ -25854,10 +27142,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-hash@npm:^1.3.1":
+"object-hash@npm:1.3.1, object-hash@npm:^1.3.1":
   version: 1.3.1
   resolution: "object-hash@npm:1.3.1"
   checksum: 035cb0b0e66b34611ec5a6bf723380b7f4b3b1292ef44aa9ba93258334a2dca8cf91be28021e9ffa5edf737f97fc54b66d0605bf62db3a63f05191b0002be7bf
+  languageName: node
+  linkType: hard
+
+"object-hash@npm:2.1.1":
+  version: 2.1.1
+  resolution: "object-hash@npm:2.1.1"
+  checksum: fe49a0864cba7ac4055c604295692ae75f5f4d22ba929aaaa987469809d17ab030d1111e8f0d425a070fa4a78b8021b55260e26e98b66b59e0f7be2bd9069fb8
   languageName: node
   linkType: hard
 
@@ -25920,7 +27215,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.0, object.entries@npm:^1.1.3":
+"object.entries@npm:^1.1.0, object.entries@npm:^1.1.4":
   version: 1.1.4
   resolution: "object.entries@npm:1.1.4"
   dependencies:
@@ -25964,7 +27259,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.pick@npm:^1.3.0":
+"object.pick@npm:1.3.0, object.pick@npm:^1.3.0":
   version: 1.3.0
   resolution: "object.pick@npm:1.3.0"
   dependencies:
@@ -25973,7 +27268,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.0, object.values@npm:^1.1.3":
+"object.values@npm:^1.1.0, object.values@npm:^1.1.3, object.values@npm:^1.1.4":
   version: 1.1.4
   resolution: "object.values@npm:1.1.4"
   dependencies:
@@ -26061,6 +27356,17 @@ fsevents@^1.2.7:
   dependencies:
     mimic-fn: ^2.1.0
   checksum: e425f6caeb20cf2598ffece94be5663932e34d074f1631b682b13d5f01cc1e0712a7dc711eff1706bb5a5aaab8a52e37bd5edcf560334e3222219d7e8b09c21c
+  languageName: node
+  linkType: hard
+
+"open@npm:8.0.9":
+  version: 8.0.9
+  resolution: "open@npm:8.0.9"
+  dependencies:
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: 936ea1a4ec8c87de8e825efe385c146307fec8bb0ec72e08ce1a79103b046e82bc268a9b74d6f1861abb21476c9b3b96a8a54b4f3becf744f0fefe30cb3e7ba3
   languageName: node
   linkType: hard
 
@@ -26746,14 +28052,14 @@ fsevents@^1.2.7:
   linkType: hard
 
 "parse-url@npm:^5.0.0":
-  version: 5.0.2
-  resolution: "parse-url@npm:5.0.2"
+  version: 5.0.3
+  resolution: "parse-url@npm:5.0.3"
   dependencies:
     is-ssh: ^1.3.0
-    normalize-url: ^3.3.0
+    normalize-url: ^6.0.1
     parse-path: ^4.0.0
     protocols: ^1.4.0
-  checksum: 412d3851bd52a3016615526034a76ccbf104432d8b4ec5c21782753b9d5e2e36dd55f7de6ce92387299002cdaae0401dc9efcc927535655fd243bc991019dc1a
+  checksum: 4f333974d82709f42e999f7992c86e750593def38bf47d350aa9ccbeef940578115da63646ab0c78bfdcde3db86bfa6456e00978d25ef1043369004211087772
   languageName: node
   linkType: hard
 
@@ -27024,7 +28330,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.0, pirates@npm:^4.0.1":
+"pirates@npm:4.0.1, pirates@npm:^4.0.0, pirates@npm:^4.0.1":
   version: 4.0.1
   resolution: "pirates@npm:4.0.1"
   dependencies:
@@ -27103,7 +28409,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"platform@npm:^1.3.5":
+"platform@npm:1.3.6, platform@npm:^1.3.5":
   version: 1.3.6
   resolution: "platform@npm:1.3.6"
   checksum: d4d10d5a55476c6d369b03e02b31df50a4e7f1c565efabe707379b8a119709fb2a66dec090ab7fe520a30b767fe3791e3c4a5aba985918e51a17df45e469189f
@@ -27119,7 +28425,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pluralize@npm:^8.0.0":
+"pluralize@npm:8.0.0, pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 5251b470a0c8e5181ac7e1d61028553f90cb2c85c34b8e468cea269ae715499524546c2c3681029ef5697d86c54bfb12e49388f5cc6082051e84f5888588f4ec
@@ -27233,11 +28539,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "polished@npm:^3.3.1":
-  version: 3.7.1
-  resolution: "polished@npm:3.7.1"
+  version: 3.7.2
+  resolution: "polished@npm:3.7.2"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: 2483fc6957697620fc5ce2e93bd0fa70f6080d04b112b719426f248afb7cd21d78b5def38939a1b8ac2bc266b9bcdd8acac74639e5ad2aae64a9ac570a82b798
+  checksum: 7392794235de1034c95335b4ab6dc1e96a70eb879417d0a12cafef3f2fd8bb560333508df8666c094e15323311c4c94ebd7da2ed84b8c1b49f86339bc696d9e7
   languageName: node
   linkType: hard
 
@@ -28085,7 +29391,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"posthtml-noopener@npm:^1.0.5":
+"posthtml-noopener@npm:1.0.5, posthtml-noopener@npm:^1.0.5":
   version: 1.0.5
   resolution: "posthtml-noopener@npm:1.0.5"
   dependencies:
@@ -28119,6 +29425,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"posthtml@npm:0.15.2, posthtml@npm:^0.15.0":
+  version: 0.15.2
+  resolution: "posthtml@npm:0.15.2"
+  dependencies:
+    posthtml-parser: ^0.7.2
+    posthtml-render: ^1.3.1
+  checksum: dac27389dcf8b8567c510ddaecb9449859fbb2dc4838f5d8f03ac63aa31d465c5960be35a3c23dc77ec461b267c28ff2d05aec776c4f2f8fbe6f66c8d254b689
+  languageName: node
+  linkType: hard
+
 "posthtml@npm:^0.12.0":
   version: 0.12.3
   resolution: "posthtml@npm:0.12.3"
@@ -28126,16 +29442,6 @@ fsevents@^1.2.7:
     posthtml-parser: ^0.4.2
     posthtml-render: ^1.2.2
   checksum: d866ee525e23659cdec3b9d370c736cabf6e924262c5cfe33b41c5e34483a1f758d9f152da18c74bdb0f8fafdf3a1b90b30d981affa07da774ed688784330fdc
-  languageName: node
-  linkType: hard
-
-"posthtml@npm:^0.15.0":
-  version: 0.15.2
-  resolution: "posthtml@npm:0.15.2"
-  dependencies:
-    posthtml-parser: ^0.7.2
-    posthtml-render: ^1.3.1
-  checksum: dac27389dcf8b8567c510ddaecb9449859fbb2dc4838f5d8f03ac63aa31d465c5960be35a3c23dc77ec461b267c28ff2d05aec776c4f2f8fbe6f66c8d254b689
   languageName: node
   linkType: hard
 
@@ -28181,7 +29487,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prettier@npm:^1.14.2, prettier@npm:^1.18.2, prettier@npm:^1.19.1":
+"prettier@npm:1.19.1, prettier@npm:^1.14.2, prettier@npm:^1.18.2, prettier@npm:^1.19.1":
   version: 1.19.1
   resolution: "prettier@npm:1.19.1"
   bin:
@@ -28381,7 +29687,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.x, prop-types@npm:^15.5.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.5.9, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:15.7.2, prop-types@npm:15.x, prop-types@npm:^15.5.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.5.9, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -28449,12 +29755,12 @@ fsevents@^1.2.7:
   linkType: hard
 
 "proxy-addr@npm:~2.0.5":
-  version: 2.0.6
-  resolution: "proxy-addr@npm:2.0.6"
+  version: 2.0.7
+  resolution: "proxy-addr@npm:2.0.7"
   dependencies:
-    forwarded: ~0.1.2
+    forwarded: 0.2.0
     ipaddr.js: 1.9.1
-  checksum: a7dcfd70258cdc3b73c5dc4a35c73db9857f3bf4cf5e6404380e8ea558f8c5569147e721a01195d00b450e36b4dde727fc9d22fdea14310ba38faa595530cd58
+  checksum: ad78682246dc20ed6ca4080539349828bc2708cf0b69c55d6a3c41532780a8d05f563dcbac6ec4b74dce367421bff6fc4bc6b700b14319ecf57c93bd62727fc6
   languageName: node
   linkType: hard
 
@@ -28846,7 +30152,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"raw.macro@npm:^0.4.2":
+"raw.macro@npm:0.4.2, raw.macro@npm:^0.4.2":
   version: 0.4.2
   resolution: "raw.macro@npm:0.4.2"
   dependencies:
@@ -28882,7 +30188,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:^3.7.2":
+"rc-tooltip@npm:3.7.3, rc-tooltip@npm:^3.7.2":
   version: 3.7.3
   resolution: "rc-tooltip@npm:3.7.3"
   dependencies:
@@ -28928,7 +30234,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-ace@npm:^6.1.4":
+"react-ace@npm:6.6.0, react-ace@npm:^6.1.4":
   version: 6.6.0
   resolution: "react-ace@npm:6.6.0"
   dependencies:
@@ -28968,7 +30274,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
+"react-butterfiles@npm:1.3.3, react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
   version: 1.3.3
   resolution: "react-butterfiles@npm:1.3.3"
   dependencies:
@@ -28991,7 +30297,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-color@npm:^2.14.1, react-color@npm:^2.17.0":
+"react-color@npm:2.19.3, react-color@npm:^2.14.1, react-color@npm:^2.17.0":
   version: 2.19.3
   resolution: "react-color@npm:2.19.3"
   dependencies:
@@ -29008,7 +30314,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-columned@npm:^1.0.0":
+"react-columned@npm:1.1.3, react-columned@npm:^1.0.0":
   version: 1.1.3
   resolution: "react-columned@npm:1.1.3"
   dependencies:
@@ -29020,7 +30326,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-custom-scrollbars@npm:^4.2.1":
+"react-custom-scrollbars@npm:4.2.1, react-custom-scrollbars@npm:^4.2.1":
   version: 4.2.1
   resolution: "react-custom-scrollbars@npm:4.2.1"
   dependencies:
@@ -29106,6 +30412,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-dnd-html5-backend@npm:9.5.1, react-dnd-html5-backend@npm:^9.3.4":
+  version: 9.5.1
+  resolution: "react-dnd-html5-backend@npm:9.5.1"
+  dependencies:
+    dnd-core: ^9.5.1
+  checksum: 047d19ddb50b8a55944625661ccfbc4f0b24470f05f5fd4abcff57fc79e482b8ef87b95147c0cd620e25f8d97b6bff54f5d2c91d4593408d62de854e447a952a
+  languageName: node
+  linkType: hard
+
 "react-dnd-html5-backend@npm:^11.1.3":
   version: 11.1.3
   resolution: "react-dnd-html5-backend@npm:11.1.3"
@@ -29115,12 +30430,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dnd-html5-backend@npm:^9.3.4":
+"react-dnd@npm:9.5.1, react-dnd@npm:^9.3.4":
   version: 9.5.1
-  resolution: "react-dnd-html5-backend@npm:9.5.1"
+  resolution: "react-dnd@npm:9.5.1"
   dependencies:
+    "@types/hoist-non-react-statics": ^3.3.1
+    "@types/shallowequal": ^1.1.1
     dnd-core: ^9.5.1
-  checksum: 047d19ddb50b8a55944625661ccfbc4f0b24470f05f5fd4abcff57fc79e482b8ef87b95147c0cd620e25f8d97b6bff54f5d2c91d4593408d62de854e447a952a
+    hoist-non-react-statics: ^3.3.0
+    shallowequal: ^1.1.0
+  peerDependencies:
+    react: ">= 16.8"
+    react-dom: ">= 16.8"
+  checksum: f5d3b4291d5bbd0275fd2b4f73ae417d358b45ffa8751c3a32d97db5cdd3bf3ab55741c33a6fb433dc2878a0a03190b51a8e390b94eb49a8bdce1c60a429ee37
   languageName: node
   linkType: hard
 
@@ -29136,22 +30458,6 @@ fsevents@^1.2.7:
     react: ">= 16.9.0"
     react-dom: ">= 16.9.0"
   checksum: ba08188a1a1bb9cc8109bcaea5cd3c3e186d4aa4f04193ef398f8baacf1fe228860f1800903cebc1e73e84473e552198a65b06d244ed7116ee95e4a16c3920c7
-  languageName: node
-  linkType: hard
-
-"react-dnd@npm:^9.3.4":
-  version: 9.5.1
-  resolution: "react-dnd@npm:9.5.1"
-  dependencies:
-    "@types/hoist-non-react-statics": ^3.3.1
-    "@types/shallowequal": ^1.1.1
-    dnd-core: ^9.5.1
-    hoist-non-react-statics: ^3.3.0
-    shallowequal: ^1.1.0
-  peerDependencies:
-    react: ">= 16.8"
-    react-dom: ">= 16.8"
-  checksum: f5d3b4291d5bbd0275fd2b4f73ae417d358b45ffa8751c3a32d97db5cdd3bf3ab55741c33a6fb433dc2878a0a03190b51a8e390b94eb49a8bdce1c60a429ee37
   languageName: node
   linkType: hard
 
@@ -29271,7 +30577,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-google-recaptcha@npm:^1.1.0":
+"react-google-recaptcha@npm:1.1.0, react-google-recaptcha@npm:^1.1.0":
   version: 1.1.0
   resolution: "react-google-recaptcha@npm:1.1.0"
   dependencies:
@@ -29309,7 +30615,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-helmet@npm:^5.2.0":
+"react-helmet@npm:5.2.1, react-helmet@npm:^5.2.0":
   version: 5.2.1
   resolution: "react-helmet@npm:5.2.1"
   dependencies:
@@ -29323,7 +30629,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-helmet@npm:^6.0.0, react-helmet@npm:^6.1.0":
+"react-helmet@npm:6.1.0, react-helmet@npm:^6.0.0, react-helmet@npm:^6.1.0":
   version: 6.1.0
   resolution: "react-helmet@npm:6.1.0"
   dependencies:
@@ -29361,7 +30667,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-hotkeyz@npm:^1.0.4":
+"react-hotkeyz@npm:1.0.4, react-hotkeyz@npm:^1.0.4":
   version: 1.0.4
   resolution: "react-hotkeyz@npm:1.0.4"
   dependencies:
@@ -29373,7 +30679,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-images@npm:^0.5.19":
+"react-images@npm:0.5.19, react-images@npm:^0.5.19":
   version: 0.5.19
   resolution: "react-images@npm:0.5.19"
   dependencies:
@@ -29406,7 +30712,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-lazy-load@npm:^3.0.13":
+"react-lazy-load@npm:3.1.13, react-lazy-load@npm:^3.0.13":
   version: 3.1.13
   resolution: "react-lazy-load@npm:3.1.13"
   dependencies:
@@ -29428,7 +30734,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-loading-skeleton@npm:^0.5.0":
+"react-loading-skeleton@npm:0.5.0, react-loading-skeleton@npm:^0.5.0":
   version: 0.5.0
   resolution: "react-loading-skeleton@npm:0.5.0"
   peerDependencies:
@@ -29520,7 +30826,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^5.0.0":
+"react-router-dom@npm:5.2.0, react-router-dom@npm:^5.0.0":
   version: 5.2.0
   resolution: "react-router-dom@npm:5.2.0"
   dependencies:
@@ -29621,7 +30927,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable-hoc@npm:^1.9.1":
+"react-sortable-hoc@npm:1.11.0, react-sortable-hoc@npm:^1.9.1":
   version: 1.11.0
   resolution: "react-sortable-hoc@npm:1.11.0"
   dependencies:
@@ -29636,7 +30942,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable-tree@npm:^2.6.0":
+"react-sortable-tree@npm:2.8.0, react-sortable-tree@npm:^2.6.0":
   version: 2.8.0
   resolution: "react-sortable-tree@npm:2.8.0"
   dependencies:
@@ -29655,7 +30961,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable@npm:^2.0.0":
+"react-sortable@npm:2.0.0, react-sortable@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-sortable@npm:2.0.0"
   dependencies:
@@ -29728,7 +31034,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:^4.3.0":
+"react-transition-group@npm:4.4.1":
   version: 4.4.1
   resolution: "react-transition-group@npm:4.4.1"
   dependencies:
@@ -29743,7 +31049,22 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-virtualized@npm:^9.21.0, react-virtualized@npm:^9.21.2":
+"react-transition-group@npm:^4.3.0":
+  version: 4.4.2
+  resolution: "react-transition-group@npm:4.4.2"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    dom-helpers: ^5.0.1
+    loose-envify: ^1.4.0
+    prop-types: ^15.6.2
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: 063c1d6e037bda8d4bc3da3fcb7f0827dca3f4ca1e1be8bb29ce6957ec917eae71853b043de4d720b3302f2ccf9ce99dcd89c88acec4a665888f1e8d492803be
+  languageName: node
+  linkType: hard
+
+"react-virtualized@npm:9.22.3, react-virtualized@npm:^9.21.0, react-virtualized@npm:^9.21.2":
   version: 9.22.3
   resolution: "react-virtualized@npm:9.22.3"
   dependencies:
@@ -29996,7 +31317,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"recoil@npm:^0.1.2":
+"recoil@npm:0.1.3, recoil@npm:^0.1.2":
   version: 0.1.3
   resolution: "recoil@npm:0.1.3"
   peerDependencies:
@@ -31009,7 +32330,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"sanitize-filename@npm:^1.6.3":
+"sanitize-filename@npm:1.6.3, sanitize-filename@npm:^1.6.3":
   version: 1.6.3
   resolution: "sanitize-filename@npm:1.6.3"
   dependencies:
@@ -31164,7 +32485,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.3.1":
+"secure-json-parse@npm:^2.3.1, secure-json-parse@npm:^2.4.0":
   version: 2.4.0
   resolution: "secure-json-parse@npm:2.4.0"
   checksum: bbf325b52d3eb399b23a337ef7185380424600b4d6c07e62e8d1ab9e9cc657258b897841e4da1ecca9c9d4a83e426756f74fff1685640b3fbe4f481f577517d4
@@ -31274,7 +32595,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:7.3.5, semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -31562,7 +32883,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"short-hash@npm:^1.0.0":
+"short-hash@npm:1.0.0, short-hash@npm:^1.0.0":
   version: 1.0.0
   resolution: "short-hash@npm:1.0.0"
   dependencies:
@@ -31571,7 +32892,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shortid@npm:^2.2.12, shortid@npm:^2.2.14, shortid@npm:^2.2.15, shortid@npm:^2.2.16":
+"shortid@npm:2.2.16, shortid@npm:^2.2.12, shortid@npm:^2.2.14, shortid@npm:^2.2.15, shortid@npm:^2.2.16":
   version: 2.2.16
   resolution: "shortid@npm:2.2.16"
   dependencies:
@@ -31712,7 +33033,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"slugify@npm:^1.2.9, slugify@npm:^1.4.0":
+"slugify@npm:1.5.3, slugify@npm:^1.2.9, slugify@npm:^1.4.0":
   version: 1.5.3
   resolution: "slugify@npm:1.5.3"
   checksum: 2f96352f294e70372761fa509d5f334c72c6c40fbc21d1b71c1ccb4d60e44ffebb9dbeb8c7e1d7bb64775c7e2bc704e8739c9b32c6ce5c7a0bbd5d846abf7133
@@ -32209,7 +33530,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"store@npm:^2.0.12":
+"store@npm:2.0.12, store@npm:^2.0.12":
   version: 2.0.12
   resolution: "store@npm:2.0.12"
   checksum: d139789bacc1078bc8d0296c9a399e9fcfcb5aa704b76076607f1be6fef8939c27edf7870110d2f5e7fcd11ba6443cb938a03da6e692e5f28647e2b2f1817404
@@ -32256,7 +33577,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stream@npm:^0.0.2":
+"stream@npm:0.0.2, stream@npm:^0.0.2":
   version: 0.0.2
   resolution: "stream@npm:0.0.2"
   dependencies:
@@ -32339,7 +33660,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"string.prototype.matchall@npm:^4.0.0 || ^3.0.1, string.prototype.matchall@npm:^4.0.4":
+"string.prototype.matchall@npm:^4.0.0 || ^3.0.1, string.prototype.matchall@npm:^4.0.5":
   version: 4.0.5
   resolution: "string.prototype.matchall@npm:4.0.5"
   dependencies:
@@ -32835,6 +34156,20 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tar@npm:6.1.0, tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "tar@npm:6.1.0"
+  dependencies:
+    chownr: ^2.0.0
+    fs-minipass: ^2.0.0
+    minipass: ^3.0.0
+    minizlib: ^2.1.1
+    mkdirp: ^1.0.3
+    yallist: ^4.0.0
+  checksum: d1d988eceb1ad2ecfaaf6fc5ecfe0c46fa005d04fe4c283355ccc52d3ffb4b6bf459a62f9ac7e36fd35251ab020399bdf527ab48b968120e06b4f61906a87d62
+  languageName: node
+  linkType: hard
+
 "tar@npm:^2.0.0":
   version: 2.2.2
   resolution: "tar@npm:2.2.2"
@@ -32858,20 +34193,6 @@ resolve@^2.0.0-next.3:
     safe-buffer: ^5.1.2
     yallist: ^3.0.3
   checksum: d325c316ac329ecb18f2b8cd3f85a80ab4a4105ada601b9253aaafae3fc14268e3cd874ccc265b6a08e60ebd17fbc31bd3dbc0d1018f874b536eb2a6e8ef6d9c
-  languageName: node
-  linkType: hard
-
-"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "tar@npm:6.1.0"
-  dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
-  checksum: d1d988eceb1ad2ecfaaf6fc5ecfe0c46fa005d04fe4c283355ccc52d3ffb4b6bf459a62f9ac7e36fd35251ab020399bdf527ab48b968120e06b4f61906a87d62
   languageName: node
   linkType: hard
 
@@ -33145,7 +34466,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"timeago-react@npm:^2.0.0":
+"timeago-react@npm:2.0.1, timeago-react@npm:^2.0.0":
   version: 2.0.1
   resolution: "timeago-react@npm:2.0.1"
   dependencies:
@@ -33427,7 +34748,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tree-kill@npm:^1.2.2":
+"tree-kill@npm:1.2.2, tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
   bin:
@@ -33451,9 +34772,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "trim-newlines@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "trim-newlines@npm:3.0.0"
-  checksum: 51bfbec0014ae58cdbf3c55e34cfe7f1a92a77d362990bb4cc8d6edf51f1c21f28b92e442adec3ef9cef69194b532b28c1a0a06d9ee78b2b0fd28d191a2b738e
+  version: 3.0.1
+  resolution: "trim-newlines@npm:3.0.1"
+  checksum: a1cc3d5992d47349fa0b48206038e524f42d0ade81913cc72322e4f5a99c5e936eb730af762c9f5bafa3c19ab1e9eaf14bdff487cbe3f2c5d525dd03f3f89fb0
   languageName: node
   linkType: hard
 
@@ -33625,7 +34946,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tsutils@npm:^3.17.1":
+"tsutils@npm:^3.17.1, tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
   dependencies:
@@ -33947,7 +35268,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"uniqid@npm:^5.0.3, uniqid@npm:^5.2.0, uniqid@npm:^5.3.0":
+"uniqid@npm:5.3.0, uniqid@npm:^5.0.3, uniqid@npm:^5.2.0, uniqid@npm:^5.3.0":
   version: 5.3.0
   resolution: "uniqid@npm:5.3.0"
   checksum: 1fcf7eb69ea09dd2cf37ffe72d8bd0f371a95586c3408b10f0018ad32e13fd533ebb7942a0fa75d8b1124ca7b4f417d241483853d6d706afeaca25d3cc7a0dcb
@@ -34319,7 +35640,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.2.0, uuid@npm:^8.3.0":
+"uuid@npm:^8.2.0, uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -34527,7 +35848,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"warning@npm:^4.0.2, warning@npm:^4.0.3":
+"warning@npm:4.0.3, warning@npm:^4.0.2, warning@npm:^4.0.3":
   version: 4.0.3
   resolution: "warning@npm:4.0.3"
   dependencies:
@@ -35207,12 +36528,27 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"ws@npm:7.4.5":
+  version: 7.4.5
+  resolution: "ws@npm:7.4.5"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 20731aa1075336b94677f6741b674469c3c7fce9b70115bb535827c7c108a9d714f0b38ce39289b63c652870f9801afaf096f8aab32da96be62d919e80e4ed32
+  languageName: node
+  linkType: hard
+
 "ws@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "ws@npm:6.2.1"
+  version: 6.2.2
+  resolution: "ws@npm:6.2.2"
   dependencies:
     async-limiter: ~1.0.0
-  checksum: 35d32b09e28f799f04708c3a7bd9eff469ae63e60543d7e18335f28689228a42ee21210f48de680aad6e5317df76b5b1183d1a1ea4b4d14cb6e0943528f40e76
+  checksum: 00d406fb98114e6404c71f445e41818d9eb23644247a70be3f8da1f981c5f1db0f8ea191bee972fa5f5387c2ebd360268622871354be324acafaab43d7612362
   languageName: node
   linkType: hard
 
@@ -35556,7 +36892,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"zip-local@npm:^0.3.4":
+"zip-local@npm:0.3.4, zip-local@npm:^0.3.4":
   version: 0.3.4
   resolution: "zip-local@npm:0.3.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/react-components@npm:3.1.5, @apollo/react-components@npm:^3.1.5":
+"@apollo/react-components@npm:^3.1.5":
   version: 3.1.5
   resolution: "@apollo/react-components@npm:3.1.5"
   dependencies:
@@ -52,7 +52,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/react-hooks@npm:3.1.5, @apollo/react-hooks@npm:^3.1.5":
+"@apollo/react-hooks@npm:^3.1.5":
   version: 3.1.5
   resolution: "@apollo/react-hooks@npm:3.1.5"
   dependencies:
@@ -79,7 +79,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/auth@npm:1.6.3, @aws-amplify/auth@npm:^1.3.3":
+"@aws-amplify/auth@npm:^1.3.3":
   version: 1.6.3
   resolution: "@aws-amplify/auth@npm:1.6.3"
   dependencies:
@@ -2000,21 +2000,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.14.0, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.14.0
-  resolution: "@babel/runtime@npm:7.14.0"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:7.9.0":
   version: 7.9.0
   resolution: "@babel/runtime@npm:7.9.0"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: b34bc3bdb86d2ea1182eba4a4e0fb7abdf5010bb263aaf4395a362b29209915dbb94d7a1f4ae02a98d8241666c1a99d8733513e7cb26e309956ddcb7071b34df
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.14.0
+  resolution: "@babel/runtime@npm:7.14.0"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: ab6653f2f8ecdaebf36674894cef458a9d4f881dc007fdcd50a8261f5c6d9731e03fda2c17e32ecf0e6c779d69eb6cf49d68a48c780aaf07d5b572e8b7ef0508
   languageName: node
   linkType: hard
 
@@ -2367,17 +2367,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@editorjs/editorjs@npm:2.21.0":
-  version: 2.21.0
-  resolution: "@editorjs/editorjs@npm:2.21.0"
-  dependencies:
-    codex-notifier: ^1.1.2
-    codex-tooltip: ^1.0.2
-    nanoid: ^3.1.22
-  checksum: b7afd0e53dcd9eff9b1fc528502fe59f8e7ff128865aebdac7b6d53eff1a8501672212fca922ecdbefa15585073e683342f28b6341b1eb12a3ab7eee77b2e870
-  languageName: node
-  linkType: hard
-
 "@editorjs/editorjs@npm:^2.19.0, @editorjs/editorjs@npm:^2.19.3, @editorjs/editorjs@npm:^2.20.1":
   version: 2.22.0
   resolution: "@editorjs/editorjs@npm:2.22.0"
@@ -2421,19 +2410,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@elastic/elasticsearch@npm:7.12.0":
-  version: 7.12.0
-  resolution: "@elastic/elasticsearch@npm:7.12.0"
-  dependencies:
-    debug: ^4.3.1
-    hpagent: ^0.1.1
-    ms: ^2.1.3
-    pump: ^3.0.0
-    secure-json-parse: ^2.3.1
-  checksum: ec823ea4f237b10d7c2ac09b0213702c0f92cbf410103bb1a7b007a9ff3daee6759888bf045204596e2533335e777e7bc4ea112d1ec24a246e3a61e45798612f
-  languageName: node
-  linkType: hard
-
 "@elastic/elasticsearch@npm:^7.9.1":
   version: 7.13.0
   resolution: "@elastic/elasticsearch@npm:7.13.0"
@@ -2472,7 +2448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/core@npm:10.1.1, @emotion/core@npm:^10.0.17, @emotion/core@npm:^10.0.20, @emotion/core@npm:^10.0.27, @emotion/core@npm:^10.0.9":
+"@emotion/core@npm:^10.0.17, @emotion/core@npm:^10.0.20, @emotion/core@npm:^10.0.27, @emotion/core@npm:^10.0.9":
   version: 10.1.1
   resolution: "@emotion/core@npm:10.1.1"
   dependencies:
@@ -2583,7 +2559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:10.0.27, @emotion/styled@npm:^10.0.17, @emotion/styled@npm:^10.0.27":
+"@emotion/styled@npm:^10.0.17, @emotion/styled@npm:^10.0.27":
   version: 10.0.27
   resolution: "@emotion/styled@npm:10.0.27"
   dependencies:
@@ -2751,7 +2727,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-svg-core@npm:1.2.35, @fortawesome/fontawesome-svg-core@npm:^1.2.8":
+"@fortawesome/fontawesome-svg-core@npm:^1.2.8":
   version: 1.2.35
   resolution: "@fortawesome/fontawesome-svg-core@npm:1.2.35"
   dependencies:
@@ -2760,7 +2736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-brands-svg-icons@npm:5.15.3, @fortawesome/free-brands-svg-icons@npm:^5.5.0":
+"@fortawesome/free-brands-svg-icons@npm:^5.5.0":
   version: 5.15.3
   resolution: "@fortawesome/free-brands-svg-icons@npm:5.15.3"
   dependencies:
@@ -2769,7 +2745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-regular-svg-icons@npm:5.15.3, @fortawesome/free-regular-svg-icons@npm:^5.6.0":
+"@fortawesome/free-regular-svg-icons@npm:^5.6.0":
   version: 5.15.3
   resolution: "@fortawesome/free-regular-svg-icons@npm:5.15.3"
   dependencies:
@@ -2778,7 +2754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/free-solid-svg-icons@npm:5.15.3, @fortawesome/free-solid-svg-icons@npm:^5.5.0":
+"@fortawesome/free-solid-svg-icons@npm:^5.5.0":
   version: 5.15.3
   resolution: "@fortawesome/free-solid-svg-icons@npm:5.15.3"
   dependencies:
@@ -2787,7 +2763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/react-fontawesome@npm:0.1.14, @fortawesome/react-fontawesome@npm:^0.1.3":
+"@fortawesome/react-fontawesome@npm:^0.1.3":
   version: 0.1.14
   resolution: "@fortawesome/react-fontawesome@npm:0.1.14"
   dependencies:
@@ -2799,7 +2775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/schema@npm:7.1.5, @graphql-tools/schema@npm:^7.0.0, @graphql-tools/schema@npm:^7.1.2":
+"@graphql-tools/schema@npm:^7.0.0, @graphql-tools/schema@npm:^7.1.2":
   version: 7.1.5
   resolution: "@graphql-tools/schema@npm:7.1.5"
   dependencies:
@@ -3970,7 +3946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material/base@npm:3.1.0, @material/base@npm:^3.1.0":
+"@material/base@npm:^3.1.0":
   version: 3.1.0
   resolution: "@material/base@npm:3.1.0"
   dependencies:
@@ -4485,7 +4461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material/textfield@npm:3.2.0, @material/textfield@npm:^3.2.0":
+"@material/textfield@npm:^3.2.0":
   version: 3.2.0
   resolution: "@material/textfield@npm:3.2.0"
   dependencies:
@@ -5140,7 +5116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/aws@npm:^3.22.0, @pulumi/aws@npm:v3.38.1":
+"@pulumi/aws@npm:^3.22.0":
   version: 3.38.1
   resolution: "@pulumi/aws@npm:3.38.1"
   dependencies:
@@ -5154,7 +5130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/pulumi@npm:2.25.2+dirty, @pulumi/pulumi@npm:^2.17.0, @pulumi/pulumi@npm:^2.21.2":
+"@pulumi/pulumi@npm:^2.17.0, @pulumi/pulumi@npm:^2.21.2":
   version: 2.25.2
   resolution: "@pulumi/pulumi@npm:2.25.2"
   dependencies:
@@ -5221,7 +5197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/base@npm:5.7.2, @rmwc/base@npm:^5.6.0, @rmwc/base@npm:^5.7.2":
+"@rmwc/base@npm:^5.6.0, @rmwc/base@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/base@npm:5.7.2"
   dependencies:
@@ -5237,7 +5213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/button@npm:5.7.2, @rmwc/button@npm:^5.6.0, @rmwc/button@npm:^5.7.2":
+"@rmwc/button@npm:^5.6.0, @rmwc/button@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/button@npm:5.7.2"
   dependencies:
@@ -5254,7 +5230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/checkbox@npm:5.7.2, @rmwc/checkbox@npm:^5.6.0":
+"@rmwc/checkbox@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/checkbox@npm:5.7.2"
   dependencies:
@@ -5272,7 +5248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/chip@npm:5.7.2, @rmwc/chip@npm:^5.6.0":
+"@rmwc/chip@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/chip@npm:5.7.2"
   dependencies:
@@ -5288,7 +5264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/dialog@npm:5.7.2, @rmwc/dialog@npm:^5.6.0":
+"@rmwc/dialog@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/dialog@npm:5.7.2"
   dependencies:
@@ -5304,7 +5280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/drawer@npm:5.7.2, @rmwc/drawer@npm:^5.6.0":
+"@rmwc/drawer@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/drawer@npm:5.7.2"
   dependencies:
@@ -5318,7 +5294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/elevation@npm:5.7.2, @rmwc/elevation@npm:^5.6.0":
+"@rmwc/elevation@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/elevation@npm:5.7.2"
   dependencies:
@@ -5332,7 +5308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/fab@npm:5.7.2, @rmwc/fab@npm:^5.6.0":
+"@rmwc/fab@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/fab@npm:5.7.2"
   dependencies:
@@ -5349,7 +5325,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/floating-label@npm:5.7.2, @rmwc/floating-label@npm:^5.6.0, @rmwc/floating-label@npm:^5.7.2":
+"@rmwc/floating-label@npm:^5.6.0, @rmwc/floating-label@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/floating-label@npm:5.7.2"
   dependencies:
@@ -5377,7 +5353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/grid@npm:5.7.2, @rmwc/grid@npm:^5.6.0":
+"@rmwc/grid@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/grid@npm:5.7.2"
   dependencies:
@@ -5391,7 +5367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/icon-button@npm:5.7.2, @rmwc/icon-button@npm:^5.6.0, @rmwc/icon-button@npm:^5.7.2":
+"@rmwc/icon-button@npm:^5.6.0, @rmwc/icon-button@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/icon-button@npm:5.7.2"
   dependencies:
@@ -5407,7 +5383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/icon@npm:5.7.2, @rmwc/icon@npm:^5.6.0, @rmwc/icon@npm:^5.7.2":
+"@rmwc/icon@npm:^5.6.0, @rmwc/icon@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/icon@npm:5.7.2"
   dependencies:
@@ -5421,7 +5397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/line-ripple@npm:5.7.2, @rmwc/line-ripple@npm:^5.6.0, @rmwc/line-ripple@npm:^5.7.2":
+"@rmwc/line-ripple@npm:^5.6.0, @rmwc/line-ripple@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/line-ripple@npm:5.7.2"
   dependencies:
@@ -5435,7 +5411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/list@npm:5.7.2, @rmwc/list@npm:^5.6.0, @rmwc/list@npm:^5.7.2":
+"@rmwc/list@npm:^5.6.0, @rmwc/list@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/list@npm:5.7.2"
   dependencies:
@@ -5452,7 +5428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/menu@npm:5.7.2, @rmwc/menu@npm:^5.6.0, @rmwc/menu@npm:^5.7.2":
+"@rmwc/menu@npm:^5.6.0, @rmwc/menu@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/menu@npm:5.7.2"
   dependencies:
@@ -5468,7 +5444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/notched-outline@npm:5.7.2, @rmwc/notched-outline@npm:^5.6.0, @rmwc/notched-outline@npm:^5.7.2":
+"@rmwc/notched-outline@npm:^5.6.0, @rmwc/notched-outline@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/notched-outline@npm:5.7.2"
   dependencies:
@@ -5495,7 +5471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/radio@npm:5.7.2, @rmwc/radio@npm:^5.6.0":
+"@rmwc/radio@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/radio@npm:5.7.2"
   dependencies:
@@ -5512,7 +5488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/ripple@npm:5.7.2, @rmwc/ripple@npm:^5.6.0, @rmwc/ripple@npm:^5.7.2":
+"@rmwc/ripple@npm:^5.6.0, @rmwc/ripple@npm:^5.7.2":
   version: 5.7.2
   resolution: "@rmwc/ripple@npm:5.7.2"
   dependencies:
@@ -5527,7 +5503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/select@npm:5.7.2, @rmwc/select@npm:^5.6.0":
+"@rmwc/select@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/select@npm:5.7.2"
   dependencies:
@@ -5548,7 +5524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/slider@npm:5.7.2, @rmwc/slider@npm:^5.6.0":
+"@rmwc/slider@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/slider@npm:5.7.2"
   dependencies:
@@ -5562,7 +5538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/snackbar@npm:5.7.2, @rmwc/snackbar@npm:^5.6.0":
+"@rmwc/snackbar@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/snackbar@npm:5.7.2"
   dependencies:
@@ -5579,7 +5555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/switch@npm:5.7.2, @rmwc/switch@npm:^5.6.0":
+"@rmwc/switch@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/switch@npm:5.7.2"
   dependencies:
@@ -5596,7 +5572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/tabs@npm:5.7.2, @rmwc/tabs@npm:^5.6.0":
+"@rmwc/tabs@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/tabs@npm:5.7.2"
   dependencies:
@@ -5635,7 +5611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/top-app-bar@npm:5.7.2, @rmwc/top-app-bar@npm:^5.6.0":
+"@rmwc/top-app-bar@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/top-app-bar@npm:5.7.2"
   dependencies:
@@ -5651,14 +5627,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/types@npm:5.6.0, @rmwc/types@npm:^5.6.0":
+"@rmwc/types@npm:^5.6.0":
   version: 5.6.0
   resolution: "@rmwc/types@npm:5.6.0"
   checksum: 1096bba42087d4581728c7d1ec6279953f942a4d623b02add9e2a44486e4d9620d19e35e8d3d6fb6404d24222969b4a6a7ed5c503900ed1398af7ac82ac2a5e0
   languageName: node
   linkType: hard
 
-"@rmwc/typography@npm:5.7.2, @rmwc/typography@npm:^5.6.0":
+"@rmwc/typography@npm:^5.6.0":
   version: 5.7.2
   resolution: "@rmwc/typography@npm:5.7.2"
   dependencies:
@@ -6678,7 +6654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime@npm:2.0.3, @types/mime@npm:^2.0.3":
+"@types/mime@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/mime@npm:2.0.3"
   checksum: 6df548a912494f8579d548cd883be0425f30eaa2922283335c405e270600f49045a06d766460c0f0edabb41dff570c614d174d3c52215de3bddd11f190ec9ae9
@@ -6832,7 +6808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-router-dom@npm:5.1.7, @types/react-router-dom@npm:^5.1.5":
+"@types/react-router-dom@npm:^5.1.5":
   version: 5.1.7
   resolution: "@types/react-router-dom@npm:5.1.7"
   dependencies:
@@ -7632,36 +7608,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-dynamodb-to-elasticsearch@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-dynamodb-to-elasticsearch@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/api-plugin-elastic-search-client": 5.7.0
-    "@webiny/handler": 5.7.0
-    aws-sdk: 2.911.0
-  checksum: c9079c0e391001a39a80584fd61230a92a7e215dacc2d693ce1e99e5b2979349700610d0046167e060c95f71e242f98352d1b1b24e95461a26062e672a41c2de
-  languageName: node
-  linkType: hard
-
-"@webiny/api-file-manager-s3@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-file-manager-s3@npm:5.7.0"
-  dependencies:
-    "@webiny/api-file-manager": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/validation": 5.7.0
-    form-data: 3.0.1
-    node-fetch: 2.6.1
-    sanitize-filename: 1.6.3
-    uniqid: 5.3.0
-  checksum: c2f35a75ad6033dd4f6e0731c0d68ea4cb98c7f21bd674419d0c0d528f6e06851343b4e11f7e1ba4a512d40cdb9601576112dc41829939ffa0de6c3ba893082d
-  languageName: node
-  linkType: hard
-
-"@webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3":
+"@webiny/api-file-manager-s3@^5.8.0-beta.0, @webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3":
   version: 0.0.0-use.local
   resolution: "@webiny/api-file-manager-s3@workspace:packages/api-file-manager-s3"
   dependencies:
@@ -7725,65 +7672,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-file-manager@npm:5.7.0, @webiny/api-file-manager@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-file-manager@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@commodo/fields": 1.1.2-beta.20
-    "@webiny/api-i18n-content": 5.7.0
-    "@webiny/api-plugin-elastic-search-client": 5.7.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/api-upgrade": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-client": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/project-utils": 5.7.0
-    "@webiny/validation": 5.7.0
-    aws-sdk: 2.911.0
-    commodo-fields-object: 1.0.6
-    mdbid: 1.0.0
-    object-hash: 1.3.1
-    sanitize-filename: 1.6.3
-  checksum: 4fef6c464913c9ac58a75ad6b3fe53836ac0572d2833f7121d5c11fc3b8d5ab59453c009497cd29189c895de6ea34aca1495e57f5d05b1091253259475d61b3b
-  languageName: node
-  linkType: hard
-
-"@webiny/api-form-builder@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-form-builder@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@commodo/fields": 1.1.2-beta.20
-    "@webiny/api-file-manager": 5.7.0
-    "@webiny/api-i18n": 5.7.0
-    "@webiny/api-i18n-content": 5.7.0
-    "@webiny/api-plugin-elastic-search-client": 5.7.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/api-upgrade": 5.7.0
-    "@webiny/db-dynamodb": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-aws": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/validation": 5.7.0
-    commodo-fields-object: 1.0.6
-    got: 9.6.0
-    json2csv: 4.5.4
-    lodash: 4.17.21
-    mdbid: 1.0.0
-    node-fetch: 2.6.1
-    slugify: 1.5.3
-  checksum: f2c541cce995e03b91486b549ae8e356f8a43e0850fcd438c55ec4ecb0eb630957fb93bd8164d224f03c1da8e9d1794ba7430ce2c516dc3a0595c3fa5758612b
-  languageName: node
-  linkType: hard
-
-"@webiny/api-form-builder@workspace:packages/api-form-builder":
+"@webiny/api-form-builder@^5.8.0-beta.0, @webiny/api-form-builder@workspace:packages/api-form-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/api-form-builder@workspace:packages/api-form-builder"
   dependencies:
@@ -7952,41 +7841,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-headless-cms@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-headless-cms@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@commodo/fields": 1.1.2-beta.20
-    "@graphql-tools/schema": 7.1.5
-    "@webiny/api-file-manager": 5.7.0
-    "@webiny/api-i18n": 5.7.0
-    "@webiny/api-i18n-content": 5.7.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/api-upgrade": 5.7.0
-    "@webiny/db-dynamodb": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-aws": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/handler-http": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/validation": 5.7.0
-    boolean: 3.0.4
-    commodo-fields-object: 1.0.6
-    dataloader: 2.0.0
-    dot-prop-immutable: 1.6.0
-    jsonpack: 1.1.5
-    lodash: 4.17.21
-    pluralize: 8.0.0
-    shortid: 2.2.16
-    slugify: 1.5.3
-  checksum: cdd89a3fbfbfb72dc0ebd56a1cac5483f16ac5f1a719a3436ec1e29974ed04b7a8d1b66072ba484edf04b2a18637d69e2f5942f6cdc989c5ccc0cfd3231abb9b
-  languageName: node
-  linkType: hard
-
 "@webiny/api-i18n-content@^5.8.0-beta.0, @webiny/api-i18n-content@workspace:packages/api-i18n-content":
   version: 0.0.0-use.local
   resolution: "@webiny/api-i18n-content@workspace:packages/api-i18n-content"
@@ -8004,19 +7858,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/api-i18n-content@npm:5.7.0, @webiny/api-i18n-content@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-i18n-content@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/api-i18n": 5.7.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-  checksum: bd12e8c8f7e229aac1e62615555b62dbcbfb4b35d748eb33f50c7f23b83419435aa7d18e804a23936935b99419181ea9c7715e4ef03c2845b0b8cb6bbb12c044
-  languageName: node
-  linkType: hard
 
 "@webiny/api-i18n@^5.8.0-beta.0, @webiny/api-i18n@workspace:packages/api-i18n":
   version: 0.0.0-use.local
@@ -8049,69 +7890,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-i18n@npm:5.7.0, @webiny/api-i18n@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-i18n@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/db-dynamodb": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-aws": 5.7.0
-    "@webiny/handler-client": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/plugins": 5.7.0
-    accept-language-parser: 1.5.0
-    i18n-locales: 0.0.2
-  checksum: 6ef62d7fb4f792ec13bc7423bfa0f18f85d67a6b4af91a4b3d40d6f2335caea28ad5f234aa3095bd07f8b4f73e9da771de2a6299799d29a5edfbce64ffb9af16
-  languageName: node
-  linkType: hard
-
-"@webiny/api-page-builder@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-page-builder@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@commodo/fields": 1.1.2-beta.20
-    "@webiny/api-file-manager": 5.7.0
-    "@webiny/api-i18n": 5.7.0
-    "@webiny/api-i18n-content": 5.7.0
-    "@webiny/api-prerendering-service": 5.7.0
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/api-upgrade": 5.7.0
-    "@webiny/cli-plugin-deploy-pulumi": 5.7.0
-    "@webiny/db-dynamodb": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-args": 5.7.0
-    "@webiny/handler-aws": 5.7.0
-    "@webiny/handler-client": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/validation": 5.7.0
-    commodo-fields-object: 1.0.6
-    dataloader: 2.0.0
-    extract-zip: 1.7.0
-    fs-extra: 7.0.1
-    jsonpack: 1.1.5
-    load-json-file: 6.2.0
-    lodash: 4.17.21
-    mdbid: 1.0.0
-    mime: 2.5.2
-    node-fetch: 2.6.1
-    rimraf: 3.0.2
-    stream: 0.0.2
-    uniqid: 5.3.0
-    zip-local: 0.3.4
-  checksum: 489a0906e64d8e2b8a904e1d722f04c69107234d746efae603426b1c5ee745681e4d45bed9b69fca3e4825cfa21bf201914905cd9670d1eabcfb79e785f45995
-  languageName: node
-  linkType: hard
-
-"@webiny/api-page-builder@workspace:packages/api-page-builder":
+"@webiny/api-page-builder@^5.8.0-beta.0, @webiny/api-page-builder@workspace:packages/api-page-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/api-page-builder@workspace:packages/api-page-builder"
   dependencies:
@@ -8186,35 +7965,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-plugin-elastic-search-client@npm:5.7.0, @webiny/api-plugin-elastic-search-client@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-plugin-elastic-search-client@npm:5.7.0"
-  dependencies:
-    "@elastic/elasticsearch": 7.12.0
-    "@webiny/handler": 5.7.0
-    aws-elasticsearch-connector: 9.0.3
-    aws-sdk: 2.911.0
-  checksum: 85d6cea6325938153f2361f92b1e65cfe66962cca6bdcbaa0a893a9787b550f598f94f46c9bdcd17cc91bd315f533d940d7a08ca8cf54435f2432a50874c7a96
-  languageName: node
-  linkType: hard
-
-"@webiny/api-plugin-security-cognito@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-plugin-security-cognito@npm:5.7.0"
-  dependencies:
-    "@webiny/api-security": 5.7.0
-    "@webiny/api-security-tenancy": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/handler-http": 5.7.0
-    jsonwebtoken: 8.5.1
-    jwk-to-pem: 2.0.5
-    node-fetch: 2.6.1
-  checksum: 3ea2a9eda78fbaea4126bf817789df4a8d291c26891a0b93b4ffee8204b956229bcadb12a0820a01a701d9467548fd735608e8091d953af970de441cecc4a899
-  languageName: node
-  linkType: hard
-
-"@webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito":
+"@webiny/api-plugin-security-cognito@^5.8.0-beta.0, @webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito":
   version: 0.0.0-use.local
   resolution: "@webiny/api-plugin-security-cognito@workspace:packages/api-plugin-security-cognito"
   dependencies:
@@ -8236,20 +7987,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-prerendering-service-aws@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-prerendering-service-aws@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/api-prerendering-service": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-args": 5.7.0
-    "@webiny/plugins": 5.7.0
-  checksum: b6c84e46ff660793cbd76172efee0919d4d2486ee055871e8827b8818d9181578ef8293c4c50dc8d55ec177043c224b5a787e205fd7ce0b0257d7d930e15dcce
-  languageName: node
-  linkType: hard
-
-"@webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws":
+"@webiny/api-prerendering-service-aws@^5.8.0-beta.0, @webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws":
   version: 0.0.0-use.local
   resolution: "@webiny/api-prerendering-service-aws@workspace:packages/api-prerendering-service-aws"
   dependencies:
@@ -8306,29 +8044,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-prerendering-service@npm:5.7.0, @webiny/api-prerendering-service@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-prerendering-service@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-args": 5.7.0
-    "@webiny/handler-client": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/plugins": 5.7.0
-    chrome-aws-lambda: 5.5.0
-    lodash: 4.17.21
-    mdbid: 1.0.0
-    object-hash: 2.1.1
-    pluralize: 8.0.0
-    posthtml: 0.15.2
-    posthtml-noopener: 1.0.5
-    shortid: 2.2.16
-  checksum: 15fa85d3fcf816b743263dbf00da862847e55084a82a500130f47bc0d49711c6fb9c90746384e0acce8e8671a60c38caf5fe36bfadba8a95e1ecaa92149ecb78
-  languageName: node
-  linkType: hard
-
 "@webiny/api-security-tenancy@^5.8.0-beta.0, @webiny/api-security-tenancy@workspace:packages/api-security-tenancy":
   version: 0.0.0-use.local
   resolution: "@webiny/api-security-tenancy@workspace:packages/api-security-tenancy"
@@ -8360,30 +8075,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-security-tenancy@npm:5.7.0, @webiny/api-security-tenancy@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-security-tenancy@npm:5.7.0"
-  dependencies:
-    "@commodo/fields": 1.1.2-beta.20
-    "@webiny/api-security": 5.7.0
-    "@webiny/db-dynamodb": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-aws": 5.7.0
-    "@webiny/handler-db": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/handler-http": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/validation": 5.7.0
-    commodo-fields-object: 1.0.6
-    dataloader: 2.0.0
-    deep-equal: 2.0.5
-    md5: 2.3.0
-    mdbid: 1.0.0
-  checksum: 70e8cbab712a24c1bf50de51fe05c55973f30582be4bfc5f4a09cacb2e1eebbdc18b9a4ad9719502f40191a338436157e60937d2d3e79d9783ae61e7d2bcf37d
-  languageName: node
-  linkType: hard
-
 "@webiny/api-security@^5.8.0-beta.0, @webiny/api-security@workspace:packages/api-security":
   version: 0.0.0-use.local
   resolution: "@webiny/api-security@workspace:packages/api-security"
@@ -8404,20 +8095,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/api-security@npm:5.7.0, @webiny/api-security@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/api-security@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-graphql": 5.7.0
-    "@webiny/plugins": 5.7.0
-    minimatch: 3.0.4
-  checksum: 934d71709ee80972b2efeb740484f96508fd6640c851de4eb4b28689db734b70d72369eaa8630661ae1f597eda6633ad7cd27968639088c75a55fd1dddf10ccc
-  languageName: node
-  linkType: hard
 
 "@webiny/api-upgrade@^5.8.0-beta.0, @webiny/api-upgrade@workspace:packages/api-upgrade":
   version: 0.0.0-use.local
@@ -8440,19 +8117,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/api-upgrade@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/api-upgrade@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/plugins": 5.7.0
-    semver: 7.3.5
-  checksum: 912d9bcbc724808e05671bf899716ff9a7d3a5291b7f182d56534be896fc9c0fe2c9f695b0b0b50f452558f18b04f8794ed2085c609d6d56bcfed32ea3cb93b2
-  languageName: node
-  linkType: hard
 
 "@webiny/app-admin@^5.8.0-beta.0, @webiny/app-admin@workspace:packages/app-admin":
   version: 0.0.0-use.local
@@ -8517,69 +8181,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-admin@npm:5.7.0, @webiny/app-admin@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-admin@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@editorjs/editorjs": 2.21.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@svgr/webpack": 4.3.3
-    "@types/mime": 2.0.3
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-utilities: 1.3.4
-    bytes: 3.1.0
-    classnames: 2.3.1
-    dataurl-to-blob: 0.0.1
-    dayjs: 1.10.4
-    dot-prop-immutable: 1.6.0
-    downshift: 3.4.8
-    emotion: 10.0.27
-    graphlib: 2.1.8
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    invariant: 2.2.4
-    lodash: 4.17.21
-    mime: 2.5.2
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-butterfiles: 1.3.3
-    react-dom: 16.14.0
-    react-hotkeyz: 1.0.4
-    react-lazy-load: 3.1.13
-    react-transition-group: 4.4.1
-    semver: 7.3.5
-    shortid: 2.2.16
-    store: 2.0.12
-  checksum: 54d2cf1ba3ae0a47a9282315c9f26a19c976902199353903bd1792e880c436cb8ad78a739d2529fe8db6e8736fab519ebe0e484d84ebfba21a18188ed7f1a430
-  languageName: node
-  linkType: hard
-
-"@webiny/app-file-manager-s3@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-file-manager-s3@npm:5.7.0"
-  dependencies:
-    "@webiny/plugins": 5.7.0
-    apollo-client: 2.6.10
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-  checksum: 779114594af2398824b7b4e98871b4afdc1d4ac7a5b0058f8abff8071d6d0c8636ba1f69ce9a1c2dbdb00cd96ef24ca11441ce79aab0e546d26a7c907caf050b
-  languageName: node
-  linkType: hard
-
-"@webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3":
+"@webiny/app-file-manager-s3@^5.8.0-beta.0, @webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3":
   version: 0.0.0-use.local
   resolution: "@webiny/app-file-manager-s3@workspace:packages/app-file-manager-s3"
   dependencies:
@@ -8596,39 +8198,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-file-manager@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-file-manager@npm:5.7.0"
-  dependencies:
-    "@apollo/react-components": 3.1.5
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-utilities: 1.3.4
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    lodash.get: 4.4.2
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-  checksum: ab6d6cd0eac02a1b64a9202c508ec5244e222425664fa055e6915a816d0ade114bfcb9ccccb5f86a357a29ed46891386502eed3299645a0b995500f92c1509fe
-  languageName: node
-  linkType: hard
-
-"@webiny/app-file-manager@workspace:packages/app-file-manager":
+"@webiny/app-file-manager@^5.8.0-beta.0, @webiny/app-file-manager@workspace:packages/app-file-manager":
   version: 0.0.0-use.local
   resolution: "@webiny/app-file-manager@workspace:packages/app-file-manager"
   dependencies:
@@ -8670,53 +8240,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-form-builder@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-form-builder@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@editorjs/editorjs": 2.21.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@rmwc/menu": 5.7.2
-    "@svgr/webpack": 4.3.3
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-page-builder": 5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-utilities: 1.3.4
-    dot-prop-immutable: 2.1.0
-    emotion: 10.0.27
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    lodash: 4.17.21
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-dnd: 9.5.1
-    react-dnd-html5-backend: 9.5.1
-    react-dom: 16.14.0
-    react-google-recaptcha: 1.1.0
-    react-helmet: 5.2.1
-    react-hotkeyz: 1.0.4
-    react-router: 5.2.0
-    react-sortable-hoc: 1.11.0
-    shortid: 2.2.16
-    timeago-react: 2.0.1
-  checksum: e7d4047a716ccb9b98a461e9e4539a955b874f89fca4d1c743554c9a8c6db5d2a2ec7bf9d26e21c4087f3514d97d10194ec0ae4d8725abd4f3f0569583fd38d4
-  languageName: node
-  linkType: hard
-
-"@webiny/app-form-builder@workspace:packages/app-form-builder":
+"@webiny/app-form-builder@^5.8.0-beta.0, @webiny/app-form-builder@workspace:packages/app-form-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/app-form-builder@workspace:packages/app-form-builder"
   dependencies:
@@ -8812,89 +8336,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-graphql-playground@npm:5.7.0, @webiny/app-graphql-playground@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-graphql-playground@npm:5.7.0"
-  dependencies:
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-i18n": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-link-context: 1.0.20
-    apollo-utilities: 1.3.4
-    graphql: 14.7.0
-    load-script: 1.0.0
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-  checksum: e94b4f2eb5112d9fb01d87b50d38df996f8412f9a398190a929a1f2dcbf8610609a2b9ae36150a1c9b2c83c5dd5200efe5a9a11fa7e4b36de54862b7b2a44427
-  languageName: node
-  linkType: hard
-
-"@webiny/app-headless-cms@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-headless-cms@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@fortawesome/fontawesome-svg-core": 1.2.35
-    "@fortawesome/free-brands-svg-icons": 5.15.3
-    "@fortawesome/free-regular-svg-icons": 5.15.3
-    "@fortawesome/free-solid-svg-icons": 5.15.3
-    "@fortawesome/react-fontawesome": 0.1.14
-    "@svgr/webpack": 4.3.3
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-graphql-playground": 5.7.0
-    "@webiny/app-i18n": 5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/error": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-utilities: 1.3.4
-    classnames: 2.3.1
-    dot-prop-immutable: 2.1.0
-    emotion: 10.0.27
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    lodash: 4.17.21
-    pluralize: 8.0.0
-    prop-types: 15.7.2
-    raw.macro: 0.4.2
-    react: 16.14.0
-    react-dnd: 9.5.1
-    react-dnd-html5-backend: 9.5.1
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-    react-hotkeyz: 1.0.4
-    react-router: 5.2.0
-    react-virtualized: 9.22.3
-    shortid: 2.2.16
-    timeago-react: 2.0.1
-  checksum: fee25c5045003b62a308d6da589ac031f69e0ac4944a72e925c3b629e079f3d6f5bfc18e3556efa57d4c38f948bfd00f676f4ada6cf7afd9458da78382f6535a
-  languageName: node
-  linkType: hard
-
-"@webiny/app-headless-cms@workspace:packages/app-headless-cms":
+"@webiny/app-headless-cms@^5.8.0-beta.0, @webiny/app-headless-cms@workspace:packages/app-headless-cms":
   version: 0.0.0-use.local
   resolution: "@webiny/app-headless-cms@workspace:packages/app-headless-cms"
   dependencies:
@@ -8962,24 +8404,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-i18n-content@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-i18n-content@npm:5.7.0"
-  dependencies:
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-i18n": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/ui": 5.7.0
-    emotion: 10.0.27
-    react: 16.14.0
-    react-dom: 16.14.0
-  checksum: 7fed1221b43108ceebb4f630bf62eb6b01785f3f1d7ff3d68ffff7140ecb536d15c785f377515616ff3aba645941945a9610bb90dfe2f0eec37d57cea39151d4
-  languageName: node
-  linkType: hard
-
-"@webiny/app-i18n-content@workspace:packages/app-i18n-content":
+"@webiny/app-i18n-content@^5.8.0-beta.0, @webiny/app-i18n-content@workspace:packages/app-i18n-content":
   version: 0.0.0-use.local
   resolution: "@webiny/app-i18n-content@workspace:packages/app-i18n-content"
   dependencies:
@@ -9050,38 +8475,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/app-i18n@npm:5.7.0, @webiny/app-i18n@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-i18n@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-link-context: 1.0.20
-    apollo-utilities: 1.3.4
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    lodash: 4.17.21
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-  checksum: 4a1362cbc0f2096d70a8a708b86535be37c49203dd9548f0468d4075c848ebe92d4ad2cf6739f6e1ba88212ffe8b5b2a2c97c7712bf677691c893cba4c83daca
-  languageName: node
-  linkType: hard
 
 "@webiny/app-page-builder@^5.8.0-beta.0, @webiny/app-page-builder@workspace:packages/app-page-builder":
   version: 0.0.0-use.local
@@ -9169,76 +8562,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-page-builder@npm:5.7.0, @webiny/app-page-builder@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-page-builder@npm:5.7.0"
-  dependencies:
-    "@apollo/react-components": 3.1.5
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@fortawesome/fontawesome-svg-core": 1.2.35
-    "@fortawesome/free-brands-svg-icons": 5.15.3
-    "@fortawesome/free-regular-svg-icons": 5.15.3
-    "@fortawesome/free-solid-svg-icons": 5.15.3
-    "@fortawesome/react-fontawesome": 0.1.14
-    "@rmwc/menu": 5.7.2
-    "@svgr/webpack": 4.3.3
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-i18n": 5.7.0
-    "@webiny/app-plugin-admin-welcome-screen": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/app-security-tenancy": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/tracking": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    aos: 2.3.4
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-utilities: 1.3.4
-    classnames: 2.3.1
-    dataurl-to-blob: 0.0.1
-    dot-prop-immutable: 1.6.0
-    emotion: 10.0.27
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    invariant: 2.2.4
-    is-hotkey: 0.1.8
-    lodash: 4.17.21
-    lodash.pick: 4.4.0
-    medium-editor: 5.23.3
-    nanoid: 3.1.23
-    object.pick: 1.3.0
-    platform: 1.3.6
-    prop-types: 15.7.2
-    react: 16.14.0
-    react-color: 2.19.3
-    react-dnd: 9.5.1
-    react-dnd-html5-backend: 9.5.1
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-    react-images: 0.5.19
-    react-sortable: 2.0.0
-    react-sortable-tree: 2.8.0
-    react-transition-group: 4.4.1
-    react-virtualized: 9.22.3
-    recoil: 0.1.3
-    slugify: 1.5.3
-    store: 2.0.12
-    timeago-react: 2.0.1
-    uniqid: 5.3.0
-    warning: 4.0.3
-  checksum: 104d346f575d2d39f6c4f20f5e55eda8afe2507796a11a9755a925b39f3c9f952aed766cec4dbed7a750b251766093d4d8132c30649b169b3fdd1a3aad4f86af
-  languageName: node
-  linkType: hard
-
 "@webiny/app-plugin-admin-welcome-screen@^5.8.0-beta.0, @webiny/app-plugin-admin-welcome-screen@workspace:packages/app-plugin-admin-welcome-screen":
   version: 0.0.0-use.local
   resolution: "@webiny/app-plugin-admin-welcome-screen@workspace:packages/app-plugin-admin-welcome-screen"
@@ -9266,56 +8589,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-plugin-admin-welcome-screen@npm:5.7.0, @webiny/app-plugin-admin-welcome-screen@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-plugin-admin-welcome-screen@npm:5.7.0"
-  dependencies:
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    emotion: 10.0.27
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-helmet: 6.1.0
-  checksum: 68291f2f53ab7bb5625e1e18ad07f5132acec90407850d19b821b1a3c93e640867f860c943808e88ac479356b57715b2863907720a641d69f24b0dd6ed5e04ec
-  languageName: node
-  linkType: hard
-
-"@webiny/app-plugin-security-cognito@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-plugin-security-cognito@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@aws-amplify/auth": 1.6.3
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/app-security-tenancy": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-link-context: 1.0.20
-    apollo-utilities: 1.3.4
-    emotion: 10.0.27
-    graphql: 14.7.0
-    lodash: 4.17.21
-    react: 16.14.0
-    react-dom: 16.14.0
-  checksum: e5ec8624aca4ba6e7447ccf9e27152c69d7eb15be5d4bc94772fa2926adabb55fc7549e087c5caf908ae26c60afdae5063ed567503f6b7350c028b76a737a601
-  languageName: node
-  linkType: hard
-
-"@webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito":
+"@webiny/app-plugin-security-cognito@^5.8.0-beta.0, @webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito":
   version: 0.0.0-use.local
   resolution: "@webiny/app-plugin-security-cognito@workspace:packages/app-plugin-security-cognito"
   dependencies:
@@ -9401,39 +8675,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-security-tenancy@npm:5.7.0, @webiny/app-security-tenancy@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-security-tenancy@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@types/react": 16.14.2
-    "@webiny/app": 5.7.0
-    "@webiny/app-admin": 5.7.0
-    "@webiny/app-security": 5.7.0
-    "@webiny/form": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    "@webiny/validation": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-utilities: 1.3.4
-    dot-prop-immutable: 1.6.0
-    emotion: 10.0.17
-    graphql: 14.7.0
-    graphql-tag: 2.12.4
-    lodash: 4.17.21
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-helmet: 5.2.1
-  checksum: ba4e67b6a1119eb1d617fafbbd5d2598bb898c04f46173b75a65763e1d68245a15c80d887e9a2288c8221d0db8ea1009056783fcdbabcde414948debf4f87ecc
-  languageName: node
-  linkType: hard
-
 "@webiny/app-security@^5.8.0-beta.0, @webiny/app-security@workspace:packages/app-security":
   version: 0.0.0-use.local
   resolution: "@webiny/app-security@workspace:packages/app-security"
@@ -9458,19 +8699,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/app-security@npm:5.7.0, @webiny/app-security@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app-security@npm:5.7.0"
-  dependencies:
-    "@webiny/app": 5.7.0
-    "@webiny/plugins": 5.7.0
-    minimatch: 3.0.4
-    react: 16.14.0
-    react-dom: 16.14.0
-  checksum: 6aca51ecab39ba705a715cc78545ba2663be90ed9a967cd61330a17b7fa73643f48d71c079065e6f17206dbcd37ae27fea35c457a9e5153efce676b3b8d564bc
-  languageName: node
-  linkType: hard
 
 "@webiny/app-typeform@workspace:packages/app-typeform":
   version: 0.0.0-use.local
@@ -9541,36 +8769,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app@npm:5.7.0, @webiny/app@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/app@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@emotion/styled": 10.0.27
-    "@types/react": 16.14.2
-    "@webiny/i18n": 5.7.0
-    "@webiny/i18n-react": 5.7.0
-    "@webiny/plugins": 5.7.0
-    "@webiny/react-router": 5.7.0
-    "@webiny/ui": 5.7.0
-    apollo-cache: 1.3.5
-    apollo-client: 2.6.10
-    apollo-link: 1.2.14
-    apollo-link-context: 1.0.20
-    apollo-link-error: 1.1.13
-    apollo-utilities: 1.3.4
-    boolean: 3.0.4
-    graphql: 14.7.0
-    invariant: 2.2.4
-    lodash: 4.17.21
-    react: 16.14.0
-    react-dom: 16.14.0
-    warning: 4.0.3
-  checksum: efafd8faf0e661be5dd2987e51c14f8c5d6cff80d4546dbca7d34d2c3c970175d5f83bb4ae1500e8af2bce45ea223a1378fcd6ad21caf750f0c5d2f07c011c0f
-  languageName: node
-  linkType: hard
-
 "@webiny/aws-layers@workspace:packages/aws-layers":
   version: 0.0.0-use.local
   resolution: "@webiny/aws-layers@workspace:packages/aws-layers"
@@ -9607,35 +8805,6 @@ __metadata:
     ws: ^7.4.5
   languageName: unknown
   linkType: soft
-
-"@webiny/cli-plugin-deploy-pulumi@npm:5.7.0, @webiny/cli-plugin-deploy-pulumi@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/cli-plugin-deploy-pulumi@npm:5.7.0"
-  dependencies:
-    "@pulumi/pulumi": 2.25.2+dirty
-    "@webiny/cli": 5.7.0
-    "@webiny/pulumi-sdk": 5.7.0
-    ansi-to-html: 0.6.15
-    blessed: 0.1.81
-    blessed-contrib: 4.8.21
-    body-parser: 1.19.0
-    chalk: 4.1.0
-    execa: 5.0.0
-    express: 4.17.1
-    handlebars: 4.7.7
-    localtunnel: 2.0.1
-    lodash: 4.17.20
-    minimatch: 3.0.4
-    ncp: 2.0.0
-    node-notifier: 7.0.2
-    open: 8.0.9
-    ora: 4.1.1
-    rimraf: 3.0.2
-    tree-kill: 1.2.2
-    ws: 7.4.5
-  checksum: 206e18b1e665d3ea9c68929fb008dfbf89a4105b48805406b84359462f2800c4a1655c8ceb3aa77729f401d0667317b4cf21908396dd348acbc38bd056cc634e
-  languageName: node
-  linkType: hard
 
 "@webiny/cli-plugin-scaffold-admin-app-module@workspace:packages/cli-plugin-scaffold-admin-app-module":
   version: 0.0.0-use.local
@@ -9820,33 +8989,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli@npm:5.7.0, @webiny/cli@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/cli@npm:5.7.0"
-  dependencies:
-    "@webiny/tracking": 5.7.0
-    camelcase: 5.3.1
-    chalk: 2.4.2
-    dotenv: 8.2.0
-    execa: 2.1.0
-    find-up: 5.0.0
-    load-json-file: 6.2.0
-    ncp: 2.0.0
-    pirates: 4.0.1
-    prettier: 1.19.1
-    public-ip: 4.0.3
-    rimraf: 3.0.2
-    semver: 7.3.4
-    typescript: 4.1.3
-    uniqid: 5.3.0
-    write-json-file: 4.3.0
-    yargs: 14.2.3
-  bin:
-    webiny: bin.js
-  checksum: 9e175ee0fb60e2e38e658bd1a906e404fd8fd3e837afb8334f5b442c9de49867116e58a8f8cc0315437206949072c0f46ac4ddcacb326fe7f7dbd29f75300b31
-  languageName: node
-  linkType: hard
-
 "@webiny/commodo@workspace:packages/commodo":
   version: 0.0.0-use.local
   resolution: "@webiny/commodo@workspace:packages/commodo"
@@ -9906,15 +9048,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/db-dynamodb@npm:5.7.0, @webiny/db-dynamodb@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/db-dynamodb@npm:5.7.0"
-  dependencies:
-    "@webiny/db": 5.7.0
-  checksum: 7fcc5185f607133305f9a3c57de539739a6b042479a14f52fbf5249926e2c34c15ca53c9ddc0da38833916b6beb9dee9444fbf48ff772125675cd33fd51dbcd2
-  languageName: node
-  linkType: hard
-
 "@webiny/db@^5.8.0-beta.0, @webiny/db@workspace:packages/db":
   version: 0.0.0-use.local
   resolution: "@webiny/db@workspace:packages/db"
@@ -9928,13 +9061,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/db@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/db@npm:5.7.0"
-  checksum: bbe75040ceacc26ccd055f7be1de3241454e14f5d2c20b5cf9d3cf92e3b6e70cbf33913e2a7c889d7e34abffaaf815313c97527adca0be9c0bb7838bcfcccbef
-  languageName: node
-  linkType: hard
-
 "@webiny/error@^5.8.0-beta.0, @webiny/error@workspace:packages/error":
   version: 0.0.0-use.local
   resolution: "@webiny/error@workspace:packages/error"
@@ -9947,13 +9073,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/error@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/error@npm:5.7.0"
-  checksum: f0029cefc2422b1e083391a8e3cc51a9c170aea6000db350ec321841e6b4cc839a3b914ccd54e7b9ee35f2da269aa1b1bfc9054fcdcf7403f5cb42cc2e2f131b
-  languageName: node
-  linkType: hard
 
 "@webiny/form@^5.8.0-beta.0, @webiny/form@workspace:packages/form":
   version: 0.0.0-use.local
@@ -9977,19 +9096,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/form@npm:5.7.0, @webiny/form@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/form@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    invariant: 2.2.4
-    lodash: 4.17.21
-  peerDependencies:
-    react: 16.14.0
-  checksum: e4efd401bc1255fd633aa8aa7890be9882551be19591e961ff714044782805be342671c81f56f23c350f8e2e4311bc2dc3a191fe881e80e2b60d482a4f3ab135
-  languageName: node
-  linkType: hard
-
 "@webiny/handler-args@^5.8.0-beta.0, @webiny/handler-args@workspace:packages/handler-args":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-args@workspace:packages/handler-args"
@@ -10005,15 +9111,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/handler-args@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-args@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-  checksum: 8b043749c94367aa9b47664f014319d006063cbc416002180d386d6891868c624f221a6d24c718802a9980b7351f41d475f9890dfd9989b0c38dd29034ff051f
-  languageName: node
-  linkType: hard
 
 "@webiny/handler-aws@^5.8.0-beta.0, @webiny/handler-aws@workspace:packages/handler-aws":
   version: 0.0.0-use.local
@@ -10038,20 +9135,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-aws@npm:5.7.0, @webiny/handler-aws@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-aws@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-args": 5.7.0
-    "@webiny/handler-client": 5.7.0
-    "@webiny/handler-http": 5.7.0
-    "@webiny/plugins": 5.7.0
-  checksum: dc9252c0387d8d65a8c7d81e59e324d692e68ac78db7de48477dd42921a4412b98240ff2db87747b7f50b51f626e33024dec3eaf41f0b9d660ab829d13cf628b
-  languageName: node
-  linkType: hard
-
 "@webiny/handler-client@^5.8.0-beta.0, @webiny/handler-client@workspace:packages/handler-client":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-client@workspace:packages/handler-client"
@@ -10074,18 +9157,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-client@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-client@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/plugins": 5.7.0
-  checksum: fc5cf5a0d7ee5f08569a2596b54de01694be0b1994d9feb8bfecba0cc6b58c195f014d118ff3605f7a4ba2e3da5279d679e0457fa9db4eb2ed1b41ab7e408ebf
-  languageName: node
-  linkType: hard
-
 "@webiny/handler-db@^5.8.0-beta.0, @webiny/handler-db@workspace:packages/handler-db":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-db@workspace:packages/handler-db"
@@ -10102,17 +9173,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/handler-db@npm:5.7.0, @webiny/handler-db@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-db@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/db": 5.7.0
-    "@webiny/handler": 5.7.0
-  checksum: 8236e9d4d40770b06c695e9a24ecfc76a64ce920fc9f797be994ead840003bd22d2729c7c61d1cc908cdb7f98d42df91320209feadf647c8391f9b9ad2d0d08e
-  languageName: node
-  linkType: hard
 
 "@webiny/handler-graphql@^5.8.0-beta.0, @webiny/handler-graphql@workspace:packages/handler-graphql":
   version: 0.0.0-use.local
@@ -10141,24 +9201,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-graphql@npm:5.7.0, @webiny/handler-graphql@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-graphql@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@graphql-tools/schema": 7.1.5
-    "@webiny/error": 5.7.0
-    "@webiny/handler": 5.7.0
-    "@webiny/handler-http": 5.7.0
-    "@webiny/plugins": 5.7.0
-    boolean: 3.0.4
-    graphql: 14.7.0
-    graphql-scalars: 1.9.3
-    graphql-tag: 2.12.4
-  checksum: 396f70e73408dbe02538c17778e89d63583284e0b1c46717e01c370dfc1d8eea0c9c391dedc11a66560cda279434c64bef65fbd8cf2b4e69d5239e071c4856d3
-  languageName: node
-  linkType: hard
-
 "@webiny/handler-http@^5.8.0-beta.0, @webiny/handler-http@workspace:packages/handler-http":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-http@workspace:packages/handler-http"
@@ -10176,28 +9218,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-http@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-http@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/handler": 5.7.0
-    boolean: 3.0.4
-  checksum: fdc37236e7be265a144329032021775b3b67f79e8a29d221857b9288c88dd458ec09200b0bf216a57d3321244ffbcc653bcab643cb2d27a90b6292d18ac06fbf
-  languageName: node
-  linkType: hard
-
-"@webiny/handler-logs@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/handler-logs@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    node-fetch: 2.6.1
-  checksum: f2a4ea7d935f2637739e0f9247c04a161e70ba76b72803c221928b0eeb7530f4d5b8c6ea02108bdae1ff39d68c9dc3c9b1a9bb9754314fa3201e75927579e77c
-  languageName: node
-  linkType: hard
-
-"@webiny/handler-logs@workspace:packages/handler-logs":
+"@webiny/handler-logs@^5.8.0-beta.0, @webiny/handler-logs@workspace:packages/handler-logs":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-logs@workspace:packages/handler-logs"
   dependencies:
@@ -10230,16 +9251,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/handler@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/plugins": 5.7.0
-  checksum: 09df0fdbb59f591ddbb76ea36a3c34c2366b80230efd5ac876d1668d5c35e47a7781bf98e447faf4650ea2b36ebca33508bb62d87a28f98aba708cec9217553f
-  languageName: node
-  linkType: hard
-
 "@webiny/i18n-react@^5.8.0-beta.0, @webiny/i18n-react@workspace:packages/i18n-react":
   version: 0.0.0-use.local
   resolution: "@webiny/i18n-react@workspace:packages/i18n-react"
@@ -10261,19 +9272,6 @@ __metadata:
     react: 16.14.0
   languageName: unknown
   linkType: soft
-
-"@webiny/i18n-react@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/i18n-react@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@webiny/i18n": 5.7.0
-    lodash: 4.17.21
-  peerDependencies:
-    react: 16.14.0
-  checksum: 2903b0df5e934c36585f84f6ba763f971aaa44738a9e7d6d83dc70aa738d87a2e822c38d5570245883d700e62353429e075f6e5db30aacccef39d493b4c3a76f
-  languageName: node
-  linkType: hard
 
 "@webiny/i18n@^5.8.0-beta.0, @webiny/i18n@workspace:packages/i18n":
   version: 0.0.0-use.local
@@ -10301,22 +9299,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/i18n@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/i18n@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    accounting: 0.4.1
-    fecha: 2.3.3
-    lodash: 4.17.21
-    short-hash: 1.0.0
-    yargs: 12.0.5
-  peerDependencies:
-    react: 16.14.0
-  checksum: f429da658dd128b4b9d3b3cb61a458166951185cc5c37de07d6f76e706587cebdbcc27d3c9dcc52fdddaa213911fb66ccbc4ecf9cc8261c11183a3627bccdf09
-  languageName: node
-  linkType: hard
-
 "@webiny/plugins@^5.8.0-beta.0, @webiny/plugins@workspace:packages/plugins":
   version: 0.0.0-use.local
   resolution: "@webiny/plugins@workspace:packages/plugins"
@@ -10331,16 +9313,6 @@ __metadata:
     uniqid: ^5.2.0
   languageName: unknown
   linkType: soft
-
-"@webiny/plugins@npm:5.7.0, @webiny/plugins@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/plugins@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    uniqid: 5.3.0
-  checksum: 5aebd133c09c16f92d16daf921481722c95ad3f358720d9bacb38af27f187552e83d13d8c0172630b8fa20769dd7b43f380436691daa5b7ee1bc08ba6167caa9
-  languageName: node
-  linkType: hard
 
 "@webiny/project-utils@^5.8.0-beta.0, @webiny/project-utils@workspace:packages/project-utils":
   version: 0.0.0-use.local
@@ -10405,70 +9377,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/project-utils@npm:5.7.0, @webiny/project-utils@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/project-utils@npm:5.7.0"
-  dependencies:
-    "@babel/core": 7.12.10
-    "@babel/plugin-proposal-class-properties": 7.12.1
-    "@babel/plugin-syntax-object-rest-spread": 7.8.3
-    "@babel/preset-env": 7.12.11
-    "@babel/preset-react": 7.12.10
-    "@babel/preset-typescript": 7.12.7
-    "@hot-loader/react-dom": 16.14.0+4.13.0
-    "@svgr/webpack": 4.3.3
-    "@types/webpack-env": 1.15.2
-    "@webiny/cli": 5.7.0
-    babel-loader: 8.0.6
-    babel-plugin-lodash: 3.3.4
-    babel-plugin-named-asset-import: 0.3.7
-    babel-preset-react-app: 9.1.2
-    boolean: 3.0.2
-    camelcase: 5.3.1
-    case-sensitive-paths-webpack-plugin: 2.2.0
-    chalk: 3.0.0
-    css-loader: 3.2.0
-    eslint: 6.8.0
-    eslint-loader: 3.0.2
-    execa: 5.0.0
-    file-loader: 4.3.0
-    fs-extra: 8.1.0
-    get-yarn-workspaces: 1.0.2
-    html-webpack-plugin: 4.0.0-beta.5
-    lodash.get: 4.4.2
-    mini-css-extract-plugin: 0.9.0
-    node-sass: 4.14.1
-    optimize-css-assets-webpack-plugin: 5.0.3
-    pnp-webpack-plugin: 1.5.0
-    postcss-flexbugs-fixes: 4.1.0
-    postcss-loader: 3.0.0
-    postcss-normalize: 8.0.1
-    postcss-preset-env: 6.7.0
-    postcss-safe-parser: 4.0.1
-    raw-loader: 4.0.2
-    react: 16.14.0
-    react-dev-utils: 10.2.1
-    react-dom: 16.14.0
-    react-native-web: 0.12.3
-    read-json-sync: 2.0.1
-    resolve: 1.12.2
-    resolve-url-loader: 3.1.1
-    rimraf: 3.0.2
-    sass-loader: 8.0.0
-    scheduler: 0.19.1
-    style-loader: 1.0.0
-    terser-webpack-plugin: 2.2.1
-    ts-pnp: 1.1.5
-    url: 0.11.0
-    url-loader: 2.3.0
-    webpack: 4.41.2
-    webpack-dev-server: 3.9.0
-    webpack-manifest-plugin: 2.2.0
-    webpackbar: 4.0.0
-  checksum: e5140d37deffecc2bb8ab834fc9bca00d084e1ad1438394a2e9f8450365b02eab524b082a1280f665dbeb48d575eb62612a07e79d3616ce756c8d86354d810b3
-  languageName: node
-  linkType: hard
-
 "@webiny/pulumi-sdk@^5.8.0-beta.0, @webiny/pulumi-sdk@workspace:packages/pulumi-sdk":
   version: 0.0.0-use.local
   resolution: "@webiny/pulumi-sdk@workspace:packages/pulumi-sdk"
@@ -10491,36 +9399,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/pulumi-sdk@npm:5.7.0":
-  version: 5.7.0
-  resolution: "@webiny/pulumi-sdk@npm:5.7.0"
-  dependencies:
-    "@pulumi/aws": v3.38.1
-    "@pulumi/pulumi": 2.25.2+dirty
-    decompress: 4.2.1
-    download: 5.0.3
-    execa: 4.1.0
-    lodash: 4.17.21
-    semver: 7.3.5
-    tar: 6.1.0
-  checksum: ded48b574d004c223e8337d78cf5e64ddd63e63b3fd39513b18835c6633996063934ec20a772f3b31c70f887ef23b4d31e717857b02c0f3265607ad77f8a1f59
-  languageName: node
-  linkType: hard
-
-"@webiny/react-rich-text-renderer@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/react-rich-text-renderer@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@editorjs/editorjs": 2.21.0
-    "@types/react": 16.14.2
-    classnames: 2.3.1
-    react: 16.14.0
-  checksum: eb3468403773506fe377b37b544b0ab03961ef7dbd75dfc16c556cb3207e1c324e0ce0b98781e3800b6a074d34289d353cc196be665f4eb7023faa2e6d921016
-  languageName: node
-  linkType: hard
-
-"@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
+"@webiny/react-rich-text-renderer@^5.8.0-beta.0, @webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
   version: 0.0.0-use.local
   resolution: "@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer"
   dependencies:
@@ -10568,26 +9447,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/react-router@npm:5.7.0, @webiny/react-router@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/react-router@npm:5.7.0"
-  dependencies:
-    "@apollo/react-hooks": 3.1.5
-    "@babel/runtime": 7.14.0
-    "@types/react-router-dom": 5.1.7
-    "@webiny/plugins": 5.7.0
-    apollo-client: 2.6.10
-    graphql: 14.7.0
-    react: 16.14.0
-    react-dom: 16.14.0
-    react-router: 5.2.0
-    react-router-dom: 5.2.0
-  peerDependencies:
-    react: 16.14.0
-  checksum: 4098c0852fc2f05a6ac95f6237632c2aed22c58be3f59ddb53cb4ac440fbfe47bd5b7ffe721f9dd354e823577e98f7f411b2732b88cbc90be71c5fcae1411919
-  languageName: node
-  linkType: hard
-
 "@webiny/storybook-utils@^5.8.0-beta.0, @webiny/storybook-utils@workspace:packages/storybook-utils":
   version: 0.0.0-use.local
   resolution: "@webiny/storybook-utils@workspace:packages/storybook-utils"
@@ -10627,17 +9486,6 @@ __metadata:
     node-fetch: 2.6.1
   languageName: unknown
   linkType: soft
-
-"@webiny/tracking@npm:5.7.0, @webiny/tracking@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/tracking@npm:5.7.0"
-  dependencies:
-    form-data: 3.0.0
-    load-json-file: 6.2.0
-    node-fetch: 2.6.1
-  checksum: 0defd19d9491d1833fb7a0d20e9f38eb04fd87c724a0cdb443ce3ad48667f5e20c240aa2e358a8123814524684f3ebf8f23d4f19495bdadd7f49cb791bdd8567
-  languageName: node
-  linkType: hard
 
 "@webiny/ui@^5.8.0-beta.0, @webiny/ui@workspace:packages/ui":
   version: 0.0.0-use.local
@@ -10735,73 +9583,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/ui@npm:5.7.0, @webiny/ui@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/ui@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    "@editorjs/editorjs": 2.21.0
-    "@emotion/core": 10.1.1
-    "@emotion/styled": 10.0.27
-    "@material/base": 3.1.0
-    "@material/textfield": 3.2.0
-    "@rmwc/base": 5.7.2
-    "@rmwc/button": 5.7.2
-    "@rmwc/checkbox": 5.7.2
-    "@rmwc/chip": 5.7.2
-    "@rmwc/dialog": 5.7.2
-    "@rmwc/drawer": 5.7.2
-    "@rmwc/elevation": 5.7.2
-    "@rmwc/fab": 5.7.2
-    "@rmwc/floating-label": 5.7.2
-    "@rmwc/grid": 5.7.2
-    "@rmwc/icon": 5.7.2
-    "@rmwc/icon-button": 5.7.2
-    "@rmwc/line-ripple": 5.7.2
-    "@rmwc/list": 5.7.2
-    "@rmwc/menu": 5.7.2
-    "@rmwc/notched-outline": 5.7.2
-    "@rmwc/radio": 5.7.2
-    "@rmwc/ripple": 5.7.2
-    "@rmwc/select": 5.7.2
-    "@rmwc/slider": 5.7.2
-    "@rmwc/snackbar": 5.7.2
-    "@rmwc/switch": 5.7.2
-    "@rmwc/tabs": 5.7.2
-    "@rmwc/textfield": "file:./rmwc/textfield"
-    "@rmwc/top-app-bar": 5.7.2
-    "@rmwc/types": 5.6.0
-    "@rmwc/typography": 5.7.2
-    "@svgr/webpack": 4.3.3
-    brace: 0.11.1
-    classnames: 2.3.1
-    cropperjs: 1.5.11
-    dot-prop-immutable: 1.6.0
-    downshift: 2.2.3
-    emotion: 10.0.17
-    keycode: 2.2.0
-    load-script: 1.0.0
-    lodash: 4.17.21
-    material-components-web: 3.2.0
-    nprogress: 0.2.0
-    nuka-carousel: 4.7.1
-    rc-tooltip: 3.7.3
-    react-ace: 6.6.0
-    react-butterfiles: 1.3.3
-    react-color: 2.19.3
-    react-columned: 1.1.3
-    react-custom-scrollbars: 4.2.1
-    react-loading-skeleton: 0.5.0
-    react-spinner-material: 1.1.4
-    react-transition-group: 4.4.1
-    shortid: 2.2.16
-  peerDependencies:
-    react: 16.14.0
-    react-dom: 16.14.0
-  checksum: 10c6b701805c5b90bc895417099c06a393656e108df917554f5e5f45f463d3d5c2b8acf172f6e3bd04c2bf7757e2be7e1752e37795096ca71a6fbd328fa6e213
-  languageName: node
-  linkType: hard
-
 "@webiny/validation@^5.8.0-beta.0, @webiny/validation@workspace:packages/validation":
   version: 0.0.0-use.local
   resolution: "@webiny/validation@workspace:packages/validation"
@@ -10822,17 +9603,6 @@ __metadata:
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
-
-"@webiny/validation@npm:5.7.0, @webiny/validation@npm:^5.5.0-beta.0":
-  version: 5.7.0
-  resolution: "@webiny/validation@npm:5.7.0"
-  dependencies:
-    "@babel/runtime": 7.14.0
-    isnumeric: 0.3.3
-    lodash: 4.17.21
-  checksum: 481d6731e39bdd646b278973a36dae1d4e7a7bb4f6fd381a6302e0d5a0ba80e00abadbd868c796eabb175c57d4980d11cb8b0b9384d37923e64225edce3847a6
-  languageName: node
-  linkType: hard
 
 "@webiny/where-parser@workspace:packages/where-parser":
   version: 0.0.0-use.local
@@ -10976,7 +9746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accept-language-parser@npm:1.5.0, accept-language-parser@npm:^1.5.0":
+"accept-language-parser@npm:^1.5.0":
   version: 1.5.0
   resolution: "accept-language-parser@npm:1.5.0"
   checksum: 598934ae1cf551a81d7adc4620a22596993a84db259f6f8bdd7516f95983018e9bbaaaa22cb87aefd045ca78b4d289e95db058353a655c63949d75f24bbdfaa9
@@ -10993,7 +9763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accounting@npm:0.4.1, accounting@npm:^0.4.1":
+"accounting@npm:^0.4.1":
   version: 0.4.1
   resolution: "accounting@npm:0.4.1"
   checksum: df31f784a2013c9e5c83fc1867e2cc26382be1a1e40db5cfc9181bcef68c606c908fabfef3cf4b8fa7662a827ee33196531447c01f4480be1eded0000dba9d00
@@ -11141,27 +9911,27 @@ __metadata:
     "@editorjs/quote": ^2.4.0
     "@editorjs/underline": ^1.0.0
     "@types/react": ^16.14.2
-    "@webiny/app": ^5.5.0-beta.0
-    "@webiny/app-admin": ^5.5.0-beta.0
-    "@webiny/app-file-manager": ^5.5.0-beta.0
-    "@webiny/app-file-manager-s3": ^5.5.0-beta.0
-    "@webiny/app-form-builder": ^5.5.0-beta.0
-    "@webiny/app-graphql-playground": ^5.5.0-beta.0
-    "@webiny/app-headless-cms": ^5.5.0-beta.0
-    "@webiny/app-i18n": ^5.5.0-beta.0
-    "@webiny/app-i18n-content": ^5.5.0-beta.0
-    "@webiny/app-page-builder": ^5.5.0-beta.0
-    "@webiny/app-plugin-admin-welcome-screen": ^5.5.0-beta.0
-    "@webiny/app-plugin-security-cognito": ^5.5.0-beta.0
-    "@webiny/app-security": ^5.5.0-beta.0
-    "@webiny/app-security-tenancy": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/cli-plugin-deploy-pulumi": ^5.5.0-beta.0
-    "@webiny/plugins": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
-    "@webiny/react-router": ^5.5.0-beta.0
-    "@webiny/tracking": ^5.5.0-beta.0
-    "@webiny/ui": ^5.5.0-beta.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-admin": ^5.8.0-beta.0
+    "@webiny/app-file-manager": ^5.8.0-beta.0
+    "@webiny/app-file-manager-s3": ^5.8.0-beta.0
+    "@webiny/app-form-builder": ^5.8.0-beta.0
+    "@webiny/app-graphql-playground": ^5.8.0-beta.0
+    "@webiny/app-headless-cms": ^5.8.0-beta.0
+    "@webiny/app-i18n": ^5.8.0-beta.0
+    "@webiny/app-i18n-content": ^5.8.0-beta.0
+    "@webiny/app-page-builder": ^5.8.0-beta.0
+    "@webiny/app-plugin-admin-welcome-screen": ^5.8.0-beta.0
+    "@webiny/app-plugin-security-cognito": ^5.8.0-beta.0
+    "@webiny/app-security": ^5.8.0-beta.0
+    "@webiny/app-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-deploy-pulumi": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/tracking": ^5.8.0-beta.0
+    "@webiny/ui": ^5.8.0-beta.0
     apollo-cache: ^1.3.5
     apollo-cache-inmemory: ^1.6.6
     apollo-client: ^2.2.8
@@ -11475,7 +10245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-to-html@npm:0.6.15, ansi-to-html@npm:^0.6.11, ansi-to-html@npm:^0.6.14":
+"ansi-to-html@npm:^0.6.11, ansi-to-html@npm:^0.6.14":
   version: 0.6.15
   resolution: "ansi-to-html@npm:0.6.15"
   dependencies:
@@ -11527,7 +10297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aos@npm:2.3.4, aos@npm:^2.3.4":
+"aos@npm:^2.3.4":
   version: 2.3.4
   resolution: "aos@npm:2.3.4"
   dependencies:
@@ -11559,12 +10329,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-dynamo-to-elastic@workspace:api/code/dynamoToElastic"
   dependencies:
-    "@webiny/api-dynamodb-to-elasticsearch": ^5.5.0-beta.0
-    "@webiny/api-plugin-elastic-search-client": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-dynamodb-to-elasticsearch": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11572,11 +10342,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-file-manager-download@workspace:api/code/fileManager/download"
   dependencies:
-    "@webiny/api-file-manager": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11584,11 +10354,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-file-manager-manage@workspace:api/code/fileManager/manage"
   dependencies:
-    "@webiny/api-file-manager": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11596,11 +10366,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-file-manager-transform@workspace:api/code/fileManager/transform"
   dependencies:
-    "@webiny/api-file-manager": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11608,26 +10378,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-graphql@workspace:api/code/graphql"
   dependencies:
-    "@webiny/api-file-manager": ^5.5.0-beta.0
-    "@webiny/api-file-manager-s3": ^5.5.0-beta.0
-    "@webiny/api-form-builder": ^5.5.0-beta.0
-    "@webiny/api-headless-cms": ^5.5.0-beta.0
+    "@webiny/api-file-manager": ^5.8.0-beta.0
+    "@webiny/api-file-manager-s3": ^5.8.0-beta.0
+    "@webiny/api-form-builder": ^5.8.0-beta.0
+    "@webiny/api-headless-cms": ^5.8.0-beta.0
     "@webiny/api-headless-cms-ddb-es": ^5.8.0-beta.0
-    "@webiny/api-i18n": ^5.5.0-beta.0
-    "@webiny/api-i18n-content": ^5.5.0-beta.0
-    "@webiny/api-page-builder": ^5.5.0-beta.0
-    "@webiny/api-plugin-elastic-search-client": ^5.5.0-beta.0
-    "@webiny/api-plugin-security-cognito": ^5.5.0-beta.0
-    "@webiny/api-prerendering-service": ^5.5.0-beta.0
-    "@webiny/api-security": ^5.5.0-beta.0
-    "@webiny/api-security-tenancy": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-graphql": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-page-builder": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-plugin-security-cognito": ^5.8.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-graphql": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11635,20 +10405,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-headless-cms@workspace:api/code/headlessCMS"
   dependencies:
-    "@webiny/api-headless-cms": ^5.5.0-beta.0
+    "@webiny/api-headless-cms": ^5.8.0-beta.0
     "@webiny/api-headless-cms-ddb-es": ^5.8.0-beta.0
-    "@webiny/api-i18n": ^5.5.0-beta.0
-    "@webiny/api-i18n-content": ^5.5.0-beta.0
-    "@webiny/api-plugin-elastic-search-client": ^5.5.0-beta.0
-    "@webiny/api-plugin-security-cognito": ^5.5.0-beta.0
-    "@webiny/api-security": ^5.5.0-beta.0
-    "@webiny/api-security-tenancy": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-i18n": ^5.8.0-beta.0
+    "@webiny/api-i18n-content": ^5.8.0-beta.0
+    "@webiny/api-plugin-elastic-search-client": ^5.8.0-beta.0
+    "@webiny/api-plugin-security-cognito": ^5.8.0-beta.0
+    "@webiny/api-security": ^5.8.0-beta.0
+    "@webiny/api-security-tenancy": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11656,14 +10426,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-page-builder-flush@workspace:api/code/prerenderingService/flush"
   dependencies:
-    "@webiny/api-prerendering-service": ^5.5.0-beta.0
-    "@webiny/api-prerendering-service-aws": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/api-prerendering-service-aws": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11671,14 +10441,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-page-builder-render@workspace:api/code/prerenderingService/render"
   dependencies:
-    "@webiny/api-prerendering-service": ^5.5.0-beta.0
-    "@webiny/api-prerendering-service-aws": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/api-prerendering-service-aws": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11686,13 +10456,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-page-builder-update-settings@workspace:api/code/pageBuilder/updateSettings"
   dependencies:
-    "@webiny/api-page-builder": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-page-builder": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11700,13 +10470,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-prerendering-service-queue-add@workspace:api/code/prerenderingService/queue/add"
   dependencies:
-    "@webiny/api-prerendering-service": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11714,13 +10484,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api-prerendering-service-queue-process@workspace:api/code/prerenderingService/queue/process"
   dependencies:
-    "@webiny/api-prerendering-service": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/db-dynamodb": ^5.5.0-beta.0
-    "@webiny/handler-aws": ^5.5.0-beta.0
-    "@webiny/handler-db": ^5.5.0-beta.0
-    "@webiny/handler-logs": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
+    "@webiny/api-prerendering-service": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/db-dynamodb": ^5.8.0-beta.0
+    "@webiny/handler-aws": ^5.8.0-beta.0
+    "@webiny/handler-db": ^5.8.0-beta.0
+    "@webiny/handler-logs": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
   languageName: unknown
   linkType: soft
 
@@ -11751,7 +10521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-client@npm:2.6.10, apollo-client@npm:^2.2.8, apollo-client@npm:^2.6.10, apollo-client@npm:^2.6.8":
+"apollo-client@npm:^2.2.8, apollo-client@npm:^2.6.10, apollo-client@npm:^2.6.8":
   version: 2.6.10
   resolution: "apollo-client@npm:2.6.10"
   dependencies:
@@ -11817,7 +10587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link-context@npm:1.0.20, apollo-link-context@npm:^1.0.20":
+"apollo-link-context@npm:^1.0.20":
   version: 1.0.20
   resolution: "apollo-link-context@npm:1.0.20"
   dependencies:
@@ -11827,7 +10597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link-error@npm:1.1.13, apollo-link-error@npm:^1.1.13":
+"apollo-link-error@npm:^1.1.13":
   version: 1.1.13
   resolution: "apollo-link-error@npm:1.1.13"
   dependencies:
@@ -11851,7 +10621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link@npm:1.2.14, apollo-link@npm:^1.0.0, apollo-link@npm:^1.2.14":
+"apollo-link@npm:^1.0.0, apollo-link@npm:^1.2.14":
   version: 1.2.14
   resolution: "apollo-link@npm:1.2.14"
   dependencies:
@@ -12346,7 +11116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-elasticsearch-connector@npm:9.0.3, aws-elasticsearch-connector@npm:^9.0.0":
+"aws-elasticsearch-connector@npm:^9.0.0":
   version: 9.0.3
   resolution: "aws-elasticsearch-connector@npm:9.0.3"
   dependencies:
@@ -12389,23 +11159,6 @@ __metadata:
     uuid: 3.3.2
     xml2js: 0.4.19
   checksum: ce7fd59a7dfe94c44ecabc02341a8097d554e407d1326775f6ff224aaf7716bea0b0b046cfd94d040ae6e892fe9c161f8808ade9ce3a67eb753aacc35daed781
-  languageName: node
-  linkType: hard
-
-"aws-sdk@npm:2.911.0":
-  version: 2.911.0
-  resolution: "aws-sdk@npm:2.911.0"
-  dependencies:
-    buffer: 4.9.2
-    events: 1.1.1
-    ieee754: 1.1.13
-    jmespath: 0.15.0
-    querystring: 0.2.0
-    sax: 1.2.1
-    url: 0.10.3
-    uuid: 3.3.2
-    xml2js: 0.4.19
-  checksum: 3453496d407dea6e0af3610b1ff303f151ebf3d207b6479c0fa2131523ee7b3593db3003030fc9fb23f50a4b35eaa4a5f80cae7a8fc7e2f29105256c4a759ddd
   languageName: node
   linkType: hard
 
@@ -13200,7 +11953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blessed-contrib@npm:4.8.21, blessed-contrib@npm:^4.8.21":
+"blessed-contrib@npm:^4.8.21":
   version: 4.8.21
   resolution: "blessed-contrib@npm:4.8.21"
   dependencies:
@@ -13321,13 +12074,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boolean@npm:3.0.4":
-  version: 3.0.4
-  resolution: "boolean@npm:3.0.4"
-  checksum: 5ba56fa07e73f6e30c6fc39a922c31710f9d428cc7f468b04a552fc74c39ad0649d640425072bc2fd935ecae3e27bfb4ccbab407d78983a64bcd1c2a72a51499
-  languageName: node
-  linkType: hard
-
 "boolean@npm:^3.0.1, boolean@npm:^3.0.2":
   version: 3.1.0
   resolution: "boolean@npm:3.1.0"
@@ -13375,7 +12121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace@npm:0.11.1, brace@npm:^0.11.1":
+"brace@npm:^0.11.1":
   version: 0.11.1
   resolution: "brace@npm:0.11.1"
   checksum: 7438fc7d700b0edaeafe5b2943eb2c79ecdafb04558fc504ac4e62973e63597b5d64f9743d115e32779e9c4216fed477a4cbd4009dc6c9050e6040b5226afab5
@@ -14354,7 +13100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrome-aws-lambda@npm:5.5.0, chrome-aws-lambda@npm:^5.5.0":
+"chrome-aws-lambda@npm:^5.5.0":
   version: 5.5.0
   resolution: "chrome-aws-lambda@npm:5.5.0"
   dependencies:
@@ -14422,7 +13168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.3.1, classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
+"classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
   version: 2.3.1
   resolution: "classnames@npm:2.3.1"
   checksum: 57d536edede609f81425d24b062d8d720a466565faf1e38d32c881e883920baa71519ac70c7b565e9cd39201fb1c1ff9bdf8aabf8e26544bac481e7924867c83
@@ -14956,7 +13702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commodo-fields-object@npm:1.0.6, commodo-fields-object@npm:^1.0.3, commodo-fields-object@npm:^1.0.6":
+"commodo-fields-object@npm:^1.0.3, commodo-fields-object@npm:^1.0.6":
   version: 1.0.6
   resolution: "commodo-fields-object@npm:1.0.6"
   dependencies:
@@ -15624,7 +14370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cropperjs@npm:1.5.11, cropperjs@npm:^1.4.3":
+"cropperjs@npm:^1.4.3":
   version: 1.5.11
   resolution: "cropperjs@npm:1.5.11"
   checksum: 450b5cbeba4ce482b9f7aacdd359281099dc883b1189e34ccec0db5bbc731ec9be206cfcf9c03067d96e8c227547407db629b7203189446877196bfa2ce6c948
@@ -16282,14 +15028,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:2.0.0, dataloader@npm:^2.0.0":
+"dataloader@npm:^2.0.0":
   version: 2.0.0
   resolution: "dataloader@npm:2.0.0"
   checksum: 0165c2e80751d269c33d2a14b0078a4f3853cb010e2531e7aa99523aba8d0cdc922b9ad67e4c2bb9074c90e0ee0a41b6e7f5f63c40d31224a71c8a0b703f4be3
   languageName: node
   linkType: hard
 
-"dataurl-to-blob@npm:0.0.1, dataurl-to-blob@npm:^0.0.1":
+"dataurl-to-blob@npm:^0.0.1":
   version: 0.0.1
   resolution: "dataurl-to-blob@npm:0.0.1"
   dependencies:
@@ -16517,7 +15263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress@npm:4.2.1, decompress@npm:^4.0.0, decompress@npm:^4.2.1":
+"decompress@npm:^4.0.0, decompress@npm:^4.2.1":
   version: 4.2.1
   resolution: "decompress@npm:4.2.1"
   dependencies:
@@ -16556,7 +15302,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:2.0.5, deep-equal@npm:^2.0.4":
+"deep-equal@npm:^1.0.1, deep-equal@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "deep-equal@npm:1.1.1"
+  dependencies:
+    is-arguments: ^1.0.4
+    is-date-object: ^1.0.1
+    is-regex: ^1.0.4
+    object-is: ^1.0.1
+    object-keys: ^1.1.1
+    regexp.prototype.flags: ^1.2.0
+  checksum: cc6a0009ce73a10230758d50795211fb3ceb7eb7f2cf8baed1c4a4cb2a06dc28857ce11e641c95ca9abb5edc1f1e86a4bb6bcffaadf9fe9d310c102d346d043b
+  languageName: node
+  linkType: hard
+
+"deep-equal@npm:^2.0.4":
   version: 2.0.5
   resolution: "deep-equal@npm:2.0.5"
   dependencies:
@@ -16576,20 +15336,6 @@ __metadata:
     which-collection: ^1.0.1
     which-typed-array: ^1.1.2
   checksum: bf99bc27fa34dc229829126b9d18d509fd54e8ac92941c7c9d2be5dddff66fdbce35e9b39026ab12b4d2235491cdcc56cb50317da41230ab558d3b57f48ec454
-  languageName: node
-  linkType: hard
-
-"deep-equal@npm:^1.0.1, deep-equal@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "deep-equal@npm:1.1.1"
-  dependencies:
-    is-arguments: ^1.0.4
-    is-date-object: ^1.0.1
-    is-regex: ^1.0.4
-    object-is: ^1.0.1
-    object-keys: ^1.1.1
-    regexp.prototype.flags: ^1.2.0
-  checksum: cc6a0009ce73a10230758d50795211fb3ceb7eb7f2cf8baed1c4a4cb2a06dc28857ce11e641c95ca9abb5edc1f1e86a4bb6bcffaadf9fe9d310c102d346d043b
   languageName: node
   linkType: hard
 
@@ -17014,24 +15760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dns-packet@npm:^5.2.4":
-  version: 5.2.4
-  resolution: "dns-packet@npm:5.2.4"
-  dependencies:
-    ip: ^1.1.5
-  checksum: 83afff421d91b11d8c6cb99b52d1cc5433986025e5aaf10f3ac3a9a6abc6dba0827584a8186768a5798ffbc4e36559e4c2ede3310a616089ab4e6fa004719707
-  languageName: node
-  linkType: hard
-
-"dns-socket@npm:^4.2.1":
-  version: 4.2.2
-  resolution: "dns-socket@npm:4.2.2"
-  dependencies:
-    dns-packet: ^5.2.4
-  checksum: 34f7509c4dd26e3f158e31d2286af387dd33d7f71c64447263dd03279b2712fd92b94295dff731cb313896ead93efcee501f2ba02bf09c536a5bdcb592091082
-  languageName: node
-  linkType: hard
-
 "dns-txt@npm:^2.0.2":
   version: 2.0.2
   resolution: "dns-txt@npm:2.0.2"
@@ -17254,14 +15982,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop-immutable@npm:1.6.0, dot-prop-immutable@npm:^1.4.0":
+"dot-prop-immutable@npm:^1.4.0":
   version: 1.6.0
   resolution: "dot-prop-immutable@npm:1.6.0"
   checksum: 32f0123e23a21a03b8e1f4b94aff87ed066c368c82ca90fa2846c7fa109ac1620c8ba0fd64765eef36e7574f897bd0b7c5590c8cad13186973f2b21626235838
   languageName: node
   linkType: hard
 
-"dot-prop-immutable@npm:2.1.0, dot-prop-immutable@npm:^2.1.0":
+"dot-prop-immutable@npm:^2.1.0":
   version: 2.1.0
   resolution: "dot-prop-immutable@npm:2.1.0"
   checksum: 5297a7bb2e63eb67b3c600391492ddacc06b077a652b79fc15dc2527dc6deb182f5a51c495b891ed2343f03ea65cc3bba5b482448e8bbc4f5d716dababc6654e
@@ -17348,7 +16076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"download@npm:5.0.3, download@npm:^5.0.3":
+"download@npm:^5.0.3":
   version: 5.0.3
   resolution: "download@npm:5.0.3"
   dependencies:
@@ -17363,7 +16091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:2.2.3, downshift@npm:^2.1.5":
+"downshift@npm:^2.1.5":
   version: 2.2.3
   resolution: "downshift@npm:2.2.3"
   dependencies:
@@ -17375,7 +16103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:3.4.8, downshift@npm:^3.1.2":
+"downshift@npm:^3.1.2":
   version: 3.4.8
   resolution: "downshift@npm:3.4.8"
   dependencies:
@@ -17638,7 +16366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emotion@npm:10.0.27, emotion@npm:^10.0.17, emotion@npm:^10.0.27":
+"emotion@npm:^10.0.17, emotion@npm:^10.0.27":
   version: 10.0.27
   resolution: "emotion@npm:10.0.27"
   dependencies:
@@ -18889,7 +17617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:1.7.0, extract-zip@npm:^1.6.7, extract-zip@npm:^1.7.0":
+"extract-zip@npm:^1.6.7, extract-zip@npm:^1.7.0":
   version: 1.7.0
   resolution: "extract-zip@npm:1.7.0"
   dependencies:
@@ -19086,7 +17814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fecha@npm:2.3.3, fecha@npm:^2.3.3":
+"fecha@npm:^2.3.3":
   version: 2.3.3
   resolution: "fecha@npm:2.3.3"
   checksum: 1761ec8cd88dc165bad8d726e5bc38c933de6cc7ae479eea83260bcbadd3dd285f67b7605db6d2d5e2f8cb92ab5fe7f7634fe09229f0746bdc032a84d824dedb
@@ -19665,7 +18393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:3.0.1, form-data@npm:^3.0.0":
+"form-data@npm:^3.0.0":
   version: 3.0.1
   resolution: "form-data@npm:3.0.1"
   dependencies:
@@ -19765,17 +18493,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:7.0.1, fs-extra@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "fs-extra@npm:7.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: 0de3773953a13b517f053dbfa291166da076cc563cdd8f0ecefc64018ab15d2614f1707860b82e6b0e41695f613c1855f410749bd01bcb585f0243b1018a6595
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
@@ -19820,6 +18537,17 @@ __metadata:
     jsonfile: ^2.1.0
     klaw: ^1.0.0
   checksum: b07d107d48524fcb6f055303dcd0546098e7c2f1e02548734abfabc5353a14232bec77738c0acfff670ac41c36e25460af7afda516bac6d647d814df102c9023
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "fs-extra@npm:7.0.1"
+  dependencies:
+    graceful-fs: ^4.1.2
+    jsonfile: ^4.0.0
+    universalify: ^0.1.0
+  checksum: 0de3773953a13b517f053dbfa291166da076cc563cdd8f0ecefc64018ab15d2614f1707860b82e6b0e41695f613c1855f410749bd01bcb585f0243b1018a6595
   languageName: node
   linkType: hard
 
@@ -20593,25 +19321,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"got@npm:9.6.0, got@npm:^9.6.0":
-  version: 9.6.0
-  resolution: "got@npm:9.6.0"
-  dependencies:
-    "@sindresorhus/is": ^0.14.0
-    "@szmarczak/http-timer": ^1.1.2
-    cacheable-request: ^6.0.0
-    decompress-response: ^3.3.0
-    duplexer3: ^0.1.4
-    get-stream: ^4.1.0
-    lowercase-keys: ^1.0.1
-    mimic-response: ^1.0.1
-    p-cancelable: ^1.0.0
-    to-readable-stream: ^1.0.0
-    url-parse-lax: ^3.0.0
-  checksum: 4cfb862eb7e2d023f486efbd9ad5ab199ea44f957dc72be9518bf54d832ad4281ef3b63eac4d861b189690c3b7674eef3e1cb4f41285a83fa43293431ab879bd
-  languageName: node
-  linkType: hard
-
 "got@npm:^11.3.0":
   version: 11.8.2
   resolution: "got@npm:11.8.2"
@@ -20675,6 +19384,25 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"got@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "got@npm:9.6.0"
+  dependencies:
+    "@sindresorhus/is": ^0.14.0
+    "@szmarczak/http-timer": ^1.1.2
+    cacheable-request: ^6.0.0
+    decompress-response: ^3.3.0
+    duplexer3: ^0.1.4
+    get-stream: ^4.1.0
+    lowercase-keys: ^1.0.1
+    mimic-response: ^1.0.1
+    p-cancelable: ^1.0.0
+    to-readable-stream: ^1.0.0
+    url-parse-lax: ^3.0.0
+  checksum: 4cfb862eb7e2d023f486efbd9ad5ab199ea44f957dc72be9518bf54d832ad4281ef3b63eac4d861b189690c3b7674eef3e1cb4f41285a83fa43293431ab879bd
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.10, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:~4.2.0":
   version: 4.2.6
   resolution: "graceful-fs@npm:4.2.6"
@@ -20704,7 +19432,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-scalars@npm:1.9.3, graphql-scalars@npm:^1.7.0":
+"graphql-scalars@npm:^1.7.0":
   version: 1.9.3
   resolution: "graphql-scalars@npm:1.9.3"
   dependencies:
@@ -20724,7 +19452,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:2.12.4, graphql-tag@npm:^2.10.1, graphql-tag@npm:^2.10.3, graphql-tag@npm:^2.11.0":
+"graphql-tag@npm:^2.10.1, graphql-tag@npm:^2.10.3, graphql-tag@npm:^2.11.0":
   version: 2.12.4
   resolution: "graphql-tag@npm:2.12.4"
   dependencies:
@@ -20735,7 +19463,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql@npm:14.7.0, graphql@npm:^14.4.2, graphql@npm:^14.5.8, graphql@npm:^14.6.0, graphql@npm:^14.7.0":
+"graphql@npm:^14.4.2, graphql@npm:^14.5.8, graphql@npm:^14.6.0, graphql@npm:^14.7.0":
   version: 14.7.0
   resolution: "graphql@npm:14.7.0"
   dependencies:
@@ -21504,7 +20232,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"i18n-locales@npm:0.0.2, i18n-locales@npm:^0.0.2":
+"i18n-locales@npm:^0.0.2":
   version: 0.0.2
   resolution: "i18n-locales@npm:0.0.2"
   checksum: 6f69fa000728cf89a1b100805b431e193ae405067f76e6dc1cf95dd01ae1e2c6dd3939799d0811b859992dfb226750a10278a9ed16c0ffbfe7cbb064a19edb5a
@@ -22058,7 +20786,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"invariant@npm:2.2.4, invariant@npm:^2.2.2, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
+"invariant@npm:^2.2.2, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -22078,13 +20806,6 @@ fsevents@^1.2.7:
   version: 2.1.0
   resolution: "ip-regex@npm:2.1.0"
   checksum: 2fd2190ada81b55a8a6f913bcb5a6fd6ff9da127905b4c01521f09a1d391e86d415dfe8c131ed2989d536949bb2f9654a71b9fa6f7ae2ac3ae6111b2026cc902
-  languageName: node
-  linkType: hard
-
-"ip-regex@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "ip-regex@npm:4.3.0"
-  checksum: 4f44f34dcfe5cfae3b79bac4b25bec81ea007c24a66a30a3a17d01eebde4fa98bb531f207590ee16e1e4721b4f8ad12f6a64ed9f49bcb4587ff13ebb7cc984a5
   languageName: node
   linkType: hard
 
@@ -22464,7 +21185,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-hotkey@npm:0.1.8, is-hotkey@npm:^0.1.3, is-hotkey@npm:^0.1.4":
+"is-hotkey@npm:^0.1.3, is-hotkey@npm:^0.1.4":
   version: 0.1.8
   resolution: "is-hotkey@npm:0.1.8"
   checksum: 711e7e4e7d59738dda34951a3d63c03519de5d1b36b4e45aa264b94ac539c4f57531e1896d655e5c6739f8393bdecacaa73e02ad6711a1b13db407b22e10494d
@@ -22485,15 +21206,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "is-interactive@npm:1.0.0"
   checksum: d79b435e5134ccd60dfe035117b1cddd5c5100e90b2d33428adfe1667e26f0114cc1bc7b3ff84a1b107de8ef27f155e3ecc3bb08c0e502a15c66300b4a45d9e5
-  languageName: node
-  linkType: hard
-
-"is-ip@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "is-ip@npm:3.1.0"
-  dependencies:
-    ip-regex: ^4.0.0
-  checksum: 9929f2f33d46f85f1c603d360796e2ce97ac718ffa95611412c1959b59b839a8e7c8aa35e495812c9061ff3a23cab8a818ec54064fa2428c46f86d11114b289f
   languageName: node
   linkType: hard
 
@@ -22897,7 +21609,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"isnumeric@npm:0.3.3, isnumeric@npm:^0.3.3":
+"isnumeric@npm:^0.3.3":
   version: 0.3.3
   resolution: "isnumeric@npm:0.3.3"
   checksum: fad036098954ac61c4e5497e7e2a96d83500ae11025d9348a2ef57fec43885704b14dc9ac1e5fecc984008e3507bcf25c9f3650edd4d4130d58c10ea0052a26d
@@ -23903,7 +22615,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json2csv@npm:4.5.4, json2csv@npm:^4.5.2":
+"json2csv@npm:^4.5.2":
   version: 4.5.4
   resolution: "json2csv@npm:4.5.4"
   dependencies:
@@ -23991,7 +22703,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jsonpack@npm:1.1.5, jsonpack@npm:^1.1.5":
+"jsonpack@npm:^1.1.5":
   version: 1.1.5
   resolution: "jsonpack@npm:1.1.5"
   checksum: 764a36d7f0c7780c5cb5ebaad3ce1bb68e792c4ba22b92b86e96fb170c93b3d9c21a6699cf6b8054864e631eee8ccd8ae174710e83dd097a9b6b9d67ce035e8d
@@ -24087,7 +22799,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jwk-to-pem@npm:2.0.5, jwk-to-pem@npm:^2.0.1":
+"jwk-to-pem@npm:^2.0.1":
   version: 2.0.5
   resolution: "jwk-to-pem@npm:2.0.5"
   dependencies:
@@ -24117,7 +22829,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"keycode@npm:2.2.0, keycode@npm:^2.2.0":
+"keycode@npm:^2.2.0":
   version: 2.2.0
   resolution: "keycode@npm:2.2.0"
   checksum: f417ba53db8eee6dde1b01d0dae4658b3a07cfbff7e6ce0a74e5a2346b088b98daf13d979fec6f05eba2c6fc169c8799bfdcf73049a9db5036a566f465796f70
@@ -24633,7 +23345,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"load-script@npm:1.0.0, load-script@npm:^1.0.0":
+"load-script@npm:^1.0.0":
   version: 1.0.0
   resolution: "load-script@npm:1.0.0"
   checksum: 9f907ee20dfe8068af210be73a072dd61a287566a23b5666b9c6b9957e66eb33cc7c6a790308cf307c373d7ff75265ab1dde779c3fff90d65535fb3a1c0a167a
@@ -24690,7 +23402,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"localtunnel@npm:2.0.1, localtunnel@npm:^2.0.1":
+"localtunnel@npm:^2.0.1":
   version: 2.0.1
   resolution: "localtunnel@npm:2.0.1"
   dependencies:
@@ -24912,7 +23624,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.pick@npm:4.4.0, lodash.pick@npm:^4.4.0":
+"lodash.pick@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.pick@npm:4.4.0"
   checksum: 3cf24484b1bd36652bfbe1e925e6955ee0332f1612919331a2d6115d5617bcaaf559e4fb21f4160d51eb2359f7a8dc0e478773da516b4ccc15ef261327064aab
@@ -25474,7 +24186,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"material-components-web@npm:3.2.0, material-components-web@npm:^3.1.1":
+"material-components-web@npm:^3.1.1":
   version: 3.2.0
   resolution: "material-components-web@npm:3.2.0"
   dependencies:
@@ -25542,7 +24254,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"md5@npm:2.3.0, md5@npm:^2.3.0":
+"md5@npm:^2.3.0":
   version: 2.3.0
   resolution: "md5@npm:2.3.0"
   dependencies:
@@ -25553,7 +24265,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mdbid@npm:1.0.0, mdbid@npm:^1.0.0":
+"mdbid@npm:^1.0.0":
   version: 1.0.0
   resolution: "mdbid@npm:1.0.0"
   dependencies:
@@ -25583,7 +24295,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"medium-editor@npm:5.23.3, medium-editor@npm:^5.23.3":
+"medium-editor@npm:^5.23.3":
   version: 5.23.3
   resolution: "medium-editor@npm:5.23.3"
   checksum: 6a5ac634942d75da20c3c3d51ffd59a9dff3c891f3e5320ff3b8c505fe81c55b6cac8d02988f889840bab0acb1530893ec1cabac4d88b673d6111278f9b33c41
@@ -26353,19 +25065,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.1.23, nanoid@npm:^3.1.20, nanoid@npm:^3.1.22":
+"nanoid@npm:^2.1.0":
+  version: 2.1.11
+  resolution: "nanoid@npm:2.1.11"
+  checksum: 41453e344e3abb189cd3baa3ab52685601d7220f86ce73f6a1d9594ebae286c2acf47a20b5aa9cf11933b587b69c6007e88f190ca266450c2fbe20be6db43a29
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.1.20, nanoid@npm:^3.1.22":
   version: 3.1.23
   resolution: "nanoid@npm:3.1.23"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: e6dea1da5a593ffdc8cf2676d1d02f0626f07a54a5947a7a1f5ff1fd07901b2f53044c285e98b87eb367f016fde285fd8785d54a2dceeab9c3721f4e618f8326
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^2.1.0":
-  version: 2.1.11
-  resolution: "nanoid@npm:2.1.11"
-  checksum: 41453e344e3abb189cd3baa3ab52685601d7220f86ce73f6a1d9594ebae286c2acf47a20b5aa9cf11933b587b69c6007e88f190ca266450c2fbe20be6db43a29
   languageName: node
   linkType: hard
 
@@ -26402,7 +25114,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"ncp@npm:2.0.0, ncp@npm:^2.0.0, ncp@npm:~2.0.0":
+"ncp@npm:^2.0.0, ncp@npm:~2.0.0":
   version: 2.0.0
   resolution: "ncp@npm:2.0.0"
   bin:
@@ -27046,7 +25758,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"nprogress@npm:0.2.0, nprogress@npm:^0.2.0":
+"nprogress@npm:^0.2.0":
   version: 0.2.0
   resolution: "nprogress@npm:0.2.0"
   checksum: 652dfcfea776f9d9a2c3ad1f79b4cbd3056a03e7c6884966eab70fb184e8e70bfca9e0343ba89d11aa1ed95370d648fb638fab91b5dc027bdad54c8d37c96478
@@ -27142,17 +25854,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-hash@npm:1.3.1, object-hash@npm:^1.3.1":
+"object-hash@npm:^1.3.1":
   version: 1.3.1
   resolution: "object-hash@npm:1.3.1"
   checksum: 035cb0b0e66b34611ec5a6bf723380b7f4b3b1292ef44aa9ba93258334a2dca8cf91be28021e9ffa5edf737f97fc54b66d0605bf62db3a63f05191b0002be7bf
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:2.1.1":
-  version: 2.1.1
-  resolution: "object-hash@npm:2.1.1"
-  checksum: fe49a0864cba7ac4055c604295692ae75f5f4d22ba929aaaa987469809d17ab030d1111e8f0d425a070fa4a78b8021b55260e26e98b66b59e0f7be2bd9069fb8
   languageName: node
   linkType: hard
 
@@ -27259,7 +25964,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.pick@npm:1.3.0, object.pick@npm:^1.3.0":
+"object.pick@npm:^1.3.0":
   version: 1.3.0
   resolution: "object.pick@npm:1.3.0"
   dependencies:
@@ -27356,17 +26061,6 @@ fsevents@^1.2.7:
   dependencies:
     mimic-fn: ^2.1.0
   checksum: e425f6caeb20cf2598ffece94be5663932e34d074f1631b682b13d5f01cc1e0712a7dc711eff1706bb5a5aaab8a52e37bd5edcf560334e3222219d7e8b09c21c
-  languageName: node
-  linkType: hard
-
-"open@npm:8.0.9":
-  version: 8.0.9
-  resolution: "open@npm:8.0.9"
-  dependencies:
-    define-lazy-prop: ^2.0.0
-    is-docker: ^2.1.1
-    is-wsl: ^2.2.0
-  checksum: 936ea1a4ec8c87de8e825efe385c146307fec8bb0ec72e08ce1a79103b046e82bc268a9b74d6f1861abb21476c9b3b96a8a54b4f3becf744f0fefe30cb3e7ba3
   languageName: node
   linkType: hard
 
@@ -28330,7 +27024,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pirates@npm:4.0.1, pirates@npm:^4.0.0, pirates@npm:^4.0.1":
+"pirates@npm:^4.0.0, pirates@npm:^4.0.1":
   version: 4.0.1
   resolution: "pirates@npm:4.0.1"
   dependencies:
@@ -28409,7 +27103,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"platform@npm:1.3.6, platform@npm:^1.3.5":
+"platform@npm:^1.3.5":
   version: 1.3.6
   resolution: "platform@npm:1.3.6"
   checksum: d4d10d5a55476c6d369b03e02b31df50a4e7f1c565efabe707379b8a119709fb2a66dec090ab7fe520a30b767fe3791e3c4a5aba985918e51a17df45e469189f
@@ -28425,7 +27119,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pluralize@npm:8.0.0, pluralize@npm:^8.0.0":
+"pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 5251b470a0c8e5181ac7e1d61028553f90cb2c85c34b8e468cea269ae715499524546c2c3681029ef5697d86c54bfb12e49388f5cc6082051e84f5888588f4ec
@@ -29391,7 +28085,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"posthtml-noopener@npm:1.0.5, posthtml-noopener@npm:^1.0.5":
+"posthtml-noopener@npm:^1.0.5":
   version: 1.0.5
   resolution: "posthtml-noopener@npm:1.0.5"
   dependencies:
@@ -29425,16 +28119,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"posthtml@npm:0.15.2, posthtml@npm:^0.15.0":
-  version: 0.15.2
-  resolution: "posthtml@npm:0.15.2"
-  dependencies:
-    posthtml-parser: ^0.7.2
-    posthtml-render: ^1.3.1
-  checksum: dac27389dcf8b8567c510ddaecb9449859fbb2dc4838f5d8f03ac63aa31d465c5960be35a3c23dc77ec461b267c28ff2d05aec776c4f2f8fbe6f66c8d254b689
-  languageName: node
-  linkType: hard
-
 "posthtml@npm:^0.12.0":
   version: 0.12.3
   resolution: "posthtml@npm:0.12.3"
@@ -29442,6 +28126,16 @@ fsevents@^1.2.7:
     posthtml-parser: ^0.4.2
     posthtml-render: ^1.2.2
   checksum: d866ee525e23659cdec3b9d370c736cabf6e924262c5cfe33b41c5e34483a1f758d9f152da18c74bdb0f8fafdf3a1b90b30d981affa07da774ed688784330fdc
+  languageName: node
+  linkType: hard
+
+"posthtml@npm:^0.15.0":
+  version: 0.15.2
+  resolution: "posthtml@npm:0.15.2"
+  dependencies:
+    posthtml-parser: ^0.7.2
+    posthtml-render: ^1.3.1
+  checksum: dac27389dcf8b8567c510ddaecb9449859fbb2dc4838f5d8f03ac63aa31d465c5960be35a3c23dc77ec461b267c28ff2d05aec776c4f2f8fbe6f66c8d254b689
   languageName: node
   linkType: hard
 
@@ -29487,7 +28181,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prettier@npm:1.19.1, prettier@npm:^1.14.2, prettier@npm:^1.18.2, prettier@npm:^1.19.1":
+"prettier@npm:^1.14.2, prettier@npm:^1.18.2, prettier@npm:^1.19.1":
   version: 1.19.1
   resolution: "prettier@npm:1.19.1"
   bin:
@@ -29687,7 +28381,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.7.2, prop-types@npm:15.x, prop-types@npm:^15.5.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.5.9, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:15.x, prop-types@npm:^15.5.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.4, prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.5.9, prop-types@npm:^15.6.0, prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -29826,17 +28520,6 @@ fsevents@^1.2.7:
     randombytes: ^2.0.1
     safe-buffer: ^5.1.2
   checksum: 85b1be24b589d3ec4e39c2cc8542d6bf914e04d60278bd1ca0b4c36c678971b9f43303288c90e80cdd82ef20f2ec1fcd2726c8f093ba88187779acd82559b208
-  languageName: node
-  linkType: hard
-
-"public-ip@npm:4.0.3":
-  version: 4.0.3
-  resolution: "public-ip@npm:4.0.3"
-  dependencies:
-    dns-socket: ^4.2.1
-    got: ^9.6.0
-    is-ip: ^3.1.0
-  checksum: 0f072bf9c40a1d5b45158eeb07252bc903e61e2d86d70691eea9983309d7d5563ba377e6c670ac4d9892010752c689289cedeee24fdb14e842c180b621dc03be
   languageName: node
   linkType: hard
 
@@ -30152,7 +28835,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"raw.macro@npm:0.4.2, raw.macro@npm:^0.4.2":
+"raw.macro@npm:^0.4.2":
   version: 0.4.2
   resolution: "raw.macro@npm:0.4.2"
   dependencies:
@@ -30188,7 +28871,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:3.7.3, rc-tooltip@npm:^3.7.2":
+"rc-tooltip@npm:^3.7.2":
   version: 3.7.3
   resolution: "rc-tooltip@npm:3.7.3"
   dependencies:
@@ -30234,7 +28917,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-ace@npm:6.6.0, react-ace@npm:^6.1.4":
+"react-ace@npm:^6.1.4":
   version: 6.6.0
   resolution: "react-ace@npm:6.6.0"
   dependencies:
@@ -30274,7 +28957,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-butterfiles@npm:1.3.3, react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
+"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
   version: 1.3.3
   resolution: "react-butterfiles@npm:1.3.3"
   dependencies:
@@ -30297,7 +28980,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-color@npm:2.19.3, react-color@npm:^2.14.1, react-color@npm:^2.17.0":
+"react-color@npm:^2.14.1, react-color@npm:^2.17.0":
   version: 2.19.3
   resolution: "react-color@npm:2.19.3"
   dependencies:
@@ -30314,7 +28997,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-columned@npm:1.1.3, react-columned@npm:^1.0.0":
+"react-columned@npm:^1.0.0":
   version: 1.1.3
   resolution: "react-columned@npm:1.1.3"
   dependencies:
@@ -30326,7 +29009,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-custom-scrollbars@npm:4.2.1, react-custom-scrollbars@npm:^4.2.1":
+"react-custom-scrollbars@npm:^4.2.1":
   version: 4.2.1
   resolution: "react-custom-scrollbars@npm:4.2.1"
   dependencies:
@@ -30412,15 +29095,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dnd-html5-backend@npm:9.5.1, react-dnd-html5-backend@npm:^9.3.4":
-  version: 9.5.1
-  resolution: "react-dnd-html5-backend@npm:9.5.1"
-  dependencies:
-    dnd-core: ^9.5.1
-  checksum: 047d19ddb50b8a55944625661ccfbc4f0b24470f05f5fd4abcff57fc79e482b8ef87b95147c0cd620e25f8d97b6bff54f5d2c91d4593408d62de854e447a952a
-  languageName: node
-  linkType: hard
-
 "react-dnd-html5-backend@npm:^11.1.3":
   version: 11.1.3
   resolution: "react-dnd-html5-backend@npm:11.1.3"
@@ -30430,19 +29104,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dnd@npm:9.5.1, react-dnd@npm:^9.3.4":
+"react-dnd-html5-backend@npm:^9.3.4":
   version: 9.5.1
-  resolution: "react-dnd@npm:9.5.1"
+  resolution: "react-dnd-html5-backend@npm:9.5.1"
   dependencies:
-    "@types/hoist-non-react-statics": ^3.3.1
-    "@types/shallowequal": ^1.1.1
     dnd-core: ^9.5.1
-    hoist-non-react-statics: ^3.3.0
-    shallowequal: ^1.1.0
-  peerDependencies:
-    react: ">= 16.8"
-    react-dom: ">= 16.8"
-  checksum: f5d3b4291d5bbd0275fd2b4f73ae417d358b45ffa8751c3a32d97db5cdd3bf3ab55741c33a6fb433dc2878a0a03190b51a8e390b94eb49a8bdce1c60a429ee37
+  checksum: 047d19ddb50b8a55944625661ccfbc4f0b24470f05f5fd4abcff57fc79e482b8ef87b95147c0cd620e25f8d97b6bff54f5d2c91d4593408d62de854e447a952a
   languageName: node
   linkType: hard
 
@@ -30458,6 +29125,22 @@ fsevents@^1.2.7:
     react: ">= 16.9.0"
     react-dom: ">= 16.9.0"
   checksum: ba08188a1a1bb9cc8109bcaea5cd3c3e186d4aa4f04193ef398f8baacf1fe228860f1800903cebc1e73e84473e552198a65b06d244ed7116ee95e4a16c3920c7
+  languageName: node
+  linkType: hard
+
+"react-dnd@npm:^9.3.4":
+  version: 9.5.1
+  resolution: "react-dnd@npm:9.5.1"
+  dependencies:
+    "@types/hoist-non-react-statics": ^3.3.1
+    "@types/shallowequal": ^1.1.1
+    dnd-core: ^9.5.1
+    hoist-non-react-statics: ^3.3.0
+    shallowequal: ^1.1.0
+  peerDependencies:
+    react: ">= 16.8"
+    react-dom: ">= 16.8"
+  checksum: f5d3b4291d5bbd0275fd2b4f73ae417d358b45ffa8751c3a32d97db5cdd3bf3ab55741c33a6fb433dc2878a0a03190b51a8e390b94eb49a8bdce1c60a429ee37
   languageName: node
   linkType: hard
 
@@ -30577,7 +29260,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-google-recaptcha@npm:1.1.0, react-google-recaptcha@npm:^1.1.0":
+"react-google-recaptcha@npm:^1.1.0":
   version: 1.1.0
   resolution: "react-google-recaptcha@npm:1.1.0"
   dependencies:
@@ -30615,7 +29298,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-helmet@npm:5.2.1, react-helmet@npm:^5.2.0":
+"react-helmet@npm:^5.2.0":
   version: 5.2.1
   resolution: "react-helmet@npm:5.2.1"
   dependencies:
@@ -30629,7 +29312,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-helmet@npm:6.1.0, react-helmet@npm:^6.0.0, react-helmet@npm:^6.1.0":
+"react-helmet@npm:^6.0.0, react-helmet@npm:^6.1.0":
   version: 6.1.0
   resolution: "react-helmet@npm:6.1.0"
   dependencies:
@@ -30667,7 +29350,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-hotkeyz@npm:1.0.4, react-hotkeyz@npm:^1.0.4":
+"react-hotkeyz@npm:^1.0.4":
   version: 1.0.4
   resolution: "react-hotkeyz@npm:1.0.4"
   dependencies:
@@ -30679,7 +29362,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-images@npm:0.5.19, react-images@npm:^0.5.19":
+"react-images@npm:^0.5.19":
   version: 0.5.19
   resolution: "react-images@npm:0.5.19"
   dependencies:
@@ -30712,7 +29395,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-lazy-load@npm:3.1.13, react-lazy-load@npm:^3.0.13":
+"react-lazy-load@npm:^3.0.13":
   version: 3.1.13
   resolution: "react-lazy-load@npm:3.1.13"
   dependencies:
@@ -30734,7 +29417,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-loading-skeleton@npm:0.5.0, react-loading-skeleton@npm:^0.5.0":
+"react-loading-skeleton@npm:^0.5.0":
   version: 0.5.0
   resolution: "react-loading-skeleton@npm:0.5.0"
   peerDependencies:
@@ -30826,7 +29509,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:5.2.0, react-router-dom@npm:^5.0.0":
+"react-router-dom@npm:^5.0.0":
   version: 5.2.0
   resolution: "react-router-dom@npm:5.2.0"
   dependencies:
@@ -30927,7 +29610,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable-hoc@npm:1.11.0, react-sortable-hoc@npm:^1.9.1":
+"react-sortable-hoc@npm:^1.9.1":
   version: 1.11.0
   resolution: "react-sortable-hoc@npm:1.11.0"
   dependencies:
@@ -30942,7 +29625,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable-tree@npm:2.8.0, react-sortable-tree@npm:^2.6.0":
+"react-sortable-tree@npm:^2.6.0":
   version: 2.8.0
   resolution: "react-sortable-tree@npm:2.8.0"
   dependencies:
@@ -30961,7 +29644,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-sortable@npm:2.0.0, react-sortable@npm:^2.0.0":
+"react-sortable@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-sortable@npm:2.0.0"
   dependencies:
@@ -31034,21 +29717,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:4.4.1":
-  version: 4.4.1
-  resolution: "react-transition-group@npm:4.4.1"
-  dependencies:
-    "@babel/runtime": ^7.5.5
-    dom-helpers: ^5.0.1
-    loose-envify: ^1.4.0
-    prop-types: ^15.6.2
-  peerDependencies:
-    react: ">=16.6.0"
-    react-dom: ">=16.6.0"
-  checksum: e14446123f820e804335c64be5270333c29e8cfaa43dfc33387e132c5d521cf4a0a7c2408058a147b254ae82a6569f373394d83e977ef340d6937bc2f4ff7d6c
-  languageName: node
-  linkType: hard
-
 "react-transition-group@npm:^4.3.0":
   version: 4.4.2
   resolution: "react-transition-group@npm:4.4.2"
@@ -31064,7 +29732,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-virtualized@npm:9.22.3, react-virtualized@npm:^9.21.0, react-virtualized@npm:^9.21.2":
+"react-virtualized@npm:^9.21.0, react-virtualized@npm:^9.21.2":
   version: 9.22.3
   resolution: "react-virtualized@npm:9.22.3"
   dependencies:
@@ -31317,7 +29985,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"recoil@npm:0.1.3, recoil@npm:^0.1.2":
+"recoil@npm:^0.1.2":
   version: 0.1.3
   resolution: "recoil@npm:0.1.3"
   peerDependencies:
@@ -32330,7 +30998,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"sanitize-filename@npm:1.6.3, sanitize-filename@npm:^1.6.3":
+"sanitize-filename@npm:^1.6.3":
   version: 1.6.3
   resolution: "sanitize-filename@npm:1.6.3"
   dependencies:
@@ -32485,7 +31153,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.3.1, secure-json-parse@npm:^2.4.0":
+"secure-json-parse@npm:^2.4.0":
   version: 2.4.0
   resolution: "secure-json-parse@npm:2.4.0"
   checksum: bbf325b52d3eb399b23a337ef7185380424600b4d6c07e62e8d1ab9e9cc657258b897841e4da1ecca9c9d4a83e426756f74fff1685640b3fbe4f481f577517d4
@@ -32595,7 +31263,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.5, semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:7.x, semver@npm:^7.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -32883,7 +31551,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"short-hash@npm:1.0.0, short-hash@npm:^1.0.0":
+"short-hash@npm:^1.0.0":
   version: 1.0.0
   resolution: "short-hash@npm:1.0.0"
   dependencies:
@@ -32892,7 +31560,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shortid@npm:2.2.16, shortid@npm:^2.2.12, shortid@npm:^2.2.14, shortid@npm:^2.2.15, shortid@npm:^2.2.16":
+"shortid@npm:^2.2.12, shortid@npm:^2.2.14, shortid@npm:^2.2.15, shortid@npm:^2.2.16":
   version: 2.2.16
   resolution: "shortid@npm:2.2.16"
   dependencies:
@@ -33033,7 +31701,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"slugify@npm:1.5.3, slugify@npm:^1.2.9, slugify@npm:^1.4.0":
+"slugify@npm:^1.2.9, slugify@npm:^1.4.0":
   version: 1.5.3
   resolution: "slugify@npm:1.5.3"
   checksum: 2f96352f294e70372761fa509d5f334c72c6c40fbc21d1b71c1ccb4d60e44ffebb9dbeb8c7e1d7bb64775c7e2bc704e8739c9b32c6ce5c7a0bbd5d846abf7133
@@ -33530,7 +32198,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"store@npm:2.0.12, store@npm:^2.0.12":
+"store@npm:^2.0.12":
   version: 2.0.12
   resolution: "store@npm:2.0.12"
   checksum: d139789bacc1078bc8d0296c9a399e9fcfcb5aa704b76076607f1be6fef8939c27edf7870110d2f5e7fcd11ba6443cb938a03da6e692e5f28647e2b2f1817404
@@ -33577,7 +32245,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"stream@npm:0.0.2, stream@npm:^0.0.2":
+"stream@npm:^0.0.2":
   version: 0.0.2
   resolution: "stream@npm:0.0.2"
   dependencies:
@@ -34156,20 +32824,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tar@npm:6.1.0, tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "tar@npm:6.1.0"
-  dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
-  checksum: d1d988eceb1ad2ecfaaf6fc5ecfe0c46fa005d04fe4c283355ccc52d3ffb4b6bf459a62f9ac7e36fd35251ab020399bdf527ab48b968120e06b4f61906a87d62
-  languageName: node
-  linkType: hard
-
 "tar@npm:^2.0.0":
   version: 2.2.2
   resolution: "tar@npm:2.2.2"
@@ -34193,6 +32847,20 @@ resolve@^2.0.0-next.3:
     safe-buffer: ^5.1.2
     yallist: ^3.0.3
   checksum: d325c316ac329ecb18f2b8cd3f85a80ab4a4105ada601b9253aaafae3fc14268e3cd874ccc265b6a08e60ebd17fbc31bd3dbc0d1018f874b536eb2a6e8ef6d9c
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "tar@npm:6.1.0"
+  dependencies:
+    chownr: ^2.0.0
+    fs-minipass: ^2.0.0
+    minipass: ^3.0.0
+    minizlib: ^2.1.1
+    mkdirp: ^1.0.3
+    yallist: ^4.0.0
+  checksum: d1d988eceb1ad2ecfaaf6fc5ecfe0c46fa005d04fe4c283355ccc52d3ffb4b6bf459a62f9ac7e36fd35251ab020399bdf527ab48b968120e06b4f61906a87d62
   languageName: node
   linkType: hard
 
@@ -34366,12 +33034,12 @@ resolve@^2.0.0-next.3:
   resolution: "theme@workspace:apps/theme"
   dependencies:
     "@apollo/react-components": ^3.1.5
-    "@webiny/app-form-builder": ^5.5.0-beta.0
-    "@webiny/app-page-builder": ^5.5.0-beta.0
-    "@webiny/form": ^5.5.0-beta.0
-    "@webiny/react-rich-text-renderer": ^5.5.0-beta.0
-    "@webiny/react-router": ^5.5.0-beta.0
-    "@webiny/validation": ^5.5.0-beta.0
+    "@webiny/app-form-builder": ^5.8.0-beta.0
+    "@webiny/app-page-builder": ^5.8.0-beta.0
+    "@webiny/form": ^5.8.0-beta.0
+    "@webiny/react-rich-text-renderer": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
+    "@webiny/validation": ^5.8.0-beta.0
     classnames: ^2.2.6
     emotion: ^10.0.17
     graphql: ^14.7.0
@@ -34466,7 +33134,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"timeago-react@npm:2.0.1, timeago-react@npm:^2.0.0":
+"timeago-react@npm:^2.0.0":
   version: 2.0.1
   resolution: "timeago-react@npm:2.0.1"
   dependencies:
@@ -34748,7 +33416,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tree-kill@npm:1.2.2, tree-kill@npm:^1.2.2":
+"tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
   bin:
@@ -35268,7 +33936,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"uniqid@npm:5.3.0, uniqid@npm:^5.0.3, uniqid@npm:^5.2.0, uniqid@npm:^5.3.0":
+"uniqid@npm:^5.0.3, uniqid@npm:^5.2.0, uniqid@npm:^5.3.0":
   version: 5.3.0
   resolution: "uniqid@npm:5.3.0"
   checksum: 1fcf7eb69ea09dd2cf37ffe72d8bd0f371a95586c3408b10f0018ad32e13fd533ebb7942a0fa75d8b1124ca7b4f417d241483853d6d706afeaca25d3cc7a0dcb
@@ -35848,7 +34516,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"warning@npm:4.0.3, warning@npm:^4.0.2, warning@npm:^4.0.3":
+"warning@npm:^4.0.2, warning@npm:^4.0.3":
   version: 4.0.3
   resolution: "warning@npm:4.0.3"
   dependencies:
@@ -36145,14 +34813,14 @@ resolve@^2.0.0-next.3:
     "@apollo/react-components": ^3.1.5
     "@apollo/react-hooks": ^3.1.5
     "@types/react": ^16.14.2
-    "@webiny/app": ^5.5.0-beta.0
-    "@webiny/app-form-builder": ^5.5.0-beta.0
-    "@webiny/app-page-builder": ^5.5.0-beta.0
-    "@webiny/cli": ^5.5.0-beta.0
-    "@webiny/cli-plugin-deploy-pulumi": ^5.5.0-beta.0
-    "@webiny/plugins": ^5.5.0-beta.0
-    "@webiny/project-utils": ^5.5.0-beta.0
-    "@webiny/react-router": ^5.5.0-beta.0
+    "@webiny/app": ^5.8.0-beta.0
+    "@webiny/app-form-builder": ^5.8.0-beta.0
+    "@webiny/app-page-builder": ^5.8.0-beta.0
+    "@webiny/cli": ^5.8.0-beta.0
+    "@webiny/cli-plugin-deploy-pulumi": ^5.8.0-beta.0
+    "@webiny/plugins": ^5.8.0-beta.0
+    "@webiny/project-utils": ^5.8.0-beta.0
+    "@webiny/react-router": ^5.8.0-beta.0
     apollo-cache-inmemory: ^1.6.6
     apollo-client: ^2.2.8
     apollo-link: ^1.2.14
@@ -36528,21 +35196,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.5":
-  version: 7.4.5
-  resolution: "ws@npm:7.4.5"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 20731aa1075336b94677f6741b674469c3c7fce9b70115bb535827c7c108a9d714f0b38ce39289b63c652870f9801afaf096f8aab32da96be62d919e80e4ed32
-  languageName: node
-  linkType: hard
-
 "ws@npm:^6.2.1":
   version: 6.2.2
   resolution: "ws@npm:6.2.2"
@@ -36892,7 +35545,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"zip-local@npm:0.3.4, zip-local@npm:^0.3.4":
+"zip-local@npm:^0.3.4":
   version: 0.3.4
   resolution: "zip-local@npm:0.3.4"
   dependencies:


### PR DESCRIPTION
## Changes
Closes https://github.com/webiny/webiny-js/issues/1688

`public-ip` package sometimes is unable to acquire the IP address. In that case the user is blocked from creating a project.
I've replaced the IP address with a `uuid` and we no longer care if IP address is obtainable or not.

Telemetry will still work because when data is sent to the telemetry endpoint, we can get the sender's IP, so our stats will not be affected.

## How Has This Been Tested?
Manually.