### PR TITLE
Broken sort settings field for List of Pages

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/PagesList.tsx
@@ -15,9 +15,8 @@ const PagesList = props => {
     );
     const pageList = components.find(cmp => cmp.componentName === component);
     const { theme } = usePageBuilder();
-
-    // only assign to `setPage` since `page` is no longer a valid variable in `LIST_PUBLISHED_PAGES`.
-    const [, setPage] = useState(1);
+    const [cursors, setCursors] = useState([null]);
+    const [page, setPage] = useState(0);
     const pageAtomValue = useRecoilValue(pageAtom);
 
     if (!pageList) {
@@ -41,6 +40,7 @@ const PagesList = props => {
             }
         },
         limit: parseInt(vars.resultsPerPage),
+        after: cursors[page],
         exclude: [pageAtomValue.path]
     };
 
@@ -65,17 +65,19 @@ const PagesList = props => {
 
     const listPublishedPages = get(data, "pageBuilder.listPublishedPages");
 
-    /**
-     * How to handle these two checks if `meta` field no longer has `previousPage` and `nextPage` fields?
-     */
     let prevPage = null;
-    if (listPublishedPages.meta.previousPage) {
-        prevPage = () => setPage(listPublishedPages.meta.previousPage);
+    if (page >= 1) {
+        prevPage = () => {
+            setPage(page => page - 1);
+        };
     }
 
     let nextPage = null;
-    if (listPublishedPages.meta.nextPage) {
-        nextPage = () => setPage(listPublishedPages.meta.nextPage);
+    if (listPublishedPages.meta.cursor) {
+        nextPage = () => {
+            setCursors(cursors => [...cursors, listPublishedPages.meta.cursor]);
+            setPage(page => page + 1);
+        };
     }
 
     return (

--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/PagesList.tsx
@@ -15,7 +15,9 @@ const PagesList = props => {
     );
     const pageList = components.find(cmp => cmp.componentName === component);
     const { theme } = usePageBuilder();
-    const [page, setPage] = useState(1);
+
+    // only assign to `setPage` since `page` is no longer a valid variable in `LIST_PUBLISHED_PAGES`.
+    const [, setPage] = useState(1);
     const pageAtomValue = useRecoilValue(pageAtom);
 
     if (!pageList) {
@@ -26,7 +28,7 @@ const PagesList = props => {
 
     let sort = null;
     if (vars.sortBy && vars.sortDirection) {
-        sort = { [vars.sortBy]: vars.sortDirection };
+        sort = `${vars.sortBy}_${vars.sortDirection.toUpperCase()}`;
     }
 
     const variables = {
@@ -39,7 +41,6 @@ const PagesList = props => {
             }
         },
         limit: parseInt(vars.resultsPerPage),
-        page,
         exclude: [pageAtomValue.path]
     };
 
@@ -64,6 +65,9 @@ const PagesList = props => {
 
     const listPublishedPages = get(data, "pageBuilder.listPublishedPages");
 
+    /**
+     * How to handle these two checks if `meta` field no longer has `previousPage` and `nextPage` fields?
+     */
     let prevPage = null;
     if (listPublishedPages.meta.previousPage) {
         prevPage = () => setPage(listPublishedPages.meta.previousPage);

--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/graphql.ts
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/graphql.ts
@@ -5,10 +5,17 @@ export const LIST_PUBLISHED_PAGES = gql`
         $where: PbListPublishedPagesWhereInput
         $limit: Int
         $sort: [PbListPagesSort!]
+        $after: String
         $exclude: [String]
     ) {
         pageBuilder {
-            listPublishedPages(where: $where, sort: $sort, limit: $limit, exclude: $exclude) {
+            listPublishedPages(
+                where: $where
+                sort: $sort
+                limit: $limit
+                exclude: $exclude
+                after: $after
+            ) {
                 data {
                     id
                     title
@@ -33,6 +40,8 @@ export const LIST_PUBLISHED_PAGES = gql`
                 }
                 meta {
                     totalCount
+                    cursor
+                    hasMoreItems
                 }
             }
         }

--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/graphql.ts
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/graphql.ts
@@ -3,19 +3,12 @@ import gql from "graphql-tag";
 export const LIST_PUBLISHED_PAGES = gql`
     query ListPublishedPages(
         $where: PbListPublishedPagesWhereInput
-        $sort: PbListPagesSortInput
         $limit: Int
-        $page: Int
+        $sort: [PbListPagesSort!]
         $exclude: [String]
     ) {
         pageBuilder {
-            listPublishedPages(
-                where: $where
-                sort: $sort
-                limit: $limit
-                page: $page
-                exclude: $exclude
-            ) {
+            listPublishedPages(where: $where, sort: $sort, limit: $limit, exclude: $exclude) {
                 data {
                     id
                     title
@@ -39,13 +32,7 @@ export const LIST_PUBLISHED_PAGES = gql`
                     }
                 }
                 meta {
-                    from
-                    to
-                    page
-                    nextPage
-                    previousPage
                     totalCount
-                    totalPages
                 }
             }
         }

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
@@ -29,7 +29,7 @@ const PagesListRender = props => {
     );
     const pageList = components.find(cmp => cmp.componentName === component);
     const { theme } = usePageBuilder();
-    const [page, setPage] = useState(1);
+    const [, setPage] = useState(1); // only assign to `setPage` since `page` is no longer a valid variable in `LIST_PUBLISHED_PAGES`
     const { location } = useRouter();
 
     // Extract page id from URL.
