### PR TITLE
Fixed serving of non-image files

### DIFF
--- a/packages/api-file-manager/src/handlers/download/index.ts
+++ b/packages/api-file-manager/src/handlers/download/index.ts
@@ -52,7 +52,7 @@ const getS3Object = async (event, s3, context) => {
     // If no processors handled the file request, just return the S3 object by default.
     const params = getObjectParams(filename);
     return {
-        object: s3.getObject(params).promise(),
+        object: await s3.getObject(params).promise(),
         params: params
     };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7588,6 +7588,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webiny/api-dynamic-pages@^5.7.0, @webiny/api-dynamic-pages@workspace:packages/api-dynamic-pages":
+  version: 0.0.0-use.local
+  resolution: "@webiny/api-dynamic-pages@workspace:packages/api-dynamic-pages"
+  dependencies:
+    "@babel/cli": ^7.5.5
+    "@babel/core": ^7.5.5
+    "@babel/plugin-proposal-object-rest-spread": ^7.5.5
+    "@babel/plugin-transform-runtime": ^7.5.5
+    "@babel/preset-env": ^7.5.5
+    "@babel/preset-typescript": ^7.0.0
+    "@babel/runtime": ^7.5.5
+    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch-mock": 0.3.0
+    "@shelf/jest-elasticsearch": ^1.0.0
+    "@webiny/api-page-builder": ^5.7.0
+    "@webiny/cli": ^5.7.0
+    "@webiny/handler-graphql": ^5.7.0
+    "@webiny/plugins": ^5.7.0
+    "@webiny/project-utils": ^5.7.0
+    dot-prop-immutable: ^2.1.0
+    execa: ^5.0.0
+    jest: ^26.6.3
+    jest-dynalite: ^3.2.0
+    rimraf: ^3.0.2
+    ttypescript: ^1.5.12
+    typescript: ^4.1.3
+  languageName: unknown
+  linkType: soft
+
 "@webiny/api-dynamodb-to-elasticsearch@^5.8.0, @webiny/api-dynamodb-to-elasticsearch@^5.8.0-beta.0, @webiny/api-dynamodb-to-elasticsearch@workspace:packages/api-dynamodb-to-elasticsearch":
   version: 0.0.0-use.local
   resolution: "@webiny/api-dynamodb-to-elasticsearch@workspace:packages/api-dynamodb-to-elasticsearch"
@@ -7794,7 +7823,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-headless-cms@^5.8.0, @webiny/api-headless-cms@^5.8.0-beta.0, @webiny/api-headless-cms@workspace:packages/api-headless-cms":
+"@webiny/api-headless-cms-dynamic-pages@workspace:packages/api-headless-cms-dynamic-pages":
+  version: 0.0.0-use.local
+  resolution: "@webiny/api-headless-cms-dynamic-pages@workspace:packages/api-headless-cms-dynamic-pages"
+  dependencies:
+    "@babel/cli": ^7.5.5
+    "@babel/core": ^7.5.5
+    "@babel/plugin-proposal-object-rest-spread": ^7.5.5
+    "@babel/plugin-transform-runtime": ^7.5.5
+    "@babel/preset-env": ^7.5.5
+    "@babel/preset-typescript": ^7.0.0
+    "@babel/runtime": ^7.5.5
+    "@webiny/api-dynamic-pages": ^5.7.0
+    "@webiny/api-headless-cms": ^5.7.0
+    "@webiny/cli": ^5.7.0
+    "@webiny/project-utils": ^5.7.0
+    dot-prop-immutable: ^2.1.0
+    node-fetch: ^2.6.1
+    ttypescript: ^1.5.12
+    typescript: ^4.1.3
+  languageName: unknown
+  linkType: soft
+
+"@webiny/api-headless-cms@^5.7.0, @webiny/api-headless-cms@^5.8.0, @webiny/api-headless-cms@^5.8.0-beta.0, @webiny/api-headless-cms@workspace:packages/api-headless-cms":
   version: 0.0.0-use.local
   resolution: "@webiny/api-headless-cms@workspace:packages/api-headless-cms"
   dependencies:
@@ -7837,6 +7888,7 @@ __metadata:
     shortid: ^2.2.15
     sinon: ^9.0.2
     slugify: ^1.4.0
+    ttypescript: ^1.5.12
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
@@ -7890,7 +7942,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-page-builder@^5.8.0-beta.0, @webiny/api-page-builder@workspace:packages/api-page-builder":
+"@webiny/api-page-builder@^5.7.0, @webiny/api-page-builder@^5.8.0-beta.0, @webiny/api-page-builder@workspace:packages/api-page-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/api-page-builder@workspace:packages/api-page-builder"
   dependencies:
@@ -8960,7 +9012,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli@^5.8.0, @webiny/cli@^5.8.0-beta.0, @webiny/cli@workspace:packages/cli":
+"@webiny/cli@^5.7.0, @webiny/cli@^5.8.0, @webiny/cli@^5.8.0-beta.0, @webiny/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@webiny/cli@workspace:packages/cli"
   dependencies:
@@ -9174,7 +9226,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/handler-graphql@^5.8.0, @webiny/handler-graphql@^5.8.0-beta.0, @webiny/handler-graphql@workspace:packages/handler-graphql":
+"@webiny/handler-graphql@^5.7.0, @webiny/handler-graphql@^5.8.0, @webiny/handler-graphql@^5.8.0-beta.0, @webiny/handler-graphql@workspace:packages/handler-graphql":
   version: 0.0.0-use.local
   resolution: "@webiny/handler-graphql@workspace:packages/handler-graphql"
   dependencies:
@@ -9299,7 +9351,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/plugins@^5.8.0, @webiny/plugins@^5.8.0-beta.0, @webiny/plugins@workspace:packages/plugins":
+"@webiny/plugins@^5.7.0, @webiny/plugins@^5.8.0, @webiny/plugins@^5.8.0-beta.0, @webiny/plugins@workspace:packages/plugins":
   version: 0.0.0-use.local
   resolution: "@webiny/plugins@workspace:packages/plugins"
   dependencies:
@@ -9314,7 +9366,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/project-utils@^5.8.0, @webiny/project-utils@^5.8.0-beta.0, @webiny/project-utils@workspace:packages/project-utils":
+"@webiny/project-utils@^5.7.0, @webiny/project-utils@^5.8.0, @webiny/project-utils@^5.8.0-beta.0, @webiny/project-utils@workspace:packages/project-utils":
   version: 0.0.0-use.local
   resolution: "@webiny/project-utils@workspace:packages/project-utils"
   dependencies:


### PR DESCRIPTION
## Changes
I prepended the `await` keyword before getting the S3 object  (via `s3.getObject` method). 

Without it, downloading files that do not have a file loader (in other words, any file that's not an image) would not be served from a CDN, but always directly from an S3 bucket. The worst part of it was that the HTTP request would always first be issued to the CDN, which would receive a redirect response header from S3, which then browser would need to follow (shown in the issue).

Closes #1705 

## How Has This Been Tested?
Manual testing.

## Documentation

Included in the 5.9.0 changelog.

