### PR TITLE
fix(cli): upgrade must take current cli version

### DIFF
--- a/packages/api-form-builder-so-ddb-es/src/operations/system/createElasticsearchIndex.ts
+++ b/packages/api-form-builder-so-ddb-es/src/operations/system/createElasticsearchIndex.ts
@@ -1,17 +1,16 @@
 import { Client } from "@elastic/elasticsearch";
 import configurations from "~/configurations";
-import { Tenant } from "@webiny/api-tenancy/types";
 
 export interface Params {
     elasticsearch: Client;
-    tenant: Tenant;
+    tenant: string;
 }
 
 export const createElasticsearchIndex = async (params: Params) => {
     const { tenant, elasticsearch } = params;
 
     const esIndex = configurations.es({
-        tenant: tenant.id
+        tenant
     });
 
     const { body: exists } = await elasticsearch.indices.exists(esIndex);

--- a/packages/api-form-builder/__tests__/formSubmissionSecurity.test.ts
+++ b/packages/api-form-builder/__tests__/formSubmissionSecurity.test.ts
@@ -102,6 +102,16 @@ describe("Forms Submission Security Test", () => {
                                         siteKey: null
                                     }
                                 }
+                            },
+                            ownedBy: {
+                                id: identityA.id,
+                                displayName: identityA.displayName,
+                                type: identityA.type
+                            },
+                            createdBy: {
+                                id: identityA.id,
+                                displayName: identityA.displayName,
+                                type: identityA.type
                             }
                         },
                         error: null

