### PR TITLE
feat(api-page-builder): add content compression plugins and default

### DIFF
--- a/packages/api-page-builder/src/graphql/crud.ts
+++ b/packages/api-page-builder/src/graphql/crud.ts
@@ -8,6 +8,7 @@ import system from "./crud/system.crud";
 import { ContextPlugin } from "@webiny/handler/plugins/ContextPlugin";
 import { PbContext } from "~/graphql/types";
 import WebinyError from "@webiny/error";
+import { JsonpackContentCompressionPlugin } from "~/plugins/JsonpackContentCompressionPlugin";
 
 const setup = () => {
     return new ContextPlugin<PbContext>(context => {
@@ -18,4 +19,18 @@ const setup = () => {
     });
 };
 
-export default [setup(), menus, categories, pages, pageValidation, pageElements, settings, system];
+export default [
+    setup(),
+    /**
+     * We must have default compression in the page builder.
+     * Maybe figure out some other way of registering the plugins.
+     */
+    new JsonpackContentCompressionPlugin(),
+    menus,
+    categories,
+    pages,
+    pageValidation,
+    pageElements,
+    settings,
+    system
+];

--- a/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
@@ -47,5 +47,10 @@ export const compressContent = async (
     if (value && value.compression) {
         return value as CompressedValue;
     }
-    return await plugin.compress(value);
+    try {
+        return await plugin.compress(value);
+    } catch (ex) {
+        console.log(`Error while compressing page "${page.id}" content: ${ex.message}`);
+        return null;
+    }
 };

--- a/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
@@ -1,36 +1,51 @@
-import jsonpack from "jsonpack";
+import { ContentCompressionPlugin, CompressedValue } from "~/plugins/ContentCompressionPlugin";
+import WebinyError from "@webiny/error";
+import { Page } from "~/types";
 
-interface CompressedContent {
-    compression: string;
-    content: string;
-}
-
+/**
+ * Decompression works in a way that we cycle through the compression plugins and find the one which can decompress the data.
+ * We get the reversed plugin array because we always compress with the last one so we try to decompress in that order.
+ */
 export const extractContent = async (
-    contentProp: CompressedContent | string | any
+    plugins: ContentCompressionPlugin[],
+    page: Page
 ): Promise<Record<string, any>> => {
-    if (!contentProp || !contentProp.compression) {
+    const value = page.content as CompressedValue;
+    if (!value || !value.compression) {
         return null;
+    }
+    const plugin = plugins.find(pl => pl.canDecompress(value));
+    if (!plugin) {
+        throw new WebinyError(
+            "There is no compression plugin to decompress the page content.",
+            "MISSING_COMPRESSION_PLUGIN",
+            {
+                compression: value.compression,
+                id: page.id
+            }
+        );
     }
 
     try {
-        return jsonpack.unpack(contentProp.content);
-    } catch {
+        return await plugin.decompress(value);
+    } catch (ex) {
+        console.log(`Error while decompressing page "${page.id}" content: ${ex.message}`);
         return null;
     }
 };
-
+/**
+ * Compressions receives reversed plugins array because we always compress with last registered plugin.
+ */
 export const compressContent = async (
-    content: Record<string, any> = null
-): Promise<CompressedContent> => {
-    let compressed = null;
-    if (content) {
-        try {
-            compressed = jsonpack.pack(content);
-        } catch {}
-    }
+    plugins: ContentCompressionPlugin[],
+    page: Page
+): Promise<CompressedValue> => {
+    const value = page.content as Record<string, any>;
 
-    return {
-        compression: "jsonpack",
-        content: compressed
-    };
+    const [plugin] = plugins;
+
+    if (value && value.compression) {
+        return value as CompressedValue;
+    }
+    return await plugin.compress(value);
 };

--- a/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
@@ -1,0 +1,33 @@
+import { Plugin } from "@webiny/plugins";
+import WebinyError from "@webiny/error";
+
+export interface CompressedValue {
+    compression: string;
+    content: string;
+}
+
+export abstract class ContentCompressionPlugin extends Plugin {
+    public static readonly type: string = "pageBuilder.page.content.compression";
+
+    public readonly identifier: string;
+
+    protected constructor(identifier: string) {
+        super();
+        if (!identifier || identifier.length < 3) {
+            throw new WebinyError(
+                "Must initialize compression plugin with identifier that has at least three letter identifier.",
+                "MALFORMED_COMPRESSION_PLUGIN_INIT",
+                {
+                    identifier
+                }
+            );
+        }
+        this.identifier = identifier;
+    }
+
+    public abstract canDecompress(value: CompressedValue): boolean;
+
+    public abstract compress(value: any): Promise<CompressedValue>;
+
+    public abstract decompress(value: CompressedValue): Promise<any>;
+}

--- a/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
@@ -6,6 +6,10 @@ export interface CompressedValue {
     content: string;
 }
 
+/**
+ * Functions that are using compress and decompress methods have try/catch around them.
+ * canDecompress only expects boolean, no try/catch around it.
+ */
 export abstract class ContentCompressionPlugin extends Plugin {
     public static readonly type: string = "pageBuilder.page.content.compression";
 
@@ -24,10 +28,20 @@ export abstract class ContentCompressionPlugin extends Plugin {
         }
         this.identifier = identifier;
     }
-
+    /**
+     * Must return if it is possible to decompress the content with given implementation.
+     * This step makes sure no invalid data is passed into decompress method.
+     */
     public abstract canDecompress(value: CompressedValue): boolean;
-
+    /**
+     * Compress the content and return the CompressedValue object.
+     * @throws
+     */
     public abstract compress(value: any): Promise<CompressedValue>;
-
+    /**
+     * Decompress the content if possible. No need to check if given compressed value can be decompressed with given implementation.
+     * It is done in the canDecompress step.
+     * @throws
+     */
     public abstract decompress(value: CompressedValue): Promise<any>;
 }

--- a/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
@@ -1,0 +1,43 @@
+import jsonpack from "jsonpack";
+import { ContentCompressionPlugin, CompressedValue } from "./ContentCompressionPlugin";
+
+const JSONPACK_COMPRESSION = "jsonpack";
+
+/**
+ * The default compression plugin for the page content field.
+ */
+export class JsonpackContentCompressionPlugin extends ContentCompressionPlugin {
+    public constructor() {
+        super(JSONPACK_COMPRESSION);
+    }
+
+    public canDecompress(value: CompressedValue): boolean {
+        return value.compression === JSONPACK_COMPRESSION;
+    }
+
+    public async compress(value: any): Promise<CompressedValue> {
+        let compressed = null;
+        try {
+            compressed = jsonpack.pack(value);
+        } catch (ex) {
+            console.log(`Error while compressing page content: ${ex.message}`);
+        }
+
+        return {
+            compression: JSONPACK_COMPRESSION,
+            content: compressed
+        };
+    }
+
+    public async decompress(value: CompressedValue): Promise<any> {
+        if (!value.content) {
+            return null;
+        }
+        try {
+            return jsonpack.unpack(value.content);
+        } catch (ex) {
+            console.log(`Error while decompressing page content: ${ex.message}`);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Changes
Added the abstract `ContentCompressionPlugin` that defines the implementation of the content compression for pages.
A default `JsonpackContentCompressionPlugin` was added.

## How Has This Been Tested?
Jest and manual testing.

## Documentation
If user wants some other type of compression on the page content it is enough to register a new plugin that extends `ContentCompressionPlugin` class and implements compress, decompress and canDecompress methods.
