### PR TITLE
`webiny watch` - Fixed `remoteRuntimeLogs` Flag

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -68,7 +68,7 @@ module.exports = [
                         "$0 watch api --env=dev --scope my-package-1 --scope my-package-2"
                     );
                     yargs.example("$0 watch api --env=dev --depth 2");
-                    yargs.example('$0 watch api --env=dev --logs "my-function*"');
+                    yargs.example('$0 watch api --env=dev -r "my-function*"');
                     yargs.example('$0 watch --env=dev --scope "my/{package1,package2}" ');
 
                     yargs.positional("folder", {
@@ -109,8 +109,8 @@ module.exports = [
                     });
                     yargs.option("remoteRuntimeLogs", {
                         alias: "r",
-                        describe: `Forward logs from deployed application code to your terminal`,
-                        type: "boolean"
+                        describe: `Forward logs from deployed application code to your terminal (optionally accepts a glob pattern for filtering purposes)`,
+                        type: "string"
                     });
                     yargs.option("debug", {
                         default: false,

--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -59,8 +59,8 @@ module.exports = async (inputs, context) => {
     }
 
     if (inputs.deploy) {
-        if (typeof inputs.logs === "string" && inputs.logs === "") {
-            inputs.logs = "*";
+        if (typeof inputs.remoteRuntimeLogs === "string" && inputs.remoteRuntimeLogs === "") {
+            inputs.remoteRuntimeLogs = "*";
         }
     }
 


### PR DESCRIPTION
## Changes
This PR fixes a couple of issues `webiny watch` command's `--remoteRuntimeLogs` (`-r`) flag. 

- updated `--remoteRuntimeLogs` (`-r`) flag's data type, description, and example usage
- within the main `watch.js` file, there was still some old code that was using the old `--logs` flag (instead of the new one)

## How Has This Been Tested?
Manual.

## Documentation
Changelog.