### PR TITLE
feat(api-headless-cms): ref field resolvers

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -1,5 +1,12 @@
 import { CmsEntry, CmsContext, CmsModelFieldToGraphQLPlugin } from "~/types";
 import { createReadTypeName } from "~/content/plugins/utils/createTypeName";
+import { parseIdentifier } from "@webiny/utils";
+
+interface RefFieldValue {
+    id?: string;
+    entryId: string;
+    modelId: string;
+}
 
 const createUnionTypeName = (model, field) => {
     return `${createReadTypeName(model.modelId)}${createReadTypeName(field.fieldId)}`;
@@ -190,7 +197,17 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                     
                     ${createFilteringTypeDef()}
                 `,
-                resolvers: {}
+                resolvers: {
+                    RefField: {
+                        entryId: (parent: RefFieldValue) => {
+                            const { id } = parseIdentifier(parent.entryId || parent.id);
+                            return id;
+                        },
+                        id: (parent: RefFieldValue) => {
+                            return parent.id || parent.entryId;
+                        }
+                    }
+                }
             };
         },
         createTypeField({ field }) {

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -199,25 +199,12 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 `,
                 resolvers: {
                     RefField: {
-                        entryId: (parent: RefFieldValue | RefFieldValue[]) => {
-                            if (Array.isArray(parent) === true) {
-                                return (parent as RefFieldValue[]).map(value => {
-                                    const { id } = parseIdentifier(value.entryId || value.id);
-                                    return id;
-                                });
-                            }
-                            const value = parent as RefFieldValue;
-                            const { id } = parseIdentifier(value.entryId || value.id);
+                        entryId: (parent: RefFieldValue) => {
+                            const { id } = parseIdentifier(parent.entryId || parent.id);
                             return id;
                         },
-                        id: (parent: RefFieldValue | RefFieldValue[]) => {
-                            if (Array.isArray(parent) === true) {
-                                return (parent as RefFieldValue[]).map(
-                                    value => value.id || value.entryId
-                                );
-                            }
-                            const value = parent as RefFieldValue;
-                            return value.id || value.entryId;
+                        id: (parent: RefFieldValue) => {
+                            return parent.id || parent.entryId;
                         }
                     }
                 }

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/ref.ts
@@ -199,12 +199,25 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 `,
                 resolvers: {
                     RefField: {
-                        entryId: (parent: RefFieldValue) => {
-                            const { id } = parseIdentifier(parent.entryId || parent.id);
+                        entryId: (parent: RefFieldValue | RefFieldValue[]) => {
+                            if (Array.isArray(parent) === true) {
+                                return (parent as RefFieldValue[]).map(value => {
+                                    const { id } = parseIdentifier(value.entryId || value.id);
+                                    return id;
+                                });
+                            }
+                            const value = parent as RefFieldValue;
+                            const { id } = parseIdentifier(value.entryId || value.id);
                             return id;
                         },
-                        id: (parent: RefFieldValue) => {
-                            return parent.id || parent.entryId;
+                        id: (parent: RefFieldValue | RefFieldValue[]) => {
+                            if (Array.isArray(parent) === true) {
+                                return (parent as RefFieldValue[]).map(
+                                    value => value.id || value.entryId
+                                );
+                            }
+                            const value = parent as RefFieldValue;
+                            return value.id || value.entryId;
                         }
                     }
                 }


### PR DESCRIPTION
## Changes
Added resolvers for the ref field so old entries with ref fields dont break because of missing id.

## How Has This Been Tested?
Jest and manually.
