### PR TITLE
Fix: PB import export

### DIFF
--- a/apps/admin/code/src/App.tsx
+++ b/apps/admin/code/src/App.tsx
@@ -14,7 +14,6 @@ import { Authentication } from "@webiny/app-security-admin-users-cognito/Authent
 import { createApolloClient } from "./components/apolloClient";
 import { Telemetry } from "./components/Telemetry";
 import { getIdentityData } from "./components/getIdentityData";
-import { PageElementsProvider } from "./components/PageElementsProvider";
 
 // Import styles which include custom theme styles
 import "./App.scss";
@@ -75,20 +74,18 @@ export const App = () => (
                                         then access is using "usePageBuilder()" hook.
                                     */}
                                     <PageBuilderProvider>
-                                        <PageElementsProvider>
-                                            {/*
+                                        {/*
                                             <CmsProvider> handles CMS environments and provides an Apollo Client instance
                                             that points to the /manage GraphQL API.
                                         */}
-                                            <CmsProvider createApolloClient={createApolloClient}>
-                                                {/*
+                                        <CmsProvider createApolloClient={createApolloClient}>
+                                            {/*
                                                 <Routes/> is a helper component that loads all "route" plugins, sorts them
                                                 in the correct "path" order and renders using the <Switch> component,
                                                 so only the matching route is rendered.
                                             */}
-                                                <Routes />
-                                            </CmsProvider>
-                                        </PageElementsProvider>
+                                            <Routes />
+                                        </CmsProvider>
                                     </PageBuilderProvider>
                                 </I18NProvider>
                             </TenancyProvider>

--- a/cypress/integration/admin/pageBuilder/page/importExportPages.spec.js
+++ b/cypress/integration/admin/pageBuilder/page/importExportPages.spec.js
@@ -1,29 +1,13 @@
-context("Export Pages", () => {
-    before(() => {
-        // use the Chrome debugger protocol to grant the current browser window
-        // access to the clipboard from the current origin
-        // https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-grantPermissions
-        // We are using cy.wrap to wait for the promise returned
-        // from the Cypress.automation call, so the test continues
-        // after the clipboard permission has been granted
-        cy.wrap(
-            Cypress.automation("remote:debugger:protocol", {
-                command: "Browser.grantPermissions",
-                params: {
-                    permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
-                    origin: window.location.origin
-                }
-            })
-        );
-    });
+context("Export & Import Pages", () => {
     beforeEach(() => cy.login());
     const pageTitle = "Welcome to Webiny";
 
     const searchForPage = title => {
         cy.findByTestId("default-data-list.search").within(() => {
             cy.findByPlaceholderText(/Search pages/i).type(title);
-            cy.wait(1000);
         });
+        // Wait for loading
+        cy.findByTestId("default-data-list.loading");
     };
 
     const clearSearch = () => {
@@ -32,7 +16,7 @@ context("Export Pages", () => {
         });
     };
 
-    it("should be able to export a page", () => {
+    it("should be able to export and import a page", () => {
         cy.visit("/page-builder/pages");
         searchForPage(pageTitle);
         // Select page for export
@@ -42,6 +26,7 @@ context("Export Pages", () => {
                 .within(() => {
                     cy.findByText(/Welcome to Webiny/i).should("exist");
                     cy.findByTestId("pages-default-data-list.select-page").click({ force: true });
+                    cy.get(`[type="checkbox"]`).should("exist");
                     cy.get(`[type="checkbox"]`).check();
                 });
         });
@@ -73,9 +58,7 @@ context("Export Pages", () => {
             cy.findByText(/Close/i).click();
         });
         clearSearch();
-    });
-    it("should be able to import page", () => {
-        cy.visit("/page-builder/pages");
+
         // Import page
         cy.findByTestId("import-page-button").click();
         // Select category

--- a/packages/app-page-builder/src/admin/views/Pages/PagesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PagesDataList.tsx
@@ -166,7 +166,7 @@ const PagesDataList = ({ onCreatePage, canCreate, onImportPage }: PagesDataListP
         () => (
             <DataListModalOverlay>
                 <Form
-                    data={{ ...where, sort: [sort] }}
+                    data={{ ...where, sort }}
                     onChange={({ status, category, sort }) => {
                         // Update "where" filter.
                         const where = { category, status: undefined };

--- a/packages/cwp-template-aws/template/api/pulumi/dev/index.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/dev/index.ts
@@ -41,6 +41,11 @@ export default () => {
             DB_TABLE: dynamoDb.table.name,
             DB_TABLE_ELASTICSEARCH: elasticSearch.table.name,
             ELASTIC_SEARCH_ENDPOINT: elasticSearch.domain.endpoint,
+
+            // Not required. Useful for testing purposes / ephemeral environments.
+            // https://www.webiny.com/docs/key-topics/ci-cd/testing/slow-ephemeral-environments
+            ELASTIC_SEARCH_INDEX_PREFIX: process.env.ELASTIC_SEARCH_INDEX_PREFIX,
+
             S3_BUCKET: fileManager.bucket.id,
             DEBUG,
             WEBINY_LOGS_FORWARD_URL

--- a/packages/cwp-template-aws/template/api/pulumi/prod/index.ts
+++ b/packages/cwp-template-aws/template/api/pulumi/prod/index.ts
@@ -47,6 +47,11 @@ export default () => {
             DB_TABLE: dynamoDb.table.name,
             DB_TABLE_ELASTICSEARCH: elasticsearch.table.name,
             ELASTIC_SEARCH_ENDPOINT: elasticsearch.domain.endpoint,
+
+            // Not required. Useful for testing purposes / ephemeral environments.
+            // https://www.webiny.com/docs/key-topics/ci-cd/testing/slow-ephemeral-environments
+            ELASTIC_SEARCH_INDEX_PREFIX: process.env.ELASTIC_SEARCH_INDEX_PREFIX,
+
             S3_BUCKET: fileManager.bucket.id,
             DEBUG,
             WEBINY_LOGS_FORWARD_URL

--- a/packages/ui/src/List/DataList/Loader.tsx
+++ b/packages/ui/src/List/DataList/Loader.tsx
@@ -36,7 +36,7 @@ const LoaderUl = styled("ul")({
 });
 
 const Loader = () => (
-    <LoaderUl>
+    <LoaderUl data-testid={"default-data-list.loading"}>
         {[1, 2, 3, 4, 5].map(item => (
             <li key={"list-" + item}>
                 <div className="graphic">

--- a/scripts/setupCypress.js
+++ b/scripts/setupCypress.js
@@ -55,6 +55,8 @@ const args = {
 
     cypressConfig.env.AWS_COGNITO_USER_POOL_ID = apiOutput.cognitoUserPoolId;
     cypressConfig.env.AWS_COGNITO_CLIENT_ID = apiOutput.cognitoAppClientId;
+    // Option for "cypress-image-snapshot" helper
+    cypressConfig.env.failOnSnapshotDiff = false;
 
     // If testing with "local" stack, use "localhost" for the app URLs, otherwise fetch from state files.
 


### PR DESCRIPTION
This PR introduces a couple of fixes for the PB import-export feature.
- fix failing cypress test
- add `ELASTIC_SEARCH_INDEX_PREFIX` env variable to page builder lambda