### PR TITLE
fix(api-headless-cms): model id checks

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.modelId.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.modelId.test.ts
@@ -1,0 +1,68 @@
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+import { CmsGroup } from "~/types";
+import camelCase from "lodash/camelCase";
+
+describe("ContentModel modelId variations", () => {
+    const manageHandlerOpts = { path: "manage/en-US" };
+
+    const { createContentModelGroupMutation } = useContentGqlHandler(manageHandlerOpts);
+
+    let contentModelGroup: CmsGroup;
+
+    beforeEach(async () => {
+        const [createCMG] = await createContentModelGroupMutation({
+            data: {
+                name: "Group",
+                slug: "group",
+                icon: "ico/ico",
+                description: "description"
+            }
+        });
+        contentModelGroup = createCMG.data.createContentModelGroup.data;
+    });
+
+    const disallowedModelIdEndings = [
+        ["Tab list", "tabList"],
+        ["Tab list", undefined],
+        ["Tab response", "tabResponse"],
+        ["Tab response", undefined],
+        ["Tab meta", "tabMeta"],
+        ["Tab meta", undefined],
+        ["Tab input", "tabInput"],
+        ["Tab input", undefined],
+        ["Tab sorter", "tabSorter"],
+        ["Tab sorter", undefined]
+    ];
+
+    test.each(disallowedModelIdEndings)(
+        "should not allow to create model with modelId that clashes with GraphQL (%s, %s)",
+        async (name: string, modelId?: string) => {
+            const { createContentModelMutation } = useContentGqlHandler(manageHandlerOpts);
+
+            const [response] = await createContentModelMutation({
+                data: {
+                    name,
+                    modelId,
+                    group: contentModelGroup.id
+                }
+            });
+
+            expect(response).toEqual({
+                data: {
+                    createContentModel: {
+                        data: null,
+                        error: {
+                            code: "MODEL_ID_NOT_ALLOWED",
+                            data: {
+                                modelId: modelId || camelCase(name)
+                            },
+                            message: expect.stringMatching(
+                                /ModelId that ends with "([a-zA-Z]+)" is not allowed./
+                            )
+                        }
+                    }
+                }
+            });
+        }
+    );
+});

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
@@ -1,20 +1,30 @@
+import WebinyError from "@webiny/error";
+import camelCase from "lodash/camelCase";
+import pluralize from "pluralize";
 import { BeforeModelCreateTopicParams, CmsModel, HeadlessCmsStorageOperations } from "~/types";
 import { Topic } from "@webiny/pubsub/types";
 import { PluginsContainer } from "@webiny/plugins";
 import { CmsModelPlugin } from "~/content/plugins/CmsModelPlugin";
-import WebinyError from "@webiny/error";
-import camelCase from "lodash/camelCase";
-import pluralize from "pluralize";
 
-const MAX_MODEL_ID_SEARCH_AMOUNT = 50;
+const disallowedModelIdList: string[] = [
+    "contentModel",
+    "contentModels",
+    "contentModelGroup",
+    "contentModelGroups"
+];
+/**
+ * This list is to disallow creating models that might interfere with GraphQL schema creation.
+ * Add more if required.
+ */
+const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Input", "Sorter"];
 
 /**
  * Checks for the uniqueness of provided modelId, against the provided list of models.
  * It also takes plural / singular forms of the provided modelId into account.
  */
