### PR TITLE
fix(api-headless-cms): get published entry revision from referenced field

### DIFF
--- a/packages/api-headless-cms-ddb/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/entry.ts
@@ -1,0 +1,78 @@
+import { Table, Entity } from "dynamodb-toolbox";
+
+interface Params {
+    table: Table;
+}
+
+const entityName = "ContentEntry";
+
+export const createEntryEntity = ({ table }: Params) => {
+    return new Entity({
+        name: entityName,
+        table,
+        attributes: {
+            PK: {
+                type: "string",
+                partitionKey: true
+            },
+            SK: {
+                type: "string",
+                sortKey: true
+            },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
+            TYPE: {
+                type: "string"
+            },
+            webinyVersion: {
+                type: "string"
+            },
+            tenant: {
+                type: "string"
+            },
+            entryId: {
+                type: "string"
+            },
+            id: {
+                type: "string"
+            },
+            createdBy: {
+                type: "map"
+            },
+            ownedBy: {
+                type: "map"
+            },
+            createdOn: {
+                type: "string"
+            },
+            savedOn: {
+                type: "string"
+            },
+            modelId: {
+                type: "string"
+            },
+            locale: {
+                type: "string"
+            },
+            publishedOn: {
+                type: "string"
+            },
+            version: {
+                type: "number"
+            },
+            locked: {
+                type: "boolean"
+            },
+            status: {
+                type: "string"
+            },
+            values: {
+                type: "map"
+            }
+        }
+    });
+};

--- a/packages/api-headless-cms-ddb/src/definitions/table.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/table.ts
@@ -1,0 +1,26 @@
+import { CmsContext } from "@webiny/api-headless-cms/types";
+import { Table } from "dynamodb-toolbox";
+import configurations from "~/configurations";
+import { getDocumentClient, getTable } from "~/operations/helpers";
+
+interface IndexParams {
+    partitionKey: string;
+    sortKey: string;
+}
+
+interface Params {
+    context: CmsContext;
+    indexes: {
+        [key: string]: IndexParams;
+    };
+}
+
+export const createTable = ({ context, indexes }: Params) => {
+    return new Table({
+        name: configurations.db().table || getTable(context),
+        partitionKey: "PK",
+        sortKey: "SK",
+        DocumentClient: getDocumentClient(context),
+        indexes
+    });
+};

--- a/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
@@ -20,18 +20,14 @@ import {
     CmsContext,
     CONTENT_ENTRY_STATUS
 } from "@webiny/api-headless-cms/types";
-import configurations from "../../configurations";
 import { zeroPad } from "@webiny/api-headless-cms/utils";
-import {
-    createBasePartitionKey,
-    decodePaginationCursor,
-    encodePaginationCursor
-} from "../../utils";
+import { createBasePartitionKey, decodePaginationCursor, encodePaginationCursor } from "~/utils";
 import { Entity, Table } from "dynamodb-toolbox";
-import { getDocumentClient, getTable } from "../helpers";
 import { filterItems, buildModelFields, sortEntryItems } from "./utils";
 import { queryOptions as DynamoDBToolboxQueryOptions } from "dynamodb-toolbox/dist/classes/Table";
 import lodashCloneDeep from "lodash.clonedeep";
+import { createEntryEntity } from "~/definitions/entry";
+import { createTable } from "~/definitions/table";
 
 export const TYPE_ENTRY = "cms.entry";
 export const TYPE_ENTRY_LATEST = TYPE_ENTRY + ".l";
