### PR TITLE
refactor(api-headless-cms): make listEntries internal use method

### DIFF
--- a/packages/api-headless-cms/src/content/plugins/modelManager/DefaultCmsModelManager.ts
+++ b/packages/api-headless-cms/src/content/plugins/modelManager/DefaultCmsModelManager.ts
@@ -1,4 +1,4 @@
-import { CmsModelManager, CmsModel, CmsContext } from "~/types";
+import { CmsModelManager, CmsModel, CmsContext, CmsEntryListParams } from "~/types";
 import { parseIdentifier } from "@webiny/utils";
 
 export class DefaultCmsModelManager implements CmsModelManager {
@@ -27,16 +27,12 @@ export class DefaultCmsModelManager implements CmsModelManager {
         return this._context.cms.getEntryById(this._model, id);
     }
 
-    public async list(args) {
-        return this._context.cms.listEntries(this._model, args);
+    public async listPublished(params: CmsEntryListParams) {
+        return this._context.cms.listPublishedEntries(this._model, params);
     }
 
-    public async listPublished(args) {
-        return this._context.cms.listPublishedEntries(this._model, args);
-    }
-
-    public async listLatest(args) {
-        return this._context.cms.listLatestEntries(this._model, args);
+    public async listLatest(params: CmsEntryListParams) {
+        return this._context.cms.listLatestEntries(this._model, params);
     }
 
     public async getPublishedByIds(ids: string[]) {

--- a/packages/api-headless-cms/src/content/plugins/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentEntries.ts
@@ -1,5 +1,5 @@
 import { Response } from "@webiny/handler-graphql";
-import { CmsEntry, CmsContext, CmsModel } from "~/types";
+import { CmsEntry, CmsContext, CmsModel, CmsEntryListWhere } from "~/types";
 import { NotAuthorizedResponse } from "@webiny/api-security";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins/GraphQLSchemaPlugin";
 import { getEntryTitle } from "~/content/plugins/utils/getEntryTitle";
@@ -68,11 +68,13 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                         .map(async model => {
                             const latest = query === "__latest__";
                             const modelManager = await context.cms.getModelManager(model.modelId);
+                            const where: CmsEntryListWhere = {};
+                            if (!latest) {
+                                where[`${model.titleFieldId}_contains`] = query;
+                            }
                             const [items] = await modelManager.listLatest({
                                 limit,
-                                where: latest
-                                    ? undefined
-                                    : { [`${model.titleFieldId}_contains`]: query }
+                                where
                             });
 
                             return items.map((entry: CmsEntry) => ({

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1160,17 +1160,13 @@ export interface CmsStorageEntry extends CmsEntry {
  */
 export interface CmsModelManager {
     /**
-     * List entries in this content model.
-     */
-    list: (params?: CmsEntryListParams) => Promise<[CmsEntry[], CmsEntryMeta]>;
-    /**
      * List only published entries in the content model.
      */
-    listPublished: (params?: CmsEntryListParams) => Promise<[CmsEntry[], CmsEntryMeta]>;
+    listPublished: (params: CmsEntryListParams) => Promise<[CmsEntry[], CmsEntryMeta]>;
     /**
      * List latest entries in the content model. Used for administration.
      */
-    listLatest: (params?: CmsEntryListParams) => Promise<[CmsEntry[], CmsEntryMeta]>;
+    listLatest: (params: CmsEntryListParams) => Promise<[CmsEntry[], CmsEntryMeta]>;
     /**
      * Get a list of published entries by the ID list.
      */
@@ -1570,7 +1566,7 @@ export interface CmsEntryContext {
      */
     listEntries: (
         model: CmsModel,
-        params?: CmsEntryListParams
+        params: CmsEntryListParams
     ) => Promise<[CmsEntry[], CmsEntryMeta]>;
     /**
      * Lists latest entries. Used for manage API.


### PR DESCRIPTION
## Changes
The `context.cms.listEntries()` should be used only for our internal coding. Added comments about that.
Added check if published / latest were sent into the `listEntries` method - cannot search if trying to search both, or none.

## How Has This Been Tested?
Jest and manually.
