### PR TITLE
feat: improve UI Composer API

### DIFF
--- a/packages/api-dynamic-pages/package.json
+++ b/packages/api-dynamic-pages/package.json
@@ -30,7 +30,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.0.0",
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@elastic/elasticsearch-mock": "0.3.0",
     "@shelf/jest-elasticsearch": "^1.0.0",
     "@webiny/cli": "^5.12.0",

--- a/packages/api-elasticsearch/package.json
+++ b/packages/api-elasticsearch/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@webiny/error": "^5.12.0",
     "@webiny/handler": "^5.12.0",
     "@webiny/plugins": "^5.12.0",

--- a/packages/api-file-manager-ddb-es/package.json
+++ b/packages/api-file-manager-ddb-es/package.json
@@ -43,7 +43,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.0.0",
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@elastic/elasticsearch-mock": "0.3.0",
     "@shelf/jest-elasticsearch": "^1.0.0",
     "@webiny/api-dynamodb-to-elasticsearch": "^5.12.0",

--- a/packages/api-form-builder/package.json
+++ b/packages/api-form-builder/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.8.3",
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@shelf/jest-elasticsearch": "^1.0.0",
     "@webiny/api-dynamodb-to-elasticsearch": "^5.12.0",
     "@webiny/api-file-manager-ddb-es": "^5.12.0",

--- a/packages/api-headless-cms-ddb-es/package.json
+++ b/packages/api-headless-cms-ddb-es/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-flow": "^7.0.0",
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@shelf/jest-elasticsearch": "^1.0.0",
     "@types/jsonpack": "^1.1.0",
     "@webiny/api-dynamodb-to-elasticsearch": "^5.12.0",

--- a/packages/api-page-builder/package.json
+++ b/packages/api-page-builder/package.json
@@ -52,7 +52,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.5.2",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.8.3",
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "7.12.0",
     "@shelf/jest-elasticsearch": "^1.0.0",
     "@types/puppeteer": "^5.4.2",
     "@webiny/api-dynamodb-to-elasticsearch": "^5.12.0",

