### PR TITLE
fix: add Cache-Control header for OPTIONS request

### DIFF
--- a/packages/api-file-manager/src/handlers/utils/createHandler.ts
+++ b/packages/api-file-manager/src/handlers/utils/createHandler.ts
@@ -6,13 +6,17 @@ const baseHeaders = {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Credentials": true
 };
+const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
 
 export default handler => async event => {
     if (event.httpMethod === "OPTIONS") {
         return {
             body: "",
             statusCode: 204,
-            headers: baseHeaders
+            headers: {
+                ...baseHeaders,
+                "Cache-Control": "public, max-age=" + DEFAULT_CACHE_MAX_AGE
+            }
         };
     }
 

--- a/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
@@ -19,7 +19,8 @@ describe("HTTP Options request", () => {
                     "Access-Control-Allow-Headers": "*",
                     "Access-Control-Allow-Methods": "OPTIONS,POST",
                     "Access-Control-Allow-Origin": "*",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
+                    "Cache-Control": "public, max-age=30758400"
                 },
                 isBase64Encoded: undefined,
                 statusCode: 204

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -35,6 +35,8 @@ const DEFAULT_HEADERS = {
     "Content-Type": "application/json"
 };
 
+const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
+
 const respond = (http, result: unknown) => {
     return http.response({
         body: JSON.stringify(result),
@@ -131,7 +133,10 @@ export const graphQLHandlerFactory = (
                 if (http.request.method === "OPTIONS") {
                     return http.response({
                         statusCode: 204,
-                        headers: DEFAULT_HEADERS
+                        headers: {
+                            ...DEFAULT_HEADERS,
+                            "Cache-Control": "public, max-age=" + DEFAULT_CACHE_MAX_AGE
+                        }
                     });
                 }
 

--- a/packages/handler-graphql/src/createGraphQLHandler.ts
+++ b/packages/handler-graphql/src/createGraphQLHandler.ts
@@ -14,6 +14,8 @@ const DEFAULT_HEADERS = {
     "Access-Control-Allow-Methods": "OPTIONS,POST"
 };
 
+const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
+
 export default (options: HandlerGraphQLOptions = {}): PluginCollection => {
     let schema;
 
@@ -33,7 +35,10 @@ export default (options: HandlerGraphQLOptions = {}): PluginCollection => {
                 if (http.request.method === "OPTIONS") {
                     return http.response({
                         statusCode: 204,
-                        headers: DEFAULT_HEADERS
+                        headers: {
+                            ...DEFAULT_HEADERS,
+                            "Cache-Control": "public, max-age=" + DEFAULT_CACHE_MAX_AGE
+                        }
                     });
                 }
 


### PR DESCRIPTION
This PR introduces a fix to add the `Cache-Control` header for `OPTIONS` requests.

## Changes
Closes #1917 

## How Has This Been Tested?
Manually