### PR TITLE
Prerendering Service - Various Fixes (Preloading, Apollo Caching, Cache-Control Headers)

### DIFF
--- a/apps/website/code/src/plugins/linkPreload.ts
+++ b/apps/website/code/src/plugins/linkPreload.ts
@@ -5,6 +5,7 @@ import { GET_PUBLISHED_PAGE } from "../components/Page/graphql";
 declare global {
     interface Window {
         __PS_RENDER_ID__: string;
+        __PS_RENDER__: boolean;
     }
 }
 
@@ -15,7 +16,8 @@ export default (): ReactRouterOnLinkPlugin => {
         name: "react-router-on-link-pb",
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
-            if (process.env.REACT_APP_ENV !== "browser") {
+            // If the page is being pre-re, then we don't want to execute this functionality.
+            if (window.__PS_RENDER__) {
                 return;
             }
 

--- a/packages/api-prerendering-service/__tests__/render/handlers/render/linkPreloading.test.ts
+++ b/packages/api-prerendering-service/__tests__/render/handlers/render/linkPreloading.test.ts
@@ -1,0 +1,93 @@
+import render from "@webiny/api-prerendering-service/render/renderUrl";
+import prettier from "prettier";
+
+const BASE_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <title>Product A1</title>
+    <link href="/static/css/2.1edd21d9.chunk.css" rel="stylesheet" />
+    <link href="/static/css/main.30bba61e.chunk.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/static/js/2.d0c5c7a4.chunk.js"></script>
+    <script src="/static/js/main.e1199ebd.chunk.js"></script>
+  </body>
+</html>
+`;
+
+describe(`Link Preloading Test`, () => {
+    it("should insert preloading attributes to CSS/JS links", async () => {
+        const [[html], meta] = await render("https://some-url.com", {
+            configuration: {},
+            renderUrlFunction: () => {
+                return {
+                    content: BASE_HTML,
+                    meta: {}
+                };
+            }
+        });
+
+        const snapshot = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link as="style" rel="preload" href="/static/css/2.1edd21d9.chunk.css" />
+    <link as="style" rel="preload" href="/static/css/main.30bba61e.chunk.css" />
+    <link as="script" rel="preload" href="/static/js/2.d0c5c7a4.chunk.js" />
+    <link as="script" rel="preload" href="/static/js/main.e1199ebd.chunk.js" />
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <title>Product A1</title>
+    <link
+      data-link-preload=""
+      data-link-preload-type="markup"
+      href="/static/css/2.1edd21d9.chunk.css"
+      rel="stylesheet"
+    />
+    <link
+      data-link-preload=""
+      data-link-preload-type="markup"
+      href="/static/css/main.30bba61e.chunk.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <script>
+      window.__APOLLO_STATE__ = undefined;
+    </script>
+    <script>
+      window.__PS_RENDER_TS__ = "${meta.ts}";
+    </script>
+    <script>
+      window.__PS_RENDER_ID__ = "${meta.id}";
+    </script>
+    <script
+      data-link-preload=""
+      data-link-preload-type="markup"
+      src="/static/js/2.d0c5c7a4.chunk.js"
+    ></script>
+    <script
+      data-link-preload=""
+      data-link-preload-type="markup"
+      src="/static/js/main.e1199ebd.chunk.js"
+    ></script>
+  </body>
+</html>
+`;
+
+        expect(
+            prettier.format(html.body, {
+                parser: "html"
+            })
+        ).toEqual(snapshot);
+    });
+});

--- a/packages/api-prerendering-service/package.json
+++ b/packages/api-prerendering-service/package.json
@@ -25,6 +25,7 @@
     "pluralize": "^8.0.0",
     "posthtml": "^0.15.0",
     "posthtml-noopener": "^1.0.5",
