### PR TITLE
Watch command with debug flag throws on windows

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -191,12 +191,16 @@ module.exports = async (inputs, context) => {
 
             // Log used values if debugging has been enabled.
             if (inputs.debug) {
+                const message = pathArg
+                    ? [
+                          "The following files and folders are being watched:",
+                          ...pathArg.map(p => "\n‣ " + p)
+                      ].join("\n")
+                    : `Watching ${projectApplication.root}.`;
+
                 output.log({
                     type: "deploy",
-                    message: [
-                        "The following files and folders are being watched:",
-                        ...pathArg.map(p => "‣ " + p)
-                    ].join("\n")
+                    message
                 });
             }
 


### PR DESCRIPTION
## Changes
When you run `watch` command with `--debug` flag on Windows it would throw an error, because there is a bad fallback on getting pulumi paths.
Fixed that by making a proper fallback for windows.

## How Has This Been Tested?
Run `watch --debug` on windows.