### PR TITLE
fix(api-headless-cms): context loading

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
@@ -1,0 +1,31 @@
+import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
+
+jest.setTimeout(15000);
+
+describe("HTTP Options request", () => {
+    const manageOpts = { path: "manage/en-US" };
+
+    test(`http options`, async () => {
+        const { invoke } = useCategoryManageHandler(manageOpts);
+
+        const response = await invoke({
+            httpMethod: "OPTIONS",
+            body: undefined
+        });
+
+        expect(response).toEqual([
+            null,
+            {
+                body: "",
+                headers: {
+                    "Access-Control-Allow-Headers": "*",
+                    "Access-Control-Allow-Methods": "OPTIONS,POST",
+                    "Access-Control-Allow-Origin": "*",
+                    "Content-Type": "application/json"
+                },
+                isBase64Encoded: undefined,
+                statusCode: 204
+            }
+        ]);
+    });
+});

--- a/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
@@ -71,6 +71,7 @@ export const useGqlHandler = (args?: GQLHandlerCallableArgs) => {
                             return {
                                 id: apiKey,
                                 name: apiKey,
+                                tenant: tenant.id,
                                 permissions: identity.permissions || [],
                                 token,
                                 createdBy: {
@@ -141,18 +142,6 @@ export const useGqlHandler = (args?: GQLHandlerCallableArgs) => {
                     return createIdentity(identity);
                 }
             },
-            {
-                type: "context",
-                apply(context) {
-                    context.cms = {
-                        ...(context.cms || {}),
-                        getLocale: () => ({
-                            code: "en-US"
-                        }),
-                        locale: "en-US"
-                    };
-                }
-            },
             //
             plugins
         ],
@@ -166,6 +155,9 @@ export const useGqlHandler = (args?: GQLHandlerCallableArgs) => {
             body: JSON.stringify(body),
             ...rest
         });
+        if (httpMethod === "OPTIONS" && !response.body) {
+            return [null, response];
+        }
         // The first element is the response body, and the second is the raw response.
         return [JSON.parse(response.body), response];
     };

--- a/packages/api-headless-cms/src/content/contextSetup.ts
+++ b/packages/api-headless-cms/src/content/contextSetup.ts
@@ -2,22 +2,13 @@ import { CmsContext } from "~/types";
 import WebinyError from "@webiny/error";
 import { ContextPlugin } from "@webiny/handler/plugins/ContextPlugin";
 
