### PR TITLE
fix: lock codex-tooltip version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,8 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "pretty-format": "25.5.0",
-    "typescript": "4.1.3"
+    "typescript": "4.1.3",
+    "codex-tooltip": "1.0.2"
   },
   "packageManager": "yarn@2.4.3"
 }

--- a/packages/cwp-template-aws/template/ddb-es/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-es/dependencies.json
@@ -89,6 +89,7 @@
     "@types/react": "16.14.4",
     "react": "16.14.0",
     "typescript": "4.1.3",
-    "react-dom": "16.14.0"
+    "react-dom": "16.14.0",
+    "codex-tooltip": "1.0.2"
   }
 }

--- a/packages/cwp-template-aws/template/ddb/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb/dependencies.json
@@ -88,6 +88,7 @@
     "@types/react": "16.14.4",
     "react": "16.14.0",
     "typescript": "4.1.3",
-    "react-dom": "16.14.0"
+    "react-dom": "16.14.0",
+    "codex-tooltip": "1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15551,7 +15551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"codex-tooltip@npm:^1.0.2":
+"codex-tooltip@npm:1.0.2":
   version: 1.0.2
   resolution: "codex-tooltip@npm:1.0.2"
   checksum: 8627bd1a4912406aebbd0ab2fb6725238eb0c8ce957786c1cf6dfdea8003a80519197a0235922e1afea08c55b75ea0036dffd1b6445a77049238bda0d52fe00f


### PR DESCRIPTION
## Changes
Locked the version of `codex-tooltip` used by editorjs to 1.0.2 because types are broken in 1.0.3 and 1.0.4.

## How Has This Been Tested?
Manually.