### PR TITLE
Fix/api security admin users

### DIFF
--- a/packages/api-security-admin-users-cognito/src/index.ts
+++ b/packages/api-security-admin-users-cognito/src/index.ts
@@ -29,6 +29,10 @@ export default ({ region, userPoolId }) => {
             `
         }),
         new UserPlugin({
+            async beforeUpdate({ updateData }) {
+                // Immediately delete password from `updateData`, as that object will be merged with the `user` data.
+                delete updateData["password"];
+            },
             async beforeCreate({ inputData, user, context }) {
                 // Immediately delete password from `user`, as that object will be stored to the database.
                 // Password field is attached by Cognito plugin, so we only want this plugin to handle it.
@@ -98,10 +102,6 @@ export default ({ region, userPoolId }) => {
                 }
             },
             async afterUpdate({ inputData, user }) {
-                // Immediately delete password from `user`, as that object will be stored to the database.
-                // Password field is attached by Cognito plugin, so we only want this plugin to handle it.
-                delete user["password"];
-
                 const params = {
                     UserAttributes: Object.keys(updateAttributes).map(attr => {
                         return { Name: attr, Value: user[updateAttributes[attr]] };

--- a/packages/api-security-admin-users-so-ddb/src/definitions/userEntity.ts
+++ b/packages/api-security-admin-users-so-ddb/src/definitions/userEntity.ts
@@ -44,9 +44,6 @@ export const createUserEntity = (params: Params): Entity<any> => {
             createdOn: {
                 type: "string"
             },
-            group: {
-                type: "string"
-            },
             ...attributes
         }
     });


### PR DESCRIPTION
## Changes
This PR fixes a bug which breaks user-to-tenant link when `UserA` updates `UserA` (self-update) using the `Users` module in the Admin Area app.

`group` attribute is now also unset from `user` record; users are linked to tenants using different groups, so having a `group` stored within user's data makes no sense.

## How Has This Been Tested?
Manually.
