### PR TITLE
Enable GraphQL Schema Extension

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/extendingGqlSchema.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/extendingGqlSchema.test.ts
@@ -1,0 +1,48 @@
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins";
+
+const graphqlSchemaPlugin = new GraphQLSchemaPlugin({
+    typeDefs: /* GraphQL */ `
+        extend type Query {
+            getOne: Int
+            getFifty: Int
+            getHundred: Int
+        }
+    `,
+    resolvers: {
+        Query: {
+            getOne: () => {
+                return 1;
+            },
+            getFifty: () => {
+                return 50;
+            },
+            getHundred: () => {
+                return 100;
+            }
+        }
+    }
+});
+
+describe("content model test no field plugin", () => {
+    test("prevent content model update if a backend plugin for a field does not exist", async () => {
+        const { invoke } = useContentGqlHandler(
+            {
+                path: "manage/en-US"
+            },
+            [graphqlSchemaPlugin]
+        );
+
+        expect(
+            await invoke({
+                body: { query: `{ getOne getFifty getHundred }` }
+            }).then(([data]) => data)
+        ).toEqual({
+            data: {
+                getOne: 1,
+                getFifty: 50,
+                getHundred: 100
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -8,6 +8,7 @@ import { PluginCollection } from "@webiny/plugins/types";
 import debugPlugins from "@webiny/handler-graphql/debugPlugins";
 import processRequestBody from "@webiny/handler-graphql/processRequestBody";
 import buildSchemaPlugins from "./plugins/buildSchemaPlugins";
+import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins";
 
 interface CreateGraphQLHandlerOptions {
     debug?: boolean;
@@ -52,12 +53,13 @@ const generateCacheKey = async (args: Args): Promise<string> => {
 const generateSchema = async (args: Args): Promise<GraphQLSchema> => {
     const { context } = args;
 
-    const schemaPlugins = await buildSchemaPlugins(context);
+    context.plugins.register(await buildSchemaPlugins(context));
 
     const typeDefs = [];
     const resolvers = [];
 
     // Get schema definitions from plugins
+    const schemaPlugins = context.plugins.byType<GraphQLSchemaPlugin>(GraphQLSchemaPlugin.type);
     for (const pl of schemaPlugins) {
         typeDefs.push(pl.schema.typeDefs);
         resolvers.push(pl.schema.resolvers);
@@ -68,6 +70,7 @@ const generateSchema = async (args: Args): Promise<GraphQLSchema> => {
         resolvers
     });
 };
+
 // gets an existing schema or rewrites existing one or creates a completely new one
 // depending on the schemaId created from type and locale parameters
 const getSchema = async (args: Args): Promise<GraphQLSchema> => {


### PR DESCRIPTION
## Changes
Right now, users aren't able to expand the Headless CMS GraphQL API with the `GraphQLSchemaPlugin`. This PR fixes this.

## How Has This Been Tested?
Jest.

## Documentation

Not at this moment.