### PR TITLE
`webiny deploy` - Added `--deploy` Flag

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/deploy.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy.js
@@ -5,7 +5,7 @@ const { getProjectApplication } = require("@webiny/cli/utils");
 const buildPackages = require("./deploy/buildPackages");
 
 module.exports = async (inputs, context) => {
-    const { env, folder, build } = inputs;
+    const { env, folder, build, deploy } = inputs;
 
     // If folder not specified, that means we want to deploy the whole project (all project applications).
     // For that, we look if there are registered plugins that perform that.
@@ -41,6 +41,11 @@ module.exports = async (inputs, context) => {
     }
 
     console.log();
+
+    if (!deploy) {
+        context.info("Skipping project application deployment.");
+        return;
+    }
 
     await login(projectApplication);
 

--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -32,6 +32,11 @@ module.exports = [
                         describe: `Build packages before deploying`,
                         type: "boolean"
                     });
+                    yargs.option("deploy", {
+                        default: true,
+                        describe: `Deploy project application after the application code has been built`,
+                        type: "boolean"
+                    });
                     yargs.option("preview", {
                         default: false,
                         describe: `Preview the deploy instead of actually performing it`,


### PR DESCRIPTION
## Changes
This PR introduces the `--deploy` flag for the `webiny deploy` command. 

Ultimately, by setting it to false (by passing `--no-deploy`), it allows users to skip the deployment step, which can be useful if they only want to build the project application.

## How Has This Been Tested?
Manual.

## Documentation
CLI help + changelog.