### PR TITLE
Various Webiny CLI Fixes

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -103,6 +103,11 @@ module.exports = [
                         describe: `Turn on debug logs`,
                         type: "boolean"
                     });
+                    yargs.option("allowProduction", {
+                        default: false,
+                        describe: `Enables running the watch command with "prod" and "production" environments (not recommended).`,
+                        type: "boolean"
+                    });
                 },
                 async argv => watch(argv, context)
             );

--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -47,9 +47,11 @@ module.exports = async (inputs, context) => {
     }
 
     if (WATCH_DISABLED_ENVIRONMENTS.includes(inputs.env)) {
-        throw new Error(
-            `${chalk.red("webiny watch")} command cannot be used with production environments.`
-        );
+        if (!inputs.allowProduction) {
+            throw new Error(
+                `${chalk.red("webiny watch")} command cannot be used with production environments.`
+            );
+        }
     }
 
     if (!inputs.build && !inputs.deploy) {
@@ -322,7 +324,7 @@ module.exports = async (inputs, context) => {
 };
 
 const printLog = ({ pattern = "*", consoleLog, output }) => {
-    const plainPrefix = `${consoleLog.meta.functionName}:`;
+    const plainPrefix = `${consoleLog.meta.functionName}: `;
     let message = consoleLog.args.join(" ").trim();
     if (message) {
         if (minimatch(plainPrefix, pattern)) {

--- a/packages/cli-plugin-scaffold-graphql-api/src/index.ts
+++ b/packages/cli-plugin-scaffold-graphql-api/src/index.ts
@@ -174,7 +174,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                                 path.join(context.project.root, input.path, "code", "graphql"),
                                 context.project.root
                             )
-                            .replace("\\", "/")
+                            .replace(/\\/g, "/")
                     }
                 ];
                 replaceInPath(p, replacements);
@@ -191,7 +191,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                                 path.join(context.project.root, input.path, "code", "graphql"),
                                 context.project.root
                             )
-                            .replace("\\", "/")
+                            .replace(/\\/g, "/")
                     }
                 ];
                 replaceInPath(p, replacements);
@@ -221,7 +221,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
 
             // Add package to workspaces.
             const rootPackageJsonPath = path.join(context.project.root, "package.json");
