### PR TITLE
feat: compress the data that goes into es ddb table

### DIFF
--- a/api/code/dynamoToElastic/src/index.ts
+++ b/api/code/dynamoToElastic/src/index.ts
@@ -4,9 +4,11 @@ import dynamoDBToElastic from "@webiny/api-dynamodb-to-elasticsearch/handler";
 import logsPlugins from "@webiny/handler-logs";
 import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
-export const handler = createHandler(
-    logsPlugins(),
-    elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
-    elasticsearchDataGzipCompression(),
-    dynamoDBToElastic()
-);
+export const handler = createHandler({
+    plugins: [
+        logsPlugins(),
+        elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
+        elasticsearchDataGzipCompression(),
+        dynamoDBToElastic()
+    ]
+});

--- a/api/code/dynamoToElastic/src/index.ts
+++ b/api/code/dynamoToElastic/src/index.ts
@@ -2,9 +2,11 @@ import { createHandler } from "@webiny/handler-aws";
 import elasticSearch from "@webiny/api-elasticsearch";
 import dynamoDBToElastic from "@webiny/api-dynamodb-to-elasticsearch/handler";
 import logsPlugins from "@webiny/handler-logs";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
 export const handler = createHandler(
     logsPlugins(),
     elasticSearch({ endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}` }),
+    elasticsearchDataGzipCompression(),
     dynamoDBToElastic()
 );

--- a/api/code/dynamoToElastic/tsconfig.json
+++ b/api/code/dynamoToElastic/tsconfig.json
@@ -1,11 +1,34 @@
 {
   "extends": "../../../tsconfig",
   "references": [
-    { "path": "../../../packages/handler-aws" },
-    { "path": "../../../packages/handler-logs" },
+    {
+      "path": "../../../packages/handler-aws"
+    },
+    {
+      "path": "../../../packages/handler-logs"
+    },
     {
       "path": "../../../packages/api-elasticsearch"
     },
-    { "path": "../../../packages/api-dynamodb-to-elasticsearch" }
-  ]
+    {
+      "path": "../../../packages/api-dynamodb-to-elasticsearch"
+    }
+  ],
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./src/*"],
+      "@webiny/api-i18n/*": ["../../../packages/api-i18n/src/*"],
+      "@webiny/api-i18n": ["../../../packages/api-i18n/src"],
+      "@webiny/handler-aws/*": ["../../../packages/handler-aws/src/*"],
+      "@webiny/handler-aws": ["../../../packages/handler-aws/src"],
+      "@webiny/handler-logs/*": ["../../../packages/handler-logs/src/*"],
+      "@webiny/handler-logs": ["../../../packages/handler-logs/src"],
+      "@webiny/api-dynamodb-to-elasticsearch/*": [
+        "../../../packages/api-dynamodb-to-elasticsearch/src/*"
+      ],
+      "@webiny/api-dynamodb-to-elasticsearch": [
+        "../../../packages/api-dynamodb-to-elasticsearch/src"
+      ]
+    }
+  }
 }

--- a/api/code/graphql/src/index.ts
+++ b/api/code/graphql/src/index.ts
@@ -20,6 +20,7 @@ import formBuilderPlugins from "@webiny/api-form-builder/plugins";
 import securityPlugins from "./security";
 import headlessCmsPlugins from "@webiny/api-headless-cms/plugins";
 import headlessCmsDynamoDbElasticStorageOperation from "@webiny/api-headless-cms-ddb-es";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
 // Imports plugins created via scaffolding utilities.
 import scaffoldsPlugins from "./plugins/scaffolds";
@@ -65,7 +66,8 @@ export const handler = createHandler({
         formBuilderPlugins(),
         headlessCmsPlugins(),
         headlessCmsDynamoDbElasticStorageOperation(),
-        scaffoldsPlugins()
+        scaffoldsPlugins(),
+        elasticsearchDataGzipCompression()
     ],
     http: { debug }
 });

--- a/api/code/headlessCMS/src/index.ts
+++ b/api/code/headlessCMS/src/index.ts
@@ -12,6 +12,7 @@ import headlessCmsDynamoDbElasticStorageOperation from "@webiny/api-headless-cms
 import securityPlugins from "./security";
 import logsPlugins from "@webiny/handler-logs";
 import securityAdminUsersDynamoDbStorageOperations from "@webiny/api-security-admin-users-so-ddb";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
 // Imports plugins created via scaffolding utilities.
 import scaffoldsPlugins from "./plugins/scaffolds";
@@ -39,7 +40,8 @@ export const handler = createHandler({
         headlessCmsPlugins({ debug }),
         headlessCmsDynamoDbElasticStorageOperation(),
         scaffoldsPlugins(),
-        securityAdminUsersDynamoDbStorageOperations()
+        securityAdminUsersDynamoDbStorageOperations(),
+        elasticsearchDataGzipCompression()
     ],
     http: { debug }
 });

--- a/api/code/pageBuilder/updateSettings/tsconfig.json
+++ b/api/code/pageBuilder/updateSettings/tsconfig.json
@@ -7,5 +7,22 @@
     { "path": "../../../../packages/handler-logs" },
     { "path": "../../../../packages/handler-db" },
     { "path": "../../../../packages/db-dynamodb" }
-  ]
+  ],
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./src/*"],
+      "@webiny/handler-aws/*": ["../../../packages/handler-aws/src/*"],
+      "@webiny/handler-aws": ["../../../packages/handler-aws/src"],
+      "@webiny/api-page-builder/*": ["../../../packages/api-page-builder/src/*"],
+      "@webiny/api-page-builder": ["../../../packages/api-page-builder/src"],
+      "@webiny/api-i18n/*": ["../../../packages/api-i18n/src/*"],
+      "@webiny/api-i18n": ["../../../packages/api-i18n/src"],
+      "@webiny/handler-logs/*": ["../../../packages/handler-logs/src/*"],
+      "@webiny/handler-logs": ["../../../packages/handler-logs/src"],
+      "@webiny/handler-db/*": ["../../../packages/handler-db/src/*"],
+      "@webiny/handler-db": ["../../../packages/handler-db/src"],
+      "@webiny/db-dynamodb/*": ["../../../packages/db-dynamodb/src/*"],
+      "@webiny/db-dynamodb": ["../../../packages/db-dynamodb/src"]
+    }
+  }
 }

--- a/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
+++ b/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
@@ -48,7 +48,7 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
             const newImage = Converter.unmarshall(record.dynamodb.NewImage);
 
             if (newImage.ignore === true) {
-                return;
+                continue;
             }
 
             const oldImage = Converter.unmarshall(record.dynamodb.OldImage);
@@ -60,7 +60,7 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
              * On operations other than REMOVE we decompress the data and store it into the Elasticsearch.
              * No need to try to decompress if operation is REMOVE since there is no data sent into that operation.
              */
-            let data: any;
+            let data: any = undefined;
             if (operation !== Operations.REMOVE) {
                 /**
                  * We must decompress the data that is going into the Elasticsearch.
@@ -71,9 +71,9 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
                  * This might happen on some error while decompressing. We will log it.
                  *
                  * Data should NEVER be null or undefined in the Elasticsearch DynamoDB table, unless it is a delete operations.
-                 * If it is null or undefined - it is a bug.
+                 * If it is - it is a bug.
                  */
-                if (!data) {
+                if (data === undefined || data === null) {
                     console.log(
                         `Could not get decompressed data, skipping ES operation "${operation}", ID ${_id}`
                     );

--- a/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
+++ b/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
@@ -65,7 +65,7 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
                 /**
                  * We must decompress the data that is going into the Elasticsearch.
                  */
-                data = await decompress(newImage.data);
+                data = await decompress(context, newImage.data);
                 /**
                  * No point in writing null or undefined data into the Elasticsearch.
                  * This might happen on some error while decompressing. We will log it.
@@ -75,7 +75,7 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
                  */
                 if (!data) {
                     console.log(
-                        `Could not get decompressed data, skipping ES operation. ID: ${_id}`
+                        `Could not get decompressed data, skipping ES operation "${operation}", ID ${_id}`
                     );
                     continue;
                 }

--- a/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
+++ b/packages/api-dynamodb-to-elasticsearch/src/handler/index.ts
@@ -4,6 +4,12 @@ import { ElasticsearchContext } from "@webiny/api-elasticsearch/types";
 import WebinyError from "@webiny/error";
 import { decompress } from "@webiny/api-elasticsearch/compression";
 
+enum Operations {
+    INSERT = "INSERT",
+    MODIFY = "MODIFY",
+    REMOVE = "REMOVE"
+}
+
 const getError = (item: any): string | null => {
     if (!item.index || !item.index.error || !item.index.error.reason) {
         return null;
@@ -48,27 +54,39 @@ export default (): HandlerPlugin<ElasticsearchContext> => ({
             const oldImage = Converter.unmarshall(record.dynamodb.OldImage);
             const keys = Converter.unmarshall(record.dynamodb.Keys);
             const _id = `${keys.PK}:${keys.SK}`;
+            const operation = record.eventName;
+
             /**
-             * We must decompress the data that is going into the Elasticsearch.
+             * On operations other than REMOVE we decompress the data and store it into the Elasticsearch.
+             * No need to try to decompress if operation is REMOVE since there is no data sent into that operation.
              */
-            const data = await decompress(newImage.data);
-            /**
-             * No point in writing null or undefined data into the Elasticsearch.
-             * This might happen on some error while decompressing. We will log it.
-             *
-             * Data should NEVER be null or undefined in the Elasticsearch DynamoDB table. If it is - it is a BUG.
-             */
-            if (!data) {
-                console.log(`Could not get decompressed data, skipping ES operation. ID: ${_id}`);
-                continue;
+            let data: any;
+            if (operation !== Operations.REMOVE) {
+                /**
+                 * We must decompress the data that is going into the Elasticsearch.
+                 */
+                data = await decompress(newImage.data);
+                /**
+                 * No point in writing null or undefined data into the Elasticsearch.
+                 * This might happen on some error while decompressing. We will log it.
+                 *
+                 * Data should NEVER be null or undefined in the Elasticsearch DynamoDB table, unless it is a delete operations.
+                 * If it is null or undefined - it is a bug.
+                 */
+                if (!data) {
+                    console.log(
+                        `Could not get decompressed data, skipping ES operation. ID: ${_id}`
+                    );
+                    continue;
+                }
             }
 
             switch (record.eventName) {
-                case "INSERT":
-                case "MODIFY":
+                case Operations.INSERT:
+                case Operations.MODIFY:
                     operations.push({ index: { _id, _index: newImage.index } }, data);
                     break;
-                case "REMOVE":
+                case Operations.REMOVE:
                     operations.push({ delete: { _id, _index: oldImage.index } });
                     break;
                 default:

--- a/packages/api-elasticsearch/package.json
+++ b/packages/api-elasticsearch/package.json
@@ -40,7 +40,8 @@
   "adio": {
     "ignore": {
       "src": [
-        "aws-sdk"
+        "aws-sdk",
+        "zlib"
       ]
     }
   },

--- a/packages/api-elasticsearch/src/compression.ts
+++ b/packages/api-elasticsearch/src/compression.ts
@@ -34,7 +34,7 @@ const convertToBuffer = value => {
     return value;
 };
 
-interface CompressedData {
+export interface CompressedData {
     compression: string;
     value: string;
 }

--- a/packages/api-elasticsearch/src/compression.ts
+++ b/packages/api-elasticsearch/src/compression.ts
@@ -1,82 +1,51 @@
-import zlib from "zlib";
+import { ContextInterface } from "@webiny/handler/types";
+import { CompressionPlugin } from "~/plugins/definition/CompressionPlugin";
 
-export const gzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
-    return new Promise(function(resolve, reject) {
-        zlib.gzip(input, options, function(error, result) {
-            if (!error) {
-                resolve(result);
-            } else {
-                reject(error);
-            }
-        });
-    });
+/**
+ * Get the compression plugins, in reverse order, because we want to use the last one added - first.
+ */
+const getCompressionPlugins = (context: ContextInterface): CompressionPlugin[] => {
+    return context.plugins.byType<CompressionPlugin>(CompressionPlugin.type).reverse();
 };
-export const ungzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
-    return new Promise(function(resolve, reject) {
-        zlib.gunzip(input, options, function(error, result) {
-            if (!error) {
-                resolve(result);
-            } else {
-                reject(error);
-            }
-        });
-    });
-};
-
-const GZIP = "gzip";
-const TO_STORAGE_ENCODING = "base64";
-const FROM_STORAGE_ENCODING = "utf8";
-
-const convertToBuffer = value => {
-    if (typeof value === "string") {
-        return Buffer.from(value, TO_STORAGE_ENCODING);
-    }
-    return value;
-};
-
-export interface CompressedData {
-    compression: string;
-    value: string;
-}
 /**
  * Method to compress the elasticsearch data that is going to be stored into the DynamoDB table that is meant for elasticsearch.
  */
-export const compress = async (data: Record<string, any>): Promise<CompressedData> => {
-    /**
-     * If already compressed, skip this.
-     */
-    if (data.compression) {
-        return data as CompressedData;
+export const compress = async (
+    context: ContextInterface,
+    data: Record<string, any>
+): Promise<Record<string, any>> => {
+    const plugins = getCompressionPlugins(context);
+    if (plugins.length === 0) {
+        return data;
     }
-
-    const value = await gzip(JSON.stringify(data));
-
-    return {
-        compression: GZIP,
-        value: value.toString(TO_STORAGE_ENCODING)
-    };
+    for (const plugin of plugins) {
+        if (plugin.canCompress(data) === false) {
+            continue;
+        }
+        return await plugin.compress(data);
+    }
+    /**
+     * Possibly no plugins that can compress, just return the data.
+     */
+    return data;
 };
 
 export const decompress = async (
-    data: CompressedData | Record<string, any>
+    context: ContextInterface,
+    data: Record<string, any>
 ): Promise<Record<string, any>> => {
-    /**
-     * Possibly it is decompressed already or it never was compressed?
-     */
-    if (!data || !data.compression) {
+    const plugins = getCompressionPlugins(context);
+    if (plugins.length === 0) {
         return data;
-    } else if (data.compression !== GZIP) {
-        console.log(
-            `Could not decompress given data since its compression is not "${GZIP}". It is "${data.compression}".`
-        );
-        return null;
     }
-    const buf = await ungzip(convertToBuffer(data.value));
-
-    try {
-        const value = buf.toString(FROM_STORAGE_ENCODING);
-        return JSON.parse(value);
-    } catch (ex) {
-        return null;
+    for (const plugin of plugins) {
+        if (plugin.canDecompress(data) === false) {
+            continue;
+        }
+        return await plugin.decompress(data);
     }
+    /**
+     * Possibly no plugins that can decompress, just return the data.
+     */
+    return data;
 };

--- a/packages/api-elasticsearch/src/compression.ts
+++ b/packages/api-elasticsearch/src/compression.ts
@@ -1,0 +1,82 @@
+import zlib from "zlib";
+
+export const gzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
+    return new Promise(function(resolve, reject) {
+        zlib.gzip(input, options, function(error, result) {
+            if (!error) {
+                resolve(result);
+            } else {
+                reject(error);
+            }
+        });
+    });
+};
+export const ungzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
+    return new Promise(function(resolve, reject) {
+        zlib.gunzip(input, options, function(error, result) {
+            if (!error) {
+                resolve(result);
+            } else {
+                reject(error);
+            }
+        });
+    });
+};
+
+const GZIP = "gzip";
+const TO_STORAGE_ENCODING = "base64";
+const FROM_STORAGE_ENCODING = "utf8";
+
+const convertToBuffer = value => {
+    if (typeof value === "string") {
+        return Buffer.from(value, TO_STORAGE_ENCODING);
+    }
+    return value;
+};
+
+interface CompressedData {
+    compression: string;
+    value: string;
+}
+/**
+ * Method to compress the elasticsearch data that is going to be stored into the DynamoDB table that is meant for elasticsearch.
+ */
+export const compress = async (data: Record<string, any>): Promise<CompressedData> => {
+    /**
+     * If already compressed, skip this.
+     */
+    if (data.compression) {
+        return data as CompressedData;
+    }
+
+    const value = await gzip(JSON.stringify(data));
+
+    return {
+        compression: GZIP,
+        value: value.toString(TO_STORAGE_ENCODING)
+    };
+};
+
+export const decompress = async (
+    data: CompressedData | Record<string, any>
+): Promise<Record<string, any>> => {
+    /**
+     * Possibly it is decompressed already or it never was compressed?
+     */
+    if (!data || !data.compression) {
+        return data;
+    } else if (data.compression !== GZIP) {
+        console.log(
+            `Could not decompress given data since its compression is not "${GZIP}". It is "${data.compression}".`
+        );
+        return null;
+    }
+    const buf = await ungzip(convertToBuffer(data.value));
+
+    try {
+        const value = buf.toString(FROM_STORAGE_ENCODING);
+        return JSON.parse(value);
+    } catch (ex) {
+        return null;
+    }
+};

--- a/packages/api-elasticsearch/src/plugins/GzipCompression.ts
+++ b/packages/api-elasticsearch/src/plugins/GzipCompression.ts
@@ -1,0 +1,95 @@
+import { CompressionPlugin } from "~/plugins/definition/CompressionPlugin";
+import zlib from "zlib";
+
+export const gzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
+    return new Promise(function(resolve, reject) {
+        zlib.gzip(input, options, function(error, result) {
+            if (!error) {
+                resolve(result);
+            } else {
+                reject(error);
+            }
+        });
+    });
+};
+export const ungzip = (input: zlib.InputType, options?: zlib.ZlibOptions): Promise<Buffer> => {
+    return new Promise(function(resolve, reject) {
+        zlib.gunzip(input, options, function(error, result) {
+            if (!error) {
+                resolve(result);
+            } else {
+                reject(error);
+            }
+        });
+    });
+};
+
+const GZIP = "gzip";
+const TO_STORAGE_ENCODING = "base64";
+const FROM_STORAGE_ENCODING = "utf8";
+
+const convertToBuffer = value => {
+    if (typeof value === "string") {
+        return Buffer.from(value, TO_STORAGE_ENCODING);
+    }
+    return value;
+};
+
+export interface CompressedData {
+    compression: string;
+    value: string;
+}
+
+interface OriginalData {
+    [key: string]: any;
+}
+
+class GzipCompression extends CompressionPlugin {
+    public canCompress(data: any): boolean {
+        /**
+         * If already compressed, skip this.
+         */
+        if (data.compression) {
+            if (data.compression !== "GZIP") {
+                console.log(`Data is already compressed with "${data.compression}".`);
+            }
+            return false;
+        }
+        return true;
+    }
+    public async compress(data) {
+        const value = await gzip(JSON.stringify(data));
+
+        return {
+            compression: GZIP,
+            value: value.toString(TO_STORAGE_ENCODING)
+        };
+    }
+
+    public canDecompress(data: CompressedData | Record<string, any>): boolean {
+        if (!data || !data.compression) {
+            return false;
+        } else if (data.compression !== GZIP) {
+            console.log(
+                `Could not decompress given data since its compression is not "${GZIP}". It is "${data.compression}".`
+            );
+            return false;
+        }
+        return true;
+    }
+
+    public async decompress(data: CompressedData): Promise<OriginalData | null> {
+        const buf = await ungzip(convertToBuffer(data.value));
+
+        try {
+            const value = buf.toString(FROM_STORAGE_ENCODING);
+            return JSON.parse(value);
+        } catch (ex) {
+            return null;
+        }
+    }
+}
+
+export default () => {
+    return new GzipCompression();
+};

--- a/packages/api-elasticsearch/src/plugins/GzipCompression.ts
+++ b/packages/api-elasticsearch/src/plugins/GzipCompression.ts
@@ -79,9 +79,8 @@ class GzipCompression extends CompressionPlugin {
     }
 
     public async decompress(data: CompressedData): Promise<OriginalData | null> {
-        const buf = await ungzip(convertToBuffer(data.value));
-
         try {
+            const buf = await ungzip(convertToBuffer(data.value));
             const value = buf.toString(FROM_STORAGE_ENCODING);
             return JSON.parse(value);
         } catch (ex) {

--- a/packages/api-elasticsearch/src/plugins/definition/CompressionPlugin.ts
+++ b/packages/api-elasticsearch/src/plugins/definition/CompressionPlugin.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "@webiny/plugins";
 
 export abstract class CompressionPlugin extends Plugin {
-    public static readonly type: "elasticsearch.compression";
+    public static readonly type = "elasticsearch.compression";
     /**
      * Check if data can be compressed.
      */

--- a/packages/api-elasticsearch/src/plugins/definition/CompressionPlugin.ts
+++ b/packages/api-elasticsearch/src/plugins/definition/CompressionPlugin.ts
@@ -1,0 +1,21 @@
+import { Plugin } from "@webiny/plugins";
+
+export abstract class CompressionPlugin extends Plugin {
+    public static readonly type: "elasticsearch.compression";
+    /**
+     * Check if data can be compressed.
+     */
+    public abstract canCompress(data: any): boolean;
+    /**
+     * Pass the data to get the compressed one back.
+     */
+    public abstract compress(data: any): Promise<any>;
+    /**
+     * Check if data can be decompressed.
+     */
+    public abstract canDecompress(data: any): boolean;
+    /**
+     * Passed the compressed data to get the original data back.
+     */
+    public abstract decompress(data: any): Promise<any>;
+}

--- a/packages/api-file-manager-ddb-es/src/operations/files/FilesStorageOperations.ts
+++ b/packages/api-file-manager-ddb-es/src/operations/files/FilesStorageOperations.ts
@@ -24,6 +24,7 @@ import { createElasticsearchBody } from "~/operations/files/body";
 import { transformFromIndex, transformToIndex } from "~/operations/files/transformers";
 import { FileIndexTransformPlugin } from "~/plugins/FileIndexTransformPlugin";
 import { createLimit } from "@webiny/api-elasticsearch/limit";
+import { compress, CompressedData } from "@webiny/api-elasticsearch/compression";
 
 interface FileItem extends File {
     PK: string;
@@ -35,7 +36,7 @@ interface EsFileItem {
     PK: string;
     SK: string;
     index: string;
-    data: File;
+    data: CompressedData;
 }
 
 interface ConstructorParams {
@@ -156,10 +157,11 @@ export class FilesStorageOperations implements FileManagerFilesStorageOperations
             plugins: this.getFileIndexTransformPlugins(),
             file
         });
+        const esCompressedData = await compress(esData);
         const esItem: EsFileItem = {
             ...keys,
             index: this.esIndex,
-            data: esData
+            data: esCompressedData
         };
         try {
             await this._entity.put(item);
@@ -193,10 +195,11 @@ export class FilesStorageOperations implements FileManagerFilesStorageOperations
             plugins: this.getFileIndexTransformPlugins(),
             file
         });
+        const esCompressedData = await compress(esData);
         const esItem: EsFileItem = {
             ...keys,
             index: this.esIndex,
-            data: esData
+            data: esCompressedData
         };
         try {
             await this._entity.put(item);
@@ -253,11 +256,12 @@ export class FilesStorageOperations implements FileManagerFilesStorageOperations
                         ...file
                     })
                 );
+                const esCompressedData = await compress(file);
                 batches.push(
                     this._esEntity.putBatch({
                         ...keys,
                         index: this.esIndex,
-                        data: file
+                        data: esCompressedData
                     })
                 );
             }

--- a/packages/api-headless-cms-ddb-es/__tests__/__api__/environment.js
+++ b/packages/api-headless-cms-ddb-es/__tests__/__api__/environment.js
@@ -7,6 +7,9 @@ const dynamoToElastic = require("@webiny/api-dynamodb-to-elasticsearch/handler")
 const { Client } = require("@elastic/elasticsearch");
 const { simulateStream } = require("@webiny/project-utils/testing/dynamodb");
 const NodeEnvironment = require("jest-environment-node");
+const elasticsearchDataGzipCompression = require("@webiny/api-elasticsearch/plugins/GzipCompression")
+    .default;
+const { ContextPlugin } = require("@webiny/handler/plugins/ContextPlugin");
 /**
  * For this to work it must load plugins that have already been built
  */
@@ -23,11 +26,18 @@ const getStorageOperationsPlugins = ({
     documentClient,
     elasticsearchClientContext
 }) => {
-    // Intercept DocumentClient operations and trigger dynamoToElastic function (almost like a DynamoDB Stream trigger)
-    simulateStream(documentClient, createHandler(elasticsearchClientContext, dynamoToElastic()));
+    /**
+     * Intercept DocumentClient operations and trigger dynamoToElastic function (almost like a DynamoDB Stream trigger)
+     */
+    const simulationContext = new ContextPlugin(async context => {
+        context.plugins.register([elasticsearchDataGzipCompression()]);
+        await elasticsearchClientContext.apply(context);
+    });
+    simulateStream(documentClient, createHandler(simulationContext, dynamoToElastic()));
 
     return () => {
         return [
+            elasticsearchDataGzipCompression(),
             plugins(),
             dbPlugins({
                 table: "HeadlessCms",

--- a/packages/api-headless-cms-ddb-es/package.json
+++ b/packages/api-headless-cms-ddb-es/package.json
@@ -27,6 +27,7 @@
     "@webiny/api-upgrade": "^5.11.0",
     "@webiny/db-dynamodb": "^5.11.0",
     "@webiny/error": "^5.11.0",
+    "@webiny/handler": "^5.11.0",
     "@webiny/handler-aws": "^5.11.0",
     "@webiny/handler-db": "^5.11.0",
     "@webiny/plugins": "^5.11.0",

--- a/packages/api-headless-cms-ddb-es/tsconfig.build.json
+++ b/packages/api-headless-cms-ddb-es/tsconfig.build.json
@@ -7,6 +7,7 @@
     "../api-dynamodb-to-elasticsearch",
     "../api-elasticsearch",
     "../api-upgrade",
+    "../handler",
     "../handler-db",
     "../handler-aws",
     "../db-dynamodb",

--- a/packages/api-headless-cms-ddb-es/tsconfig.json
+++ b/packages/api-headless-cms-ddb-es/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../plugins"
     },
     {
+      "path": "../handler"
+    },
+    {
       "path": "../handler-db"
     },
     {
@@ -43,6 +46,8 @@
       "@webiny/plugins": ["../plugins/src"],
       "@webiny/handler-db/*": ["../handler-db/src/*"],
       "@webiny/handler-db": ["../handler-db/src"],
+      "@webiny/handler/*": ["../handler/src/*"],
+      "@webiny/handler": ["../handler/src"],
       "@webiny/handler-aws/*": ["../handler-aws/src/*"],
       "@webiny/handler-aws": ["../handler-aws/src"],
       "@webiny/db-dynamodb/*": ["../db-dynamodb/src/*"],

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -692,7 +692,13 @@ describe("filtering", () => {
         // If this `until` resolves successfully, we know entry is accessible via the "read" API
         await until(
             () => productReader.listProducts({}).then(([data]) => data),
-            ({ data }) => data.listProducts.data.length === 4,
+            ({ data }) => {
+                if (data.listProducts.data.length !== 4) {
+                    return false;
+                }
+                return true;
+                // return (data.listProducts.data as any[]).every(item => !!item.meta.publishedOn);
+            },
             { name: "list all products", tries: 10 }
         );
         /*************************

--- a/packages/cli/commands/upgrade/upgrades/5.12.0/index.js
+++ b/packages/cli/commands/upgrade/upgrades/5.12.0/index.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const securityUpgrade = require("./upgradeApiSecurity");
+const elasticsearchUpgrade = require("./upgradeElasticsearch");
 
 const targetVersion = "5.12.0";
 
@@ -59,14 +60,25 @@ module.exports = {
 
         const project = createMorphProject(files);
         /**
-         * Upgrade the graphql with new packages.
+         * Upgrade the graphql with new security packages.
          */
         await securityUpgrade.upgradeGraphQLIndex(project, context);
         /**
-         * Upgrade the api headless cms with new packages.
+         * Upgrade the api headless cms with new security packages.
          */
         await securityUpgrade.upgradeHeadlessCMSIndex(project, context);
-
+        /**
+         * Upgrade the dynamodb to elasticsearch with new compression package.
+         */
+        await elasticsearchUpgrade.upgradeDynamoDbToElasticIndex(project, context);
+        /**
+         * Upgrade the graphql with new compression package.
+         */
+        await elasticsearchUpgrade.upgradeGraphQLIndex(project, context);
+        /**
+         * Upgrade the api headless cms to elasticsearch with new compression package.
+         */
+        await elasticsearchUpgrade.upgradeHeadlessCMSIndex(project, context);
         info("Adding dependencies...");
 
         addPackagesToDependencies(path.resolve(process.cwd(), "api/code/graphql"), {

--- a/packages/cli/commands/upgrade/upgrades/5.12.0/index.js
+++ b/packages/cli/commands/upgrade/upgrades/5.12.0/index.js
@@ -52,11 +52,14 @@ module.exports = {
             prettierFormat
         } = require("../utils");
 
-        const files = await glob([...Object.values(securityUpgrade.files)], {
-            cwd: context.project.root,
-            onlyFiles: true,
-            ignore: ["**/node_modules/**"]
-        });
+        const files = await glob(
+            [...Object.values(securityUpgrade.files), ...Object.values(elasticsearchUpgrade.files)],
+            {
+                cwd: context.project.root,
+                onlyFiles: true,
+                ignore: ["**/node_modules/**"]
+            }
+        );
 
         const project = createMorphProject(files);
         /**

--- a/packages/cli/commands/upgrade/upgrades/5.12.0/upgradeElasticsearch.js
+++ b/packages/cli/commands/upgrade/upgrades/5.12.0/upgradeElasticsearch.js
@@ -1,3 +1,4 @@
+const tsMorph = require("ts-morph");
 const { addImportsToSource } = require("../utils");
 const FILES = {
     dynamodbToElastic: "api/code/dynamoToElastic/src/index.ts",
@@ -19,17 +20,18 @@ const upgradeDynamoDbToElasticIndex = (project, context) => {
      */
     const plugins = source.getFirstDescendant(
         node =>
-            Node.isPropertyAssignment(node) &&
-            Node.isArrayLiteralExpression(node) &&
+            tsMorph.Node.isPropertyAssignment(node) &&
+            tsMorph.Node.isArrayLiteralExpression(node) &&
             node.getName() === "plugins"
     );
     /**
      * We need to upgrade the old createHandler if plugins do not exist.
      */
     if (!plugins) {
-        const createHandler = file.getFirstDescendant(
+        const createHandler = source.getFirstDescendant(
             node =>
-                Node.isCallExpression(node) && node.getExpression().getText() === "createHandler"
+                tsMorph.Node.isCallExpression(node) &&
+                node.getExpression().getText() === "createHandler"
         );
 
         const createHandlerPlugins = createHandler.getArguments();
@@ -104,5 +106,6 @@ const upgradeHeadlessCMSIndex = (project, context) => {
 module.exports = {
     upgradeDynamoDbToElasticIndex,
     upgradeGraphQLIndex,
-    upgradeHeadlessCMSIndex
+    upgradeHeadlessCMSIndex,
+    files: FILES
 };

--- a/packages/cli/commands/upgrade/upgrades/5.12.0/upgradeElasticsearch.js
+++ b/packages/cli/commands/upgrade/upgrades/5.12.0/upgradeElasticsearch.js
@@ -1,0 +1,108 @@
+const { addImportsToSource } = require("../utils");
+const FILES = {
+    dynamodbToElastic: "api/code/dynamoToElastic/src/index.ts",
+    graphql: "api/code/graphql/src/index.ts",
+    headlessCMS: "api/code/headlessCMS/src/index.ts"
+};
+
+const elementName = "elasticsearchDataGzipCompression";
+const importPath = "@webiny/api-elasticsearch/plugins/GzipCompression";
+
+const upgradeDynamoDbToElasticIndex = (project, context) => {
+    const { info } = context;
+    const file = FILES.dynamodbToElastic;
+    info(`Upgrading ${info.hl(file)}`);
+
+    const source = project.getSourceFile(file);
+    /**
+     * First we need to check if there are plugins in the createHandler because user might have added it.
+     */
+    const plugins = source.getFirstDescendant(
+        node =>
+            Node.isPropertyAssignment(node) &&
+            Node.isArrayLiteralExpression(node) &&
+            node.getName() === "plugins"
+    );
+    /**
+     * We need to upgrade the old createHandler if plugins do not exist.
+     */
+    if (!plugins) {
+        const createHandler = file.getFirstDescendant(
+            node =>
+                Node.isCallExpression(node) && node.getExpression().getText() === "createHandler"
+        );
+
+        const createHandlerPlugins = createHandler.getArguments();
+        const pluginsList = createHandlerPlugins.map(plugin => plugin.getFullText());
+        /**
+         * Remove existing arguments.
+         */
+        for (const plugin of createHandlerPlugins) {
+            createHandler.removeArgument(plugin);
+        }
+        /**
+         * Add new way of creating the handler.
+         */
+        createHandler.addArgument(`{plugins: [${pluginsList.join(",")}]}`);
+    }
+    /**
+     * Then add whats required to the plugins.
+     */
+    addImportsToSource({
+        context,
+        source,
+        imports: [
+            {
+                elementName,
+                importPath
+            }
+        ],
+        file
+    });
+};
+
+const upgradeGraphQLIndex = (project, context) => {
+    const { info } = context;
+    const file = FILES.graphql;
+    info(`Upgrading ${info.hl(file)}`);
+
+    const source = project.getSourceFile(file);
+
+    addImportsToSource({
+        context,
+        source,
+        imports: [
+            {
+                elementName,
+                importPath
+            }
+        ],
+        file
+    });
+};
+
+const upgradeHeadlessCMSIndex = (project, context) => {
+    const { info } = context;
+    const file = FILES.headlessCMS;
+    info(`Upgrading ${info.hl(file)}`);
+
+    const source = project.getSourceFile(file);
+
+    addImportsToSource({
+        context,
+        source,
+        imports: [
+            {
+                elementName,
+                importPath
+            }
+        ],
+        file
+    });
+};
+
+module.exports = {
+    upgradeDynamoDbToElasticIndex,
+    upgradeGraphQLIndex,
+    upgradeHeadlessCMSIndex
+};

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -111,7 +111,7 @@ module.exports = async function createProject({
                 // Setup yarn@2
                 title: "Setup yarn@^2",
                 task: async () => {
-                    await execa("yarn", ["set", "version", "berry"], { cwd: projectRoot });
+                    await execa("yarn", ["set", "version", "2"], { cwd: projectRoot });
 
                     const yamlPath = path.join(projectRoot, ".yarnrc.yml");
                     const parsedYaml = yaml.load(fs.readFileSync(yamlPath, "utf-8"));

--- a/packages/cwp-template-aws/template/api/code/dynamoToElastic/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/dynamoToElastic/src/index.ts
@@ -1,10 +1,14 @@
 import { createHandler } from "@webiny/handler-aws";
 import elasticsearchClientContextPlugin from "@webiny/api-elasticsearch";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 import dynamoDBToElastic from "@webiny/api-dynamodb-to-elasticsearch/handler";
 
-export const handler = createHandler(
-    elasticsearchClientContextPlugin({
-        endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}`
-    }),
-    dynamoDBToElastic()
-);
+export const handler = createHandler({
+    plugins: [
+        elasticsearchClientContextPlugin({
+            endpoint: `https://${process.env.ELASTIC_SEARCH_ENDPOINT}`
+        }),
+        elasticsearchDataGzipCompression(),
+        dynamoDBToElastic()
+    ]
+});

