### PR TITLE
Increase Execution Timeout for GraphQL API Lambda Function

### DIFF
--- a/api/pulumi/dev/graphql.ts
+++ b/api/pulumi/dev/graphql.ts
@@ -64,7 +64,7 @@ class Graphql {
                 runtime: "nodejs12.x",
                 handler: "handler.handler",
                 role: this.role.arn,
-                timeout: 30,
+                timeout: 60,
                 memorySize: 512,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")

--- a/api/pulumi/prod/graphql.ts
+++ b/api/pulumi/prod/graphql.ts
@@ -66,7 +66,7 @@ class Graphql {
                 runtime: "nodejs12.x",
                 handler: "handler.handler",
                 role: this.role.arn,
-                timeout: 30,
+                timeout: 60,
                 memorySize: 512,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")

--- a/packages/cwp-template-aws/template/api/pulumi/dev/graphql.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/graphql.ts
@@ -33,7 +33,7 @@ class Graphql {
                 runtime: "nodejs12.x",
                 handler: "handler.handler",
                 role: this.role.arn,
-                timeout: 30,
+                timeout: 60,
                 memorySize: 512,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")

--- a/packages/cwp-template-aws/template/api/pulumi/prod/graphql.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/graphql.ts
@@ -34,7 +34,7 @@ class Graphql {
                 runtime: "nodejs12.x",
                 handler: "handler.handler",
                 role: this.role.arn,
-                timeout: 30,
+                timeout: 60,
                 memorySize: 512,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")


### PR DESCRIPTION
## Changes
We are increasing the default timeout value for the GraphQL API Lambda function from 30sec to 60sec.

This is mainly because in the installation process, an installation step may take more than 30secs, and then users receive an error, ending being not able to finish the install process.

This is a fix that it takes the least amount of time, and ideally, we should probably take some time and improve the installation wizard altogether. But for now, this will suffice.

## How Has This Been Tested?
Manual.

## Documentation
N/A