### PR TITLE
fix: disable help processing until after plugins are imported

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -8,6 +8,10 @@ const { boolean } = require("boolean");
 // This way we ensure all of the environment variables are not loaded too late.
 const project = getProject();
 let paths = [path.join(project.root, ".env")];
+
+// Disable help processing until after plugins are imported
+yargs.help(false);
+
 if (yargs.argv.env) {
     paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
 }
@@ -99,5 +103,5 @@ yargs
 (async () => {
     await createCommands(yargs, context);
     // Run
-    yargs.argv;
+    yargs.help().argv;
 })();


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #1925

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I have manually tested this.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
No documentation changes are needed.
