### PR TITLE
fix(api-headless-cms): publish flow

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -696,39 +696,30 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
                 ids: [publishedStorageEntry.id]
             });
 
-            previouslyPublishedEntry.status = CONTENT_ENTRY_STATUS.UNPUBLISHED;
-
             items.push(
                 /**
                  * Update currently published entry (unpublish it)
                  */
                 entity.putBatch({
                     ...previouslyPublishedEntry,
+                    status: CONTENT_ENTRY_STATUS.UNPUBLISHED,
                     savedOn: entry.savedOn,
                     TYPE: createType(),
                     PK: createPartitionKey(publishedStorageEntry),
                     SK: createRevisionSortKey(publishedStorageEntry)
-                }),
-                /**
-                 * Update the helper item in DB with the new published entry ID
-                 */
-                entity.putBatch({
-                    ...storageEntry,
-                    TYPE: createType(),
-                    PK: createPartitionKey(storageEntry),
-                    SK: createPublishedSortKey()
-                })
-            );
-        } else {
-            items.push(
-                entity.putBatch({
-                    ...storageEntry,
-                    PK: createPartitionKey(storageEntry),
-                    SK: createPublishedSortKey(),
-                    TYPE: createPublishedType()
                 })
             );
         }
+        /**
+         * Update the helper item in DB with the new published entry
+         */
+        items.push(
+            entity.putBatch({
+                ...storageEntry,
+                ...publishedKeys,
+                TYPE: createPublishedType()
+            })
+        );
 
         /**
          * We need the latest entry to check if it neds to be updated as well in the Elasticsearch.
@@ -779,8 +770,7 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
 
         esItems.push(
             esEntity.putBatch({
-                PK: createPartitionKey(entry),
-                SK: createPublishedSortKey(),
+                ...publishedKeys,
                 index,
                 data: esLatestData
             })

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -1209,7 +1209,8 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
         model: CmsModel,
         params: CmsEntryStorageOperationsGetPreviousRevisionParams
     ) => {
-        const { tenant, locale, entryId, version } = params;
+        const { tenant, locale } = model;
+        const { entryId, version } = params;
         const queryParams: QueryOneParams = {
             entity,
             partitionKey: createPartitionKey({

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -462,7 +462,8 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
         model: CmsModel,
         params: CmsEntryStorageOperationsGetPreviousRevisionParams
     ) => {
-        const { tenant, locale, entryId, version } = params;
+        const { tenant, locale } = model;
+        const { entryId, version } = params;
         const queryParams: QueryOneParams = {
             entity,
             partitionKey: createPartitionKey({

--- a/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
@@ -302,12 +302,20 @@ describe("latest entries", function () {
                                 {
                                     id: `${updatedFruitCategory.id}`,
                                     title: updatedFruitCategory.title,
-                                    slug: updatedFruitCategory.slug
+                                    slug: updatedFruitCategory.slug,
+                                    meta: {
+                                        status: "published",
+                                        version: 2
+                                    }
                                 },
                                 {
                                     id: fruitCategory.id,
                                     title: fruitCategory.title,
-                                    slug: fruitCategory.slug
+                                    slug: fruitCategory.slug,
+                                    meta: {
+                                        status: "unpublished",
+                                        version: 1
+                                    }
                                 }
                             ]
                         },

--- a/packages/api-headless-cms/__tests__/contentAPI/requestReview.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/requestReview.test.ts
@@ -64,6 +64,7 @@ describe("Request review", () => {
             console.error(`[beforeEach] ${update.errors[0].message}`);
             process.exit(1);
         }
+        return update.data.updateContentModel.data;
     };
 
     test("request review, get and edit", async () => {
@@ -74,6 +75,7 @@ describe("Request review", () => {
             requestCategoryReview,
             updateCategory,
             listCategories
+            // storageOperations
         } = useCategoryManageHandler(manageOpts);
 
         const [createResponse] = await createCategory({
@@ -109,9 +111,31 @@ describe("Request review", () => {
             { name: "create category" }
         );
 
+        // const cmsModel: CmsModel = {
+        //     ...(model as any),
+        //     tenant: "root",
+        //     locale: "en-US"
+        // };
+
         const [requestReviewResponse] = await requestCategoryReview({
             revision: fruits.id
         });
+
+        // const getSoResult = await storageOperations.entries.get(cmsModel, {
+        //     where: {
+        //         id: fruits.id
+        //     }
+        // });
+        //
+        // expect()
+        //
+        // const soResult = await storageOperations.entries.getRevisions(cmsModel, {
+        //     id: fruits.id
+        // });
+        //
+        // const x = soResult;
+        // const y = getSoResult;
+        // console.log(x, y);
 
         expect(requestReviewResponse).toEqual({
             data: {
@@ -120,6 +144,15 @@ describe("Request review", () => {
                         ...fruits,
                         meta: {
                             ...fruits.meta,
+                            revisions: fruits.meta.revisions.map(revision => {
+                                return {
+                                    ...revision,
+                                    meta: {
+                                        ...revision.meta,
+                                        status: "reviewRequested"
+                                    }
+                                };
+                            }),
                             status: "reviewRequested"
                         }
                     },
@@ -151,6 +184,16 @@ describe("Request review", () => {
                         ...fruits,
                         meta: {
                             ...fruits.meta,
+                            revisions: fruits.meta.revisions.map(revision => {
+                                return {
+                                    ...revision,
+                                    meta: {
+                                        ...revision.meta,
+                                        status: "reviewRequested",
+                                        version: 1
+                                    }
+                                };
+                            }),
                             status: "reviewRequested"
                         }
                     },
@@ -179,7 +222,11 @@ describe("Request review", () => {
                             revisions: [
                                 {
                                     ...fruits.meta.revisions[0],
-                                    title: "Fruits updated"
+                                    title: "Fruits updated",
+                                    meta: {
+                                        status: "reviewRequested",
+                                        version: 1
+                                    }
                                 }
                             ],
                             title: "Fruits updated",

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.apiKey.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.apiKey.manage.test.ts
@@ -155,7 +155,11 @@ describe("MANAGE - resolvers - api key", () => {
                                 {
                                     id: expect.any(String),
                                     slug: "vegetables",
-                                    title: "Vegetables"
+                                    title: "Vegetables",
+                                    meta: {
+                                        status: "draft",
+                                        version: 1
+                                    }
                                 }
                             ],
                             status: "draft",
@@ -207,7 +211,11 @@ describe("MANAGE - resolvers - api key", () => {
                                 {
                                     id: category.id,
                                     slug: "vegetables",
-                                    title: "Vegetables"
+                                    title: "Vegetables",
+                                    meta: {
+                                        status: "draft",
+                                        version: 1
+                                    }
                                 }
                             ],
                             status: "draft",
@@ -254,7 +262,11 @@ describe("MANAGE - resolvers - api key", () => {
                                 {
                                     id: expect.any(String),
                                     slug: "green-vegetables",
-                                    title: "Green vegetables"
+                                    title: "Green vegetables",
+                                    meta: {
+                                        status: "draft",
+                                        version: 1
+                                    }
                                 }
                             ],
                             status: "draft",
@@ -300,7 +312,11 @@ describe("MANAGE - resolvers - api key", () => {
                                     {
                                         id: updatedCategory.id,
                                         slug: updatedCategory.slug,
-                                        title: updatedCategory.title
+                                        title: updatedCategory.title,
+                                        meta: {
+                                            status: "draft",
+                                            version: 1
+                                        }
                                     }
                                 ],
                                 status: "draft",

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -1,5 +1,5 @@
 import Error from "@webiny/error";
-import { CmsEntry, CmsGroup } from "~/types";
+import { CmsEntry, CmsGroup, CmsModel } from "~/types";
 import { useContentGqlHandler } from "../utils/useContentGqlHandler";
 import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
 import { useCategoryReadHandler } from "../utils/useCategoryReadHandler";
@@ -58,7 +58,7 @@ describe("MANAGE - Resolvers", () => {
 
     // This function is not directly within `beforeEach` as we don't always setup the same content model.
     // We call this function manually at the beginning of each test, where needed.
-    const setupContentModel = async (model = null) => {
+    const setupModel = async (model: CmsModel = null) => {
         if (!model) {
             model = models.find(m => m.modelId === "category");
         }
@@ -107,7 +107,7 @@ describe("MANAGE - Resolvers", () => {
     };
 
     const createCategories = async (): Promise<CreateCategoriesResult> => {
-        await setupContentModel();
+        await setupModel();
         // Use "manage" API to create and publish entries
         const { createCategory, listCategories } = useCategoryManageHandler(manageOpts);
 
@@ -139,7 +139,7 @@ describe("MANAGE - Resolvers", () => {
     };
 
     test(`get category`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { createCategory, getCategory, listCategories } =
             useCategoryManageHandler(manageOpts);
 
@@ -186,7 +186,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`error when getting category without specific groups and models permissions`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { createCategory, listCategories } = useCategoryManageHandler(manageOpts);
 
         const [create] = await createCategory({ data: { title: "Hardware", slug: "hardware" } });
@@ -220,7 +220,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`get category with specific groups and models permissions`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { createCategory, listCategories } = useCategoryManageHandler(manageOpts);
 
         const [create] = await createCategory({ data: { title: "Hardware", slug: "hardware" } });
@@ -275,7 +275,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`list categories (no parameters)`, async () => {
-        await setupContentModel();
+        await setupModel();
         // Use "manage" API to create and publish entries
         const { until, createCategory, publishCategory, listCategories } =
             useCategoryManageHandler(manageOpts);
@@ -347,7 +347,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test("get entries by given ids", async () => {
-        await setupContentModel();
+        await setupModel();
         // Use "manage" API to create and publish entries
         const { createCategory, getCategoriesByIds } = useCategoryManageHandler(manageOpts);
 
@@ -394,7 +394,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`should create category`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { until, createCategory, listCategories } = useCategoryManageHandler(manageOpts);
         const [create1] = await createCategory({ data: { title: "Hardware", slug: "hardware" } });
 
@@ -436,7 +436,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`should return validation error`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { createCategory } = useCategoryManageHandler(manageOpts);
 
         const [response] = await createCategory({ data: { title: "Hardware" } });
@@ -462,7 +462,7 @@ describe("MANAGE - Resolvers", () => {
 
     test(`should create an entry (fields without validation)`, async () => {
         const model = modelsWithoutValidation.find(m => m.modelId === "category");
-        await setupContentModel(model);
+        await setupModel(model);
 
         const { until, createCategory, listCategories } = useCategoryManageHandler(manageOpts);
         const [result] = await createCategory({ data: { title: "Hardware", slug: "hardware" } });
@@ -505,7 +505,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`create category revision`, async () => {
-        await setupContentModel();
+        await setupModel();
 
         const { until, createCategory, createCategoryFrom, listCategories } =
             useCategoryManageHandler(manageOpts);
@@ -592,7 +592,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`update category`, async () => {
-        await setupContentModel();
+        await setupModel();
         const { until, createCategory, updateCategory, listCategories } =
             useCategoryManageHandler(manageOpts);
         const [create] = await createCategory({ data: { title: "Hardware", slug: "hardware" } });
@@ -655,7 +655,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`delete category`, async () => {
-        await setupContentModel();
+        await setupModel();
         const {
             until,
             createCategory,
@@ -767,7 +767,7 @@ describe("MANAGE - Resolvers", () => {
     });
 
     test(`publish and unpublish a category`, async () => {
-        await setupContentModel();
+        await setupModel();
         const {
             until,
             createCategory,
@@ -1011,7 +1011,7 @@ describe("MANAGE - Resolvers", () => {
 
     test("should store and retrieve nested objects", async () => {
         const model = models.find(model => model.modelId === "product");
-        await setupContentModel(model);
+        await setupModel(model);
 
         const { vegetables } = await createCategories();
 
@@ -1101,6 +1101,117 @@ describe("MANAGE - Resolvers", () => {
                         }
                     }
                 ]
+            }
+        });
+    });
+
+    it("should have all entry revisions published", async () => {
+        const { getCategory, createCategory, publishCategory, createCategoryFrom, listCategories } =
+            useCategoryManageHandler(manageOpts);
+
+        // const { getCategory: getReadCategory } = useCategoryReadHandler(readOpts);
+
+        await setupModel();
+
+        const title = "Webiny Serverless Framework";
+        const slug = "webiny-serverless-framework";
+        const [createWebinyResponse] = await createCategory({
+            data: {
+                title,
+                slug
+            }
+        });
+
+        expect(createWebinyResponse).toMatchObject({
+            data: {
+                createCategory: {
+                    data: {
+                        id: expect.any(String),
+                        title,
+                        slug,
+                        meta: {
+                            status: "draft",
+                            version: 1
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const webiny = createWebinyResponse.data.createCategory.data;
+        await publishCategory({
+            revision: webiny.id
+        });
+        for (let i = 0; i < 5; i++) {
+            const [response] = await createCategoryFrom({
+                revision: webiny.id
+            });
+
+            await publishCategory({
+                revision: response.data.createCategoryFrom.data.id
+            });
+        }
+
+        await until(
+            () => listCategories().then(([data]) => data),
+            ({ data }) => {
+                if (data.listCategories.data.length !== 1) {
+                    return false;
+                }
+                const [last] = data.listCategories.data;
+                if (!last || last.meta.version !== 6) {
+                    return false;
+                }
+
+                return true;
+            },
+            { name: "list categories after creating revisions" }
+        );
+
+        const [listResponse] = await listCategories();
+
+        expect(listResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            entryId: webiny.entryId,
+                            meta: {
+                                version: 6,
+                                status: "published"
+                            }
+                        }
+                    ],
+                    meta: {
+                        hasMoreItems: false,
+                        cursor: null,
+                        totalCount: 1
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const id = `${webiny.entryId}#0006`;
+
+        const [getResponse] = await getCategory({
+            revision: id
+        });
+
+        expect(getResponse).toEqual({
+            data: {
+                getCategory: {
+                    data: {
+                        id,
+                        title,
+                        slug,
+                        entryId: webiny.entryId,
+                        createdOn: expect.stringMatching(/^20/),
+                        savedOn: expect.stringMatching(/^20/)
+                    },
+                    error: null
+                }
             }
         });
     });

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -132,7 +132,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data.length === Object.keys(values).length,
-            { name: "list all categories after creation in setupCategories" }
+            {
+                name: "list all categories after creation in setupCategories"
+            }
         );
 
         return categories;
@@ -150,7 +152,10 @@ describe("MANAGE - Resolvers", () => {
         // Need to wait until the new entry is propagated
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === id
+            ({ data }) => data.listCategories.data[0].id === id,
+            {
+                name: "list categories after create"
+            }
         );
 
         const [response] = await getCategory({ revision: id });
@@ -177,6 +182,10 @@ describe("MANAGE - Resolvers", () => {
                 revisions: [
                     {
                         id: expect.any(String),
+                        meta: {
+                            status: "draft",
+                            version: 1
+                        },
                         title: "Hardware",
                         slug: "hardware"
                     }
@@ -196,7 +205,10 @@ describe("MANAGE - Resolvers", () => {
         // Need to wait until the new entry is propagated to Elastic Search index
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === id
+            ({ data }) => data.listCategories.data[0].id === id,
+            {
+                name: "list categories after create"
+            }
         );
 
         const { getCategory } = useCategoryManageHandler({
@@ -230,7 +242,10 @@ describe("MANAGE - Resolvers", () => {
         // Need to wait until the new entry is propagated to Elastic Search index
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === id
+            ({ data }) => data.listCategories.data[0].id === id,
+            {
+                name: "list categories after create"
+            }
         );
 
         const { getCategory } = useCategoryManageHandler({
@@ -265,6 +280,10 @@ describe("MANAGE - Resolvers", () => {
                 revisions: [
                     {
                         id: expect.any(String),
+                        meta: {
+                            status: "draft",
+                            version: 1
+                        },
                         title: "Hardware",
                         slug: "hardware"
                     }
@@ -297,7 +316,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data[0].meta.status === "published",
-            { name: "wait for entry to be published" }
+            {
+                name: "wait for entry to be published"
+            }
         );
 
         const [response] = await listCategories();
@@ -326,7 +347,11 @@ describe("MANAGE - Resolvers", () => {
                                     {
                                         id: expect.any(String),
                                         slug: "slug-1",
-                                        title: "Title 1"
+                                        title: "Title 1",
+                                        meta: {
+                                            version: 1,
+                                            status: "published"
+                                        }
                                     }
                                 ],
                                 status: "published",
@@ -423,7 +448,11 @@ describe("MANAGE - Resolvers", () => {
                     {
                         id: expect.any(String),
                         title: "Hardware",
-                        slug: "hardware"
+                        slug: "hardware",
+                        meta: {
+                            version: 1,
+                            status: "draft"
+                        }
                     }
                 ]
             }
@@ -431,7 +460,10 @@ describe("MANAGE - Resolvers", () => {
 
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === category1.id
+            ({ data }) => data.listCategories.data[0].id === category1.id,
+            {
+                name: "list categories after create"
+            }
         );
     });
 
@@ -492,7 +524,11 @@ describe("MANAGE - Resolvers", () => {
                     {
                         id: expect.any(String),
                         title: "Hardware",
-                        slug: "hardware"
+                        slug: "hardware",
+                        meta: {
+                            status: "draft",
+                            version: 1
+                        }
                     }
                 ]
             }
@@ -500,7 +536,10 @@ describe("MANAGE - Resolvers", () => {
 
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === category.id
+            ({ data }) => data.listCategories.data[0].id === category.id,
+            {
+                name: "list categories after create"
+            }
         );
     });
 
@@ -516,7 +555,10 @@ describe("MANAGE - Resolvers", () => {
         // Wait until the new category is propagated to ES index (listCategories works with ES directly in MANAGE API)
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === id
+            ({ data }) => data.listCategories.data[0].id === id,
+            {
+                name: "list categories after create"
+            }
         );
 
         const [revision] = await createCategoryFrom({ revision: id });
@@ -545,12 +587,20 @@ describe("MANAGE - Resolvers", () => {
                                 {
                                     id: expect.any(String),
                                     slug: "hardware",
-                                    title: "Hardware"
+                                    title: "Hardware",
+                                    meta: {
+                                        status: "draft",
+                                        version: 2
+                                    }
                                 },
                                 {
                                     id: expect.any(String),
                                     slug: "hardware",
-                                    title: "Hardware"
+                                    title: "Hardware",
+                                    meta: {
+                                        status: "draft",
+                                        version: 1
+                                    }
                                 }
                             ],
                             status: "draft",
@@ -573,7 +623,9 @@ describe("MANAGE - Resolvers", () => {
                 }
                 return entry.id === newEntry.id && entry.savedOn === newEntry.savedOn;
             },
-            { name: "list after create revision" }
+            {
+                name: "list after create revision"
+            }
         );
 
         expect(response).toEqual({
@@ -627,7 +679,11 @@ describe("MANAGE - Resolvers", () => {
                                 {
                                     id: expect.any(String),
                                     title: "New title",
-                                    slug: "hardware-store"
+                                    slug: "hardware-store",
+                                    meta: {
+                                        status: "draft",
+                                        version: 1
+                                    }
                                 }
                             ],
                             title: "New title",
@@ -650,7 +706,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listCategories({}).then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === updatedCategory.id,
-            { name: "create category" }
+            {
+                name: "create category"
+            }
         );
     });
 
@@ -673,7 +731,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data.length > 0,
-            { name: "create first revision" }
+            {
+                name: "create first revision"
+            }
         );
 
         // Create 2 more revisions
@@ -717,7 +777,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === id3,
-            { name: "after create 2 more revisions" }
+            {
+                name: "after create 2 more revisions"
+            }
         );
 
         // Delete latest revision
@@ -735,8 +797,12 @@ describe("MANAGE - Resolvers", () => {
         // Wait until the previous revision is indexed
         await until(
             () => listCategories().then(([data]) => data),
-            ({ data }) => data.listCategories.data[0].id === id2,
-            { name: "delete latest revision" }
+            ({ data }) => {
+                return data.listCategories.data[0].id === id2;
+            },
+            {
+                name: "after delete latest revision"
+            }
         );
 
         // Make sure revision #2 is now "latest"
@@ -786,7 +852,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listLatestCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data.length > 0,
-            { name: "create first revision" }
+            {
+                name: "create first revision"
+            }
         );
 
         // Create 2 more revisions
@@ -818,7 +886,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listLatestCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === id3,
-            { name: "create 2 more revisions" }
+            {
+                name: "create 2 more revisions"
+            }
         );
 
         // Publish latest revision
@@ -837,7 +907,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listPublishedCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === id3,
-            { name: "publish latest revision" }
+            {
+                name: "publish latest revision"
+            }
         );
 
         const [unpublish] = await unpublishCategory({ revision: id3 });
@@ -857,7 +929,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listPublishedCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data.length === 0,
-            { name: "unpublish revision" }
+            {
+                name: "unpublish revision"
+            }
         );
 
         // Publish the latest revision again
@@ -876,7 +950,9 @@ describe("MANAGE - Resolvers", () => {
         await until(
             () => listPublishedCategories().then(([data]) => data),
             ({ data }) => data.listCategories.data[0].id === id3,
-            { name: "publish latest revision again" }
+            {
+                name: "publish latest revision again"
+            }
         );
     });
 
@@ -1109,7 +1185,7 @@ describe("MANAGE - Resolvers", () => {
         const { getCategory, createCategory, publishCategory, createCategoryFrom, listCategories } =
             useCategoryManageHandler(manageOpts);
 
-        // const { getCategory: getReadCategory } = useCategoryReadHandler(readOpts);
+        const { getCategory: getReadCategory } = useCategoryReadHandler(readOpts);
 
         await setupModel();
 
@@ -1143,18 +1219,25 @@ describe("MANAGE - Resolvers", () => {
             revision: createWebinyResponse.data.createCategory.data.id
         });
         const webiny = publishWebinyResponse.data.publishCategory.data;
-
-        const revisions = [webiny];
+        /**
+         * Only publish categories with these versions.
+         * Rest should be draft.
+         * This is to test if unpublished updated works correctly.
+         */
+        const publishCategoriesList = [1, 3, 6];
         for (let i = 0; i < 5; i++) {
             const [response] = await createCategoryFrom({
                 revision: webiny.id
             });
 
-            const [publishResponse] = await publishCategory({
+            const createdCategory = response.data.createCategoryFrom.data;
+            if (publishCategoriesList.includes(createdCategory.meta.version) === false) {
+                continue;
+            }
+
+            await publishCategory({
                 revision: response.data.createCategoryFrom.data.id
             });
-
-            revisions.push(publishResponse.data.publishCategory.data);
         }
 
         await until(
@@ -1164,13 +1247,15 @@ describe("MANAGE - Resolvers", () => {
                     return false;
                 }
                 const [last] = data.listCategories.data;
-                if (!last || last.meta.version !== 6) {
+                if (!last || last.meta.version !== 6 || last.meta.status !== "published") {
                     return false;
                 }
 
                 return true;
             },
-            { name: "list categories after creating revisions" }
+            {
+                name: "list categories after creating revisions"
+            }
         );
 
         const [listResponse] = await listCategories();
@@ -1218,23 +1303,90 @@ describe("MANAGE - Resolvers", () => {
                             locked: true,
                             modelId: "category",
                             publishedOn: expect.stringMatching(/^20/),
-                            revisions: revisions.reverse().map(revision => {
-                                return {
-                                    id: revision.id,
+                            revisions: [
+                                {
+                                    id: `${webiny.entryId}#0006`,
                                     meta: {
-                                        status:
-                                            revision.meta.version === 6
-                                                ? "published"
-                                                : "unpublished"
+                                        status: "published",
+                                        version: 6
                                     },
                                     title,
                                     slug
-                                };
-                            }),
+                                },
+                                {
+                                    id: `${webiny.entryId}#0005`,
+                                    meta: {
+                                        status: "draft",
+                                        version: 5
+                                    },
+                                    title,
+                                    slug
+                                },
+                                {
+                                    id: `${webiny.entryId}#0004`,
+                                    meta: {
+                                        status: "draft",
+                                        version: 4
+                                    },
+                                    title,
+                                    slug
+                                },
+                                {
+                                    id: `${webiny.entryId}#0003`,
+                                    meta: {
+                                        status: "unpublished",
+                                        version: 3
+                                    },
+                                    title,
+                                    slug
+                                },
+                                {
+                                    id: `${webiny.entryId}#0002`,
+                                    meta: {
+                                        status: "draft",
+                                        version: 2
+                                    },
+                                    title,
+                                    slug
+                                },
+                                {
+                                    id: `${webiny.entryId}#0001`,
+                                    meta: {
+                                        status: "unpublished",
+                                        version: 1
+                                    },
+                                    title,
+                                    slug
+                                }
+                            ],
                             status: "published",
                             title,
                             version: 6
                         }
+                    },
+                    error: null
+                }
+            }
+        });
+        /**
+         * Should get the version 6 as the published version
+         */
+        const [getReadCategoryResponse] = await getReadCategory({
+            where: {
+                entryId: webiny.entryId
+            }
+        });
+
+        expect(getReadCategoryResponse).toEqual({
+            data: {
+                getCategory: {
+                    data: {
+                        id: `${webiny.entryId}#0006`,
+                        entryId: webiny.entryId,
+                        savedOn: expect.stringMatching(/^20/),
+                        createdOn: expect.stringMatching(/^20/),
+                        slug,
+                        title
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/utils/storageOperations.ts
+++ b/packages/api-headless-cms/__tests__/utils/storageOperations.ts
@@ -1,9 +1,14 @@
 import { Plugin, PluginCollection } from "@webiny/plugins/types";
+import { HeadlessCmsStorageOperations } from "~/types";
 
 export interface Params {
     plugins?: Plugin | Plugin[] | Plugin[][] | PluginCollection;
 }
-export const getStorageOperations = (params: Params) => {
+export interface Response {
+    storageOperations: HeadlessCmsStorageOperations;
+    plugins: Plugin[] | Plugin[][] | PluginCollection;
+}
+export const getStorageOperations = (params: Params): Response => {
     // @ts-ignore
     if (typeof __getCreateStorageOperations !== "function") {
         throw new Error(`There is no global "__getCreateStorageOperations" function.`);

--- a/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
@@ -24,6 +24,7 @@ const categoryFields = `
             slug
             meta {
                 status
+                version
             }
         }
     }

--- a/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
@@ -22,6 +22,9 @@ const categoryFields = `
             id
             title
             slug
+            meta {
+                status
+            }
         }
     }
     # user defined fields

--- a/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
@@ -156,6 +156,7 @@ export const useGqlHandler = (params: GQLHandlerCallableParams) => {
         sleep,
         handler,
         invoke,
+        storageOperations: ops.storageOperations,
         async introspect() {
             return invoke({ body: { query: introspectionQuery } });
         },

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -220,8 +220,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
         await utils.checkModelAccess(context, model);
 
         const entries = await storageOperations.entries.getByIds(model, {
-            tenant: getTenant().id,
-            locale: getLocale().code,
             ids
         });
 
@@ -278,8 +276,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             await utils.checkModelAccess(context, model);
 
             const entries = await storageOperations.entries.getPublishedByIds(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 ids
             });
 
@@ -293,8 +289,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             await utils.checkModelAccess(context, model);
 
             const entries = await storageOperations.entries.getLatestByIds(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 ids
             });
 
@@ -303,8 +297,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
 
         getEntryRevisions: async (model, entryId) => {
             return storageOperations.entries.getRevisions(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id: entryId
             });
         },
@@ -485,15 +477,11 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             const [uniqueId] = sourceId.split("#");
 
             const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id: sourceId
             });
             const latestStorageEntry = await storageOperations.entries.getLatestRevisionByEntryId(
                 model,
                 {
-                    tenant: getTenant().id,
-                    locale: getLocale().code,
                     id: uniqueId
                 }
             );
@@ -602,8 +590,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
              * The entry we are going to update.
              */
             const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id
             });
 
