### PR TITLE
fix(api-headless-cms-ddb-es): missing rawValues on elasticsearch entry

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/helpers/entryIndexHelpers.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/entryIndexHelpers.ts
@@ -144,7 +144,10 @@ export const extractEntriesFromIndex = ({
                         getFieldIndexPlugin,
                         getFieldTypePlugin,
                         value: entry.values[field.fieldId],
-                        rawValue: entry.rawValues[field.fieldId]
+                        /**
+                         * Possibly no rawValues so we must check for the existence of the field.
+                         */
+                        rawValue: entry.rawValues ? entry.rawValues[field.fieldId] : null
                     });
                 } catch (ex) {
                     throw new Error(


### PR DESCRIPTION
## Changes
In early versions of the Elasticsearch entry there was no rawValues property so it was breaking on extracting data from index entry. We now check for that property.

## How Has This Been Tested?
Jest tests.