### PR TITLE
fix(app-headless-cms): missing createdBy when created new content model

### DIFF
--- a/packages/app-headless-cms/src/admin/viewsGraphql.ts
+++ b/packages/app-headless-cms/src/admin/viewsGraphql.ts
@@ -18,6 +18,11 @@ const BASE_CONTENT_MODEL_FIELDS = `
         id
         name
     }
+    createdBy {
+        id
+        displayName
+        type
+    }
 `;
 
 // Fetches data needed for constructing content models list in the main menu.
@@ -47,11 +52,6 @@ export const LIST_CONTENT_MODELS = gql`
         listContentModels {
             data {
                 ${BASE_CONTENT_MODEL_FIELDS}
-                createdBy {
-                    id
-                    displayName
-                    type
-                }
             }
         }
     }


### PR DESCRIPTION
## Changes
Added createdBy field to GQL when creating new content model.

## How Has This Been Tested?
Manually.
