### PR TITLE
fix(api-headless-cms): data loader fetch records

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
@@ -17,7 +17,7 @@ const getAllEntryRevisions = (params: LoaderParams) => {
     const { entity, model } = params;
     const { tenant, locale } = model;
     return new DataLoader<string, CmsEntry[]>(async ids => {
-        const results: CmsEntry[][] = [];
+        const results: Record<string, CmsEntry[]> = {};
         for (const id of ids) {
             const queryAllParams: QueryAllParams = {
                 entity,
@@ -31,11 +31,13 @@ const getAllEntryRevisions = (params: LoaderParams) => {
                 }
             };
             const items = await queryAll<CmsEntry>(queryAllParams);
-            const entries = cleanupItems(entity, items);
-            results.push(entries);
+
+            results[id] = cleanupItems(entity, items);
         }
 
-        return results;
+        return ids.map(id => {
+            return results[id] || [];
+        });
     });
 };
 

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
@@ -16,7 +16,7 @@ import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 const getAllEntryRevisions = (params: LoaderParams) => {
     const { entity, model } = params;
     const { tenant, locale } = model;
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const results: Record<string, CmsEntry[]> = {};
         for (const id of ids) {
             const queryAllParams: QueryAllParams = {
@@ -89,7 +89,7 @@ const getPublishedRevisionByEntryId = (params: LoaderParams) => {
 
     const publishedKey = createPublishedSortKey();
 
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const queries = ids.reduce((collection, id) => {
             const partitionKey = createPartitionKey({
                 tenant,
@@ -127,7 +127,7 @@ const getLatestRevisionByEntryId = (params: LoaderParams) => {
 
     const latestKey = createLatestSortKey();
 
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const queries = ids.reduce((collection, id) => {
             const partitionKey = createPartitionKey({
                 tenant,

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearchFields.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearchFields.ts
@@ -21,6 +21,10 @@ export const elasticsearchFields = [
         field: "createdBy",
         path: "createdBy.id"
     }),
+    new CmsEntryElasticsearchFieldPlugin({
+        field: "version",
+        path: "version"
+    }),
     /**
      * Always add the ALL fields plugin because of the keyword/path build.
      */

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/fields.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/fields.ts
@@ -36,6 +36,14 @@ const systemFields = {
         keyword: false,
         sortable: false,
         unmappedType: "date"
+    }),
+    version: new CmsEntryElasticsearchFieldPlugin({
+        field: "version",
+        path: "version",
+        sortable: true,
+        searchable: true,
+        keyword: false,
+        unmappedType: "number"
     })
 };
 

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -5,7 +5,6 @@ import {
     CmsEntryStorageOperationsCreateRevisionFromParams,
     CmsEntryStorageOperationsDeleteParams,
     CmsEntryStorageOperationsDeleteRevisionParams,
-    CmsEntryStorageOperationsGetAllRevisionsParams,
     CmsEntryStorageOperationsGetByIdsParams,
     CmsEntryStorageOperationsGetLatestByIdsParams,
     CmsEntryStorageOperationsGetLatestRevisionParams,
@@ -1107,16 +1106,6 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
         return storageEntry;
     };
 
-    const getAllRevisionsByIds = async (
-        model: CmsModel,
-        params: CmsEntryStorageOperationsGetAllRevisionsParams
-    ) => {
-        return await dataLoaders.getAllEntryRevisions({
-            model,
-            ids: params.ids
-        });
-    };
-
     const getLatestRevisionByEntryId = async (
         model: CmsModel,
         params: CmsEntryStorageOperationsGetLatestRevisionParams
@@ -1258,7 +1247,6 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
         requestReview,
         requestChanges,
         list,
-        getAllRevisionsByIds,
         getLatestRevisionByEntryId,
         getPublishedRevisionByEntryId,
         getRevisionById,

--- a/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
@@ -17,7 +17,7 @@ const getAllEntryRevisions = (params: LoaderParams) => {
     const { entity, model } = params;
     const { tenant, locale } = model;
     return new DataLoader<string, CmsEntry[]>(async ids => {
-        const results: CmsEntry[][] = [];
+        const results: Record<string, CmsEntry[]> = {};
         for (const id of ids) {
             const queryAllParams: QueryAllParams = {
                 entity,
@@ -31,11 +31,12 @@ const getAllEntryRevisions = (params: LoaderParams) => {
                 }
             };
             const items = await queryAll<CmsEntry>(queryAllParams);
-            const entries = cleanupItems(entity, items);
-            results.push(entries);
+            results[id] = cleanupItems(entity, items);
         }
 
-        return results;
+        return ids.map(id => {
+            return results[id] || [];
+        });
     });
 };
 

--- a/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
@@ -16,7 +16,7 @@ import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 const getAllEntryRevisions = (params: LoaderParams) => {
     const { entity, model } = params;
     const { tenant, locale } = model;
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const results: Record<string, CmsEntry[]> = {};
         for (const id of ids) {
             const queryAllParams: QueryAllParams = {
@@ -88,7 +88,7 @@ const getPublishedRevisionByEntryId = (params: LoaderParams) => {
 
     const publishedKey = createPublishedSortKey();
 
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const queries = ids.reduce((collection, id) => {
             const partitionKey = createPartitionKey({
                 tenant,
@@ -126,7 +126,7 @@ const getLatestRevisionByEntryId = (params: LoaderParams) => {
 
     const latestKey = createLatestSortKey();
 
-    return new DataLoader<string, CmsEntry[]>(async ids => {
+    return new DataLoader<string, CmsEntry[]>(async (ids: readonly string[]) => {
         const queries = ids.reduce((collection, id) => {
             const partitionKey = createPartitionKey({
                 tenant,

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -7,7 +7,6 @@ import {
     CmsEntryStorageOperationsCreateRevisionFromParams,
     CmsEntryStorageOperationsDeleteParams,
     CmsEntryStorageOperationsDeleteRevisionParams,
-    CmsEntryStorageOperationsGetAllRevisionsParams,
     CmsEntryStorageOperationsGetByIdsParams,
     CmsEntryStorageOperationsGetLatestByIdsParams,
     CmsEntryStorageOperationsGetLatestRevisionParams,
@@ -370,15 +369,6 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
             });
         }
     };
-    const getAllRevisionsByIds = async (
-        model: CmsModel,
-        params: CmsEntryStorageOperationsGetAllRevisionsParams
-    ) => {
-        return await dataLoaders.getAllEntryRevisions({
-            model,
-            ids: params.ids
-        });
-    };
 
     const getLatestRevisionByEntryId = async (
         model: CmsModel,
@@ -511,7 +501,7 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
 
     const list = async (model: CmsModel, params: CmsEntryStorageOperationsListParams) => {
         const { limit: initialLimit = 10, where: originalWhere, after, sort } = params;
-        const limit = initialLimit <= 0 || initialLimit >= 100 ? 100 : initialLimit;
+        const limit = initialLimit <= 0 || initialLimit >= 10000 ? 10000 : initialLimit;
 
         const type = originalWhere.published ? "P" : "L";
 
@@ -892,7 +882,6 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
         getByIds,
         getRevisionById,
         getPublishedRevisionByEntryId,
-        getAllRevisionsByIds,
         getLatestRevisionByEntryId,
         get,
         getRevisions,

--- a/packages/api-headless-cms-ddb/src/operations/entry/systemFields.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/systemFields.ts
@@ -40,5 +40,10 @@ export const systemFields: Record<string, CmsModelField> = {
         settings: {
             path: "ownedBy.id"
         }
+    }),
+    version: createSystemField({
+        id: "version",
+        type: "number",
+        fieldId: "version"
     })
 };

--- a/packages/api-headless-cms/__tests__/storageOperations/entries.test.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/entries.test.ts
@@ -1,0 +1,130 @@
+import { createPersonEntries, createPersonModel, PersonEntriesResult } from "./helpers";
+import { useAdminGqlHandler } from "../utils/useAdminGqlHandler";
+import { CmsModel, HeadlessCmsStorageOperations } from "~/types";
+
+interface WaitPersonRecordsParams {
+    records: PersonEntriesResult;
+    storageOperations: HeadlessCmsStorageOperations;
+    name: string;
+    until: Function;
+    model: CmsModel;
+}
+const waitPersonRecords = async (params: WaitPersonRecordsParams): Promise<void> => {
+    const { records, storageOperations, until, model, name } = params;
+    await until(
+        () => {
+            return storageOperations.entries.list(model, {
+                where: {
+                    latest: true
+                },
+                sort: ["version_ASC"],
+                limit: 10000
+            });
+        },
+        ({ items }) => {
+            /**
+             * There must be item for each result last revision id.
+             */
+            return Object.values(records).every(record => {
+                return items.some(item => item.id === record.last.id);
+            });
+        },
+        {
+            name
+        }
+    );
+};
+
+describe("Entries storage operations", () => {
+    const { storageOperations, until } = useAdminGqlHandler({
+        path: "manage/en-US"
+    });
+
+    it("getRevisions - should get revisions of all the entries", async () => {
+        const personModel = createPersonModel();
+        const amount = 102;
+        const results = await createPersonEntries({
+            amount,
+            storageOperations,
+            maxRevisions: 3
+        });
+        /**
+         * We run a check that results have last entry as the amount of revisions.
+         */
+        for (const entryId in results) {
+            const result = results[entryId];
+
+            expect(result.last.version).toEqual(result.revisions.length);
+        }
+
+        await waitPersonRecords({
+            records: results,
+            storageOperations,
+            name: "list all person entries after create",
+            until,
+            model: personModel
+        });
+
+        /**
+         * There must be "amount" of results.
+         */
+        expect(Object.values(results)).toHaveLength(amount);
+
+        for (const entryId in results) {
+            const first = results[entryId].first;
+            const revisions = results[entryId].revisions;
+
+            const revisionIdList: string[] = [];
+            /**
+             * We fetch revisions of each first entry.
+             */
+            const resultRevisions = await storageOperations.entries.getRevisions(personModel, {
+                id: first.id
+            });
+            /**
+             * We must have exact amount of revisions as created.
+             */
+            expect(resultRevisions).toHaveLength(revisions.length);
+
+            for (const rev of revisions) {
+                const res = resultRevisions.filter(r => r.id === rev.id);
+                /**
+                 * Each revision must be loaded only once.
+                 */
+                expect(res).toHaveLength(1);
+                /**
+                 * And we cannot have same IDs in the revisions.
+                 */
+                expect(revisionIdList).not.toContain(rev.id);
+
+                revisionIdList.push(rev.id);
+            }
+        }
+    });
+
+    it("getByIds - should get all entries by id list", async () => {
+        const personModel = createPersonModel();
+        const amount = 202;
+        const results = await createPersonEntries({
+            amount,
+            storageOperations,
+            maxRevisions: 1
+        });
+
+        await waitPersonRecords({
+            records: results,
+            storageOperations,
+            name: "list all person entries after create",
+            until,
+            model: personModel
+        });
+
+        const items = Object.values(results);
+
+        const records = await storageOperations.entries.getByIds(personModel, {
+            ids: items.map(result => result.last.id)
+        });
+
+        expect(records).toHaveLength(items.length);
+    });
+});

--- a/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
@@ -61,7 +61,7 @@ const personModelFields: Record<string, CmsModelField> = {
         fieldId: "biography",
         label: "Biography",
         multipleValues: false,
-        type: "richText"
+        type: "text"
     }
 };
 

--- a/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
@@ -1,0 +1,214 @@
+import shortId from "shortid";
+import mdbid from "mdbid";
+import {
+    CmsEntry,
+    CmsModel,
+    CmsModelField,
+    CreatedBy,
+    HeadlessCmsStorageOperations
+} from "~/types";
+import { CmsGroupPlugin } from "~/content/plugins/CmsGroupPlugin";
+import { createIdentifier } from "@webiny/utils";
+import crypto from "crypto";
+
+const cliPackageJson = require("@webiny/cli/package.json");
+const webinyVersion = cliPackageJson.version;
+
+const baseGroup = new CmsGroupPlugin({
+    name: "Base group",
+    tenant: "root",
+    locale: "en-US",
+    id: "group",
+    slug: "group"
+});
+
+const biography = crypto.randomBytes(65536).toString("hex");
+
+const personModelFields: Record<string, CmsModelField> = {
+    name: {
+        id: shortId.generate(),
+        fieldId: "name",
+        label: "Name",
+        multipleValues: false,
+        type: "text"
+    },
+    dateOfBirth: {
+        id: shortId.generate(),
+        fieldId: "dateOfBirth",
+        label: "Date Of Birth",
+        multipleValues: false,
+        type: "datetime",
+        settings: {
+            type: "date"
+        }
+    },
+    children: {
+        id: shortId.generate(),
+        fieldId: "children",
+        label: "Children",
+        multipleValues: false,
+        type: "number"
+    },
+    married: {
+        id: shortId.generate(),
+        fieldId: "married",
+        label: "Married",
+        multipleValues: false,
+        type: "boolean"
+    },
+    biography: {
+        id: shortId.generate(),
+        fieldId: "biography",
+        label: "Biography",
+        multipleValues: false,
+        type: "richText"
+    }
+};
+
+export const createPersonModel = (): CmsModel => {
+    return {
+        name: "Person Model",
+        group: {
+            id: baseGroup.contentModelGroup.id,
+            name: baseGroup.contentModelGroup.name
+        },
+        modelId: "personModel",
+        locale: "en-US",
+        tenant: "root",
+        titleFieldId: personModelFields.name.id,
+        fields: Object.values(personModelFields),
+        layout: Object.values(personModelFields).map(field => {
+            return [field.id];
+        }),
+        webinyVersion
+    };
+};
+
+const createdBy: CreatedBy = {
+    id: "admin",
+    type: "admin",
+    displayName: "admin"
+};
+const ownedBy: CreatedBy = {
+    id: "admin",
+    type: "admin",
+    displayName: "admin"
+};
+
+interface CreatePersonEntriesParams {
+    amount: number;
+    storageOperations: HeadlessCmsStorageOperations;
+    maxRevisions?: number;
+}
+
+export interface PersonEntriesResult {
+    [key: string]: {
+        first: CmsEntry;
+        revisions: CmsEntry[];
+        last: CmsEntry;
+    };
+}
+export const createPersonEntries = async (
+    params: CreatePersonEntriesParams
+): Promise<PersonEntriesResult> => {
+    const { amount, storageOperations, maxRevisions = 1 } = params;
+    const personModel = createPersonModel();
+
+    const entries: CmsEntry[] = [];
+
+    for (let i = 1; i <= amount; i++) {
+        const entryId = mdbid();
+        const id = createIdentifier({
+            id: entryId,
+            version: 1
+        });
+        const entry: CmsEntry = {
+            id,
+            entryId,
+            version: 1,
+            createdBy,
+            ownedBy,
+            createdOn: new Date().toISOString(),
+            savedOn: new Date().toISOString(),
+            modelId: personModel.modelId,
+            locale: personModel.locale,
+            tenant: personModel.tenant,
+            webinyVersion: personModel.webinyVersion,
+            locked: false,
+            status: "draft",
+            values: {
+                name: `Person #${i}`,
+                biography
+            }
+        };
+
+        const revisionAmount = (i % maxRevisions) + 1;
+
+        const entryResult = await storageOperations.entries.create(personModel, {
+            entry,
+            storageEntry: entry,
+            input: {} as any
+        });
+
+        entries.push(entryResult);
+
+        let nextVersion = entry.version + 1;
+
+        while (nextVersion <= revisionAmount) {
+            const id = createIdentifier({
+                id: entry.entryId,
+                version: nextVersion
+            });
+            const revision: CmsEntry = {
+                id,
+                entryId,
+                version: nextVersion,
+                createdBy,
+                ownedBy,
+                createdOn: new Date().toISOString(),
+                savedOn: new Date().toISOString(),
+                modelId: personModel.modelId,
+                locale: personModel.locale,
+                tenant: personModel.tenant,
+                webinyVersion: personModel.webinyVersion,
+                locked: false,
+                status: "draft",
+                values: {
+                    name: `Person #${i}-${nextVersion}`,
+                    biography
+                }
+            };
+
+            const entryRevisionResult = await storageOperations.entries.create(personModel, {
+                entry: revision,
+                storageEntry: revision,
+                input: {} as any
+            });
+            entries.push(entryRevisionResult);
+            /**
+             * Need to increase for next version run.
+             */
+            nextVersion = revision.version + 1;
+        }
+    }
+
+    const result: PersonEntriesResult = {};
+    for (const entry of entries) {
+        if (!result[entry.entryId]) {
+            result[entry.entryId] = {
+                first: entry,
+                revisions: [entry],
+                last: entry
+            };
+            continue;
+        }
+        if (entry.version < result[entry.entryId].first.version) {
+            result[entry.entryId].first = entry;
+        }
+        if (entry.version > result[entry.entryId].last.version) {
+            result[entry.entryId].last = entry;
+        }
+        result[entry.entryId].revisions.push(entry);
+    }
+    return result;
+};

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2073,10 +2073,6 @@ export interface CmsEntryStorageOperationsRequestReviewParams<
     originalStorageEntry: T;
 }
 
-export interface CmsEntryStorageOperationsGetAllRevisionsParams {
-    ids: readonly string[];
-}
-
 export interface CmsEntryStorageOperationsGetByIdsParams {
     ids: readonly string[];
 }
@@ -2168,10 +2164,10 @@ export interface CmsEntryStorageOperations<T extends CmsStorageEntry = CmsStorag
     /**
      * Get all revisions of all of the given IDs.
      */
-    getAllRevisionsByIds: (
-        model: CmsModel,
-        params: CmsEntryStorageOperationsGetAllRevisionsParams
-    ) => Promise<T[]>;
+    // getAllRevisionsByIds: (
+    //     model: CmsModel,
+    //     params: CmsEntryStorageOperationsGetAllRevisionsParams
+    // ) => Promise<T[]>;
     /**
      * Get the entry by the given revision id.
      */

--- a/packages/db-dynamodb/src/utils/batchRead.ts
+++ b/packages/db-dynamodb/src/utils/batchRead.ts
@@ -1,4 +1,6 @@
 import { Table } from "dynamodb-toolbox";
+import lodashChunk from "lodash/chunk";
+import WebinyError from "@webiny/error";
 
 interface Item {
     Table: Table;
@@ -9,6 +11,8 @@ interface Params {
     items: Item[];
 }
 
+const MAX_BATCH_ITEMS = 100;
+
 const flatten = (responses: Record<string, any[]>): any[] => {
     const entries = [];
     const values = Object.values(responses);
@@ -17,35 +21,66 @@ const flatten = (responses: Record<string, any[]>): any[] => {
     }
     return entries;
 };
+
+interface BatchReadAllChunkParams {
+    table: Table;
+    items: Item[];
+}
+const batchReadAllChunk = async <T = any>(params: BatchReadAllChunkParams): Promise<T[]> => {
+    const { table, items } = params;
+    const records: T[] = [];
+
+    const result = await table.batchGet(items);
+    if (!result || !result.Responses) {
+        return records;
+    }
+    records.push(...flatten(result.Responses));
+    if (!result.next || typeof result.next !== "function") {
+        return records;
+    }
+    let previous = result;
+    while (typeof previous.next === "function") {
+        const nextResult = await previous.next();
+        if (!nextResult) {
+            return records;
+        }
+        records.push(...flatten(nextResult.Responses));
+        previous = nextResult;
+    }
+    return records;
+};
 /**
  * This helper function is meant to be used to batch read from one table.
  * It will fetch all results, as there is a next() method call built in.
  */
-export const batchReadAll = async <T = any>(params: Params): Promise<T[]> => {
+export const batchReadAll = async <T = any>(
+    params: Params,
+    maxChunk = MAX_BATCH_ITEMS
+): Promise<T[]> => {
     if (params.items.length === 0) {
         return [];
-    }
-    const items: T[] = [];
-    const result = await params.table.batchGet(params.items);
-
-    if (result.Responses) {
-        items.push(...flatten(result.Responses));
-    }
-
-    if (typeof result.next === "function") {
-        let previous = result;
-        let nextResult;
-        while ((nextResult = await previous.next())) {
-            if (!nextResult) {
-                return items;
+    } else if (maxChunk > MAX_BATCH_ITEMS) {
+        throw new WebinyError(
+            `Cannot set to load more than ${MAX_BATCH_ITEMS} items from the DynamoDB at once.`,
+            "DYNAMODB_MAX_BATCH_GET_LIMIT_ERROR",
+            {
+                maxChunk
             }
-            items.push(...flatten(nextResult.Responses));
-            if (!nextResult || typeof nextResult.next !== "function") {
-                return items;
-            }
-            previous = nextResult;
-        }
+        );
     }
 
-    return items;
+    const records: T[] = [];
+
+    const chunkItemsList: Item[][] = lodashChunk(params.items, maxChunk);
+
+    for (const chunkItems of chunkItemsList) {
+        const results = await batchReadAllChunk<T>({
+            table: params.table,
+            items: chunkItems
+        });
+
+        records.push(...results);
+    }
+
+    return records;
 };


### PR DESCRIPTION
## Changes

Closes #2086

Mapping of id -> entry in data loader getAllEntryRevisions was wrong.
DynamoDB Toolbox batchRead does cannot take more than 100 items to fetch - fixed in helper method.

Added a [test](https://github.com/webiny/webiny-js/blob/2a8f0f41c295d1a1a03ee320058f06d93116142d/packages/api-headless-cms/__tests__/storageOperations/entries.test.ts) that inserts 202 items and then fetches them via data loader method which loads all items at once.

## How Has This Been Tested?
Jest and manually.