--- a/packages/app-admin/src/plugins/menu/renderers/MenuGroupRenderer.tsx
+++ b/packages/app-admin/src/plugins/menu/renderers/MenuGroupRenderer.tsx
@@ -47,7 +47,7 @@ const menuTitleActive = css({
 
 export class MenuGroupRenderer extends UIRenderer<NavigationMenuElement> {
     canRender(element: NavigationMenuElement): boolean {
-        const isInContent = Boolean(element.getParentOfType(ContentElement));
+        const isInContent = Boolean(element.getParentByType(ContentElement));
         return element.depth === 1 && isInContent && !element.config.path;
     }
 

--- a/packages/app-admin/src/plugins/menu/renderers/MenuGroupRenderer.tsx
+++ b/packages/app-admin/src/plugins/menu/renderers/MenuGroupRenderer.tsx
@@ -52,7 +52,7 @@ export class MenuGroupRenderer extends UIRenderer<NavigationMenuElement> {
     }
 
     render({ element, props, next }: UIRenderParams<NavigationMenuElement>): React.ReactNode {
-        const hasChildren = element.getElements().length > 0;
+        const hasChildren = element.getChildren().length > 0;
 
         if (!hasChildren) {
             return null;

--- a/packages/app-admin/src/plugins/menu/renderers/MenuLinkRenderer.tsx
+++ b/packages/app-admin/src/plugins/menu/renderers/MenuLinkRenderer.tsx
@@ -9,7 +9,7 @@ import { FooterElement } from "~/ui/views/NavigationView/FooterElement";
 
 export class MenuLinkRenderer extends UIRenderer<NavigationMenuElement> {
     canRender(element: NavigationMenuElement): boolean {
-        const isInFooter = Boolean(element.getParentOfType(FooterElement));
+        const isInFooter = Boolean(element.getParentByType(FooterElement));
         return element.depth === 1 && isInFooter;
     }
 

--- a/packages/app-admin/src/plugins/menu/renderers/MenuSectionRenderer.tsx
+++ b/packages/app-admin/src/plugins/menu/renderers/MenuSectionRenderer.tsx
@@ -21,7 +21,7 @@ export class MenuSectionRenderer extends UIRenderer<NavigationMenuElement> {
         return element.depth === 2;
     }
 
-    render({ element, props, next }: UIRenderParams<NavigationMenuElement>): React.ReactNode {
+    render({ element, next }: UIRenderParams<NavigationMenuElement>): React.ReactNode {
         return (
             <Fragment>
                 <div className={menuSectionTitle}>

--- a/packages/app-admin/src/plugins/menu/renderers/MenuSectionRenderer.tsx
+++ b/packages/app-admin/src/plugins/menu/renderers/MenuSectionRenderer.tsx
@@ -28,7 +28,7 @@ export class MenuSectionRenderer extends UIRenderer<NavigationMenuElement> {
                     <div className={iconWrapper}>{element.config.icon}</div>
                     <Typography use="overline">{element.config.label}</Typography>
                 </div>
-                {next(props)}
+                {next()}
             </Fragment>
         );
     }

--- a/packages/app-admin/src/ui/UIElement.tsx
+++ b/packages/app-admin/src/ui/UIElement.tsx
@@ -1,9 +1,3 @@
-export type {
-    UIElementConfig,
-    UIElementWrapper,
-    UIElementWrapperProps,
-    ApplyFunction,
-    ShouldRender
-} from "@webiny/ui-composer/UIElement";
+export type { UIElementConfig, ApplyFunction, ShouldRender } from "@webiny/ui-composer/UIElement";
 
 export { UIElement, UIElementPlugin } from "@webiny/ui-composer/UIElement";

--- a/packages/app-admin/src/ui/UIView.tsx
+++ b/packages/app-admin/src/ui/UIView.tsx
@@ -1,2 +1,6 @@
-export type { ApplyFunction } from "@webiny/ui-composer/UIView";
+export type {
+    ApplyFunction,
+    UIElementWrapperProps,
+    UIElementWrapper
+} from "@webiny/ui-composer/UIView";
 export { UIView, UIViewComponent, UIViewPlugin } from "@webiny/ui-composer/UIView";

--- a/packages/app-admin/src/ui/elements/NavigationMenuElement.tsx
+++ b/packages/app-admin/src/ui/elements/NavigationMenuElement.tsx
@@ -18,11 +18,13 @@ export enum TAGS {
     APP = "app"
 }
 
-export class NavigationMenuElement extends UIElement<NavigationMenuElementConfig> {
+export class NavigationMenuElement<
+    TConfig extends NavigationMenuElementConfig = NavigationMenuElementConfig
+> extends UIElement<TConfig> {
     private _isExpanded = false;
     private _sorters = [];
 
-    constructor(id: string, config: NavigationMenuElementConfig) {
+    constructor(id: string, config: TConfig) {
         super(id, config);
 
         this.useGrid(false);

--- a/packages/app-admin/src/ui/views/AdminView.tsx
+++ b/packages/app-admin/src/ui/views/AdminView.tsx
@@ -42,7 +42,7 @@ export class AdminView extends UIView {
         const content = this.getContentElement();
 
         // Remove previous content
-        content.getElements().forEach(el => el.remove());
+        content.getChildren().forEach(el => el.remove());
 
         // Add new content
         content.addElement(element);

--- a/packages/app-admin/src/ui/views/AdminView/ContentElement.tsx
+++ b/packages/app-admin/src/ui/views/AdminView/ContentElement.tsx
@@ -1,21 +1,24 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { UIElement } from "~/ui/UIElement";
+import { UIRenderer } from "~/ui/UIRenderer";
 
 const ContentWrapper = styled("div")({
     width: "100%",
     paddingTop: 67
 });
 
+class ContentElementRenderer extends UIRenderer<ContentElement> {
+    render({ next, props }): React.ReactNode {
+        return <ContentWrapper>{props.children ? props.children : next()}</ContentWrapper>;
+    }
+}
+
 export class ContentElement extends UIElement {
     constructor(id: string) {
         super(id);
         this.useGrid(false);
-    }
-
-    render(props): React.ReactNode {
-        return (
-            <ContentWrapper>{props.children ? props.children : super.render(props)}</ContentWrapper>
-        );
+        this.addRenderer(new ContentElementRenderer());
+        this.applyPlugins(ContentElement);
     }
 }

--- a/packages/app-admin/src/ui/views/AdminView/HeaderElement.tsx
+++ b/packages/app-admin/src/ui/views/AdminView/HeaderElement.tsx
@@ -7,10 +7,17 @@ import { HeaderSectionLeftElement } from "./HeaderSectionLeftElement";
 import { HeaderSectionCenterElement } from "./HeaderSectionCenterElement";
 import { HeaderSectionRightElement } from "./HeaderSectionRightElement";
 import Hamburger from "./components/Hamburger";
+import { UIRenderer } from "~/ui/UIRenderer";
 
 enum ElementID {
     MenuButton = "headerMenuButton",
     Logo = "headerLogo"
+}
+
+class HeaderElementRenderer extends UIRenderer<HeaderElement> {
+    render({ next }): React.ReactNode {
+        return <TopAppBarPrimary fixed>{next()}</TopAppBarPrimary>;
+    }
 }
 
 export class HeaderElement extends UIElement {
@@ -26,7 +33,10 @@ export class HeaderElement extends UIElement {
         this.addElement(new HeaderSectionCenterElement("headerCenter"));
         this.addElement(new HeaderSectionRightElement("headerRight"));
 
+        this.addRenderer(new HeaderElementRenderer());
+
         this.setMenuButton(<Hamburger />);
+        this.applyPlugins(HeaderElement);
     }
 
     getLeftSection(): HeaderSectionLeftElement {
@@ -56,9 +66,5 @@ export class HeaderElement extends UIElement {
                 return menuButton;
             })
         );
-    }
-
-    render(props): React.ReactNode {
-        return <TopAppBarPrimary fixed>{super.render(props)}</TopAppBarPrimary>;
     }
 }

--- a/packages/app-admin/src/ui/views/NavigationView.tsx
+++ b/packages/app-admin/src/ui/views/NavigationView.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment } from "react";
 import sortBy from "lodash/sortBy";
 import { nanoid } from "nanoid";
-import { Drawer } from "@webiny/ui/Drawer";
 import { UIView } from "~/ui/UIView";
 import { plugins } from "@webiny/plugins";
 import { GenericElement } from "~/ui/elements/GenericElement";
@@ -14,6 +13,7 @@ import { AdminMenuPlugin } from "~/types";
 import { NavigationMenuElement, TAGS } from "~/ui/elements/NavigationMenuElement";
 import { ItemProps, MenuProps, SectionProps } from "./NavigationView/legacyMenu";
 import { ReactComponent as SettingsIcon } from "~/assets/icons/round-settings-24px.svg";
+import { NavigationViewRenderer } from "./NavigationView/NavigationViewRenderer";
 
 export enum ElementID {
     Header = "navigationHeader",
@@ -47,6 +47,8 @@ export class NavigationView extends UIView {
 
         // Load legacy plugins and convert them into elements
         this.setupLegacyMenuPlugins();
+
+        this.addRenderer(new NavigationViewRenderer());
 
         this.applyPlugins(NavigationView);
     }
@@ -89,16 +91,6 @@ export class NavigationView extends UIView {
         return this.getElement(ElementID.SettingsMenu);
     }
 
-    render(props?: any): React.ReactNode {
-        const { menuIsShown, hideMenu } = this.getNavigationHook();
-
-        return (
-            <Drawer modal open={menuIsShown()} onClose={hideMenu}>
-                {super.render(props)}
-            </Drawer>
-        );
-    }
-
     private setupLegacyMenuPlugins() {
         // IMPORTANT! The following piece of code is for BACKWARDS COMPATIBILITY purposes only!
         const menuPlugins = plugins.byType<AdminMenuPlugin>("admin-menu");
@@ -129,7 +121,7 @@ export class NavigationView extends UIView {
         };
 
         const Section = ({ parent, ...props }: SectionProps) => {
-            const sectionMenu = parent.addElement(
+            const sectionMenu = parent.addElement<NavigationMenuElement>(
                 new NavigationMenuElement(nanoid(), {
                     label: props.label
                 })
@@ -148,7 +140,7 @@ export class NavigationView extends UIView {
         };
 
         const Item = ({ parent, ...props }: ItemProps) => {
-            parent.addElement(
+            parent.addElement<NavigationMenuElement>(
                 new NavigationMenuElement(nanoid(), {
                     label: props.label,
                     path: props.path

--- a/packages/app-admin/src/ui/views/NavigationView/NavigationViewRenderer.tsx
+++ b/packages/app-admin/src/ui/views/NavigationView/NavigationViewRenderer.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { UIRenderer, UIRenderParams } from "~/ui/UIRenderer";
+import { NavigationView } from "~/ui/views/NavigationView";
+import { Drawer } from "@webiny/ui/Drawer";
+
+export class NavigationViewRenderer extends UIRenderer<NavigationView> {
+    render({ element, children }: UIRenderParams<NavigationView>): React.ReactNode {
+        const { menuIsShown, hideMenu } = element.getNavigationHook();
+
+        return (
+            <Drawer modal open={menuIsShown()} onClose={hideMenu}>
+                {children()}
+            </Drawer>
+        );
+    }
+}

--- a/packages/app-admin/src/ui/views/SplitView/SplitViewPanelElement.tsx
+++ b/packages/app-admin/src/ui/views/SplitView/SplitViewPanelElement.tsx
@@ -21,7 +21,7 @@ export class SplitViewPanelElement extends UIElement<any> {
 
     setContentElement(element: UIElement) {
         // Remove previous content
-        this.getElements().forEach(el => el.remove());
+        this.getChildren().forEach(el => el.remove());
 
         // Add new content
         this.addElement(element);

--- a/packages/app-file-manager/src/admin/plugins/menus.tsx
+++ b/packages/app-file-manager/src/admin/plugins/menus.tsx
@@ -62,7 +62,7 @@ export default [
             permission: PERMISSION_FM_SETTINGS
         });
 
-        fileManagerSettings.addElement(
+        fileManagerSettings.addElement<NavigationMenuElement>(
             new NavigationMenuElement("menu.settings.fileManager.general", {
                 label: "General",
                 path: "/settings/file-manager/general"

--- a/packages/app-form-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-form-builder/src/admin/plugins/settings/index.tsx
@@ -37,7 +37,7 @@ const plugins = [
             })
         );
 
-        formBuilder.addElement(
+        formBuilder.addElement<NavigationMenuElement>(
             new NavigationMenuElement("menu.settings.formBuilder.recaptcha", {
                 label: "reCAPTCHA",
                 path: "/settings/form-builder/recaptcha"

--- a/packages/app-headless-cms/src/admin/plugins/menus/CmsMenuLoader.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/menus/CmsMenuLoader.tsx
@@ -54,14 +54,14 @@ export const CmsMenuLoader = React.memo(({ view }: Props) => {
          * Add "Content Models" section if the user can create either models or groups.
          */
         if (canCreateContentModels || canCreateContentModelGroups) {
-            const contentModelsMenu = mainMenu.addElement(
+            const contentModelsMenu = mainMenu.addElement<NavigationMenuElement>(
                 new NavigationMenuElement("headlessCms.contentModels", {
                     label: "Content Models"
                 })
             );
 
             if (canCreateContentModels) {
-                contentModelsMenu.addElement(
+                contentModelsMenu.addElement<NavigationMenuElement>(
                     new NavigationMenuElement("headlessCms.contentModels.models", {
                         label: "Models",
                         path: "/cms/content-models"
@@ -70,7 +70,7 @@ export const CmsMenuLoader = React.memo(({ view }: Props) => {
             }
 
             if (canCreateContentModelGroups) {
-                contentModelsMenu.addElement(
+                contentModelsMenu.addElement<NavigationMenuElement>(
                     new NavigationMenuElement("headlessCms.contentModels.groups", {
                         label: "Groups",
                         path: "/cms/content-model-groups"

--- a/packages/app-i18n/src/admin/plugins/menus.tsx
+++ b/packages/app-i18n/src/admin/plugins/menus.tsx
@@ -17,7 +17,7 @@ export default [
             })
         );
 
-        localesMenu.addElement(
+        localesMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("locales.crud", {
                 label: "Locales",
                 path: "/i18n/locales"

--- a/packages/app-page-builder/src/admin/plugins/settings/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/settings/index.tsx
@@ -57,14 +57,14 @@ const allPlugins = [
             })
         );
 
-        pageBuilderMenu.addElement(
+        pageBuilderMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("menu.settings.pageBuilder.website", {
                 label: "Website",
                 path: "/settings/page-builder/website"
             })
         );
 
-        pageBuilderMenu.addElement(
+        pageBuilderMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("menu.settings.pageBuilder.prerendering", {
                 label: "Prerendering",
                 path: "/settings/page-builder/prerendering"

--- a/packages/app-page-builder/src/editor/ui/views/PageSettingsView/PageSettingsFormView.tsx
+++ b/packages/app-page-builder/src/editor/ui/views/PageSettingsView/PageSettingsFormView.tsx
@@ -18,7 +18,7 @@ export class PageSettingsFormView extends FormView {
     }
 
     getPageSettingsHook() {
-        const parent = this.getParentOfType<PageSettingsView>(PageSettingsView);
+        const parent = this.getParentByType<PageSettingsView>(PageSettingsView);
         return parent.getPageSettingsHook();
     }
 }

--- a/packages/app-security-admin-users/src/plugins/menus.tsx
+++ b/packages/app-security-admin-users/src/plugins/menus.tsx
@@ -15,7 +15,7 @@ export default new UIViewPlugin<NavigationView>(NavigationView, async view => {
         return;
     }
 
-    const mainMenu = view.getSettingsMenuElement().addElement(
+    const mainMenu = view.getSettingsMenuElement().addElement<NavigationMenuElement>(
         new NavigationMenuElement("security", {
             label: "Security",
             tags: [TAGS.UTILS]
@@ -23,7 +23,7 @@ export default new UIViewPlugin<NavigationView>(NavigationView, async view => {
     );
 
     if (users) {
-        mainMenu.addElement(
+        mainMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("users", {
                 label: "Users",
                 path: "/security/users"
@@ -32,7 +32,7 @@ export default new UIViewPlugin<NavigationView>(NavigationView, async view => {
     }
 
     if (groups) {
-        mainMenu.addElement(
+        mainMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("groups", {
                 label: "Groups",
                 path: "/security/groups"
@@ -41,7 +41,7 @@ export default new UIViewPlugin<NavigationView>(NavigationView, async view => {
     }
 
     if (apiKeys) {
-        mainMenu.addElement(
+        mainMenu.addElement<NavigationMenuElement>(
             new NavigationMenuElement("apiKeys", {
                 label: "API Keys",
                 path: "/security/api-keys"

--- a/packages/app-security/src/contexts/Security.tsx
+++ b/packages/app-security/src/contexts/Security.tsx
@@ -11,9 +11,6 @@ export type SecurityContextValue = {
 export const SecurityProvider = props => {
     const [identity, setIdentity] = useState(null);
 
-    // @ts-ignore
-    window.SecurityIdentity = identity;
-
     const value = useMemo(
         () => ({
             identity,

--- a/packages/ui-composer/src/UIElement.ts
+++ b/packages/ui-composer/src/UIElement.ts
@@ -118,7 +118,7 @@ export class UIElement<TConfig extends UIElementConfig = UIElementConfig> {
         return this._parent;
     }
 
-    getParentOfType<TParent extends UIElement = UIElement>(type: Class<TParent>): TParent {
+    getParentByType<TParent extends UIElement = UIElement>(type: Class<TParent>): TParent {
         let parent = this.getParent();
         while (parent) {
             if (parent instanceof (type as any)) {
@@ -131,7 +131,22 @@ export class UIElement<TConfig extends UIElementConfig = UIElementConfig> {
         return parent as TParent;
     }
 
-    getDescendentsOfType<TElement extends UIElement = UIElement>(
+    getDescendentsByTag(tag: string): UIElement[] {
+        const elements = Array.from(this._elements.values());
+
+        // Search child elements recursively
+        for (const element of elements) {
+            if (element instanceof UIElement) {
+                const children = element.getChildren();
+                for (const child of children) {
+                    child.getDescendentsByTag(tag).forEach(el => elements.push(el));
+                }
+            }
+        }
+        return elements.filter(el => el.hasTag(tag));
+    }
+
+    getDescendentsByType<TElement extends UIElement = UIElement>(
         type: Class<TElement>
     ): TElement[] {
         const elements = Array.from(this._elements.values());
@@ -140,7 +155,7 @@ export class UIElement<TConfig extends UIElementConfig = UIElementConfig> {
         for (const element of elements) {
             const children = element.getChildren();
             for (const child of children) {
-                child.getDescendentsOfType(type).forEach(el => {
+                child.getDescendentsByType(type).forEach(el => {
                     elements.push(el);
                 });
             }
@@ -209,21 +224,6 @@ export class UIElement<TConfig extends UIElementConfig = UIElementConfig> {
 
     getChildren(): UIElement[] {
         return Array.from(this._elements.values());
-    }
-
-    getDescendentsByTag(tag: string): UIElement[] {
-        const elements = Array.from(this._elements.values());
-
-        // Search child elements recursively
-        for (const element of elements) {
-            if (element instanceof UIElement) {
-                const children = element.getChildren();
-                for (const child of children) {
-                    child.getDescendentsByTag(tag).forEach(el => elements.push(el));
-                }
-            }
-        }
-        return elements.filter(el => el.hasTag(tag));
     }
 
     moveInto(targetElement: UIElement) {

--- a/packages/ui-composer/src/UIRenderer.ts
+++ b/packages/ui-composer/src/UIRenderer.ts
@@ -2,10 +2,15 @@ export interface UIRenderParams<TElement, TProps = any> {
     element: TElement;
     props: TProps;
     next: RenderNext;
+    children: RenderChildren;
 }
 
 export interface RenderNext {
-    (props?: any): React.ReactNode;
+    (): React.ReactNode;
+}
+
+export interface RenderChildren {
+    (): React.ReactNode;
 }
 
 export abstract class UIRenderer<TElement, TProps = any> {

--- a/packages/ui-composer/src/elements/ViewElement.tsx
+++ b/packages/ui-composer/src/elements/ViewElement.tsx
@@ -16,8 +16,8 @@ export class ViewElement extends UIElement<ViewElementConfig> {
         return this.config.view.getChildren();
     }
 
-    getDescendentsOfType<TElement extends UIElement = UIElement>(type: any): TElement[] {
-        return this.config.view.getDescendentsOfType(type) as TElement[];
+    getDescendentsByType<TElement extends UIElement = UIElement>(type: any): TElement[] {
+        return this.config.view.getDescendentsByType(type) as TElement[];
     }
 
     render(props?: any): React.ReactNode {

--- a/packages/ui-composer/src/elements/ViewElement.tsx
+++ b/packages/ui-composer/src/elements/ViewElement.tsx
@@ -12,6 +12,14 @@ export class ViewElement extends UIElement<ViewElementConfig> {
         config.view.setParent(this);
     }
 
+    getChildren(): UIElement[] {
+        return this.config.view.getChildren();
+    }
+
+    getDescendentsOfType<TElement extends UIElement = UIElement>(type: any): TElement[] {
+        return this.config.view.getDescendentsOfType(type) as TElement[];
+    }
+
     render(props?: any): React.ReactNode {
         if (!this.config.view) {
             return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,9 +597,9 @@ __metadata:
   linkType: hard
 
 "@aws-sdk/types@npm:^3.1.0":
-  version: 3.22.0
-  resolution: "@aws-sdk/types@npm:3.22.0"
-  checksum: 868f53b2c435ad585029eed05b275461945f79219b7cb953d883332088cbe417b74af7d39fbd4fb5802771d922189fbc633e3bccf5f2c79619f5f45eea67f850
+  version: 3.25.0
+  resolution: "@aws-sdk/types@npm:3.25.0"
+  checksum: 64338de11b7e10fab8dd43b41f83c0f1d202b57b1568d4682d4808db407e3dfb2d175f490d05fbab0c0a82ec8fcc03c5497ae3bc12616bd30c908e740c092a88
   languageName: node
   linkType: hard
 
@@ -833,10 +833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.12.7, @babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.14.5, @babel/compat-data@npm:^7.14.7, @babel/compat-data@npm:^7.14.9, @babel/compat-data@npm:^7.9.0":
-  version: 7.14.9
-  resolution: "@babel/compat-data@npm:7.14.9"
-  checksum: 63b7093d84e8cb9488777a1a46bd91cc24e230896e04f5d7618f211dba725e0d441b667395e37eb606d7eebfb058d011c12d7fdbfbeb4fcc07f1e8baec52e639
+"@babel/compat-data@npm:^7.12.7, @babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.14.7, @babel/compat-data@npm:^7.15.0, @babel/compat-data@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/compat-data@npm:7.15.0"
+  checksum: 76db9ec4fb897b6a1de1057411a65b134bc2016b156ebf7ce39fbe97b4f1eeaf661b81d457126a71164cbc2de31a06c68f74d0ebbdce3720a000139683f787d0
   languageName: node
   linkType: hard
 
@@ -863,26 +863,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.14.8, @babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.4.5, @babel/core@npm:^7.5.5, @babel/core@npm:^7.7.5":
-  version: 7.14.8
-  resolution: "@babel/core@npm:7.14.8"
+"@babel/core@npm:7.15.0, @babel/core@npm:^7.0.0, @babel/core@npm:^7.1.0, @babel/core@npm:^7.4.5, @babel/core@npm:^7.5.5, @babel/core@npm:^7.7.5":
+  version: 7.15.0
+  resolution: "@babel/core@npm:7.15.0"
   dependencies:
     "@babel/code-frame": ^7.14.5
-    "@babel/generator": ^7.14.8
-    "@babel/helper-compilation-targets": ^7.14.5
-    "@babel/helper-module-transforms": ^7.14.8
+    "@babel/generator": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.0
+    "@babel/helper-module-transforms": ^7.15.0
     "@babel/helpers": ^7.14.8
-    "@babel/parser": ^7.14.8
+    "@babel/parser": ^7.15.0
     "@babel/template": ^7.14.5
-    "@babel/traverse": ^7.14.8
-    "@babel/types": ^7.14.8
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.1.2
     semver: ^6.3.0
     source-map: ^0.5.0
-  checksum: cfb715d659b9e1ebaf9f11d87363171121d6e363b8b82766cbd4a723c04066d65d0f1ce12d6ef569a83dc5ee88efa3da0e5e6fac6945c5d627d8dc387a027b26
+  checksum: 014611573c66a84c97eb20e4536e8d359bdeac86c3e23ab127a2852b9d4c1c28c3f6dfd1c4938402029a90ed75dad661b63e3bf6d26ac9f4866b17e727a46bd0
   languageName: node
   linkType: hard
 
@@ -910,14 +910,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.10, @babel/generator@npm:^7.12.11, @babel/generator@npm:^7.14.8, @babel/generator@npm:^7.14.9, @babel/generator@npm:^7.9.0":
-  version: 7.14.9
-  resolution: "@babel/generator@npm:7.14.9"
+"@babel/generator@npm:^7.12.10, @babel/generator@npm:^7.12.11, @babel/generator@npm:^7.15.0, @babel/generator@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/generator@npm:7.15.0"
   dependencies:
-    "@babel/types": ^7.14.9
+    "@babel/types": ^7.15.0
     jsesc: ^2.5.1
     source-map: ^0.5.0
-  checksum: 4f3ff00dd58c0e69fc58eba8c8565ccea19d80105720ea900262d1b03a6f4faf96e79799be2b88a0746a0e6d9c2b59833369abe2337689adf8d33ab1d9fcb450
+  checksum: f25da8b93418cc081d23a4d8d31cff9d4e7107387f9214f866f6d35a0ef1b11a4c59ecda33d264a1356edbffa137e69df33ad4a4a21a278316da3c8029485b48
   languageName: node
   linkType: hard
 
@@ -940,33 +940,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.14.5, @babel/helper-compilation-targets@npm:^7.8.7":
-  version: 7.14.5
-  resolution: "@babel/helper-compilation-targets@npm:7.14.5"
+"@babel/helper-compilation-targets@npm:^7.12.5, @babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.14.5, @babel/helper-compilation-targets@npm:^7.15.0, @babel/helper-compilation-targets@npm:^7.8.7":
+  version: 7.15.0
+  resolution: "@babel/helper-compilation-targets@npm:7.15.0"
   dependencies:
-    "@babel/compat-data": ^7.14.5
+    "@babel/compat-data": ^7.15.0
     "@babel/helper-validator-option": ^7.14.5
     browserslist: ^4.16.6
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: db7d58fc7309fcd925ee3cbf724fd796fc5779545de4da97badc772c7f05f087155538fb8ed503cf2e8075fb939c79a6e806fb5b7901c20dbe09c1d194a12ed2
+  checksum: 9a0389fd608011650c99c6ab60bc638428cea33ae59ae4921d7c7ac3e800a1cb27d60f30cdfb5da2cc41f8de3ed405e0b893cc2e6ba659dfdffe6f933d7f40a5
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.14.5, @babel/helper-create-class-features-plugin@npm:^7.14.6, @babel/helper-create-class-features-plugin@npm:^7.8.3":
-  version: 7.14.8
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.14.8"
+"@babel/helper-create-class-features-plugin@npm:^7.12.1, @babel/helper-create-class-features-plugin@npm:^7.14.5, @babel/helper-create-class-features-plugin@npm:^7.15.0, @babel/helper-create-class-features-plugin@npm:^7.8.3":
+  version: 7.15.0
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.15.0"
   dependencies:
     "@babel/helper-annotate-as-pure": ^7.14.5
     "@babel/helper-function-name": ^7.14.5
-    "@babel/helper-member-expression-to-functions": ^7.14.7
+    "@babel/helper-member-expression-to-functions": ^7.15.0
     "@babel/helper-optimise-call-expression": ^7.14.5
-    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-replace-supers": ^7.15.0
     "@babel/helper-split-export-declaration": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 89faaec0a6514659f055f1231984610c8cf2aa49f5c01077d10a00ae6617168b2c34a2d3844784a21d12f72c9499ee3bd6f453717cd3d192b8d2d17ea1d4a179
+  checksum: d8c38bbb8a15027bbdc507fc1ab360bc616556d0b15bde5b0181f5d8f4e64e96306ba2a3a36ef48ccbb5746451f51ca5453d20b927cb4d71b1997e458914faa0
   languageName: node
   linkType: hard
 
@@ -1038,12 +1038,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.14.5, @babel/helper-member-expression-to-functions@npm:^7.14.7":
-  version: 7.14.7
-  resolution: "@babel/helper-member-expression-to-functions@npm:7.14.7"
+"@babel/helper-member-expression-to-functions@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.15.0"
   dependencies:
-    "@babel/types": ^7.14.5
-  checksum: 8a45a0f6b2e945eab5072e3401f54b0e9366c22e41b91dfa6b1cb232368d99c31c99f59fd50aff28ba989008ab47e3bfa9921dc17ea32e9fea78817a10b22fb9
+    "@babel/types": ^7.15.0
+  checksum: c424da342d3846945c449e775a19f0d305d39e7421273c87e1d78aaba7988b7b521aca92b64a63bdcfcfd98be5267951fd1c20f1c102f52ea29f383c117127cc
   languageName: node
   linkType: hard
 
@@ -1056,19 +1056,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.14.5, @babel/helper-module-transforms@npm:^7.14.8, @babel/helper-module-transforms@npm:^7.9.0":
-  version: 7.14.8
-  resolution: "@babel/helper-module-transforms@npm:7.14.8"
+"@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.14.5, @babel/helper-module-transforms@npm:^7.15.0, @babel/helper-module-transforms@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/helper-module-transforms@npm:7.15.0"
   dependencies:
     "@babel/helper-module-imports": ^7.14.5
-    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-replace-supers": ^7.15.0
     "@babel/helper-simple-access": ^7.14.8
     "@babel/helper-split-export-declaration": ^7.14.5
-    "@babel/helper-validator-identifier": ^7.14.8
+    "@babel/helper-validator-identifier": ^7.14.9
     "@babel/template": ^7.14.5
-    "@babel/traverse": ^7.14.8
-    "@babel/types": ^7.14.8
-  checksum: f8b5dc617e1c13ef215d0987e53fce8b085a1726a9dced3d45ab750b357400ae0ccc02c9699a6fd2bad21f5c27c85f34be9b4c9bfa0988b2dcd1407d32772b51
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+  checksum: 4e12f23b9eeccd1dc6da9370f46da97bf987606e255e3d54b5c54867e9f4487e217d004b7f1a8ba762dbec72a7c4950c141f2b64dd5005cfb0217da225632667
   languageName: node
   linkType: hard
 
@@ -1099,19 +1099,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.14.5":
-  version: 7.14.5
-  resolution: "@babel/helper-replace-supers@npm:7.14.5"
+"@babel/helper-replace-supers@npm:^7.14.5, @babel/helper-replace-supers@npm:^7.15.0":
+  version: 7.15.0
+  resolution: "@babel/helper-replace-supers@npm:7.15.0"
   dependencies:
-    "@babel/helper-member-expression-to-functions": ^7.14.5
+    "@babel/helper-member-expression-to-functions": ^7.15.0
     "@babel/helper-optimise-call-expression": ^7.14.5
-    "@babel/traverse": ^7.14.5
-    "@babel/types": ^7.14.5
-  checksum: 368aba02e75a3bdae7e79d424c7ec98c72a3d8ced95920899e9efc39d274a414c7ab0ac9ed49c9af21e6430a5c5063e382de93d2dd83ff27c8f469a011a658a0
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+  checksum: d6fa9b6f8a268ad87aeda21471ee49dbc27e63df5e0a623119e6a16275342e0ddbc555b03171e6dea44a536b0382bbbe50f0872e534243fa30a7b867f2e47200
   languageName: node
   linkType: hard
 
-"@babel/helper-simple-access@npm:^7.14.5, @babel/helper-simple-access@npm:^7.14.8":
+"@babel/helper-simple-access@npm:^7.14.8":
   version: 7.14.8
   resolution: "@babel/helper-simple-access@npm:7.14.8"
   dependencies:
@@ -1138,7 +1138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.14.5, @babel/helper-validator-identifier@npm:^7.14.8, @babel/helper-validator-identifier@npm:^7.14.9":
+"@babel/helper-validator-identifier@npm:^7.14.5, @babel/helper-validator-identifier@npm:^7.14.9":
   version: 7.14.9
   resolution: "@babel/helper-validator-identifier@npm:7.14.9"
   checksum: a4825ac127a83def2def864fbf14f3601037c8bc35e8347a413b21d06f0257e8a8b0cde88885262e6c0401f71d24b158ba8e8c4e08c1c915dbdba1db7ec8d043
@@ -1165,13 +1165,13 @@ __metadata:
   linkType: hard
 
 "@babel/helpers@npm:^7.12.5, @babel/helpers@npm:^7.14.8, @babel/helpers@npm:^7.9.0":
-  version: 7.14.8
-  resolution: "@babel/helpers@npm:7.14.8"
+  version: 7.15.3
+  resolution: "@babel/helpers@npm:7.15.3"
   dependencies:
     "@babel/template": ^7.14.5
-    "@babel/traverse": ^7.14.8
-    "@babel/types": ^7.14.8
-  checksum: 5a1aea6d8f38f90ef00cd0a3fec9f25bce7207efa628898c8362b50d8fcc997a1e69a52a133794719a9fb065752b8edced92196f5ccba53171b9e046b13bb824
+    "@babel/traverse": ^7.15.0
+    "@babel/types": ^7.15.0
+  checksum: 8cecbaf6223e49a87144d57d6c72d1c38926ff6b3cccc4896a952c78ee1cc361887dcd6b24f982b30d6b8df4d3e0cf6af7e692f6c7eb6e7bdd4a967ea147065f
   languageName: node
   linkType: hard
 
@@ -1186,12 +1186,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.10, @babel/parser@npm:^7.14.5, @babel/parser@npm:^7.14.8, @babel/parser@npm:^7.14.9, @babel/parser@npm:^7.6.4, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.9.0":
-  version: 7.14.9
-  resolution: "@babel/parser@npm:7.14.9"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.10, @babel/parser@npm:^7.14.5, @babel/parser@npm:^7.15.0, @babel/parser@npm:^7.6.4, @babel/parser@npm:^7.7.0, @babel/parser@npm:^7.9.0":
+  version: 7.15.3
+  resolution: "@babel/parser@npm:7.15.3"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: a6e95303dc93b8075f0f679d086c8ef127c658de8bd5baa3ec56da8e2da46e3004431b86477302c8ca7ed84e848189216a2b6394f2040f5930f4c6e108dff3b4
+  checksum: 51cfbd379195684089a44f0ebf739ef412b9464dbc6faf61695a595ac3f9e23e45499c8237ec9e72a4df6238c6789d4e51c0dae7e4d27f3960e1c7d417bf6fc1
   languageName: node
   linkType: hard
 
@@ -1771,13 +1771,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-block-scoping@npm:^7.12.11, @babel/plugin-transform-block-scoping@npm:^7.14.5, @babel/plugin-transform-block-scoping@npm:^7.8.3":
-  version: 7.14.5
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.14.5"
+  version: 7.15.3
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.15.3"
   dependencies:
     "@babel/helper-plugin-utils": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f514565a5e2a612b39badb4be19fef83c49bd66e780631e06f6c44cd04af63653b6ad1a20d7836d405634829f7b351a16c79a396415c0ae9fe346a4fbaa416b7
+  checksum: 22e7411a9d0d390de956e534a21927238b57cc49f50fca139a825ec3f05e5f0d7abd76f0d69a76d4c0ea67b8e57b905c7fde5c7f1f7edc2388ecb1cc29cd09af
   languageName: node
   linkType: hard
 
@@ -1937,17 +1937,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.12.1, @babel/plugin-transform-modules-commonjs@npm:^7.14.5, @babel/plugin-transform-modules-commonjs@npm:^7.9.0":
-  version: 7.14.5
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.14.5"
+"@babel/plugin-transform-modules-commonjs@npm:^7.12.1, @babel/plugin-transform-modules-commonjs@npm:^7.15.0, @babel/plugin-transform-modules-commonjs@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.15.0"
   dependencies:
-    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helper-module-transforms": ^7.15.0
     "@babel/helper-plugin-utils": ^7.14.5
-    "@babel/helper-simple-access": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.8
     babel-plugin-dynamic-import-node: ^2.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 569e82c8deb34f4418383eccd090df0335e715a8c0bdae29dc6fd5545ca317522825ef0c99b16f831d834e7f8044a21fd2e430a8449f01e832910abb594fadd3
+  checksum: dff0ea0395b9979a019c6e9ca9a413e8fed95d09d9143b5ce71153ee44d3effe61ab387506fcc52e6a93d48690b183fec80d655145bb210b797bc0470ba0a2eb
   languageName: node
   linkType: hard
 
@@ -2057,13 +2057,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-display-name@npm:^7.12.1, @babel/plugin-transform-react-display-name@npm:^7.14.5, @babel/plugin-transform-react-display-name@npm:^7.8.3":
-  version: 7.14.5
-  resolution: "@babel/plugin-transform-react-display-name@npm:7.14.5"
+  version: 7.15.1
+  resolution: "@babel/plugin-transform-react-display-name@npm:7.15.1"
   dependencies:
     "@babel/helper-plugin-utils": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 2fc76afb1df5a53bf8f66acc1e4deb9f3755b52e8a3b7853e1309af5b2f04dbf9475177cdaeae30b9e172d22cc8c36945e9b454aadd0c71571cf32c43717ba20
+  checksum: 898dc3bf2b147d6e7d1acb4feae83939a371530cf480c9f075fb3640f42b27ee272e9326ed3b2f868ae2e5cfddd116b6edba4a904236685fbec8409ee1ade034
   languageName: node
   linkType: hard
 
@@ -2164,8 +2164,8 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-runtime@npm:^7.5.5":
-  version: 7.14.5
-  resolution: "@babel/plugin-transform-runtime@npm:7.14.5"
+  version: 7.15.0
+  resolution: "@babel/plugin-transform-runtime@npm:7.15.0"
   dependencies:
     "@babel/helper-module-imports": ^7.14.5
     "@babel/helper-plugin-utils": ^7.14.5
@@ -2175,7 +2175,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 5d5683e0962459bec177415aaa6dd1f518252f0b923e5dad77847faccdb2e0d1b15984bc79141d44c9aa8441c1753cc3699858f87975d262132d35c4305f3be0
+  checksum: 159c3a02e24cabc67e121e22d6446e72af47c3ae94d10851fb30facdf62f920f735302273ff4b8df565a633c47d44d20a85eb290717635d4ec4c4fa48fdfd9f4
   languageName: node
   linkType: hard
 
@@ -2235,16 +2235,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.12.1, @babel/plugin-transform-typescript@npm:^7.14.5, @babel/plugin-transform-typescript@npm:^7.9.0":
-  version: 7.14.6
-  resolution: "@babel/plugin-transform-typescript@npm:7.14.6"
+"@babel/plugin-transform-typescript@npm:^7.12.1, @babel/plugin-transform-typescript@npm:^7.15.0, @babel/plugin-transform-typescript@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/plugin-transform-typescript@npm:7.15.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": ^7.14.6
+    "@babel/helper-create-class-features-plugin": ^7.15.0
     "@babel/helper-plugin-utils": ^7.14.5
     "@babel/plugin-syntax-typescript": ^7.14.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 81cf43bbf5efe88c165ac09ab37c884b25dbcf96202a0548b9126224f6e7fb067ff298618e225c3803732de7c91607dd27af86898044333c7955b3693361be7e
+  checksum: c550eb8f04030086c6aec2f4bb2389ef17f440cf3ebfbc479a5b261e2fdd4a4761b67a15b1810619b70a3bf56f4896f2e8688c4fe69b2a967f8f66d7294c75cf
   languageName: node
   linkType: hard
 
@@ -2428,11 +2428,11 @@ __metadata:
   linkType: hard
 
 "@babel/preset-env@npm:^7.4.5, @babel/preset-env@npm:^7.5.5":
-  version: 7.14.9
-  resolution: "@babel/preset-env@npm:7.14.9"
+  version: 7.15.0
+  resolution: "@babel/preset-env@npm:7.15.0"
   dependencies:
-    "@babel/compat-data": ^7.14.9
-    "@babel/helper-compilation-targets": ^7.14.5
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.0
     "@babel/helper-plugin-utils": ^7.14.5
     "@babel/helper-validator-option": ^7.14.5
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.14.5
@@ -2480,7 +2480,7 @@ __metadata:
     "@babel/plugin-transform-literals": ^7.14.5
     "@babel/plugin-transform-member-expression-literals": ^7.14.5
     "@babel/plugin-transform-modules-amd": ^7.14.5
-    "@babel/plugin-transform-modules-commonjs": ^7.14.5
+    "@babel/plugin-transform-modules-commonjs": ^7.15.0
     "@babel/plugin-transform-modules-systemjs": ^7.14.5
     "@babel/plugin-transform-modules-umd": ^7.14.5
     "@babel/plugin-transform-named-capturing-groups-regex": ^7.14.9
@@ -2498,7 +2498,7 @@ __metadata:
     "@babel/plugin-transform-unicode-escapes": ^7.14.5
     "@babel/plugin-transform-unicode-regex": ^7.14.5
     "@babel/preset-modules": ^0.1.4
-    "@babel/types": ^7.14.9
+    "@babel/types": ^7.15.0
     babel-plugin-polyfill-corejs2: ^0.2.2
     babel-plugin-polyfill-corejs3: ^0.2.2
     babel-plugin-polyfill-regenerator: ^0.2.2
@@ -2506,7 +2506,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: a04fc4b7bd9660159060f3f1a6402ccfcb8a8faed51c1ade0a262901449715ad54bd1b0540fd1389844c7698174cc51e19536c42acca769ce67288b3f4894530
+  checksum: 4b51a025229b3e38c7e77fa16b0fc0fbc77573b679f797a63b628527ee6445e64ee7662a3568857b4c04f128acc67cba90e367ff0706af3718b899c91dd68e63
   languageName: node
   linkType: hard
 
@@ -2611,21 +2611,21 @@ __metadata:
   linkType: hard
 
 "@babel/preset-typescript@npm:^7.0.0, @babel/preset-typescript@npm:^7.8.3":
-  version: 7.14.5
-  resolution: "@babel/preset-typescript@npm:7.14.5"
+  version: 7.15.0
+  resolution: "@babel/preset-typescript@npm:7.15.0"
   dependencies:
     "@babel/helper-plugin-utils": ^7.14.5
     "@babel/helper-validator-option": ^7.14.5
-    "@babel/plugin-transform-typescript": ^7.14.5
+    "@babel/plugin-transform-typescript": ^7.15.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: d2fdf3d875a155a97b04cb2799c001cce41de001fe16091657f636eaa56d789715a6fe768fa63222d9046c71d1975e4c165be74b71a93358e0ce376bf0a297e4
+  checksum: c5459aefeb191d189f06670ebabcb561d9f1f1f59fdcb378901802cd4205b6f11026e81767c799d717848af7e19511d87f7336c49d06c9a0b593b9a9f0304d07
   languageName: node
   linkType: hard
 
 "@babel/register@npm:^7.5.5":
-  version: 7.14.5
-  resolution: "@babel/register@npm:7.14.5"
+  version: 7.15.3
+  resolution: "@babel/register@npm:7.15.3"
   dependencies:
     clone-deep: ^4.0.1
     find-cache-dir: ^2.0.0
@@ -2634,17 +2634,17 @@ __metadata:
     source-map-support: ^0.5.16
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 2f6be54e6f6deeecf7fec2cd8071aae02f63de770dd13e5b6a2dcf69012a8b03775abd5f57bec56004cc1ab702e038ad79cfa9a1422e62127ac9110d5433986a
+  checksum: a339ae3a2aa65eb8e8ad0f85987b9a6f33a4e4144280708bccedb53f7a6dffdcd5c874f33a4e79a38bf7e7b343e4240d057dc2046ad3dfdd85053b1d8be900b9
   languageName: node
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.14.9
-  resolution: "@babel/runtime-corejs3@npm:7.14.9"
+  version: 7.15.3
+  resolution: "@babel/runtime-corejs3@npm:7.15.3"
   dependencies:
     core-js-pure: ^3.16.0
     regenerator-runtime: ^0.13.4
-  checksum: 1d211ab3bfc16e48b9d7e50e3ce2229b75303f850abd8b4122b02b525b8579360b758c11a648809217d94fa8754a33a5df4a1fdd8c0c2d99408dc2f3ad0a5dc4
+  checksum: d0c7e970fc75091f03251075e4a5ba4a0232fbb0fd365dd6263eb3e556a9cfe9a2769c493dff3376309fe6249d8cbcd564f1c2cbc2a2456fbba226fd730f91f2
   languageName: node
   linkType: hard
 
@@ -2658,18 +2658,18 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.4.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.14.8
-  resolution: "@babel/runtime@npm:7.14.8"
+  version: 7.15.3
+  resolution: "@babel/runtime@npm:7.15.3"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: ebadb3e013a26e0f62abea0da6f6f5d83c9566f0d900e65069885f93088066c64586076d15dcbe6e093c536f66cffc9e2e136ad5d8b3e66235af62f0051afa42
+  checksum: dfb5ba324d36b141f3ed5a6af8a4c03b6b5c94cc2453b265dbdd56ae3b5c28c1a44640b31fa9d7462d8278c7c8af967be8004024a87c795175c724cd77c5cce1
   languageName: node
   linkType: hard
 
 "@babel/standalone@npm:^7.4.5":
-  version: 7.14.9
-  resolution: "@babel/standalone@npm:7.14.9"
-  checksum: 3d16f4e1896a6ba39f9de6d201c51ba6ad670d5a6c7e5cf26284296c352645425fb9a4f66d51147467aa84d2f7e5e9f405eb21e59d19ef8188762fb1d76c48cd
+  version: 7.15.3
+  resolution: "@babel/standalone@npm:7.15.3"
+  checksum: 9330db28ad75cd035cd4396e1b7a1c45dde52c3df8221043b373f21fa0cddfc2f487248334dcde1249e1e078ca2f92567169f03a2065480140f175233ad44b20
   languageName: node
   linkType: hard
 
@@ -2684,30 +2684,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.10, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.14.5, @babel/traverse@npm:^7.14.8, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.9.0":
-  version: 7.14.9
-  resolution: "@babel/traverse@npm:7.14.9"
+"@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.10, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.14.5, @babel/traverse@npm:^7.15.0, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/traverse@npm:7.15.0"
   dependencies:
     "@babel/code-frame": ^7.14.5
-    "@babel/generator": ^7.14.9
+    "@babel/generator": ^7.15.0
     "@babel/helper-function-name": ^7.14.5
     "@babel/helper-hoist-variables": ^7.14.5
     "@babel/helper-split-export-declaration": ^7.14.5
-    "@babel/parser": ^7.14.9
-    "@babel/types": ^7.14.9
+    "@babel/parser": ^7.15.0
+    "@babel/types": ^7.15.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 89e8f10472c3b4ebda951c87ebefc6613071e6d8383543f851c4ecb5b7b8bf1ba2b081de950a51e678efb423c1584eb3780afc5c942322b4b8064c565e496964
+  checksum: 1caca0000161bf381a5ec89e14de1725c677c0ad175f05ae26e3a4412a9b7545418e5180fd20832000a6958c32a057d8c8c38cf71f4791b62cca2e8df647236f
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.49, @babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.14.5, @babel/types@npm:^7.14.8, @babel/types@npm:^7.14.9, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3, @babel/types@npm:^7.9.0":
-  version: 7.14.9
-  resolution: "@babel/types@npm:7.14.9"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.0.0-beta.49, @babel/types@npm:^7.12.10, @babel/types@npm:^7.12.11, @babel/types@npm:^7.14.5, @babel/types@npm:^7.14.8, @babel/types@npm:^7.14.9, @babel/types@npm:^7.15.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3, @babel/types@npm:^7.9.0":
+  version: 7.15.0
+  resolution: "@babel/types@npm:7.15.0"
   dependencies:
     "@babel/helper-validator-identifier": ^7.14.9
     to-fast-properties: ^2.0.0
-  checksum: c993256040066ed62bbeb1fff6e79a19127411ee46911830dfc82162e43ab76e1b3d90fa4d1fdf4203c4d0bfc64114e18afd4ba1b22e9eb2e878eb9b4ce019c9
+  checksum: 05095d384f6f645474bcb422d2abe89c48ce273fe8e30a860bcace748adfbe466c661bba4415f148474458236a8cfcbf03e98a37c56f4a8fdc0e23817a0c5cdc
   languageName: node
   linkType: hard
 
@@ -3060,14 +3060,14 @@ __metadata:
   linkType: hard
 
 "@elastic/elasticsearch@npm:^7.9.1":
-  version: 7.13.0
-  resolution: "@elastic/elasticsearch@npm:7.13.0"
+  version: 7.14.0
+  resolution: "@elastic/elasticsearch@npm:7.14.0"
   dependencies:
     debug: ^4.3.1
     hpagent: ^0.1.1
     ms: ^2.1.3
     secure-json-parse: ^2.4.0
-  checksum: 9881b32643540512947ed55253005fb2c42ad41a4f4cb304c643a2ffa58fef3f23eb4eacd3c35e2a7bb16c4ce6837fff7668b974bed088a4f734507514cdaa1f
+  checksum: 71ca559618698eaa7ce4f29d9a6d5262854b637240fee75aea564108dff8e8432ddb71b256b5eb34564c3a56e405f58c00f02fe5cc80fefced2ecf4c5c210fa7
   languageName: node
   linkType: hard
 
@@ -3369,58 +3369,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-common-types@npm:^0.2.35":
-  version: 0.2.35
-  resolution: "@fortawesome/fontawesome-common-types@npm:0.2.35"
-  checksum: d8a25c567cb4949ea63fd63ad320ca1ccd95094ec2e011215af7e415fc6108afa64719cefa3f85b8cf65abf2d349b76fefdb368418ba3c27cc7ba23fcbf4d485
+"@fortawesome/fontawesome-common-types@npm:^0.2.36":
+  version: 0.2.36
+  resolution: "@fortawesome/fontawesome-common-types@npm:0.2.36"
+  checksum: a923cb94def9ac6e7965c6078f9ff2a9ffed9fe3847077c7a845def4d9e30b5b72ed215aab22c8d106c085bf1df18f0db2c74c4bf99d4e944aafa70ee953ff17
   languageName: node
   linkType: hard
 
 "@fortawesome/fontawesome-svg-core@npm:^1.2.8":
-  version: 1.2.35
-  resolution: "@fortawesome/fontawesome-svg-core@npm:1.2.35"
+  version: 1.2.36
+  resolution: "@fortawesome/fontawesome-svg-core@npm:1.2.36"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.2.35
-  checksum: 2457135c46ff06c32b8dd88cc3e1df96e8d9175657cb57cb74c3e26e7047cd3989a2c76c2d784a37d1edc724e1f3b9ac10e82bf7cc06d74a6a438370b4deac2b
+    "@fortawesome/fontawesome-common-types": ^0.2.36
+  checksum: cf3bca5bfecd140f15c276ba4d5297816bd9b0028b700b3fec24d5a0b6ec8f75d5a40dbf6142d1c9d342aa9210aff65cdf729c92be71246e3cdb7fa3ae7b59bd
   languageName: node
   linkType: hard
 
 "@fortawesome/free-brands-svg-icons@npm:^5.5.0":
-  version: 5.15.3
-  resolution: "@fortawesome/free-brands-svg-icons@npm:5.15.3"
+  version: 5.15.4
+  resolution: "@fortawesome/free-brands-svg-icons@npm:5.15.4"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.2.35
-  checksum: aafd60827b01902fb7ff5d0cd18a2c95d8f663c11ff3be40086f2aa82da0909f66ba8f8ac4e20dab24b82c1b31dc8e4cb3f2430c6b6897472287cf278b16e575
+    "@fortawesome/fontawesome-common-types": ^0.2.36
+  checksum: 4f4924900c5bcb938bbdc256ab52c988c412f325cde2d29c1ee445d5a481b5b7a62bb7e6b2bbceca282d7579660444422e10c2e1083d20110065e2c4e033398a
   languageName: node
   linkType: hard
 
 "@fortawesome/free-regular-svg-icons@npm:^5.6.0":
-  version: 5.15.3
-  resolution: "@fortawesome/free-regular-svg-icons@npm:5.15.3"
+  version: 5.15.4
+  resolution: "@fortawesome/free-regular-svg-icons@npm:5.15.4"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.2.35
-  checksum: af6dbf342b2c24e2a2b583148988ca16aefbb5caeefc5d99e115fc831461522d1edfc2f1f1e06c9d4a8045c0ec919cf1b1762a39a8265aa79dbb456c8e3134ec
+    "@fortawesome/fontawesome-common-types": ^0.2.36
+  checksum: 96bcdfbfa1a0c2694bd7c55ba0a821e6910ea296e429ffc46a1725ccbc9c57f48084b84e4ec60e047c537a3f11a6dfe7cf3e4e79df58b32e934880bc410c098c
   languageName: node
   linkType: hard
 
 "@fortawesome/free-solid-svg-icons@npm:^5.5.0":
-  version: 5.15.3
-  resolution: "@fortawesome/free-solid-svg-icons@npm:5.15.3"
+  version: 5.15.4
+  resolution: "@fortawesome/free-solid-svg-icons@npm:5.15.4"
   dependencies:
-    "@fortawesome/fontawesome-common-types": ^0.2.35
-  checksum: dd5c7e006ad8794ec40da55eb2af4a160ddfaff6ea95dba12e95a0a8a88eb7fae6376f1a0be494a8b4012ef60c52aee3caa353896678f2042141bfb5957be1c7
+    "@fortawesome/fontawesome-common-types": ^0.2.36
+  checksum: 65c3d375875d27590fdf29110ec141e0c0c5ccd2e11cb18dbe5dc22d716dbde52a55cf1fd95eb2cfbb1f91b2d2d80275e12d3eae5b8dba68cca279c774307cbe
   languageName: node
   linkType: hard
 
 "@fortawesome/react-fontawesome@npm:^0.1.3":
-  version: 0.1.14
-  resolution: "@fortawesome/react-fontawesome@npm:0.1.14"
+  version: 0.1.15
+  resolution: "@fortawesome/react-fontawesome@npm:0.1.15"
   dependencies:
     prop-types: ^15.7.2
   peerDependencies:
     "@fortawesome/fontawesome-svg-core": ^1.2.32
     react: ">=16.x"
-  checksum: 8e9f2b94d360e82a3cafa5ff660461a012bead11279bd37dd12910bbf084bf0dd997db439c254a318106b69666ff6b3c749982f972ab7da0f7578a1d857d94cf
+  checksum: 304b313e7d942a6191ba26a8d3c37da9006129a72250f8bbdff7d489c3afcc827753aaccf42a6f5918cff81293a5c987f3514d297b09b49f33611b11183d5486
   languageName: node
   linkType: hard
 
@@ -3451,11 +3451,11 @@ __metadata:
   linkType: hard
 
 "@grpc/grpc-js@npm:^1.2.7":
-  version: 1.3.6
-  resolution: "@grpc/grpc-js@npm:1.3.6"
+  version: 1.3.7
+  resolution: "@grpc/grpc-js@npm:1.3.7"
   dependencies:
     "@types/node": ">=12.12.47"
-  checksum: cd56e22bdabed91b8c25241f103c640879f28138c6bfd49906de502298a4ebf3a63fe29aa902d62a4ff1852ce405cd5f23afa73c5eb3fae49ed4d33b3c24f816
+  checksum: fabcc38f5c41aa92e651bf3c96b404c66520622a4c934b16d20e83da5c5c6c870f3d31b9f9adff9e4e25912739dde59c54bd6836e1d54a03caed5efa8ac63ed5
   languageName: node
   linkType: hard
 
@@ -5427,8 +5427,8 @@ __metadata:
   linkType: hard
 
 "@octokit/oauth-app@npm:^3.3.0, @octokit/oauth-app@npm:^3.3.2":
-  version: 3.4.0
-  resolution: "@octokit/oauth-app@npm:3.4.0"
+  version: 3.5.1
+  resolution: "@octokit/oauth-app@npm:3.5.1"
   dependencies:
     "@octokit/auth-oauth-app": ^4.0.0
     "@octokit/auth-oauth-user": ^1.3.0
@@ -5438,14 +5438,14 @@ __metadata:
     "@octokit/oauth-methods": ^1.2.2
     fromentries: ^1.3.1
     universal-user-agent: ^6.0.0
-  checksum: 5ea4f4c00623b476ecfbfed7cfb271e357e73fa40d76305ada0dcda0cc6d77c1d2e55c2ffeea55c4b11580a11f1a131966d4079a7c9e0220ac710b9f7ba49f52
+  checksum: ad830ef168289e0c51589f799401e91c9958c9af4a05e080e5c9d1c7b6751b54346089ce47393272d30496de9093db0405da894e725fc1743fc6e9fa59827215
   languageName: node
   linkType: hard
 
 "@octokit/oauth-authorization-url@npm:^4.2.1, @octokit/oauth-authorization-url@npm:^4.3.1":
-  version: 4.3.2
-  resolution: "@octokit/oauth-authorization-url@npm:4.3.2"
-  checksum: 73fd66625350075465cae0e5109fdd5f6aa58d6eec1060fab5c389e0a9cf1b31dd37af0044b60f938ca324e419b877848e3a6b468f8e9795c65764973bae92cf
+  version: 4.3.3
+  resolution: "@octokit/oauth-authorization-url@npm:4.3.3"
+  checksum: c728188c4abc06b69c8cabd956d6cf00f02b3f901d7a18ba35eb9769ae557c5e8246b1542e85be0354801603d07eb2c3f098ad727ea43aa2dcd00b498aff1876
   languageName: node
   linkType: hard
 
@@ -5462,10 +5462,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "@octokit/openapi-types@npm:9.2.0"
-  checksum: a649bc6734fe910b5d00cc1fa599adce5649a456f861cb44ff89640ea6fc9ce9dce17efb952d84a91ad840c59ae785d1f250b47e1b5272f4efc294160ddb4ab5
+"@octokit/openapi-types@npm:^9.5.0":
+  version: 9.7.0
+  resolution: "@octokit/openapi-types@npm:9.7.0"
+  checksum: 240c2487ed46e4aa50ba9f3641bd4fc73d685136c6dbb131cf8229cf5b659f5116c4e2b4055b12d1e0e047738ee9938d96f8e5b6fe7848abd3d4426254cba044
   languageName: node
   linkType: hard
 
@@ -5486,13 +5486,13 @@ __metadata:
   linkType: hard
 
 "@octokit/plugin-paginate-rest@npm:^2.13.3":
-  version: 2.14.0
-  resolution: "@octokit/plugin-paginate-rest@npm:2.14.0"
+  version: 2.15.1
+  resolution: "@octokit/plugin-paginate-rest@npm:2.15.1"
   dependencies:
-    "@octokit/types": ^6.18.0
+    "@octokit/types": ^6.24.0
   peerDependencies:
     "@octokit/core": ">=2"
-  checksum: a94cbc932fd40e14f76baac4100a00d346fd46b70a85c73b9f4495b97356d27d9b6c571b29425ff8d259e6e579f3b7583bae64f350cf5358c6c3b870f2d79219
+  checksum: de97dc34f873be38929cb8dc61bc29c5fc79b73dfeeab9f10547f10516e206a55ad2359d19d2c4e9bc197c1795c136ddd200cfa82dfef09b991adc471cf09696
   languageName: node
   linkType: hard
 
@@ -5515,15 +5515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-rest-endpoint-methods@npm:^5.0.0":
-  version: 5.5.2
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:5.5.2"
+"@octokit/plugin-rest-endpoint-methods@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:5.8.0"
   dependencies:
-    "@octokit/types": ^6.22.0
+    "@octokit/types": ^6.25.0
     deprecation: ^2.3.1
   peerDependencies:
     "@octokit/core": ">=3"
-  checksum: 5ff95ec65f70de3bc3a5dd24b101afb514226124bd2c09318863f1b3838b830f98ff403c21f457635df150b7d8e1967f17549084dca391758350cf1c7346c4ed
+  checksum: 5e2379089504e8be92d0ed966420f2206943a3eb9a6be2269c2d0060096fd00a17963c60304519b04aee836c4d9d2af7d7afdda6607bd6ed3cf8727fdab47ca6
   languageName: node
   linkType: hard
 
@@ -5572,8 +5572,8 @@ __metadata:
   linkType: hard
 
 "@octokit/request@npm:^5.2.0, @octokit/request@npm:^5.3.0, @octokit/request@npm:^5.4.14, @octokit/request@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "@octokit/request@npm:5.6.0"
+  version: 5.6.1
+  resolution: "@octokit/request@npm:5.6.1"
   dependencies:
     "@octokit/endpoint": ^6.0.1
     "@octokit/request-error": ^2.1.0
@@ -5581,7 +5581,7 @@ __metadata:
     is-plain-object: ^5.0.0
     node-fetch: ^2.6.1
     universal-user-agent: ^6.0.0
-  checksum: d9a6312f53292ee1b7c73e88fac1b26870bb524fcc8d80d3e5fc0b3d87d941e0728ba6ae2e1d8ac292a23ccaa73cfb27dbeb1cef73e185c24b97231f982d06a1
+  checksum: c4a7fabecdb8d40591a42d732f286165c0aad4f96d86746abdca624fcd55aad0a5ae3e4e9eb821995db98d6c46d76ffc3be6a29efa75e479f8110dd06c94d675
   languageName: node
   linkType: hard
 
@@ -5618,12 +5618,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^6.0.1, @octokit/types@npm:^6.0.3, @octokit/types@npm:^6.10.0, @octokit/types@npm:^6.12.2, @octokit/types@npm:^6.13.0, @octokit/types@npm:^6.16.1, @octokit/types@npm:^6.18.0, @octokit/types@npm:^6.22.0":
-  version: 6.22.0
-  resolution: "@octokit/types@npm:6.22.0"
+"@octokit/types@npm:^6.0.1, @octokit/types@npm:^6.0.3, @octokit/types@npm:^6.10.0, @octokit/types@npm:^6.12.2, @octokit/types@npm:^6.13.0, @octokit/types@npm:^6.16.1, @octokit/types@npm:^6.24.0, @octokit/types@npm:^6.25.0":
+  version: 6.25.0
+  resolution: "@octokit/types@npm:6.25.0"
   dependencies:
-    "@octokit/openapi-types": ^9.2.0
-  checksum: b653587f44fe06ab022a4f336a1b0aeeafc9e097c82334c8aadd72ae3181a182a116b3f00f4fecc0f91b1f9e19e9f9a6b6b95b5d5467f0b0c38c1451876661d8
+    "@octokit/openapi-types": ^9.5.0
+  checksum: eca1412b295557b607a93afcb2b11ddd9f1ce60aab9baf9e724b410d04bfe72a918de31418ab4056b237df40a7d61ad9debc74c83a4af2d054b2345bdf6881f6
   languageName: node
   linkType: hard
 
@@ -5634,22 +5634,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/webhooks-types@npm:4.2.0":
-  version: 4.2.0
-  resolution: "@octokit/webhooks-types@npm:4.2.0"
-  checksum: 0347c49dcad90ec3a744dc6dc01dd35b81e4a06eabfb1c2df11b92f88e5cc04e9bcdbbc8954557ac772d7dc39c89e527f1807c844540696fb4cd118a1ee2620e
+"@octokit/webhooks-types@npm:4.3.0":
+  version: 4.3.0
+  resolution: "@octokit/webhooks-types@npm:4.3.0"
+  checksum: 089f71cdeaa29283f158ccabcef7d256c9dbe26eca72975cd3e849089f5c7122ef17f1307329ea9bcf086d3593bef18060183a60f754166d916482720a54cb73
   languageName: node
   linkType: hard
 
 "@octokit/webhooks@npm:^9.0.1":
-  version: 9.11.0
-  resolution: "@octokit/webhooks@npm:9.11.0"
+  version: 9.12.0
+  resolution: "@octokit/webhooks@npm:9.12.0"
   dependencies:
     "@octokit/request-error": ^2.0.2
     "@octokit/webhooks-methods": ^2.0.0
-    "@octokit/webhooks-types": 4.2.0
+    "@octokit/webhooks-types": 4.3.0
     aggregate-error: ^3.1.0
-  checksum: 77da9845a0d5f23fb56b964d388cf677993a831e58763192c2a1caa42761f32ad0172b991db8e6c8097b2c3ea93eb6507b6c59df4a1abfb134da00a2968fb49c
+  checksum: 252d0ccdba5258371843c6820d27486af6d316d4713a791ced02e0f61ca0440d441e52d2e36063ab6ca02df6c63b055867a3a3ad402b656678e5a9abdbf2c434
   languageName: node
   linkType: hard
 
@@ -5823,8 +5823,8 @@ __metadata:
   linkType: hard
 
 "@pulumi/aws@npm:^4.10.0":
-  version: 4.14.0
-  resolution: "@pulumi/aws@npm:4.14.0"
+  version: 4.15.0
+  resolution: "@pulumi/aws@npm:4.15.0"
   dependencies:
     "@pulumi/pulumi": ^3.0.0
     aws-sdk: ^2.0.0
@@ -5832,13 +5832,13 @@ __metadata:
     mime: ^2.0.0
     read-package-tree: ^5.2.1
     resolve: ^1.7.1
-  checksum: bec1de34133279f144029cf695c4109083e7c2deb7af691cf73b591c99fe05c1d03593a9187bd1d19bee3a5cada2b2bc6b5c4dca5ec1f5ef280cc10cda099cbc
+  checksum: 856e89ea4473f0c756d82c7749bdc309cc556e0c54624a35024fab73af6997279db8593ebc7390f5360f73c07bd4173e24f2bcea084389146aeb5921309933d7
   languageName: node
   linkType: hard
 
 "@pulumi/pulumi@npm:^3.0.0, @pulumi/pulumi@npm:^3.6.0":
-  version: 3.9.1
-  resolution: "@pulumi/pulumi@npm:3.9.1"
+  version: 3.10.0
+  resolution: "@pulumi/pulumi@npm:3.10.0"
   dependencies:
     "@grpc/grpc-js": ^1.2.7
     "@logdna/tail-file": ^2.0.6
@@ -5855,7 +5855,7 @@ __metadata:
     ts-node: ^7.0.1
     typescript: ~3.7.3
     upath: ^1.1.0
-  checksum: 17a839864ec0cd5f26fdbe5ede77f37e6004fc67a8383eaf588585b5f6dd3ecd46cf4ac076680db27d964fe2732e231f4983169c4cb3e31685e01a0e3ed5cd58
+  checksum: 16273732d527c4332c1d58ade068e82d419910a01e403ab1cc63554cbca2e0da168a823b1bbd654f851a716d36c102cc4192508b0d42277b1266d1353ebfad2d
   languageName: node
   linkType: hard
 
@@ -7316,9 +7316,9 @@ __metadata:
   linkType: hard
 
 "@types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8":
-  version: 7.0.8
-  resolution: "@types/json-schema@npm:7.0.8"
-  checksum: 435a3d18a88aeac7bc88c2cdd2c19466c62ce79303493edd72380cd4af9775c05f35d424d5e76ffe3f94575ebb535305c6cae928c5bfb9c39eafbfb6932520a1
+  version: 7.0.9
+  resolution: "@types/json-schema@npm:7.0.9"
+  checksum: 3252f0faa7aada7ad27c59bb64ff7bee0c9ad0fb7c21a3b7d255f56c732b94fe94a876f5a5f6fee27a41feac09efac082fad54314c3ce542db02445d7a6059f8
   languageName: node
   linkType: hard
 
@@ -7409,9 +7409,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:>=6":
-  version: 16.4.10
-  resolution: "@types/node@npm:16.4.10"
-  checksum: fcbd20531909ebc1edbc3183d7128a6c72a5e543c4a6966ba787d9be6b5619e4074a4e1ddeb12f694f99526bf1c5f55e653fcde12215fd9a0999a0db8501af2b
+  version: 16.6.0
+  resolution: "@types/node@npm:16.6.0"
+  checksum: 7adfde1fd1eb43c511029e72db932cda94ce63fb284e783db9f927a01065afc86054d1025330d968fda885b5884aaa30fd6bbedaa17f4af62e0ca86206a61cb9
   languageName: node
   linkType: hard
 
@@ -7430,9 +7430,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^12.12.22":
-  version: 12.20.18
-  resolution: "@types/node@npm:12.20.18"
-  checksum: d92edf861bbed6e468d06018a508bb69c11b4ba7c24e61c75b17255a2cf5c015a28c805758b02cd8ac009368b0066bf4dd7fc62612bebacc21c0700316ff606a
+  version: 12.20.19
+  resolution: "@types/node@npm:12.20.19"
+  checksum: 6cb723e8e601a884e5eaba6a3d93edf21843cf8afedb6878731813fd9da16d999e0dfddef29a8391f6d3380428cc60ae523a125054be2f95fb540c67c31a2994
   languageName: node
   linkType: hard
 
@@ -7692,13 +7692,13 @@ __metadata:
   linkType: hard
 
 "@types/webpack-sources@npm:*":
-  version: 2.1.1
-  resolution: "@types/webpack-sources@npm:2.1.1"
+  version: 3.2.0
+  resolution: "@types/webpack-sources@npm:3.2.0"
   dependencies:
     "@types/node": "*"
     "@types/source-list-map": "*"
     source-map: ^0.7.3
-  checksum: d9a37142f7ed6376dae19a02d01a14a6635ffe8a1cbd80e9d74239bdde431f55226fcf7ec423a32a6b32c616dc782713cd213ed2f7dcdaad693fbe2ac219c867
+  checksum: c7205a1fb86247ef05e42075abf63094cb530efcc7fb035f70dce8a3554937fd65f27fce59421c566047e7c8be8f1666059bd5dc7cfa81f6ec61d8c8ceb54a03
   languageName: node
   linkType: hard
 
@@ -7758,11 +7758,11 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^4.14.1":
-  version: 4.28.5
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.28.5"
+  version: 4.29.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.29.1"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.28.5
-    "@typescript-eslint/scope-manager": 4.28.5
+    "@typescript-eslint/experimental-utils": 4.29.1
+    "@typescript-eslint/scope-manager": 4.29.1
     debug: ^4.3.1
     functional-red-black-tree: ^1.0.1
     regexpp: ^3.1.0
@@ -7774,23 +7774,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 1ef8adf5db302f468e81983aead2b8b1d04112256068043b15cf1e1f4512a81e1533675cdeb954d4846ea1262ae74c7f322e88a39071b242f4403c963f90d525
+  checksum: 2397e2276cd7f85eea7648787350b8ea8caf8cd4390feae2c6b61d207a76e96112e6fe5aa47ea94e10e782aa57980e8a983b591417e6343c01db4672f0d30f40
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.28.5":
-  version: 4.28.5
-  resolution: "@typescript-eslint/experimental-utils@npm:4.28.5"
+"@typescript-eslint/experimental-utils@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@typescript-eslint/experimental-utils@npm:4.29.1"
   dependencies:
     "@types/json-schema": ^7.0.7
-    "@typescript-eslint/scope-manager": 4.28.5
-    "@typescript-eslint/types": 4.28.5
-    "@typescript-eslint/typescript-estree": 4.28.5
+    "@typescript-eslint/scope-manager": 4.29.1
+    "@typescript-eslint/types": 4.29.1
+    "@typescript-eslint/typescript-estree": 4.29.1
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 558a49aae06341581a2dac9112a9d9f9ffde0eb5c50b6eb09f7b88954ca9ef30780c4f7739fbc084407d2571c82278cfabbc2bd0d17f19443910a8776430fb7f
+  checksum: de6766b1b9a6db18525abf7e46cbcab27f2ecaf4ca6f236d3281a1e91ea2bd38693a635d793fa39189e30381f2bfc80fdd1641bbd783e08d00593e3e2024ef4a
   languageName: node
   linkType: hard
 
@@ -7809,36 +7809,36 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^4.14.1":
-  version: 4.28.5
-  resolution: "@typescript-eslint/parser@npm:4.28.5"
+  version: 4.29.1
+  resolution: "@typescript-eslint/parser@npm:4.29.1"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.28.5
-    "@typescript-eslint/types": 4.28.5
-    "@typescript-eslint/typescript-estree": 4.28.5
+    "@typescript-eslint/scope-manager": 4.29.1
+    "@typescript-eslint/types": 4.29.1
+    "@typescript-eslint/typescript-estree": 4.29.1
     debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 4c44a3fbbb7071ca2a0844e253de325dbbb5be21a0f193d3bdad2be93731137da686dbb91e6c9786ba38a5a64946344af381cd00615f8d62ff7a040e8f8f3b02
+  checksum: 669983b43a854116a20985bf790b52a47357e9542a32a0e26715169ecafee84b93b6a312799e35a8dd7b2ca94b2726408af3bba051b2e003d9c79704f76c5644
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.28.5":
-  version: 4.28.5
-  resolution: "@typescript-eslint/scope-manager@npm:4.28.5"
+"@typescript-eslint/scope-manager@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@typescript-eslint/scope-manager@npm:4.29.1"
   dependencies:
-    "@typescript-eslint/types": 4.28.5
-    "@typescript-eslint/visitor-keys": 4.28.5
-  checksum: d18e0e4736486517fabe0e5dfa760402e1c753b0cb147b9a85d7c00b5649630c29b5ed558ce02a8653b6806983eaf83da192f1c21c77ce14e260c48e63e821ce
+    "@typescript-eslint/types": 4.29.1
+    "@typescript-eslint/visitor-keys": 4.29.1
+  checksum: 06c0c3138ba20bde8a142a5a1e71bcd5ba8be77c74f7a062dbcead68f4abc501bc7563cb6e3d8b8980e4d6cddf529688ceabb413dc18047720e8a9a98b08f7fb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.28.5":
-  version: 4.28.5
-  resolution: "@typescript-eslint/types@npm:4.28.5"
-  checksum: 243b8b70c9b57df03e1f18037a5ea98cbd0aef1212fe2964eab6eaee4533a584d1fefec99be05b951f9612d7a7712c57570a5be5b0991a92f6f42c3ccd1dc877
+"@typescript-eslint/types@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@typescript-eslint/types@npm:4.29.1"
+  checksum: 9a3c89c751c5cdb72cb569f778717f0869c4b5230640f68f27735d0bffbe1bfb2920dc1ea2b0070472812d6455b12d44b6349430d7c52f7bc85622e7d6844466
   languageName: node
   linkType: hard
 
@@ -7860,12 +7860,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.28.5":
-  version: 4.28.5
-  resolution: "@typescript-eslint/typescript-estree@npm:4.28.5"
+"@typescript-eslint/typescript-estree@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@typescript-eslint/typescript-estree@npm:4.29.1"
   dependencies:
-    "@typescript-eslint/types": 4.28.5
-    "@typescript-eslint/visitor-keys": 4.28.5
+    "@typescript-eslint/types": 4.29.1
+    "@typescript-eslint/visitor-keys": 4.29.1
     debug: ^4.3.1
     globby: ^11.0.3
     is-glob: ^4.0.1
@@ -7874,17 +7874,17 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0483a9b8d163929fe46f780a5a8b82bf26483aae4d7f2887265d13719eb83afaf3dc68616dd6eb21eca2e451582d44a46bbc7ac0a4f7bae9193bbf5860619fc6
+  checksum: cb42fea8386aa603d534c3283d4055b392cd5ed6b2502eebfefeb3ee7e7252353b5d8ce997dabb5e94ccde90626f849522c1ecd5cbe08e077c3495cbda3818da
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.28.5":
-  version: 4.28.5
-  resolution: "@typescript-eslint/visitor-keys@npm:4.28.5"
+"@typescript-eslint/visitor-keys@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@typescript-eslint/visitor-keys@npm:4.29.1"
   dependencies:
-    "@typescript-eslint/types": 4.28.5
+    "@typescript-eslint/types": 4.29.1
     eslint-visitor-keys: ^2.0.0
-  checksum: a32b7c549a70b33f2e973a14c8ecc007b029d2f6e6ff4fa47cbd0edad6edaac5c36df85a2a622d230f64b1f3ab2eef6da423d2b7c35f8020f06a7869d3f2662e
+  checksum: ff30d97feaa968abcb9f87aeeab59f098744f554749e85649dfcf0d565a6bbb30f92d83dc08c1b05d080bdc900ea5325dd8a52bc0840df2207c2f336cd70afdb
   languageName: node
   linkType: hard
 
@@ -12063,7 +12063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:3.2.0, async@npm:^3.2.0, async@npm:~3.2.0":
+"async@npm:3.2.0":
   version: 3.2.0
   resolution: "async@npm:3.2.0"
   checksum: 5c7913c08496877a9896dc6670d3a6c64f02d350e74b9e9191194959c473414a0732539ebdfec0fd2f34c20f439714773a30c20e0e68eb27bd8ee5ec9d8ff5ba
@@ -12083,6 +12083,13 @@ __metadata:
   dependencies:
     lodash: ^4.17.14
   checksum: 5c30ec6f3d64308dd96d56dae16a00a23b9e6278fe8f66492837896d958508698648c59c53457d3fdf05fd04484e16538efeca2be38337cd78df0284e764ab34
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.2.0, async@npm:~3.2.0":
+  version: 3.2.1
+  resolution: "async@npm:3.2.1"
+  checksum: 2ec69da2266d9418eefbf828a4b238f62cf07a5d5ba2d7fb91bc74aa588e38bbf7aef03df6d267dd38999802e97061768e5f58c8a38c62d71eb5c1a0b2957ef4
   languageName: node
   linkType: hard
 
@@ -12142,7 +12149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"available-typed-arrays@npm:^1.0.2":
+"available-typed-arrays@npm:^1.0.4":
   version: 1.0.4
   resolution: "available-typed-arrays@npm:1.0.4"
   checksum: 9474a48bed7a4bfa5ea9389acc73da5e321fac5fc299b9ba58ee9fd41d6489b6f92663a76d1b723e80c06dfe340c6b3b9f2b08762db009c53ce891e68fb0a61c
@@ -12179,8 +12186,8 @@ __metadata:
   linkType: hard
 
 "aws-sdk@npm:^2.0.0, aws-sdk@npm:^2.539.0":
-  version: 2.958.0
-  resolution: "aws-sdk@npm:2.958.0"
+  version: 2.966.0
+  resolution: "aws-sdk@npm:2.966.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -12191,7 +12198,7 @@ __metadata:
     url: 0.10.3
     uuid: 3.3.2
     xml2js: 0.4.19
-  checksum: 00afb5ecf247b508f7f789095b2eac25656d2712b4ee3ad1f0aa7231dfa589e6ad690bcb753577779337a381054d63ae67b5e4eb097ca98a6093524f777fdd45
+  checksum: 7c7d364f3c8b33bf4dbf5e69971c50147e676d67c09e533713af475251a51466606bcdb94424121adfc1fabf081275c6196da12b68eec9f148a81a327381326a
   languageName: node
   linkType: hard
 
@@ -13319,18 +13326,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.16.6, browserslist@npm:^4.6.2, browserslist@npm:^4.6.4, browserslist@npm:^4.9.1":
-  version: 4.16.6
-  resolution: "browserslist@npm:4.16.6"
+"browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.16.6, browserslist@npm:^4.16.7, browserslist@npm:^4.6.2, browserslist@npm:^4.6.4, browserslist@npm:^4.9.1":
+  version: 4.16.7
+  resolution: "browserslist@npm:4.16.7"
   dependencies:
-    caniuse-lite: ^1.0.30001219
+    caniuse-lite: ^1.0.30001248
     colorette: ^1.2.2
-    electron-to-chromium: ^1.3.723
+    electron-to-chromium: ^1.3.793
     escalade: ^3.1.1
-    node-releases: ^1.1.71
+    node-releases: ^1.1.73
   bin:
     browserslist: cli.js
-  checksum: ebb0ab279c5e61f882467f7ccd7d22c0edfcc01201eba06e85e835ca4d355e682f9aa3310bfa18c3a23bb244f0b8e498b3113dae3e9b0fa4908c5ffb4a26b3a2
+  checksum: 19450967eb61ae0225a9064e992af0376fdd5aee2e473a67157e0cb52269a38d770a7f42eef8d9737bdbf39f41663a40037ea8e8432bbf957149b95f2e6f999d
   languageName: node
   linkType: hard
 
@@ -13864,10 +13871,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30000989, caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001219":
-  version: 1.0.30001248
-  resolution: "caniuse-lite@npm:1.0.30001248"
-  checksum: 8b8bb2714bba27242f51ec3707f8e111e2a25d3cb8fd8e956d4b5de2705a6f7160736d681d92334074d39a52bb26661f01e537a17ed6b958534325b16d88b12f
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30000989, caniuse-lite@npm:^1.0.30001035, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001248":
+  version: 1.0.30001251
+  resolution: "caniuse-lite@npm:1.0.30001251"
+  checksum: 6d7d4b93bdaa4d7859b830c5afdfa40ef2cc15a88edfae446c6ded1ae77ae4de50b5b5ba63c4a56ecdde5a530f26252ef56b86abbe7aa0dda5de8f1d793a454e
   languageName: node
   linkType: hard
 
@@ -14098,7 +14105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^1.0.1, chownr@npm:^1.1.1, chownr@npm:^1.1.2":
+"chownr@npm:^1.0.1, chownr@npm:^1.1.1, chownr@npm:^1.1.2, chownr@npm:^1.1.4":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
   checksum: 4a7f1a0b2637450fd15ddb085b10649487ddd1d59a8d9335b1aa5b1e9ad55840a591ab7d7f9b568001cb6777d017334477ab2e32e048788b13a069d011cd5781
@@ -14562,9 +14569,9 @@ __metadata:
   linkType: hard
 
 "colorette@npm:^1.2.1, colorette@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "colorette@npm:1.2.2"
-  checksum: e240f0c94b8d9f34b52bd17b50fc13a3b74f9e662edeaa2b0c65e06ec6b1fc6367fb42b834ec5a1d819d68b74a3d850f3bd3e284f9e614d6c4ffa122f83c6ec5
+  version: 1.3.0
+  resolution: "colorette@npm:1.3.0"
+  checksum: d3bcd778d0f0cb81fc1367168f494b9a9998109f6aa4a2e8f8b1d3a43107b3a1d43e00a569f687ad57ae0d536b8767ccec6354a69ae3d1d3e0bee91ab500f8e5
   languageName: node
   linkType: hard
 
@@ -15180,19 +15187,19 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.14.0, core-js-compat@npm:^3.16.0, core-js-compat@npm:^3.6.2, core-js-compat@npm:^3.8.0":
-  version: 3.16.0
-  resolution: "core-js-compat@npm:3.16.0"
+  version: 3.16.1
+  resolution: "core-js-compat@npm:3.16.1"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.16.7
     semver: 7.0.0
-  checksum: 36f001d8de116558dd32aad512fdad1a34eefbd54fdc71afb087d25f6f59f45734e11613ec1d190abc38ced40701130e621435a6fc0b7b1a9cc1844e7d329852
+  checksum: ab80700c5d624c5da8ef4b6cf348256b8f8161fc08f9afbf4bf3949287a4f49456066f40ed067e7ea52fb02282f7929c4816a1b8636bfa45afec9341d4073057
   languageName: node
   linkType: hard
 
 "core-js-pure@npm:^3.0.1, core-js-pure@npm:^3.16.0":
-  version: 3.16.0
-  resolution: "core-js-pure@npm:3.16.0"
-  checksum: d118dbca14e5a4df6a39784bcbc7bc27c8f71804e563dd14143806c7099db976ff58ecf03bb0891339f67e2c18e036a71c79afe6ac01fe8822e66a1fda1b1037
+  version: 3.16.1
+  resolution: "core-js-pure@npm:3.16.1"
+  checksum: 57bebea1220ee5aea612cd9f10646b948374d76d70fd0d39bb371c9f0af74c1f66fda1ffc7cb40ee805910f04eb7fb4a239ba70511d7fef347eb2ae481afbb79
   languageName: node
   linkType: hard
 
@@ -15211,9 +15218,9 @@ __metadata:
   linkType: hard
 
 "core-js@npm:^3.0.1, core-js@npm:^3.0.4, core-js@npm:^3.6.1":
-  version: 3.16.0
-  resolution: "core-js@npm:3.16.0"
-  checksum: 5a9743b324e5a67d119fe0b8074888c47ab12d8e92222db9c56b853e74016e71a09422bbd93a526b78a870951bd7a72872df75ee777f92f4878490ef74d57315
+  version: 3.16.1
+  resolution: "core-js@npm:3.16.1"
+  checksum: d54dfe6518910ab10f9e0d561b51c00474ba4cca5a0502bd798c4de5abc68e6c9a84d119add374e2c06d493841f80b0934919ef64610df0cf80d1a7a0751b0c0
   languageName: node
   linkType: hard
 
@@ -16859,9 +16866,9 @@ __metadata:
   linkType: hard
 
 "dom-accessibility-api@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "dom-accessibility-api@npm:0.5.6"
-  checksum: b579681083e683291df022bdf094dae2c7e39db0ff28f70ed2c8368eda203fe4c45bcf92f1c623ce4b746cb245f9a5dc9d176f1781d600b9218728d3a1d1580f
+  version: 0.5.7
+  resolution: "dom-accessibility-api@npm:0.5.7"
+  checksum: 93b146130150c4f484489522cda4c6866fe807b0c1647d67fe2e1cdfe67808cfe4abac18de794a016e644f6cd5d96749d7344c6b32b1cc5cd41ccd5882c6aa47
   languageName: node
   linkType: hard
 
@@ -17333,10 +17340,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.247, electron-to-chromium@npm:^1.3.378, electron-to-chromium@npm:^1.3.723":
-  version: 1.3.792
-  resolution: "electron-to-chromium@npm:1.3.792"
-  checksum: 950723349049b422872f109b150717ffba0096b7f8cf619622aebd53720d71e2c06b3a55b112fd91314c908f2053511f33fbc467430377bccccc64033a8511af
+"electron-to-chromium@npm:^1.3.247, electron-to-chromium@npm:^1.3.378, electron-to-chromium@npm:^1.3.793":
+  version: 1.3.803
+  resolution: "electron-to-chromium@npm:1.3.803"
+  checksum: f8c4b23adcc9affefbf48d497d300b84c8ef4f66a063c4eae17395a4b8dc3bcf1bec75a7a8c45ba3abcc666aec929423cac7b04bef6b637098e89e421e4fdbe8
   languageName: node
   linkType: hard
 
@@ -17624,7 +17631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.2, es-abstract@npm:^1.18.0-next.1, es-abstract@npm:^1.18.0-next.2, es-abstract@npm:^1.18.2":
+"es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.2, es-abstract@npm:^1.18.0-next.1, es-abstract@npm:^1.18.0-next.2, es-abstract@npm:^1.18.2, es-abstract@npm:^1.18.5":
   version: 1.18.5
   resolution: "es-abstract@npm:1.18.5"
   dependencies:
@@ -17843,13 +17850,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "eslint-import-resolver-node@npm:0.3.4"
+"eslint-import-resolver-node@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "eslint-import-resolver-node@npm:0.3.5"
   dependencies:
-    debug: ^2.6.9
-    resolve: ^1.13.1
-  checksum: 825e34e662c988ece8229e6956a95f12d2fa19265b429e3e3db14e58bfe72e270c999cda0cfc690793ed6e6a3e49ffa8df0e0a8842d668a1f0f7de5ae1aa36f9
+    debug: ^3.2.7
+    resolve: ^1.20.0
+  checksum: 4ea679b68449a9bf33a150e1031f7cafb5fdbbf7a1687f291680d083b9a357d18a9dd00a6e61e14dbfa29fc1601831b5ff538ff5a364e75c1535362f315a6f71
   languageName: node
   linkType: hard
 
@@ -17869,13 +17876,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "eslint-module-utils@npm:2.6.1"
+"eslint-module-utils@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "eslint-module-utils@npm:2.6.2"
   dependencies:
     debug: ^3.2.7
     pkg-dir: ^2.0.0
-  checksum: 3de93ecfd7a0b803a2cd91afd5cbb32dca559f58c22e92f95ec4700ff75e008035587ee032b9196d6565fbd73f799992122a8dc8ea0b979c07229b51735a8bed
+  checksum: ca81aa3678c7103b1159b8467c6f4b68dc4ca2a69c1d7e60d19676125bad4b533703be30bb1787911545396242e0fc883ba04621144862cbce383c06f13b742e
   languageName: node
   linkType: hard
 
@@ -17892,15 +17899,15 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-import@npm:^2.22.1":
-  version: 2.23.4
-  resolution: "eslint-plugin-import@npm:2.23.4"
+  version: 2.24.0
+  resolution: "eslint-plugin-import@npm:2.24.0"
   dependencies:
     array-includes: ^3.1.3
     array.prototype.flat: ^1.2.4
     debug: ^2.6.9
     doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.4
-    eslint-module-utils: ^2.6.1
+    eslint-import-resolver-node: ^0.3.5
+    eslint-module-utils: ^2.6.2
     find-up: ^2.0.0
     has: ^1.0.3
     is-core-module: ^2.4.0
@@ -17912,7 +17919,7 @@ __metadata:
     tsconfig-paths: ^3.9.0
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-  checksum: d15a470088381cb14821480f35fe23258f6365d704ea9fc724b87e1ccf9eb45f4bb048ff033784af0cacff368ae1542c2b1dfbe6cd4dbec7138f8f6dca090a57
+  checksum: 32fa4d6b0de9c8b5998bb2a8727fc7335653d5a75f33128d0d746a8d9cd129d84ba78f5449722cd1e49cb37f4803e03dc005a6d77c1697fc01c247624da9519c
   languageName: node
   linkType: hard
 
@@ -19644,7 +19651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^1.2.5":
+"fs-minipass@npm:^1.2.7":
   version: 1.2.7
   resolution: "fs-minipass@npm:1.2.7"
   dependencies:
@@ -20485,9 +20492,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "graceful-fs@npm:^4.1.10, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:~4.2.0":
-  version: 4.2.6
-  resolution: "graceful-fs@npm:4.2.6"
-  checksum: 84d39c7756892553da990a9db7e45f844b3309b37b5a00174cbb4748476f2250c54f24594d4d252f64f085c65c2fdac7c809419bf6d55f0e6e42eb07ac0f5bf2
+  version: 4.2.8
+  resolution: "graceful-fs@npm:4.2.8"
+  checksum: b07e032c0a17e928d3e8ab0f0fea1492efd4568b55a3d2675aaaccf1619eca91156edfa0cb05e99b923e24edf5e26fdce22ffa58ec14d5b13a3b1392460f37f0
   languageName: node
   linkType: hard
 
@@ -20703,6 +20710,15 @@ fsevents@^1.2.7:
   dependencies:
     has-symbol-support-x: ^1.4.1
   checksum: fbbd620826e992b5c31d85a7af5fe4edc643299f1aa266648a912d967282be7a480f02a95c7214ae4212b3d9c948b12783bde242d300dbaf88b5aefeeabe7489
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "has-tostringtag@npm:1.0.0"
+  dependencies:
+    has-symbols: ^1.0.2
+  checksum: f66b738e6b641f47a67f75a39afbdc7e2505bf174ea5fbab97082ad4d3ece66201508ea768775b2b72cdb849de63f3fedb2f005aac390d268db9f273a779df4a
   languageName: node
   linkType: hard
 
@@ -21947,11 +21963,12 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "is-arguments@npm:1.1.0"
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
   dependencies:
-    call-bind: ^1.0.0
-  checksum: 967bf47b472eba6c07685a0a2c59724c5a2f3ecc9183ebbf3d33989906e2353d0d669ca7e06b0482f31cc8e6f1785b4a2775cb9506acb48cadd0e1d5c5cf12ad
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 51b8bf285540cca90e49a712910d9a35f3dea61bd0bee4db04d5c4ebacbce2f493725191ab56846bce5fbc496fcc122fa8cc387c08b3cf75478a0a0b1c502bde
   languageName: node
   linkType: hard
 
@@ -21970,9 +21987,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-bigint@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "is-bigint@npm:1.0.2"
-  checksum: 818680e551dc0a33ed8662b869cd3cb3236f6b94994850c1701200816cf9ad7e82a24fb4efbfc7046f167cd6429a71ba3672c73a7507093164c6ee9123bf30a9
+  version: 1.0.4
+  resolution: "is-bigint@npm:1.0.4"
+  dependencies:
+    has-bigints: ^1.0.1
+  checksum: 213e652ee9382a185b97e1c33956bdaa44a50eb466bec5d3a5c89d53bfca397e970ae70a75f5989332bb2790c6356f35ac1be5181f3622a84d8b8401dae13dad
   languageName: node
   linkType: hard
 
@@ -21995,11 +22014,12 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-boolean-object@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "is-boolean-object@npm:1.1.1"
+  version: 1.1.2
+  resolution: "is-boolean-object@npm:1.1.2"
   dependencies:
     call-bind: ^1.0.2
-  checksum: 9a45d29418f5cc7ff5ddf8eebf4a7d6bd2b3be730000e42d339029658db40e9e0ecafb1397588f6f5f17728ea9b7a8959b5d2ee000db5d95ff126c8b54218391
+    has-tostringtag: ^1.0.0
+  checksum: 2ce475fb2a4993a27a128054646a848e51c4864469dd9a6a1a077f19cc292fc0454b0bf73a9614b3b87614b7facbc100ce004920d206f7097563283bba5fcee3
   languageName: node
   linkType: hard
 
@@ -22011,9 +22031,9 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-callable@npm:^1.1.4, is-callable@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "is-callable@npm:1.2.3"
-  checksum: 8180a1c4e227e204e199ff355c4f24a80f74536898e16716583aa6a09167f2cceecc188cea750a2f3ae3b163577691595ae8d22bf7bb94b4bbb9fbdfea1bc5c3
+  version: 1.2.4
+  resolution: "is-callable@npm:1.2.4"
+  checksum: 57680330ce65115efc87e82e1b85238e1abaef5c385e98742449a57205e9693be7371f29b41439ded26d790f864e9bde82367371eac4d98edca82413c1489c0a
   languageName: node
   linkType: hard
 
@@ -22081,9 +22101,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-date-object@npm:^1.0.1, is-date-object@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "is-date-object@npm:1.0.4"
-  checksum: f159a5cff60f657792a9677892b87d0802ac95e15cf26e7bba7f36064e8ffde41c8ac73921629ad976f14a8c0e2fe785818ef67172b906be0300919d4d4ea553
+  version: 1.0.5
+  resolution: "is-date-object@npm:1.0.5"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: 9d48e00933092f2a9649a4276fe014f23b41d848339fb63a20774a270af312b74a5f98e2a0697c0345ac5f61eed72e99aded0569a5a8d32aa059f5cee67578f4
   languageName: node
   linkType: hard
 
@@ -22323,9 +22345,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-number-object@npm:^1.0.4":
-  version: 1.0.5
-  resolution: "is-number-object@npm:1.0.5"
-  checksum: 2725b594081cb159766a8fca6af2dab65da601caf656a1be1baf6c100ad614cae2fa1a6c7c1dfc90ad8e78cf668d2761f9efaeac5dd7ab7ecd5d648e7d240399
+  version: 1.0.6
+  resolution: "is-number-object@npm:1.0.6"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: 43562c4c0223a21fc00072a8e36394237082afb2b373d55792d9e878f0226a0176845aec8a6506136c591ace6dddc1fd0a3c6bab48ca8202e5b1f4ffde722e02
   languageName: node
   linkType: hard
 
@@ -22496,12 +22520,12 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-regex@npm:^1.0.4, is-regex@npm:^1.1.1, is-regex@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "is-regex@npm:1.1.3"
+  version: 1.1.4
+  resolution: "is-regex@npm:1.1.4"
   dependencies:
     call-bind: ^1.0.2
-    has-symbols: ^1.0.2
-  checksum: 1beb14b9f8df6e302c6ba0cafdea4a393fd58b93cd66b4ef3017b74f72683c50f7a82d08c86e20e5b555a2a6a5e5b681e62eb4e4b49e62986da01ffd073d19eb
+    has-tostringtag: ^1.0.0
+  checksum: a9c466f93191ec306c5293d9d61a4360178bcdad0b642ef24d612a7392176c0f217498fde1e7c8e1cb3c520ac5c1b6d59da4b9148c23afbdd4374dec33127d0e
   languageName: node
   linkType: hard
 
@@ -22564,9 +22588,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "is-string@npm:^1.0.5, is-string@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "is-string@npm:1.0.6"
-  checksum: 5eb4860eafb9bfd4d9adf56bd530ca0e0cabade776df1e9394e5ca9376bdd6fa0a99879c2b0c3a517076fa31ac739821c2956be6d30ee1458f50ca24a4962478
+  version: 1.0.7
+  resolution: "is-string@npm:1.0.7"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: 29acb230cceafc33005a9710e1a25161c601282afc61fa2109cb60cf28f78ef0ef0b3ec20b1833f7b572f32ddf5034a0efa0c118af1a8ec58c277423c9d63418
   languageName: node
   linkType: hard
 
@@ -22588,16 +22614,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.3":
-  version: 1.1.5
-  resolution: "is-typed-array@npm:1.1.5"
+"is-typed-array@npm:^1.1.6":
+  version: 1.1.7
+  resolution: "is-typed-array@npm:1.1.7"
   dependencies:
-    available-typed-arrays: ^1.0.2
+    available-typed-arrays: ^1.0.4
     call-bind: ^1.0.2
-    es-abstract: ^1.18.0-next.2
+    es-abstract: ^1.18.5
     foreach: ^2.0.5
-    has-symbols: ^1.0.1
-  checksum: 35b216dba19e3005bf14d3b46b2a20de244818e2bd726c344a011f89673d9b50ba35b0ace81f8dfd870d96f82763389bb5cc00cd7718ac317076b6f06479c03d
+    has-tostringtag: ^1.0.0
+  checksum: eb833d61ff7f5a0483c0f5a106bb35d312465139ea30ddc7ab6252de87b4697ecb3540f375fb0376f05dafbc8c474cabef90890c390d20285d22825cb1752acb
   languageName: node
   linkType: hard
 
@@ -23675,8 +23701,8 @@ fsevents@^1.2.7:
   linkType: hard
 
 "jshint@npm:^2.9.2":
-  version: 2.13.0
-  resolution: "jshint@npm:2.13.0"
+  version: 2.13.1
+  resolution: "jshint@npm:2.13.1"
   dependencies:
     cli: ~1.0.0
     console-browserify: 1.1.x
@@ -23688,7 +23714,7 @@ fsevents@^1.2.7:
     strip-json-comments: 1.0.x
   bin:
     jshint: bin/jshint
-  checksum: e2fe6410a678aeccbe35efecd9eefed8b7ea41f24cd0c6f752e980dc86a6501e04c391e7724cbb4f272cefafe4f77365a796249196c2b0e2dabf03bc238dd8bb
+  checksum: ba978adb528c3817c3c5e49f493f8c8f61875fe9b1d2286ce177367636ded48a48052fcea623c5d25747a18b5df0d6647007dd36b0bfda8919dc7be6f03459a7
   languageName: node
   linkType: hard
 
@@ -24811,13 +24837,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lodash.toarray@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.toarray@npm:4.4.0"
-  checksum: f2b8de1812789321335dd5f4cb60625c4b8874cb3b300367d8a22990072459b76eb893feacd243686493393cccd035115cc149563f7aa5123d06d9a3b2825bf1
-  languageName: node
-  linkType: hard
-
 "lodash.trim@npm:^4.4.2":
   version: 4.5.1
   resolution: "lodash.trim@npm:4.5.1"
@@ -25909,7 +25928,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"minipass@npm:^2.3.5, minipass@npm:^2.6.0, minipass@npm:^2.8.6, minipass@npm:^2.9.0":
+"minipass@npm:^2.3.5, minipass@npm:^2.6.0, minipass@npm:^2.9.0":
   version: 2.9.0
   resolution: "minipass@npm:2.9.0"
   dependencies:
@@ -25928,7 +25947,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^1.2.1":
+"minizlib@npm:^1.3.3":
   version: 1.3.3
   resolution: "minizlib@npm:1.3.3"
   dependencies:
@@ -26188,11 +26207,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "nan@npm:^2.12.1, nan@npm:^2.13.2, nan@npm:^2.14.0":
-  version: 2.14.2
-  resolution: "nan@npm:2.14.2"
+  version: 2.15.0
+  resolution: "nan@npm:2.15.0"
   dependencies:
     node-gyp: latest
-  checksum: 36349b2e5df4182aa0d0cc43fcd6cc782ca560a83c2764743d80c14ba5028d0c54041a2f464b8d4cb18a884e04415034a0a764c745e1d5502ea34a5cb6470a39
+  checksum: 85bc21e90bcf7a1f1349f1e4fcf73190dcb43e5e7aac1082259b8b18baff618fef04d9eaf6ce896963341daa92461fd12908e2cd41795984462e2eeca327d161
   languageName: node
   linkType: hard
 
@@ -26204,11 +26223,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "nanoid@npm:^3.1.20, nanoid@npm:^3.1.22, nanoid@npm:^3.1.23":
-  version: 3.1.23
-  resolution: "nanoid@npm:3.1.23"
+  version: 3.1.25
+  resolution: "nanoid@npm:3.1.25"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: e6dea1da5a593ffdc8cf2676d1d02f0626f07a54a5947a7a1f5ff1fd07901b2f53044c285e98b87eb367f016fde285fd8785d54a2dceeab9c3721f4e618f8326
+  checksum: caab76af9a899969f87fb2105e15ef192f9e7bbf4230c2dea5a87b752c94bfd1c13a3877c388fd464826a7752fb49db5a4ff39a44458a32b740e6a1ff072e55e
   languageName: node
   linkType: hard
 
@@ -26351,11 +26370,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "node-emoji@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "node-emoji@npm:1.10.0"
+  version: 1.11.0
+  resolution: "node-emoji@npm:1.11.0"
   dependencies:
-    lodash.toarray: ^4.4.0
-  checksum: 9c73cd0af03965131225c388339ec5cb3b7239f9d63f15c7755540d265b20a4ecac855fd270af216fb14cdf8232ec4687ab5a52b4b475a681ee1bd74f7562ced
+    lodash: ^4.17.21
+  checksum: 2d85355dbde7dc13dc96747eb572a1f1884bbe1b5769dcbe9847557fc29ec0c939c4758270e9a78a1be7ad2a35e98453470805ef6bcb3a5fbdc0a7e88d882483
   languageName: node
   linkType: hard
 
@@ -26562,10 +26581,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^1.1.29, node-releases@npm:^1.1.52, node-releases@npm:^1.1.71":
-  version: 1.1.73
-  resolution: "node-releases@npm:1.1.73"
-  checksum: 8dbc7dd438c4e0a01e546cf73b8d3cc766f1ba3c40848d5cc8c6027eb8d87d54c4617eae036bed3c02e16f25e241ee2a4bd48fa528ebf6fe97d2c86c71ddfedc
+"node-releases@npm:^1.1.29, node-releases@npm:^1.1.52, node-releases@npm:^1.1.73":
+  version: 1.1.74
+  resolution: "node-releases@npm:1.1.74"
+  checksum: fbc4a1f8a589da895a1997fc17cc81a4c24d882f0e277a89f8c508031aa8074116d35613699559214f834607ac964d76178af5e0b67dfee1145c21d3479a0ddd
   languageName: node
   linkType: hard
 
@@ -27139,18 +27158,18 @@ fsevents@^1.2.7:
   linkType: hard
 
 "octokit@npm:^1.0.4":
-  version: 1.1.0
-  resolution: "octokit@npm:1.1.0"
+  version: 1.4.0
+  resolution: "octokit@npm:1.4.0"
   dependencies:
     "@octokit/app": ^12.0.0
     "@octokit/core": ^3.3.1
     "@octokit/oauth-app": ^3.3.0
     "@octokit/plugin-paginate-rest": ^2.13.3
-    "@octokit/plugin-rest-endpoint-methods": ^5.0.0
+    "@octokit/plugin-rest-endpoint-methods": 5.8.0
     "@octokit/plugin-retry": ^3.0.8
     "@octokit/plugin-throttling": ^3.4.3
     "@octokit/types": ^6.16.1
-  checksum: 1d1aac2f9035cb3573b14012adec1113165851c5750ebc9c0714da6208b53d7daa97739ae4b470ebb018df44ec7b5c9bbb17f8c0090eaede5fd956dbed660c05
+  checksum: 8305f5f3066197a56ca19c9a46cae86c0bf8f9bdb3cbce04c1785d44ccb7249293b45388f8abc3850e7c4ef58a916e5dffa4d1773464cac4914a5daef8c3e563
   languageName: node
   linkType: hard
 
@@ -31235,11 +31254,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "redux@npm:^4.0.4":
-  version: 4.1.0
-  resolution: "redux@npm:4.1.0"
+  version: 4.1.1
+  resolution: "redux@npm:4.1.1"
   dependencies:
     "@babel/runtime": ^7.9.2
-  checksum: d939d0df1e12982c66c0ea767c8ec98276ee981ce0381222239b7f823c6ad02ea3e3c622859bcb4934446b3f86d735db35d7bd8b1697d359070e5fbef1f4ad49
+  checksum: 063e1d52588d62d438bb392975e57c0091c79f9abdbb8594c44c1680a73415280f6133c3d9cb3b116fe1ceb7e1aefb44775d6136b8bb6b9eb6a2c1a23e32a840
   languageName: node
   linkType: hard
 
@@ -31452,13 +31471,13 @@ fsevents@^1.2.7:
   linkType: hard
 
 "replace-in-path@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "replace-in-path@npm:1.0.4"
+  version: 1.1.0
+  resolution: "replace-in-path@npm:1.1.0"
   dependencies:
     globby: ^11.0.1
   bin:
     replace-in-path: dist/bin/replace-in-path.js
-  checksum: 0385d861f3c73d5e8b45df451c9baa633fb2e670cda302d52b3b10eefcec0de217da3cd256c2d162ffd234244b14af0d8a41cf4beea43f6190c7de193a13423b
+  checksum: b28daeb563092349217a448c14ee5809f768a7efff332d82d32e26290aaeb970fb5de709a3d0ba361d7e9d2d651bf0f245b80aeb54670207418888c9d83e1b8f
   languageName: node
   linkType: hard
 
@@ -32898,9 +32917,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "smart-buffer@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "smart-buffer@npm:4.1.0"
-  checksum: 00a23d82a20eced9622cbba18ba781f9f8968ccfa70af7a33336ae55f54651c073aa072084c521f7e78199767e5b3584a0bbf3a47bb60e3e5b79ea4fc1ca61a1
+  version: 4.2.0
+  resolution: "smart-buffer@npm:4.2.0"
+  checksum: 644e012e31a8e17334df717cd2337ad5339139c3f9354c1e52dbafe93e5cd19f89129a831833ad54002bd5872873ec9affcdfbc81ee41a0513ad39a0c9b6dad1
   languageName: node
   linkType: hard
 
@@ -33165,9 +33184,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "spdx-license-ids@npm:^3.0.0":
-  version: 3.0.9
-  resolution: "spdx-license-ids@npm:3.0.9"
-  checksum: a4d970d859bc5eeef3a95d7597fa39b36b2c046153d3d2c9876293d84457b0456a56aef7f45e1d3c3129cf7557c35305dffaddbcff630f7df72cb359aed78ce1
+  version: 3.0.10
+  resolution: "spdx-license-ids@npm:3.0.10"
+  checksum: f5abd60c833d9a37cb12486cc753fa0262d018b6e707d3a66f34aad79c1396cefb6141ecc2d5506ebea68b6efaa7dfac2053fb39bd160e9116da58f75bfe1dbc
   languageName: node
   linkType: hard
 
@@ -34025,23 +34044,23 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "tar@npm:^4.4.10, tar@npm:^4.4.12, tar@npm:^4.4.8":
-  version: 4.4.15
-  resolution: "tar@npm:4.4.15"
+  version: 4.4.17
+  resolution: "tar@npm:4.4.17"
   dependencies:
-    chownr: ^1.1.1
-    fs-minipass: ^1.2.5
-    minipass: ^2.8.6
-    minizlib: ^1.2.1
-    mkdirp: ^0.5.0
-    safe-buffer: ^5.1.2
-    yallist: ^3.0.3
-  checksum: 15b6a6f3e3981a49485abbd991d6eadf51236faf797069df3401b2be9f8548fdf029efcca7a943c4267ee1f89345e627ed86e70cb7c039edfeafb34c924493b8
+    chownr: ^1.1.4
+    fs-minipass: ^1.2.7
+    minipass: ^2.9.0
+    minizlib: ^1.3.3
+    mkdirp: ^0.5.5
+    safe-buffer: ^5.2.1
+    yallist: ^3.1.1
+  checksum: 4a8bbb3d71f1b7934f9f0ea4be94e42f7d8607cce4eb0317b9c79931ec3d2eb21af3540357d6915d42a2b21b4543a19a95f1576b4ac5ab18f606319556e461c4
   languageName: node
   linkType: hard
 
 "tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.0":
-  version: 6.1.2
-  resolution: "tar@npm:6.1.2"
+  version: 6.1.8
+  resolution: "tar@npm:6.1.8"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
@@ -34049,7 +34068,7 @@ resolve@^2.0.0-next.3:
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: 36dc986434c7519b5f07c901a0302927f2a5b3a2b9adb1b5a56db7a430db5eaf1be118b43aee860dde235239409003a02a97232326632f3753a6c7967b369c35
+  checksum: fce79e7f6e72bbaf41d2d902d6f6bd75bd1b8da6e89c2a024cf570e8e582b5df0754569cbd6df6e814f461481870ece19beef35b4719153ecff16c99e986f2ca
   languageName: node
   linkType: hard
 
@@ -34782,9 +34801,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "tslib@npm:2.3.0"
-  checksum: 7b4fc9feff0f704743c3760f5d8d708f6417fac6458159e63df3a6b1100f0736e3b99edb9fe370f274ad15160a1f49ff05cb49402534c818ff552c48e38c3e6e
+  version: 2.3.1
+  resolution: "tslib@npm:2.3.1"
+  checksum: 5ae2f209c5127bad284974c78916f02c72082615f65889a7ed0c7ca6d5f935c30338a0ee7310e1d9652dabc7b7507fd2905035487446d09d45fc1f19de71cf05
   languageName: node
   linkType: hard
 
@@ -36172,17 +36191,16 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "which-typed-array@npm:^1.1.2":
-  version: 1.1.4
-  resolution: "which-typed-array@npm:1.1.4"
+  version: 1.1.6
+  resolution: "which-typed-array@npm:1.1.6"
   dependencies:
-    available-typed-arrays: ^1.0.2
-    call-bind: ^1.0.0
-    es-abstract: ^1.18.0-next.1
+    available-typed-arrays: ^1.0.4
+    call-bind: ^1.0.2
+    es-abstract: ^1.18.5
     foreach: ^2.0.5
-    function-bind: ^1.1.1
-    has-symbols: ^1.0.1
-    is-typed-array: ^1.1.3
-  checksum: aa89770be09f62f8836f2334080513f8de82ec6e9a503eb9b8867775ac47db72c0a75ac8ac7e5f71825a7b8e5eb6ef0b65dd66cea54709cf73f2ae81b722d5ec
+    has-tostringtag: ^1.0.0
+    is-typed-array: ^1.1.6
+  checksum: 7c22766b4652df5b810d345539dca4f279e5ec415da8bd6dd91ca9783390746a842e661bb9e80095a59dc46904aa2ea0fb16faf4ca30cabcc9496545604ad5f0
   languageName: node
   linkType: hard
 
@@ -36554,7 +36572,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"yallist@npm:^3.0.0, yallist@npm:^3.0.2, yallist@npm:^3.0.3":
+"yallist@npm:^3.0.0, yallist@npm:^3.0.2, yallist@npm:^3.1.1":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: f352c93b92f601bb0399210bca37272e669c961e9bd886bac545380598765cbfdfb4f166e7b6c57ca4ec8a5af4ab3fa0fd78a47f9a7d655a3d580ff0fc9e7d79

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,15 +3059,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@elastic/elasticsearch@npm:^7.9.1":
-  version: 7.14.0
-  resolution: "@elastic/elasticsearch@npm:7.14.0"
+"@elastic/elasticsearch@npm:7.12.0":
+  version: 7.12.0
+  resolution: "@elastic/elasticsearch@npm:7.12.0"
   dependencies:
     debug: ^4.3.1
     hpagent: ^0.1.1
     ms: ^2.1.3
-    secure-json-parse: ^2.4.0
-  checksum: 71ca559618698eaa7ce4f29d9a6d5262854b637240fee75aea564108dff8e8432ddb71b256b5eb34564c3a56e405f58c00f02fe5cc80fefced2ecf4c5c210fa7
+    pump: ^3.0.0
+    secure-json-parse: ^2.3.1
+  checksum: ec823ea4f237b10d7c2ac09b0213702c0f92cbf410103bb1a7b007a9ff3daee6759888bf045204596e2533335e777e7bc4ea112d1ec24a246e3a61e45798612f
   languageName: node
   linkType: hard
 
@@ -8321,7 +8322,7 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.0.0
     "@babel/runtime": ^7.5.5
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@elastic/elasticsearch-mock": 0.3.0
     "@shelf/jest-elasticsearch": ^1.0.0
     "@webiny/api-page-builder": ^5.12.0
@@ -8366,7 +8367,7 @@ __metadata:
   dependencies:
     "@babel/cli": ^7.5.5
     "@babel/core": ^7.5.5
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@webiny/cli": ^5.12.0
     "@webiny/error": ^5.12.0
     "@webiny/handler": ^5.12.0
@@ -8392,7 +8393,7 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-typescript": ^7.0.0
     "@babel/runtime": ^7.5.5
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@elastic/elasticsearch-mock": 0.3.0
     "@shelf/jest-elasticsearch": ^1.0.0
     "@webiny/api-dynamodb-to-elasticsearch": ^5.12.0
@@ -8516,7 +8517,7 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
     "@commodo/fields": 1.1.2-beta.20
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@shelf/jest-elasticsearch": ^1.0.0
     "@webiny/api-dynamodb-to-elasticsearch": ^5.12.0
     "@webiny/api-elasticsearch": ^5.12.0
@@ -8562,7 +8563,7 @@ __metadata:
     "@babel/preset-env": ^7.5.5
     "@babel/preset-flow": ^7.0.0
     "@babel/runtime": ^7.5.5
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@shelf/jest-elasticsearch": ^1.0.0
     "@types/jsonpack": ^1.1.0
     "@webiny/api-dynamodb-to-elasticsearch": ^5.12.0
@@ -8786,7 +8787,7 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@babel/runtime": ^7.5.5
     "@commodo/fields": beta
-    "@elastic/elasticsearch": ^7.9.1
+    "@elastic/elasticsearch": 7.12.0
     "@shelf/jest-elasticsearch": ^1.0.0
     "@types/puppeteer": ^5.4.2
     "@webiny/api-dynamodb-to-elasticsearch": ^5.12.0
@@ -32361,7 +32362,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.4.0":
+"secure-json-parse@npm:^2.3.1":
   version: 2.4.0
   resolution: "secure-json-parse@npm:2.4.0"
   checksum: bbf325b52d3eb399b23a337ef7185380424600b4d6c07e62e8d1ab9e9cc657258b897841e4da1ecca9c9d4a83e426756f74fff1685640b3fbe4f481f577517d4


### PR DESCRIPTION
## Changes
This PR brings several improvements to the UI Composer API, as well as some of the built-in `app-admin` elements.

- `getParentOfType()` renamed to `getParentByType()` (to match other methods)
- `getChildren()` - returns direct children of the element
- `getDescendentsByType(class)` - returns descendents that match the given class
- `getDescendentsByTag(tag)` - returns descendents that match the given tag
- element renderers now get `next` and `children` callbacks: `next` calls next renderer in chain; `children` prevents the chained execution of renderers and renders children immediately.
- `UIViewComponent` now correctly renders wrappers (which can also be context providers), so all custom hooks now work as expected


## How Has This Been Tested?
Manually.

