### PR TITLE
fix(app-headless-cms): help text display on file field

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
@@ -4,6 +4,7 @@ import { i18n } from "@webiny/app/i18n";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { FileManager } from "@webiny/app-admin/components";
 import File from "./File";
+import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 
 const t = i18n.ns("app-headless-cms/admin/fields/file");
 
@@ -48,6 +49,9 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                 </FileManager>
                             )}
                         </Bind>
+                        {field.helpText && (
+                            <FormElementMessage>{field.helpText}</FormElementMessage>
+                        )}
                     </Cell>
                 </Grid>
             );


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
This fixes the non-displayed helpText on a fileField.
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
![image](https://user-images.githubusercontent.com/9900846/130526406-7ba9b74e-b205-4b7c-af46-7dc2d9d4d8d2.png)

<!--- If solving an existing issue, make sure to link it. -->
Closes #1804

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I used the contribution guide to run a basic Webiny app in dev env. I made the changes on the field renderer and then I saw the preview on the admin (that was automatically refresh since I watched the `app-headless-cms` package.

## Documentation
I think this is not needed since it's a bugfix
