### PR TITLE
fix(pulumi-sdk): fix PULUMI_HOME and PATH variables

### DIFF
--- a/packages/pulumi-sdk/src/index.ts
+++ b/packages/pulumi-sdk/src/index.ts
@@ -92,7 +92,7 @@ export class Pulumi {
             env: {
                 ...(args.execa.env || {}),
                 /**
-                 * Do to an issue with Pulumi https://github.com/pulumi/pulumi/issues/8374, and even though this
+                 * Due to an issue with Pulumi https://github.com/pulumi/pulumi/issues/8374, and even though this
                  * commit suggests it should already work like that https://github.com/pulumi/pulumi/commit/c878916901a997a9c0ffcbed23560e19e224a6f1,
                  * we need to specify the exact location of our Pulumi binaries, using the PATH environment variable, so it can correctly resolve
                  * plugins necessary for custom resources and dynamic providers to work.


### PR DESCRIPTION
## Changes
This PR fixes an issue with PULUMI_HOME path, as well as PATH variable, to help pulumi correctly resolve its plugins.
This is required in order to use custom resources and dynamic providers.

## How Has This Been Tested?
Manually
