### PR TITLE
Page Builder - Button Element  - Fix Link Assignment

### DIFF
--- a/packages/app-page-builder/src/render/plugins/elements/button/Button.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/button/Button.tsx
@@ -20,7 +20,8 @@ const Button = ({ element }: { element: PbElement }) => {
     // element object, if it exists otherwise, we'll use the newer "action" element object
     let href: string, newTab: boolean;
 
-    if (link && !action) {
+    // If `link.href` is truthy, assume we're using link, not action.
+    if (link && link.href) {
         href = link?.href;
         newTab = link?.newTab;
     } else {


### PR DESCRIPTION
## Changes
This PR introduces a fix for a bug in the `Button` page element, which was introduced in 5.18.0, and made buttons not clickable. This happened because of a wrong "do I apply link or action settings?" check.

Closes #2061 

## How Has This Been Tested?
Manually.

## Documentation
N/A