### PR TITLE
fix(api-headless-cms): error when referenced entry is deleted

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/CmsContentEntryDynamoElastic.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/CmsContentEntryDynamoElastic.ts
@@ -1217,6 +1217,13 @@ export default class CmsContentEntryDynamoElastic implements CmsContentEntryStor
             }
         );
         /**
+         * When there are no lower versions from the given one, it seems that random one is taken.
+         * So just make sure that fetched entry version is not greater or equal to requested one.
+         */
+        if (!entry || entry.version >= version) {
+            return null;
+        }
+        /**
          * We need this due to possibly getting latest or published if given revision does not exist
          */
         if ((entry as any).TYPE !== TYPE_ENTRY) {

--- a/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
@@ -183,6 +183,7 @@ describe("latest entries", function() {
                         createdBy: expect.any(Object),
                         ownedBy: expect.any(Object),
                         savedOn: expect.any(String),
+                        category: null,
                         meta: {
                             title,
                             modelId: articleModel.modelId,
@@ -248,6 +249,7 @@ describe("latest entries", function() {
                             createdBy: article.createdBy,
                             ownedBy: article.ownedBy,
                             savedOn: article.savedOn,
+                            category: null,
                             title,
                             body,
                             categories: [
@@ -346,6 +348,7 @@ describe("latest entries", function() {
                             createdBy: article.createdBy,
                             ownedBy: article.ownedBy,
                             savedOn: article.savedOn,
+                            category: null,
                             title,
                             body,
                             categories: [

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -1,6 +1,6 @@
 import shortId from "shortid";
 import contentModelGroup from "./contentModelGroup";
-import { CmsContentModel } from "../../../src/types";
+import { CmsContentModel } from "~/types";
 
 const ids = {
     // product category
@@ -45,7 +45,8 @@ const ids = {
     // article
     field701: shortId.generate(),
     field702: shortId.generate(),
-    field703: shortId.generate()
+    field703: shortId.generate(),
+    field704: shortId.generate()
 };
 
 const models: CmsContentModel[] = [
@@ -1146,7 +1147,7 @@ const models: CmsContentModel[] = [
             id: contentModelGroup.id,
             name: contentModelGroup.name
         },
-        layout: [[ids.field701, ids.field702, ids.field703]],
+        layout: [[ids.field701, ids.field702, ids.field703, ids.field704]],
         fields: [
             {
                 id: ids.field701,
@@ -1194,6 +1195,27 @@ const models: CmsContentModel[] = [
                 validation: [],
                 listValidation: [],
                 placeholderText: "Categories",
+                predefinedValues: {
+                    enabled: false,
+                    values: []
+                },
+                renderer: {
+                    name: "renderer"
+                },
+                settings: {
+                    models: [{ modelId: "category" }]
+                }
+            },
+            {
+                id: ids.field704,
+                multipleValues: false,
+                helpText: "",
+                label: "Category",
+                type: "ref",
+                fieldId: "category",
+                validation: [],
+                listValidation: [],
+                placeholderText: "Category",
                 predefinedValues: {
                     enabled: false,
                     values: []

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -437,20 +437,45 @@ describe("entry references", () => {
             },
             { name: "list all categories after delete", tries: 10 }
         );
-    
+
+        const [listAfterDeleteManageResponse] = await articleManager.listArticles();
+        expect(listAfterDeleteManageResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [techArticle],
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 1
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [getAfterDeleteManageResponse] = await articleManager.getArticle({
+            revision: techArticle.id
+        });
+        expect(getAfterDeleteManageResponse).toEqual({
+            data: {
+                getArticle: {
+                    data: techArticle,
+                    error: null
+                }
+            }
+        });
+
         const [listAfterDeleteReadResponse] = await articleRead.listArticles();
         expect(listAfterDeleteReadResponse).toEqual({
             data: {
                 listArticles: {
-                    data: [
-                        extractReadArticle(techArticle),
-                    ],
+                    data: [extractReadArticle(techArticle)],
                     meta: {
                         cursor: null,
                         hasMoreItems: false,
-                        totalCount: 1,
+                        totalCount: 1
                     },
-                    error: null,
+                    error: null
                 }
             }
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -108,7 +108,13 @@ const extractReadArticle = (
                       title: category.title
                   }
               ]
-            : []
+            : [],
+        category: category
+            ? {
+                  id: category.id,
+                  title: category.title
+              }
+            : null
     };
 };
 
@@ -140,6 +146,10 @@ describe("entry references", () => {
             data: {
                 title: "Tech article",
                 body: null,
+                category: {
+                    entryId: techCategory.id,
+                    modelId: "category"
+                },
                 categories: [
                     {
                         entryId: techCategory.id,
@@ -165,6 +175,10 @@ describe("entry references", () => {
             data: {
                 title: "Tech article 2",
                 body: null,
+                category: {
+                    entryId: techCategory2.id,
+                    modelId: "category"
+                },
                 categories: [
                     {
                         entryId: techCategory2.id,
@@ -191,6 +205,10 @@ describe("entry references", () => {
             data: {
                 title: "Tech article 3",
                 body: null,
+                category: {
+                    entryId: techCategory3.id,
+                    modelId: "category"
+                },
                 categories: [
                     {
                         entryId: techCategory3.id,
@@ -310,6 +328,10 @@ describe("entry references", () => {
             data: {
                 title: "Tech article",
                 body: null,
+                category: {
+                    entryId: techCategory.id,
+                    modelId: "category"
+                },
                 categories: [
                     {
                         entryId: techCategory.id,

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -437,6 +437,23 @@ describe("entry references", () => {
             },
             { name: "list all categories after delete", tries: 10 }
         );
+    
+        const [listAfterDeleteReadResponse] = await articleRead.listArticles();
+        expect(listAfterDeleteReadResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [
+                        extractReadArticle(techArticle),
+                    ],
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 1,
+                    },
+                    error: null,
+                }
+            }
+        });
 
         const [getAfterDeleteReadResponse] = await articleRead.getArticle({
             where: {

--- a/packages/api-headless-cms/__tests__/utils/useArticleManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useArticleManageHandler.ts
@@ -35,6 +35,10 @@ const fields = `
         modelId
         entryId
     }
+    category {
+        modelId
+        entryId
+    }
 `;
 
 const errorFields = `

--- a/packages/api-headless-cms/__tests__/utils/useArticleReadHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useArticleReadHandler.ts
@@ -22,6 +22,10 @@ const fields = `
         id
         title
     }
+    category {
+        id
+        title
+    }
 `;
 
 const errorFields = `

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -91,7 +91,12 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                       await model.getPublishedByIds([value.entryId])
                     : // `preview` API works with `latest` data
                       await model.getLatestByIds([value.entryId]);
-
+                /**
+                 * If there are no revisions we must return null.
+                 */
+                if (!revisions || revisions.length === 0) {
+                    return null;
+                }
                 return { ...revisions[0], __typename: modelIdToTypeName.get(value.modelId) };
             };
         },

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/commonFieldResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/commonFieldResolvers.ts
@@ -1,4 +1,4 @@
-import { CmsContentEntry } from "../../../../types";
+import { CmsContentEntry } from "~/types";
 
 export const commonFieldResolvers = () => ({
     id: (entry: CmsContentEntry) => entry.id || null,


### PR DESCRIPTION
## Changes
A fix where previous entry is not actually previous version of the given entry.

## How Has This Been Tested?
Jest tests and manual testing.

## Documentation


## Test
Steps to verify that deleting the referenced entry does not break the API response.

1. create category
2. create article with category
3. create new revision of the category
4. delete first revision of the category
5. [manage api] verify that listArticles is returning the article
6. [manage api] verify that getArticle is returning the article
7. [read api] verify that listArticles is returning the article with last category revision
8. [read api] verify that getArticle is returning the article with last category revision 
9. delete category
10. verify that there are no categories in the database
11. [manage api] verify that listArticles is not breaking - it also has category referenced because it is a field
12. [manage api] verify that getArticle is not breaking - it also has category referenced because it is a field
13. [read api] verify that listArticles is not breaking - it does not have category referenced
14. [read api] verify that getArticle is not breaking - it does not have category referenced