### PR TITLE
Pulumi CLI - Download Binaries Into Local `.webiny` Folder

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
@@ -2,6 +2,8 @@ const { green } = require("chalk");
 const { Pulumi } = require("@webiny/pulumi-sdk");
 const ora = require("ora");
 const merge = require("lodash/merge");
+const { getProject } = require("@webiny/cli/utils");
+const path = require("path");
 
 module.exports = async (args = {}, options = {}) => {
     const spinner = new ora();
@@ -9,6 +11,7 @@ module.exports = async (args = {}, options = {}) => {
     const pulumi = new Pulumi(
         merge(
             {
+                pulumiFolder: path.join(getProject().root, ".webiny"),
                 beforePulumiInstall: () => {
                     console.log(
                         `It looks like this is your first time using ${green(

--- a/packages/pulumi-sdk/src/index.ts
+++ b/packages/pulumi-sdk/src/index.ts
@@ -100,17 +100,13 @@ export class Pulumi {
 
         if (installed) {
             const { version } = require("@pulumi/aws/package.json");
-            await execa(
-                this.pulumiBinaryPath,
-                ["plugin", "install", "resource", "aws", version],
-                {
-                    stdio: "inherit",
-                    env: {
-                        PULUMI_HOME: this.pulumiFolder,
-                        PULUMI_SKIP_UPDATE_CHECK: "true"
-                    }
+            await execa(this.pulumiBinaryPath, ["plugin", "install", "resource", "aws", version], {
+                stdio: "inherit",
+                env: {
+                    PULUMI_HOME: this.pulumiFolder,
+                    PULUMI_SKIP_UPDATE_CHECK: "true"
                 }
-            );
+            });
         }
 
         return installed;


### PR DESCRIPTION
## Changes
This PR changes the folder into which the Pulumi CLI is downloaded. By default, it would be downloaded into `{project-root}/node_modules/@webiny/pulumi-sdk/pulumi`, but that can cause a couple of different issues:

- re-installing dependencies can delete downloaded Pulumi binaries / plugins, forcing the user to re-download everything
- Pulumi CLI can store `credentials.json` file here, which can definitely introduce security-related issues

## How Has This Been Tested?
Manual testing.

## Documentation
This change will be included in the release notes.