### PR TITLE
Lock Versions of `@pulumi/*` Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,9 @@
     "react-dom": "16.14.0",
     "pretty-format": "25.5.0",
     "typescript": "4.1.3",
-    "codex-tooltip": "1.0.2"
+    "codex-tooltip": "1.0.2",
+    "@pulumi/pulumi": "3.19.0",
+    "@pulumi/aws": "4.28.0"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/packages/cwp-template-aws/template/ddb-es/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-es/dependencies.json
@@ -90,6 +90,8 @@
     "react": "16.14.0",
     "typescript": "4.1.3",
     "react-dom": "16.14.0",
-    "codex-tooltip": "1.0.2"
+    "codex-tooltip": "1.0.2",
+    "@pulumi/pulumi": "3.19.0",
+    "@pulumi/aws": "4.28.0"
   }
 }

--- a/packages/cwp-template-aws/template/ddb/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb/dependencies.json
@@ -89,6 +89,8 @@
     "react": "16.14.0",
     "typescript": "4.1.3",
     "react-dom": "16.14.0",
-    "codex-tooltip": "1.0.2"
+    "codex-tooltip": "1.0.2",
+    "@pulumi/pulumi": "3.19.0",
+    "@pulumi/aws": "4.28.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6041,7 +6041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/aws@npm:^4.10.0":
+"@pulumi/aws@npm:4.28.0":
   version: 4.28.0
   resolution: "@pulumi/aws@npm:4.28.0"
   dependencies:
@@ -6055,9 +6055,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pulumi/pulumi@npm:< 3.18.0":
-  version: 3.17.1
-  resolution: "@pulumi/pulumi@npm:3.17.1"
+"@pulumi/pulumi@npm:3.19.0":
+  version: 3.19.0
+  resolution: "@pulumi/pulumi@npm:3.19.0"
   dependencies:
     "@grpc/grpc-js": ~1.3.8
     "@logdna/tail-file": ^2.0.6
@@ -6074,30 +6074,7 @@ __metadata:
     ts-node: ^7.0.1
     typescript: ~3.7.3
     upath: ^1.1.0
-  checksum: bff63698970d1d13fde8810c7129caa14889571476d2b6a3ac801621257fb8acc3d3da61dcf7d4b4d2bd1d90831e2ba2622369006622ba6ad29f3937636ae867
-  languageName: node
-  linkType: hard
-
-"@pulumi/pulumi@npm:^3.0.0":
-  version: 3.18.0
-  resolution: "@pulumi/pulumi@npm:3.18.0"
-  dependencies:
-    "@grpc/grpc-js": ~1.3.8
-    "@logdna/tail-file": ^2.0.6
-    "@pulumi/query": ^0.3.0
-    google-protobuf: ^3.5.0
-    js-yaml: ^3.14.0
-    minimist: ^1.2.0
-    normalize-package-data: ^2.4.0
-    protobufjs: ^6.8.6
-    read-package-tree: ^5.3.1
-    require-from-string: ^2.0.1
-    semver: ^6.1.0
-    source-map-support: ^0.4.16
-    ts-node: ^7.0.1
-    typescript: ~3.7.3
-    upath: ^1.1.0
-  checksum: 2a342c416e9cdfbab310f64acf08f42e48a9ec52fd82466367c67fb3de68620c2038f3f8d6398f2e2be63f71c08164df03465a37a5b4c2730df45802c072b288
+  checksum: 7f3e8f0f2dc0542d36fd19f126efc3aae5ee19d9b2ee63ad54f25f8262f512107e4e6f642f99161a5683657d871d7fa790f7f909950eb7b171ebb40727cc5a92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
In attempt to make things a bit more stable, this PR introduces locking of versions for `@pulumi/*` packages. Locking has been achieved via the `resolutions` property in the root `package.json` file.

## How Has This Been Tested?
Manual.

## Documentation
Will include this fix in the changelog.