### PR TITLE
New `acl` and `cacheControl` params on the `uploadFolderToS3` Utility Function

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
@@ -26,7 +26,9 @@ module.exports = async ({
     bucket,
     onFileUploadSuccess,
     onFileUploadError,
-    onFileUploadSkip
+    onFileUploadSkip,
+    acl = "public-read",
+    cacheControl = "max-age=31536000"
 }) => {
     const s3 = new S3Client({ region: process.env.AWS_REGION });
 
@@ -83,8 +85,8 @@ module.exports = async ({
                                 .putObject({
                                     Bucket: bucket,
                                     Key: key,
-                                    ACL: "public-read",
-                                    CacheControl: "max-age=31536000",
+                                    ACL: acl,
+                                    CacheControl: cacheControl,
                                     ContentType: mime.getType(path) || undefined,
                                     Body: fs.readFileSync(path),
                                     Metadata: {


### PR DESCRIPTION
…derToS3

Allow for specifying the acl to use when uploading files to s3.

## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #2065

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

I have installed into our environment using this patch.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
