### PR TITLE
fix(api-page-builder): decompress content only on output

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/simple.pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/simple.pages.test.ts
@@ -93,7 +93,7 @@ describe("pages simple actions", () => {
         });
     });
 
-    it("should create new page and update it with new title and content and then publish the page", async () => {
+    it("should create new page and update it with new title and content and then publish the page and unpublish", async () => {
         const category = await createCategory();
 
         const [createResponse] = await handler.createPage({
@@ -158,6 +158,64 @@ describe("pages simple actions", () => {
                             id,
                             title,
                             status: "published",
+                            content
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+
+        const [getAfterPublishResponse] = await handler.getPage({
+            id
+        });
+        expect(getAfterPublishResponse).toMatchObject({
+            data: {
+                pageBuilder: {
+                    getPage: {
+                        data: {
+                            id,
+                            title,
+                            status: "published",
+                            content
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+
+        const [unpublishResponse] = await handler.unpublishPage({
+            id
+        });
+
+        expect(unpublishResponse).toMatchObject({
+            data: {
+                pageBuilder: {
+                    unpublishPage: {
+                        data: {
+                            id,
+                            title,
+                            status: "unpublished",
+                            content
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+
+        const [getAfterUnpublishResponse] = await handler.getPage({
+            id
+        });
+        expect(getAfterUnpublishResponse).toMatchObject({
+            data: {
+                pageBuilder: {
+                    getPage: {
+                        data: {
+                            id,
+                            title,
+                            status: "unpublished",
                             content
                         },
                         error: null

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -321,10 +321,8 @@ export default new ContextPlugin<PbContext>(async context => {
                 rwd: "w"
             });
 
-            const original = await storageOperations.get({
-                where: {
-                    id
-                }
+            const original = await context.pageBuilder.pages.get(id, {
+                decompress: false
             });
 
             if (!original) {
@@ -613,10 +611,8 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "p"
             });
 
-            const original = await storageOperations.get({
-                where: {
-                    id
-                }
+            const original = await context.pageBuilder.pages.get(id, {
+                decompress: false
             });
 
             if (original.status === STATUS_PUBLISHED) {
@@ -729,10 +725,8 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "u"
             });
 
-            const original = await storageOperations.get({
-                where: {
-                    id
-                }
+            const original = await context.pageBuilder.pages.get(id, {
+                decompress: false
             });
             /**
              * Latest revision of the this page.
@@ -809,10 +803,8 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "r"
             });
 
-            const original = await storageOperations.get({
-                where: {
-                    id
-                }
+            const original = await context.pageBuilder.pages.get(id, {
+                decompress: false
             });
 
             const allowedStatuses = [STATUS_DRAFT, STATUS_CHANGES_REQUESTED];
@@ -866,10 +858,8 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "c"
             });
 
-            const original = await storageOperations.get({
-                where: {
-                    id
-                }
+            const original = await context.pageBuilder.pages.get(id, {
+                decompress: false
             });
             if (original.status !== STATUS_REVIEW_REQUESTED) {
                 throw new WebinyError(
@@ -921,7 +911,7 @@ export default new ContextPlugin<PbContext>(async context => {
             }
         },
 
-        async get(id) {
+        async get(id, options) {
             const permission = await checkBasePermissions(context, PERMISSION_NAME, {
                 rwd: "r"
             });
@@ -947,6 +937,10 @@ export default new ContextPlugin<PbContext>(async context => {
 
             const identity = context.security.getIdentity();
             checkOwnPermissions(identity, permission, page, "ownedBy");
+
+            if (options && options.decompress === false) {
+                return page;
+            }
 
             return (await extractPageContent(contentCompressionPlugins, page)) as any;
         },

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -168,15 +168,10 @@ export default new ContextPlugin<PbContext>(async context => {
                         latest: key.latest,
                         published: key.published
                     };
-                    const page = await storageOperations.get({
+                    const page: Page | null = await storageOperations.get({
                         where
                     });
-                    if (!page) {
-                        pages.push(null);
-                        continue;
-                    }
-                    const newPage = await extractPageContent(contentCompressionPlugins, page);
-                    pages.push(newPage);
+                    pages.push(page);
                 }
                 return pages;
             } catch (ex) {
@@ -308,8 +303,7 @@ export default new ContextPlugin<PbContext>(async context => {
                     context,
                     page: result
                 });
-                delete result.content;
-                return result as any;
+                return (await extractPageContent(contentCompressionPlugins, page)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not create new page.",
@@ -327,7 +321,11 @@ export default new ContextPlugin<PbContext>(async context => {
                 rwd: "w"
             });
 
-            const original = await context.pageBuilder.pages.get(id);
+            const original = await storageOperations.get({
+                where: {
+                    id
+                }
+            });
 
             if (!original) {
                 throw new NotFoundError(`Page not found.`);
@@ -389,7 +387,7 @@ export default new ContextPlugin<PbContext>(async context => {
                  * Clear the dataLoader cache.
                  */
                 clearDataLoaderCache([original, page, latestPage]);
-                return result as any;
+                return (await extractPageContent(contentCompressionPlugins, page)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not create from existing page.",
@@ -615,7 +613,11 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "p"
             });
 
-            const original = await context.pageBuilder.pages.get(id);
+            const original = await storageOperations.get({
+                where: {
+                    id
+                }
+            });
 
             if (original.status === STATUS_PUBLISHED) {
                 throw new NotFoundError(`Page is already published.`);
@@ -705,7 +707,7 @@ export default new ContextPlugin<PbContext>(async context => {
                     publishedPage,
                     publishedPathPage
                 ]);
-                return result as any;
+                return (await extractPageContent(contentCompressionPlugins, result)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not publish page.",
@@ -727,7 +729,11 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "u"
             });
 
-            const original = await context.pageBuilder.pages.get(id);
+            const original = await storageOperations.get({
+                where: {
+                    id
+                }
+            });
             /**
              * Latest revision of the this page.
              */
@@ -782,7 +788,7 @@ export default new ContextPlugin<PbContext>(async context => {
                     }
                 );
                 clearDataLoaderCache([original, latestPage]);
-                return result as any;
+                return (await extractPageContent(contentCompressionPlugins, result)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not unpublish page.",
@@ -803,7 +809,11 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "r"
             });
 
-            const original = await context.pageBuilder.pages.get(id);
+            const original = await storageOperations.get({
+                where: {
+                    id
+                }
+            });
 
             const allowedStatuses = [STATUS_DRAFT, STATUS_CHANGES_REQUESTED];
             if (!allowedStatuses.includes(original.status)) {
@@ -836,7 +846,7 @@ export default new ContextPlugin<PbContext>(async context => {
                     latestPage
                 });
                 clearDataLoaderCache([original, latestPage]);
-                return result;
+                return (await extractPageContent(contentCompressionPlugins, result)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not request review for the page.",
@@ -856,7 +866,11 @@ export default new ContextPlugin<PbContext>(async context => {
                 pw: "c"
             });
 
-            const original = await context.pageBuilder.pages.get(id);
+            const original = await storageOperations.get({
+                where: {
+                    id
+                }
+            });
             if (original.status !== STATUS_REVIEW_REQUESTED) {
                 throw new WebinyError(
                     `Cannot request changes on a page that's not under review.`,
@@ -892,7 +906,7 @@ export default new ContextPlugin<PbContext>(async context => {
                     latestPage
                 });
                 clearDataLoaderCache([original, latestPage]);
-                return result;
+                return (await extractPageContent(contentCompressionPlugins, result)) as any;
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not request review for the page.",
@@ -934,7 +948,7 @@ export default new ContextPlugin<PbContext>(async context => {
             const identity = context.security.getIdentity();
             checkOwnPermissions(identity, permission, page, "ownedBy");
 
-            return page as any;
+            return (await extractPageContent(contentCompressionPlugins, page)) as any;
         },
 
         async getPublishedById(params) {
@@ -964,7 +978,7 @@ export default new ContextPlugin<PbContext>(async context => {
                 throw new NotFoundError(`Page not found.`);
             }
 
-            return page as any;
+            return (await extractPageContent(contentCompressionPlugins, page)) as any;
         },
 
         async getPublishedByPath(params) {

--- a/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/contentCompression.ts
@@ -11,8 +11,11 @@ export const extractContent = async (
     page: Page
 ): Promise<Record<string, any>> => {
     const value = page.content as CompressedValue;
+    /**
+     * Possibly no compression on the content so lets return what ever is inside the content.
+     */
     if (!value || !value.compression) {
-        return null;
+        return value;
     }
     const plugin = plugins.find(pl => pl.canDecompress(value));
     if (!plugin) {

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -55,13 +55,17 @@ export interface ListLatestPagesOptions {
     auth?: boolean;
 }
 
+export interface GetPagesOptions {
+    decompress?: boolean;
+}
+
 export interface PagesCrud {
     /**
      * To be used internally in our code.
      * @internal
      */
     storageOperations: PageStorageOperations;
-    get<TPage extends Page = Page>(id: string): Promise<TPage>;
+    get<TPage extends Page = Page>(id: string, options?: GetPagesOptions): Promise<TPage>;
     listLatest<TPage extends Page = Page>(
         args: ListPagesParams,
         options?: ListLatestPagesOptions

--- a/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
@@ -16,6 +16,12 @@ export class JsonpackContentCompressionPlugin extends ContentCompressionPlugin {
     }
 
     public async compress(value: any): Promise<CompressedValue> {
+        if (!value) {
+            return {
+                compression: JSONPACK_COMPRESSION,
+                content: null
+            };
+        }
         let compressed = null;
         try {
             compressed = jsonpack.pack(value);
@@ -30,7 +36,7 @@ export class JsonpackContentCompressionPlugin extends ContentCompressionPlugin {
     }
 
     public async decompress(value: CompressedValue): Promise<any> {
-        if (!value.content) {
+        if (!value || !value.content) {
             return null;
         }
         try {


### PR DESCRIPTION
## Changes
There was a bug in content compression/decompression when publishing, requesting review and requesting changes. 

## How Has This Been Tested?
New jest tests that confirm existence of the content after each of the operations in question.
