### PR TITLE
Ensure `.env` files are loaded from project root, not CWD

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
+const path = require("path");
 const yargs = require("yargs");
-const { log } = require("./utils");
+const { log, getProject } = require("./utils");
 
-// Immediately load .env.{--env} and .env files.
+// Immediately load .env.{PASSED_ENVIRONMENT} and .env files.
 // This way we ensure all of the environment variables are not loaded too late.
-const paths = yargs.argv.env ? [".env", `.env.${yargs.argv.env}`] : [".env"];
+const project = getProject();
+let paths = [path.join(project.root, ".env")];
+if (yargs.argv.env) {
+    paths.push(path.join(project.root, `.env.${yargs.argv.env}`))
+}
+
 for (let i = 0; i < paths.length; i++) {
     const path = paths[i];
     const { error } = require("dotenv").config({ path });

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -8,7 +8,7 @@ const { log, getProject } = require("./utils");
 const project = getProject();
 let paths = [path.join(project.root, ".env")];
 if (yargs.argv.env) {
-    paths.push(path.join(project.root, `.env.${yargs.argv.env}`))
+    paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
 }
 
 for (let i = 0; i < paths.length; i++) {


### PR DESCRIPTION
## Changes
At the moment, the environment variables files are searched in runtime's current working directory, not in project root. This poses an issue if you run a command from a nested folder, for example running `yarn webiny run xyz` from `apps/admin/code`.

This PR ensures environment variables files are always loaded from project root, and not CWD.

## How Has This Been Tested?
Manual testing.

## Documentation
N/A (internal fix)