### PR TITLE
feat(api-file-manager): add and_in operator for tags querying

### DIFF
--- a/packages/api-elasticsearch/__tests__/index.test.ts
+++ b/packages/api-elasticsearch/__tests__/index.test.ts
@@ -16,6 +16,7 @@ const operators = [
     "gt",
     "gte",
     "in",
+    "and_in",
     "lt",
     "lte",
     "not",

--- a/packages/api-elasticsearch/src/index.ts
+++ b/packages/api-elasticsearch/src/index.ts
@@ -15,6 +15,7 @@ import {
     ElasticsearchQueryBuilderOperatorLesserThanPlugin,
     ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin,
     ElasticsearchQueryBuilderOperatorInPlugin,
+    ElasticsearchQueryBuilderOperatorAndInPlugin,
     ElasticsearchQueryBuilderOperatorNotInPlugin
 } from "~/plugins/operator";
 import WebinyError from "@webiny/error";
@@ -60,6 +61,7 @@ export default (options: ElasticsearchClientOptions): ContextPlugin<Elasticsearc
             new ElasticsearchQueryBuilderOperatorLesserThanPlugin(),
             new ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin(),
             new ElasticsearchQueryBuilderOperatorInPlugin(),
+            new ElasticsearchQueryBuilderOperatorAndInPlugin(),
             new ElasticsearchQueryBuilderOperatorNotInPlugin()
         ]);
     });

