### PR TITLE
fix(@webiny/validation): add exclamation mark to url validation regexp

### DIFF
--- a/packages/validation/__tests__/url.test.js
+++ b/packages/validation/__tests__/url.test.js
@@ -82,4 +82,13 @@ describe("url test", () => {
             ValidationError
         );
     });
+
+    it("should pass - Google Maps embed URL (with exclamation mark)", async () => {
+        await expect(
+            validation.validate(
+                "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2482.6342726998337!2d-0.13235738423882193!3d51.51992537963726!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b2de379bf0f%3A0x94d194cc3e61963a!2s3%20Gower%20St%2C%20London%20WC1E%206HA%2C%20Vereinigtes%20K%C3%B6nigreich!5e0!3m2!1sde!2sde!4v1638353426946!5m2!1sde!2sde",
+                "url"
+            )
+        ).resolves.toBe(true);
+    });
 });

--- a/packages/validation/src/validators/url.ts
+++ b/packages/validation/src/validators/url.ts
@@ -3,7 +3,7 @@ import ValidationError from "./../validationError";
 const regex = {
     base: new RegExp(
         // eslint-disable-next-line
-        /^(https?:\/\/)((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/i
+        /^(https?:\/\/)((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=!-]*)?(\#[-a-z\d_]*)?$/i
     ),
     ip: new RegExp(
         // eslint-disable-next-line


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #2059

Fixes the URL validation to accept exclamation marks (used in Google Maps embed URLs for example).

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested with Jest and in the Admin app (page builder, localhost and cloud).

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
No updated documentation needed, instead the new iframe page element works better. See issue.