### PR TITLE
Introducing App Config

### DIFF
--- a/packages/app-admin-cognito/src/index.tsx
+++ b/packages/app-admin-cognito/src/index.tsx
@@ -15,6 +15,8 @@ import ForgotPassword from "~/views/ForgotPassword";
 import SetNewPassword from "~/views/SetNewPassword";
 import SignedIn from "~/views/SignedIn";
 import { useSecurity } from "@webiny/app-security";
+import { config as appConfig } from "@webiny/app/config";
+
 const createApolloLinkPlugin = () => {
     return new ApolloLinkPlugin(() => {
         return setContext(async (_, { headers }) => {
@@ -41,9 +43,12 @@ const createApolloLinkPlugin = () => {
 };
 
 const defaultOptions = {
-    region: process.env.REACT_APP_USER_POOL_REGION,
-    userPoolId: process.env.REACT_APP_USER_POOL_ID,
-    userPoolWebClientId: process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID
+    region: appConfig.getKey("USER_POOL_REGION", process.env.REACT_APP_USER_POOL_REGION),
+    userPoolId: appConfig.getKey("USER_POOL_ID", process.env.REACT_APP_USER_POOL_ID),
+    userPoolWebClientId: appConfig.getKey(
+        "USER_POOL_WEB_CLIENT_ID",
+        process.env.REACT_APP_USER_POOL_WEB_CLIENT_ID
+    )
 };
 
 export interface Props {

--- a/packages/app-admin-users-cognito/src/plugins/cognito.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/cognito.tsx
@@ -11,9 +11,16 @@ import { createPasswordValidator, PasswordPolicy } from "~/createPasswordValidat
 import { config as appConfig } from "@webiny/app/config";
 
 export default (): PluginCollection => {
+    let envPasswordValidatorPolicy;
+    try {
+        envPasswordValidatorPolicy = JSON.parse(process.env.REACT_APP_USER_POOL_PASSWORD_POLICY);
+    } catch {
+        // Do nothing.
+    }
+
     const passwordValidatorPolicy = appConfig.getKey<PasswordPolicy>(
         "USER_POOL_PASSWORD_POLICY",
-        JSON.parse(process.env.REACT_APP_USER_POOL_PASSWORD_POLICY)
+        envPasswordValidatorPolicy
     );
 
     const passwordValidator = createPasswordValidator(passwordValidatorPolicy);

--- a/packages/app-admin-users-cognito/src/plugins/cognito.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/cognito.tsx
@@ -8,11 +8,15 @@ import { UIViewPlugin } from "@webiny/app-admin/ui/UIView";
 import { UsersFormView } from "~/ui/views/Users/UsersFormView";
 import { PasswordElement } from "@webiny/app-admin/ui/elements/form/PasswordElement";
 import { createPasswordValidator, PasswordPolicy } from "~/createPasswordValidator";
+import { config as appConfig } from "@webiny/app/config";
 
 export default (): PluginCollection => {
-    const passwordValidator = createPasswordValidator(
-        JSON.parse(process.env.REACT_APP_USER_POOL_PASSWORD_POLICY) as PasswordPolicy
+    const passwordValidatorPolicy = appConfig.getKey<PasswordPolicy>(
+        "USER_POOL_PASSWORD_POLICY",
+        JSON.parse(process.env.REACT_APP_USER_POOL_PASSWORD_POLICY)
     );
+
+    const passwordValidator = createPasswordValidator(passwordValidatorPolicy);
     return [
         // Add password input to admin user installation
         new ViewPlugin({

--- a/packages/app-admin-users-cognito/src/ui/views/Account/Account.tsx
+++ b/packages/app-admin-users-cognito/src/ui/views/Account/Account.tsx
@@ -12,6 +12,7 @@ import { Cell, Grid } from "@webiny/ui/Grid";
 import { validation } from "@webiny/validation";
 import AvatarImage from "../../components/AvatarImage";
 import { GET_CURRENT_USER, UPDATE_CURRENT_USER } from "./graphql";
+import { config as appConfig } from "@webiny/app/config";
 
 import {
     SimpleForm,
@@ -65,7 +66,10 @@ const UserAccountForm = () => {
 
     const user = currentUser.loading ? {} : currentUser.data.adminUsers.user.data;
 
-    const emailIsDisabled = process.env.REACT_APP_ADMIN_USER_CAN_CHANGE_EMAIL === "false";
+    const emailIsDisabled = appConfig.getKey(
+        "ADMIN_USER_CAN_CHANGE_EMAIL",
+        process.env.REACT_APP_ADMIN_USER_CAN_CHANGE_EMAIL === "false"
+    );
 
     return (
         <Grid>

--- a/packages/app-admin-users-cognito/src/ui/views/Users/UsersFormView.tsx
+++ b/packages/app-admin-users-cognito/src/ui/views/Users/UsersFormView.tsx
@@ -16,6 +16,7 @@ import { GroupAutocompleteElement } from "~/ui/elements/GroupAutocompleteElement
 import { UseUserForm, useUserForm } from "~/ui/views/Users/hooks/useUserForm";
 import { FormView } from "@webiny/app-admin/ui/views/FormView";
 import { FormElementRenderProps } from "@webiny/app-admin/ui/elements/form/FormElement";
+import { config as appConfig } from "@webiny/app/config";
 
 const FormWrapper = styled("div")({
     margin: "0 100px"
@@ -139,7 +140,10 @@ export class UsersFormView extends UIView {
                         return false;
                     }
 
-                    return process.env.REACT_APP_ADMIN_USER_CAN_CHANGE_EMAIL === "false";
+                    return appConfig.getKey(
+                        "ADMIN_USER_CAN_CHANGE_EMAIL",
+                        process.env.REACT_APP_ADMIN_USER_CAN_CHANGE_EMAIL === "false"
+                    );
                 }
             })
         );

--- a/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
+++ b/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
@@ -120,7 +120,7 @@ const Sidebar = ({ allInstallers, installer, showLogin }) => {
     const upgrades = allInstallers.filter(installer => installer.type === "upgrade");
     const installations = allInstallers.filter(installer => installer.type === "install");
 
-    const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+    const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
 
     return (
         <SidebarWrapper>
@@ -131,8 +131,7 @@ const Sidebar = ({ allInstallers, installer, showLogin }) => {
                 <Installations
                     title={
                         <span>
-                            The following apps will be upgraded to{" "}
-                            <strong>{wbyVersion}</strong>:
+                            The following apps will be upgraded to <strong>{wbyVersion}</strong>:
                         </span>
                     }
                     allInstallers={upgrades}

--- a/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
+++ b/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
@@ -5,6 +5,7 @@ import classSet from "classnames";
 
 import webinyLogo from "../../assets/images/webiny-orange-logo.svg";
 import signInDivider from "./assets/sign-in-divider.svg";
+import { config as appConfig } from "@webiny/app/config";
 
 const SidebarWrapper = styled("div")({});
 
@@ -119,6 +120,8 @@ const Sidebar = ({ allInstallers, installer, showLogin }) => {
     const upgrades = allInstallers.filter(installer => installer.type === "upgrade");
     const installations = allInstallers.filter(installer => installer.type === "install");
 
+    const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+
     return (
         <SidebarWrapper>
             <Logo>
@@ -129,7 +132,7 @@ const Sidebar = ({ allInstallers, installer, showLogin }) => {
                     title={
                         <span>
                             The following apps will be upgraded to{" "}
-                            <strong>{process.env.REACT_APP_WEBINY_VERSION}</strong>:
+                            <strong>{wbyVersion}</strong>:
                         </span>
                     }
                     allInstallers={upgrades}

--- a/packages/app-admin/src/components/AppInstaller/index.tsx
+++ b/packages/app-admin/src/components/AppInstaller/index.tsx
@@ -17,18 +17,20 @@ import {
     installerSplitView,
     SuccessDialog
 } from "./styled";
+import { config as appConfig } from "@webiny/app/config";
 
 export const AppInstaller = ({ Authentication, children }) => {
     const tenantId = localStorage.get("webiny_tenant") || "root";
 
     const lsKey = `webiny_installation_${tenantId}`;
+    const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
 
     const markInstallerAsCompleted = () => {
-        localStorage.set(lsKey, process.env.REACT_APP_WEBINY_VERSION);
+        localStorage.set(lsKey, wbyVersion);
     };
 
     const isInstallerCompleted = () => {
-        return localStorage.get(lsKey) === process.env.REACT_APP_WEBINY_VERSION;
+        return localStorage.get(lsKey) === wbyVersion;
     };
 
     const [finished, setFinished] = useState(false);

--- a/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
@@ -5,6 +5,7 @@ import { useApolloClient } from "@apollo/react-hooks";
 import { plugins } from "@webiny/plugins";
 import { AdminInstallationPlugin } from "~/types";
 import { CircularProgress } from "@webiny/ui/Progress";
+import { config as appConfig } from "@webiny/app/config";
 
 const Loader = ({ children, ...props }) => (
     <Suspense fallback={<CircularProgress label={"Loading..."} />}>
@@ -79,9 +80,11 @@ export const useInstaller = ({ isInstalled }) => {
                     installed: false
                 });
             } else {
+                const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+
                 const upgrades = (installer.plugin.upgrades || []).filter(({ version }) => {
                     return (
-                        lte(version, process.env.REACT_APP_WEBINY_VERSION) &&
+                        lte(version, wbyVersion) &&
                         gt(version, installer.installed)
                     );
                 });

--- a/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
@@ -80,13 +80,13 @@ export const useInstaller = ({ isInstalled }) => {
                     installed: false
                 });
             } else {
-                const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+                const wbyVersion = appConfig.getKey(
+                    "WEBINY_VERSION",
+                    process.env.REACT_APP_WEBINY_VERSION
+                );
 
                 const upgrades = (installer.plugin.upgrades || []).filter(({ version }) => {
-                    return (
-                        lte(version, wbyVersion) &&
-                        gt(version, installer.installed)
-                    );
+                    return lte(version, wbyVersion) && gt(version, installer.installed);
                 });
 
                 if (upgrades.length > 1) {

--- a/packages/app-admin/src/ui/views/NavigationView/FooterElement.tsx
+++ b/packages/app-admin/src/ui/views/NavigationView/FooterElement.tsx
@@ -23,7 +23,7 @@ export class FooterElement extends UIElement<FooterElementConfig> {
             new PlaceholderElement("navigation.footer.placeholder")
         );
 
-        const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+        const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
 
         new GenericElement("webiny.version", () => {
             return (

--- a/packages/app-admin/src/ui/views/NavigationView/FooterElement.tsx
+++ b/packages/app-admin/src/ui/views/NavigationView/FooterElement.tsx
@@ -5,6 +5,7 @@ import { GenericElement } from "~/ui/elements/GenericElement";
 import { PlaceholderElement } from "~/ui/elements/PlaceholderElement";
 import { NavigationMenuElement } from "~/ui/elements/NavigationMenuElement";
 import { MenuFooter, subFooter } from "./Styled";
+import { config as appConfig } from "@webiny/app/config";
 
 interface FooterElementConfig extends UIElementConfig {
     closeMenu: () => void;
@@ -22,10 +23,12 @@ export class FooterElement extends UIElement<FooterElementConfig> {
             new PlaceholderElement("navigation.footer.placeholder")
         );
 
+        const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION)
+
         new GenericElement("webiny.version", () => {
             return (
                 <ListItem ripple={false} className={subFooter}>
-                    Webiny v{process.env.REACT_APP_WEBINY_VERSION}
+                    Webiny v{wbyVersion}
                 </ListItem>
             );
         }).moveAfter(this._footerPlaceholder);

--- a/packages/app-file-manager/src/admin/plugins/installation.tsx
+++ b/packages/app-file-manager/src/admin/plugins/installation.tsx
@@ -7,6 +7,7 @@ import { Alert } from "@webiny/ui/Alert";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { SimpleForm, SimpleFormContent } from "@webiny/app-admin/components/SimpleForm";
 import styled from "@emotion/styled";
+import { config as appConfig } from "@webiny/app/config";
 
 const SimpleFormPlaceholder = styled.div({
     minHeight: 300,
@@ -41,11 +42,13 @@ const FMInstaller = ({ onInstalled }) => {
     const client = useApolloClient();
     const [error, setError] = useState(null);
 
+    const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
+
     useEffect(() => {
         client
             .mutate({
                 mutation: INSTALL,
-                variables: { srcPrefix: process.env.REACT_APP_API_URL + "/files" }
+                variables: { srcPrefix: apiUrl + "/files" }
             })
             .then(({ data }) => {
                 const { error } = data.fileManager.install;

--- a/packages/app-graphql-playground/src/plugins/Playground.tsx
+++ b/packages/app-graphql-playground/src/plugins/Playground.tsx
@@ -9,6 +9,7 @@ import { useSecurity } from "@webiny/app-security";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { playgroundDialog, PlaygroundContainer } from "./Playground.styles";
 import { settings } from "./settings";
+import { config as appConfig } from "@webiny/app/config";
 
 const withHeaders = (link, headers) => {
     return ApolloLink.from([
@@ -53,7 +54,8 @@ const Playground = ({ createApolloClient }) => {
 
     const createApolloLink = useCallback(({ endpoint, headers }) => {
         // If the request endpoint is not know to us, return the first available
-        if (!endpoint.includes(process.env.REACT_APP_API_URL)) {
+        const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
+        if (!endpoint.includes(apiUrl)) {
             return { link: withHeaders(Object.values(links.current)[0], headers) };
         }
 

--- a/packages/app-graphql-playground/src/plugins/index.tsx
+++ b/packages/app-graphql-playground/src/plugins/index.tsx
@@ -12,6 +12,7 @@ import placeholder from "!!raw-loader!./placeholder.graphql";
 import { NavigationMenuElement } from "@webiny/app-admin/ui/elements/NavigationMenuElement";
 import { UIViewPlugin } from "@webiny/app-admin/ui/UIView";
 import { NavigationView } from "@webiny/app-admin/ui/views/NavigationView";
+import { config as appConfig } from "@webiny/app/config";
 
 type GraphQLPlaygroundOptions = {
     createApolloClient(params: { uri: string }): ApolloClient<any>;
@@ -52,9 +53,10 @@ export default (options: GraphQLPlaygroundOptions) => [
     {
         type: "graphql-playground-tab",
         tab() {
+            const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
             return {
                 name: "Main API",
-                endpoint: process.env.REACT_APP_API_URL + "/graphql",
+                endpoint: apiUrl + "/graphql",
                 headers: {},
                 query: placeholder
             };

--- a/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
+++ b/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ApolloClient from "apollo-client";
 import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { CircularProgress } from "@webiny/ui/Progress";
+import { config as appConfig } from "@webiny/app/config";
 
 export interface CmsContextValue {
     getApolloClient(locale: string): ApolloClient<any>;
@@ -19,6 +20,7 @@ type CmsProviderProps = {
 };
 
 export function CmsProvider(props: CmsProviderProps) {
+    const apiUrl = appConfig.getKey('API_URL', process.env.REACT_APP_API_URL);
     const { getCurrentLocale } = useI18N();
 
     const currentLocale = getCurrentLocale("content");
@@ -31,7 +33,7 @@ export function CmsProvider(props: CmsProviderProps) {
 
     if (currentLocale && !apolloClientsCache[currentLocale]) {
         apolloClientsCache[currentLocale] = props.createApolloClient({
-            uri: `${process.env.REACT_APP_API_URL}/cms/manage/${currentLocale}`
+            uri: `${apiUrl}/cms/manage/${currentLocale}`
         });
     }
 
@@ -39,7 +41,7 @@ export function CmsProvider(props: CmsProviderProps) {
         getApolloClient(locale: string) {
             if (!apolloClientsCache[locale]) {
                 apolloClientsCache[locale] = props.createApolloClient({
-                    uri: `${process.env.REACT_APP_API_URL}/cms/manage/${locale}`
+                    uri: `${apiUrl}/cms/manage/${locale}`
                 });
             }
             return apolloClientsCache[locale];

--- a/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
+++ b/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
@@ -20,7 +20,7 @@ type CmsProviderProps = {
 };
 
 export function CmsProvider(props: CmsProviderProps) {
-    const apiUrl = appConfig.getKey('API_URL', process.env.REACT_APP_API_URL);
+    const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
     const { getCurrentLocale } = useI18N();
 
     const currentLocale = getCurrentLocale("content");

--- a/packages/app-headless-cms/src/admin/plugins/apiInformation/index.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/apiInformation/index.tsx
@@ -3,19 +3,21 @@ import raw from "raw.macro";
 const manageQuery = raw("./placeholder.manage.graphql");
 const readQuery = raw("./placeholder.read.graphql");
 const previewQuery = raw("./placeholder.preview.graphql");
+import { config as appConfig } from "@webiny/app/config";
 
 const plugins: GraphQLPlaygroundTabPlugin[] = [
     {
         type: "graphql-playground-tab",
         name: "graphql-playground-tab-manage",
         tab({ locale, identity }) {
+            const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
             if (!identity.getPermission("cms.endpoint.manage")) {
                 return null;
             }
 
             return {
                 name: "Headless CMS - Manage API",
-                endpoint: process.env.REACT_APP_API_URL + "/cms/manage/" + locale,
+                endpoint: apiUrl + "/cms/manage/" + locale,
                 headers: {},
                 query: manageQuery
             };
@@ -25,13 +27,14 @@ const plugins: GraphQLPlaygroundTabPlugin[] = [
         type: "graphql-playground-tab",
         name: "graphql-playground-tab-read",
         tab({ locale, identity }) {
+            const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
             if (!identity.getPermission("cms.endpoint.read")) {
                 return null;
             }
 
             return {
                 name: "Headless CMS - Read API",
-                endpoint: process.env.REACT_APP_API_URL + "/cms/read/" + locale,
+                endpoint: apiUrl + "/cms/read/" + locale,
                 headers: {},
                 query: readQuery
             };
@@ -41,13 +44,14 @@ const plugins: GraphQLPlaygroundTabPlugin[] = [
         type: "graphql-playground-tab",
         name: "graphql-playground-tab-preview",
         tab({ locale, identity }) {
+            const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
             if (!identity.getPermission("cms.endpoint.preview")) {
                 return null;
             }
 
             return {
                 name: "Headless CMS - Preview API",
-                endpoint: process.env.REACT_APP_API_URL + "/cms/preview/" + locale,
+                endpoint: apiUrl + "/cms/preview/" + locale,
                 headers: {},
                 query: previewQuery
             };

--- a/packages/app-tenancy/src/contexts/Tenancy.tsx
+++ b/packages/app-tenancy/src/contexts/Tenancy.tsx
@@ -3,6 +3,7 @@ import { default as localStorage } from "store";
 import { plugins } from "@webiny/plugins";
 import { TenantHeaderLinkPlugin } from "@webiny/app/plugins/TenantHeaderLinkPlugin";
 export const TenancyContext = React.createContext(null);
+import { config as appConfig } from "@webiny/app/config";
 
 export interface Tenant {
     id: string;
@@ -59,7 +60,10 @@ export const TenancyProvider = props => {
         () => ({
             tenant: currentTenant,
             setTenant: changeTenant,
-            isMultiTenant: process.env.REACT_APP_WEBINY_MULTI_TENANCY === "true"
+            isMultiTenant: appConfig.getKey(
+                "WEBINY_MULTI_TENANCY",
+                process.env.REACT_APP_WEBINY_MULTI_TENANCY === "true"
+            )
         }),
         [currentTenant]
     );

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -1,4 +1,4 @@
-export type Config = Record<string, any>
+export type Config = Record<string, any>;
 
 interface AppConfig {
     set(config: Config): void;

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -1,0 +1,34 @@
+export type Config = Record<string, any>
+
+interface AppConfig {
+    set(config: Config): void;
+    get(): Config;
+    getKey<T = string>(key: string, defaultValue: T): T;
+}
+
+const deepFreeze = obj => {
+    Object.keys(obj).forEach(prop => {
+        if (typeof obj[prop] === "object" && !Object.isFrozen(obj[prop])) {
+            deepFreeze(obj[prop]);
+        }
+    });
+    return Object.freeze(obj);
+};
+
+function createConfig(): AppConfig {
+    let _config = {};
+
+    return {
+        set(config: Config) {
+            _config = deepFreeze(config);
+        },
+        get() {
+            return _config;
+        },
+        getKey(key, defaultValue) {
+            return key in _config ? _config[key] : defaultValue;
+        }
+    };
+}
+
+export const config = createConfig();

--- a/packages/app/src/plugins/NetworkErrorLinkPlugin.ts
+++ b/packages/app/src/plugins/NetworkErrorLinkPlugin.ts
@@ -3,6 +3,7 @@ import { onError } from "apollo-link-error";
 import { print } from "graphql/language";
 import createErrorOverlay from "./NetworkErrorLinkPlugin/createErrorOverlay";
 import { boolean } from "boolean";
+import { config as appConfig } from "~/config";
 
 /**
  * This plugin creates an ApolloLink that checks for `NetworkError` and shows an ErrorOverlay in the browser.
@@ -10,7 +11,7 @@ import { boolean } from "boolean";
 export class NetworkErrorLinkPlugin extends ApolloLinkPlugin {
     createLink() {
         return onError(({ networkError, operation }) => {
-            const debug = boolean(process.env.REACT_APP_DEBUG);
+            const debug = appConfig.getKey("DEBUG", boolean(process.env.REACT_APP_DEBUG));
 
             if (networkError && debug) {
                 createErrorOverlay({ query: print(operation.query), networkError });


### PR DESCRIPTION
## Changes
This PR introduces App Config, a global object that can be used to store React application runtime configuration and settings-related values. The object doesn't operate in React scope, which means the object can be used from anywhere.

With this change, from now on, all of the Webiny Serverless CMS apps (Page Builder, Headless CMS, ...) will first try to consume its configuration values from this new App Config, and, as a fallback, as always, use environment variables.
 
For example:

```ts
import { config as appConfig } from "@webiny/app/config";

(...)

const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
```

## How Has This Been Tested?
Manual testing + existing Cypress tests.

## Documentation
WIP