--- a/packages/api-elasticsearch/src/plugins/operator/andIn.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/andIn.ts
@@ -2,7 +2,7 @@ import { ElasticsearchQueryBuilderOperatorPlugin } from "~/plugins/definition/El
 import { ElasticsearchBoolQueryConfig, ElasticsearchQueryBuilderArgsPlugin } from "~/types";
 
 export class ElasticsearchQueryBuilderOperatorAndInPlugin extends ElasticsearchQueryBuilderOperatorPlugin {
-    public name = "elasticsearch.queryBuilder.operator.in.default";
+    public name = "elasticsearch.queryBuilder.operator.andIn.default";
 
     public getOperator(): string {
         return "and_in";

--- a/packages/api-elasticsearch/src/plugins/operator/andIn.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/andIn.ts
@@ -1,0 +1,40 @@
+import { ElasticsearchQueryBuilderOperatorPlugin } from "~/plugins/definition/ElasticsearchQueryBuilderOperatorPlugin";
+import { ElasticsearchBoolQueryConfig, ElasticsearchQueryBuilderArgsPlugin } from "~/types";
+
+export class ElasticsearchQueryBuilderOperatorAndInPlugin extends ElasticsearchQueryBuilderOperatorPlugin {
+    public name = "elasticsearch.queryBuilder.operator.in.default";
+
+    public getOperator(): string {
+        return "and_in";
+    }
+
+    public apply(
+        query: ElasticsearchBoolQueryConfig,
+        params: ElasticsearchQueryBuilderArgsPlugin
+    ): void {
+        const { value: values, path, basePath } = params;
+        const isArray = Array.isArray(values);
+        if (isArray === false || values.length === 0) {
+            throw new Error(
+                `You cannot filter field "${path}" with "in" operator and not send an array of values.`
+            );
+        }
+
+        let useBasePath = false;
+        // Only use ".keyword" if all of the provided values are strings.
+        for (const value of values) {
+            if (typeof value !== "string") {
+                useBasePath = true;
+                break;
+            }
+        }
+
+        for (const value of values) {
+            query.must.push({
+                term: {
+                    [useBasePath ? basePath : path]: value
+                }
+            });
+        }
+    }
+}

--- a/packages/api-elasticsearch/src/plugins/operator/index.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/index.ts
@@ -3,6 +3,7 @@ export * from "./contains";
 export * from "./equal";
 export * from "./gt";
 export * from "./gte";
+export * from "./andIn";
 export * from "./in";
 export * from "./lt";
 export * from "./lte";

--- a/packages/api-file-manager-ddb-es/src/operations/files/fields.ts
+++ b/packages/api-file-manager-ddb-es/src/operations/files/fields.ts
@@ -2,6 +2,11 @@ import { FileElasticsearchFieldPlugin } from "~/plugins/FileElasticsearchFieldPl
 
 export default () => [
     new FileElasticsearchFieldPlugin({
+        field: "id",
+        unmappedType: "string",
+        keyword: true
+    }),
+    new FileElasticsearchFieldPlugin({
         field: "createdOn",
         unmappedType: "date"
     }),

--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -115,7 +115,10 @@ describe("Files CRUD test", () => {
             data: {
                 fileManager: {
                     updateFile: {
-                        data: fileAData,
+                        data: {
+                            ...fileAData,
+                            tags: ["sketch"]
+                        },
                         error: null
                     }
                 }
@@ -130,6 +133,7 @@ describe("Files CRUD test", () => {
                 data.fileManager.listFiles.data[0].tags.length === 1,
             {
                 tries: 10,
+                wait: 400,
                 name: "list files after update tags"
             }
         );
@@ -160,7 +164,10 @@ describe("Files CRUD test", () => {
             data: {
                 fileManager: {
                     getFile: {
-                        data: fileAData,
+                        data: {
+                            ...fileAData,
+                            tags: ["sketch"]
+                        },
                         error: null
                     }
                 }
@@ -183,11 +190,18 @@ describe("Files CRUD test", () => {
                     listFiles: {
                         data: [
                             // Files are sorted by `id` in descending order
-                            { ...fileBData, id: fileBId },
-                            { ...fileAData, id: fileAId }
+                            {
+                                ...fileBData,
+                                id: fileBId
+                            },
+                            {
+                                ...fileAData,
+                                id: fileAId,
+                                tags: ["sketch"]
+                            }
                         ],
                         meta: {
-                            cursor: null,
+                            cursor: expect.any(String),
                             totalCount: expect.any(Number),
                             hasMoreItems: false
                         },
@@ -289,7 +303,7 @@ describe("Files CRUD test", () => {
                         error: null,
                         meta: {
                             hasMoreItems: false,
-                            cursor: null,
+                            cursor: expect.any(String),
                             totalCount: 2
                         }
                     }
@@ -313,10 +327,12 @@ describe("Files CRUD test", () => {
             }
         });
 
+        const tags = ["art", "file-a", "file-b", "file-c", "sketch", "webiny"];
+
         await until(
             () => listTags().then(([data]) => data),
             ({ data }) => {
-                return data.fileManager.listTags.length === 3;
+                return data.fileManager.listTags.length === tags.length;
             },
             { name: "bulk list all tags", tries: 10 }
         );
@@ -326,7 +342,7 @@ describe("Files CRUD test", () => {
         expect(response).toEqual({
             data: {
                 fileManager: {
-                    listTags: ["art", "sketch", "webiny"]
+                    listTags: tags
                 }
             }
         });
@@ -364,7 +380,7 @@ describe("Files CRUD test", () => {
                         meta: {
                             hasMoreItems: false,
                             totalCount: 1,
-                            cursor: null
+                            cursor: expect.any(String)
                         }
                     }
                 }
@@ -395,7 +411,7 @@ describe("Files CRUD test", () => {
                         meta: {
                             hasMoreItems: false,
                             totalCount: 2,
-                            cursor: null
+                            cursor: expect.any(String)
                         }
                     }
                 }

--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -15,21 +15,21 @@ const fileAData = {
     name: "filenameA.png",
     size: 123456,
     type: "image/png",
-    tags: ["sketch"]
+    tags: ["sketch", "file-a", "webiny"]
 };
 const fileBData = {
     key: "/files/filenameB.png",
     name: "filenameB.png",
     size: 123456,
     type: "image/png",
-    tags: ["art"]
+    tags: ["art", "file-b"]
 };
 const fileCData = {
     key: "/files/filenameC.png",
     name: "filenameC.png",
     size: 123456,
     type: "image/png",
-    tags: ["art", "sketch", "webiny"]
+    tags: ["art", "sketch", "webiny", "file-c"]
 };
 
 describe("Files CRUD test", () => {
@@ -187,7 +187,7 @@ describe("Files CRUD test", () => {
                             { ...fileAData, id: fileAId }
                         ],
                         meta: {
-                            cursor: expect.any(String),
+                            cursor: null,
                             totalCount: expect.any(Number),
                             hasMoreItems: false
                         },
@@ -289,7 +289,7 @@ describe("Files CRUD test", () => {
                         error: null,
                         meta: {
                             hasMoreItems: false,
-                            cursor: expect.any(String),
+                            cursor: null,
                             totalCount: 2
                         }
                     }
@@ -327,6 +327,77 @@ describe("Files CRUD test", () => {
             data: {
                 fileManager: {
                     listTags: ["art", "sketch", "webiny"]
+                }
+            }
+        });
+    });
+
+    it("should find all files with given multiple tags - and operator", async () => {
+        await createFiles({
+            data: [fileAData, fileBData, fileCData]
+        });
+        await until(
+            () => listFiles().then(([data]) => data),
+            ({ data }) => {
+                return data.fileManager.listFiles.data.length === 3;
+            },
+            { name: "list all files", tries: 20 }
+        );
+
+        const [cResponse] = await listFiles({
+            where: {
+                tag_and_in: ["art", "webiny"]
+            }
+        });
+
+        expect(cResponse).toEqual({
+            data: {
+                fileManager: {
+                    listFiles: {
+                        data: [
+                            {
+                                ...fileCData,
+                                id: expect.any(String)
+                            }
+                        ],
+                        error: null,
+                        meta: {
+                            hasMoreItems: false,
+                            totalCount: 1,
+                            cursor: null
+                        }
+                    }
+                }
+            }
+        });
+
+        const [acResponse] = await listFiles({
+            where: {
+                tag_and_in: ["sketch", "webiny"]
+            }
+        });
+
+        expect(acResponse).toEqual({
+            data: {
+                fileManager: {
+                    listFiles: {
+                        data: [
+                            {
+                                ...fileCData,
+                                id: expect.any(String)
+                            },
+                            {
+                                ...fileAData,
+                                id: expect.any(String)
+                            }
+                        ],
+                        error: null,
+                        meta: {
+                            hasMoreItems: false,
+                            totalCount: 2,
+                            cursor: null
+                        }
+                    }
                 }
             }
         });

--- a/packages/api-file-manager/__tests__/graphql/file.ts
+++ b/packages/api-file-manager/__tests__/graphql/file.ts
@@ -105,6 +105,7 @@ export const LIST_FILES = (fields: string[]) => {
             $tags: [String],
             $ids: [ID],
             $search: String,
+            $where: FileWhereInput
         ) {
             fileManager {
                 listFiles(
@@ -113,7 +114,8 @@ export const LIST_FILES = (fields: string[]) => {
                     types: $types,
                     tags: $tags,
                     ids: $ids,
-                    search: $search
+                    search: $search,
+                    where: $where
                 ) {
                     data ${DATA_FIELD_WITH_ID(fields)}
                     meta {

--- a/packages/api-file-manager/src/plugins/crud/files.crud.ts
+++ b/packages/api-file-manager/src/plugins/crud/files.crud.ts
@@ -357,20 +357,12 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
             const sort =
                 Array.isArray(initialSort) && initialSort.length > 0 ? initialSort : ["id_DESC"];
             try {
-                const [files, meta] = await storageOperations.list({
+                return await storageOperations.list({
                     where,
                     after,
                     limit,
                     sort
                 });
-
-                return [
-                    files,
-                    {
-                        ...meta,
-                        cursor: meta.hasMoreItems ? meta.cursor : null
-                    }
-                ];
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not list files by given parameters.",

--- a/packages/api-file-manager/src/plugins/crud/files.crud.ts
+++ b/packages/api-file-manager/src/plugins/crud/files.crud.ts
@@ -305,12 +305,15 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
                 types = [],
                 tags = [],
                 ids = [],
-                after = null
+                after = null,
+                where: initialWhere,
+                sort: initialSort
             } = params;
 
             const { i18nContent } = context;
 
             const where: FileManagerFilesStorageOperationsListParamsWhere = {
+                ...initialWhere,
                 private: false,
                 locale: i18nContent.locale.code
             };
@@ -322,37 +325,65 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
                 where.createdBy = identity.id;
             }
             /**
+             * We need to map the old GraphQL definition to the new one.
+             * That GQL definition is marked as deprecated.
+             */
+            /**
              * To have standardized where objects across the applications, we transform the types into type_in.
              */
-            if (Array.isArray(types) && types.length > 0) {
+            if (Array.isArray(types) && types.length > 0 && !where.type_in) {
                 where.type_in = types;
             }
             /**
              * TODO: determine the change of this part.
              * Either assign search keyword to something meaningful or throw it out.
              */
-            if (search) {
+            if (search && !where.search) {
                 where.search = search;
             }
             /**
              * Same as on types/type_in.
              */
-            if (Array.isArray(tags) && tags.length > 0) {
+            if (Array.isArray(tags) && tags.length > 0 && !where.tag_in) {
                 where.tag_in = tags.map(tag => tag.toLowerCase());
             }
             /**
              * Same as on types/type_in.
              */
-            if (Array.isArray(ids) && ids.length > 0) {
+            if (Array.isArray(ids) && ids.length > 0 && !where.id_in) {
                 where.id_in = ids;
             }
 
-            return storageOperations.list({
-                where,
-                after,
-                limit,
-                sort: ["id_DESC"]
-            });
+            const sort =
+                Array.isArray(initialSort) && initialSort.length > 0 ? initialSort : ["id_DESC"];
+            try {
+                const [files, meta] = await storageOperations.list({
+                    where,
+                    after,
+                    limit,
+                    sort
+                });
+
+                return [
+                    files,
+                    {
+                        ...meta,
+                        cursor: meta.hasMoreItems ? meta.cursor : null
+                    }
+                ];
+            } catch (ex) {
+                throw new WebinyError(
+                    ex.message || "Could not list files by given parameters.",
+                    ex.code || "FILE_TAG_SEARCH_ERROR",
+                    {
+                        ...(ex.data || {}),
+                        where,
+                        after,
+                        limit,
+                        sort
+                    }
+                );
+            }
         },
         async listTags({ after, limit }) {
             await checkBasePermissions(context);

--- a/packages/api-file-manager/src/plugins/graphql.ts
+++ b/packages/api-file-manager/src/plugins/graphql.ts
@@ -109,7 +109,8 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
                 type: String
                 type_in: [String!]
                 tag: String
-                tags_in: [String!]
+                tag_in: [String!]
+                tag_and_in: [String!]
                 id_in: [ID!]
                 id: ID
             }
@@ -124,6 +125,7 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
                     tags: [String]
                     ids: [ID]
                     search: String
+                    where: FileWhereInput
                 ): FileListResponse
 
                 listTags: [String]

--- a/packages/api-file-manager/src/types.ts
+++ b/packages/api-file-manager/src/types.ts
@@ -60,6 +60,16 @@ export interface FileInput {
     tags: [string];
 }
 
+export interface FileListWhereParams {
+    search?: string;
+    type?: string;
+    type_in?: string[];
+    tag?: string;
+    tag_in?: string[];
+    tag_and_in?: string[];
+    id_in?: string[];
+    id?: string;
+}
 export interface FilesListOpts {
     search?: string;
     types?: string[];
@@ -67,6 +77,8 @@ export interface FilesListOpts {
     ids?: string[];
     limit?: number;
     after?: string;
+    where?: FileListWhereParams;
+    sort?: string[];
 }
 
 export interface FileListMeta {

--- a/packages/db-dynamodb/__tests__/plugins/filters.test.ts
+++ b/packages/db-dynamodb/__tests__/plugins/filters.test.ts
@@ -13,6 +13,7 @@ describe("filters", () => {
     const operations = [
         ["eq"],
         ["in"],
+        ["and_in"],
         ["gt"],
         ["gte"],
         ["lt"],
@@ -358,4 +359,26 @@ describe("filters", () => {
             expect(result).toBe(false);
         }
     );
+
+    test("must match all the given tags", () => {
+        const plugin = findFilterPlugin("and_in");
+
+        const result = plugin.matches({
+            value: ["tag1", "tag2"],
+            compareValue: ["tag1", "tag2"]
+        });
+
+        expect(result).toBe(true);
+    });
+
+    test("not match because not all tags are present", () => {
+        const plugin = findFilterPlugin("and_in");
+
+        const result = plugin.matches({
+            value: ["tag1", "tag2"],
+            compareValue: ["tag1", "tag2", "tag3"]
+        });
+
+        expect(result).toBe(false);
+    });
 });

--- a/packages/db-dynamodb/src/plugins/filters/andIn.ts
+++ b/packages/db-dynamodb/src/plugins/filters/andIn.ts
@@ -1,0 +1,27 @@
+import { ValueFilterPlugin } from "../definitions/ValueFilterPlugin";
+import WebinyError from "@webiny/error";
+
+interface MatchesParams {
+    value: any[];
+    compareValue?: any[];
+}
+
+export default new ValueFilterPlugin({
+    operation: "and_in",
+    matches: ({ value, compareValue }: MatchesParams) => {
+        if (!compareValue || Array.isArray(compareValue) === false) {
+            throw new WebinyError(
+                `The value given as "compareValue" must be an array!`,
+                "COMPARE_VALUE_ERROR",
+                {
+                    value,
+                    compareValue
+                }
+            );
+        }
+        if (Array.isArray(value) === true) {
+            return compareValue.every(c => value.includes(c));
+        }
+        return compareValue.includes(value);
+    }
+});

--- a/packages/db-dynamodb/src/plugins/filters/index.ts
+++ b/packages/db-dynamodb/src/plugins/filters/index.ts
@@ -1,6 +1,7 @@
 import eqFilter from "./eq";
 import betweenFilter from "./between";
 import inFilter from "./in";
+import andInFilter from "./andIn";
 import gtFilter from "./gt";
 import gteFilter from "./gte";
 import ltFilter from "./lt";
@@ -15,5 +16,6 @@ export default () => [
     gteFilter,
     lteFilter,
     betweenFilter,
-    containsFilter
+    containsFilter,
+    andInFilter
 ];


### PR DESCRIPTION
## Changes
Closes #1908 

I added the operator and_in for both Elasticsearch and DynamoDB and GraphQL type tag_and_in to listFiles where query.
Please note that where parameter should be used in that query because types, tags, ids and search parameters are deprecated (unfortunately cannot mark them deprecated)

## How Has This Been Tested?
Jest and manual testing.
