### PR TITLE
feat(api-headless-cms): move all crud ops to root of context cms object

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/index.ts
@@ -107,7 +107,7 @@ export const createStorageOperations: StorageOperationsFactory = params => {
 
     return {
         init: async (cms: HeadlessCms) => {
-            cms.system.onBeforeSystemInstall.subscribe(async () => {
+            cms.onBeforeSystemInstall.subscribe(async () => {
                 await createElasticsearchTemplate({
                     elasticsearch
                 });

--- a/packages/api-headless-cms-dynamic-pages/src/GetEntryDataSource.ts
+++ b/packages/api-headless-cms-dynamic-pages/src/GetEntryDataSource.ts
@@ -11,9 +11,9 @@ interface Config {
 
 export class GetEntryDataSource extends DataSource<Config, CmsContext> {
     async loadData(variables, config: Config, context: CmsContext) {
-        const apiKey = await context.cms.system.getReadAPIKey();
+        const apiKey = await context.cms.getReadAPIKey();
 
-        const res = await fetch(config.url, {
+        return await fetch(config.url, {
             method: "POST",
             headers: { "Content-Type": "application/json", Authorization: apiKey },
             body: JSON.stringify({
@@ -21,7 +21,5 @@ export class GetEntryDataSource extends DataSource<Config, CmsContext> {
                 variables: interpolateVariables(config.variables, variables)
             })
         }).then(res => res.json());
-
-        return res;
     }
 }

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
@@ -31,22 +31,22 @@ export const assignModelEvents = () => {
         if (!context.cms) {
             throw new Error("Missing cms on context.");
         }
-        context.cms.models.onBeforeModelCreate.subscribe(async () => {
+        context.cms.onBeforeModelCreate.subscribe(async () => {
             pubSubTracker.track("contentModel:beforeCreate");
         });
-        context.cms.models.onAfterModelCreate.subscribe(async () => {
+        context.cms.onAfterModelCreate.subscribe(async () => {
             pubSubTracker.track("contentModel:afterCreate");
         });
-        context.cms.models.onBeforeModelUpdate.subscribe(async () => {
+        context.cms.onBeforeModelUpdate.subscribe(async () => {
             pubSubTracker.track("contentModel:beforeUpdate");
         });
-        context.cms.models.onAfterModelUpdate.subscribe(async () => {
+        context.cms.onAfterModelUpdate.subscribe(async () => {
             pubSubTracker.track("contentModel:afterUpdate");
         });
-        context.cms.models.onBeforeModelDelete.subscribe(async () => {
+        context.cms.onBeforeModelDelete.subscribe(async () => {
             pubSubTracker.track("contentModel:beforeDelete");
         });
-        context.cms.models.onAfterModelDelete.subscribe(async () => {
+        context.cms.onAfterModelDelete.subscribe(async () => {
             pubSubTracker.track("contentModel:afterDelete");
         });
     });
@@ -57,58 +57,58 @@ export const assignEntryEvents = () => {
         if (!context.cms) {
             throw new Error("Missing cms on context.");
         }
-        context.cms.entries.onBeforeEntryCreate.subscribe(async () => {
+        context.cms.onBeforeEntryCreate.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeCreate");
         });
-        context.cms.entries.onAfterEntryCreate.subscribe(async () => {
+        context.cms.onAfterEntryCreate.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterCreate");
         });
-        context.cms.entries.onBeforeEntryRevisionCreate.subscribe(async () => {
+        context.cms.onBeforeEntryRevisionCreate.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeCreateRevisionFrom");
         });
-        context.cms.entries.onAfterEntryRevisionCreate.subscribe(async () => {
+        context.cms.onAfterEntryRevisionCreate.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterCreateRevisionFrom");
         });
-        context.cms.entries.onBeforeEntryUpdate.subscribe(async () => {
+        context.cms.onBeforeEntryUpdate.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeUpdate");
         });
-        context.cms.entries.onAfterEntryUpdate.subscribe(async () => {
+        context.cms.onAfterEntryUpdate.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterUpdate");
         });
-        context.cms.entries.onBeforeEntryDelete.subscribe(async () => {
+        context.cms.onBeforeEntryDelete.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeDelete");
         });
-        context.cms.entries.onAfterEntryDelete.subscribe(async () => {
+        context.cms.onAfterEntryDelete.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterDelete");
         });
-        context.cms.entries.onBeforeEntryRevisionDelete.subscribe(async () => {
+        context.cms.onBeforeEntryRevisionDelete.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeDeleteRevision");
         });
-        context.cms.entries.onAfterEntryRevisionDelete.subscribe(async () => {
+        context.cms.onAfterEntryRevisionDelete.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterDeleteRevision");
         });
-        context.cms.entries.onBeforeEntryPublish.subscribe(async () => {
+        context.cms.onBeforeEntryPublish.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforePublish");
         });
-        context.cms.entries.onAfterEntryPublish.subscribe(async () => {
+        context.cms.onAfterEntryPublish.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterPublish");
         });
-        context.cms.entries.onBeforeEntryUnpublish.subscribe(async () => {
+        context.cms.onBeforeEntryUnpublish.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeUnpublish");
         });
-        context.cms.entries.onAfterEntryUnpublish.subscribe(async () => {
+        context.cms.onAfterEntryUnpublish.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterUnpublish");
         });
-        context.cms.entries.onBeforeEntryRequestReview.subscribe(async () => {
+        context.cms.onBeforeEntryRequestReview.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeRequestReview");
         });
-        context.cms.entries.onAfterEntryRequestReview.subscribe(async () => {
+        context.cms.onAfterEntryRequestReview.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterRequestReview");
         });
-        context.cms.entries.onBeforeEntryRequestChanges.subscribe(async () => {
+        context.cms.onBeforeEntryRequestChanges.subscribe(async () => {
             pubSubTracker.track("contentEntry:beforeRequestChanges");
         });
-        context.cms.entries.onAfterEntryRequestChanges.subscribe(async () => {
+        context.cms.onAfterEntryRequestChanges.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterRequestChanges");
         });
     });

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -46,7 +46,7 @@ const schemaList = new Map<string, SchemaCache>();
 
 const generateCacheKey = async (args: Args): Promise<string> => {
     const { context, locale, type } = args;
-    const lastModelChange = await context.cms.settings.getContentModelLastChange();
+    const lastModelChange = await context.cms.getContentModelLastChange();
     return [locale.code, type, lastModelChange.toISOString()].join("#");
 };
 

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -241,7 +241,6 @@ export const createContentEntryCrud = (params: Params): CmsContentEntryContext =
         onAfterEntryRequestChanges: onAfterRequestChanges,
         onBeforeEntryRequestReview: onBeforeRequestReview,
         onAfterEntryRequestReview: onAfterRequestReview,
-        operations: storageOperations.entries,
         /**
          * Get entries by exact revision IDs from the database.
          */
@@ -297,7 +296,7 @@ export const createContentEntryCrud = (params: Params): CmsContentEntryContext =
         getEntry: async (model, args) => {
             await checkEntryPermissions({ rwd: "r" });
 
-            const [items] = await context.cms.entries.listEntries(model, {
+            const [items] = await context.cms.listEntries(model, {
                 ...args,
                 limit: 1
             });
@@ -347,7 +346,7 @@ export const createContentEntryCrud = (params: Params): CmsContentEntryContext =
         listLatestEntries: async function (model, params) {
             const where = params ? params.where : {};
 
-            return context.cms.entries.listEntries(model, {
+            return context.cms.listEntries(model, {
                 sort: ["createdOn_DESC"],
                 ...(params || {}),
                 where: {
@@ -359,7 +358,7 @@ export const createContentEntryCrud = (params: Params): CmsContentEntryContext =
         listPublishedEntries: async function (model, params) {
             const where = params ? params.where : {};
 
-            return context.cms.entries.listEntries(model, {
+            return context.cms.listEntries(model, {
                 sort: ["createdOn_DESC"],
                 ...(params || {}),
                 where: {

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry/markLockedFields.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry/markLockedFields.ts
@@ -55,7 +55,7 @@ export const markLockedFields = async ({ model, context }: Args): Promise<void> 
     const newLockedFields = existingLockedFields.concat(lockedFields);
 
     try {
-        await context.cms.models.updateModelDirect({
+        await context.cms.updateModelDirect({
             original: model,
             model: {
                 ...model,

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -176,8 +176,6 @@ export const createModelsCrud = (params: Params): CmsContentModelContext => {
         return await updateManager(context, model);
     };
 
-    context.cms.getModelManager = getManager;
-
     const onBeforeCreate = createTopic<BeforeModelCreateTopicParams>();
     const onAfterCreate = createTopic<AfterModelCreateTopicParams>();
     const onBeforeUpdate = createTopic<BeforeModelUpdateTopicParams>();
@@ -222,7 +220,6 @@ export const createModelsCrud = (params: Params): CmsContentModelContext => {
         onAfterModelUpdate: onAfterUpdate,
         onBeforeModelDelete: onBeforeDelete,
         onAfterModelDelete: onAfterDelete,
-        operations: storageOperations.models,
         noAuthModel: () => {
             return {
                 get: modelsGet,
@@ -252,7 +249,7 @@ export const createModelsCrud = (params: Params): CmsContentModelContext => {
             await createdData.validate();
             const input = await createdData.toJSON();
 
-            const group = await context.cms.groups.noAuthGroup().get(input.group);
+            const group = await context.cms.noAuthGroup().get(input.group);
             if (!group) {
                 throw new NotFoundError(`There is no group "${input.group}".`);
             }
@@ -353,7 +350,7 @@ export const createModelsCrud = (params: Params): CmsContentModelContext => {
                 return {} as any;
             }
             if (input.group) {
-                const group = await context.cms.groups.noAuthGroup().get(input.group);
+                const group = await context.cms.noAuthGroup().get(input.group);
                 if (!group) {
                     throw new NotFoundError(`There is no group "${input.group}".`);
                 }
@@ -426,7 +423,7 @@ export const createModelsCrud = (params: Params): CmsContentModelContext => {
 
             managers.delete(model.modelId);
         },
-        getManager,
+        getModelManager: getManager,
         getManagers: () => managers
     };
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreate.ts
@@ -9,6 +9,6 @@ export const assignAfterModelCreate = (params: Params) => {
     const { onAfterCreate, context } = params;
 
     onAfterCreate.subscribe(async () => {
-        await context.cms.settings.updateContentModelLastChange();
+        await context.cms.updateContentModelLastChange();
     });
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterDelete.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterDelete.ts
@@ -9,6 +9,6 @@ export const assignAfterModelDelete = (params: Params) => {
     const { onAfterDelete, context } = params;
 
     onAfterDelete.subscribe(async () => {
-        await context.cms.settings.updateContentModelLastChange();
+        await context.cms.updateContentModelLastChange();
     });
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterUpdate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterUpdate.ts
@@ -9,6 +9,6 @@ export const assignAfterModelUpdate = (params: Params) => {
     const { onAfterUpdate, context } = params;
 
     onAfterUpdate.subscribe(async () => {
-        await context.cms.settings.updateContentModelLastChange();
+        await context.cms.updateContentModelLastChange();
     });
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
@@ -185,7 +185,6 @@ export const createModelGroupsCrud = (params: Params): CmsContentModelGroupConte
         onAfterGroupUpdate: onAfterUpdate,
         onBeforeGroupDelete: onBeforeDelete,
         onAfterGroupDelete: onAfterDelete,
-        operations: storageOperations.groups,
         noAuthGroup: () => {
             return {
                 get: groupsGet,

--- a/packages/api-headless-cms/src/content/plugins/crud/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/index.ts
@@ -38,39 +38,42 @@ export const createContentCruds = (params: Params) => {
             context.plugins.register(storageOperations.plugins);
         }
 
-        context.cms.system = createSystemCrud({
-            context,
-            getTenant,
-            getIdentity,
-            storageOperations
-        });
-        context.cms.settings = createSettingsCrud({
-            context,
-            getTenant,
-            getLocale,
-            storageOperations
-        });
-        context.cms.groups = createModelGroupsCrud({
-            context,
-            getTenant,
-            getLocale,
-            getIdentity,
-            storageOperations
-        });
-        context.cms.models = createModelsCrud({
-            context,
-            getLocale,
-            getTenant,
-            getIdentity,
-            storageOperations
-        });
-        context.cms.entries = createContentEntryCrud({
-            context,
-            getLocale,
-            getTenant,
-            getIdentity,
-            storageOperations
-        });
+        context.cms = {
+            ...context.cms,
+            ...createSystemCrud({
+                context,
+                getTenant,
+                getIdentity,
+                storageOperations
+            }),
+            ...createSettingsCrud({
+                context,
+                getTenant,
+                getLocale,
+                storageOperations
+            }),
+            ...createModelGroupsCrud({
+                context,
+                getTenant,
+                getLocale,
+                getIdentity,
+                storageOperations
+            }),
+            ...createModelsCrud({
+                context,
+                getLocale,
+                getTenant,
+                getIdentity,
+                storageOperations
+            }),
+            ...createContentEntryCrud({
+                context,
+                getLocale,
+                getTenant,
+                getIdentity,
+                storageOperations
+            })
+        };
 
         if (!storageOperations.init) {
             return;

--- a/packages/api-headless-cms/src/content/plugins/internalSecurity/InternalAuthenticationPlugin.ts
+++ b/packages/api-headless-cms/src/content/plugins/internalSecurity/InternalAuthenticationPlugin.ts
@@ -16,7 +16,7 @@ export class InternalAuthenticationPlugin extends AuthenticationPlugin {
         const { headers } = context.http.request;
         const header = headers["Authorization"] || headers["authorization"];
         const apiKey = header ? header.split(" ").pop() : null;
-        if (!apiKey || apiKey !== (await context.cms.system.getReadAPIKey())) {
+        if (!apiKey || apiKey !== (await context.cms.getReadAPIKey())) {
             return;
         }
 

--- a/packages/api-headless-cms/src/content/plugins/modelManager/DefaultContentModelManager.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelManager/DefaultContentModelManager.ts
@@ -10,42 +10,42 @@ export class DefaultContentModelManager implements CmsContentModelManager {
     }
 
     public async create(data) {
-        return this._context.cms.entries.createEntry(this._model, data);
+        return this._context.cms.createEntry(this._model, data);
     }
 
     public async delete(id: string) {
         if (id.includes("#")) {
-            return this._context.cms.entries.deleteEntryRevision(this._model, id);
+            return this._context.cms.deleteEntryRevision(this._model, id);
         }
 
-        return this._context.cms.entries.deleteEntry(this._model, id);
+        return this._context.cms.deleteEntry(this._model, id);
     }
 
     public async get(args) {
-        return this._context.cms.entries.getEntry(this._model, args);
+        return this._context.cms.getEntry(this._model, args);
     }
 
     public async list(args) {
-        return this._context.cms.entries.listEntries(this._model, args);
+        return this._context.cms.listEntries(this._model, args);
     }
 
     public async listPublished(args) {
-        return this._context.cms.entries.listPublishedEntries(this._model, args);
+        return this._context.cms.listPublishedEntries(this._model, args);
     }
 
     public async listLatest(args) {
-        return this._context.cms.entries.listLatestEntries(this._model, args);
+        return this._context.cms.listLatestEntries(this._model, args);
     }
 
     public async getPublishedByIds(ids: string[]) {
-        return this._context.cms.entries.getPublishedEntriesByIds(this._model, ids);
+        return this._context.cms.getPublishedEntriesByIds(this._model, ids);
     }
 
     public async getLatestByIds(ids: string[]) {
-        return this._context.cms.entries.getLatestEntriesByIds(this._model, ids);
+        return this._context.cms.getLatestEntriesByIds(this._model, ids);
     }
 
     public async update(id, data) {
-        return this._context.cms.entries.updateEntry(this._model, id, data);
+        return this._context.cms.updateEntry(this._model, id, data);
     }
 }

--- a/packages/api-headless-cms/src/content/plugins/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentEntries.ts
@@ -57,7 +57,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             Query: {
                 async searchContentEntries(_, args, context) {
                     const { modelIds, query, limit = 10 } = args;
-                    const models = await context.cms.models.listModels();
+                    const models = await context.cms.listModels();
 
                     const getters = models
                         .filter(model => modelIds.includes(model.modelId))
@@ -96,14 +96,14 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 },
                 async getContentEntry(_, args, context) {
                     const { modelId, entryId } = args.entry;
-                    const models = await context.cms.models.listModels();
+                    const models = await context.cms.listModels();
                     const model = models.find(m => m.modelId === modelId);
 
                     if (!model) {
                         return new NotAuthorizedResponse({ data: { modelId } });
                     }
 
-                    const [entry] = await context.cms.entries.getEntriesByIds(model, [entryId]);
+                    const [entry] = await context.cms.getEntriesByIds(model, [entryId]);
 
                     return new Response({
                         id: entry.id,
@@ -116,7 +116,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                     });
                 },
                 async getContentEntries(_, args, context) {
-                    const models = await context.cms.models.listModels();
+                    const models = await context.cms.listModels();
                     const entriesByModel = args.entries.map((ref, index) => {
                         return {
                             entryId: ref.entryId,
@@ -128,7 +128,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                     const getters = entriesByModel.map(async ({ modelId, entryId }) => {
                         // Get model manager, to get access to CRUD methods
                         const model = models.find(m => m.modelId === modelId);
-                        const entries = await context.cms.entries.getEntriesByIds(model, [entryId]);
+                        const entries = await context.cms.getEntriesByIds(model, [entryId]);
                         return entries.map(entry => ({
                             id: entry.id,
                             model: {

--- a/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentModelGroups.ts
@@ -73,11 +73,11 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
         resolvers = {
             CmsContentModelGroup: {
                 contentModels: async (group, _, context) => {
-                    const models = await context.cms.models.silentAuthModel().list();
+                    const models = await context.cms.silentAuthModel().list();
                     return models.filter(m => m.group.id === group.id);
                 },
                 totalContentModels: async (group, _, context) => {
-                    const models = await context.cms.models.silentAuthModel().list();
+                    const models = await context.cms.silentAuthModel().list();
                     return models.filter(m => m.group === group.id).length;
                 },
                 plugin: async (group, _, context: CmsContext) => {
@@ -95,7 +95,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 getContentModelGroup: async (_, args: ReadContentModelGroupArgs, context) => {
                     try {
                         const { id } = args;
-                        const model = await context.cms.groups.getGroup(id);
+                        const model = await context.cms.getGroup(id);
                         return new Response(model);
                     } catch (e) {
                         return new ErrorResponse(e);
@@ -103,7 +103,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 },
                 listContentModelGroups: async (_, __, context) => {
                     try {
-                        const models = await context.cms.groups.listGroups();
+                        const models = await context.cms.listGroups();
                         return new Response(models);
                     } catch (e) {
                         return new ErrorResponse(e);
@@ -113,7 +113,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             Mutation: {
                 createContentModelGroup: async (_, args: CreateContentModelGroupArgs, context) => {
                     try {
-                        const model = await context.cms.groups.createGroup(args.data);
+                        const model = await context.cms.createGroup(args.data);
                         return new Response(model);
                     } catch (e) {
                         return new ErrorResponse(e);
@@ -121,7 +121,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 },
                 updateContentModelGroup: async (_, args: UpdateContentModelGroupArgs, context) => {
                     try {
-                        const group = await context.cms.groups.updateGroup(args.id, args.data);
+                        const group = await context.cms.updateGroup(args.id, args.data);
                         return new Response(group);
                     } catch (e) {
                         return new ErrorResponse(e);
@@ -129,7 +129,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 },
                 deleteContentModelGroup: async (_, args: DeleteContentModelGroupArgs, context) => {
                     try {
-                        await context.cms.groups.deleteGroup(args.id);
+                        await context.cms.deleteGroup(args.id);
                         return new Response(true);
                     } catch (e) {
                         return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/content/plugins/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentModels.ts
@@ -25,7 +25,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
         Query: {
             getContentModel: async (_: unknown, args: ReadContentModelArgs, context) => {
                 try {
-                    const model = await context.cms.models.getModel(args.modelId);
+                    const model = await context.cms.getModel(args.modelId);
                     return new Response(model);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -33,7 +33,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             },
             listContentModels: async (_: unknown, __: unknown, context: CmsContext) => {
                 try {
-                    const model = await context.cms.models.listModels();
+                    const model = await context.cms.listModels();
                     return new Response(model);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -58,7 +58,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
         resolvers.Mutation = {
             createContentModel: async (_: unknown, args: CreateContentModelArgs, context) => {
                 try {
-                    const model = await context.cms.models.createModel(args.data);
+                    const model = await context.cms.createModel(args.data);
                     return new Response(model);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -67,7 +67,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             updateContentModel: async (_: unknown, args: UpdateContentModelArgs, context) => {
                 const { modelId, data } = args;
                 try {
-                    const model = await context.cms.models.updateModel(modelId, data);
+                    const model = await context.cms.updateModel(modelId, data);
                     return new Response(model);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -76,7 +76,7 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             deleteContentModel: async (_: unknown, args: DeleteContentModelArgs, context) => {
                 const { modelId } = args;
                 try {
-                    await context.cms.models.deleteModel(modelId);
+                    await context.cms.deleteModel(modelId);
                     return new Response(true);
                 } catch (e) {
                     return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
@@ -78,7 +78,7 @@ export const createManageResolvers: CreateManageResolvers = ({
             },
             async revisions(entry, _, context: CmsContext) {
                 const entryId = entry.id.split("#")[0];
-                const revisions = await context.cms.entries.getEntryRevisions(model, entryId);
+                const revisions = await context.cms.getEntryRevisions(model, entryId);
                 return revisions.sort((a, b) => b.version - a.version);
             }
         }

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveCreate.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveCreate.ts
@@ -7,7 +7,7 @@ export const resolveCreate: ResolveCreate =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const entry = await cms.entries.createEntry(model, args.data);
+            const entry = await cms.createEntry(model, args.data);
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveCreateFrom.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveCreateFrom.ts
@@ -7,7 +7,7 @@ export const resolveCreateFrom: ResolveCreateFrom =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const newRevision = await cms.entries.createEntryRevisionFrom(
+            const newRevision = await cms.createEntryRevisionFrom(
                 model,
                 args.revision,
                 args.data || {}

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveDelete.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveDelete.ts
@@ -6,9 +6,9 @@ export const resolveDelete: ResolverFactory =
     async (_, { revision }, { cms }) => {
         try {
             if (revision.includes("#")) {
-                await cms.entries.deleteEntryRevision(model, revision);
+                await cms.deleteEntryRevision(model, revision);
             } else {
-                await cms.entries.deleteEntry(model, revision);
+                await cms.deleteEntry(model, revision);
             }
 
             return new Response(true);

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGet.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGet.ts
@@ -5,7 +5,7 @@ export const resolveGet: ResolverFactory =
     ({ model }) =>
     async (_, args, context) => {
         try {
-            const entry = await context.cms.entries.getEntryById(model, args.revision);
+            const entry = await context.cms.getEntryById(model, args.revision);
             return new Response(entry);
         } catch (e) {
             return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGetByIds.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGetByIds.ts
@@ -5,10 +5,7 @@ export const resolveGetByIds: ResolverFactory =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const response: CmsContentEntry[] = await cms.entries.getEntriesByIds(
-                model,
-                args.revisions
-            );
+            const response: CmsContentEntry[] = await cms.getEntriesByIds(model, args.revisions);
 
             return new Response(response);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGetRevisions.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveGetRevisions.ts
@@ -5,10 +5,7 @@ export const resolveGetRevisions: ResolverFactory =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const revisions: CmsContentEntry[] = await cms.entries.getEntryRevisions(
-                model,
-                args.id
-            );
+            const revisions: CmsContentEntry[] = await cms.getEntryRevisions(model, args.id);
 
             return new Response(revisions.sort((a, b) => b.version - a.version));
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveList.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveList.ts
@@ -9,8 +9,10 @@ export const resolveList: ResolverFactory =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const response: [CmsContentEntry[], CmsContentEntryMeta] =
-                await cms.entries.listLatestEntries(model, args);
+            const response: [CmsContentEntry[], CmsContentEntryMeta] = await cms.listLatestEntries(
+                model,
+                args
+            );
 
             return new ListResponse(...response);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolvePublish.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolvePublish.ts
@@ -5,7 +5,7 @@ export const resolvePublish: ResolverFactory =
     ({ model }) =>
     async (_, args, context) => {
         try {
-            const entry = await context.cms.entries.publishEntry(model, args.revision);
+            const entry = await context.cms.publishEntry(model, args.revision);
             return new Response(entry);
         } catch (e) {
             return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRequestChanges.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRequestChanges.ts
@@ -7,7 +7,7 @@ export const resolveRequestChanges: ResolveRequestChanges =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const entry = await cms.entries.requestEntryChanges(model, args.revision);
+            const entry = await cms.requestEntryChanges(model, args.revision);
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRequestReview.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRequestReview.ts
@@ -7,7 +7,7 @@ export const resolveRequestReview: ResolveRequestReview =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const entry = await cms.entries.requestEntryReview(model, args.revision);
+            const entry = await cms.requestEntryReview(model, args.revision);
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveUnpublish.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveUnpublish.ts
@@ -5,7 +5,7 @@ export const resolveUnpublish: ResolverFactory =
     ({ model }) =>
     async (_, args, context) => {
         try {
-            const entry = await context.cms.entries.unpublishEntry(model, args.revision);
+            const entry = await context.cms.unpublishEntry(model, args.revision);
             return new Response(entry);
         } catch (e) {
             return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveUpdate.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveUpdate.ts
@@ -7,7 +7,7 @@ export const resolveUpdate: ResolveUpdate =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const entry = await cms.entries.updateEntry(model, args.revision, args.data);
+            const entry = await cms.updateEntry(model, args.revision, args.data);
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/preview/resolveGet.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/preview/resolveGet.ts
@@ -6,7 +6,7 @@ export const resolveGet: ResolverFactory =
     ({ model }) =>
     async (_, args, context) => {
         try {
-            const [[entry]] = await context.cms.entries.listLatestEntries(model, {
+            const [[entry]] = await context.cms.listLatestEntries(model, {
                 ...args,
                 limit: 1
             });

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/preview/resolveList.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/preview/resolveList.ts
@@ -9,8 +9,10 @@ export const resolveList: ResolverFactory =
     ({ model }) =>
     async (_, args, { cms }) => {
         try {
-            const response: [CmsContentEntry[], CmsContentEntryMeta] =
-                await cms.entries.listLatestEntries(model, args);
+            const response: [CmsContentEntry[], CmsContentEntryMeta] = await cms.listLatestEntries(
+                model,
+                args
+            );
 
             return new ListResponse(...response);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/read/resolveGet.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/read/resolveGet.ts
@@ -6,7 +6,7 @@ export const resolveGet: ResolverFactory =
     ({ model }) =>
     async (_, args, context) => {
         try {
-            const [[entry]] = await context.cms.entries.listPublishedEntries(model, {
+            const [[entry]] = await context.cms.listPublishedEntries(model, {
                 ...args,
                 limit: 1
             });

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/read/resolveList.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/read/resolveList.ts
@@ -10,7 +10,7 @@ export const resolveList: ResolverFactory =
     async (_, args, { cms }) => {
         try {
             const response: [CmsContentEntry[], CmsContentEntryMeta] =
-                await cms.entries.listPublishedEntries(model, args);
+                await cms.listPublishedEntries(model, args);
 
             return new ListResponse(...response);
         } catch (e) {

--- a/packages/api-headless-cms/src/content/plugins/schema/schemaPlugins.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/schemaPlugins.ts
@@ -21,7 +21,7 @@ export const generateSchemaPlugins = async (
         }, {});
 
     // Load model data
-    const models = await cms.models.noAuthModel().list();
+    const models = await cms.noAuthModel().list();
 
     const schemas = getSchemaFromFieldPlugins({ models, fieldTypePlugins, type: cms.type });
 

--- a/packages/api-headless-cms/src/plugins/crud/index.ts
+++ b/packages/api-headless-cms/src/plugins/crud/index.ts
@@ -37,25 +37,28 @@ export const createAdminCruds = (params: Params) => {
             context.plugins.register(storageOperations.plugins);
         }
 
-        context.cms.system = createSystemCrud({
-            context,
-            getTenant,
-            getIdentity,
-            storageOperations
-        });
-        context.cms.settings = createSettingsCrud({
-            context,
-            getTenant,
-            getLocale,
-            storageOperations
-        });
-        context.cms.groups = createModelGroupsCrud({
-            context,
-            getTenant,
-            getLocale,
-            getIdentity,
-            storageOperations
-        });
+        context.cms = {
+            ...context.cms,
+            ...createSystemCrud({
+                context,
+                getTenant,
+                getIdentity,
+                storageOperations
+            }),
+            ...createSettingsCrud({
+                context,
+                getTenant,
+                getLocale,
+                storageOperations
+            }),
+            ...createModelGroupsCrud({
+                context,
+                getTenant,
+                getLocale,
+                getIdentity,
+                storageOperations
+            })
+        };
 
         if (!storageOperations.init) {
             return;

--- a/packages/api-headless-cms/src/plugins/crud/system.crud.ts
+++ b/packages/api-headless-cms/src/plugins/crud/system.crud.ts
@@ -119,7 +119,7 @@ export const createSystemCrud = (params: Params): CmsSystemContext => {
              * Add default content model group.
              */
             try {
-                await context.cms.groups.createGroup(initialContentModelGroup);
+                await context.cms.createGroup(initialContentModelGroup);
             } catch (ex) {
                 throw new WebinyError(ex.message, "CMS_INSTALLATION_CONTENT_MODEL_GROUP_ERROR", {
                     group: initialContentModelGroup

--- a/packages/api-headless-cms/src/plugins/graphql/system.ts
+++ b/packages/api-headless-cms/src/plugins/graphql/system.ts
@@ -20,7 +20,7 @@ export default {
         CmsQuery: {
             version: async (_, __, context: CmsContext) => {
                 try {
-                    return context.cms.system.getSystemVersion();
+                    return context.cms.getSystemVersion();
                 } catch (e) {
                     return new ErrorResponse(e);
                 }
@@ -29,7 +29,7 @@ export default {
         CmsMutation: {
             install: async (_, __, { cms }: CmsContext) => {
                 try {
-                    const version = await cms.system.getSystemVersion();
+                    const version = await cms.getSystemVersion();
                     if (version) {
                         return new ErrorResponse({
                             code: "CMS_INSTALLATION_ERROR",
@@ -37,7 +37,7 @@ export default {
                         });
                     }
 
-                    await cms.system.installSystem();
+                    await cms.installSystem();
                     return new Response(true);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -45,7 +45,7 @@ export default {
             },
             upgrade: async (_, { version }, { cms }: CmsContext) => {
                 try {
-                    await cms.system.upgradeSystem(version);
+                    await cms.upgradeSystem(version);
                     return new Response(true);
                 } catch (e) {
                     return new ErrorResponse(e);

--- a/packages/api-headless-cms/src/plugins/upgrades/v5.5.0/index.ts
+++ b/packages/api-headless-cms/src/plugins/upgrades/v5.5.0/index.ts
@@ -45,7 +45,7 @@ const plugin: UpgradePlugin<CmsContext> = {
                 // Migrate CMS permissions
                 const newCMSContentPermissions = await migrateCMSPermissions(
                     CmsContentPermissions,
-                    cms.models.getModel
+                    cms.getModel
                 );
 
                 const newPermissions = [...restPermissions, ...newCMSContentPermissions];
@@ -97,7 +97,7 @@ const plugin: UpgradePlugin<CmsContext> = {
                 // Migrate CMS permissions.
                 const newCMSContentPermissions = await migrateCMSPermissions(
                     CmsContentPermissions,
-                    cms.models.getModel
+                    cms.getModel
                 );
 
                 const newPermissions = [...restPermissions, ...newCMSContentPermissions];

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -882,10 +882,6 @@ export interface AfterGroupDeleteTopicParams {
  */
 export interface CmsContentModelGroupContext {
     /**
-     * Plain operations on the storage level.
-     */
-    operations: CmsContentModelGroupStorageOperations;
-    /**
      * A function defining usage of a method without authenticating the user.
      */
     noAuthGroup: () => {
@@ -1262,10 +1258,6 @@ export interface CmsContentModelUpdateInternalParams {
  */
 export interface CmsContentModelContext {
     /**
-     * Plain operations on the storage level.
-     */
-    operations: CmsContentModelStorageOperations;
-    /**
      * A function defining usage of a method without authenticating the user.
      */
     noAuthModel: () => {
@@ -1321,7 +1313,7 @@ export interface CmsContentModelContext {
      *
      * @see CmsContentModelManager
      */
-    getManager: (modelId: string) => Promise<CmsContentModelManager>;
+    getModelManager: (modelId: string) => Promise<CmsContentModelManager>;
     /**
      * Get all content model managers mapped by modelId.
      * @see CmsContentModelManager
@@ -1575,10 +1567,6 @@ export interface AfterEntryRevisionDeleteTopicParams {
  */
 export interface CmsContentEntryContext {
     /**
-     * Plain operations on the storage level.
-     */
-    operations: CmsContentEntryStorageOperations;
-    /**
      * Get a single content entry for a model.
      */
     getEntry: (
@@ -1701,31 +1689,13 @@ export interface CmsContentEntryContext {
  *
  * @category Context
  */
-interface CmsCrudContextObject {
-    /**
-     * Settings CRUD methods.
-     */
-    settings: CmsSettingsContext;
-    /**
-     * Content model group CRUD methods.
-     */
-    groups: CmsContentModelGroupContext;
-    /**
-     * Content model CRUD methods.
-     */
-    models: CmsContentModelContext;
-    /**
-     * Fetch the content entry manager. It calls content entry methods internally, with given model as the target.
-     */
-    getModelManager: (modelId: string) => Promise<CmsContentModelManager>;
-    /**
-     * Content entry CRUD methods.
-     */
-    entries: CmsContentEntryContext;
-    /**
-     * System CRUD methods
-     */
-    system: CmsSystemContext;
+interface CmsCrudContextObject
+    extends CmsSettingsContext,
+        CmsSystemContext,
+        CmsContentModelGroupContext,
+        CmsContentModelContext,
+        CmsContentEntryContext {
+    storageOperations: HeadlessCmsStorageOperations;
 }
 
 /**


### PR DESCRIPTION
## Changes
Moved all the crud operations (admin and content) to context.cms root object.
I also had to rename some operations, but it should not affect anybody because those are internals.

## How Has This Been Tested?
Jest tests.

