### PR TITLE
Refactor plugins into class based

### DIFF
--- a/packages/app-form-builder/src/page-builder/admin/plugins/index.tsx
+++ b/packages/app-form-builder/src/page-builder/admin/plugins/index.tsx
@@ -20,9 +20,8 @@ const PreviewBox = styled("div")({
 
 export default () => [
     formElement,
-    {
+    new PbEditorPageElementPlugin({
         name: "pb-page-element-form",
-        type: "pb-editor-page-element",
         elementType: "form",
         toolbar: {
             title: "Form",
@@ -52,7 +51,7 @@ export default () => [
                 settings: {}
             };
         }
-    } as PbEditorPageElementPlugin,
+    }),
     {
         name: "pb-element-advanced-settings-form",
         type: "pb-editor-page-element-advanced-settings",

--- a/packages/app-page-builder/src/admin/plugins/menuItems/folder/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/menuItems/folder/index.tsx
@@ -3,9 +3,8 @@ import { ReactComponent as LinkIcon } from "./round-folder-24px.svg";
 import FolderForm from "./FolderForm";
 import { PbMenuItemPlugin } from "../../../../types";
 
-const plugin: PbMenuItemPlugin = {
+export default new PbMenuItemPlugin({
     name: "pb-menu-item-folder",
-    type: "pb-menu-item",
     menuItem: {
         type: "folder",
         title: "Folder",
@@ -15,6 +14,4 @@ const plugin: PbMenuItemPlugin = {
             return <FolderForm {...props} />;
         }
     }
-};
-
-export default plugin;
+});

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/pageOptionsMenu/PageOptionsMenu.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/pageOptionsMenu/PageOptionsMenu.tsx
@@ -147,13 +147,9 @@ const PageOptionsMenu = props => {
                 </MenuItem>
             </SecureView>
 
-            {plugins
-                .byType<PbPageDetailsHeaderRightOptionsMenuItemPlugin>(
-                    "pb-page-details-header-right-options-menu-item"
-                )
-                .map(plugin => (
-                    <React.Fragment key={plugin.name}>{plugin.render(props)}</React.Fragment>
-                ))}
+            {plugins.byType(PbPageDetailsHeaderRightOptionsMenuItemPlugin).map(plugin => (
+                <React.Fragment key={plugin.name}>{plugin.render(props)}</React.Fragment>
+            ))}
         </Menu>
     );
 };

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/index.tsx
@@ -3,9 +3,8 @@ import { Tab } from "@webiny/ui/Tabs";
 import { PbPageDetailsRevisionContentPlugin } from "../../../../types";
 import RevisionsList from "./RevisionsList";
 
-const plugin: PbPageDetailsRevisionContentPlugin = {
+export default new PbPageDetailsRevisionContentPlugin({
     name: "pb-page-details-revision-content-revisions",
-    type: "pb-page-details-revision-content",
     render(props) {
         return (
             <Tab label={"Revisions"} disabled={props.getPageQuery.loading}>
@@ -13,6 +12,4 @@ const plugin: PbPageDetailsRevisionContentPlugin = {
             </Tab>
         );
     }
-};
-
-export default plugin;
+});

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/index.tsx
@@ -20,9 +20,8 @@ const RenderBlock = styled("div")({
 });
 
 const plugins = [
-    {
+    new PbPageDetailsRevisionContentPlugin({
         name: "pb-page-details-revision-content-preview",
-        type: "pb-page-details-revision-content",
         render(props) {
             const { getPageQuery } = props;
 
@@ -39,14 +38,13 @@ const plugins = [
                 </Tab>
             );
         }
-    } as PbPageDetailsRevisionContentPlugin,
-    {
+    }),
+    new PbPageDetailsRevisionContentPreviewPlugin({
         name: "pb-page-details-revision-preview",
-        type: "pb-page-details-revision-content-preview",
         render(props) {
             return <PagePreview {...props} />;
         }
-    } as PbPageDetailsRevisionContentPreviewPlugin
+    })
 ];
 
 export default plugins;

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/revisionContent/index.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/revisionContent/index.tsx
@@ -1,24 +1,17 @@
 import * as React from "react";
 import { renderPlugins } from "@webiny/app/plugins";
-import { PbPageDetailsPlugin, PbPageDetailsRevisionContentPlugin } from "../../../../types";
+import { PbPageDetailsPlugin } from "../../../../types";
 import { Tabs } from "@webiny/ui/Tabs";
 
-const plugin: PbPageDetailsPlugin = {
+export default new PbPageDetailsPlugin({
     name: "pb-page-details-revision-content",
-    type: "pb-page-details",
     render(props) {
         return (
             <Tabs>
-                {renderPlugins<PbPageDetailsRevisionContentPlugin>(
-                    "pb-page-details-revision-content",
-                    props,
-                    {
-                        wrapper: false
-                    }
-                )}
+                {renderPlugins("pb-page-details-revision-content", props, {
+                    wrapper: false
+                })}
             </Tabs>
         );
     }
-};
-
-export default plugin;
+});

--- a/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
+++ b/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
@@ -5,7 +5,7 @@ import { PbEditorElement, PbEditorPageElementPlugin } from "../../types";
 import Title from "./components/Title";
 
 export default (el: PbEditorElement) => {
-    const elementPlugins = plugins.byType<PbEditorPageElementPlugin>("pb-editor-page-element");
+    const elementPlugins = plugins.byType(PbEditorPageElementPlugin);
     const rootPlugin = elementPlugins.find(pl => pl.elementType === el.content.type);
 
     if (!rootPlugin) {
@@ -14,31 +14,32 @@ export default (el: PbEditorElement) => {
 
     const name = "saved-element-" + el.id;
 
-    plugins.register({
-        name,
-        title: el.name,
-        type: "pb-editor-page-element",
-        elementType: name,
-        target: rootPlugin.target,
-        toolbar: {
-            title({ refresh }) {
-                return <Title plugin={name} title={el.name} id={el.id} refresh={refresh} />;
+    plugins.register(
+        new PbEditorPageElementPlugin({
+            name,
+            // title: el.name,
+            elementType: name,
+            target: rootPlugin.target,
+            toolbar: {
+                title({ refresh }) {
+                    return <Title plugin={name} title={el.name} id={el.id} refresh={refresh} />;
+                },
+                group: "pb-editor-element-group-saved",
+                preview() {
+                    return (
+                        <img
+                            src={el.preview.src}
+                            alt={el.name}
+                            style={{ width: 227, height: "auto", backgroundColor: "#fff" }}
+                        />
+                    );
+                }
             },
-            group: "pb-editor-element-group-saved",
-            preview() {
-                return (
-                    <img
-                        src={el.preview.src}
-                        alt={el.name}
-                        style={{ width: 227, height: "auto", backgroundColor: "#fff" }}
-                    />
-                );
+            onCreate: "skip",
+            settings: rootPlugin ? rootPlugin.settings : [],
+            create() {
+                return cloneDeep(el.content);
             }
-        },
-        onCreate: "skip",
-        settings: rootPlugin ? rootPlugin.settings : [],
-        create() {
-            return cloneDeep(el.content);
-        }
-    });
+        })
+    );
 };

--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -32,7 +32,7 @@ const getElementPlugin = (element: PbEditorElement): PbEditorPageElementPlugin =
         return null;
     }
 
-    const pluginsByType = plugins.byType<PbEditorPageElementPlugin>("pb-editor-page-element");
+    const pluginsByType = plugins.byType(PbEditorPageElementPlugin);
     return pluginsByType.find(pl => pl.elementType === element.type);
 };
 

--- a/packages/app-page-builder/src/editor/helpers.ts
+++ b/packages/app-page-builder/src/editor/helpers.ts
@@ -45,9 +45,7 @@ interface CreateElement {
 }
 
 export const createElement: CreateElement = (type, options = {}, parent) => {
-    const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
-        .find(pl => pl.elementType === type);
+    const plugin = plugins.byType(PbEditorPageElementPlugin).find(pl => pl.elementType === type);
 
     invariant(plugin, `Missing element plugin for type "${type}"!`);
 

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/basic/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/basic/index.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { ReactComponent as TextIcon } from "../../../assets/icons/round-text_format-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-const basicGroup: PbEditorPageElementGroupPlugin = {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-basic",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Basic",
         icon: <TextIcon />
     }
-};
-
-export default basicGroup;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/code/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/code/index.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { ReactComponent as CodeIcon } from "./code.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-export default {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-code",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Code",
         icon: <CodeIcon />
     }
-} as PbEditorPageElementGroupPlugin;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/form/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/form/index.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { ReactComponent as FormIcon } from "./round-developer_board-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-export default {
-    type: "pb-editor-page-element-group",
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-form",
     group: {
         title: "Form",
         icon: <FormIcon />
     }
-} as PbEditorPageElementGroupPlugin;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/image/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/image/index.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { ReactComponent as ImageGroupIcon } from "../../../assets/icons/round-collections-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-const imageGroup: PbEditorPageElementGroupPlugin = {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-image",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Image",
         icon: <ImageGroupIcon />
     }
-};
-
-export default imageGroup;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/layout/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/layout/index.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { ReactComponent as LayoutIcon } from "../../../assets/icons/round-view_quilt-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-const layoutGroup: PbEditorPageElementGroupPlugin = {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-layout",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Layout",
         icon: <LayoutIcon />
     }
