### PR TITLE
`webiny pulumi` Command - Introduce `--debug` Flag 

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -192,6 +192,11 @@ module.exports = [
                         describe: `Environment`,
                         type: "string"
                     });
+                    yargs.option("debug", {
+                        default: false,
+                        describe: `Turn on debug logs`,
+                        type: "boolean"
+                    });
                 },
                 async argv => {
                     await require("./pulumiRun")(argv, context);

--- a/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
@@ -5,9 +5,7 @@ const path = require("path");
 
 module.exports = async (inputs, context) => {
     const [, ...command] = inputs._;
-    const { env, folder } = inputs;
-
-    const jsonOutput = !!command.find(item => item === "--json");
+    const { env, folder, debug } = inputs;
 
     await loadEnvVariables(inputs, context);
 
@@ -25,7 +23,11 @@ module.exports = async (inputs, context) => {
     });
 
     if (env) {
-        !jsonOutput && context.info(`Environment provided - selecting ${green(env)} Pulumi stack.`);
+        debug &&
+            context.debug(
+                `Environment provided - selecting ${context.debug.hl(env)} Pulumi stack.`
+            );
+
         let stackExists = true;
         try {
             const PULUMI_SECRETS_PROVIDER = process.env.PULUMI_SECRETS_PROVIDER;
@@ -53,8 +55,15 @@ module.exports = async (inputs, context) => {
         }
     }
 
-    !jsonOutput && context.info(`Running the following command in ${green(folder)} folder:`);
-    !jsonOutput && context.info(`${green("pulumi " + command.join(" "))}`);
+    if (debug) {
+        const pulumiCommand = `${context.debug.hl("pulumi " + command.join(" "))}`;
+        debug &&
+            context.debug(
+                `Running the following command in ${context.debug.hl(
+                    folder
+                )} folder: ${pulumiCommand}`
+            );
+    }
 
     return pulumi.run({
         command,

--- a/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/pulumiRun.js
@@ -1,4 +1,4 @@
-const { green, red } = require("chalk");
+const { red } = require("chalk");
 const { login, getPulumi, loadEnvVariables } = require("../utils");
 const { getProjectApplication } = require("@webiny/cli/utils");
 const path = require("path");


### PR DESCRIPTION
## Changes
This PR ensures that the `webiny pulumi` command simply returns the output received from the Pulumi CLI and nothing else. Additional informative messages that we had before are not shown anymore by default, only when the `--debug` flag has been passed.

This will help users who want to run the Pulumi CLI via the Webiny CLI, and, for example, are expecting to receive a JSON which they will then be able to parse. With the way this currently works, they need to discard the extra messages coming from our CLI, making this unnecessarily complicated.

So, this is the new default behaviour:

![image](https://user-images.githubusercontent.com/5121148/144298384-9e9c7ae7-e496-41a8-acd3-ad70103a1885.png)

And this is what gets displayed when the `--debug` flag has been passed:

![image](https://user-images.githubusercontent.com/5121148/144298218-aa78d313-dc76-4164-ba46-c7f279070b4c.png)

## How Has This Been Tested?
Manual testing.

## Documentation
Webiny CLI's `--help` flag.