@@ -47,7 +47,7 @@ const PagesListRender = props => {
 
     let sort = null;
     if (vars.sortBy && vars.sortDirection) {
-        sort = { [vars.sortBy]: vars.sortDirection };
+        sort = `${vars.sortBy}_${vars.sortDirection.toUpperCase()}`;
     }
 
     // Lets ensure the trailing "/" is removed.
@@ -63,7 +63,6 @@ const PagesListRender = props => {
             }
         },
         limit: parseInt(vars.resultsPerPage),
-        page,
         /**
          * When rendering page preview inside admin app there will be no page path/slug present in URL.
          * In that case we'll use the extracted page id from URL.
@@ -91,6 +90,9 @@ const PagesListRender = props => {
 
     const listPublishedPages = get(data, "pageBuilder.listPublishedPages");
 
+    /**
+     * How to handle these two checks if `meta` field no longer has `previousPage` and `nextPage` fields?
+     */
     let prevPage = null;
     if (listPublishedPages.meta.previousPage) {
         prevPage = () => setPage(listPublishedPages.meta.previousPage);

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/PagesList.tsx
@@ -29,7 +29,8 @@ const PagesListRender = props => {
     );
     const pageList = components.find(cmp => cmp.componentName === component);
     const { theme } = usePageBuilder();
-    const [, setPage] = useState(1); // only assign to `setPage` since `page` is no longer a valid variable in `LIST_PUBLISHED_PAGES`
+    const [cursors, setCursors] = useState([null]);
+    const [page, setPage] = useState(0);
     const { location } = useRouter();
 
     // Extract page id from URL.
@@ -63,6 +64,7 @@ const PagesListRender = props => {
             }
         },
         limit: parseInt(vars.resultsPerPage),
+        after: cursors[page],
         /**
          * When rendering page preview inside admin app there will be no page path/slug present in URL.
          * In that case we'll use the extracted page id from URL.
@@ -90,17 +92,19 @@ const PagesListRender = props => {
 
     const listPublishedPages = get(data, "pageBuilder.listPublishedPages");
 
-    /**
-     * How to handle these two checks if `meta` field no longer has `previousPage` and `nextPage` fields?
-     */
     let prevPage = null;
-    if (listPublishedPages.meta.previousPage) {
-        prevPage = () => setPage(listPublishedPages.meta.previousPage);
+    if (page >= 1) {
+        prevPage = () => {
+            setPage(page => page - 1);
+        };
     }
 
     let nextPage = null;
-    if (listPublishedPages.meta.nextPage) {
-        nextPage = () => setPage(listPublishedPages.meta.nextPage);
+    if (listPublishedPages.meta.cursor) {
+        nextPage = () => {
+            setCursors(cursors => [...cursors, listPublishedPages.meta.cursor]);
+            setPage(page => page + 1);
+        };
     }
 
     return (

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
@@ -5,10 +5,17 @@ export const LIST_PUBLISHED_PAGES = gql`
         $where: PbListPublishedPagesWhereInput
         $limit: Int
         $sort: [PbListPagesSort!]
+        $after: String
         $exclude: [String]
     ) {
         pageBuilder {
-            listPublishedPages(where: $where, sort: $sort, limit: $limit, exclude: $exclude) {
+            listPublishedPages(
+                where: $where
+                sort: $sort
+                limit: $limit
+                exclude: $exclude
+                after: $after
+            ) {
                 data {
                     id
                     title
@@ -33,6 +40,8 @@ export const LIST_PUBLISHED_PAGES = gql`
                 }
                 meta {
                     totalCount
+                    cursor
+                    hasMoreItems
                 }
             }
         }

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
@@ -3,19 +3,12 @@ import gql from "graphql-tag";
 export const LIST_PUBLISHED_PAGES = gql`
     query ListPublishedPages(
         $where: PbListPublishedPagesWhereInput
-        $sort: PbListPagesSortInput
         $limit: Int
-        $page: Int
+        $sort: [PbListPagesSort!]
         $exclude: [String]
     ) {
         pageBuilder {
-            listPublishedPages(
-                where: $where
-                sort: $sort
-                limit: $limit
-                page: $page
-                exclude: $exclude
-            ) {
+            listPublishedPages(where: $where, sort: $sort, limit: $limit, exclude: $exclude) {
                 data {
                     id
                     title
@@ -39,13 +32,7 @@ export const LIST_PUBLISHED_PAGES = gql`
                     }
                 }
                 meta {
-                    from
-                    to
-                    page
-                    nextPage
-                    previousPage
                     totalCount
-                    totalPages
                 }
             }
         }


### PR DESCRIPTION
## Starting point for fix: #1994 

## Changes
change `sort` argument type to `[PbListPagesSort!]` and remove `page` arguments from `LIST_PUBLISHED_PAGES` query used in `pagesLists` for render and editor plugins. Also remove no longer existing fields from `meta` in `LIST_PUBLISHED_PAGES`:            

```typescript
export const LIST_PUBLISHED_PAGES = gql`
    query ListPublishedPages(
        $where: PbListPublishedPagesWhereInput
        $limit: Int
        $sort: [PbListPagesSort!]
        $exclude: [String]
    ) {
        pageBuilder {
            listPublishedPages(where: $where, sort: $sort, limit: $limit, exclude: $exclude) {
                data {
                    id
                    title
                    path
                    url
                    snippet
                    tags
                    images {
                        general {
                            src
                        }
                    }
                    publishedOn
                    createdBy {
                        id
                        displayName
                    }
                    category {
                        slug
                        name
                    }
                }
                meta {
                    totalCount
                }
            }
        }
    }
`;
```

## How Has This Been Tested?
Manually. By Adding the `list of pages` page builder element to page and validating that it works as expected (before breaking). Would be happy to add some test if anyone can point me in the right direction 😄 
