### PR TITLE
fix(api-headless-cms): schema break when no fields in nested obj

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -45,6 +45,7 @@ const ids = {
     field217: shortId.generate(),
     field218: shortId.generate(),
     field219: shortId.generate(),
+    field220: shortId.generate(),
     // product review
     field31: shortId.generate(),
     field32: shortId.generate(),
@@ -177,7 +178,8 @@ const models: CmsModel[] = [
             [ids.field208],
             [ids.field209],
             [ids.field210],
-            [ids.field211]
+            [ids.field211],
+            [ids.field220]
         ],
         fields: [
             {
@@ -637,6 +639,27 @@ const models: CmsModel[] = [
                             }
                         }
                     ]
+                },
+                validation: [],
+                listValidation: [],
+                placeholderText: "",
+                predefinedValues: {
+                    enabled: false,
+                    values: []
+                },
+                renderer: {
+                    name: "renderer"
+                }
+            },
+            {
+                id: ids.field220,
+                multipleValues: false,
+                helpText: "",
+                label: "No fields object",
+                fieldId: "noFieldsObject",
+                type: "object",
+                settings: {
+                    fields: []
                 },
                 validation: [],
                 listValidation: [],

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -90,6 +90,9 @@ describe("MANAGE - Resolvers", () => {
         if (create.errors) {
             console.error(`[beforeEach] ${create.errors[0].message}`);
             process.exit(1);
+        } else if (create.data.createContentModel.error) {
+            console.error(`[beforeEach] ${create.data.createContentModel.error.message}`);
+            process.exit(1);
         }
 
         const [update] = await updateContentModelMutation({
@@ -103,7 +106,11 @@ describe("MANAGE - Resolvers", () => {
         if (update.errors) {
             console.error(`[beforeEach] ${update.errors[0].message}`);
             process.exit(1);
+        } else if (update.data.updateContentModel.error) {
+            console.error(`[beforeEach] ${update.data.updateContentModel.error.message}`);
+            process.exit(1);
         }
+        return update.data.updateContentModel.data;
     };
 
     const createCategories = async (): Promise<CreateCategoriesResult> => {

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/object.ts
@@ -4,13 +4,27 @@ import { renderField } from "~/content/plugins/utils/renderFields";
 import { renderInputField } from "~/content/plugins/utils/renderInputFields";
 import { createManageTypeName, createTypeName } from "~/content/plugins/utils/createTypeName";
 
-const typeFromField = ({ typeOfType, model, type, field, fieldTypePlugins }) => {
+interface TypeFromFieldResponse {
+    fieldType: string;
+    typeDefs: string;
+}
+const typeFromField = ({
+    typeOfType,
+    model,
+    type,
+    field,
+    fieldTypePlugins
+}): TypeFromFieldResponse | null => {
     const typeSuffix = typeOfType === "input" ? "Input" : "";
     const typeName = createTypeName(model.modelId);
     const mTypeName = createManageTypeName(typeName);
 
     // `field` is an "object" field
     const fields = field.settings.fields as CmsModelField[];
+
+    if (!fields || fields.length === 0) {
+        return null;
+    }
     const fieldTypeName = `${mTypeName}_${upperFirst(field.fieldId)}`;
 
     const typeFields = [];
@@ -55,7 +69,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
     isSearchable: false,
     read: {
         createTypeField({ field, model, fieldTypePlugins }) {
-            const { fieldType, typeDefs } = typeFromField({
+            const result = typeFromField({
                 typeOfType: "type",
                 model,
                 type: "read",
@@ -63,25 +77,39 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 fieldTypePlugins
             });
 
+            if (!result) {
+                return {
+                    fields: "",
+                    typeDefs: ""
+                };
+            }
+            const { fieldType, typeDefs } = result;
+
             return {
                 fields: `${field.fieldId}: ${field.multipleValues ? `[${fieldType}!]` : fieldType}`,
                 typeDefs
             };
         },
         createResolver({ field, createFieldResolvers, graphQLType }) {
+            if (!field.settings.fields || field.settings.fields.length === 0) {
+                return false;
+            }
+
             const fieldType = `${graphQLType}_${upperFirst(field.fieldId)}`;
+
+            const typeResolvers = createFieldResolvers({
+                graphQLType: fieldType,
+                fields: field.settings.fields
+            });
             return {
                 resolver: null,
-                typeResolvers: createFieldResolvers({
-                    graphQLType: fieldType,
-                    fields: field.settings.fields
-                })
+                typeResolvers: typeResolvers || {}
             };
         }
     },
     manage: {
         createTypeField({ model, field, fieldTypePlugins }) {
-            const { fieldType, typeDefs } = typeFromField({
+            const result = typeFromField({
                 typeOfType: "type",
                 model,
                 type: "manage",
@@ -89,19 +117,34 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 fieldTypePlugins
             });
 
+            if (!result) {
+                return {
+                    fields: "",
+                    typeDefs: ""
+                };
+            }
+            const { fieldType, typeDefs } = result;
+
             return {
                 fields: `${field.fieldId}: ${field.multipleValues ? `[${fieldType}!]` : fieldType}`,
                 typeDefs
             };
         },
         createInputField({ model, field, fieldTypePlugins }) {
-            const { fieldType, typeDefs } = typeFromField({
+            const result = typeFromField({
                 typeOfType: "input",
                 model,
                 type: "manage",
                 field,
                 fieldTypePlugins
             });
+            if (!result) {
+                return {
+                    fields: "",
+                    typeDefs: ""
+                };
+            }
+            const { fieldType, typeDefs } = result;
 
             return {
                 fields: `${field.fieldId}: ${field.multipleValues ? `[${fieldType}!]` : fieldType}`,
@@ -109,13 +152,17 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             };
         },
         createResolver({ graphQLType, field, createFieldResolvers }) {
+            if (!field.settings.fields || field.settings.fields.length === 0) {
+                return false;
+            }
             const fieldType = `${graphQLType}_${upperFirst(field.fieldId)}`;
+            const typeResolvers = createFieldResolvers({
+                graphQLType: fieldType,
+                fields: field.settings.fields
+            });
             return {
                 resolver: null,
-                typeResolvers: createFieldResolvers({
-                    graphQLType: fieldType,
-                    fields: field.settings.fields
-                })
+                typeResolvers: typeResolvers || {}
             };
         }
     }

--- a/packages/api-headless-cms/src/content/plugins/schema/createFieldResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createFieldResolvers.ts
@@ -37,6 +37,10 @@ export function createFieldResolversFactory({ endpointType, models, model, field
                 ? createResolver({ graphQLType, models, model, field, createFieldResolvers })
                 : null;
 
+            /**
+             * When fieldResolver is false it will completely skip adding fieldId into the resolvers.
+             * This is to fix the breaking of GraphQL schema.
+             */
             if (fieldResolver === false) {
                 continue;
             } else if (typeof fieldResolver === "function") {

--- a/packages/api-headless-cms/src/content/plugins/schema/createFieldResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createFieldResolvers.ts
@@ -37,9 +37,11 @@ export function createFieldResolversFactory({ endpointType, models, model, field
                 ? createResolver({ graphQLType, models, model, field, createFieldResolvers })
                 : null;
 
-            if (typeof fieldResolver === "function") {
+            if (fieldResolver === false) {
+                continue;
+            } else if (typeof fieldResolver === "function") {
                 resolver = fieldResolver;
-            } else if (fieldResolver !== null) {
+            } else if (fieldResolver) {
                 resolver = fieldResolver.resolver;
                 Object.assign(typeResolvers, fieldResolver.typeResolvers);
             }

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
@@ -40,6 +40,19 @@ export const createManageResolvers: CreateManageResolvers = ({
         fieldTypePlugins
     });
 
+    const fieldResolvers = createFieldResolvers({
+        graphQLType: mTypeName,
+        fields: model.fields,
+        isRoot: true,
+        // These are extra fields we want to apply to field resolvers of "gqlType"
+        extraResolvers: {
+            ...commonFieldResolvers(),
+            meta(entry) {
+                return entry;
+            }
+        }
+    });
+
     return {
         Query: {
             [`get${typeName}`]: resolveGet({ model }),
@@ -57,18 +70,7 @@ export const createManageResolvers: CreateManageResolvers = ({
             [`request${typeName}Review`]: resolveRequestReview({ model }),
             [`request${typeName}Changes`]: resolveRequestChanges({ model })
         },
-        ...createFieldResolvers({
-            graphQLType: mTypeName,
-            fields: model.fields,
-            isRoot: true,
-            // These are extra fields we want to apply to field resolvers of "gqlType"
-            extraResolvers: {
-                ...commonFieldResolvers(),
-                meta(entry) {
-                    return entry;
-                }
-            }
-        }),
+        ...fieldResolvers,
         [`${mTypeName}Meta`]: {
             title(entry) {
                 return getEntryTitle(model, entry);

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
@@ -27,7 +27,7 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
     const fields = renderFields({ model, type: "manage", fieldTypePlugins });
 
     return /* GraphQL */ `
-        """${model.description}"""
+        """${model.description || model.modelId}"""
         ${fields
             .map(f => f.typeDefs)
             .filter(Boolean)

--- a/packages/api-headless-cms/src/content/plugins/schema/createPreviewResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createPreviewResolvers.ts
@@ -29,15 +29,17 @@ export const createPreviewResolvers: CreateReadResolvers = ({
         fieldTypePlugins
     });
 
+    const fieldResolvers = createFieldResolvers({
+        graphQLType: rTypeName,
+        fields: model.fields,
+        isRoot: true
+    });
+
     return {
         Query: {
             [`get${typeName}`]: resolveGet({ model }),
             [`list${pluralizedTypeName(typeName)}`]: resolveList({ model })
         },
-        ...createFieldResolvers({
-            graphQLType: rTypeName,
-            fields: model.fields,
-            isRoot: true
-        })
+        ...fieldResolvers
     };
 };

--- a/packages/api-headless-cms/src/content/plugins/schema/createReadResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createReadResolvers.ts
@@ -25,15 +25,17 @@ export const createReadResolvers: CreateReadResolvers = ({ models, model, fieldT
         fieldTypePlugins
     });
 
+    const fieldResolvers = createFieldResolvers({
+        graphQLType: rTypeName,
+        fields: model.fields,
+        isRoot: true
+    });
+
     return {
         Query: {
             [`get${typeName}`]: resolveGet({ model }),
             [`list${pluralizedTypeName(typeName)}`]: resolveList({ model })
         },
-        ...createFieldResolvers({
-            graphQLType: rTypeName,
-            fields: model.fields,
-            isRoot: true
-        })
+        ...fieldResolvers
     };
 };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -390,7 +390,8 @@ export interface CmsModelFieldToGraphQLCreateResolver {
         createFieldResolvers: any;
     }):
         | GraphQLFieldResolver
-        | { resolver: GraphQLFieldResolver; typeResolvers: Resolvers<CmsContext> };
+        | { resolver: GraphQLFieldResolver; typeResolvers: Resolvers<CmsContext> }
+        | false;
 }
 
 /**


### PR DESCRIPTION
## Changes

Closes #2001

Fixed GraphQL schema which breaks when adding CMS object field with no nested fields.

## How Has This Been Tested?
Jest and manual testing.
