### PR TITLE
Fixed Pulumi Stack Existence Check

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/destroy.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/destroy.js
@@ -28,7 +28,20 @@ module.exports = async (inputs, context) => {
 
     let stackExists = true;
     try {
-        await pulumi.run({ command: ["stack", "select", env] });
+        const PULUMI_SECRETS_PROVIDER = process.env.PULUMI_SECRETS_PROVIDER;
+        const PULUMI_CONFIG_PASSPHRASE = process.env.PULUMI_CONFIG_PASSPHRASE;
+
+        await pulumi.run({
+            command: ["stack", "select", env],
+            args: {
+                secretsProvider: PULUMI_SECRETS_PROVIDER
+            },
+            execa: {
+                env: {
+                    PULUMI_CONFIG_PASSPHRASE
+                }
+            }
+        });
     } catch (e) {
         stackExists = false;
     }

--- a/packages/cli-plugin-deploy-pulumi/commands/output.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/output.js
@@ -24,7 +24,20 @@ module.exports = async (inputs, context) => {
 
     let stackExists = true;
     try {
-        await pulumi.run({ command: ["stack", "select", env] });
+        const PULUMI_SECRETS_PROVIDER = process.env.PULUMI_SECRETS_PROVIDER;
+        const PULUMI_CONFIG_PASSPHRASE = process.env.PULUMI_CONFIG_PASSPHRASE;
+
+        await pulumi.run({
+            command: ["stack", "select", env],
+            args: {
+                secretsProvider: PULUMI_SECRETS_PROVIDER
+            },
+            execa: {
+                env: {
+                    PULUMI_CONFIG_PASSPHRASE
+                }
+            }
+        });
     } catch (e) {
         stackExists = false;
     }

--- a/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
@@ -27,7 +27,20 @@ module.exports = async (inputs, context) => {
 
         let stackExists = true;
         try {
-            await pulumi.run({ command: ["stack", "select", env] });
+            const PULUMI_SECRETS_PROVIDER = process.env.PULUMI_SECRETS_PROVIDER;
+            const PULUMI_CONFIG_PASSPHRASE = process.env.PULUMI_CONFIG_PASSPHRASE;
+
+            await pulumi.run({
+                command: ["stack", "select", env],
+                args: {
+                    secretsProvider: PULUMI_SECRETS_PROVIDER
+                },
+                execa: {
+                    env: {
+                        PULUMI_CONFIG_PASSPHRASE
+                    }
+                }
+            });
         } catch (e) {
             stackExists = false;
         }

--- a/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
@@ -9,11 +9,6 @@ module.exports = async (args = {}, options = {}) => {
     const pulumi = new Pulumi(
         merge(
             {
-                execa: {
-                    env: {
-                        PULUMI_CONFIG_PASSPHRASE: process.env.PULUMI_CONFIG_PASSPHRASE
-                    }
-                },
                 beforePulumiInstall: () => {
                     console.log(
                         `It looks like this is your first time using ${green(

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -111,7 +111,10 @@ module.exports = async function createProject({
                 // Setup yarn@2
                 title: "Setup yarn@^2",
                 task: async () => {
+                    // We are forcing the 2.x version.
+                    // https://github.com/yarnpkg/berry/issues/3180#issuecomment-887332050
                     await execa("yarn", ["set", "version", "berry"], { cwd: projectRoot });
+                    await execa("yarn", ["set", "version", "2.x"], { cwd: projectRoot });
 
                     const yamlPath = path.join(projectRoot, ".yarnrc.yml");
                     const parsedYaml = yaml.load(fs.readFileSync(yamlPath, "utf-8"));


### PR DESCRIPTION
## Changes
Upon running the deploy command, if an error occurred while selecting a stack, a new stack would be created, which would basically break users' Pulumi state files, and force the Pulumi CLI to deploy everything from scratch. Certainly, something that should not happen.

## How Has This Been Tested?
Manual.

## Documentation
No docs, internal fix.