### PR TITLE
fix(app-security-admin-users): allow custom form fields

### DIFF
--- a/packages/app-security-admin-users-cognito/src/index.tsx
+++ b/packages/app-security-admin-users-cognito/src/index.tsx
@@ -87,16 +87,20 @@ export default (options: Options): PluginCollection => {
         // Add password input to admin user form
         new UIViewPlugin<UsersFormView>(UsersFormView, view => {
             const bioSection = view.getElement("bio");
+
+            const useFormHook = () => view.getUserFormHook();
+
             bioSection.addElement(
                 new PasswordElement("password", {
                     name: "password",
                     label: "Password",
-                    description: props => {
-                        const { data } = props.formProps;
-                        return data.createdOn && "Type a new password to reset it.";
+                    description: () => {
+                        const { isNewUser } = useFormHook();
+                        return !isNewUser && "Type a new password to reset it.";
                     },
-                    validators: props => {
-                        if (!props.formProps.data.createdOn) {
+                    validators: () => {
+                        const { isNewUser } = useFormHook();
+                        if (isNewUser) {
                             return [...passwordValidators, validation.create("required")];
                         }
                         return passwordValidators;

--- a/packages/app-security-admin-users/src/ui/views/Users/graphql.ts
+++ b/packages/app-security-admin-users/src/ui/views/Users/graphql.ts
@@ -1,17 +1,26 @@
 import gql from "graphql-tag";
 
-const fields = /* GraphQL */ `
+const listUserFields = /* GraphQL */ `
     {
         login
         firstName
         lastName
         avatar
         gravatar
+        createdOn
+    }
+`;
+
+const userFormFields = /* GraphQL */ `
+    {
+        login
+        firstName
+        lastName
+        avatar
         group {
             slug
             name
         }
-        createdOn
     }
 `;
 
@@ -36,7 +45,7 @@ export const READ_USER: any = gql`
     query GetUser($login: String!) {
         security {
             user: getUser(login: $login){
-                data ${fields}
+                data ${userFormFields}
                 error {
                     code
                     message
@@ -50,7 +59,7 @@ export const CREATE_USER: any = gql`
     mutation CreateUser($data: SecurityUserCreateInput!){
         security {
             user: createUser(data: $data) {
-                data ${fields}
+                data ${listUserFields}
                 error {
                     code
                     message
@@ -65,7 +74,7 @@ export const UPDATE_USER: any = gql`
     mutation UpdateUser($login: String!, $data: SecurityUserUpdateInput!){
         security {
             user: updateUser(login: $login, data: $data) {
-                data ${fields}
+                data ${userFormFields}
                 error {
                     code
                     message

--- a/packages/app-security-admin-users/src/ui/views/Users/hooks/useUserForm.ts
+++ b/packages/app-security-admin-users/src/ui/views/Users/hooks/useUserForm.ts
@@ -1,18 +1,9 @@
 import { useCallback } from "react";
 import { useMutation, useQuery } from "@apollo/react-hooks";
-import pick from "lodash/pick";
 import isEmpty from "lodash/isEmpty";
 import { useRouter } from "@webiny/react-router";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { CREATE_USER, LIST_USERS, READ_USER, UPDATE_USER } from "~/ui/views/Users/graphql";
-
-const pickDataForCreateOperation = data => {
-    return pick(data, ["login", "password", "firstName", "lastName", "avatar", "group"]);
-};
-
-const pickDataForUpdateOperation = data => {
-    return pick(data, ["password", "firstName", "lastName", "avatar", "group"]);
-};
 
 export type UseUserForm = ReturnType<typeof useUserForm>;
 
@@ -52,25 +43,10 @@ export function useUserForm() {
 
     const onSubmit = useCallback(
         async data => {
-            const isUpdate = data.createdOn;
-            const [operation, args] = isUpdate
-                ? [
-                      update,
-                      {
-                          variables: {
-                              login: data.login,
-                              data: pickDataForUpdateOperation(data)
-                          }
-                      }
-                  ]
-                : [
-                      create,
-                      {
-                          variables: {
-                              data: pickDataForCreateOperation(data)
-                          }
-                      }
-                  ];
+            const { login, ...rest } = data;
+            const [operation, args] = !newUser
+                ? [update, { variables: { login, data: rest } }]
+                : [create, { variables: { data } }];
 
             const result = await operation(args);
 
@@ -80,7 +56,7 @@ export function useUserForm() {
                 return showSnackbar(error.message);
             }
 
-            !isUpdate && history.push(`/security/users?login=${encodeURIComponent(user.login)}`);
+            newUser && history.push(`/security/users?login=${encodeURIComponent(user.login)}`);
             showSnackbar("User saved successfully.");
         },
         [login]
@@ -95,6 +71,7 @@ export function useUserForm() {
         loading,
         user,
         onSubmit,
+        isNewUser: newUser,
         fullName: `${user.firstName || ""} ${user.lastName || ""}`.trim(),
         showEmptyView,
         createUser() {


### PR DESCRIPTION
## Changes
This PR removes data picking functions, and allows you to add custom fields to user form.
To achieve this, I had to stop relying on `createdOn` field as a source of `is new?` information, and instead move that logic into `useUserForm` hook, which is now encapsulated and available everywhere.

## How Has This Been Tested?
Manually.