@@ -103,11 +99,8 @@ export class CmsContentEntryDynamo implements CmsContentEntryStorageOperations {
         this._modelPartitionKey = `${this._partitionKey}#M`;
         this._dataLoaders = new DataLoadersHandler(context, this);
 
-        this._table = new Table({
-            name: configurations.db().table || getTable(context),
-            partitionKey: "PK",
-            sortKey: "SK",
-            DocumentClient: getDocumentClient(context),
+        this._table = createTable({
+            context,
             indexes: {
                 [GSI1_INDEX]: {
                     partitionKey: "GSI1_PK",
@@ -116,73 +109,8 @@ export class CmsContentEntryDynamo implements CmsContentEntryStorageOperations {
             }
         });
 
-        this._entity = new Entity({
-            name: "ContentEntry",
-            table: this._table,
-            attributes: {
-                PK: {
-                    type: "string",
-                    partitionKey: true
-                },
-                SK: {
-                    type: "string",
-                    sortKey: true
-                },
-                GSI1_PK: {
-                    type: "string"
-                },
-                GSI1_SK: {
-                    type: "string"
-                },
-                TYPE: {
-                    type: "string"
-                },
-                webinyVersion: {
-                    type: "string"
-                },
-                tenant: {
-                    type: "string"
-                },
-                entryId: {
-                    type: "string"
-                },
-                id: {
-                    type: "string"
-                },
-                createdBy: {
-                    type: "map"
-                },
-                ownedBy: {
-                    type: "map"
-                },
-                createdOn: {
-                    type: "string"
-                },
-                savedOn: {
-                    type: "string"
-                },
-                modelId: {
-                    type: "string"
-                },
-                locale: {
-                    type: "string"
-                },
-                publishedOn: {
-                    type: "string"
-                },
-                version: {
-                    type: "number"
-                },
-                locked: {
-                    type: "boolean"
-                },
-                status: {
-                    type: "string"
-                },
-                values: {
-                    type: "map"
-                }
-            }
+        this._entity = createEntryEntity({
+            table: this._table
         });
     }
 
@@ -1002,17 +930,6 @@ export class CmsContentEntryDynamo implements CmsContentEntryStorageOperations {
     public getSortKeyRevision(version: string | number) {
         if (typeof version === "string" && version.includes("#") === true) {
             version = version.split("#").pop();
-        }
-        return `REV#${zeroPad(version)}`;
-    }
-    
-    public getSortKeyFromId(id: string): string | null {
-        if (!id) {
-            return null;
-        }
-        const [, version] = id.split("#");
-        if (!version) {
-            return null;
         }
         return `REV#${zeroPad(version)}`;
     }

--- a/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/CmsContentEntryDynamo.ts
@@ -1005,6 +1005,17 @@ export class CmsContentEntryDynamo implements CmsContentEntryStorageOperations {
         }
         return `REV#${zeroPad(version)}`;
     }
+    
+    public getSortKeyFromId(id: string): string | null {
+        if (!id) {
+            return null;
+        }
+        const [, version] = id.split("#");
+        if (!version) {
+            return null;
+        }
+        return `REV#${zeroPad(version)}`;
+    }
 
     public getSortKeyLatest(): string {
         return "L";

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -1,6 +1,6 @@
 import { useFruitManageHandler } from "../utils/useFruitManageHandler";
 import { useContentGqlHandler } from "../utils/useContentGqlHandler";
-import { CmsContentModelGroup } from "../../src/types";
+import { CmsContentModelGroup } from "~/types";
 import models from "./mocks/contentModels";
 import { useFruitReadHandler } from "../utils/useFruitReadHandler";
 import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
@@ -55,6 +55,74 @@ const bananaData = {
     dateTime: new Date("2020-12-03T12:12:21").toISOString(),
     dateTimeZ: "2020-12-03T14:52:41+01:00",
     time: "11:59:01"
+};
+
+const createCategoryItem = async({manager, from = null, publish, data}) => {
+    const [response] = await (from ? manager.createCategoryFrom({revision: from.id,}) : manager.createCategory({data,}));
+    const category = from ? response?.data?.createCategoryFrom?.data : response?.data?.createCategory?.data;
+    const error = from ? response?.data?.createCategoryFrom?.error : response?.data?.createCategory?.error;
+    if (!category?.id || error) {
+        console.log(error.message);
+        console.log(JSON.stringify(error.data));
+        throw new Error("Could not create category.");
+    }
+    if (from){
+        const [updateResponse] = await manager.updateCategory({
+            revision: category.id,
+            data,
+        });
+        const updatedCategory = updateResponse?.data?.updateCategory?.data;
+        const updatedError = updateResponse?.data?.updateCategory?.error;
+        if (!updatedCategory?.id || updatedError) {
+            console.log(updatedError.message);
+            throw new Error("Could not update category.");
+        }
+    }
+    if (!publish) {
+        return category;
+    }
+    const [publishResponse] = await manager.publishCategory({
+        revision: category.id,
+    });
+    if (!publishResponse?.data?.publishCategory?.data?.id) {
+        console.log(publishResponse?.data?.publishCategory?.error?.message);
+        throw new Error("Could not publish category.");
+    }
+    return publishResponse.data.publishCategory.data;
+};
+
+const createArticleItem = async({manager, from = null, publish, data}) => {
+    const [response] = await (from ? manager.createArticleFrom({revision: from.id,}) : manager.createArticle({data,}));
+    const article = from ? response?.data?.createArticleFrom?.data : response?.data?.createArticle?.data;
+    const error = from ? response?.data?.createArticleFrom?.error : response?.data?.createArticle?.error;
+    if (!article?.id || error) {
+        console.log(error.message);
+        console.log(JSON.stringify(error.data));
+        throw new Error("Could not create article.");
+    }
+    if (from){
+        const [updateResponse] = await manager.updateArticle({
+            revision: article.id,
+            data,
+        });
+        const updatedArticle = updateResponse?.data?.updateArticle?.data;
+        const updatedError = updateResponse?.data?.updateArticle?.error;
+        if (!updatedArticle?.id || updatedError) {
+            console.log(updatedError.message);
+            throw new Error("Could not update article.");
+        }
+    }
+    if (!publish) {
+        return article;
+    }
+    const [publishResponse] = await manager.publishArticle({
+        revision: article.id,
+    });
+    if (!publishResponse?.data?.publishArticle?.data?.id) {
+        console.log(publishResponse?.data?.publishArticle?.error?.message);
+        throw new Error("Could not publish article.");
+    }
+    return publishResponse.data.publishArticle.data;
 };
 
 describe("filtering", () => {
@@ -1746,5 +1814,119 @@ describe("filtering", () => {
                 }
             }
         });
+    });
+    
+    it("should get all revisions", async() => {
+        const group = await setupContentModelGroup();
+        await setupContentModel(group, "category");
+        await setupContentModel(group, "article");
+        
+        const categoryManager = useCategoryManageHandler(manageOpts);
+        const articleManager = useArticleManageHandler(manageOpts);
+        const articleRead = useArticleReadHandler(readOpts);
+        
+        
+        const techCategory = await createCategoryItem({
+            manager: categoryManager,
+            data: {
+                title: "Tech category",
+                slug: "tech-category",
+            },
+            publish: true,
+        });
+        
+        const techArticle = await createArticleItem({
+            manager: articleManager,
+            data: {
+                title: "Tech article",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory.id,
+                        modelId: "category",
+                    }
+                ]
+            },
+            publish: true,
+        });
+        const techCategory2 = await createCategoryItem({
+            manager: categoryManager,
+            from: techCategory,
+            data: {
+                title: "Tech category 2",
+                slug: "tech-category-2",
+            },
+            publish: true,
+        });
+        
+        const techArticle2 = await createArticleItem({
+            manager: articleManager,
+            // from: techArticle,
+            data: {
+                title: "Tech article 2",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory2.id,
+                        modelId: "category",
+                    }
+                ]
+            },
+            publish: true,
+        });
+    
+        const techCategory3 = await createCategoryItem({
+            manager: categoryManager,
+            from: techCategory2,
+            data: {
+                title: "Tech category 3",
+                slug: "tech-category-3",
+            },
+            publish: true,
+        });
+        
+        const techArticle3 = await createArticleItem({
+            manager: articleManager,
+            // from: techArticle2,
+            data: {
+                title: "Tech article 3",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory3.id,
+                        modelId: "category",
+                    }
+                ]
+            },
+            publish: true,
+        });
+    
+        // /**
+        //  * Make sure we have all articles published.
+        //  */
+        // await until(
+        //     () => articleManager.listArticles().then(([data]) => data),
+        //     ({ data }) => {
+        //         const entries = data?.listArticles?.data || [];
+        //         if (entries.length !== 3) {
+        //             return false;
+        //         }
+        //         return entries.every(entry => {
+        //             return !!entry.meta.publishedOn;
+        //         });
+        //     },
+        //     { name: "list all published articles", tries: 10 }
+        // );
+        
+        const [readListResponse] = await articleRead.listArticles({});
+        
+        expect(readListResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [],
+                    error: null,
+                }
+            }
+        })
     });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -1828,7 +1828,7 @@ describe("filtering", () => {
         });
     });
 
