### PR TITLE
Fixed logging incorrect AWS profile during deploy

### DIFF
--- a/packages/cwp-template-aws/cli/aws/checkCredentials.js
+++ b/packages/cwp-template-aws/cli/aws/checkCredentials.js
@@ -23,8 +23,6 @@ module.exports = {
             process.exit(1);
         }
 
-        const { profile } = config.credentials;
-
         if (!config.region) {
             console.log();
             context.error("You must define an AWS Region to deploy to!");
@@ -41,6 +39,11 @@ module.exports = {
         // We assign the region to the appropriate ENV variable for easier access in the stack definition files.
         process.env.AWS_REGION = config.region;
 
-        context.info(`Using profile ${green(profile)} in ${green(config.region)} region.`);
+        const { profile } = config.credentials;
+        if (profile) {
+            context.info(`Using profile ${green(profile)} in ${green(config.region)} region.`);
+        } else {
+            context.info(`Using ${green(config.region)} region.`);
+        }
     }
 };

--- a/packages/cwp-template-aws/cli/aws/checkCredentials.js
+++ b/packages/cwp-template-aws/cli/aws/checkCredentials.js
@@ -39,11 +39,13 @@ module.exports = {
         // We assign the region to the appropriate ENV variable for easier access in the stack definition files.
         process.env.AWS_REGION = config.region;
 
-        const { profile } = config.credentials;
+        const { region } = config;
+        const { profile, accessKeyId } = config.credentials;
+
         if (profile) {
-            context.info(`Using profile ${green(profile)} in ${green(config.region)} region.`);
+            context.info(`Using profile ${green(profile)} in ${green(region)} region.`);
         } else {
-            context.info(`Using ${green(config.region)} region.`);
+            context.info(`Using access key id ${green(accessKeyId)} in ${green(region)} region.`);
         }
     }
 };

--- a/packages/cwp-template-aws/cli/aws/checkCredentials.js
+++ b/packages/cwp-template-aws/cli/aws/checkCredentials.js
@@ -45,7 +45,7 @@ module.exports = {
         if (profile) {
             context.info(`Using profile ${green(profile)} in ${green(region)} region.`);
         } else {
-            context.info(`Using access key id ${green(accessKeyId)} in ${green(region)} region.`);
+            context.info(`Using access key ID ${green(accessKeyId)} in ${green(region)} region.`);
         }
     }
 };


### PR DESCRIPTION
## Changes
When running webiny deploy command, if AWS credentials are passed via environment variables (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY), then the profile doesn't get loaded and we get a minor error in the logs.

## How Has This Been Tested?
Set AWS credentials via `.env` file and checked the console output on deploy.

## Documentation
Not needed