### PR TITLE
Fix: file manager API delete file

### DIFF
--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -29,7 +29,7 @@ describe("Files CRUD test", () => {
     const {
         tenant,
         elasticSearch,
-        sleep,
+        until,
         createFile,
         updateFile,
         createFiles,
@@ -134,6 +134,17 @@ describe("Files CRUD test", () => {
             }
         });
 
+        await until(
+            () => listFiles().then(([data]) => data),
+            ({ data }) =>
+                Array.isArray(data.fileManager.listFiles.data) &&
+                data.fileManager.listFiles.data.length === 1 &&
+                data.fileManager.listFiles.data[0].tags.length === 1,
+            {
+                tries: 10
+            }
+        );
+
         // Let's create multiple files
         const [create2] = await createFiles({
             data: [fileBData]
@@ -167,14 +178,12 @@ describe("Files CRUD test", () => {
             }
         });
 
-        // TODO: replace with the `until` utility we have in api-form-builder and api-page-builder
-        while (true) {
-            await sleep(1000);
-            const [list1] = await listFiles({});
-            if (Array.isArray(list1.data.fileManager.listFiles.data)) {
-                break;
-            }
-        }
+        await until(
+            () => listFiles().then(([data]) => data),
+            ({ data }) =>
+                Array.isArray(data.fileManager.listFiles.data) &&
+                data.fileManager.listFiles.data.length === 2
+        );
 
         // Let's get a all files
         const [list2] = await listFiles();
@@ -210,7 +219,12 @@ describe("Files CRUD test", () => {
             }
         }
 
-        await sleep(1000);
+        await until(
+            () => listFiles({ limit: testFiles.length }).then(([response]) => response),
+            ({ data }) =>
+                Array.isArray(data.fileManager.listFiles.data) &&
+                data.fileManager.listFiles.meta.totalCount === testFiles.length
+        );
 
         const inElastic = testFiles.reverse();
 

--- a/packages/api-file-manager/src/plugins/graphql.ts
+++ b/packages/api-file-manager/src/plugins/graphql.ts
@@ -209,7 +209,10 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
                     return resolve(() => context.fileManager.files.createFilesInBatch(args.data));
                 },
                 async deleteFile(_, args, context) {
-                    return resolve(() => context.fileManager.files.deleteFile(args.id));
+                    return resolve(async () => {
+                        const file = await context.fileManager.files.getFile(args.id);
+                        return context.fileManager.storage.delete({ id: file.id, key: file.key });
+                    });
                 },
                 async install(_, args, context) {
                     return resolve(() =>


### PR DESCRIPTION
Now deleting a file via File Manager will also delete it from storage i.e S3

Changes:
- Update tests to use `until` instead of `sleep`