+    "posthtml-plugin-link-preload": "^1.0.0",
     "shortid": "^2.2.16"
   },
   "devDependencies": {

--- a/packages/api-prerendering-service/src/render/renderUrl.ts
+++ b/packages/api-prerendering-service/src/render/renderUrl.ts
@@ -1,6 +1,7 @@
 import chromium from "chrome-aws-lambda";
 import posthtml from "posthtml";
 import { noopener } from "posthtml-noopener";
+import posthtmlPluginLinkPreload from "posthtml-plugin-link-preload";
 import injectApolloState from "./injectApolloState";
 import injectRenderId from "./injectRenderId";
 import injectRenderTs from "./injectRenderTs";
@@ -37,9 +38,24 @@ export default async (url: string, args: Args): Promise<[File[], Meta]> => {
     // TODO: should be plugins (will also eliminate lower @ts-ignore instructions).
     console.log("Processing HTML...");
 
+    // TODO: regular text processing plugins...
+
+    {
+        const regex = /<script (src="\/static\/js\/)/gm;
+        const subst = `<script data-link-preload data-link-preload-type="markup" src="/static/js/`;
+        render.content = render.content.replace(regex, subst);
+    }
+
+    {
+        const regex = /<link href="\/static\/css\//gm;
+        const subst = `<link data-link-preload data-link-preload-type="markup" href="/static/css/`;
+        render.content = render.content.replace(regex, subst);
+    }
+
     const allArgs = { render, args, url, id, ts };
     const { html } = await posthtml([
         noopener(),
+        posthtmlPluginLinkPreload(),
         // @ts-ignore
         injectRenderId(allArgs),
         // @ts-ignore

--- a/packages/api-prerendering-service/src/render/renderUrl.ts
+++ b/packages/api-prerendering-service/src/render/renderUrl.ts
@@ -160,7 +160,9 @@ export const defaultRenderUrlFunction = async (url: string, args: Args): Promise
             for (let i = 0; i < operations.length; i++) {
                 const { operationName, query, variables } = operations[i];
 
-                if (operationName === "PbGetPublishedPage") {
+                // TODO: Should be handled via a plugin.
+                const operationsAllowedToCached = ["PbGetPublishedPage", "PbListPublishedPages"];
+                if (operationsAllowedToCached.includes(operationName)) {
                     gqlCache.push({
                         query,
                         variables,

--- a/packages/app-page-builder/src/render/plugins/apolloCacheObjectId.ts
+++ b/packages/app-page-builder/src/render/plugins/apolloCacheObjectId.ts
@@ -5,7 +5,7 @@ interface PageBuilderObject extends Object {
 }
 
 export default new ApolloCacheObjectIdPlugin<PageBuilderObject>(obj => {
-    if (obj.__typename === "PbPage" || "PbPageListItem") {
+    if (obj.__typename === "PbPage" || obj.__typename === "PbPageListItem") {
         return obj.__typename + obj.id;
     }
 });

--- a/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
@@ -38,6 +38,7 @@ module.exports = async ({ path: root, bucket, onFileUploadSuccess, onFileUploadE
                                 Bucket: bucket,
                                 Key: key,
                                 ACL: "public-read",
+                                CacheControl: "max-age=31536000",
                                 ContentType: mime.getType(path) || undefined,
                                 Body: fs.readFileSync(path)
                             })

--- a/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
+++ b/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
@@ -5,6 +5,7 @@ import { GET_PUBLISHED_PAGE } from "../components/Page/graphql";
 declare global {
     interface Window {
         __PS_RENDER_ID__: string;
+        __PS_RENDER__: boolean;
     }
 }
 
@@ -15,7 +16,8 @@ export default (): ReactRouterOnLinkPlugin => {
         name: "react-router-on-link-pb",
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
-            if (process.env.REACT_APP_ENV !== "browser") {
+            // If the page is being pre-re, then we don't want to execute this functionality.
+            if (window.__PS_RENDER__) {
                 return;
             }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,6 +8746,7 @@ __metadata:
     pluralize: ^8.0.0
     posthtml: ^0.15.0
     posthtml-noopener: ^1.0.5
+    posthtml-plugin-link-preload: ^1.0.0
     prettier: ^1.14.2
     rimraf: ^3.0.2
     shortid: ^2.2.16
@@ -28915,6 +28916,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"posthtml-match-helper@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "posthtml-match-helper@npm:1.0.1"
+  peerDependencies:
+    posthtml: ">=0.5.0"
+  checksum: 943790e29fcc127c207b85da36adf6d901913fc13bd99c0a78c44d3aab9ca33285223ec51cc3aac3bebc978a05f0651a7e6f05d3569e6c0f1cc2f3fdc9e88757
+  languageName: node
+  linkType: hard
+
 "posthtml-noopener@npm:^1.0.5":
   version: 1.0.5
   resolution: "posthtml-noopener@npm:1.0.5"
@@ -28939,6 +28949,15 @@ fsevents@^1.2.7:
   dependencies:
     htmlparser2: ^6.0.0
   checksum: f2b855cd794fe86b119348e8a299cec0dcfdd7448545e059541546c7146b269212c15c0d4bc99090810c6b86db54026638e0432e2fa11d50933438d6a8cf89a4
+  languageName: node
+  linkType: hard
+
+"posthtml-plugin-link-preload@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "posthtml-plugin-link-preload@npm:1.0.0"
+  dependencies:
+    posthtml-match-helper: ^1.0.1
+  checksum: 9832de6f9784563a1a4da460c484a1d90f38a4ea340024e2e32154e4e645c42cdc12c44fc2670c8b0ef9d7222922a74011d59fb670dc2e913b398b2877327e7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR introduces several fixes and improvements to the prerendering service.

#### 1. Fix - Link Preloading

On an imaginary page, a menu that contains links to pages A, B, C, and D, should cause these pages to be automatically pulled, which means once a user clicks on one of these, the page should be immediately served to him/her. No delay between page navigation should be present.

This is the way it was supposed to work from the beginning, but there was a bug in the `react-router-on-link` (`apps/website/code/src/plugins/linkPreload.ts`) plugin, which caused this feature not to work correctly.

This works as expected now.

#### 2. Improvement - Preloading CSS/JS Files

Added preloading of CSS/JS files, so that these get immediately downloaded once the initial HTML has been received by the browser. Should speed up the page load.

Example HTML:
```
<link as="style" rel="preload" href="/static/css/main.30bba61e.chunk.css">
<link as="script" rel="preload" href="/static/js/2.d0c5c7a4.chunk.js">
```

#### 3. Fix - added missing cache-control header

Static files (JS/CSS) downloaded on the public website will now contain the `cache-control` header, which means browsers will cache files locally, instead of issuing HTTP requests each time. Should make loading of CSS/JS files instant.

#### 

## How Has This Been Tested?
Added Jest test that ensures preloading attributes were correctly appended to JS / CSS links.

## Documentation

None, internal fixes (might add this to changelog).