### PR TITLE
fix: upgrade webiny error url

### DIFF
--- a/packages/api-upgrade/__tests__/upgrade.test.ts
+++ b/packages/api-upgrade/__tests__/upgrade.test.ts
@@ -43,7 +43,7 @@ describe("api upgrade", () => {
             })
         ).toThrowError(
             new Error(
-                `Skipping of upgrades is not allowed: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny`
+                `Skipping of upgrades is not allowed: https://www.webiny.com/docs/how-to-guides/upgrade-webiny/overview/`
             )
         );
     });

--- a/packages/api-upgrade/src/index.ts
+++ b/packages/api-upgrade/src/index.ts
@@ -51,7 +51,7 @@ export function getApplicablePlugin(args: RunUpgradeArgs): UpgradePlugin {
 
     if (upgrades.length > 0) {
         throw new Error(
-            `Skipping of upgrades is not allowed: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny`,
+            `Skipping of upgrades is not allowed: https://www.webiny.com/docs/how-to-guides/upgrade-webiny/overview/`,
             "SKIPPING_UPGRADES_NOT_ALLOWED",
             {
                 deployedVersion: deployedVersion,


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Upgrade URL was not accessible, URL fixed
Closes #ISSUE_NUMBER
![image](https://user-images.githubusercontent.com/24965764/124377295-b434ec00-dcc4-11eb-9bd1-a654d532417e.png)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