@@ -693,23 +679,17 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             const { id: entryId, version } = parseIdentifier(revisionId);
 
             const storageEntryToDelete = await storageOperations.entries.getRevisionById(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id: revisionId
             });
             const latestStorageEntry = await storageOperations.entries.getLatestRevisionByEntryId(
                 model,
                 {
-                    tenant: getTenant().id,
-                    locale: getLocale().code,
                     id: entryId
                 }
             );
             const previousStorageEntry = await storageOperations.entries.getPreviousRevision(
                 model,
                 {
-                    tenant: getTenant().id,
-                    locale: getLocale().code,
                     entryId,
                     version
                 }
@@ -785,8 +765,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             await utils.checkModelAccess(context, model);
 
             const storageEntry = await storageOperations.entries.getLatestRevisionByEntryId(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id: entryId
             });
 
@@ -808,12 +786,7 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             const permission = await checkEntryPermissions({ pw: "p" });
             await utils.checkModelAccess(context, model);
 
-            const tenant = getTenant().id;
-            const locale = getLocale().code;
-
             const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
-                tenant,
-                locale,
                 id
             });
 
@@ -880,8 +853,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             const permission = await checkEntryPermissions({ pw: "c" });
 
             const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id
             });
 
@@ -957,15 +928,11 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
             const [entryId] = id.split("#");
 
             const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