-const checkModelIdUniqueness = (models: string[], modelId: string) => {
-    if (models.includes(modelId) === true) {
-        throw Error(`Content model with modelId "${modelId}" already exists.`);
+const checkModelIdUniqueness = (modelIdList: string[], modelId: string) => {
+    if (modelIdList.includes(modelId) === true) {
+        throw new WebinyError(`Content model with modelId "${modelId}" already exists.`);
     }
     /**
      * Additionally, check if the plural form of the received modelId exists too. This prevents users
@@ -22,8 +32,8 @@ const checkModelIdUniqueness = (models: string[], modelId: string) => {
      * 1. First check if user wants to create the "event" model, but the "events" model already exists.
      */
     const pluralizedModelIdCamelCase = pluralize(modelId);
-    if (models.includes(pluralizedModelIdCamelCase) === true) {
-        throw Error(
+    if (modelIdList.includes(pluralizedModelIdCamelCase) === true) {
+        throw new WebinyError(
             `Content model with modelId "${modelId}" does not exist, but a model with modelId "${pluralizedModelIdCamelCase}" does.`
         );
     }
@@ -32,67 +42,51 @@ const checkModelIdUniqueness = (models: string[], modelId: string) => {
      * 2. Then check if user wants to create the "events" model, but the "event" model already exists.
      */
     const singularizedModelIdCamelCase = pluralize.singular(modelId);
-    if (models.includes(singularizedModelIdCamelCase) === true) {
-        throw Error(
+    if (modelIdList.includes(singularizedModelIdCamelCase) === true) {
+        throw new WebinyError(
             `Content model with modelId "${modelId}" does not exist, but a model with modelId "${singularizedModelIdCamelCase}" does.`
         );
     }
 };
 
-/**
- * Also used to check uniqueness of the provided modelId, although this one just returns a simple boolean value.
- */
-const isUniqueModelId = (models: string[], modelId: string) => {
-    try {
-        checkModelIdUniqueness(models, modelId);
-        return true;
-    } catch {
-        /**
-         * If an error has been thrown - we return false.
-         */
-        return false;
+const checkModelIdAllowed = (modelId: string): void => {
+    if (disallowedModelIdList.includes(modelId) === false) {
+        return;
     }
+    throw new WebinyError(`Provided model ID "${modelId}" is not allowed.`);
 };
 
-const DISALLOWED_MODEL_IDS = [
-    "contentModel",
-    "contentModels",
-    "contentModelGroup",
-    "contentModelGroups"
-];
-
-const checkModelIdAllowed = (modelId: string) => {
-    if (DISALLOWED_MODEL_IDS.includes(modelId)) {
-        throw new Error(`Provided model ID "${modelId}" is not allowed.`);
-    }
-};
-
-const isAllowedModelId = (modelId: string) => {
-    return !DISALLOWED_MODEL_IDS.includes(modelId);
-};
-
-const createNewModelId = (existingModels: string[], model: CmsModel): string => {
-    const modelIdCamelCase = camelCase(model.name);
-    let counter = 0;
-    while (true) {
-        if (counter > MAX_MODEL_ID_SEARCH_AMOUNT) {
-            throw new Error(
-                `While loop reached #${MAX_MODEL_ID_SEARCH_AMOUNT} when checking for unique "modelId".`
-            );
+const checkModelIdEndingAllowed = (modelId: string): void => {
+    for (const ending of disallowedModelIdEndingList) {
+        const re = new RegExp(`${ending}$`, "i");
+        const matched = modelId.match(re);
+        if (matched === null) {
+            continue;
         }
-
-        /**
-         * Let's try generating a new modelId and immediately check for its uniqueness.
-         */
-        const generatedModelId = `${modelIdCamelCase}${counter || ""}`;
-        if (
-            isAllowedModelId(generatedModelId) &&
-            isUniqueModelId(existingModels, generatedModelId)
-        ) {
-            return generatedModelId;
-        }
-        counter++;
+        throw new WebinyError(
+            `ModelId that ends with "${ending}" is not allowed.`,
+            "MODEL_ID_NOT_ALLOWED",
+            {
+                modelId
+            }
+        );
     }
+};
+
+const getModelId = (model: CmsModel): string => {
+    const { modelId, name } = model;
+    if (modelId) {
+        return camelCase(modelId.trim());
+    } else if (name) {
+        return camelCase(name.trim());
+    }
+    throw new WebinyError(
+        `There is no "modelId" or "name" passed into the create model method.`,
+        "MISSING_MODEL_DATA",
+        {
+            model
+        }
+    );
 };
 
 export interface Params {
@@ -100,15 +94,18 @@ export interface Params {
     storageOperations: HeadlessCmsStorageOperations;
     plugins: PluginsContainer;
 }
+
 export const assignBeforeModelCreate = (params: Params) => {
     const { onBeforeCreate, storageOperations, plugins } = params;
 
     onBeforeCreate.subscribe(async params => {
         const { model } = params;
 
+        const modelId = getModelId(model);
+
         const modelPlugin: CmsModelPlugin = plugins
             .byType<CmsModelPlugin>(CmsModelPlugin.type)
-            .find((item: CmsModelPlugin) => item.contentModel.modelId === model.modelId);
+            .find((item: CmsModelPlugin) => item.contentModel.modelId === modelId);
 
         if (modelPlugin) {
             throw new WebinyError(
@@ -128,21 +125,15 @@ export const assignBeforeModelCreate = (params: Params) => {
         });
         const modelIdList = models.map(m => m.modelId);
 
-        const currentId = (model.modelId || "").trim();
-
         /**
-         * If there is a modelId assigned, check if it's unique ...
+         * We need to check for:
+         *  - is that exact modelId allowed
+         *  - is modelId unique
+         *  - is model ending allowed
          */
-        if (currentId) {
-            const modelIdCamelCase = camelCase(currentId);
-            checkModelIdAllowed(modelIdCamelCase);
-            checkModelIdUniqueness(modelIdList, modelIdCamelCase);
-            model.modelId = modelIdCamelCase;
-            return;
-        }
-        /**
-         * ... otherwise, assign a unique modelId automatically.
-         */
-        model.modelId = createNewModelId(modelIdList, model);
+        checkModelIdAllowed(modelId);
+        checkModelIdEndingAllowed(modelId);
+        checkModelIdUniqueness(modelIdList, modelId);
+        model.modelId = modelId;
     });
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
@@ -24,7 +24,13 @@ const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Inpu
  */
 const checkModelIdUniqueness = (modelIdList: string[], modelId: string) => {
     if (modelIdList.includes(modelId) === true) {
-        throw new WebinyError(`Content model with modelId "${modelId}" already exists.`);
+        throw new WebinyError(
+            `Content model with modelId "${modelId}" already exists.`,
+            "MODEL_ID_EXISTS",
+            {
+                modelId
+            }
+        );
     }
     /**
      * Additionally, check if the plural form of the received modelId exists too. This prevents users
@@ -34,7 +40,12 @@ const checkModelIdUniqueness = (modelIdList: string[], modelId: string) => {
     const pluralizedModelIdCamelCase = pluralize(modelId);
     if (modelIdList.includes(pluralizedModelIdCamelCase) === true) {
         throw new WebinyError(
-            `Content model with modelId "${modelId}" does not exist, but a model with modelId "${pluralizedModelIdCamelCase}" does.`
+            `Content model with modelId "${modelId}" does not exist, but a model with modelId "${pluralizedModelIdCamelCase}" does.`,
+            "MODEL_ID_PLURAL_ERROR",
+            {
+                modelId,
+                plural: pluralizedModelIdCamelCase
+            }
         );
     }
 
@@ -44,7 +55,12 @@ const checkModelIdUniqueness = (modelIdList: string[], modelId: string) => {
     const singularizedModelIdCamelCase = pluralize.singular(modelId);
     if (modelIdList.includes(singularizedModelIdCamelCase) === true) {
         throw new WebinyError(
-            `Content model with modelId "${modelId}" does not exist, but a model with modelId "${singularizedModelIdCamelCase}" does.`
+            `Content model with modelId "${modelId}" does not exist, but a model with modelId "${singularizedModelIdCamelCase}" does.`,
+            "MODEL_ID_SINGULAR_ERROR",
+            {
+                modelId,
+                singular: singularizedModelIdCamelCase
+            }
         );
     }
 };

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -34,6 +34,12 @@ export type NewContentModelDialogProps = {
     onClose: UID.DialogOnClose;
 };
 
+/**
+ * This list is to disallow creating models that might interfere with GraphQL schema creation.
+ * Add more if required.
+ */
+const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Input", "Sorter"];
+
 const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onClose }) => {
     const [loading, setLoading] = React.useState(false);
     const { showSnackbar } = useSnackbar();
@@ -63,11 +69,20 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
     });
 
     const nameValidator = useCallback(name => {
+        name = name.trim();
         if (!name.charAt(0).match(/[a-zA-Z]/)) {
             throw new Error("Value is not valid - must not start with a number.");
         }
-        if (name.trim().toLowerCase() === "id") {
+        if (name.toLowerCase() === "id") {
             throw new Error('Value is not valid - "id" is an auto-generated field.');
+        }
+        for (const ending of disallowedModelIdEndingList) {
+            const re = new RegExp(`${ending}$`, "i");
+            const matched = name.match(re);
+            if (matched === null) {
+                continue;
+            }
+            throw new Error(`Model name that ends with "${ending}" is not allowed.`);
         }
         return true;
     }, undefined);

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -68,17 +68,17 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
         return { value: item.id, label: item.name };
     });
 
-    const nameValidator = useCallback(name => {
-        name = name.trim();
-        if (!name.charAt(0).match(/[a-zA-Z]/)) {
+    const nameValidator = useCallback((name: string) => {
+        const target = (name || "").trim();
+        if (!target.charAt(0).match(/[a-zA-Z]/)) {
             throw new Error("Value is not valid - must not start with a number.");
         }
-        if (name.toLowerCase() === "id") {
+        if (target.toLowerCase() === "id") {
             throw new Error('Value is not valid - "id" is an auto-generated field.');
         }
         for (const ending of disallowedModelIdEndingList) {
             const re = new RegExp(`${ending}$`, "i");
-            const matched = name.match(re);
+            const matched = target.match(re);
             if (matched === null) {
                 continue;
             }


### PR DESCRIPTION
## Changes
Disallow some words in the end of the content model naming / id because it breaks the GraphQL schema.

## How Has This Been Tested?
Jest and manually.