### PR TITLE
Ensure Data Is Injected at the Top of the HTML Document

### DIFF
--- a/packages/api-prerendering-service/__tests__/render/handlers/render/linkPreloading.test.ts
+++ b/packages/api-prerendering-service/__tests__/render/handlers/render/linkPreloading.test.ts
@@ -59,17 +59,17 @@ describe(`Link Preloading Test`, () => {
       href="/static/css/main.30bba61e.chunk.css"
       rel="stylesheet"
     />
-  </head>
-  <body>
     <script>
-      window.__APOLLO_STATE__ = undefined;
+      window.__PS_RENDER_ID__ = "${meta.id}";
     </script>
     <script>
       window.__PS_RENDER_TS__ = "${meta.ts}";
     </script>
     <script>
-      window.__PS_RENDER_ID__ = "${meta.id}";
+      window.__APOLLO_STATE__ = undefined;
     </script>
+  </head>
+  <body>
     <script
       data-link-preload=""
       data-link-preload-type="markup"

--- a/packages/api-prerendering-service/__tests__/render/handlers/render/renderUrl.test.ts
+++ b/packages/api-prerendering-service/__tests__/render/handlers/render/renderUrl.test.ts
@@ -1,7 +1,7 @@
 import render from "@webiny/api-prerendering-service/render/renderUrl";
 import prettier from "prettier";
 
-const BASE_HTML = `<html><body><div id="root">A sample page.</div></body></html>`;
+const BASE_HTML = `<html lang="en"><head><meta charset="utf-8" /></head><body><div id="root">A sample page.</div></body></html>`;
 
 describe(`"renderUrl" Function Test`, () => {
     it("should insert basic meta data into the received HTML", async () => {
@@ -15,18 +15,21 @@ describe(`"renderUrl" Function Test`, () => {
             }
         });
 
-        const snapshot = `<html>
-  <body>
-    <div id="root">A sample page.</div>
+        const snapshot = `<html lang="en">
+  <head>
+    <meta charset="utf-8" />
     <script>
-      window.__APOLLO_STATE__ = undefined;
+      window.__PS_RENDER_ID__ = "${meta.id}";
     </script>
     <script>
       window.__PS_RENDER_TS__ = "${meta.ts}";
     </script>
     <script>
-      window.__PS_RENDER_ID__ = "${meta.id}";
+      window.__APOLLO_STATE__ = undefined;
     </script>
+  </head>
+  <body>
+    <div id="root">A sample page.</div>
   </body>
 </html>
 `;
@@ -56,24 +59,27 @@ describe(`"renderUrl" Function Test`, () => {
             }
         });
 
-        const snapshot = `<html>
-  <body>
-    <div id="root">A sample page.</div>
+        const snapshot = `<html lang="en">
+  <head>
+    <meta charset="utf-8" />
     <script>
-      window.__PS_RENDER_LOCALE__ = "en-US";
-    </script>
-    <script>
-      window.__PS_RENDER_TENANT__ = "root";
-    </script>
-    <script>
-      window.__APOLLO_STATE__ = undefined;
+      window.__PS_RENDER_ID__ = "${meta.id}";
     </script>
     <script>
       window.__PS_RENDER_TS__ = "${meta.ts}";
     </script>
     <script>
-      window.__PS_RENDER_ID__ = "${meta.id}";
+      window.__APOLLO_STATE__ = undefined;
     </script>
+    <script>
+      window.__PS_RENDER_TENANT__ = "root";
+    </script>
+    <script>
+      window.__PS_RENDER_LOCALE__ = "en-US";
+    </script>
+  </head>
+  <body>
+    <div id="root">A sample page.</div>
   </body>
 </html>
 `;

--- a/packages/api-prerendering-service/src/render/injectApolloState.ts
+++ b/packages/api-prerendering-service/src/render/injectApolloState.ts
@@ -2,14 +2,12 @@ export default ({ render }) =>
     async tree => {
         console.log("Injecting Apollo state into HTML.");
 
-        const apolloScript = `<script>window.__APOLLO_STATE__ = ${JSON.stringify(
-            render.meta.apolloState
-        )};</script>`;
+        tree.match({ tag: "head" }, node => {
+            const script = `<script>window.__APOLLO_STATE__ = ${JSON.stringify(
+                render.meta.apolloState
+            )};</script>`;
 
-        tree.match({ tag: "body" }, node => {
-            const index = node.content.findIndex(n => n.tag === "div" && n.attrs.id === "root");
-            node.content.splice(index + 1, 0, apolloScript);
-
+            node.content.push(script);
             return node;
         });
     };

--- a/packages/api-prerendering-service/src/render/injectNotFoundPageFlag.ts
+++ b/packages/api-prerendering-service/src/render/injectNotFoundPageFlag.ts
@@ -6,11 +6,8 @@ export default args => async tree => {
 
     console.log("Injecting not-found page flag (__PS_NOT_FOUND_PAGE__) into HTML.");
 
-    const apolloScript = `<script>window.__PS_NOT_FOUND_PAGE__ = true;</script>`;
-
-    tree.match({ tag: "body" }, node => {
-        const index = node.content.findIndex(n => n.tag === "div" && n.attrs.id === "root");
-        node.content.splice(index + 1, 0, apolloScript);
+    tree.match({ tag: "head" }, node => {
+        node.content.push(`<script>window.__PS_NOT_FOUND_PAGE__ = true;</script>`);
         return node;
     });
 };

--- a/packages/api-prerendering-service/src/render/injectRenderId.ts
+++ b/packages/api-prerendering-service/src/render/injectRenderId.ts
@@ -2,11 +2,8 @@ export default ({ id }) =>
     async tree => {
         console.log("Injecting render hash (__PS_RENDER_ID__) into HTML.");
 
-        const apolloScript = `<script>window.__PS_RENDER_ID__ = "${id}";</script>`;
-
-        tree.match({ tag: "body" }, node => {
-            const index = node.content.findIndex(n => n.tag === "div" && n.attrs.id === "root");
-            node.content.splice(index + 1, 0, apolloScript);
+        tree.match({ tag: "head" }, node => {
+            node.content.push(`<script>window.__PS_RENDER_ID__ = "${id}";</script>`);
             return node;
         });
     };

--- a/packages/api-prerendering-service/src/render/injectRenderTs.ts
+++ b/packages/api-prerendering-service/src/render/injectRenderTs.ts
@@ -2,11 +2,8 @@ export default ({ ts }) =>
     async tree => {
         console.log("Injecting render timestamp (__PS_RENDER_TS__) into HTML.");
 
-        const apolloScript = `<script>window.__PS_RENDER_TS__ = "${ts}";</script>`;
-
-        tree.match({ tag: "body" }, node => {
-            const index = node.content.findIndex(n => n.tag === "div" && n.attrs.id === "root");
-            node.content.splice(index + 1, 0, apolloScript);
+        tree.match({ tag: "head" }, node => {
+            node.content.push(`<script>window.__PS_RENDER_TS__ = "${ts}";</script>`);
             return node;
         });
     };

--- a/packages/api-prerendering-service/src/render/injectTenantLocale.ts
+++ b/packages/api-prerendering-service/src/render/injectTenantLocale.ts
@@ -5,16 +5,13 @@ export default args => async tree => {
         return;
     }
 
-    tree.match({ tag: "body" }, node => {
-        const index = node.content.findIndex(n => n.tag === "div" && n.attrs.id === "root");
+    tree.match({ tag: "head" }, node => {
         if (meta.tenant) {
-            const tenant = `<script>window.__PS_RENDER_TENANT__ = "${meta.tenant}";</script>`;
-            node.content.splice(index + 1, 0, tenant);
+            node.content.push(`<script>window.__PS_RENDER_TENANT__ = "${meta.tenant}";</script>`);
         }
 
         if (meta.locale) {
-            const locale = `<script>window.__PS_RENDER_LOCALE__ = "${meta.locale}";</script>`;
-            node.content.splice(index + 1, 0, locale);
+            node.content.push(`<script>window.__PS_RENDER_LOCALE__ = "${meta.locale}";</script>`);
         }
 
         return node;


### PR DESCRIPTION
## Changes
Having the data injected at the top of the HTML (instead of the bottom) ensures all JS code that's about to be executed has access to it.

## How Has This Been Tested?
Existing Jest tests updated.

## Documentation
No, internal fix.