-interface CmsHttpParameters {
-    type: string;
-    locale: string;
-}
-
-const throwPlainError = (type: string): void => {
-    throw new Error(`Missing context.http.request.path parameter "${type}".`);
-};
-
-const extractHandlerHttpParameters = (context: CmsContext): CmsHttpParameters => {
-    const { key = "" } = context.http.request.path.parameters || {};
+const extractHandlerHttpParameters = (context: CmsContext) => {
+    const { key = "" } = context.http?.request?.path?.parameters || {};
     const [type, locale] = key.split("/");
     if (!type) {
-        throwPlainError("type");
+        throw new WebinyError(`Missing context.http.request.path parameter "type".`);
     } else if (!locale) {
-        throwPlainError("locale");
+        throw new WebinyError(`Missing context.http.request.path parameter "locale".`);
     }
 
     return {
@@ -28,11 +19,11 @@ const extractHandlerHttpParameters = (context: CmsContext): CmsHttpParameters =>
 
 export default () => {
     return new ContextPlugin<CmsContext>(async context => {
-        if (context.http.request.method === "OPTIONS") {
+        if (context.http?.request?.method === "OPTIONS") {
             return;
         } else if (context.cms) {
             throw new WebinyError(
-                "Context setup plugin must be first to run. Cannot have anything before it.",
+                "Context setup plugin must be first to be registered. Cannot have anything before it.",
                 "CMS_CONTEXT_INITIALIZED_ERROR"
             );
         }

--- a/packages/api-headless-cms/src/content/index.ts
+++ b/packages/api-headless-cms/src/content/index.ts
@@ -17,9 +17,9 @@ interface CmsContentPluginsIndexArgs {
 }
 
 export default (options: CmsContentPluginsIndexArgs = {}) => [
+    contextSetup(),
     modelManager(),
     pluginsCrudSetup(),
-    contextSetup(),
     contentModelGroupCrud(),
     contentModelCrud(),
     contentEntry(),

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -117,7 +117,13 @@ export default (): ContextPlugin<CmsContext> => ({
     type: "context",
     name: "context-content-model-entry",
     async apply(context) {
-        const { security } = context;
+        /**
+         * If cms is not defined on the context, do not continue, but log it.
+         */
+        if (!context.cms) {
+            console.log("Missing cms on context. Skipping ContentEntry crud.");
+            return;
+        }
 
         const pluginType = "cms-content-entry-storage-operations-provider";
         const providerPlugins = context.plugins.byType<CmsContentEntryStorageOperationsProvider>(
@@ -314,7 +320,7 @@ export default (): ContextPlugin<CmsContext> => ({
 
                 await validateModelEntryData(context, model, input);
 
-                const identity = security.getIdentity();
+                const identity = context.security.getIdentity();
                 const locale = context.cms.getLocale();
 
                 const owner = {
@@ -429,7 +435,7 @@ export default (): ContextPlugin<CmsContext> => ({
                     latestStorageEntry
                 );
 
-                const identity = security.getIdentity();
+                const identity = context.security.getIdentity();
 
                 const latestId = latestStorageEntry ? latestStorageEntry.id : sourceId;
                 const { id, version: nextVersion } = increaseEntryIdVersion(latestId);

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -31,6 +31,14 @@ export default (): ContextPlugin<CmsContext> => ({
     type: "context",
     name: "context-content-model-storageOperations",
     async apply(context) {
+        /**
+         * If cms is not defined on the context, do not continue, but log it.
+         */
+        if (!context.cms) {
+            console.log("Missing cms on context. Skipping ContentModel crud.");
+            return;
+        }
+
         const pluginType = "cms-content-model-storage-operations-provider";
         const providerPlugins = context.plugins.byType<CmsContentModelStorageOperationsProvider>(
             pluginType

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
@@ -37,6 +37,13 @@ const UpdateContentModelGroupModel = withFields({
 export default (): ContextPlugin<CmsContext> => ({
     type: "context",
     async apply(context) {
+        /**
+         * If cms is not defined on the context, do not continue, but log it.
+         */
+        if (!context.cms) {
+            console.log("Missing cms on context. Skipping ContentModelGroup crud.");
+            return;
+        }
         const pluginType = "cms-content-model-group-storage-operations-provider";
         const providerPlugins = context.plugins.byType<
             CmsContentModelGroupStorageOperationsProvider

--- a/packages/api-headless-cms/src/content/plugins/modelManager/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelManager/index.ts
@@ -1,4 +1,4 @@
-import { ContentModelManagerPlugin } from "../../../types";
+import { ContentModelManagerPlugin } from "~/types";
 import { DefaultContentModelManager } from "./DefaultContentModelManager";
 
 const plugin: ContentModelManagerPlugin = {

--- a/packages/api-headless-cms/src/plugins/crud/settings.crud.ts
+++ b/packages/api-headless-cms/src/plugins/crud/settings.crud.ts
@@ -6,13 +6,20 @@ import {
     CmsSettingsPermission,
     CmsSettings,
     CmsSettingsStorageOperationsProviderPlugin
-} from "../../types";
+} from "~/types";
 import WebinyError from "@webiny/error";
 
 export default {
     type: "context",
     name: "context-settings-crud",
     apply: async context => {
+        /**
+         * If cms is not defined on the context, do not continue, but log it.
+         */
+        if (!context.cms) {
+            console.log("Missing cms on context. Skipping Settings crud.");
+            return;
+        }
         const pluginType = "cms-settings-storage-operations-provider";
         const providerPlugins = context.plugins.byType<CmsSettingsStorageOperationsProviderPlugin>(
             pluginType

--- a/packages/api-headless-cms/src/plugins/crud/system.crud.ts
+++ b/packages/api-headless-cms/src/plugins/crud/system.crud.ts
@@ -16,7 +16,13 @@ const initialContentModelGroup = {
 };
 
 export default new ContextPlugin<CmsContext>(async context => {
-    const { tenancy } = context;
+    /**
+     * If cms is not defined on the context, do not continue, but log it.
+     */
+    if (!context.cms) {
+        console.log("Missing cms on context. Skipping System crud.");
+        return;
+    }
 
     const pluginType = "cms-system-storage-operations-provider";
     const providerPlugins = context.plugins.byType<CmsSystemStorageOperationsProviderPlugin>(
@@ -41,7 +47,7 @@ export default new ContextPlugin<CmsContext>(async context => {
         ...context.cms,
         system: {
             async getVersion() {
-                if (!tenancy.getCurrentTenant()) {
+                if (!context.tenancy.getCurrentTenant()) {
                     return null;
                 }
 


### PR DESCRIPTION
## Changes
When context is loading on the request, it was not stopped if request was http OPTIONS one.
I added check in each of the cruds so they do not load if not necessary.

Test for http options request was added to check if everything is ok now. This test could be added to other applications as well.

Also:
Closes #1635 

## How Has This Been Tested?
Jest and manual testing.
