### PR TITLE
fix(api-headless-cms): empty nested object as first field

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/model.nestedField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/model.nestedField.test.ts
@@ -1,0 +1,111 @@
+import { CmsGroup, CmsModelField } from "~/types";
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+
+const noNestedFieldsObject: CmsModelField = {
+    id: "nonestedfieldsobject",
+    multipleValues: false,
+    helpText: "",
+    label: "No fields object",
+    fieldId: "noFieldsObject",
+    type: "object",
+    settings: {
+        fields: []
+    },
+    validation: [],
+    listValidation: [],
+    placeholderText: "",
+    predefinedValues: {
+        enabled: false,
+        values: []
+    },
+    renderer: {
+        name: "renderer"
+    }
+};
+
+describe("Model - nested field", () => {
+    const manageOpts = { path: "manage/en-US" };
+
+    const {
+        createContentModelMutation,
+        getContentModelQuery,
+        listContentModelsQuery,
+        updateContentModelMutation,
+        createContentModelGroupMutation
+    } = useContentGqlHandler(manageOpts);
+
+    let contentModelGroup: CmsGroup;
+
+    beforeEach(async () => {
+        const [createCMG] = await createContentModelGroupMutation({
+            data: {
+                name: "Group",
+                slug: "group",
+                icon: "ico/ico",
+                description: "description"
+            }
+        });
+        contentModelGroup = createCMG.data.createContentModelGroup.data;
+    });
+
+    it("should not fail list models if any model has empty nested field", async () => {
+        const [createResponse] = await createContentModelMutation({
+            data: {
+                name: "Test Model",
+                group: contentModelGroup.id
+            }
+        });
+
+        expect(createResponse).toEqual({
+            data: {
+                createContentModel: {
+                    data: expect.any(Object),
+                    error: null
+                }
+            }
+        });
+
+        const [updateResponse] = await updateContentModelMutation({
+            modelId: "testModel",
+            data: {
+                fields: [noNestedFieldsObject],
+                layout: [[noNestedFieldsObject.id]]
+            }
+        });
+
+        expect(updateResponse).toEqual({
+            data: {
+                updateContentModel: {
+                    data: expect.any(Object),
+                    error: null
+                }
+            }
+        });
+
+        const [getResponse] = await getContentModelQuery({
+            modelId: "testModel"
+        });
+
+        expect(getResponse).toEqual({
+            data: {
+                getContentModel: {
+                    data: expect.any(Object),
+                    error: null
+                }
+            }
+        });
+
+        const [listResponse] = await listContentModelsQuery({
+            modelId: "testModel"
+        });
+
+        expect(listResponse).toEqual({
+            data: {
+                listContentModels: {
+                    data: expect.any(Array),
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/src/content/plugins/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/content/plugins/graphqlFields/object.ts
@@ -78,10 +78,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             });
 
             if (!result) {
-                return {
-                    fields: "",
-                    typeDefs: ""
-                };
+                return null;
             }
             const { fieldType, typeDefs } = result;
 
@@ -118,10 +115,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
             });
 
             if (!result) {
-                return {
-                    fields: "",
-                    typeDefs: ""
-                };
+                return null;
             }
             const { fieldType, typeDefs } = result;
 
@@ -139,10 +133,7 @@ const plugin: CmsModelFieldToGraphQLPlugin = {
                 fieldTypePlugins
             });
             if (!result) {
-                return {
-                    fields: "",
-                    typeDefs: ""
-                };
+                return null;
             }
             const { fieldType, typeDefs } = result;
 

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageResolvers.ts
@@ -32,6 +32,12 @@ export const createManageResolvers: CreateManageResolvers = ({
     model,
     fieldTypePlugins
 }) => {
+    if (model.fields.length === 0) {
+        return {
+            Query: {},
+            Mutation: {}
+        };
+    }
     const typeName = createTypeName(model.modelId);
     const mTypeName = createManageTypeName(typeName);
     const createFieldResolvers = createFieldResolversFactory({

--- a/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createManageSDL.ts
@@ -26,6 +26,10 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
     const inputFields = renderInputFields({ model, fieldTypePlugins });
     const fields = renderFields({ model, type: "manage", fieldTypePlugins });
 
+    if (inputFields.length === 0) {
+        return "";
+    }
+
     return /* GraphQL */ `
         """${model.description || model.modelId}"""
         ${fields

--- a/packages/api-headless-cms/src/content/plugins/schema/createPreviewResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createPreviewResolvers.ts
@@ -19,6 +19,11 @@ export const createPreviewResolvers: CreateReadResolvers = ({
     model,
     fieldTypePlugins
 }) => {
+    if (model.fields.length === 0) {
+        return {
+            Query: {}
+        };
+    }
     const typeName = createTypeName(model.modelId);
     const rTypeName = createReadTypeName(typeName);
 

--- a/packages/api-headless-cms/src/content/plugins/schema/createReadResolvers.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createReadResolvers.ts
@@ -15,6 +15,11 @@ export interface CreateReadResolvers {
 }
 
 export const createReadResolvers: CreateReadResolvers = ({ models, model, fieldTypePlugins }) => {
+    if (model.fields.length === 0) {
+        return {
+            Query: {}
+        };
+    }
     const typeName = createTypeName(model.modelId);
     const rTypeName = createReadTypeName(typeName);
 

--- a/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/createReadSDL.ts
@@ -24,6 +24,10 @@ export const createReadSDL: CreateManageSDL = ({ model, fieldTypePlugins }): str
     const getFilterFieldsRender = renderGetFilterFields({ model, fieldTypePlugins });
     const fieldsRender = renderFields({ model, type: "read", fieldTypePlugins });
 
+    if (fieldsRender.length === 0) {
+        return "";
+    }
+
     return `
         """${model.description || ""}"""
         ${fieldsRender

--- a/packages/api-headless-cms/src/content/plugins/schema/schemaPlugins.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/schemaPlugins.ts
@@ -76,5 +76,5 @@ export const generateSchemaPlugins = async (
             }
         });
 
-    return newPlugins;
+    return newPlugins.filter(pl => !!pl.schema.typeDefs);
 };

--- a/packages/api-headless-cms/src/content/plugins/utils/renderFields.ts
+++ b/packages/api-headless-cms/src/content/plugins/utils/renderFields.ts
@@ -31,7 +31,9 @@ export const renderField = ({ model, type, field, fieldTypePlugins }) => {
         fieldTypePlugins
     });
 
-    if (typeof defs === "string") {
+    if (!defs) {
+        return null;
+    } else if (typeof defs === "string") {
         return { fields: defs };
     }
 

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -477,7 +477,7 @@ export interface CmsModelFieldToGraphQLPlugin extends Plugin {
             model: CmsModel;
             field: CmsModelField;
             fieldTypePlugins: CmsFieldTypePlugins;
-        }): CmsModelFieldDefinition | string;
+        }): CmsModelFieldDefinition | string | null;
         /**
          * Definition for field resolver.
          * By default it is simple return of the `instance.values[fieldId]` but if required, users can define their own.
@@ -575,7 +575,7 @@ export interface CmsModelFieldToGraphQLPlugin extends Plugin {
             model: CmsModel;
             field: CmsModelField;
             fieldTypePlugins: CmsFieldTypePlugins;
-        }) => CmsModelFieldDefinition | string;
+        }) => CmsModelFieldDefinition | string | null;
         /**
          * Definition for input GraphQL field type.
          *

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -50,6 +50,7 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
             const { data: model, error } = data.createContentModel;
 
             if (error) {
+                setLoading(false);
                 return showSnackbar(error.message);
             }
 


### PR DESCRIPTION
## Changes
When creating content model with first field being a object field, and it is empty, schema generation breaks.

## How Has This Been Tested?
Jest and manually.