-};
-
-export default layoutGroup;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/media/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/media/index.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { ReactComponent as MediaIcon } from "./round-music_video-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-export default {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-media",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Media",
         icon: <MediaIcon />
     }
-} as PbEditorPageElementGroupPlugin;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/saved/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/saved/index.tsx
@@ -4,9 +4,8 @@ import { PbEditorPageElementGroupPlugin } from "../../../../types";
 import EmptyElementGroupView from "../../../components/EmptyElementGroupView";
 import { ReactComponent as ContentIcon } from "../../../assets/icons/insights.svg";
 
-export default {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-saved",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Saved",
         icon: <SavedIcon />,
@@ -19,4 +18,4 @@ export default {
             />
         )
     }
-} as PbEditorPageElementGroupPlugin;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementGroups/social/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementGroups/social/index.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { ReactComponent as SocialIcon } from "./round-people-24px.svg";
 import { PbEditorPageElementGroupPlugin } from "../../../../types";
 
-export default {
+export default new PbEditorPageElementGroupPlugin({
     name: "pb-editor-element-group-social",
-    type: "pb-editor-page-element-group",
     group: {
         title: "Social",
         icon: <SocialIcon />
     }
-} as PbEditorPageElementGroupPlugin;
+});

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/AdvancedSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/AdvancedSettings.tsx
@@ -52,7 +52,7 @@ const AdvancedSettings: React.FunctionComponent<AdvancedSettingsPropsType> = ({ 
         <Form key={element && element.id} data={data} onSubmit={onSubmit}>
             {({ submit, Bind, data, form }) => (
                 <>
-                    {renderPlugins<PbEditorPageElementAdvancedSettingsPlugin>(
+                    {renderPlugins(
                         "pb-editor-page-element-advanced-settings",
                         { Bind, data, form, submit },
                         {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/advancedSettingsEditorAction.ts
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/advancedSettingsEditorAction.ts
@@ -9,7 +9,7 @@ export const advancedSettingsEditorAction: CreateElementEventActionCallable = (
 ) => {
     // Check the source of the element (could be `saved` element which behaves differently from other elements)
     const sourcePlugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === source.type);
     if (!sourcePlugin) {
         return {};
@@ -18,7 +18,7 @@ export const advancedSettingsEditorAction: CreateElementEventActionCallable = (
     if (!sourceOnCreate || sourceOnCreate !== "skip") {
         // If source element does not define a specific `onCreate` behavior - continue with the actual element plugin
         const plugin = plugins
-            .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+            .byType(PbEditorPageElementPlugin)
             .find(pl => pl.elementType === element.type);
         if (!plugin) {
             return {};

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/align/HorizontalAlignFlexSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/align/HorizontalAlignFlexSettings.tsx
@@ -104,7 +104,7 @@ const HorizontalAlignFlexSettings: React.FunctionComponent<PbEditorPageElementSe
         };
 
         const plugin = plugins
-            .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+            .byType(PbEditorPageElementPlugin)
             .find(pl => pl.elementType === element.type);
 
         if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/align/HorizontalAlignSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/align/HorizontalAlignSettings.tsx
@@ -98,7 +98,7 @@ const HorizontalAlignSettings: React.FunctionComponent<
     };
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === element.type);
 
     if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/align/VerticalAlignSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/align/VerticalAlignSettings.tsx
@@ -106,7 +106,7 @@ const VerticalAlignSettings: React.FunctionComponent<PbEditorPageElementSettings
         };
 
         const plugin = plugins
-            .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+            .byType(PbEditorPageElementPlugin)
             .find(pl => pl.elementType === element.type);
 
         if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/clone/CloneAction.ts
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/clone/CloneAction.ts
@@ -26,7 +26,7 @@ const CloneAction: React.FunctionComponent<CloneActionPropsType> = ({ children }
     };
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === element.type);
 
     if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/delete/DeleteAction.ts
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/delete/DeleteAction.ts
@@ -27,7 +27,7 @@ const DeleteAction: React.FunctionComponent<DeleteActionPropsType> = ({ children
     }, [activeElementId]);
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === element.type);
 
     if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/hooks/useElementSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/hooks/useElementSettings.tsx
@@ -64,7 +64,7 @@ const useElementSettings = () => {
     });
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === elementType);
 
     return getElementActions(plugin);

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/hooks/useElementStyleSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/hooks/useElementStyleSettings.tsx
@@ -68,7 +68,7 @@ const useElementStyleSettings = () => {
     });
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === elementType);
 
     return getElementActions(plugin);

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
@@ -138,7 +138,7 @@ const SaveAction: React.FunctionComponent = ({ children }) => {
     }
 
     const plugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === element.type);
 
     if (!plugin) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog/ElementPreview.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog/ElementPreview.tsx
@@ -6,7 +6,7 @@ import { PbEditorPageElementPlugin } from "../../../../../types";
 
 const replaceContent = (element: any, doc: Document): Document => {
     const pl = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === element.type);
 
     if (!pl) {

--- a/packages/app-page-builder/src/editor/plugins/elements/block/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/block/index.tsx
@@ -17,7 +17,7 @@ import {
 import { AfterDropElementActionEvent } from "../../../recoil/actions/afterDropElement";
 import { createInitialPerDeviceSettingValue } from "../../elementSettings/elementSettingsUtils";
 
-export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorElementPluginArgs = {}) => {
     const elementSettings = [
         "pb-editor-page-element-style-settings-background",
         "pb-editor-page-element-style-settings-animation",
@@ -35,9 +35,8 @@ export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin
 
     const elementType = kebabCase(args.elementType || "block");
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
-        type: "pb-editor-page-element",
         elementType: elementType,
         settings:
             typeof args.settings === "function" ? args.settings(elementSettings) : elementSettings,
@@ -126,5 +125,5 @@ export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin
             );
             return result;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/button/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/index.tsx
@@ -42,9 +42,8 @@ const buttonElementPluginsFactory = (args: PbEditorElementPluginArgs = {}) => {
     const elementType = kebabCase(args.elementType || "button");
 
     return [
-        {
+        new PbEditorPageElementPlugin({
             name: `pb-editor-page-element-${elementType}`,
-            type: "pb-editor-page-element",
             elementType: elementType,
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -78,7 +77,7 @@ const buttonElementPluginsFactory = (args: PbEditorElementPluginArgs = {}) => {
             render({ element }) {
                 return <Button element={element} />;
             }
-        } as PbEditorPageElementPlugin,
+        }),
         {
             name: "pb-editor-page-element-style-settings-button",
             type: "pb-editor-page-element-style-settings",

--- a/packages/app-page-builder/src/editor/plugins/elements/cell/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/cell/index.tsx
@@ -32,8 +32,7 @@ const cellPlugin = (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPl
 
     const elementType = kebabCase(args.elementType || "cell");
 
-    return {
-        type: "pb-editor-page-element",
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
         elementType,
         settings:
@@ -110,7 +109,7 @@ const cellPlugin = (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPl
         render(props) {
             return <CellContainer {...props} elementId={props.element.id} />;
         }
-    };
+    });
 };
 // this is required because when saving cell element it cannot be without grid element
 const saveActionPlugin = {

--- a/packages/app-page-builder/src/editor/plugins/elements/document/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/document/index.tsx
@@ -2,10 +2,9 @@ import React from "react";
 import Document from "./Document";
 import { PbEditorPageElementPlugin, PbEditorElement } from "../../../../types";
 
-export default (): PbEditorPageElementPlugin => {
-    return {
+export default () => {
+    return new PbEditorPageElementPlugin({
         name: "pb-editor-page-element-document",
-        type: "pb-editor-page-element",
         elementType: "document",
         create(options = {}) {
             return {
@@ -18,5 +17,5 @@ export default (): PbEditorPageElementPlugin => {
             // TODO figure out if we can change this on the plugin type level
             return <Document element={element as unknown as PbEditorElement} />;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/grid/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/grid/index.tsx
@@ -36,7 +36,7 @@ const createDefaultCells = (cellsType: string) => {
     });
 };
 
-export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorElementPluginArgs = {}) => {
     const defaultSettings = [
         "pb-editor-page-element-style-settings-grid",
         "pb-editor-page-element-style-settings-background",
@@ -67,8 +67,7 @@ export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin
         }
     };
 
-    return {
-        type: "pb-editor-page-element",
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
         elementType: elementType,
         toolbar: typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -130,5 +129,5 @@ export default (args: PbEditorElementPluginArgs = {}): PbEditorPageElementPlugin
         render({ element }) {
             return <GridContainer element={element} />;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/heading/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/heading/index.tsx
@@ -5,7 +5,7 @@ import { createInitialPerDeviceSettingValue } from "../../elementSettings/elemen
 import { createInitialTextValue } from "../utils/textUtils";
 import Heading from "./Heading";
 
-export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorTextElementPluginsArgs = {}) => {
     const defaultText = "Heading";
 
     const defaultSettings = [
@@ -32,9 +32,8 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
 
     const elementType = kebabCase(args.elementType || "heading");
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
-        type: "pb-editor-page-element",
         elementType: elementType,
         toolbar: typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
         settings:
@@ -82,5 +81,5 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         render(props) {
             return <Heading {...props} mediumEditorOptions={args.mediumEditorOptions} />;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/icon/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/icon/index.tsx
@@ -53,9 +53,8 @@ export default (args: PbEditorElementPluginArgs = {}) => {
     ];
 
     return [
-        {
+        new PbEditorPageElementPlugin({
             name: `pb-editor-page-element-${elementType}`,
-            type: "pb-editor-page-element",
             elementType: elementType,
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -93,7 +92,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             render(props) {
                 return <Icon {...props} />;
             }
-        } as PbEditorPageElementPlugin,
+        }),
         {
             name: "pb-editor-page-element-style-settings-icon",
             type: "pb-editor-page-element-style-settings",

--- a/packages/app-page-builder/src/editor/plugins/elements/image/imageCreatedEditorAction.ts
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/imageCreatedEditorAction.ts
@@ -30,7 +30,7 @@ export const imageCreatedEditorAction: CreateElementEventActionCallable = (
 
     // Check the source of the element (could be `saved` element which behaves differently from other elements)
     const imagePlugin = plugins
-        .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+        .byType(PbEditorPageElementPlugin)
         .find(pl => pl.elementType === source.type);
 
     if (!imagePlugin) {

--- a/packages/app-page-builder/src/editor/plugins/elements/image/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/index.tsx
@@ -54,9 +54,8 @@ export default (args: PbEditorElementPluginArgs = {}): Plugin[] => {
     ];
 
     return [
-        {
+        new PbEditorPageElementPlugin({
             name: `pb-editor-page-element-${elementType}`,
-            type: "pb-editor-page-element",
             elementType: elementType,
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -93,7 +92,7 @@ export default (args: PbEditorElementPluginArgs = {}): Plugin[] => {
             render({ element }) {
                 return <Image element={element} />;
             }
-        } as PbEditorPageElementPlugin,
+        }),
         {
             name: "pb-editor-page-element-style-settings-image",
             type: "pb-editor-page-element-style-settings",

--- a/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
@@ -41,9 +41,8 @@ export default (args: PbEditorElementPluginArgs = {}) => {
     const defaultSettings = ["pb-editor-page-element-settings-delete"];
 
     return [
-        {
+        new PbEditorPageElementPlugin({
             name: `pb-editor-page-element-${elementType}`,
-            type: "pb-editor-page-element",
             elementType: elementType,
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -77,7 +76,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             render({ element }) {
                 return <ImagesList data={element.data} />;
             }
-        } as PbEditorPageElementPlugin,
+        }),
         {
             name: "pb-editor-page-element-advanced-settings-images-list-filter",
             type: "pb-editor-page-element-advanced-settings",

--- a/packages/app-page-builder/src/editor/plugins/elements/list/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/list/index.tsx
@@ -5,7 +5,7 @@ import List, { className } from "./List";
 import { createInitialTextValue } from "../utils/textUtils";
 import { createInitialPerDeviceSettingValue } from "../../elementSettings/elementSettingsUtils";
 
-export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorTextElementPluginsArgs = {}) => {
     const elementType = kebabCase(args.elementType || "list");
 
     const defaultToolbar = {
@@ -35,9 +35,8 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         "pb-editor-page-element-settings-delete"
     ];
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
-        type: "pb-editor-page-element",
         elementType: elementType,
         toolbar: typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
         settings:
@@ -86,5 +85,5 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         render({ element }) {
             return <List elementId={element.id} mediumEditorOptions={args.mediumEditorOptions} />;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/pagesList/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/pagesList/index.tsx
@@ -41,9 +41,8 @@ export default (args: PbEditorElementPluginArgs = {}): PluginCollection => {
     const defaultSettings = ["pb-editor-page-element-settings-delete"];
 
     return [
-        {
+        new PbEditorPageElementPlugin({
             name: `pb-editor-page-element-${elementType}`,
-            type: "pb-editor-page-element",
             elementType: elementType,
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
@@ -78,7 +77,7 @@ export default (args: PbEditorElementPluginArgs = {}): PluginCollection => {
             render({ element }) {
                 return <PagesList data={element.data} />;
             }
-        } as PbEditorPageElementPlugin,
+        }),
         {
             name: "pb-editor-page-element-advanced-settings-pages-list-filter",
             type: "pb-editor-page-element-advanced-settings",

--- a/packages/app-page-builder/src/editor/plugins/elements/paragraph/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/paragraph/index.tsx
@@ -5,7 +5,7 @@ import Paragraph, { textClassName } from "./Paragraph";
 import { createInitialTextValue } from "../utils/textUtils";
 import { createInitialPerDeviceSettingValue } from "../../elementSettings/elementSettingsUtils";
 
-export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorTextElementPluginsArgs = {}) => {
     const defaultText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
      Suspendisse varius enim in eros elementum tristique.
      Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat.
@@ -32,9 +32,8 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         "pb-editor-page-element-settings-delete"
     ];
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
-        type: "pb-editor-page-element",
         elementType: elementType,
         toolbar: typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
         settings:
@@ -80,5 +79,5 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
                 <Paragraph elementId={element.id} mediumEditorOptions={args.mediumEditorOptions} />
             );
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/quote/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/quote/index.tsx
@@ -5,7 +5,7 @@ import { DisplayMode, PbEditorPageElementPlugin, PbEditorTextElementPluginsArgs 
 import { createInitialTextValue } from "../utils/textUtils";
 import { createInitialPerDeviceSettingValue } from "../../elementSettings/elementSettingsUtils";
 
-export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementPlugin => {
+export default (args: PbEditorTextElementPluginsArgs = {}) => {
     const defaultText = "Block Quote";
     const elementType = kebabCase(args.elementType || "quote");
     const defaultToolbar = {
@@ -32,9 +32,8 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         "pb-editor-page-element-settings-delete"
     ];
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: `pb-editor-page-element-${elementType}`,
-        type: "pb-editor-page-element",
         elementType: elementType,
         toolbar: typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
         settings:
@@ -77,5 +76,5 @@ export default (args: PbEditorTextElementPluginsArgs = {}): PbEditorPageElementP
         render({ element }) {
             return <Quote elementId={element.id} mediumEditorOptions={args.mediumEditorOptions} />;
         }
-    };
+    });
 };

--- a/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/createEmbedPlugin.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/createEmbedPlugin.tsx
@@ -36,12 +36,11 @@ type EmbedPluginConfig = {
     }) => React.ReactElement;
 };
 
-export const createEmbedPlugin = (config: EmbedPluginConfig): PbEditorPageElementPlugin => {
+export const createEmbedPlugin = (config: EmbedPluginConfig) => {
     const defaultSettings = ["pb-editor-page-element-settings-delete"];
 
-    return {
+    return new PbEditorPageElementPlugin({
         name: "pb-editor-page-element-" + config.type,
-        type: "pb-editor-page-element",
         elementType: config.type,
         toolbar: config.toolbar,
         settings:
@@ -80,7 +79,7 @@ export const createEmbedPlugin = (config: EmbedPluginConfig): PbEditorPageElemen
         },
         onCreate: config.onCreate || "open-settings",
         renderElementPreview: config.renderElementPreview
-    };
+    });
 };
 
 type EmbedPluginSidebarConfig = {

--- a/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/useRenderEmptyEmbed.ts
+++ b/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/useRenderEmptyEmbed.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { plugins } from "@webiny/plugins";
-import { PbEditorElement } from "../../../../../types";
+import { PbEditorElement, PbEditorPageElementPlugin } from "../../../../../types";
 
 export default (element: PbEditorElement) => {
     return useCallback(() => {
@@ -9,7 +9,7 @@ export default (element: PbEditorElement) => {
         }
 
         const [pageElementPlugin] = plugins
-            .byType("pb-editor-page-element")
+            .byType(PbEditorPageElementPlugin)
             .filter(pl => pl.elementType === element.type);
         return pageElementPlugin.toolbar.preview();
     }, [element]);

--- a/packages/app-page-builder/src/editor/plugins/toolbar/addElement/AddElement.tsx
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/addElement/AddElement.tsx
@@ -66,12 +66,12 @@ const AddElement: React.FunctionComponent = () => {
         handler.trigger(new DropElementActionEvent(args));
     }, []);
     const getGroups = useCallback(() => {
-        return plugins.byType<PbEditorPageElementGroupPlugin>("pb-editor-page-element-group");
+        return plugins.byType(PbEditorPageElementGroupPlugin);
     }, []);
 
     const getGroupElements = useCallback(group => {
         return plugins
-            .byType<PbEditorPageElementPlugin>("pb-editor-page-element")
+            .byType(PbEditorPageElementPlugin)
             .filter(el => el.toolbar && el.toolbar.group === group);
     }, []);
 

--- a/packages/app-page-builder/src/editor/recoil/actions/afterDropElement/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/afterDropElement/action.ts
@@ -2,13 +2,13 @@ import { plugins } from "@webiny/plugins";
 import { EventActionCallable, PbEditorPageElementPlugin } from "../../../../types";
 import { AfterDropElementActionArgsType } from "./types";
 
-const elementPluginType = "pb-editor-page-element";
-
-const getElementTypePlugin = (type: string): PbEditorPageElementPlugin => {
-    const pluginsByType = plugins.byType<PbEditorPageElementPlugin>(elementPluginType);
+const getElementTypePlugin = (type: string) => {
+    const pluginsByType = plugins.byType(PbEditorPageElementPlugin);
     const plugin = pluginsByType.find(pl => pl.elementType === type);
     if (!plugin) {
-        throw new Error(`There is no plugin in "${elementPluginType}" for element type ${type}`);
+        throw new Error(
+            `There is no plugin in "${PbEditorPageElementPlugin.type}" for element type ${type}`
+        );
     }
     return plugin;
 };

--- a/packages/app-page-builder/src/editor/recoil/actions/dropElement/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/dropElement/action.ts
@@ -9,13 +9,13 @@ import {
 import { plugins } from "@webiny/plugins";
 import { DropElementActionArgsType } from "./types";
 
-const elementPluginType = "pb-editor-page-element";
-
 const getElementTypePlugin = (type: string): PbEditorPageElementPlugin => {
-    const pluginsByType = plugins.byType<PbEditorPageElementPlugin>(elementPluginType);
+    const pluginsByType = plugins.byType(PbEditorPageElementPlugin);
     const plugin = pluginsByType.find(pl => pl.elementType === type);
     if (!plugin) {
-        throw new Error(`There is no plugin in "${elementPluginType}" for element type ${type}`);
+        throw new Error(
+            `There is no plugin in "${PbEditorPageElementPlugin.type}" for element type ${type}`
+        );
     }
     return plugin;
 };

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -8,6 +8,7 @@ import { BindComponent } from "@webiny/form/Bind";
 import { IconPrefix, IconName } from "@fortawesome/fontawesome-svg-core";
 import { Form, FormSetValue } from "@webiny/form/Form";
 import { CoreOptions } from "medium-editor";
+import { definePlugin, PluginInstance } from "@webiny/plugins";
 
 export enum PageImportExportTaskStatus {
     PENDING = "pending",
@@ -282,26 +283,30 @@ export type PbAddonRenderPlugin = Plugin & {
 export type PbDocumentElementPlugin = Plugin & {
     elementType: "document";
     create(options?: any): PbElement;
-    render(props): ReactElement;
 };
 
-export type PbPageDetailsRevisionContentPlugin = Plugin & {
-    type: "pb-page-details-revision-content";
+export interface PbPageDetailsPluginConfig {
     render(params: { page: Record<string, any>; getPageQuery: any }): ReactElement;
-};
+}
 
-export type PbPageDetailsHeaderRightOptionsMenuItemPlugin = Plugin & {
-    type: "pb-page-details-header-right-options-menu-item";
-    render(props: any): ReactElement;
-};
+export const PbPageDetailsPlugin = definePlugin<PbPageDetailsPluginConfig>({
+    type: "pb-page-details"
+});
 
-export type PbPageDetailsRevisionContentPreviewPlugin = Plugin & {
-    type: "pb-page-details-revision-content-preview";
-    render(params: { page: Record<string, any>; getPageQuery: any }): ReactElement;
-};
+export const PbPageDetailsRevisionContentPlugin = definePlugin<PbPageDetailsPluginConfig>({
+    type: "pb-page-details-revision-content"
+});
 
-export type PbMenuItemPlugin = Plugin & {
-    type: "pb-menu-item";
+export const PbPageDetailsHeaderRightOptionsMenuItemPlugin =
+    definePlugin<PbPageDetailsPluginConfig>({
+        type: "pb-page-details-header-right-options-menu-item"
+    });
+
+export const PbPageDetailsRevisionContentPreviewPlugin = definePlugin<PbPageDetailsPluginConfig>({
+    type: "pb-page-details-revision-content-preview"
+});
+
+export interface PbMenuItemPluginConfig {
     menuItem: {
         /* Item type (this will be stored to DB when menu is saved) */
         type: string;
@@ -318,10 +323,13 @@ export type PbMenuItemPlugin = Plugin & {
             onCancel: Function;
         }) => ReactElement;
     };
-};
+}
 
-export type PbEditorPageElementGroupPlugin = Plugin & {
-    type: "pb-editor-page-element-group";
+export const PbMenuItemPlugin = definePlugin<PbMenuItemPluginConfig>({
+    type: "pb-menu-item"
+});
+
+export interface PbEditorPageElementGroupPluginConfig {
     group: {
         // Title rendered in the toolbar.
         title: string;
@@ -330,12 +338,15 @@ export type PbEditorPageElementGroupPlugin = Plugin & {
         // Empty element group view rendered in the toolbar.
         emptyView?: ReactElement;
     };
-};
+}
+
+export const PbEditorPageElementGroupPlugin = definePlugin<PbEditorPageElementGroupPluginConfig>({
+    type: "pb-editor-page-element-group"
+});
 
 export type PbEditorPageElementTitle = (params: { refresh: () => void }) => ReactNode;
 
-export type PbEditorPageElementPlugin = Plugin & {
-    type: "pb-editor-page-element";
+export interface PbEditorPageElementPluginConfig {
     elementType: string;
     toolbar?: {
         // Element title in the toolbar.
@@ -343,7 +354,7 @@ export type PbEditorPageElementPlugin = Plugin & {
         // Element group this element belongs to.
         group?: string;
         // A function to render an element preview in the toolbar.
-        preview?: ({ theme: PbTheme }) => ReactNode;
+        preview?(params?: { theme?: PbTheme }): ReactNode;
     };
     // Help link
     help?: string;
@@ -357,7 +368,11 @@ export type PbEditorPageElementPlugin = Plugin & {
         parent?: PbEditorElement
     ) => Omit<PbEditorElement, "id">;
     // A function to render an element in the editor.
-    render: (params: { theme?: PbTheme; element: PbEditorElement; isActive: boolean }) => ReactNode;
+    render?: (params: {
+        theme?: PbTheme;
+        element: PbEditorElement;
+        isActive: boolean;
+    }) => ReactNode;
     // A function to check if an element can be deleted.
     canDelete?: (params: { element: PbEditorElement }) => boolean;
     // Executed when another element is dropped on the drop zones of current element.
@@ -382,15 +397,17 @@ export type PbEditorPageElementPlugin = Plugin & {
         width: number;
         height: number;
     }) => ReactElement;
-};
+}
+
+export const PbEditorPageElementPlugin = definePlugin<PbEditorPageElementPluginConfig>({
+    type: "pb-editor-page-element"
+});
+
+export type PbEditorPageElementPlugin = PluginInstance<typeof PbEditorPageElementPlugin>;
 
 export type PbEditorPageElementActionPlugin = Plugin & {
     type: "pb-editor-page-element-action";
     render: (params: { element: PbEditorElement; plugin: PbEditorPageElementPlugin }) => ReactNode;
-};
-
-export type PbPageDetailsPlugin = Plugin & {
-    render: (params: { page: Record<string, any>; [key: string]: any }) => ReactNode;
 };
 
 export type PbEditorPageSettingsPlugin = Plugin & {

--- a/packages/app-typeform/src/admin/index.tsx
+++ b/packages/app-typeform/src/admin/index.tsx
@@ -29,9 +29,8 @@ const PreviewBox = styled("div")({
 
 export default () => [
     render(),
-    {
+    new PbEditorPageElementPlugin({
         name: "pb-page-element-typeform",
-        type: "pb-editor-page-element",
         elementType: "typeform",
         toolbar: {
             title: "Typeform",
@@ -69,7 +68,7 @@ export default () => [
                 }
             };
         }
-    } as PbEditorPageElementPlugin,
+    }),
     {
         name: "pb-editor-page-element-advanced-settings-typeform",
         type: "pb-editor-page-element-advanced-settings",

--- a/packages/plugins/src/Plugin.ts
+++ b/packages/plugins/src/Plugin.ts
@@ -1,14 +1,69 @@
-export abstract class Plugin {
-    public static readonly type: string;
-    public name: string;
+export interface PluginOptions {
+    /**
+     * Name of the plugin.
+     * Used for example for logging purposes.
+     */
+    readonly name?: string;
+}
 
-    constructor() {
+export interface PluginBase {
+    readonly name?: string;
+    readonly type: string;
+}
+
+export abstract class Plugin implements PluginBase {
+    public static readonly type: string;
+    public readonly name?: string;
+
+    constructor(options: PluginOptions) {
         if (!(this.constructor as typeof Plugin).type) {
             throw Error(`Missing "type" definition in "${this.constructor.name}"!`);
         }
+
+        this.name = options.name;
     }
 
     get type() {
         return (this.constructor as typeof Plugin).type;
     }
+}
+
+export abstract class PluginWithConfig<TConfig> extends Plugin {
+    public readonly name?: string;
+
+    constructor(public readonly config: TConfig & PluginOptions) {
+        super(config);
+    }
+}
+
+export interface PluginConstructor<TPlugin extends Plugin = Plugin, TConfig extends {} = {}> {
+    new (config: TConfig & PluginOptions): TPlugin;
+    prototype: TPlugin;
+    readonly type: string;
+}
+
+export type PluginInstance<T extends PluginConstructor> = T extends PluginConstructor<
+    infer TPlugin,
+    infer TConfig
+>
+    ? TPlugin & TConfig
+    : never;
+
+interface DefinePluginOptions {
+    type: string;
+}
+
+export function definePlugin<T>(options: DefinePluginOptions) {
+    const { type } = options;
+    const plugin = class extends Plugin {
+        public static readonly type = type;
+        public readonly name?: string;
+
+        constructor(config: T & PluginOptions) {
+            super(config);
+            Object.assign(this, config);
+        }
+    };
+
+    return plugin as PluginConstructor<Plugin & T, T>;
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -3,4 +3,5 @@ import { Plugin } from "./Plugin";
 
 const plugins = new PluginsContainer();
 
+export * from "./Plugin";
 export { Plugin, PluginsContainer, plugins };


### PR DESCRIPTION
## Changes
Currently, plugins are written as plain objects with the required `type` property, that serves as a discriminator.
This has several drawbacks:
- typings are hard, we lose the whole power of Typescript
- there is no intellisense, no way to tell which properties are required for the plugin config
- documentation for plugins is difficult to create, no tool will auto-generate a reference docs for that

We want to migrate to more class-based plugins, so every plugin instance will be created with a constructor `new MyPlugin({ ... })`. This way we can ensure good TypeScript types, and inline docs for each plugin parameter. It will be also easier to navigate between available plugins in the reference documentation (that is about to be created).

Basically, this task is a big epic, that will require a lot of work, to be finished, so probably we won't do it in one shot.
This mechanism will be backward compatible, so it should not break your code.

## How Has This Been Tested?
❌Not tested yet, draft only

## Documentation
⌛Will have to update current plugin docs after making the changes.
