### PR TITLE
fix(api-headless-cms): republishing entries

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/helpers/createElasticsearchQueryBody.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/createElasticsearchQueryBody.ts
@@ -138,17 +138,9 @@ const createInitialQueryValue = (
         });
     }
     // we do not allow not published and not latest
-    else if (where.published === false) {
+    else {
         throw new WebinyError(
-            `Cannot call Elasticsearch query with "published" set at false.`,
-            "ELASTICSEARCH_UNSUPPORTED_QUERY",
-            {
-                where
-            }
-        );
-    } else if (where.latest === false) {
-        throw new WebinyError(
-            `Cannot call Elasticsearch query with "latest" set at false.`,
+            `Cannot call Elasticsearch query when not setting "published" or "latest".`,
             "ELASTICSEARCH_UNSUPPORTED_QUERY",
             {
                 where

--- a/packages/api-headless-cms/__tests__/utils/tenancySecurity.ts
+++ b/packages/api-headless-cms/__tests__/utils/tenancySecurity.ts
@@ -48,7 +48,7 @@ export const createTenancyAndSecurity = ({ setupGraphQL, permissions, identity }
                 id: "root",
                 name: "Root",
                 webinyVersion: context.WEBINY_VERSION
-            });
+            } as any);
 
             context.security.addAuthenticator(async () => {
                 return (

--- a/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
@@ -161,6 +161,17 @@ const publishProductMutation = /* GraphQL */ `
     }
 `;
 
+const republishProductMutation = /* GraphQL */ `
+    mutation RepublishProduct($revision: ID!) {
+        republishProduct(revision: $revision) {
+            data {
+                ${productFields}
+            }
+            ${errorFields}
+        }
+    }
+`;
+
 const unpublishProductMutation = /* GraphQL */ `
     mutation UnpublishProduct($revision: ID!) {
         unpublishProduct(revision: $revision) {
@@ -236,6 +247,16 @@ export const useProductManageHandler = (
                 headers
             });
         },
+        async republishProduct(variables, headers: Record<string, any> = {}) {
+            return await contentHandler.invoke({
+                body: {
+                    query: republishProductMutation,
+                    variables
+                },
+                headers
+            });
+        },
+
         async unpublishProduct(variables, headers: Record<string, any> = {}) {
             return await contentHandler.invoke({
                 body: {

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry/referenceFieldsMapping.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry/referenceFieldsMapping.ts
@@ -108,6 +108,19 @@ const buildReferenceFieldPaths = (params: BuildReferenceFieldPaths): string[] =>
         }, []);
 };
 
+const getReferenceFieldValue = (ref: any): { id: string | null; modelId: string | null } => {
+    if (!ref) {
+        return {
+            id: null,
+            modelId: null
+        };
+    }
+    return {
+        id: (ref.id || ref.entryId || "").trim() || null,
+        modelId: (ref.modelId || "").trim() || null
+    };
+};
+
 export const referenceFieldsMapping = async (params: Params): Promise<Record<string, any>> => {
     const { context, model, input } = params;
 
@@ -129,17 +142,20 @@ export const referenceFieldsMapping = async (params: Params): Promise<Record<str
 
     for (const path of referenceFieldPaths) {
         const ref = dotProp.get(output, path) as ReferenceObject | any;
-        if (!ref || !ref.id || !ref.modelId) {
+
+        const { id, modelId } = getReferenceFieldValue(ref);
+
+        if (!id || !modelId) {
             continue;
         }
-        if (!referencesByModel[ref.modelId]) {
-            referencesByModel[ref.modelId] = [];
+        if (!referencesByModel[modelId]) {
+            referencesByModel[modelId] = [];
         }
-        referencesByModel[ref.modelId].push(ref.id);
-        if (!pathsByReferenceId[ref.id]) {
-            pathsByReferenceId[ref.id] = [];
+        referencesByModel[modelId].push(id);
+        if (!pathsByReferenceId[id]) {
+            pathsByReferenceId[id] = [];
         }
-        pathsByReferenceId[ref.id].push(path);
+        pathsByReferenceId[id].push(path);
     }
 
     /**

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeDelete.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeDelete.ts
@@ -34,7 +34,8 @@ export const assignBeforeModelDelete = (params: Params) => {
             const result = await storageOperations.entries.list(model, {
                 where: {
                     tenant: model.tenant,
-                    locale: model.locale
+                    locale: model.locale,
+                    latest: true
                 },
                 limit: 1
             });


### PR DESCRIPTION
## Changes
Upgrade for the 5.19.0 did not work in env with ES. Added tests directly for storage operations and fixed the bug.

## How Has This Been Tested?
Jest and manually.
