### PR TITLE
fix(project-utils): add mjs webpack rule

### DIFF
--- a/packages/project-utils/bundling/function/webpack.build.config.js
+++ b/packages/project-utils/bundling/function/webpack.build.config.js
@@ -37,6 +37,11 @@ module.exports = ({ entry, output, debug = false, babelOptions, define }) => {
             exprContextCritical: false,
             rules: [
                 {
+                    test: /\.mjs$/,
+                    include: /node_modules/,
+                    type: "javascript/auto"
+                },
+                {
                     test: /\.(js|ts)$/,
                     loader: require.resolve("babel-loader"),
                     exclude: /node_modules/,

--- a/packages/project-utils/bundling/function/webpack.watch.config.js
+++ b/packages/project-utils/bundling/function/webpack.watch.config.js
@@ -38,6 +38,11 @@ module.exports = ({ entry, output, debug = false, babelOptions, define }) => {
             exprContextCritical: false,
             rules: [
                 {
+                    test: /\.mjs$/,
+                    include: /node_modules/,
+                    type: "javascript/auto"
+                },
+                {
                     test: /\.(js|ts)$/,
                     loader: require.resolve("babel-loader"),
                     exclude: /node_modules/,


### PR DESCRIPTION
## Changes
This PR adds an `.mjs` rule to webpack config for bundling Lambda functions, to support `.mjs` modules.

## How Has This Been Tested?
Tested by @econtentmaps as he had a ready test case in his project 🍻