### PR TITLE
feat(api-headless-cms): republish existing entries

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -682,7 +682,7 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
             model
         });
 
-        if (publishedStorageEntry) {
+        if (publishedStorageEntry && publishedStorageEntry.id !== entry.id) {
             /**
              * If there is a `published` entry already, we need to set it to `unpublished`. We need to
              * execute two updates: update the previously published entry's status and the published entry record.

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -770,7 +770,7 @@ export const createEntriesStorageOperations = (params: Params): CmsEntryStorageO
                 })
             );
         }
-        if (publishedStorageEntry) {
+        if (publishedStorageEntry && publishedStorageEntry.id !== entry.id) {
             items.push(
                 entity.putBatch({
                     ...publishedStorageEntry,

--- a/packages/api-headless-cms/__tests__/contentAPI/republish.entries.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/republish.entries.test.ts
@@ -1,0 +1,174 @@
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+import { CmsGroup, CmsModel } from "~/types";
+import models from "./mocks/contentModels";
+import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
+
+describe("Republish entries", () => {
+    const manageOpts = { path: "manage/en-US" };
+
+    const {
+        createContentModelMutation,
+        updateContentModelMutation,
+        createContentModelGroupMutation
+    } = useContentGqlHandler(manageOpts);
+
+    // This function is not directly within `beforeEach` as we don't always setup the same content model.
+    // We call this function manually at the beginning of each test, where needed.
+    const setupGroup = async (): Promise<CmsGroup> => {
+        const [createCMG] = await createContentModelGroupMutation({
+            data: {
+                name: "Group",
+                slug: "group",
+                icon: "ico/ico",
+                description: "description"
+            }
+        });
+        return createCMG.data.createContentModelGroup.data;
+    };
+
+    const setupCategoryModel = async (contentModelGroup: CmsGroup): Promise<CmsModel> => {
+        const model = models.find(m => m.modelId === "category");
+        // Create initial record
+        const [create] = await createContentModelMutation({
+            data: {
+                name: model.name,
+                modelId: model.modelId,
+                group: contentModelGroup.id
+            }
+        });
+
+        if (create.errors) {
+            console.error(`[beforeEach] ${create.errors[0].message}`);
+            process.exit(1);
+        }
+
+        const [update] = await updateContentModelMutation({
+            modelId: create.data.createContentModel.data.modelId,
+            data: {
+                fields: model.fields,
+                layout: model.layout
+            }
+        });
+        return update.data.updateContentModel.data;
+    };
+
+    test("should republish entries without changing them", async () => {
+        const group = await setupGroup();
+        await setupCategoryModel(group);
+
+        const { createCategory, publishCategory, republishCategory } =
+            useCategoryManageHandler(manageOpts);
+
+        /**
+         * Create test categories.
+         */
+        const [appleResponse] = await createCategory({
+            data: {
+                title: "Apple",
+                slug: "apple"
+            }
+        });
+        const appleOriginal = appleResponse.data.createCategory.data;
+        const [bananaResponse] = await createCategory({
+            data: {
+                title: "Banana",
+                slug: "banana"
+            }
+        });
+        const bananaOriginal = bananaResponse.data.createCategory.data;
+        const [orangeResponse] = await createCategory({
+            data: {
+                title: "Orange",
+                slug: "orange"
+            }
+        });
+        const orangeOriginal = orangeResponse.data.createCategory.data;
+
+        /**
+         * Publish all the categories.
+         */
+        const [applePublishResponse] = await publishCategory({
+            revision: appleOriginal.id
+        });
+        const apple = applePublishResponse.data.publishCategory.data;
+
+        const [bananaPublishResponse] = await publishCategory({
+            revision: bananaOriginal.id
+        });
+        const banana = bananaPublishResponse.data.publishCategory.data;
+        const [orangePublishResponse] = await publishCategory({
+            revision: orangeOriginal.id
+        });
+        const orange = orangePublishResponse.data.publishCategory.data;
+        /**
+         * Now we republish all categories and expect they did not change.
+         */
+        const [appleRepublishResponse] = await republishCategory({
+            revision: appleOriginal.id
+        });
+        expect(appleRepublishResponse).toEqual({
+            data: {
+                republishCategory: {
+                    data: apple,
+                    error: null
+                }
+            }
+        });
+        const [bananaRepublishResponse] = await republishCategory({
+            revision: bananaOriginal.id
+        });
+        expect(bananaRepublishResponse).toEqual({
+            data: {
+                republishCategory: {
+                    data: banana,
+                    error: null
+                }
+            }
+        });
+        const [orangeRepublishResponse] = await republishCategory({
+            revision: orangeOriginal.id
+        });
+        expect(orangeRepublishResponse).toEqual({
+            data: {
+                republishCategory: {
+                    data: orange,
+                    error: null
+                }
+            }
+        });
+    });
+
+    test("should not allow republishing of unpublished entries", async () => {
+        const group = await setupGroup();
+        await setupCategoryModel(group);
+
+        const { createCategory, republishCategory } = useCategoryManageHandler(manageOpts);
+
+        /**
+         * Create test categories.
+         */
+        const [appleResponse] = await createCategory({
+            data: {
+                title: "Apple",
+                slug: "apple"
+            }
+        });
+        const apple = appleResponse.data.createCategory.data;
+
+        const [appleRepublishResponse] = await republishCategory({
+            revision: apple.id
+        });
+        expect(appleRepublishResponse).toEqual({
+            data: {
+                republishCategory: {
+                    data: null,
+                    error: {
+                        message: "Entry with given ID is not published!",
+                        code: "NOT_PUBLISHED_ERROR",
+                        data: expect.any(Object)
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -140,6 +140,8 @@ export default /* GraphQL */ `
         deleteCategory(revision: ID!): CmsDeleteResponse
 
         publishCategory(revision: ID!): CategoryResponse
+    
+        republishCategory(revision: ID!): CategoryResponse
 
         unpublishCategory(revision: ID!): CategoryResponse
         

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -241,6 +241,8 @@ export default /* GraphQL */ `
         deleteProduct(revision: ID!): CmsDeleteResponse
 
         publishProduct(revision: ID!): ProductResponse
+    
+        republishProduct(revision: ID!): ProductResponse
 
         unpublishProduct(revision: ID!): ProductResponse
         

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -150,6 +150,8 @@ export default /* GraphQL */ `
         deleteReview(revision: ID!): CmsDeleteResponse
 
         publishReview(revision: ID!): ReviewResponse
+    
+        republishReview(revision: ID!): ReviewResponse
 
         unpublishReview(revision: ID!): ReviewResponse
         

--- a/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useCategoryManageHandler.ts
@@ -137,6 +137,17 @@ const publishCategoryMutation = /* GraphQL */ `
     }
 `;
 
+const republishCategoryMutation = /* GraphQL */ `
+    mutation RepublishCategory($revision: ID!) {
+        republishCategory(revision: $revision) {
+            data {
+                ${categoryFields}
+            }
+            ${errorFields}
+        }
+    }
+`;
+
 const unpublishCategoryMutation = /* GraphQL */ `
     mutation UnpublishCategory($revision: ID!) {
         unpublishCategory(revision: $revision) {
@@ -229,6 +240,15 @@ export const useCategoryManageHandler = (
             return await contentHandler.invoke({
                 body: {
                     query: publishCategoryMutation,
+                    variables
+                },
+                headers
+            });
+        },
+        async republishCategory(variables, headers: Record<string, any> = {}) {
+            return await contentHandler.invoke({
+                body: {
+                    query: republishCategoryMutation,
                     variables
                 },
                 headers

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -728,6 +728,8 @@ export const createContentEntryCrud = (params: Params): CmsEntryContext => {
 
             const entry: CmsEntry = {
                 ...originalEntry,
+                savedOn: new Date().toISOString(),
+                webinyVersion: context.WEBINY_VERSION,
                 values
             };
 

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
@@ -10,6 +10,7 @@ import { resolveRequestReview } from "./resolvers/manage/resolveRequestReview";
 import { resolveRequestChanges } from "./resolvers/manage/resolveRequestChanges";
 import { resolveDelete } from "./resolvers/manage/resolveDelete";
 import { resolvePublish } from "./resolvers/manage/resolvePublish";
+import { resolveRepublish } from "./resolvers/manage/resolveRepublish";
 import { resolveUnpublish } from "./resolvers/manage/resolveUnpublish";
 import { resolveCreateFrom } from "./resolvers/manage/resolveCreateFrom";
 import { createFieldResolversFactory } from "~/content/plugins/schema/createFieldResolvers";
@@ -52,6 +53,7 @@ export const createManageResolvers: CreateManageResolvers = ({
             [`update${typeName}`]: resolveUpdate({ model }),
             [`delete${typeName}`]: resolveDelete({ model }),
             [`publish${typeName}`]: resolvePublish({ model }),
+            [`republish${typeName}`]: resolveRepublish({ model }),
             [`unpublish${typeName}`]: resolveUnpublish({ model }),
             [`create${typeName}From`]: resolveCreateFrom({ model }),
             [`request${typeName}Review`]: resolveRequestReview({ model }),

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
@@ -134,6 +134,8 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
             delete${typeName}(revision: ID!): CmsDeleteResponse
 
             publish${typeName}(revision: ID!): ${mTypeName}Response
+        
+            republish${typeName}(revision: ID!): ${mTypeName}Response
 
             unpublish${typeName}(revision: ID!): ${mTypeName}Response
             

--- a/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRepublish.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/resolvers/manage/resolveRepublish.ts
@@ -1,0 +1,13 @@
+import { Response, ErrorResponse } from "@webiny/handler-graphql/responses";
+import { CmsEntryResolverFactory as ResolverFactory } from "~/types";
+
+export const resolveRepublish: ResolverFactory =
+    ({ model }) =>
+    async (_, args, context) => {
+        try {
+            const entry = await context.cms.republishEntry(model, args.revision);
+            return new Response(entry);
+        } catch (e) {
+            return new ErrorResponse(e);
+        }
+    };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1610,6 +1610,11 @@ export interface CmsEntryContext {
      */
     updateEntry: (model: CmsModel, id: string, data?: Record<string, any>) => Promise<CmsEntry>;
     /**
+     * Method that republishes entry with given identifier.
+     * @internal
+     */
+    republishEntry: (model: CmsModel, id: string) => Promise<CmsEntry>;
+    /**
      * Delete only a certain revision of the entry.
      */
     deleteEntryRevision: (model: CmsModel, id: string) => Promise<void>;

--- a/packages/api-upgrade/src/index.ts
+++ b/packages/api-upgrade/src/index.ts
@@ -2,6 +2,13 @@ import { UpgradePlugin } from "~/types";
 import Error from "@webiny/error";
 import { gt, lt, coerce } from "semver";
 
+export enum ErrorCode {
+    UPGRADE_VERSION_MISMATCH = "UPGRADE_VERSION_MISMATCH",
+    VERSION_ALREADY_INSTALLED = "VERSION_ALREADY_INSTALLED",
+    SKIPPING_UPGRADES_NOT_ALLOWED = "SKIPPING_UPGRADES_NOT_ALLOWED",
+    UPGRADE_NOT_AVAILABLE = "UPGRADE_NOT_AVAILABLE"
+}
+
 interface RunUpgradeArgs {
     /**
      * Version of Webiny that is currently deployed (context.WEBINY_VERSION).
@@ -31,7 +38,7 @@ export function getApplicablePlugin(args: RunUpgradeArgs): UpgradePlugin {
     if (upgradeToVersion !== deployedVersion) {
         throw new Error(
             `The requested upgrade version does not match the deployed version.`,
-            "UPGRADE_VERSION_MISMATCH",
+            ErrorCode.UPGRADE_VERSION_MISMATCH,
             {
                 deployedVersion: deployedVersion,
                 requestedUpgradeTo: upgradeToVersion
@@ -42,7 +49,7 @@ export function getApplicablePlugin(args: RunUpgradeArgs): UpgradePlugin {
     if (installedAppVersion === upgradeToVersion) {
         throw new Error(
             `Version ${upgradeToVersion} is already installed!`,
-            "VERSION_ALREADY_INSTALLED"
+            ErrorCode.VERSION_ALREADY_INSTALLED
         );
     }
 
@@ -53,7 +60,7 @@ export function getApplicablePlugin(args: RunUpgradeArgs): UpgradePlugin {
     if (upgrades.length > 0) {
         throw new Error(
             `Skipping of upgrades is not allowed: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny`,
-            "SKIPPING_UPGRADES_NOT_ALLOWED",
+            ErrorCode.SKIPPING_UPGRADES_NOT_ALLOWED,
             {
                 deployedVersion: deployedVersion,
                 skippedVersions: upgrades.map(pl => pl.version),
@@ -67,7 +74,7 @@ export function getApplicablePlugin(args: RunUpgradeArgs): UpgradePlugin {
     if (!upgrade) {
         throw new Error(
             `Upgrade to version ${upgradeToVersion} is not available.`,
-            "UPGRADE_NOT_AVAILABLE"
+            ErrorCode.UPGRADE_NOT_AVAILABLE
         );
     }
 

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -40,6 +40,7 @@
     "apollo-cache": "^1.3.5",
     "apollo-client": "^2.6.10",
     "apollo-link": "^1.2.14",
+    "apollo-link-batch-http": "^1.2.14",
     "apollo-utilities": "^1.3.4",
     "classnames": "^2.2.6",
     "dot-prop-immutable": "^2.1.0",

--- a/packages/app-headless-cms/src/admin/plugins/install.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/install.tsx
@@ -112,6 +112,12 @@ const plugin: AdminInstallationPlugin = {
             getComponent() {
                 return lazy(() => import("./upgrades/v5.8.0"));
             }
+        },
+        {
+            version: "5.19.0",
+            getComponent() {
+                return lazy(() => import("./upgrades/v5.19.0"));
+            }
         }
     ]
 };

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/UpgradeItemsInfo.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/UpgradeItemsInfo.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Typography } from "@webiny/ui/Typography";
+import { UpgradeItems } from "./types";
+import { CmsEditorContentModel } from "~/types";
+
+interface UpgradingModelResponse {
+    model: CmsEditorContentModel;
+    total: number;
+    current: number;
+    locale: string;
+}
+const findUpgradingModel = (locales: UpgradeItems["locales"]): UpgradingModelResponse | null => {
+    for (const locale in locales) {
+        if (!locales[locale]) {
+            continue;
+        }
+        const modelsData = Object.values(locales[locale]);
+        for (const modelId in modelsData) {
+            if (modelsData[modelId].upgrading !== true) {
+                continue;
+            }
+            return {
+                locale,
+                model: modelsData[modelId].model,
+                total: modelsData[modelId].entries.length,
+                current: modelsData[modelId].entries.filter(item => item.done).length
+            };
+        }
+    }
+    return null;
+};
+
+interface UpgradeItemsInfoProps {
+    upgradeItems: UpgradeItems | null;
+}
+export const UpgradeItemsInfo: React.FunctionComponent<UpgradeItemsInfoProps> = props => {
+    const { upgradeItems } = props;
+    if (!upgradeItems || upgradeItems.loadedModels !== true || !upgradeItems.locales) {
+        return null;
+    }
+    const { locales } = upgradeItems;
+
+    const result = findUpgradingModel(locales);
+    if (!result) {
+        return <></>;
+    }
+    const { locale, model, current, total } = result;
+    return (
+        <Typography use={"body1"} tag={"div"}>
+            Upgrading model <strong>{model.name}</strong> in locale <strong>{locale}</strong> (
+            {current} of {total} updated)
+        </Typography>
+    );
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createCmsApolloClient.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createCmsApolloClient.ts
@@ -1,0 +1,53 @@
+import ApolloClient from "apollo-client";
+import { ApolloLink } from "apollo-link";
+import { ApolloDynamicLink } from "@webiny/app/plugins/ApolloDynamicLink";
+import { InMemoryCache } from "@webiny/app/apollo-client/InMemoryCache";
+import { plugins } from "@webiny/plugins";
+import { ApolloCacheObjectIdPlugin } from "@webiny/app/plugins/ApolloCacheObjectIdPlugin";
+import { BatchHttpLink } from "apollo-link-batch-http";
+
+export interface Params {
+    locale: string;
+    apiUrl: string;
+    endpoint: "manage" | "read";
+}
+export const createCmsApolloClient = ({ locale, apiUrl, endpoint }: Params) => {
+    return new ApolloClient({
+        link: ApolloLink.from([
+            /**
+             * This will process links from plugins on every request.
+             */
+            new ApolloDynamicLink(),
+            /**
+             * This batches requests made to the API to pack multiple requests into a single HTTP request.
+             */
+            new BatchHttpLink({
+                uri: `${apiUrl}/cms/${endpoint}/${locale}`
+            })
+        ]),
+        cache: new InMemoryCache({
+            addTypename: true,
+            dataIdFromObject: obj => {
+                /**
+                 * Since every data type coming from API can have a different data structure,
+                 * we cannot rely on having an `id` field.
+                 */
+                const getters = plugins.byType<ApolloCacheObjectIdPlugin>(
+                    ApolloCacheObjectIdPlugin.type
+                );
+
+                for (let i = 0; i < getters.length; i++) {
+                    const id = getters[i].getObjectId(obj);
+                    if (typeof id !== "undefined") {
+                        return id;
+                    }
+                }
+
+                /**
+                 * As a fallback, try getting object's `id`.
+                 */
+                return obj.id || null;
+            }
+        })
+    });
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createListEntriesQuery.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createListEntriesQuery.ts
@@ -1,0 +1,34 @@
+import { CmsEditorContentModel } from "~/types";
+import upperFirst from "lodash/upperFirst";
+import pluralize from "pluralize";
+import gql from "graphql-tag";
+
+export const createListEntriesQuery = (model: CmsEditorContentModel) => {
+    const ucFirstPluralizedModelId = upperFirst(pluralize(model.modelId));
+    const ucFirstModelId = upperFirst(model.modelId);
+
+    return gql`
+        query CmsEntriesList${ucFirstPluralizedModelId}($where: ${ucFirstModelId}ListWhereInput, $sort: [${ucFirstModelId}ListSorter], $limit: Int, $after: String) {
+            content: list${ucFirstPluralizedModelId}(
+            where: $where
+            sort: $sort
+            limit: $limit
+            after: $after
+            ) {
+            data {
+                id
+            }
+            meta {
+                cursor
+                hasMoreItems
+                totalCount
+            }
+            error {
+                message
+                code
+                data
+            }
+        }
+        }
+    `;
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createListModelsQuery.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createListModelsQuery.ts
@@ -1,0 +1,23 @@
+import gql from "graphql-tag";
+
+export const createListModelsQuery = () => {
+    return gql`
+        query CmsListContentModels {
+            listContentModels {
+                data {
+                    modelId
+                    name
+                    fields {
+                        id
+                        type
+                    }
+                }
+                error {
+                    message
+                    code
+                    data
+                }
+            }
+        }
+    `;
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createRepublishMutation.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createRepublishMutation.ts
@@ -1,0 +1,20 @@
+import upperFirst from "lodash/upperFirst";
+import gql from "graphql-tag";
+
+export const createRepublishMutation = model => {
+    const ucFirstModelId = upperFirst(model.modelId);
+
+    return gql`
+        mutation CmsRepublish${ucFirstModelId}($revision: ID!) {
+            content: republish${ucFirstModelId}(revision: $revision) {
+            data {
+                id
+            }
+            error {
+                message
+                data
+                code
+            }
+        }
+    }`;
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createUpgradeMutation.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/createUpgradeMutation.ts
@@ -1,0 +1,18 @@
+import gql from "graphql-tag";
+
+export const createUpgradeMutation = () => {
+    return gql`
+        mutation UpgradeCMS($version: String!) {
+            cms {
+                upgrade(version: $version) {
+                    data
+                    error {
+                        code
+                        message
+                        data
+                    }
+                }
+            }
+        }
+    `;
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/fetchModelEntries.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/fetchModelEntries.ts
@@ -1,0 +1,68 @@
+import { CmsEditorContentEntry, CmsEditorContentModel } from "~/types";
+import { ApolloClient } from "apollo-client";
+import { createListEntriesQuery } from "~/admin/plugins/upgrades/5.19.0/createListEntriesQuery";
+
+interface FetchEntriesParams {
+    client: ApolloClient<any>;
+    query: any;
+    variables: {
+        limit: number;
+        after: string | null;
+        where: Record<string, string>;
+    };
+}
+interface FetchEntriesResult {
+    hasMoreItems: boolean;
+    totalCount: number;
+    items: CmsEditorContentEntry[];
+    cursor: string | null;
+}
+const fetchEntries = async (params: FetchEntriesParams): Promise<FetchEntriesResult | null> => {
+    const { client, query, variables } = params;
+    const response = await client.query({
+        query,
+        variables
+    });
+    const { data: items, error, meta } = response.data.content;
+    if (error) {
+        console.error(error.message);
+        return null;
+    }
+
+    return {
+        items: items || [],
+        hasMoreItems: meta.hasMoreItems,
+        cursor: meta.cursor,
+        totalCount: meta.totalCount
+    };
+};
+
+export interface Params {
+    model: CmsEditorContentModel;
+    client: ApolloClient<any>;
+}
+export const fetchModelEntries = async (params: Params): Promise<string[]> => {
+    const { model, client } = params;
+    const items: string[] = [];
+
+    const query = createListEntriesQuery(model);
+
+    const variables = {
+        limit: 100,
+        after: null,
+        where: {}
+    };
+    let result: FetchEntriesResult;
+    while ((result = await fetchEntries({ client, query, variables }))) {
+        if (!result) {
+            return items;
+        }
+        items.push(...result.items.map(item => item.id));
+
+        if (result.hasMoreItems === false) {
+            return items;
+        }
+        variables.after = result.cursor;
+    }
+    return items;
+};

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/types.ts
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/5.19.0/types.ts
@@ -1,0 +1,51 @@
+import { ApolloClient } from "apollo-client";
+import { CmsEditorContentModel } from "~/types";
+
+export interface Clients {
+    read: ApolloClient<any>;
+    manage: ApolloClient<any>;
+}
+
+export interface CurrentlyUpgrading {
+    locale: string;
+    model: CmsEditorContentModel;
+    running: boolean;
+    fetchingEntries: boolean;
+    after: string;
+    entry: string | null;
+    totalCount: number | null;
+    currentEntry: number | null;
+    error?: {
+        message: string;
+        code: string;
+        data: any;
+    };
+    entries: { id: string; done: boolean }[];
+}
+
+export interface UpgradeEntryItem {
+    id: string;
+    done: boolean;
+}
+
+export interface UpgradeModelItem {
+    model: CmsEditorContentModel;
+    entries: UpgradeEntryItem[];
+    done: boolean;
+    upgrading: boolean;
+}
+
+export interface UpgradeModelItems {
+    [modelId: string]: UpgradeModelItem;
+}
+
+export interface UpgradeItems {
+    loadedModels: boolean;
+    locales: Record<string, UpgradeModelItems>;
+}
+
+export interface ErrorValue {
+    code?: string;
+    data?: any;
+    message: string;
+}

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
@@ -107,13 +107,6 @@ const Upgrade = ({ onInstalled }) => {
 
     const [status, setStatus] = useState<JobStatus>("pending");
 
-    // const [modelsLoading, setModelsLoading] = useState(null);
-
-    // const [models, setModels] = useState({});
-    // const [clients, setClients] = useState<Clients>({});
-
-    // const [currentlyUpgrading, setCurrentlyUpgrading] = useState<CurrentlyUpgrading>(null);
-
     const [upgradeItems, setUpgradeItems] = useState<UpgradeItems>(null);
 
     useEffect(() => {

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
@@ -373,8 +373,10 @@ const Upgrade = ({ onInstalled }) => {
         <Alert title={t`Something went wrong`} type={"danger"}>
             {error.message}
         </Alert>
-    ) : (
+    ) : upgrade ? (
         t`Upgrading Headless CMS...`
+    ) : (
+        "Loading Headless CMS information"
     );
 
     return (

--- a/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/upgrades/v5.19.0.tsx
@@ -1,0 +1,406 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { i18n } from "@webiny/app/i18n";
+import {
+    SimpleForm,
+    SimpleFormContent,
+    SimpleFormFooter,
+    SimpleFormHeader
+} from "@webiny/app-admin/components/SimpleForm";
+import { useApolloClient } from "@apollo/react-hooks";
+import { Alert } from "@webiny/ui/Alert";
+import { CircularProgress } from "@webiny/ui/Progress";
+import { Cell, Grid } from "@webiny/ui/Grid";
+import { ButtonPrimary } from "@webiny/ui/Button";
+import { Typography } from "@webiny/ui/Typography";
+import { createCmsApolloClient } from "./5.19.0/createCmsApolloClient";
+import { config as appConfig } from "@webiny/app/config";
+import { LIST_LOCALES } from "@webiny/app-i18n/admin/views/locales/hooks/graphql";
+import { CmsEditorContentModel } from "~/types";
+import { Clients, ErrorValue, UpgradeItems } from "./5.19.0/types";
+import { UpgradeItemsInfo } from "./5.19.0/UpgradeItemsInfo";
+import { fetchModelEntries } from "./5.19.0/fetchModelEntries";
+import { createRepublishMutation } from "./5.19.0/createRepublishMutation";
+import { createUpgradeMutation } from "./5.19.0/createUpgradeMutation";
+import { createListModelsQuery } from "./5.19.0/createListModelsQuery";
+
+const t = i18n.ns("app-headless-cms/admin/installation");
+
+const clients: Record<string, Clients> = {};
+
+const getClient = (locale: string) => {
+    if (!clients[locale]) {
+        throw new Error(`There are no clients for locale "${locale}".`);
+    }
+    return clients[locale];
+};
+const getManageClient = (locale: string) => {
+    return getClient(locale).manage;
+};
+const getReadClient = (locale: string) => {
+    return getClient(locale).read;
+};
+
+interface CreateUpgradeItemsParams {
+    locales: {
+        code: string;
+    }[];
+}
+const createUpgradeItems = (params: CreateUpgradeItemsParams): UpgradeItems => {
+    const { locales } = params;
+    const items: UpgradeItems = {
+        loadedModels: false,
+        locales: {}
+    };
+    const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
+    for (const locale of locales) {
+        items.locales[locale.code] = null;
+
+        clients[locale.code] = {
+            read: createCmsApolloClient({
+                locale: locale.code,
+                apiUrl,
+                endpoint: "read"
+            }),
+            manage: createCmsApolloClient({
+                locale: locale.code,
+                apiUrl,
+                endpoint: "manage"
+            })
+        };
+    }
+    return items;
+};
+
+interface UpdateUpgradeItemsParams {
+    previous: UpgradeItems;
+    models: Record<string, CmsEditorContentModel[]>;
+}
+const updateUpgradeItems = (params: UpdateUpgradeItemsParams): UpgradeItems => {
+    const { previous, models } = params;
+
+    const locales: UpgradeItems["locales"] = {};
+    for (const locale in previous.locales) {
+        locales[locale] = (models[locale] || []).reduce((collection, model) => {
+            collection[model.modelId] = {
+                model,
+                done: false,
+                entries: [],
+                upgrading: false
+            };
+            return collection;
+        }, {});
+    }
+    return {
+        loadedModels: true,
+        locales
+    };
+};
+
+type JobStatus = "pending" | "upgrading" | "completed";
+
+const Upgrade = ({ onInstalled }) => {
+    const client = useApolloClient();
+    const [error, setError] = useState<ErrorValue>(null);
+    const [loading, setLoading] = useState(false);
+
+    const [upgrade, setUpgrade] = useState(false);
+
+    const [status, setStatus] = useState<JobStatus>("pending");
+
+    // const [modelsLoading, setModelsLoading] = useState(null);
+
+    // const [models, setModels] = useState({});
+    // const [clients, setClients] = useState<Clients>({});
+
+    // const [currentlyUpgrading, setCurrentlyUpgrading] = useState<CurrentlyUpgrading>(null);
+
+    const [upgradeItems, setUpgradeItems] = useState<UpgradeItems>(null);
+
+    useEffect(() => {
+        /**
+         * Never do this if we have upgrade items.
+         */
+        if (upgradeItems || loading === true) {
+            return;
+        }
+        setLoading(true);
+        const fetchLocales = async () => {
+            const response = await client.query({
+                query: LIST_LOCALES
+            });
+            if (
+                !response ||
+                !response.data ||
+                !response.data.i18n ||
+                !response.data.i18n.listI18NLocales
+            ) {
+                console.error("Missing response when fetching locales.");
+                return;
+            } else if (response.data.i18n.listI18NLocales.error) {
+                console.error(response.data.i18n.listI18NLocales.error.message);
+                setError(error);
+                return;
+            }
+
+            /**
+             * New state for the upgrade items.
+             */
+            setUpgradeItems(() => {
+                return createUpgradeItems({
+                    locales: response.data.i18n.listI18NLocales.data
+                });
+            });
+            /**
+             * And stop the spinner.
+             */
+            setLoading(false);
+        };
+
+        fetchLocales();
+    }, []);
+
+    useEffect(() => {
+        if (
+            !upgradeItems ||
+            !upgradeItems.locales ||
+            upgradeItems.loadedModels === true ||
+            loading === true
+        ) {
+            return;
+        }
+
+        setLoading(true);
+        const fetchModels = async () => {
+            const models: Record<string, CmsEditorContentModel[]> = {};
+            /**
+             * Load all models from locales, one by one so we dont nuke API too much.
+             */
+            const { locales } = upgradeItems;
+            /**
+             * Query does not care about locale so we can create it before the loop.
+             */
+            const query = createListModelsQuery();
+            /**
+             *
+             */
+            for (const locale in locales) {
+                const response = (await getManageClient(locale).query({
+                    query
+                })) as any;
+                const { listContentModels } = response.data || {};
+                const { data, error } = listContentModels;
+                if (error) {
+                    setError(error);
+                    return;
+                } else if (!data) {
+                    setError({
+                        message: `No data received when loading all models in locale "${locale}".`
+                    });
+                    return;
+                } else if (data.length === 0) {
+                    continue;
+                }
+                /**
+                 * We only need models that have at least one ref field or an object field that MIGHT contain ref fields.
+                 */
+                models[locale] = data.filter(model => {
+                    return model.fields.some(
+                        field => field.type === "object" || field.type === "ref"
+                    );
+                });
+            }
+            /**
+             * We add models only once to skip unnecessary state changes.
+             */
+            setUpgradeItems(previous => {
+                return updateUpgradeItems({
+                    previous,
+                    models: models
+                });
+            });
+            setLoading(false);
+        };
+
+        fetchModels();
+    }, [upgradeItems, loading]);
+
+    const startUpgrade = useCallback(() => {
+        if (!upgradeItems || upgradeItems.loadedModels !== true || upgrade === true) {
+            return;
+        }
+
+        setUpgrade(true);
+    }, [upgradeItems]);
+
+    useEffect(() => {
+        if (
+            !upgrade ||
+            !upgradeItems ||
+            !upgradeItems.locales ||
+            upgradeItems.loadedModels === false ||
+            status !== "pending"
+        ) {
+            return;
+        }
+
+        const { locales } = upgradeItems;
+
+        setStatus("upgrading");
+
+        const republish = async () => {
+            for (const locale in locales) {
+                const localeData = locales[locale];
+
+                const manageClient = getManageClient(locale);
+                const readClient = getReadClient(locale);
+
+                for (const modelId in localeData) {
+                    const modelData = localeData[modelId];
+                    /**
+                     * This should never be true but let's check just in case of some missed loop breaks.
+                     */
+                    if (modelData.done || modelData.upgrading) {
+                        continue;
+                    }
+                    const entries = await fetchModelEntries({
+                        model: modelData.model,
+                        client: readClient
+                    });
+                    setUpgradeItems(previous => {
+                        return {
+                            ...previous,
+                            locales: {
+                                ...previous.locales,
+                                [locale]: {
+                                    ...previous.locales[locale],
+                                    [modelId]: {
+                                        model: modelData.model,
+                                        done: false,
+                                        upgrading: true,
+                                        entries: entries.map(id => {
+                                            return {
+                                                id,
+                                                done: false
+                                            };
+                                        })
+                                    }
+                                }
+                            }
+                        };
+                    });
+
+                    const mutation = createRepublishMutation(modelData.model);
+
+                    for (const id of entries) {
+                        const republishResponse = await manageClient.mutate({
+                            mutation,
+                            variables: {
+                                revision: id
+                            }
+                        });
+                        const { error } = republishResponse.data.content;
+                        if (error) {
+                            setError(error);
+                            return;
+                        }
+                        setUpgradeItems(previous => {
+                            return {
+                                ...previous,
+                                locales: {
+                                    ...previous.locales,
+                                    [locale]: {
+                                        ...previous.locales[locale],
+                                        [modelId]: {
+                                            model: previous.locales[locale][modelId].model,
+                                            entries: previous.locales[locale][modelId].entries.map(
+                                                info => {
+                                                    return {
+                                                        id: info.id,
+                                                        done: info.done === true || id === info.id
+                                                    };
+                                                }
+                                            ),
+                                            done: false,
+                                            upgrading: true
+                                        }
+                                    }
+                                }
+                            };
+                        });
+                    }
+
+                    setUpgradeItems(previous => {
+                        return {
+                            ...previous,
+                            locales: {
+                                ...previous.locales,
+                                [locale]: {
+                                    ...previous.locales[locale],
+                                    [modelId]: {
+                                        model: modelData.model,
+                                        entries: [],
+                                        done: true,
+                                        upgrading: false
+                                    }
+                                }
+                            }
+                        };
+                    });
+                }
+            }
+
+            const response = await client.mutate({
+                mutation: createUpgradeMutation(),
+                variables: {
+                    version: "5.19.0"
+                }
+            });
+
+            const { error } = response.data.cms.upgrade;
+            setStatus("completed");
+            if (error) {
+                setError(error);
+                return;
+            }
+
+            onInstalled();
+        };
+
+        republish();
+    }, [upgrade, upgradeItems, status]);
+
+    const label = error ? (
+        <Alert title={t`Something went wrong`} type={"danger"}>
+            {error.message}
+        </Alert>
+    ) : (
+        t`Upgrading Headless CMS...`
+    );
+
+    return (
+        <SimpleForm>
+            {(loading || error) && <CircularProgress label={label} />}
+            <SimpleFormHeader title={"Upgrade Headless CMS"} />
+            <SimpleFormContent>
+                <Grid>
+                    <Cell span={12}>
+                        <Typography use={"body1"} tag={"div"}>
+                            This upgrade will do the following:
+                            <ul>
+                                <li>update entries</li>
+                            </ul>
+                            <UpgradeItemsInfo upgradeItems={upgradeItems} />
+                        </Typography>
+                    </Cell>
+                </Grid>
+            </SimpleFormContent>
+            <SimpleFormFooter>
+                <ButtonPrimary disabled={loading || upgrade} onClick={startUpgrade}>
+                    Upgrade
+                </ButtonPrimary>
+            </SimpleFormFooter>
+        </SimpleForm>
+    );
+};
+
+export default Upgrade;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10148,6 +10148,7 @@ __metadata:
     apollo-cache: ^1.3.5
     apollo-client: ^2.6.10
     apollo-link: ^1.2.14
+    apollo-link-batch-http: ^1.2.14
     apollo-utilities: ^1.3.4
     babel-plugin-emotion: ^9.2.8
     babel-plugin-lodash: ^3.3.4


### PR DESCRIPTION
## Changes

UI process to republish existing entries in all locales.

## How Has This Been Tested?
Jest and manually.

## Screenshots
![Screenshot 2021-12-08 at 14 34 22](https://user-images.githubusercontent.com/10399339/145217410-3a407fa9-ec6d-4b40-b6a7-9b32b1bbe864.png)


