### PR TITLE
Fix Caching of Pages Lists Page Elements

### DIFF
--- a/apps/website/code/src/plugins/linkPreload.ts
+++ b/apps/website/code/src/plugins/linkPreload.ts
@@ -5,7 +5,6 @@ import { GET_PUBLISHED_PAGE } from "../components/Page/graphql";
 declare global {
     interface Window {
         __PS_RENDER_ID__: string;
-        __PS_RENDER__: boolean;
     }
 }
 
@@ -16,8 +15,8 @@ export default (): ReactRouterOnLinkPlugin => {
         name: "react-router-on-link-pb",
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
-            // If the page is being pre-re, then we don't want to execute this functionality.
-            if (window.__PS_RENDER__) {
+            // Only if we're serving a pre-rendered page, we want to activate this feature.
+            if (window.__PS_RENDER_ID__) {
                 return;
             }
 

--- a/apps/website/code/src/plugins/linkPreload.ts
+++ b/apps/website/code/src/plugins/linkPreload.ts
@@ -16,7 +16,7 @@ export default (): ReactRouterOnLinkPlugin => {
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
             // Only if we're serving a pre-rendered page, we want to activate this feature.
-            if (window.__PS_RENDER_ID__) {
+            if (!window.__PS_RENDER_ID__) {
                 return;
             }
 

--- a/apps/website/code/src/plugins/linkPreload.ts
+++ b/apps/website/code/src/plugins/linkPreload.ts
@@ -30,11 +30,7 @@ export default (): ReactRouterOnLinkPlugin => {
 
             preloadedPaths.push(path);
 
-            let graphqlJson = "graphql.json";
-            if (window.__PS_RENDER_ID__) {
-                graphqlJson += `?k=${window.__PS_RENDER_ID__}`;
-            }
-
+            const graphqlJson = `graphql.json?k=${window.__PS_RENDER_ID__}`;
             const fetchPath = path !== "/" ? `${path}/${graphqlJson}` : `/${graphqlJson}`;
             const pageState = await fetch(fetchPath)
                 .then(res => res.json())

--- a/packages/api-page-builder/src/graphql/crud/utils/getNormalizedListPagesArgs.ts
+++ b/packages/api-page-builder/src/graphql/crud/utils/getNormalizedListPagesArgs.ts
@@ -1,5 +1,6 @@
 import { ListPagesParams, PbContext } from "../../types";
 import { ElasticsearchBoolQueryConfig } from "@webiny/api-elasticsearch/types";
+import trimEnd from "lodash/trimEnd";
 
 /**
  * Returns arguments suited to be sent to ElasticSearch's `search` method.
@@ -77,7 +78,8 @@ const getQuery = (args: ListPagesParams, context: PbContext): ElasticsearchBoolQ
         exclude.forEach(item => {
             // Page "path" will always starts with a slash.
             if (item.includes("/")) {
-                paths.push(item);
+                // Let's also ensure the trailing slash is removed.
+                paths.push(trimEnd(item, "/"));
             } else {
                 pageIds.push(item);
             }

--- a/packages/api-prerendering-service/src/render/renderUrl.ts
+++ b/packages/api-prerendering-service/src/render/renderUrl.ts
@@ -177,7 +177,7 @@ export const defaultRenderUrlFunction = async (url: string, args: Args): Promise
                 const { operationName, query, variables } = operations[i];
 
                 // TODO: Should be handled via a plugin.
-                const operationsAllowedToCached = ["PbGetPublishedPage", "PbListPublishedPages"];
+                const operationsAllowedToCached = ["PbGetPublishedPage", "PbPageListResponse"];
                 if (operationsAllowedToCached.includes(operationName)) {
                     gqlCache.push({
                         query,

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
@@ -4,7 +4,9 @@ import { useQuery } from "@apollo/react-hooks";
 import { usePageBuilder } from "../../../../hooks/usePageBuilder";
 import { LIST_PUBLISHED_PAGES } from "./graphql";
 import { plugins } from "@webiny/plugins";
-import { get } from "lodash";
+import get from "lodash/get";
+import trimEnd from "lodash/trimEnd";
+
 import { PbPageElementPagesListComponentPlugin } from "../../../../types";
 
 declare global {
@@ -48,6 +50,9 @@ const PagesListRender = props => {
         sort = { [vars.sortBy]: vars.sortDirection };
     }
 
+    // Lets ensure the trailing "/" is removed.
+    const path = trimEnd(location.pathname, "/");
+
     const variables = {
         sort,
         where: {
@@ -63,7 +68,7 @@ const PagesListRender = props => {
          * When rendering page preview inside admin app there will be no page path/slug present in URL.
          * In that case we'll use the extracted page id from URL.
          */
-        exclude: [pageId ? pageId : location.pathname]
+        exclude: [pageId ? pageId : path]
     };
 
     const { data, loading } = useQuery(LIST_PUBLISHED_PAGES, {

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
@@ -73,8 +73,7 @@ const PagesListRender = props => {
 
     const { data, loading } = useQuery(LIST_PUBLISHED_PAGES, {
         variables,
-        skip: !ListComponent,
-        fetchPolicy: "network-only"
+        skip: !ListComponent
     });
 
     if (!ListComponent) {

--- a/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
+++ b/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
@@ -5,7 +5,6 @@ import { GET_PUBLISHED_PAGE } from "../components/Page/graphql";
 declare global {
     interface Window {
         __PS_RENDER_ID__: string;
-        __PS_RENDER__: boolean;
     }
 }
 
@@ -16,8 +15,8 @@ export default (): ReactRouterOnLinkPlugin => {
         name: "react-router-on-link-pb",
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
-            // If the page is being pre-re, then we don't want to execute this functionality.
-            if (window.__PS_RENDER__) {
+            // Only if we're serving a pre-rendered page, we want to activate this feature.
+            if (window.__PS_RENDER_ID__) {
                 return;
             }
 

--- a/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
+++ b/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
@@ -16,7 +16,7 @@ export default (): ReactRouterOnLinkPlugin => {
         type: "react-router-on-link",
         async onLink({ link: path, apolloClient }) {
             // Only if we're serving a pre-rendered page, we want to activate this feature.
-            if (window.__PS_RENDER_ID__) {
+            if (!window.__PS_RENDER_ID__) {
                 return;
             }
 

--- a/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
+++ b/packages/cwp-template-aws/template/apps/website/code/src/plugins/linkPreload.ts
@@ -30,11 +30,7 @@ export default (): ReactRouterOnLinkPlugin => {
 
             preloadedPaths.push(path);
 
-            let graphqlJson = "graphql.json";
-            if (window.__PS_RENDER_ID__) {
-                graphqlJson += `?k=${window.__PS_RENDER_ID__}`;
-            }
-
+            const graphqlJson = `graphql.json?k=${window.__PS_RENDER_ID__}`;
             const fetchPath = path !== "/" ? `${path}/${graphqlJson}` : `/${graphqlJson}`;
             const pageState = await fetch(fetchPath)
                 .then(res => res.json())


### PR DESCRIPTION
## Changes

This PR fixes a couple of issues related to the PB's "Pages List" page element.

The first issue was the `fetchPolicy: "network-only"` property that was assigned to the `listPublishedPages` query, executed within the Pages List page element. This would prevent the Apollo from accessing its cache, and once we'd visit the actual static page, we'd always have the data fetched from the API, when in fact the data was already present in Apollo's cache.

The second fix is related to the trailing slash, which would get appended while accessing static pages (gets appended by CF/S3 combo automatically, we can do nothing about that). This would introduce errors in the Apollo cache, because in it, we'd have a value without trailing slash, and then while the page is being served, Apollo client would receive it, which means Apollo cannot pull the value from its cache.

We've ensured that the trailing slash is always removed, and now, finally, page loading / pulling from cache works correctly.

Finally, the prerendering service would only cache `PbGetPublishedPage` operations, which means results received in the Pages List page elements would not be cached. We've added `PbPageListResponse` to the list of the operations we want to cache, and now the these results are properly cached.

## How Has This Been Tested?
Manual.

## Documentation
None (internal fixes).