### PR TITLE
Ensure imports made with `~` works in React apps

### DIFF
--- a/api/code/graphql/src/security.ts
+++ b/api/code/graphql/src/security.ts
@@ -54,7 +54,7 @@ export default () => [
 
     /**
      * Cognito authentication plugin.
-     * This plugin will verify the authorization token against a provided User Pool.
+     * This plugin will verify the JWT token against a provided User Pool.
      */
     cognitoAuthentication({
         region: process.env.COGNITO_REGION,

--- a/api/code/headlessCMS/src/security.ts
+++ b/api/code/headlessCMS/src/security.ts
@@ -41,7 +41,7 @@ export default () => [
 
     /**
      * Cognito authentication plugin.
-     * This plugin will verify the authorization token against a provided User Pool.
+     * This plugin will verify the JWT token against a provided User Pool.
      */
     cognitoAuthentication({
         region: process.env.COGNITO_REGION,

--- a/packages/cli-plugin-scaffold-react-app/template/code/src/components/Layout.tsx
+++ b/packages/cli-plugin-scaffold-react-app/template/code/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import transparentBackground from "../images/inner-transparent-bg.svg";
+import transparentBackground from "~/images/inner-transparent-bg.svg";
 import { Link } from "@webiny/react-router";
 
 interface Props {

--- a/packages/cli-plugin-scaffold-react-app/template/code/src/plugins/routes/home.tsx
+++ b/packages/cli-plugin-scaffold-react-app/template/code/src/plugins/routes/home.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { RoutePlugin } from "@webiny/app/plugins/RoutePlugin";
 import { Route } from "@webiny/react-router";
-import { ReactComponent as WebinyLogo } from "../../images/webiny.svg";
-import Layout from "../../components/Layout";
+import { ReactComponent as WebinyLogo } from "~/images/webiny.svg";
+import Layout from "~/components/Layout";
 import UsefulLink from "./home/UsefulLink";
 import UsefulLinks from "./home/UsefulLinks";
 

--- a/packages/cli-plugin-scaffold-react-app/template/code/src/plugins/routes/notFound.tsx
+++ b/packages/cli-plugin-scaffold-react-app/template/code/src/plugins/routes/notFound.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { RoutePlugin } from "@webiny/app/plugins/RoutePlugin";
 import { Route, Link, RouteChildrenProps } from "@webiny/react-router";
-import { ReactComponent as WebinyLogo } from "../../images/webiny.svg";
-import Layout from "../../components/Layout";
+import { ReactComponent as WebinyLogo } from "~/images/webiny.svg";
+import Layout from "~/components/Layout";
 
 // A simple not-found page.
 function NotFound(props: RouteChildrenProps) {

--- a/packages/cli-plugin-scaffold-react-app/template/pulumi/index.ts
+++ b/packages/cli-plugin-scaffold-react-app/template/pulumi/index.ts
@@ -1,4 +1,4 @@
-import pulumi from "@pulumi/pulumi";
+import * as pulumi from "@pulumi/pulumi";
 import { tagResources } from "@webiny/cli-plugin-deploy-pulumi/utils";
 
 /**

--- a/packages/cwp-template-aws/template/api/code/graphql/src/security.ts
+++ b/packages/cwp-template-aws/template/api/code/graphql/src/security.ts
@@ -49,7 +49,7 @@ export default () => [
 
     /**
      * Cognito authentication plugin.
-     * This plugin will verify the authorization token against a provided User Pool.
+     * This plugin will verify the JWT token against a provided User Pool.
      */
     cognitoAuthentication({
         region: process.env.COGNITO_REGION,

--- a/packages/cwp-template-aws/template/api/code/headlessCMS/src/security.ts
+++ b/packages/cwp-template-aws/template/api/code/headlessCMS/src/security.ts
@@ -44,7 +44,7 @@ export default () => [
 
     /**
      * Cognito authentication plugin.
-     * This plugin will verify the authorization token against a provided User Pool.
+     * This plugin will verify the JWT token against a provided User Pool.
      */
     cognitoAuthentication({
         region: process.env.COGNITO_REGION,

--- a/packages/project-utils/bundling/app/config/webpack.config.js
+++ b/packages/project-utils/bundling/app/config/webpack.config.js
@@ -399,6 +399,15 @@ module.exports = function (webpackEnv, { paths, babelCustomizer }) {
                                                 }
                                             }
                                         }
+                                    ],
+                                    [
+                                        "babel-plugin-module-resolver",
+                                        {
+                                            cwd: paths.appPath,
+                                            alias: {
+                                                "~": "./src"
+                                            }
+                                        }
                                     ]
                                 ],
                                 // This is a feature of `babel-loader` for webpack (not Babel itself).


### PR DESCRIPTION
## Changes
Trying to import a TS file or an asset using "~" would not work. This PR will enable this by applying a fix in the webpack config used by React apps.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.