--- a/packages/cwp-template-aws/template/api/code/graphql/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/graphql/src/index.ts
@@ -19,6 +19,7 @@ import formBuilderPlugins from "@webiny/api-form-builder/plugins";
 import securityPlugins from "./security";
 import headlessCmsPlugins from "@webiny/api-headless-cms/plugins";
 import headlessCmsDynamoDbElasticStorageOperation from "@webiny/api-headless-cms-ddb-es";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
 // Imports plugins created via scaffolding utilities.
 import scaffoldsPlugins from "./plugins/scaffolds";
@@ -65,7 +66,8 @@ export const handler = createHandler({
         formBuilderPlugins(),
         headlessCmsPlugins(),
         headlessCmsDynamoDbElasticStorageOperation(),
-        scaffoldsPlugins()
+        scaffoldsPlugins(),
+        elasticsearchDataGzipCompression()
     ],
     http: { debug }
 });

--- a/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
+++ b/packages/cwp-template-aws/template/api/code/headlessCMS/src/index.ts
@@ -11,6 +11,7 @@ import securityPlugins from "./security";
 import headlessCmsDynamoDbElasticStorageOperation from "@webiny/api-headless-cms-ddb-es";
 import logsPlugins from "@webiny/handler-logs";
 import securityAdminUsersDynamoDbStorageOperations from "@webiny/api-security-admin-users-so-ddb";
