### PR TITLE
Fix/cms form

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Fields.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Fields.tsx
@@ -12,7 +12,7 @@ interface Props {
     gridClassName?: string;
 }
 
-const getFieldById = (fields, id) => fields.find(field => field.id === id);
+const getFieldById = (fields, id): CmsEditorField => fields.find(field => field.id === id);
 
 export const Fields = ({ Bind, fields, layout, contentModel, gridClassName }: Props) => {
     return (

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useCallback, cloneElement } from "react";
-import { BindComponentRenderProp } from "@webiny/form";
+import { BindComponent, BindComponentRenderProp } from "@webiny/form";
 import { createValidators } from "./functions/createValidators";
+import { CmsEditorField } from "~/types";
 
 interface FieldBindProps extends BindComponentRenderProp {
     appendValue: (value: any) => void;
@@ -9,7 +10,12 @@ interface FieldBindProps extends BindComponentRenderProp {
     removeValue: (index: number) => void;
 }
 
-export function useBind({ Bind: ParentBind, field }) {
+interface UseBindProps {
+    field: CmsEditorField;
+    Bind: BindComponent & { parentName?: string };
+}
+
+export function useBind({ Bind: ParentBind, field }: UseBindProps) {
     const memoizedBindComponents = useRef({});
 
     return useCallback(

--- a/packages/form/src/FormNew.tsx
+++ b/packages/form/src/FormNew.tsx
@@ -382,7 +382,7 @@ export const Form = React.forwardRef((props: FormProps, ref) => {
         inputs.current[name] = { defaultValue, validators, afterChange };
 
         return {
-            form: formRef.current,
+            form: getFormRef(),
             disabled: isDisabled(),
             validate: getValidateFn(name),
             validation: getValidationState(name),
@@ -395,6 +395,7 @@ export const Form = React.forwardRef((props: FormProps, ref) => {
         data: state.data,
         setValue,
         validate,
+        validateInput,
         submit
     });
 

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -11,6 +11,7 @@ export interface FormAPI {
     submit: (event?: React.SyntheticEvent<any, any>) => Promise<void>;
     setValue: FormSetValue;
     validate: () => void;
+    validateInput: (name: string) => Promise<boolean | any>;
 }
 
 export type BindComponentRenderProp = {


### PR DESCRIPTION
## Changes
This PR fixes a reference to the `form` object in nested Bind components within ContentEntryForm.

## How Has This Been Tested?
Manually, by adding single and multiple RichText fields to a content model.

