### PR TITLE
fix: problem with richtexteditor RTL support

### DIFF
--- a/packages/app-admin/src/components/RichTextEditor/tools/header/index.ts
+++ b/packages/app-admin/src/components/RichTextEditor/tools/header/index.ts
@@ -117,7 +117,7 @@ class Header {
 
         newData.text = data.text || "";
         newData.level = parseInt(data.level) || this.defaultLevel.number;
-        newData.textAlign = data.textAlign || TextAlign.LEFT;
+        newData.textAlign = data.textAlign || TextAlign.START;
 
         return newData;
     }
@@ -329,7 +329,7 @@ class Header {
      * @returns {TextAlign} textAlign
      */
     getTextAlign(className) {
-        let textAlign = TextAlign.LEFT;
+        let textAlign = TextAlign.START;
         // Match className with alignment
         this.alignments.forEach(alignment => {
             if (className.includes(`ce-header-text--${alignment.name}`)) {
@@ -512,7 +512,7 @@ class Header {
         let alignment = this.alignments.find(alignment => alignment.name === this._data.textAlign);
 
         if (!alignment) {
-            alignment = { name: TextAlign.LEFT, svg: ALIGNMENT_ICONS.left };
+            alignment = { name: TextAlign.START, svg: ALIGNMENT_ICONS.start };
         }
 
         return alignment;

--- a/packages/app-admin/src/components/RichTextEditor/tools/header/styles.scss
+++ b/packages/app-admin/src/components/RichTextEditor/tools/header/styles.scss
@@ -37,12 +37,12 @@
   display: none;
 }
 
-.ce-header-text--left {
-  text-align: left;
+.ce-header-text--start {
+  text-align: start;
 }
 .ce-header-text--center {
   text-align: center;
 }
-.ce-header-text--right {
-  text-align: right;
+.ce-header-text--end {
+  text-align: end;
 }

--- a/packages/app-admin/src/components/RichTextEditor/tools/paragraph/index.ts
+++ b/packages/app-admin/src/components/RichTextEditor/tools/paragraph/index.ts
@@ -210,7 +210,7 @@ class Paragraph {
         let alignment = this.alignments.find(alignment => alignment.name === this._data.textAlign);
 
         if (!alignment) {
-            alignment = { name: TextAlign.LEFT, svg: ALIGNMENT_ICONS.left };
+            alignment = { name: TextAlign.START, svg: ALIGNMENT_ICONS.start };
         }
 
         return alignment;
@@ -395,7 +395,7 @@ class Paragraph {
      * @returns {TextAlign} textAlign
      */
     getTextAlign(className) {
-        let textAlign = TextAlign.LEFT;
+        let textAlign = TextAlign.START;
         // Match className with alignment
         this.alignments.forEach(alignment => {
             if (className.includes(`ce-header-text--${alignment.name}`)) {
@@ -469,7 +469,7 @@ class Paragraph {
         }
 
         newData.text = data.text || "";
-        newData.textAlign = data.textAlign || TextAlign.LEFT;
+        newData.textAlign = data.textAlign || TextAlign.START;
         newData.className = data.className || "";
 
         return newData;

--- a/packages/app-admin/src/components/RichTextEditor/tools/paragraph/styles.scss
+++ b/packages/app-admin/src/components/RichTextEditor/tools/paragraph/styles.scss
@@ -3,7 +3,7 @@
   outline: none;
 }
 
-.ce-paragraph[data-placeholder]:empty::before{
+.ce-paragraph[data-placeholder]:empty::before {
   content: attr(data-placeholder);
   color: #707684;
   font-weight: normal;
@@ -11,19 +11,19 @@
 }
 
 /** Show placeholder at the first paragraph if Editor is empty */
-.codex-editor--empty .ce-block:first-child .ce-paragraph[data-placeholder]:empty::before {
+.codex-editor--empty .ce-block:first-of-type .ce-paragraph[data-placeholder]:empty::before {
   opacity: 1;
 }
 
-.codex-editor--toolbox-opened .ce-block:first-child .ce-paragraph[data-placeholder]:empty::before,
-.codex-editor--empty .ce-block:first-child .ce-paragraph[data-placeholder]:empty:focus::before {
+.codex-editor--toolbox-opened .ce-block:first-of-type .ce-paragraph[data-placeholder]:empty::before,
+.codex-editor--empty .ce-block:first-of-type .ce-paragraph[data-placeholder]:empty:focus::before {
   opacity: 0;
 }
 
-.ce-paragraph p:first-of-type{
+.ce-paragraph p:first-of-type {
   margin-top: 0;
 }
 
-.ce-paragraph p:last-of-type{
+.ce-paragraph p:last-of-type {
   margin-bottom: 0;
 }

--- a/packages/app-admin/src/components/RichTextEditor/tools/utils.ts
+++ b/packages/app-admin/src/components/RichTextEditor/tools/utils.ts
@@ -1,6 +1,6 @@
 export enum TextAlign {
-    LEFT = "left",
-    RIGHT = "right",
+    START = "start",
+    END = "end",
     CENTER = "center"
 }
 
@@ -10,14 +10,14 @@ export type Alignment = {
 };
 
 export const ALIGNMENT_ICONS = {
-    left:
+    start:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">\n' +
         '  <path fill="none" d="M0 0h24v24H0V0z"/>\n' +
         "  <g>\n" +
         '    <path fill="currentColor" d="M14 15H4c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1zm0-8H4c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1zM4 13h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zm0 8h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1zM3 4c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1z"/>\n' +
         "  </g>\n" +
         "</svg>",
-    right:
+    end:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">\n' +
         '  <path fill="none" d="M0 0h24v24H0V0z"/>\n' +
         "  <g>\n" +
@@ -42,15 +42,15 @@ export const ALIGNMENT_ICONS = {
 
 export const ALIGNMENTS = [
     {
-        name: TextAlign.LEFT,
-        svg: ALIGNMENT_ICONS.left
+        name: TextAlign.START,
+        svg: ALIGNMENT_ICONS.start
     },
     {
         name: TextAlign.CENTER,
         svg: ALIGNMENT_ICONS.center
     },
     {
-        name: TextAlign.RIGHT,
-        svg: ALIGNMENT_ICONS.right
+        name: TextAlign.END,
+        svg: ALIGNMENT_ICONS.end
     }
 ];


### PR DESCRIPTION
## Changes
RTE now stores 'start' and 'end' instead of 'left' and 'right' in the textAlign property for paragraphs.

As this property is used directly by the richtext renderer package (which applies it inline in the JSX as a textAlign property) the browser is now able to correctly align paragraphs for RTL languages because it interprets start/end according to the html tag's property direction (which is ltr by default).

This PR also includes accordingly updated CSS for the editor.

Fixes #1892

## How Has This Been Tested?
Checked that the textAlign property of paragraphs is now start/end. Also checked (using the webiny-richtext-renderer package) that existing paragraphs with left/right specified still render correctly and that changing the HTML direction property makes new paragraphs (i.e. ones using start/end) correctly changes the alignment of paragraphs.

