### PR TITLE
Fix: PB button element label editing

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/link/HrefSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/link/HrefSettings.tsx
@@ -4,14 +4,11 @@ import { merge } from "dot-prop-immutable";
 import { Switch } from "@webiny/ui/Switch";
 import { Form } from "@webiny/form";
 import { validation } from "@webiny/validation";
-import { withActiveElement } from "../../../components";
-import { DelayedOnChange } from "../../../components/DelayedOnChange";
-import { useEventActionHandler } from "../../../hooks/useEventActionHandler";
-import { UpdateElementActionEvent } from "../../../recoil/actions";
-import {
-    PbEditorPageElementSettingsRenderComponentProps,
-    PbEditorElement
-} from "../../../../types";
+import { withActiveElement } from "~/editor/components";
+import { DelayedOnChange } from "~/editor/components/DelayedOnChange";
+import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
+import { UpdateElementActionEvent } from "~/editor/recoil/actions";
+import { PbEditorPageElementSettingsRenderComponentProps, PbEditorElement } from "~/types";
 // Components
 import Accordion from "../components/Accordion";
 import Wrapper from "../components/Wrapper";
@@ -49,6 +46,10 @@ const LinkSettingsComponent: React.FunctionComponent<
     };
 
     const updateSettings = data => {
+        // Skip update if nothing is change.
+        if (data.newTab === newTab && data.href === href) {
+            return;
+        }
         const attrKey = `data.link`;
         const newElement: PbEditorElement = merge(element, attrKey, data);
         updateElement(newElement);

--- a/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
@@ -5,10 +5,10 @@ import classNames from "classnames";
 import kebabCase from "lodash/kebabCase";
 import merge from "lodash/merge";
 import set from "lodash/set";
-import { PbEditorElement } from "../../../../types";
-import { useEventActionHandler } from "../../../hooks/useEventActionHandler";
-import { UpdateElementActionEvent } from "../../../recoil/actions";
-import { elementByIdSelector, uiAtom } from "../../../recoil/modules";
+import { PbEditorElement } from "~/types";
+import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
+import { UpdateElementActionEvent } from "~/editor/recoil/actions";
+import { elementByIdSelector, uiAtom } from "~/editor/recoil/modules";
 import SimpleEditableText from "./SimpleEditableText";
 
 const buttonEditStyle = css({
@@ -65,7 +65,8 @@ const ButtonContainer: React.FunctionComponent<ButtonContainerPropsType> = ({
         eventActionHandler.trigger(
             new UpdateElementActionEvent({
                 element: newElement,
-                history: true
+                history: true,
+                debounce: false
             })
         );
     }, [elementId, element.data]);

--- a/packages/app-page-builder/src/editor/plugins/elements/button/SimpleEditableText.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/SimpleEditableText.tsx
@@ -33,7 +33,6 @@ const SimpleEditableText: React.FunctionComponent<SimpleTextPropsType> = ({
                 return false;
             }
             value.current = elementValue;
-            onChange(elementValue);
         },
         [onChange]
     );
@@ -42,6 +41,7 @@ const SimpleEditableText: React.FunctionComponent<SimpleTextPropsType> = ({
         if (!onBlur) {
             return;
         }
+        onChange(value.current);
         onBlur();
     }, [onBlur]);
 


### PR DESCRIPTION
This PR introduces the fix for PB `button` element label editing.
## Changes
- Cursor doesn't randomly reset to very start while typing the button label

## How Has This Been Tested?
Manually