### PR TITLE
fix(cli-plugin-scaffold-ci): repositories fetched limit

### DIFF
--- a/packages/cli-plugin-scaffold-ci/src/githubActions/fetchAllRepositories.ts
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/fetchAllRepositories.ts
@@ -1,0 +1,35 @@
+import { Octokit } from "octokit";
+
+// TODO: try to add octokit types properly based on
+// https://www.npmjs.com/package/@octokit/types
+type GithubRepository = {
+    full_name: string;
+    name: string;
+    owner: { login: string };
+};
+
+export default async (args: { octokit: Octokit }): Promise<GithubRepository[]> => {
+    const octokit = args.octokit;
+
+    let page = 0;
+    const results: GithubRepository[] = [];
+
+    while (true) {
+        const pageResult = (
+            await octokit.rest.repos.listForAuthenticatedUser({ page, per_page: 100 })
+        ).data;
+
+        // Add pageResult to all results
+        results.push(...pageResult);
+
+        // Stop the loop if there are no more results
+        if (pageResult.length === 0) {
+            break;
+        }
+
+        // Fetch next page
+        page++;
+    }
+
+    return results;
+};


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
This change the behavior of repositories fetching, it does not limit to a certain number anymore but instead, browse all repositories the user has.
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #1785

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Yes, manually, I can now access all my repository in the ci scaffold
## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
