### PR TITLE
Fix Page Preview

### DIFF
--- a/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
@@ -81,7 +81,7 @@ export function usePageBuilderSettings() {
         const query = [
             "preview=" + encodeURIComponent(page.id),
             "__locale=" + getCurrentLocale("content"),
-            tenant ? "__tenant=" + tenant : null
+            tenant ? "__tenant=" + tenant.id : null
         ];
 
         return url + "?" + query.filter(Boolean).join("&");


### PR DESCRIPTION
## Changes
When previewing pages via the Page Builder editor, the passed `__tenant` query param would always be equal to `[Object object]`. With this fix, the tenant ID will always be correctly passed.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.