-                tenant: getTenant().id,
-                locale: getLocale().code,
                 id
             });
             const latestEntryRevision = await storageOperations.entries.getLatestRevisionByEntryId(
                 model,
                 {
-                    tenant: getTenant().id,
-                    locale: getLocale().code,
                     id: entryId
                 }
             );
@@ -1042,8 +1009,6 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
 
             const originalStorageEntry =
                 await storageOperations.entries.getPublishedRevisionByEntryId(model, {
-                    tenant: getTenant().id,
-                    locale: getLocale().code,
                     id: entryId
                 });
 

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2062,56 +2062,38 @@ export interface CmsEntryStorageOperationsRequestReviewParams<
 
 export interface CmsEntryStorageOperationsGetAllRevisionsParams {
     ids: readonly string[];
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetByIdsParams {
     ids: readonly string[];
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetLatestByIdsParams {
     ids: readonly string[];
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetPublishedByIdsParams {
     ids: readonly string[];
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetRevisionsParams {
     id: string;
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetRevisionParams {
     id: string;
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetPublishedRevisionParams {
     id: string;
-    tenant: string;
-    locale: string;
 }
 export interface CmsEntryStorageOperationsGetLatestRevisionParams {
     id: string;
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsGetPreviousRevisionParams {
     entryId: string;
     version: number;
-    tenant: string;
-    locale: string;
 }
 
 export interface CmsEntryStorageOperationsListResponse<


### PR DESCRIPTION
## Changes
Closes #1965

Added a test `should have all entry revisions published` in [resolvers.manage.test.ts](https://github.com/webiny/webiny-js/blob/next/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts) which pointed to a bug in requestReview method. No errors in publish/unpublish flow found.

## How Has This Been Tested?
Jest testings.