+import elasticsearchDataGzipCompression from "@webiny/api-elasticsearch/plugins/GzipCompression";
 
 // Imports plugins created via scaffolding utilities.
 import scaffoldsPlugins from "./plugins/scaffolds";
@@ -39,7 +40,8 @@ export const handler = createHandler({
         i18nContentPlugins(),
         headlessCmsPlugins({ debug }),
         headlessCmsDynamoDbElasticStorageOperation(),
-        scaffoldsPlugins()
+        scaffoldsPlugins(),
+        elasticsearchDataGzipCompression()
     ],
     http: { debug }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8572,6 +8572,7 @@ __metadata:
     "@webiny/cli": ^5.11.0
     "@webiny/db-dynamodb": ^5.11.0
     "@webiny/error": ^5.11.0
+    "@webiny/handler": ^5.11.0
     "@webiny/handler-aws": ^5.11.0
     "@webiny/handler-db": ^5.11.0
     "@webiny/plugins": ^5.11.0


### PR DESCRIPTION
## Changes
Closes #1819

When storing data to the Elasticsearch it goes through the DynamoDB table. It has 400kb limit.
So we are compresing the data before it goes into the table and then decompress before storing into the Elasticsearch.

Compression and decompression are handled by a plugin, so if plugin is not imported, there is no compress/decompress.
If plugin is imported on the headless cms or graphql lambda - it MUST be imported in the dynamoToElastic lambda - otherwise decompression will not work and data is going to be lost.

## How Has This Been Tested?
Jest and manual testing.
Tested on old projects to verify that nothing breaks.