-    it("should get all revisions", async () => {
+    it("should get published referenced entry revisions", async () => {
         const group = await setupContentModelGroup();
         await setupContentModel(group, "category");
         await setupContentModel(group, "article");

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -57,19 +57,25 @@ const bananaData = {
     time: "11:59:01"
 };
 
-const createCategoryItem = async({manager, from = null, publish, data}) => {
-    const [response] = await (from ? manager.createCategoryFrom({revision: from.id,}) : manager.createCategory({data,}));
-    const category = from ? response?.data?.createCategoryFrom?.data : response?.data?.createCategory?.data;
-    const error = from ? response?.data?.createCategoryFrom?.error : response?.data?.createCategory?.error;
+const createCategoryItem = async ({ manager, from = null, publish, data }) => {
+    const [response] = await (from
+        ? manager.createCategoryFrom({ revision: from.id })
+        : manager.createCategory({ data }));
+    const category = from
+        ? response?.data?.createCategoryFrom?.data
+        : response?.data?.createCategory?.data;
+    const error = from
+        ? response?.data?.createCategoryFrom?.error
+        : response?.data?.createCategory?.error;
     if (!category?.id || error) {
         console.log(error.message);
         console.log(JSON.stringify(error.data));
         throw new Error("Could not create category.");
     }
-    if (from){
+    if (from) {
         const [updateResponse] = await manager.updateCategory({
             revision: category.id,
-            data,
+            data
         });
         const updatedCategory = updateResponse?.data?.updateCategory?.data;
         const updatedError = updateResponse?.data?.updateCategory?.error;
@@ -82,7 +88,7 @@ const createCategoryItem = async({manager, from = null, publish, data}) => {
         return category;
     }
     const [publishResponse] = await manager.publishCategory({
-        revision: category.id,
+        revision: category.id
     });
     if (!publishResponse?.data?.publishCategory?.data?.id) {
         console.log(publishResponse?.data?.publishCategory?.error?.message);
@@ -91,19 +97,25 @@ const createCategoryItem = async({manager, from = null, publish, data}) => {
     return publishResponse.data.publishCategory.data;
 };
 
-const createArticleItem = async({manager, from = null, publish, data}) => {
-    const [response] = await (from ? manager.createArticleFrom({revision: from.id,}) : manager.createArticle({data,}));
-    const article = from ? response?.data?.createArticleFrom?.data : response?.data?.createArticle?.data;
-    const error = from ? response?.data?.createArticleFrom?.error : response?.data?.createArticle?.error;
+const createArticleItem = async ({ manager, from = null, publish, data }) => {
+    const [response] = await (from
+        ? manager.createArticleFrom({ revision: from.id })
+        : manager.createArticle({ data }));
+    const article = from
+        ? response?.data?.createArticleFrom?.data
+        : response?.data?.createArticle?.data;
+    const error = from
+        ? response?.data?.createArticleFrom?.error
+        : response?.data?.createArticle?.error;
     if (!article?.id || error) {
         console.log(error.message);
         console.log(JSON.stringify(error.data));
         throw new Error("Could not create article.");
     }
-    if (from){
+    if (from) {
         const [updateResponse] = await manager.updateArticle({
             revision: article.id,
-            data,
+            data
         });
         const updatedArticle = updateResponse?.data?.updateArticle?.data;
         const updatedError = updateResponse?.data?.updateArticle?.error;
@@ -116,7 +128,7 @@ const createArticleItem = async({manager, from = null, publish, data}) => {
         return article;
     }
     const [publishResponse] = await manager.publishArticle({
-        revision: article.id,
+        revision: article.id
     });
     if (!publishResponse?.data?.publishArticle?.data?.id) {
         console.log(publishResponse?.data?.publishArticle?.error?.message);
@@ -1815,26 +1827,25 @@ describe("filtering", () => {
             }
         });
     });
-    
-    it("should get all revisions", async() => {
+
+    it("should get all revisions", async () => {
         const group = await setupContentModelGroup();
         await setupContentModel(group, "category");
         await setupContentModel(group, "article");
-        
+
         const categoryManager = useCategoryManageHandler(manageOpts);
         const articleManager = useArticleManageHandler(manageOpts);
         const articleRead = useArticleReadHandler(readOpts);
-        
-        
+
         const techCategory = await createCategoryItem({
             manager: categoryManager,
             data: {
                 title: "Tech category",
-                slug: "tech-category",
+                slug: "tech-category"
             },
-            publish: true,
+            publish: true
         });
-        
+
         const techArticle = await createArticleItem({
             manager: articleManager,
             data: {
@@ -1843,22 +1854,22 @@ describe("filtering", () => {
                 categories: [
                     {
                         entryId: techCategory.id,
-                        modelId: "category",
+                        modelId: "category"
                     }
                 ]
             },
-            publish: true,
+            publish: true
         });
         const techCategory2 = await createCategoryItem({
             manager: categoryManager,
             from: techCategory,
             data: {
                 title: "Tech category 2",
-                slug: "tech-category-2",
+                slug: "tech-category-2"
             },
-            publish: true,
+            publish: true
         });
-        
+
         const techArticle2 = await createArticleItem({
             manager: articleManager,
             // from: techArticle,
@@ -1868,23 +1879,23 @@ describe("filtering", () => {
                 categories: [
                     {
                         entryId: techCategory2.id,
-                        modelId: "category",
+                        modelId: "category"
                     }
                 ]
             },
-            publish: true,
+            publish: true
         });
-    
+
         const techCategory3 = await createCategoryItem({
             manager: categoryManager,
             from: techCategory2,
             data: {
                 title: "Tech category 3",
-                slug: "tech-category-3",
+                slug: "tech-category-3"
             },
-            publish: true,
+            publish: true
         });
-        
+
         const techArticle3 = await createArticleItem({
             manager: articleManager,
             // from: techArticle2,
@@ -1894,39 +1905,71 @@ describe("filtering", () => {
                 categories: [
                     {
                         entryId: techCategory3.id,
-                        modelId: "category",
+                        modelId: "category"
                     }
                 ]
             },
-            publish: true,
+            publish: true
         });
-    
-        // /**
-        //  * Make sure we have all articles published.
-        //  */
-        // await until(
-        //     () => articleManager.listArticles().then(([data]) => data),
-        //     ({ data }) => {
-        //         const entries = data?.listArticles?.data || [];
-        //         if (entries.length !== 3) {
-        //             return false;
-        //         }
-        //         return entries.every(entry => {
-        //             return !!entry.meta.publishedOn;
-        //         });
-        //     },
-        //     { name: "list all published articles", tries: 10 }
-        // );
-        
-        const [readListResponse] = await articleRead.listArticles({});
-        
+
+        /**
+         * Make sure we have all articles published.
+         */
+        await until(
+            () => articleManager.listArticles().then(([data]) => data),
+            ({ data }) => {
+                const entries = data?.listArticles?.data || [];
+                if (entries.length !== 3) {
+                    return false;
+                }
+                return entries.every(entry => {
+                    return !!entry.meta.publishedOn;
+                });
+            },
+            { name: "list all published articles", tries: 10 }
+        );
+
+        const [readListResponse] = await articleRead.listArticles({
+            sort: ["createdOn_DESC"]
+        });
+        /**
+         * We need only certain values from the article data when created.
+         */
+        const extractReadArticle = (item: Record<string, any>): Record<string, any> => {
+            return {
+                id: item.id,
+                entryId: item.entryId,
+                createdOn: item.createdOn,
+                savedOn: item.savedOn,
+                createdBy: item.createdBy,
+                ownedBy: item.ownedBy,
+                title: item.title,
+                body: item.body,
+                categories: [
+                    {
+                        id: techCategory3.id,
+                        title: techCategory3.title
+                    }
+                ]
+            };
+        };
+
         expect(readListResponse).toEqual({
             data: {
                 listArticles: {
-                    data: [],
+                    data: [
+                        extractReadArticle(techArticle3),
+                        extractReadArticle(techArticle2),
+                        extractReadArticle(techArticle)
+                    ],
                     error: null,
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 3
+                    }
                 }
             }
-        })
+        });
     });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -1,0 +1,237 @@
+import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
+import { useArticleManageHandler } from "../utils/useArticleManageHandler";
+import { useArticleReadHandler } from "../utils/useArticleReadHandler";
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+import { setupContentModelGroup, setupContentModels } from "../utils/setup";
+import { until } from "../utils/helpers";
+
+const createCategoryItem = async ({ manager, from = null, publish, data }) => {
+    const [response] = await (from
+        ? manager.createCategoryFrom({ revision: from.id })
+        : manager.createCategory({ data }));
+    const category = from
+        ? response?.data?.createCategoryFrom?.data
+        : response?.data?.createCategory?.data;
+    const error = from
+        ? response?.data?.createCategoryFrom?.error
+        : response?.data?.createCategory?.error;
+    if (!category?.id || error) {
+        console.log(error.message);
+        console.log(JSON.stringify(error.data));
+        throw new Error("Could not create category.");
+    }
+    if (from) {
+        const [updateResponse] = await manager.updateCategory({
+            revision: category.id,
+            data
+        });
+        const updatedCategory = updateResponse?.data?.updateCategory?.data;
+        const updatedError = updateResponse?.data?.updateCategory?.error;
+        if (!updatedCategory?.id || updatedError) {
+            console.log(updatedError.message);
+            throw new Error("Could not update category.");
+        }
+    }
+    if (!publish) {
+        return category;
+    }
+    const [publishResponse] = await manager.publishCategory({
+        revision: category.id
+    });
+    if (!publishResponse?.data?.publishCategory?.data?.id) {
+        console.log(publishResponse?.data?.publishCategory?.error?.message);
+        throw new Error("Could not publish category.");
+    }
+    return publishResponse.data.publishCategory.data;
+};
+
+const createArticleItem = async ({ manager, from = null, publish, data }) => {
+    const [response] = await (from
+        ? manager.createArticleFrom({ revision: from.id })
+        : manager.createArticle({ data }));
+    const article = from
+        ? response?.data?.createArticleFrom?.data
+        : response?.data?.createArticle?.data;
+    const error = from
+        ? response?.data?.createArticleFrom?.error
+        : response?.data?.createArticle?.error;
+    if (!article?.id || error) {
+        console.log(error.message);
+        console.log(JSON.stringify(error.data));
+        throw new Error("Could not create article.");
+    }
+    if (from) {
+        const [updateResponse] = await manager.updateArticle({
+            revision: article.id,
+            data
+        });
+        const updatedArticle = updateResponse?.data?.updateArticle?.data;
+        const updatedError = updateResponse?.data?.updateArticle?.error;
+        if (!updatedArticle?.id || updatedError) {
+            console.log(updatedError.message);
+            throw new Error("Could not update article.");
+        }
+    }
+    if (!publish) {
+        return article;
+    }
+    const [publishResponse] = await manager.publishArticle({
+        revision: article.id
+    });
+    if (!publishResponse?.data?.publishArticle?.data?.id) {
+        console.log(publishResponse?.data?.publishArticle?.error?.message);
+        throw new Error("Could not publish article.");
+    }
+    return publishResponse.data.publishArticle.data;
+};
+
+describe("references", () => {
+    const manageOpts = { path: "manage/en-US" };
+    const readOpts = { path: "read/en-US" };
+
+    const mainManager = useContentGqlHandler(manageOpts);
+
+    it("should get the published references on entries", async () => {
+        const group = await setupContentModelGroup(mainManager);
+        await setupContentModels(mainManager, group, ["category", "article"]);
+
+        const categoryManager = useCategoryManageHandler(manageOpts);
+        const articleManager = useArticleManageHandler(manageOpts);
+        const articleRead = useArticleReadHandler(readOpts);
+
+        const techCategory = await createCategoryItem({
+            manager: categoryManager,
+            data: {
+                title: "Tech category",
+                slug: "tech-category"
+            },
+            publish: true
+        });
+
+        const techArticle = await createArticleItem({
+            manager: articleManager,
+            data: {
+                title: "Tech article",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory.id,
+                        modelId: "category"
+                    }
+                ]
+            },
+            publish: true
+        });
+        const techCategory2 = await createCategoryItem({
+            manager: categoryManager,
+            from: techCategory,
+            data: {
+                title: "Tech category 2",
+                slug: "tech-category-2"
+            },
+            publish: true
+        });
+
+        const techArticle2 = await createArticleItem({
+            manager: articleManager,
+            // from: techArticle,
+            data: {
+                title: "Tech article 2",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory2.id,
+                        modelId: "category"
+                    }
+                ]
+            },
+            publish: true
+        });
+
+        const techCategory3 = await createCategoryItem({
+            manager: categoryManager,
+            from: techCategory2,
+            data: {
+                title: "Tech category 3",
+                slug: "tech-category-3"
+            },
+            publish: true
+        });
+
+        const techArticle3 = await createArticleItem({
+            manager: articleManager,
+            // from: techArticle2,
+            data: {
+                title: "Tech article 3",
+                body: null,
+                categories: [
+                    {
+                        entryId: techCategory3.id,
+                        modelId: "category"
+                    }
+                ]
+            },
+            publish: true
+        });
+
+        /**
+         * Make sure we have all articles published.
+         */
+        await until(
+            () => articleManager.listArticles().then(([data]) => data),
+            ({ data }) => {
+                const entries = data?.listArticles?.data || [];
+                if (entries.length !== 3) {
+                    return false;
+                }
+                return entries.every(entry => {
+                    return !!entry.meta.publishedOn;
+                });
+            },
+            { name: "list all published articles", tries: 10 }
+        );
+
+        const [readListResponse] = await articleRead.listArticles({
+            sort: ["createdOn_DESC"]
+        });
+        /**
+         * We need only certain values from the article data when created.
+         */
+        const extractReadArticle = (item: Record<string, any>): Record<string, any> => {
+            return {
+                id: item.id,
+                entryId: item.entryId,
+                createdOn: item.createdOn,
+                savedOn: item.savedOn,
+                createdBy: item.createdBy,
+                ownedBy: item.ownedBy,
+                title: item.title,
+                body: item.body,
+                categories: [
+                    {
+                        id: techCategory3.id,
+                        title: techCategory3.title
+                    }
+                ]
+            };
+        };
+
+        expect(readListResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [
+                        extractReadArticle(techArticle3),
+                        extractReadArticle(techArticle2),
+                        extractReadArticle(techArticle)
+                    ],
+                    error: null,
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 3
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -85,7 +85,7 @@ const createArticleItem = async ({ manager, from = null, publish, data }) => {
     return publishResponse.data.publishArticle.data;
 };
 
-describe("references", () => {
+describe("entry references", () => {
     const manageOpts = { path: "manage/en-US" };
     const readOpts = { path: "read/en-US" };
 
@@ -215,7 +215,9 @@ describe("references", () => {
                 ]
             };
         };
-
+        /**
+         * All the articles must have last published revision of the category.
+         */
         expect(readListResponse).toEqual({
             data: {
                 listArticles: {
@@ -230,6 +232,48 @@ describe("references", () => {
                         hasMoreItems: false,
                         totalCount: 3
                     }
+                }
+            }
+        });
+        /**
+         * First article is expected to have the published revision of the category when loading a single article
+         */
+        const [readArticleResponse] = await articleRead.getArticle({
+            where: {
+                id: techArticle.id
+            }
+        });
+        expect(readArticleResponse).toEqual({
+            data: {
+                getArticle: {
+                    data: extractReadArticle(techArticle),
+                    error: null
+                }
+            }
+        });
+        /**
+         * When loading the article via manage API it must have the assigned revision of the category.
+         */
+        const [readArticleManageResponse] = await articleManager.getArticle({
+            revision: techArticle.id
+        });
+
+        expect(readArticleManageResponse).toEqual({
+            data: {
+                getArticle: {
+                    data: {
+                        ...techArticle,
+                        /**
+                         * This is to prove that category in the loaded article really is the first one created and assigned to the article.
+                         */
+                        categories: [
+                            {
+                                entryId: techCategory.id,
+                                modelId: techCategory.meta.modelId
+                            }
+                        ]
+                    },
+                    error: null
                 }
             }
         });

--- a/packages/api-headless-cms/__tests__/utils/setup.ts
+++ b/packages/api-headless-cms/__tests__/utils/setup.ts
@@ -1,0 +1,84 @@
+import { CmsContentModelGroup } from "~/types";
+import models from "../contentAPI/mocks/contentModels";
+
+export const setupContentModelGroup = async (manager: any): Promise<CmsContentModelGroup> => {
+    const [response] = await manager.createContentModelGroupMutation({
+        data: {
+            name: "Group",
+            slug: "group",
+            icon: "ico/ico",
+            description: "description"
+        }
+    });
+    const error = response?.data?.createContentModelGroup?.error || response?.errors?.shift();
+    if (error) {
+        console.log("[setupContentModelGroup] could not create group");
+        console.log(error.message);
+        process.exit(1);
+    }
+    return response.data.createContentModelGroup.data;
+};
+
+const setupContentModel = async (
+    manager: any,
+    contentModelGroup: CmsContentModelGroup,
+    name: string
+) => {
+    const model = models.find(m => m.modelId === name);
+    if (!model) {
+        console.log(`[setupContentModel] There is no model "${name}" defined.`);
+        process.exit(1);
+    }
+    const [createResponse] = await manager.createContentModelMutation({
+        data: {
+            name: model.name,
+            modelId: model.modelId,
+            group: contentModelGroup.id
+        }
+    });
+
+    if (createResponse.errors) {
+        console.error(`[setupContentModel] ${createResponse.errors[0].message}`);
+        process.exit(1);
+    } else if (createResponse.data.createContentModel.data.error) {
+        console.error(
+            `[setupContentModel] ${createResponse.data.createContentModel.data.error.message}`
+        );
+        process.exit(1);
+    }
+
+    const [updateResponse] = await manager.updateContentModelMutation({
+        modelId: createResponse.data.createContentModel.data.modelId,
+        data: {
+            fields: model.fields,
+            layout: model.layout
+        }
+    });
+    if (updateResponse.errors) {
+        console.error(`[setupContentModel] ${updateResponse.errors[0].message}`);
+        process.exit(1);
+    } else if (updateResponse.data.updateContentModel.data.error) {
+        console.error(
+            `[setupContentModel] ${updateResponse.data.updateContentModel.data.error.message}`
+        );
+        process.exit(1);
+    }
+    return updateResponse.data.updateContentModel.data;
+};
+export const setupContentModels = async (
+    manager: any,
+    contentModelGroup: CmsContentModelGroup,
+    modelsList: string[]
+): Promise<Record<string, any>> => {
+    const items = modelsList.reduce((acc, m) => {
+        acc[m] = null;
+        return acc;
+    }, {});
+    for (const name in items) {
+        if (items.hasOwnProperty(name) === false) {
+            continue;
+        }
+        items[name] = await setupContentModel(manager, contentModelGroup, name);
+    }
+    return items;
+};


### PR DESCRIPTION
## Changes
Closes #1704

When using read api, referenced entry will always be the published one, no matter which version is actually referenced.

## How Has This Been Tested?
Jest tests and manual testing.
