### PR TITLE
fix(app): do not overwrite tenant header

### DIFF
--- a/packages/app/src/plugins/TenantHeaderLinkPlugin.ts
+++ b/packages/app/src/plugins/TenantHeaderLinkPlugin.ts
@@ -27,6 +27,11 @@ export class TenantHeaderLinkPlugin extends ApolloLinkPlugin {
 
     createLink() {
         return setContext((_, { headers }) => {
+            // If tenant header is already set, do not overwrite it.
+            if ("x-tenant" in headers) {
+                return { headers };
+            }
+
             if (this.tenant) {
                 return {
                     headers: {


### PR DESCRIPTION
## Changes
This PR adds a check to `TenantHeaderLinkPlugin` to skip adding the `x-tenant` header if it is already set in the request headers.

## How Has This Been Tested?
Manually.