-            const pathToAdd = `${input.path}/code/graphql`.replace("\\", "/");
+            const pathToAdd = `${input.path}/code/graphql`.replace(/\\/g, "/");
             await addWorkspaceToRootPackageJson(rootPackageJsonPath, pathToAdd);
 
             ora.stopAndPersist({

--- a/packages/cli-plugin-scaffold-graphql-api/src/index.ts
+++ b/packages/cli-plugin-scaffold-graphql-api/src/index.ts
@@ -169,10 +169,12 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                 const replacements = [
                     {
                         find: "PATH",
-                        replaceWith: path.relative(
-                            path.join(context.project.root, input.path, "code", "graphql"),
-                            context.project.root
-                        )
+                        replaceWith: path
+                            .relative(
+                                path.join(context.project.root, input.path, "code", "graphql"),
+                                context.project.root
+                            )
+                            .replace("\\", "/")
                     }
                 ];
                 replaceInPath(p, replacements);
@@ -184,10 +186,12 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
                 const replacements = [
                     {
                         find: "PATH",
-                        replaceWith: path.relative(
-                            path.join(context.project.root, input.path, "code", "graphql"),
-                            context.project.root
-                        )
+                        replaceWith: path
+                            .relative(
+                                path.join(context.project.root, input.path, "code", "graphql"),
+                                context.project.root
+                            )
+                            .replace("\\", "/")
                     }
                 ];
                 replaceInPath(p, replacements);
@@ -217,7 +221,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
 
             // Add package to workspaces.
             const rootPackageJsonPath = path.join(context.project.root, "package.json");
-            const pathToAdd = `${input.path}/code/graphql`;
+            const pathToAdd = `${input.path}/code/graphql`.replace("\\", "/");
             await addWorkspaceToRootPackageJson(rootPackageJsonPath, pathToAdd);
 
             ora.stopAndPersist({

--- a/packages/cli-plugin-scaffold-graphql-service/template/resolvers/TargetDataModelsMutation.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/resolvers/TargetDataModelsMutation.ts
@@ -39,7 +39,7 @@ interface TargetDataModelsMutation {
  * To define our GraphQL resolvers, we are using the "class method resolvers" approach.
  * https://www.graphql-tools.com/docs/resolvers#class-method-resolvers
  */
-export default class TargetDataModelsMutationResolver
+export default class TargetDataModelsMutation
     extends TargetDataModelsResolver
     implements TargetDataModelsMutation
 {

--- a/packages/cli-plugin-scaffold-graphql-service/template/resolvers/TargetDataModelsQuery.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/resolvers/TargetDataModelsQuery.ts
@@ -34,7 +34,7 @@ interface TargetDataModelsQuery {
  * To define our GraphQL resolvers, we are using the "class method resolvers" approach.
  * https://www.graphql-tools.com/docs/resolvers#class-method-resolvers
  */
-export default class TargetDataModelsQueryResolver
+export default class TargetDataModelsQuery
     extends TargetDataModelsResolver
     implements TargetDataModelsQuery
 {

--- a/packages/cli-plugin-scaffold-graphql-service/template/typeDefs.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/typeDefs.ts
@@ -41,9 +41,9 @@ export default /* GraphQL */ `
     }
 
     type TargetDataModelQuery {
-        # Returns a single TargetDataModel entry. 
+        # Returns a single TargetDataModel entry.
         getTargetDataModel(id: ID!): TargetDataModel
-        
+
         # Lists one or more TargetDataModel entries.
         listTargetDataModels(
             limit: Int

--- a/packages/cli-plugin-scaffold-graphql-service/template/typeDefs.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/template/typeDefs.ts
@@ -41,7 +41,10 @@ export default /* GraphQL */ `
     }
 
     type TargetDataModelQuery {
+        # Returns a single TargetDataModel entry. 
         getTargetDataModel(id: ID!): TargetDataModel
+        
+        # Lists one or more TargetDataModel entries.
         listTargetDataModels(
             limit: Int
             before: String

--- a/packages/cli-plugin-scaffold-react-app/src/index.ts
+++ b/packages/cli-plugin-scaffold-react-app/src/index.ts
@@ -174,7 +174,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
 
             // Add package to workspaces.
             const rootPackageJsonPath = path.join(context.project.root, "package.json");
-            const pathToAdd = `${input.path}/code`;
+            const pathToAdd = `${input.path}/code`.replace("\\", "/");
             await addWorkspaceToRootPackageJson(rootPackageJsonPath, pathToAdd);
 
             ora.stopAndPersist({

--- a/packages/cli-plugin-scaffold-react-app/src/index.ts
+++ b/packages/cli-plugin-scaffold-react-app/src/index.ts
@@ -174,7 +174,7 @@ export default (): CliCommandScaffoldTemplate<Input> => ({
 
             // Add package to workspaces.
             const rootPackageJsonPath = path.join(context.project.root, "package.json");
-            const pathToAdd = `${input.path}/code`.replace("\\", "/");
+            const pathToAdd = `${input.path}/code`.replace(/\\/g, "/");
             await addWorkspaceToRootPackageJson(rootPackageJsonPath, pathToAdd);
 
             ora.stopAndPersist({

--- a/packages/cli-plugin-scaffold/src/utils/addWorkspaceToRootPackageJson.ts
+++ b/packages/cli-plugin-scaffold/src/utils/addWorkspaceToRootPackageJson.ts
@@ -4,6 +4,9 @@ import writeJson from "write-json-file";
 import { PackageJson } from "@webiny/cli-plugin-scaffold/types";
 
 export default async (packageJsonPath, pathToAdd) => {
+    // Ensure forward slashes are used.
+    pathToAdd = pathToAdd.replace("\\", "/");
+
     const rootPackageJson = await readJson<PackageJson>(packageJsonPath);
     if (!rootPackageJson.workspaces.packages.includes(pathToAdd)) {
         rootPackageJson.workspaces.packages.push(pathToAdd);

--- a/packages/cli-plugin-scaffold/src/utils/addWorkspaceToRootPackageJson.ts
+++ b/packages/cli-plugin-scaffold/src/utils/addWorkspaceToRootPackageJson.ts
@@ -5,7 +5,7 @@ import { PackageJson } from "@webiny/cli-plugin-scaffold/types";
 
 export default async (packageJsonPath, pathToAdd) => {
     // Ensure forward slashes are used.
-    pathToAdd = pathToAdd.replace("\\", "/");
+    pathToAdd = pathToAdd.replace(/\\/g, "/");
 
     const rootPackageJson = await readJson<PackageJson>(packageJsonPath);
     if (!rootPackageJson.workspaces.packages.includes(pathToAdd)) {

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -4,13 +4,13 @@ const yargs = require("yargs");
 const { log, getProject } = require("./utils");
 const { boolean } = require("boolean");
 
+// Disable help processing until after plugins are imported.
+yargs.help(false);
+
 // Immediately load .env.{PASSED_ENVIRONMENT} and .env files.
 // This way we ensure all of the environment variables are not loaded too late.
 const project = getProject();
 let paths = [path.join(project.root, ".env")];
-
-// Disable help processing until after plugins are imported
-yargs.help(false);
 
 if (yargs.argv.env) {
     paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
@@ -102,6 +102,6 @@ yargs
 
 (async () => {
     await createCommands(yargs, context);
-    // Run
+    // Enable help and run the CLI.
     yargs.help().argv;
 })();


### PR DESCRIPTION
## Changes
This PR introduces a couple of fixes to our CLI.

Closes #1918.

### Full Stack Application Scaffold
Fixed a couple of Windows-only related issues, for example the one outlined in the linked #1918 issue.

### Extend GraphQL API
A couple of minor fixes were applied to the Extend GraphQL API scaffold as well:
- missing comments in `typeDefs.ts` file, for get/list GraphQL fields
- fixed class names (for example `[TargetDataModels]QueryResolver` is now `[TargetDataModels]Query`)

### `webiny watch` Command: Introduced the `--allow-production` Flag
By default, the `webiny watch` command doesn't allow for watching `prod` or `production` environments. This can be overriden with the  `--allow-production` flag, for example:

```bash
yarn webiny watch api/code/graphql --env production --allow-production
```

### Improved the "Deploy" Pane for the `webiny watch` Command
The output in the "Deploy" pane bi now a bit cleaner that it initially was.

![Frame 1](https://user-images.githubusercontent.com/5121148/136545806-7f0c8874-3cba-4042-bdce-68873772d6c7.png)

## How Has This Been Tested?
Manual testing.

## Documentation
No dedicated docs needed. Change will included in the release notes.
