### PR TITLE
fix(api-file-manager): list tags when no tags defined

### DIFF
--- a/packages/api-file-manager-ddb/src/operations/files/FilesStorageOperations.ts
+++ b/packages/api-file-manager-ddb/src/operations/files/FilesStorageOperations.ts
@@ -328,7 +328,8 @@ export class FilesStorageOperations implements FileManagerFilesStorageOperations
          * Aggregate all the tags from all the items in the database.
          */
         const tagsObject = results.reduce((collection, item) => {
-            for (const tag of item.tags) {
+            const tags = Array.isArray(item.tags) ? item.tags : [];
+            for (const tag of tags) {
                 if (!collection[tag]) {
                     collection[tag] = [];
                 }

--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -525,4 +525,44 @@ describe("Files CRUD test", () => {
             }
         });
     });
+
+    it("should have no tags if files uploaded have no tags", async () => {
+        const [createResponse] = await createFiles({
+            data: [fileAData, fileBData, fileCData].map(file => {
+                return {
+                    ...file,
+                    tags: undefined
+                };
+            })
+        });
+        expect(createResponse).toEqual({
+            data: {
+                fileManager: {
+                    createFiles: {
+                        data: expect.any(Array),
+                        error: null
+                    }
+                }
+            }
+        });
+        await until(
+            () => listFiles().then(([data]) => data),
+            ({ data }) => {
+                return data.fileManager.listFiles.data.length === 3;
+            },
+            {
+                name: "list files after create"
+            }
+        );
+
+        const [tagsResponse] = await listTags({});
+
+        expect(tagsResponse).toEqual({
+            data: {
+                fileManager: {
+                    listTags: []
+                }
+            }
+        });
+    });
 });

--- a/packages/api-file-manager/src/plugins/crud/files.crud.ts
+++ b/packages/api-file-manager/src/plugins/crud/files.crud.ts
@@ -103,6 +103,7 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
 
             const file: File = {
                 ...input,
+                tags: Array.isArray(input.tags) ? input.tags : [],
                 id,
                 meta: {
                     private: false,
@@ -163,9 +164,14 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
 
             checkOwnership(original, permission, context);
 
-            const file = {
+            const file: File = {
                 ...original,
                 ...input,
+                tags: Array.isArray(input.tags)
+                    ? input.tags
+                    : Array.isArray(original.tags)
+                    ? original.tags
+                    : [],
                 id: original.id,
                 webinyVersion: context.WEBINY_VERSION
             };
@@ -277,6 +283,7 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
             const files: File[] = inputs.map(input => {
                 return {
                     ...input,
+                    tags: Array.isArray(input.tags) ? input.tags : [],
                     meta: {
                         private: false,
                         ...(input.meta || {})
@@ -413,11 +420,10 @@ const filesContextCrudPlugin = new ContextPlugin<FileManagerContext>(async conte
             };
 
             try {
-                /**
-                 * There is a meta object on the second key.
-                 * TODO: use when changing GraphQL output of the tags.
-                 */
                 const [tags] = await storageOperations.tags(params);
+                if (Array.isArray(tags) === false) {
+                    return [];
+                }
                 /**
                  * just to keep it standardized, sort by the tag ASC
                  */


### PR DESCRIPTION
## Changes
In FileManager DynamoDB storage operations list tags breaks if any file uploaded did not have tags.

#### api-file-manager
Added a check before create and update of file and set empty array if no tags defined - this is a fix for new / updated files.

#### api-file-manager-ddb
Use empty array as default if no tags inserted with the file - this is a fix for existing files.

## How Has This Been Tested?
Jest and manually.
