### PR TITLE
fix(api-security-admin-users): disable auth when getting group data

### DIFF
--- a/packages/api-security-admin-users/src/plugins/AnonymousAuthorizationPlugin.ts
+++ b/packages/api-security-admin-users/src/plugins/AnonymousAuthorizationPlugin.ts
@@ -1,7 +1,10 @@
+import { SecurityPermission } from "@webiny/api-security/types";
 import { AdminUsersContext } from "~/types";
 import { AuthorizationPlugin } from "@webiny/api-security/plugins/AuthorizationPlugin";
 
 export class AnonymousAuthorizationPlugin extends AuthorizationPlugin<AdminUsersContext> {
+    private _permissionCache = new Map<string, SecurityPermission[] | null>();
+
     async getPermissions({ security, tenancy }: AdminUsersContext) {
         const tenant = tenancy.getCurrentTenant();
         if (!tenant) {
@@ -12,11 +15,18 @@ export class AnonymousAuthorizationPlugin extends AuthorizationPlugin<AdminUsers
             return;
         }
 
+        if (this._permissionCache.has(tenant.id)) {
+            return this._permissionCache.get(tenant.id);
+        }
+
         // We assume that all other authorization plugins have already been executed.
         // If we've reached this far, it means that we have an anonymous user
         // and we need to load permissions from the "anonymous" group.
-        const group = await security.groups.getGroup("anonymous");
+        const group = await security.groups.getGroup("anonymous", { auth: false });
 
-        return group ? group.permissions || [] : [];
+        const permissions = group ? group.permissions || [] : [];
+        this._permissionCache.set(tenant.id, permissions);
+
+        return permissions;
     }
 }


### PR DESCRIPTION
## Changes
This PR fixes permission loading for `anonymous` requests, in the `AnonymousAuthorizationPlugin` class. When getting user group, we need to call it without authorization checks. I also brought back permissions caching for this particular plugin, until we implement DataLoader in the Groups crud module.

## How Has This Been Tested?
Manually, by exposing `/cms/read` endpoint to anonymous user group and sending requests from GraphQL Playground.
