### PR TITLE
feat(api-headless-cms): add get and list before events

### DIFF
--- a/packages/api-elasticsearch/src/plugins/definition/ElasticsearchBodyModifierPlugin.ts
+++ b/packages/api-elasticsearch/src/plugins/definition/ElasticsearchBodyModifierPlugin.ts
@@ -6,19 +6,21 @@ export interface ModifyBodyParams {
     body: SearchBody;
 }
 
-interface Callable {
-    (params: ModifyBodyParams): void;
+export interface ModifyBodyCallable<T extends ModifyBodyParams> {
+    (params: T): void;
 }
 
-export abstract class ElasticsearchBodyModifierPlugin extends Plugin {
-    private readonly callable?: Callable;
+export abstract class ElasticsearchBodyModifierPlugin<
+    T extends ModifyBodyParams = ModifyBodyParams
+> extends Plugin {
+    private readonly callable?: ModifyBodyCallable<T>;
 
-    public constructor(callable?: Callable) {
+    public constructor(callable?: ModifyBodyCallable<T>) {
         super();
         this.callable = callable;
     }
 
-    public modifyBody(params: ModifyBodyParams): void {
+    public modifyBody(params: T): void {
         if (typeof this.callable !== "function") {
             throw new WebinyError(
                 `Missing modification for the body.`,

--- a/packages/api-elasticsearch/src/plugins/definition/ElasticsearchQueryModifierPlugin.ts
+++ b/packages/api-elasticsearch/src/plugins/definition/ElasticsearchQueryModifierPlugin.ts
@@ -7,19 +7,21 @@ export interface ModifyQueryParams {
     where: Record<string, any>;
 }
 
-interface Callable {
-    (params: ModifyQueryParams): void;
+export interface ModifyQueryCallable<T extends ModifyQueryParams> {
+    (params: T): void;
 }
 
-export abstract class ElasticsearchQueryModifierPlugin extends Plugin {
-    private readonly callable?: Callable;
+export abstract class ElasticsearchQueryModifierPlugin<
+    T extends ModifyQueryParams = ModifyQueryParams
+> extends Plugin {
+    private readonly callable?: ModifyQueryCallable<T>;
 
-    public constructor(callable?: Callable) {
+    public constructor(callable?: ModifyQueryCallable<T>) {
         super();
         this.callable = callable;
     }
 
-    public modifyQuery(params: ModifyQueryParams): void {
+    public modifyQuery(params: T): void {
         if (typeof this.callable !== "function") {
             throw new WebinyError(
                 `Missing modification for the query.`,

--- a/packages/api-elasticsearch/src/plugins/definition/ElasticsearchSortModifierPlugin.ts
+++ b/packages/api-elasticsearch/src/plugins/definition/ElasticsearchSortModifierPlugin.ts
@@ -6,19 +6,21 @@ export interface ModifySortParams {
     sort: Sort;
 }
 
-interface Callable {
-    (params: ModifySortParams): void;
+export interface ModifySortCallable<T extends ModifySortParams> {
+    (params: T): void;
 }
 
-export abstract class ElasticsearchSortModifierPlugin extends Plugin {
-    private readonly callable?: Callable;
+export abstract class ElasticsearchSortModifierPlugin<
+    T extends ModifySortParams = ModifySortParams
+> extends Plugin {
+    private readonly callable?: ModifySortCallable<T>;
 
-    public constructor(callable?: Callable) {
+    public constructor(callable?: ModifySortCallable<T>) {
         super();
         this.callable = callable;
     }
 
-    public modifySort(params: ModifySortParams): void {
+    public modifySort(params: T): void {
         if (typeof this.callable !== "function") {
             throw new WebinyError(
                 `Missing modification for the sort.`,

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchBodyModifierPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchBodyModifierPlugin.ts
@@ -1,5 +1,30 @@
-import { ElasticsearchBodyModifierPlugin } from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchBodyModifierPlugin";
+import {
+    ElasticsearchBodyModifierPlugin,
+    ModifyBodyCallable,
+    ModifyBodyParams as BaseModifyBodyParams
+} from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchBodyModifierPlugin";
+import { CmsModel } from "@webiny/api-headless-cms/types";
 
-export class CmsEntryElasticsearchBodyModifierPlugin extends ElasticsearchBodyModifierPlugin {
+export interface ModifyBodyParams extends BaseModifyBodyParams {
+    model: CmsModel;
+}
+
+export interface Config {
+    modifyBody: ModifyBodyCallable<ModifyBodyParams>;
+    /**
+     * If modelId is not passed, there is no filtering of plugins by it when plugin is applied during the runtime.
+     */
+    modelId?: string;
+}
+
+export class CmsEntryElasticsearchBodyModifierPlugin extends ElasticsearchBodyModifierPlugin<ModifyBodyParams> {
     public static readonly type: string = "cms.elasticsearch.modifier.body.entry";
+
+    public readonly modelId?: string;
+
+    public constructor(config: Config) {
+        super(config.modifyBody);
+
+        this.modelId = config.modelId;
+    }
 }

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFieldPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFieldPlugin.ts
@@ -1,5 +1,22 @@
-import { ElasticsearchFieldPlugin } from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchFieldPlugin";
+import {
+    ElasticsearchFieldPlugin,
+    Params as BaseParams
+} from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchFieldPlugin";
 
+export interface Params extends BaseParams {
+    /**
+     * If modelId is not passed, there is no filtering of plugins by it when plugin is applied during the runtime.
+     */
+    modelId?: string;
+}
 export class CmsEntryElasticsearchFieldPlugin extends ElasticsearchFieldPlugin {
     public static readonly type: string = "elasticsearch.fieldDefinition.cms.entry";
+
+    public readonly modelId?: string;
+
+    public constructor(params: Params) {
+        super(params);
+
+        this.modelId = params.modelId;
+    }
 }

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryModifierPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryModifierPlugin.ts
@@ -1,5 +1,30 @@
-import { ElasticsearchQueryModifierPlugin } from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchQueryModifierPlugin";
+import {
+    ElasticsearchQueryModifierPlugin,
+    ModifyQueryCallable,
+    ModifyQueryParams as BaseModifyQueryParams
+} from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchQueryModifierPlugin";
+import { CmsModel } from "@webiny/api-headless-cms/types";
 
-export class CmsEntryElasticsearchQueryModifierPlugin extends ElasticsearchQueryModifierPlugin {
+export interface ModifyQueryParams extends BaseModifyQueryParams {
+    model: CmsModel;
+}
+
+export interface Config {
+    modifyQuery: ModifyQueryCallable<ModifyQueryParams>;
+    /**
+     * If modelId is not passed, there is no filtering of plugins by it when plugin is applied during the runtime.
+     */
+    modelId?: string;
+}
+
+export class CmsEntryElasticsearchQueryModifierPlugin extends ElasticsearchQueryModifierPlugin<ModifyQueryParams> {
     public static readonly type: string = "cms.elasticsearch.modifier.query.entry";
+
+    public readonly modelId?: string;
+
+    public constructor(config: Config) {
+        super(config.modifyQuery);
+
+        this.modelId = config.modelId;
+    }
 }

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchSortModifierPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchSortModifierPlugin.ts
@@ -1,5 +1,29 @@
-import { ElasticsearchSortModifierPlugin } from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchSortModifierPlugin";
+import {
+    ElasticsearchSortModifierPlugin,
+    ModifySortCallable,
+    ModifySortParams as BaseModifySortParams
+} from "@webiny/api-elasticsearch/plugins/definition/ElasticsearchSortModifierPlugin";
+import { CmsModel } from "@webiny/api-headless-cms/types";
 
-export class CmsEntryElasticsearchSortModifierPlugin extends ElasticsearchSortModifierPlugin {
+export interface ModifySortParams extends BaseModifySortParams {
+    model: CmsModel;
+}
+
+export interface Config {
+    modifySort: ModifySortCallable<ModifySortParams>;
+    /**
+     * If modelId is not passed, there is no filtering of plugins by it when plugin is applied during the runtime.
+     */
+    modelId?: string;
+}
+
+export class CmsEntryElasticsearchSortModifierPlugin extends ElasticsearchSortModifierPlugin<ModifySortParams> {
     public static readonly type: string = "cms.elasticsearch.modifier.sort.entry";
+
+    public readonly modelId?: string;
+
+    public constructor(config: Config) {
+        super(config.modifySort);
+        this.modelId = config.modelId;
+    }
 }

--- a/packages/api-headless-cms-ddb-es/src/types.ts
+++ b/packages/api-headless-cms-ddb-es/src/types.ts
@@ -3,14 +3,9 @@ import {
     CmsEntry,
     CmsModel,
     CmsModelField,
-    CmsContext,
     CmsModelFieldToGraphQLPlugin,
     HeadlessCmsStorageOperations as BaseHeadlessCmsStorageOperations
 } from "@webiny/api-headless-cms/types";
-import {
-    ElasticsearchBoolQueryConfig,
-    ElasticsearchQueryOperator
-} from "@webiny/api-elasticsearch/types";
 import { DynamoDBTypes, TableConstructor } from "dynamodb-toolbox/dist/classes/Table";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import {
@@ -20,69 +15,6 @@ import {
 import { Client } from "@elastic/elasticsearch";
 import { Entity, Table } from "dynamodb-toolbox";
 import { PluginsContainer } from "@webiny/plugins";
-
-/**
- * Definition for arguments of the ElasticsearchQueryBuilderPlugin.apply method.
- *
- * @see ElasticsearchQueryBuilderPlugin.apply
- *
- * @category Plugin
- * @category Elasticsearch
- */
-export interface ElasticsearchQueryBuilderArgsPlugin {
-    field: string;
-    value: any;
-    context: CmsContext;
-    parentObject?: string;
-    originalField?: string;
-}
-
-/**
- * Arguments for ElasticsearchQueryPlugin.
- *
- * @see ElasticsearchQueryPlugin.modify
- */
-interface ElasticsearchQueryPluginArgs {
-    query: ElasticsearchBoolQueryConfig;
-    model: CmsModel;
-}
-
-/**
- * A plugin definition to modify Elasticsearch query.
- *
- * @category Plugin
- * @category Elasticsearch
- */
-export interface ElasticsearchQueryPlugin extends Plugin {
-    type: "cms-elasticsearch-query";
-    modify: (args: ElasticsearchQueryPluginArgs) => void;
-}
-
-/**
- * A plugin definition to build Elasticsearch query.
- *
- * @category Plugin
- * @category Elasticsearch
- */
-export interface ElasticsearchQueryBuilderPlugin extends Plugin {
-    /**
-     * A plugin type.
-     */
-    type: "cms-elastic-search-query-builder";
-    /**
-     * Name of the plugin. Name it for better debugging experience.
-     */
-    name: string;
-    /**
-     * Target operator.
-     */
-    operator: ElasticsearchQueryOperator;
-    /**
-     * Method used to modify received query object.
-     * Has access to whole query object so it can remove something added by other plugins.
-     */
-    apply: (query: ElasticsearchBoolQueryConfig, args: ElasticsearchQueryBuilderArgsPlugin) => void;
-}
 
 /**
  * Arguments for ElasticsearchQueryBuilderValueSearchPlugin.

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntryHooks.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntryHooks.test.ts
@@ -534,4 +534,117 @@ describe("contentEntryHooks", () => {
         expect(pubSubTracker.isExecutedOnce("contentEntry:beforeRequestReview")).toEqual(true);
         expect(pubSubTracker.isExecutedOnce("contentEntry:afterRequestReview")).toEqual(true);
     });
+
+    test("should execute hooks on get and list", async () => {
+        const { createCategory, getCategory, listCategories, until } = useCategoryManageHandler({
+            ...manageOpts,
+            plugins: [assignEntryEvents()]
+        });
+
+        const [createResponse] = await createCategory({
+            data: {
+                title: "category",
+                slug: "category"
+            }
+        });
+
+        const category = createResponse.data.createCategory.data;
+        const { id } = category;
+
+        await until(
+            () => listCategories(),
+            ([response]) => {
+                return response.data.listCategories.data.length > 0;
+            },
+            {
+                name: "list categories after create"
+            }
+        );
+
+        pubSubTracker.reset();
+
+        const [getResponse] = await getCategory({
+            revision: id
+        });
+
+        expect(getResponse).toEqual({
+            data: {
+                getCategory: {
+                    data: category,
+                    error: null
+                }
+            }
+        });
+
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeCreateRevisionFrom")).toEqual(
+            false
+        );
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterCreateRevisionFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeDeleteRevision")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterDeleteRevision")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeDelete")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterDelete")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforePublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterPublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeUnpublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterUnpublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeRequestChanges")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterRequestChanges")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeRequestReview")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterRequestReview")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeGet")).toEqual(true);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeList")).toEqual(false);
+
+        pubSubTracker.reset();
+        const [listResponse] = await listCategories({
+            where: {
+                id_in: [id]
+            }
+        });
+
+        expect(listResponse).toEqual({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            ...category
+                        }
+                    ],
+                    meta: {
+                        hasMoreItems: false,
+                        totalCount: 1,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeCreateRevisionFrom")).toEqual(
+            false
+        );
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterCreateRevisionFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeDeleteRevision")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterDeleteRevision")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeDelete")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterDelete")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforePublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterPublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeUnpublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterUnpublish")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeRequestChanges")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterRequestChanges")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeRequestReview")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:afterRequestReview")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeGet")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentEntry:beforeList")).toEqual(true);
+    });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
@@ -111,5 +111,11 @@ export const assignEntryEvents = () => {
         context.cms.onAfterEntryRequestChanges.subscribe(async () => {
             pubSubTracker.track("contentEntry:afterRequestChanges");
         });
+        context.cms.onBeforeEntryGet.subscribe(async () => {
+            pubSubTracker.track("contentEntry:beforeGet");
+        });
+        context.cms.onBeforeEntryList.subscribe(async () => {
+            pubSubTracker.track("contentEntry:beforeList");
+        });
     });
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -252,7 +252,14 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
          * Get a single entry by revision ID from the database.
          */
         getEntryById: async (model, id) => {
-            const [entry] = await getEntriesByIds(model, [id]);
+            const where = {
+                id
+            };
+            await onBeforeGet.publish({
+                where,
+                model
+            });
+            const [entry] = await getEntriesByIds(model, [where.id]);
             if (!entry) {
                 throw new NotFoundError(`Entry by ID "${id}" not found.`);
             }

--- a/packages/api-headless-cms/src/content/plugins/modelManager/DefaultCmsModelManager.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelManager/DefaultCmsModelManager.ts
@@ -21,8 +21,8 @@ export class DefaultCmsModelManager implements CmsModelManager {
         return this._context.cms.deleteEntry(this._model, id);
     }
 
-    public async get(args) {
-        return this._context.cms.getEntry(this._model, args);
+    public async get(id: string) {
+        return this._context.cms.getEntryById(this._model, id);
     }
 
     public async list(args) {

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1176,7 +1176,7 @@ export interface CmsModelManager {
     /**
      * Get an entry filtered by given params. Will always get one.
      */
-    get: (params?: CmsEntryGetParams) => Promise<CmsEntry>;
+    get: (id: string) => Promise<CmsEntry>;
     /**
      * Create a entry.
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1517,6 +1517,16 @@ export interface AfterEntryRevisionDeleteTopicParams {
     model: CmsModel;
 }
 
+export interface BeforeEntryGetTopicParams {
+    model: CmsModel;
+    where: CmsEntryListWhere;
+}
+
+export interface BeforeEntryListTopicParams {
+    where: CmsEntryListWhere;
+    model: CmsModel;
+}
+
 /**
  * Cms Entry CRUD methods in the context.
  *
@@ -1630,6 +1640,8 @@ export interface CmsEntryContext {
     onAfterEntryRequestChanges: Topic<AfterEntryRequestChangesTopicParams>;
     onBeforeEntryRequestReview: Topic<BeforeEntryRequestReviewTopicParams>;
     onAfterEntryRequestReview: Topic<AfterEntryRequestReviewTopicParams>;
+    onBeforeEntryGet: Topic<BeforeEntryGetTopicParams>;
+    onBeforeEntryList: Topic<BeforeEntryListTopicParams>;
 }
 
 /**


### PR DESCRIPTION
## Changes
Added events for before get and list entries so users can modify the `where` conditions.

## How Has This Been Tested?
Jest and manually.
