### PR TITLE
Fixes for recently introduced scaffolds

### DIFF
--- a/packages/cli-plugin-scaffold-full-stack-app/src/index.ts
+++ b/packages/cli-plugin-scaffold-full-stack-app/src/index.ts
@@ -80,7 +80,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
             ];
         },
         generate: async options => {
-            const { input, context, inquirer } = options;
+            const { input, context, inquirer, wait } = options;
 
             const appPath = path.join(input.path, "/app");
             const apiPath = path.join(input.path, "/api");
@@ -139,6 +139,15 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
 
             const templateFolderPath = path.join(__dirname, "templates", "essentials");
             await ncp(templateFolderPath, appPath);
+
+            await wait(500);
+
+            // Replace generic "TargetDataModel" with received "dataModelName" argument.
+            const codeReplacements = [
+                { find: "project-applications-path", replaceWith: input.path }
+            ];
+
+            replaceInPath(path.join(appPath, "code", "webiny.config.ts"), codeReplacements);
         },
         onSuccess: async options => {
             const { input, inquirer, context, wait } = options;
@@ -204,7 +213,6 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                     },
                     { find: "target-data-model", replaceWith: Case.kebab(dataModelName.singular) },
                     { find: "Target Data Model", replaceWith: Case.title(dataModelName.singular) },
-                    { find: "project-applications-path", replaceWith: input.path }
                 ];
 
                 replaceInPath(path.join(appPath, "code", "**/*.ts"), codeReplacements);

--- a/packages/cli-plugin-scaffold-full-stack-app/src/index.ts
+++ b/packages/cli-plugin-scaffold-full-stack-app/src/index.ts
@@ -212,7 +212,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                         replaceWith: Case.constant(dataModelName.singular)
                     },
                     { find: "target-data-model", replaceWith: Case.kebab(dataModelName.singular) },
-                    { find: "Target Data Model", replaceWith: Case.title(dataModelName.singular) },
+                    { find: "Target Data Model", replaceWith: Case.title(dataModelName.singular) }
                 ];
 
                 replaceInPath(path.join(appPath, "code", "**/*.ts"), codeReplacements);

--- a/packages/cli-plugin-scaffold-react-app/template/code/src/styles/global.scss
+++ b/packages/cli-plugin-scaffold-react-app/template/code/src/styles/global.scss
@@ -4,7 +4,7 @@ body {
   margin: 0;
   color: white;
   background-color: white;
-  font-family: "Source Sans Pro", serif !important;
+  font-family: 'Trebuchet MS', sans-serif;
 }
 
 a {


### PR DESCRIPTION
## Changes
This PR introduces two fixes.

#### 1. Full Stack Application - `webiny.config.ts` values now injected correctly

The paths in the `webiny.config.ts` would not be correctly set when skipping the GraphQL API Example step. Now, now matter what the user answered, the paths will be correctly set.

#### 2. React Application - use a supported font
Prior to this fix, the React application code used a non-standard `Source Sans Pro` font, which is in 99% of cases not available on users' machines, making the React application not looking esthetically pleasing. :)

This has now been addressed.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.