### PR TITLE
fix(api-headless-cms-ddb-es): ref field id and entryId exact matches

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/search/refSearch.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/search/refSearch.ts
@@ -4,10 +4,11 @@ import {
     TransformCallable
 } from "~/plugins/CmsEntryElasticsearchQueryBuilderValueSearchPlugin";
 
-const createPath: CreatePathCallable<string> = params => {
-    const value = `${params.value || ""}`;
-    const target = value && value.includes("#") ? "id" : "entryId";
-    return `${params.field.fieldId}.${target}`;
+const createPath: CreatePathCallable<string> = ({ field, key }) => {
+    if (key && key.match("entryId") === null) {
+        return `${field.fieldId}.id`;
+    }
+    return `${field.fieldId}.entryId`;
 };
 
 const transform: TransformCallable<string> = params => {

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryBuilderValueSearchPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryBuilderValueSearchPlugin.ts
@@ -3,6 +3,7 @@ import { CmsModelField } from "@webiny/api-headless-cms/types";
 
 export interface CreatePathCallableParams<T = any> {
     field: CmsModelField;
+    key: string;
     value: T;
 }
 

--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -523,7 +523,7 @@ describe("entry references", () => {
     });
 
     it("should list articles filtered by reference", async () => {
-        expect.assertions(8);
+        expect.assertions(12);
 
         const group = await setupContentModelGroup(mainManager);
         await setupContentModels(mainManager, group, ["category", "article"]);
@@ -723,6 +723,50 @@ describe("entry references", () => {
                     meta: {
                         hasMoreItems: false,
                         totalCount: 3,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listArticlesEntryIdWrongResponse] = await articleReader.listArticles({
+            where: {
+                category: {
+                    entryId: techCategory.id
+                }
+            },
+            sort: ["createdOn_ASC"]
+        });
+        expect(listArticlesEntryIdWrongResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [],
+                    meta: {
+                        hasMoreItems: false,
+                        totalCount: 0,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listArticlesIdWrongResponse] = await articleReader.listArticles({
+            where: {
+                category: {
+                    id: techCategory.entryId
+                }
+            },
+            sort: ["createdOn_ASC"]
+        });
+        expect(listArticlesIdWrongResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [],
+                    meta: {
+                        hasMoreItems: false,
+                        totalCount: 0,
                         cursor: null
                     },
                     error: null
@@ -932,6 +976,52 @@ describe("entry references", () => {
                     meta: {
                         hasMoreItems: false,
                         totalCount: 3,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listArticlesMultipleEntryIdWrongResponse] = await articleReader.listArticles({
+            where: {
+                categories: {
+                    entryId_in: [techCategory.id]
+                }
+            },
+            sort: ["createdOn_ASC"]
+        });
+
+        expect(listArticlesMultipleEntryIdWrongResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [],
+                    meta: {
+                        hasMoreItems: false,
+                        totalCount: 0,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listArticlesMultipleIdWrongResponse] = await articleReader.listArticles({
+            where: {
+                categories: {
+                    id_in: [techCategory.entryId]
+                }
+            },
+            sort: ["createdOn_ASC"]
+        });
+
+        expect(listArticlesMultipleIdWrongResponse).toEqual({
+            data: {
+                listArticles: {
+                    data: [],
+                    meta: {
+                        hasMoreItems: false,
+                        totalCount: 0,
                         cursor: null
                     },
                     error: null


### PR DESCRIPTION
## Changes
Because of the way creating Elasticsearch works, we searched for either entryId or id, depending if the string passed had # or not.

Added a test for that.

## How Has This Been Tested?
Jest and manually.
