### PR TITLE
fix: Form builder field validators, ref-1771

### DIFF
--- a/apps/website/code/src/plugins/formBuilder.ts
+++ b/apps/website/code/src/plugins/formBuilder.ts
@@ -1,29 +1,29 @@
-// import formsRedirectTrigger from "@webiny/app-form-builder/site/plugins/triggers/redirect";
-// import formValidatorGte from "@webiny/app-form-builder/site/plugins/validators/gte";
-// import formValidatorIn from "@webiny/app-form-builder/site/plugins/validators/in";
-// import formValidatorLte from "@webiny/app-form-builder/site/plugins/validators/lte";
-// import formValidatorMaxLength from "@webiny/app-form-builder/site/plugins/validators/maxLength";
-// import formValidatorMinLength from "@webiny/app-form-builder/site/plugins/validators/minLength";
-// import formValidatorPattern from "@webiny/app-form-builder/site/plugins/validators/pattern";
-// import formValidatorRequired from "@webiny/app-form-builder/site/plugins/validators/required";
-// import formValidatorUpperCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/upperCase";
-// import formValidatorLowerCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/lowerCase";
-// import formValidatorEmail from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/email";
-// import formValidatorUrl from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/url";
+import formsRedirectTrigger from "@webiny/app-form-builder/site/plugins/triggers/redirect";
+import formValidatorGte from "@webiny/app-form-builder/site/plugins/validators/gte";
+import formValidatorIn from "@webiny/app-form-builder/site/plugins/validators/in";
+import formValidatorLte from "@webiny/app-form-builder/site/plugins/validators/lte";
+import formValidatorMaxLength from "@webiny/app-form-builder/site/plugins/validators/maxLength";
+import formValidatorMinLength from "@webiny/app-form-builder/site/plugins/validators/minLength";
+import formValidatorPattern from "@webiny/app-form-builder/site/plugins/validators/pattern";
+import formValidatorRequired from "@webiny/app-form-builder/site/plugins/validators/required";
+import formValidatorUpperCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/upperCase";
+import formValidatorLowerCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/lowerCase";
+import formValidatorEmail from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/email";
+import formValidatorUrl from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/url";
 import formElement from "@webiny/app-form-builder/page-builder/render/plugins/formElement";
 
 export default [
-    // formsRedirectTrigger,
-    // formValidatorGte,
-    // formValidatorIn,
-    // formValidatorLte,
-    // formValidatorMaxLength,
-    // formValidatorMinLength,
-    // formValidatorPattern,
-    // formValidatorRequired,
-    // formValidatorUpperCase,
-    // formValidatorLowerCase,
-    // formValidatorEmail,
-    // formValidatorUrl,
+    formsRedirectTrigger,
+    formValidatorGte,
+    formValidatorIn,
+    formValidatorLte,
+    formValidatorMaxLength,
+    formValidatorMinLength,
+    formValidatorPattern,
+    formValidatorRequired,
+    formValidatorUpperCase,
+    formValidatorLowerCase,
+    formValidatorEmail,
+    formValidatorUrl,
     formElement
 ];

--- a/packages/app-form-builder/tsconfig.json
+++ b/packages/app-form-builder/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../app-admin"
     },
     {
+      "path": "../app-form-builder"
+    },
+    {
       "path": "../app-page-builder"
     },
     {
@@ -38,6 +41,8 @@
       "@webiny/app": ["../app/src"],
       "@webiny/app-admin/*": ["../app-admin/src/*"],
       "@webiny/app-admin": ["../app-admin/src"],
+      "@webiny/app-form-builder/*": ["../app-form-builder/src/*"],
+      "@webiny/app-form-builder": ["../app-form-builder/src"],
       "@webiny/app-page-builder/*": ["../app-page-builder/src/*"],
       "@webiny/app-page-builder": ["../app-page-builder/src"],
       "@webiny/app-plugin-admin-welcome-screen/*": ["../app-plugin-admin-welcome-screen/src/*"],

--- a/packages/cwp-template-aws/template/apps/website/code/src/plugins/formBuilder.ts
+++ b/packages/cwp-template-aws/template/apps/website/code/src/plugins/formBuilder.ts
@@ -1,29 +1,29 @@
-// import formsRedirectTrigger from "@webiny/app-form-builder/site/plugins/triggers/redirect";
-// import formValidatorGte from "@webiny/app-form-builder/site/plugins/validators/gte";
-// import formValidatorIn from "@webiny/app-form-builder/site/plugins/validators/in";
-// import formValidatorLte from "@webiny/app-form-builder/site/plugins/validators/lte";
-// import formValidatorMaxLength from "@webiny/app-form-builder/site/plugins/validators/maxLength";
-// import formValidatorMinLength from "@webiny/app-form-builder/site/plugins/validators/minLength";
-// import formValidatorPattern from "@webiny/app-form-builder/site/plugins/validators/pattern";
-// import formValidatorRequired from "@webiny/app-form-builder/site/plugins/validators/required";
-// import formValidatorUpperCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/upperCase";
-// import formValidatorLowerCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/lowerCase";
-// import formValidatorEmail from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/email";
-// import formValidatorUrl from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/url";
+import formsRedirectTrigger from "@webiny/app-form-builder/site/plugins/triggers/redirect";
+import formValidatorGte from "@webiny/app-form-builder/site/plugins/validators/gte";
+import formValidatorIn from "@webiny/app-form-builder/site/plugins/validators/in";
+import formValidatorLte from "@webiny/app-form-builder/site/plugins/validators/lte";
+import formValidatorMaxLength from "@webiny/app-form-builder/site/plugins/validators/maxLength";
+import formValidatorMinLength from "@webiny/app-form-builder/site/plugins/validators/minLength";
+import formValidatorPattern from "@webiny/app-form-builder/site/plugins/validators/pattern";
+import formValidatorRequired from "@webiny/app-form-builder/site/plugins/validators/required";
+import formValidatorUpperCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/upperCase";
+import formValidatorLowerCase from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/lowerCase";
+import formValidatorEmail from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/email";
+import formValidatorUrl from "@webiny/app-form-builder/site/plugins/validators/patternPlugins/url";
 import formElement from "@webiny/app-form-builder/page-builder/render/plugins/formElement";
 
 export default [
-    // formsRedirectTrigger,
-    // formValidatorGte,
-    // formValidatorIn,
-    // formValidatorLte,
-    // formValidatorMaxLength,
-    // formValidatorMinLength,
-    // formValidatorPattern,
-    // formValidatorRequired,
-    // formValidatorUpperCase,
-    // formValidatorLowerCase,
-    // formValidatorEmail,
-    // formValidatorUrl,
+    formsRedirectTrigger,
+    formValidatorGte,
+    formValidatorIn,
+    formValidatorLte,
+    formValidatorMaxLength,
+    formValidatorMinLength,
+    formValidatorPattern,
+    formValidatorRequired,
+    formValidatorUpperCase,
+    formValidatorLowerCase,
+    formValidatorEmail,
+    formValidatorUrl,
     formElement
 ];


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #1771 

##Solution
The form validators were not working because their paths were missing on the tsconfig.json. I added the paths, uncommented the code in the file and corresponding file in cwp-template-aws

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