--- a/packages/api-form-builder/__tests__/forms.test.ts
+++ b/packages/api-form-builder/__tests__/forms.test.ts
@@ -25,7 +25,8 @@ describe('Form Builder "Form" Test', () => {
         getPublishedForm,
         createFormSubmission,
         listFormSubmissions,
-        exportFormSubmissions
+        exportFormSubmissions,
+        defaultIdentity
     } = useGqlHandler();
 
     beforeEach(async () => {
@@ -53,7 +54,9 @@ describe('Form Builder "Form" Test', () => {
                             id: expect.any(String),
                             createdOn: /^20/,
                             savedOn: /^20/,
-                            status: "draft"
+                            status: "draft",
+                            createdBy: defaultIdentity,
+                            ownedBy: defaultIdentity
                         },
                         error: null
                     }

--- a/packages/api-form-builder/__tests__/graphql/forms.ts
+++ b/packages/api-form-builder/__tests__/graphql/forms.ts
@@ -35,6 +35,16 @@ export const FORM_DATA_FIELD = /* GraphQL */ `
             submissions
             conversionRate
         }
+        createdBy {
+            id
+            displayName
+            type
+        }
+        ownedBy {
+            id
+            displayName
+            type
+        }
     }
 `;
 

--- a/packages/api-form-builder/__tests__/useGqlHandler.ts
+++ b/packages/api-form-builder/__tests__/useGqlHandler.ts
@@ -52,6 +52,12 @@ export interface UseGqlHandlerParams {
     tenant?: Tenant;
 }
 
+const defaultIdentity = new SecurityIdentity({
+    id: "mocked",
+    displayName: "Mocked Identity",
+    type: "admin"
+});
+
 export default (params: UseGqlHandlerParams = {}) => {
     const { permissions, identity, tenant, plugins = [] } = params;
     // @ts-ignore
@@ -102,13 +108,7 @@ export default (params: UseGqlHandlerParams = {}) => {
         },
         {
             type: "security-authentication",
-            authenticate: () =>
-                identity ||
-                new SecurityIdentity({
-                    id: "mocked",
-                    displayName: "Mocked Identity",
-                    type: "admin"
-                })
+            authenticate: () => identity || defaultIdentity
         },
         {
             type: "api-file-manager-storage",
@@ -156,6 +156,7 @@ export default (params: UseGqlHandlerParams = {}) => {
         },
         handler,
         invoke,
+        defaultIdentity,
         // Form builder settings
         async updateSettings(variables = {}) {
             return invoke({ body: { query: UPDATE_SETTINGS, variables } });

--- a/packages/api-form-builder/src/plugins/crud/forms.crud.ts
+++ b/packages/api-form-builder/src/plugins/crud/forms.crud.ts
@@ -19,13 +19,13 @@ import { I18NLocale } from "@webiny/api-i18n/types";
 import { createIdentifier } from "@webiny/utils";
 
 export interface Params {
-    tenant: Tenant;
-    locale: I18NLocale;
+    getTenant: () => Tenant;
+    getLocale: () => I18NLocale;
     context: FormBuilderContext;
 }
 
 export const createFormsCrud = (params: Params): FormsCRUD => {
-    const { context, tenant, locale } = params;
+    const { context, getTenant, getLocale } = params;
 
     return {
         async getForm(this: FormBuilder, id, options) {
@@ -39,8 +39,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 form = await this.storageOperations.getForm({
                     where: {
                         id,
-                        tenant: tenant.id,
-                        locale: locale.code
+                        tenant: getTenant().id,
+                        locale: getLocale().code
                     }
                 });
             } catch (ex) {
@@ -100,8 +100,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
 
             const listFormParams: FormBuilderStorageOperationsListFormsParams = {
                 where: {
-                    tenant: tenant.id,
-                    locale: locale.code
+                    tenant: getTenant().id,
+                    locale: getLocale().code
                 },
                 limit: 10000,
                 sort: ["savedOn_DESC"],
@@ -138,8 +138,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 const forms = await this.storageOperations.listFormRevisions({
                     where: {
                         id,
-                        tenant: tenant.id,
-                        locale: locale.code
+                        tenant: getTenant().id,
+                        locale: getLocale().code
                     }
                 });
                 if (forms.length === 0 || !permission) {
@@ -173,8 +173,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                         formId,
                         version: Number(version),
                         published: true,
-                        tenant: tenant.id,
-                        locale: locale.code
+                        tenant: getTenant().id,
+                        locale: getLocale().code
                     }
                 });
             } catch (ex) {
@@ -203,8 +203,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                     where: {
                         formId,
                         published: true,
-                        tenant: tenant.id,
-                        locale: locale.code
+                        tenant: getTenant().id,
+                        locale: getLocale().code
                     }
                 });
             } catch (ex) {
@@ -245,8 +245,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
             const form: FbForm = {
                 id,
                 formId,
-                locale: locale.code,
-                tenant: tenant.id,
+                locale: getLocale().code,
+                tenant: getTenant().id,
                 savedOn: new Date().toISOString(),
                 createdOn: new Date().toISOString(),
                 createdBy: {
@@ -307,8 +307,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
             const original = await this.storageOperations.getForm({
                 where: {
                     id,
-                    tenant: tenant.id,
-                    locale: locale.code
+                    tenant: getTenant().id,
+                    locale: getLocale().code
                 }
             });
 
@@ -326,7 +326,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 ...original,
                 ...data,
                 savedOn: new Date().toISOString(),
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 
@@ -354,8 +354,8 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
             const form = await this.storageOperations.getForm({
                 where: {
                     id,
-                    tenant: tenant.id,
-                    locale: locale.code
+                    tenant: getTenant().id,
+                    locale: getLocale().code
                 }
             });
 
@@ -443,7 +443,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 locked: true,
                 savedOn: new Date().toISOString(),
                 status: utils.getStatus({ published: true, locked: true }),
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 
@@ -481,7 +481,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 published: false,
                 savedOn: new Date().toISOString(),
                 status: utils.getStatus({ published: false, locked: true }),
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 
@@ -543,7 +543,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                 published: false,
                 publishedOn: null,
                 status: utils.getStatus({ published: false, locked: false }),
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 
@@ -576,7 +576,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                     ...original.stats,
                     views: original.stats.views + 1
                 },
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 
@@ -609,7 +609,7 @@ export const createFormsCrud = (params: Params): FormsCRUD => {
                     ...original.stats,
                     submissions: original.stats.submissions + 1
                 },
-                tenant: tenant.id,
+                tenant: getTenant().id,
                 webinyVersion: context.WEBINY_VERSION
             };
 

--- a/packages/api-form-builder/src/plugins/crud/index.ts
+++ b/packages/api-form-builder/src/plugins/crud/index.ts
@@ -14,25 +14,33 @@ export default (params: Params) => {
     const { storageOperations } = params;
 
     return new ContextPlugin<FormBuilderContext>(async context => {
-        const tenant = context.tenancy.getCurrentTenant();
-        const identity = context.security.getIdentity();
-        const locale = context.i18nContent.getLocale();
+        const getLocale = () => {
+            return context.i18nContent.getLocale();
+        };
+
+        const getIdentity = () => {
+            return context.security.getIdentity();
+        };
+
+        const getTenant = () => {
+            return context.tenancy.getCurrentTenant();
+        };
 
         context.formBuilder = {
             storageOperations,
             ...createSystemCrud({
-                identity,
-                tenant,
+                getIdentity,
+                getTenant,
                 context
             }),
             ...createSettingsCrud({
-                tenant,
-                locale,
+                getTenant,
+                getLocale,
                 context
             }),
             ...createFormsCrud({
-                tenant,
-                locale,
+                getTenant,
+                getLocale,
                 context
             }),
             ...createSubmissionsCrud({

--- a/packages/api-form-builder/src/plugins/crud/settings.crud.ts
+++ b/packages/api-form-builder/src/plugins/crud/settings.crud.ts
@@ -7,13 +7,13 @@ import { I18NLocale } from "@webiny/api-i18n/types";
 import { NotFoundError } from "@webiny/handler-graphql";
 
 export interface Params {
-    tenant: Tenant;
-    locale: I18NLocale;
+    getTenant: () => Tenant;
+    getLocale: () => I18NLocale;
     context: FormBuilderContext;
 }
 
 export const createSettingsCrud = (params: Params): SettingsCRUD => {
-    const { tenant, locale, context } = params;
+    const { getTenant, getLocale, context } = params;
 
     return {
         async getSettings(this: FormBuilder, params) {
@@ -26,8 +26,8 @@ export const createSettingsCrud = (params: Params): SettingsCRUD => {
             let settings: Settings = null;
             try {
                 settings = await this.storageOperations.getSettings({
-                    tenant: tenant.id,
-                    locale: locale.code
+                    tenant: getTenant().id,
+                    locale: getLocale().code
                 });
             } catch (ex) {
                 throw new WebinyError(
@@ -62,8 +62,8 @@ export const createSettingsCrud = (params: Params): SettingsCRUD => {
             const settings: Settings = {
                 domain: data.domain,
                 reCaptcha: data.reCaptcha,
-                tenant: tenant.id,
-                locale: locale.code
+                tenant: getTenant().id,
+                locale: getLocale().code
             };
             try {
                 return await this.storageOperations.createSettings({
@@ -104,8 +104,8 @@ export const createSettingsCrud = (params: Params): SettingsCRUD => {
                 },
                 {
                     ...original,
-                    tenant: tenant.id,
-                    locale: locale.code
+                    tenant: getTenant().id,
+                    locale: getLocale().code
                 }
             );
             try {

--- a/packages/api-form-builder/src/types.ts
+++ b/packages/api-form-builder/src/types.ts
@@ -1,5 +1,5 @@
 import { Plugin } from "@webiny/plugins/types";
-import { TenancyContext, Tenant } from "@webiny/api-tenancy/types";
+import { TenancyContext } from "@webiny/api-tenancy/types";
 import { I18NContentContext } from "@webiny/api-i18n-content/types";
 import { ElasticsearchContext } from "@webiny/api-elasticsearch/types";
 import { SecurityPermission } from "@webiny/api-security/types";
@@ -160,11 +160,11 @@ export interface SubmissionsCRUD {
 }
 
 export interface BeforeInstallTopic {
-    tenant: Tenant;
+    tenant: string;
 }
 
 export interface AfterInstallTopic {
-    tenant: Tenant;
+    tenant: string;
 }
 
 export interface SystemCRUD {

--- a/packages/cli/commands/upgrade/upgrades/5.16.0/index.js
+++ b/packages/cli/commands/upgrade/upgrades/5.16.0/index.js
@@ -4,7 +4,7 @@
  */
 const {
     prettierFormat,
-    yarnInstall,
+    yarnUp,
     addWorkspaceToRootPackageJson,
     removeWorkspaceToRootPackageJson
 } = require("../utils");
@@ -158,7 +158,7 @@ const assignPackageVersions = (context, initialTargets) => {
                     dependencies[key] = json.dependencies[key];
                     return dependencies;
                 } else if (json.dependencies[key] === "latest") {
-                    dependencies[key] = `^${targetVersion}`;
+                    dependencies[key] = `${targetVersion}`;
                 } else {
                     dependencies[key] = json.dependencies[key];
                 }
@@ -175,7 +175,7 @@ const assignPackageVersions = (context, initialTargets) => {
                             dependencies[key] = json.devDependencies[key];
                             return dependencies;
                         } else if (json.devDependencies[key] === "latest") {
-                            dependencies[key] = `^${targetVersion}`;
+                            dependencies[key] = `${targetVersion}`;
                         } else {
                             dependencies[key] = json.devDependencies[key];
                         }
@@ -308,10 +308,11 @@ module.exports = {
         );
 
         /**
-         * Install new packages.
+         * Up the versions again and install the packages.
          */
-        await yarnInstall({
-            context
+        await yarnUp({
+            context,
+            targetVersion
         });
 
         context.info("\n");

--- a/packages/cli/commands/upgrade/upgrades/5.16.0/index.js
+++ b/packages/cli/commands/upgrade/upgrades/5.16.0/index.js
@@ -11,8 +11,9 @@ const {
 const path = require("path");
 const fs = require("fs");
 const fsExtra = require("fs-extra");
+const cliPackageJson = require("@webiny/cli/package.json");
 
-const targetVersion = "5.16.0";
+const targetVersion = cliPackageJson.version;
 
 const checkFiles = files => {
     for (const initialFile of files) {

--- a/packages/cli/commands/upgrade/upgrades/utils.js
+++ b/packages/cli/commands/upgrade/upgrades/utils.js
@@ -175,6 +175,26 @@ const yarnInstall = async ({ context }) => {
 };
 
 /**
+ * Run to up the versions of all packages.
+ */
+const yarnUp = async ({ context, targetVersion }) => {
+    const { info, error } = context;
+    try {
+        info(`Updating all package versions to ${targetVersion}...`);
+        await execa(`yarn`, [`up`, `@webiny/*@${targetVersion}`], { cwd: process.cwd() });
+        await execa("yarn", { cwd: process.cwd() });
+        info("Finished update packages.");
+    } catch (ex) {
+        error("Updating of the packages failed.");
+        console.log(ex);
+        console.log(error(ex.message));
+        if (ex.stdout) {
+            console.log(ex.stdout);
+        }
+    }
+};
+
+/**
  *
  * @param plugins {tsMorph.Node}
  * @param afterElement {String|undefined}
@@ -356,6 +376,7 @@ module.exports = {
     createMorphProject,
     prettierFormat,
     yarnInstall,
+    yarnUp,
     addImportsToSource,
     addWorkspaceToRootPackageJson,
     removeWorkspaceToRootPackageJson


### PR DESCRIPTION
## Changes
Use current `@webiny/cli` version as the reference one.
Add yarn up after the cli upgrade. Newly added package.json files had latest set as version.
Fix the form builder cruds to accept getters for tenant, identity and locale.

## How Has This Been Tested?
Manual test of webiny upgrade script.
