### PR TITLE
fix(cli): use forward slash and disable path filtering on Windows

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -1,3 +1,4 @@
+const os = require("os");
 const execa = require("execa");
 const chalk = require("chalk");
 const localtunnel = require("localtunnel");
@@ -162,10 +163,12 @@ module.exports = async (inputs, context) => {
                 inputs.folder,
                 "**/build"
             ].join("/");
+
             const buildFolders = glob.sync(buildFoldersGlob, { onlyFiles: false });
 
             // The final array of values that will be sent to Pulumi CLI's "--path" argument.
-            const pathArg = [pulumiFolder, ...buildFolders];
+            // NOTE: for Windows, there's a bug in Pulumi preventing us to use path filtering.
+            const pathArg = os.platform() === "win32" ? undefined : [pulumiFolder, ...buildFolders];
 
             // Log used values if debugging has been enabled.
             if (inputs.debug) {

--- a/packages/cli/utils/getProject.js
+++ b/packages/cli/utils/getProject.js
@@ -7,13 +7,13 @@ const projectConfigs = ["webiny.project.js", "webiny.project.ts"];
 function getRoot({ cwd } = {}) {
     let root = findUp.sync(projectConfigs, { cwd });
     if (root) {
-        return dirname(root);
+        return dirname(root).replace(/\\/g, "/");
     }
 
     // For backwards compatibility
     root = findUp.sync("webiny.root.js", { cwd });
     if (root) {
-        return dirname(root);
+        return dirname(root).replace(/\\/g, "/");
     }
 
     throw new Error("Couldn't detect Webiny project.");

--- a/packages/cli/utils/getProjectApplication.js
+++ b/packages/cli/utils/getProjectApplication.js
@@ -13,11 +13,12 @@ module.exports = args => {
         throw new Error(`Could not detect project application in given directory (${args.cwd}).`);
     }
 
-    const applicationRoot = dirname(applicationRootFile);
+    const rootFile = applicationRootFile.replace(/\\/g, "/");
+    const applicationRoot = dirname(rootFile);
 
     let applicationConfig;
-    if (appConfigs.includes(basename(applicationRootFile))) {
-        applicationConfig = importModule(applicationRootFile);
+    if (appConfigs.includes(basename(rootFile))) {
+        applicationConfig = importModule(rootFile);
     }
 
     let name, id;


### PR DESCRIPTION
## Changes
This PR enforces the use of forward slashes when constructing project path in the CLI.
There's currently a bug in the Pulumi path detection for `watch`, so on Windows, where paths start with `C:`, Pulumi thinks it's a relative path, and constructs a wrong file path to watch. To bypass this issue, we've temporarily disabled path filtering on Windows.

Watch works just a good, but you might experience a case of double update on Lambda functions.  Not a major problem, just a little detail you'll most likely not even notice, if you don't pay attention to deploy logs.

## How Has This Been Tested?
Manually.