### PR TITLE
feat(api-headless-cms): clone model

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.clone.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.clone.test.ts
@@ -1,0 +1,148 @@
+import { useContentGqlHandler } from "../utils/useContentGqlHandler";
+import { CmsGroup, CmsModel, CmsModelField } from "~/types";
+import models from "./mocks/contentModels";
+
+const setEmptyTextsAsNull = (fields: CmsModelField[]): CmsModelField[] => {
+    return fields.map(field => {
+        field.helpText = field.helpText || null;
+        field.placeholderText = field.placeholderText || null;
+
+        if (field?.settings?.fields) {
+            field.settings.fields = setEmptyTextsAsNull(field.settings.fields);
+        }
+
+        return field;
+    });
+};
+
+describe("content model - cloning", () => {
+    const manageOpts = {
+        path: "manage/en-US"
+    };
+
+    const {
+        createContentModelGroupMutation,
+        createContentModelMutation,
+        updateContentModelMutation,
+        createContentModelFromMutation,
+        getContentModelQuery,
+        listContentModelsQuery
+    } = useContentGqlHandler(manageOpts);
+
+    let contentModelGroup: CmsGroup;
+    let originalModel: CmsModel;
+
+    beforeEach(async () => {
+        const [createCMG] = await createContentModelGroupMutation({
+            data: {
+                name: "Group",
+                slug: "group",
+                icon: "ico/ico",
+                description: "description"
+            }
+        });
+        contentModelGroup = createCMG.data.createContentModelGroup.data;
+
+        const targetModel = models.find(m => m.modelId === "product");
+        const [createModelResponse] = await createContentModelMutation({
+            data: {
+                name: targetModel.name,
+                modelId: targetModel.modelId,
+                group: contentModelGroup.id
+            }
+        });
+        const createdModel = createModelResponse.data.createContentModel.data;
+
+        const [updateModelResponse] = await updateContentModelMutation({
+            modelId: createdModel.modelId,
+            data: {
+                fields: targetModel.fields,
+                layout: targetModel.layout
+            }
+        });
+        originalModel = updateModelResponse.data.updateContentModel.data;
+    });
+
+    it("should properly clone content model", async () => {
+        const [cloneResponse] = await createContentModelFromMutation({
+            modelId: originalModel.modelId,
+            data: {
+                name: "Cloned model",
+                description: "Cloned model description"
+            }
+        });
+
+        const expectedModel: CmsModel = {
+            ...originalModel,
+            fields: setEmptyTextsAsNull(originalModel.fields),
+            createdOn: expect.stringMatching(/^20/),
+            savedOn: expect.stringMatching(/^20/),
+            name: "Cloned model",
+            description: "Cloned model description",
+            modelId: "clonedModel"
+        };
+
+        expect(cloneResponse).toEqual({
+            data: {
+                createContentModelFrom: {
+                    data: expectedModel,
+                    error: null
+                }
+            }
+        });
+
+        const clonedModel = cloneResponse.data.createContentModelFrom.data;
+
+        const [getResponse] = await getContentModelQuery({
+            modelId: clonedModel.modelId
+        });
+
+        expect(getResponse).toEqual({
+            data: {
+                getContentModel: {
+                    data: expectedModel,
+                    error: null
+                }
+            }
+        });
+
+        const [listResponse] = await listContentModelsQuery({
+            where: {}
+        });
+
+        expect(listResponse).toEqual({
+            data: {
+                listContentModels: {
+                    data: [clonedModel, originalModel],
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should not allow to clone a model and give it existing modelId", async () => {
+        const [cloneResponse] = await createContentModelFromMutation({
+            modelId: originalModel.modelId,
+            data: {
+                name: "Cloned model",
+                modelId: originalModel.modelId,
+                description: "Cloned model description"
+            }
+        });
+
+        expect(cloneResponse).toEqual({
+            data: {
+                createContentModelFrom: {
+                    data: null,
+                    error: {
+                        code: "MODEL_ID_EXISTS",
+                        data: {
+                            modelId: originalModel.modelId
+                        },
+                        message: `Content model with modelId "${originalModel.modelId}" already exists.`
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -97,6 +97,7 @@ describe("content model test", () => {
         expect(getTypeFields(ReadMutation)).toEqual([]);
         expect(getTypeFields(ManageMutation)).toEqual([
             "createContentModel",
+            "createContentModelFrom",
             "updateContentModel",
             "deleteContentModel",
             "createContentModelGroup",

--- a/packages/api-headless-cms/__tests__/utils/graphql/contentModel.ts
+++ b/packages/api-headless-cms/__tests__/utils/graphql/contentModel.ts
@@ -84,6 +84,15 @@ export const CREATE_CONTENT_MODEL_MUTATION = /* GraphQL */ `
     }
 `;
 
+export const CREATE_CONTENT_MODEL_FROM_MUTATION = /* GraphQL */ `
+    mutation CreateContentModelFromMutation($modelId: ID!, $data: CmsContentModelCreateFromInput!) {
+        createContentModelFrom(modelId: $modelId, data: $data) {
+            data ${DATA_FIELD}
+            error ${ERROR_FIELD}
+        }
+    }
+`;
+
 export const UPDATE_CONTENT_MODEL_MUTATION = /* GraphQL */ `
     mutation UpdateContentModelMutation($modelId: ID!, $data: CmsContentModelUpdateInput!) {
         updateContentModel(modelId: $modelId, data: $data) {

--- a/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useGqlHandler.ts
@@ -16,6 +16,7 @@ import {
     UPDATE_CONTENT_MODEL_GROUP_MUTATION
 } from "./graphql/contentModelGroup";
 import {
+    CREATE_CONTENT_MODEL_FROM_MUTATION,
     CREATE_CONTENT_MODEL_MUTATION,
     DELETE_CONTENT_MODEL_MUTATION,
     GET_CONTENT_MODEL_QUERY,
@@ -193,6 +194,9 @@ export const useGqlHandler = (params: GQLHandlerCallableParams) => {
         },
         async createContentModelMutation(variables: Record<string, any>) {
             return invoke({ body: { query: CREATE_CONTENT_MODEL_MUTATION, variables } });
+        },
+        async createContentModelFromMutation(variables: Record<string, any>) {
+            return invoke({ body: { query: CREATE_CONTENT_MODEL_FROM_MUTATION, variables } });
         },
         async updateContentModelMutation(variables: Record<string, any>) {
             return invoke({ body: { query: UPDATE_CONTENT_MODEL_MUTATION, variables } });

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -10,7 +10,9 @@ import {
     BeforeModelUpdateTopicParams,
     AfterModelUpdateTopicParams,
     BeforeModelDeleteTopicParams,
-    AfterModelDeleteTopicParams
+    AfterModelDeleteTopicParams,
+    BeforeModelCreateFromTopicParams,
+    AfterModelCreateFromTopicParams
 } from "~/types";
 import * as utils from "~/utils";
 import DataLoader from "dataloader";
@@ -151,7 +153,7 @@ export const createModelsCrud = (params: Params): CmsModelContext => {
         });
     };
 
-    const get = async (modelId: string) => {
+    const get = async (modelId: string): Promise<CmsModel> => {
         const permission = await checkModelPermissions("r");
 
         const model = await modelsGet(modelId);
@@ -176,6 +178,8 @@ export const createModelsCrud = (params: Params): CmsModelContext => {
 
     const onBeforeCreate = createTopic<BeforeModelCreateTopicParams>();
     const onAfterCreate = createTopic<AfterModelCreateTopicParams>();
+    const onBeforeCreateFrom = createTopic<BeforeModelCreateFromTopicParams>();
+    const onAfterCreateFrom = createTopic<AfterModelCreateFromTopicParams>();
     const onBeforeUpdate = createTopic<BeforeModelUpdateTopicParams>();
     const onAfterUpdate = createTopic<AfterModelUpdateTopicParams>();
     const onBeforeDelete = createTopic<BeforeModelDeleteTopicParams>();
@@ -185,6 +189,7 @@ export const createModelsCrud = (params: Params): CmsModelContext => {
      */
     assignBeforeModelCreate({
         onBeforeCreate,
+        onBeforeCreateFrom,
         plugins: context.plugins,
         storageOperations
     });
@@ -214,6 +219,8 @@ export const createModelsCrud = (params: Params): CmsModelContext => {
     return {
         onBeforeModelCreate: onBeforeCreate,
         onAfterModelCreate: onAfterCreate,
+        onBeforeModelCreateFrom: onBeforeCreateFrom,
+        onAfterModelCreateFrom: onAfterCreateFrom,
         onBeforeModelUpdate: onBeforeUpdate,
         onAfterModelUpdate: onAfterUpdate,
         onBeforeModelDelete: onBeforeDelete,
@@ -329,6 +336,61 @@ export const createModelsCrud = (params: Params): CmsModelContext => {
             });
 
             return resultModel;
+        },
+        async createModelFrom(modelId, data) {
+            await checkModelPermissions("w");
+            // Get a model record; this will also perform ownership validation.
+            const original = await get(modelId);
+
+            const createdData = new CreateContentModelModel().populate({
+                name: data.name,
+                modelId: data.modelId,
+                description: data.description || original.description,
+                group: original.group.id
+            });
+
+            await createdData.validate();
+            const input = await createdData.toJSON();
+
+            const identity = getIdentity();
+            const model: CmsModel = {
+                ...original,
+                name: input.name,
+                modelId: input.modelId || undefined,
+                description: input.description,
+                createdBy: {
+                    id: identity.id,
+                    displayName: identity.displayName,
+                    type: identity.type
+                },
+                createdOn: new Date().toISOString() as any,
+                savedOn: new Date().toISOString() as any,
+                lockedFields: [],
+                webinyVersion: context.WEBINY_VERSION
+            };
+
+            await onBeforeCreateFrom.publish({
+                model,
+                original,
+                input
+            });
+
+            const createdModel = await storageOperations.models.create({
+                input,
+                model
+            });
+
+            loaders.listModels.clearAll();
+
+            await updateManager(context, model);
+
+            await onAfterCreateFrom.publish({
+                input,
+                original,
+                model: createdModel
+            });
+
+            return createdModel;
         },
         async updateModel(modelId, inputData) {
             await checkModelPermissions("w");

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeCreate.ts
@@ -1,7 +1,12 @@
 import WebinyError from "@webiny/error";
 import camelCase from "lodash/camelCase";
 import pluralize from "pluralize";
-import { BeforeModelCreateTopicParams, CmsModel, HeadlessCmsStorageOperations } from "~/types";
+import {
+    BeforeModelCreateFromTopicParams,
+    BeforeModelCreateTopicParams,
+    CmsModel,
+    HeadlessCmsStorageOperations
+} from "~/types";
 import { Topic } from "@webiny/pubsub/types";
 import { PluginsContainer } from "@webiny/plugins";
 import { CmsModelPlugin } from "~/content/plugins/CmsModelPlugin";
@@ -112,16 +117,12 @@ const getModelId = (model: CmsModel): string => {
     );
 };
 
-export interface Params {
-    onBeforeCreate: Topic<BeforeModelCreateTopicParams>;
-    storageOperations: HeadlessCmsStorageOperations;
+interface CreateOnBeforeCreateCbParams {
     plugins: PluginsContainer;
+    storageOperations: HeadlessCmsStorageOperations;
 }
-
-export const assignBeforeModelCreate = (params: Params) => {
-    const { onBeforeCreate, storageOperations, plugins } = params;
-
-    onBeforeCreate.subscribe(async params => {
+const createOnBeforeCb = ({ plugins, storageOperations }: CreateOnBeforeCreateCbParams) => {
+    return async (params: BeforeModelCreateTopicParams | BeforeModelCreateFromTopicParams) => {
         const { model } = params;
 
         const modelId = getModelId(model);
@@ -158,5 +159,34 @@ export const assignBeforeModelCreate = (params: Params) => {
         checkModelIdEndingAllowed(modelId);
         checkModelIdUniqueness(modelIdList, modelId);
         model.modelId = modelId;
-    });
+    };
+};
+
+export interface Params {
+    onBeforeCreate: Topic<BeforeModelCreateTopicParams>;
+    onBeforeCreateFrom: Topic<BeforeModelCreateTopicParams>;
+    storageOperations: HeadlessCmsStorageOperations;
+    plugins: PluginsContainer;
+}
+
+/**
+ * We attach both on before create and createFrom events here.
+ * Callables are identical.
+ */
+export const assignBeforeModelCreate = (params: Params) => {
+    const { onBeforeCreate, onBeforeCreateFrom, storageOperations, plugins } = params;
+
+    onBeforeCreate.subscribe(
+        createOnBeforeCb({
+            storageOperations,
+            plugins
+        })
+    );
+
+    onBeforeCreateFrom.subscribe(
+        createOnBeforeCb({
+            storageOperations,
+            plugins
+        })
+    );
 };

--- a/packages/api-headless-cms/src/content/plugins/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/content/plugins/schema/contentModels.ts
@@ -8,6 +8,11 @@ interface CreateCmsModelArgs {
     data: CmsModelCreateInput;
 }
 
+interface CreateFromCmsModelFromArgs {
+    modelId: string;
+    data: CmsModelCreateInput;
+}
+
 interface ReadCmsModelArgs {
     modelId: string;
 }
@@ -57,6 +62,18 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
             createContentModel: async (_: unknown, args: CreateCmsModelArgs, context) => {
                 try {
                     const model = await context.cms.createModel(args.data);
+                    return new Response(model);
+                } catch (e) {
+                    return new ErrorResponse(e);
+                }
+            },
+            createContentModelFrom: async (
+                _: unknown,
+                args: CreateFromCmsModelFromArgs,
+                context
+            ) => {
+                try {
+                    const model = await context.cms.createModelFrom(args.modelId, args.data);
                     return new Response(model);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -124,6 +141,12 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
                 description: String
             }
 
+            input CmsContentModelCreateFromInput {
+                name: String!
+                modelId: String
+                description: String
+            }
+
             input CmsContentModelUpdateInput {
                 name: String
                 group: RefInput
@@ -135,6 +158,11 @@ const plugin = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
 
             extend type Mutation {
                 createContentModel(data: CmsContentModelCreateInput!): CmsContentModelResponse
+
+                createContentModelFrom(
+                    modelId: ID!
+                    data: CmsContentModelCreateFromInput!
+                ): CmsContentModelResponse
 
                 updateContentModel(
                     modelId: ID!

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1201,6 +1201,16 @@ export interface AfterModelCreateTopicParams {
     input: Partial<CmsModel>;
     model: CmsModel;
 }
+export interface BeforeModelCreateFromTopicParams {
+    input: Partial<CmsModel>;
+    original: CmsModel;
+    model: CmsModel;
+}
+export interface AfterModelCreateFromTopicParams {
+    input: Partial<CmsModel>;
+    original: CmsModel;
+    model: CmsModel;
+}
 export interface BeforeModelUpdateTopicParams {
     input: Partial<CmsModel>;
     original: CmsModel;
@@ -1252,11 +1262,14 @@ export interface CmsModelContext {
      */
     createModel: (data: CmsModelCreateInput) => Promise<CmsModel>;
     /**
+     * Create a content model from the given model - clone.
+     */
+    createModelFrom: (
+        modelId: string,
+        data: Omit<CmsModelCreateInput, "group">
+    ) => Promise<CmsModel>;
+    /**
      * Update content model without data validation. Used internally.
-     *
-     * @param model - existing content model
-     * @param data - data to be updated
-     *
      * @hidden
      */
     updateModelDirect: (params: CmsModelUpdateDirectParams) => Promise<CmsModel>;
@@ -1284,6 +1297,8 @@ export interface CmsModelContext {
      */
     onBeforeModelCreate: Topic<BeforeModelCreateTopicParams>;
     onAfterModelCreate: Topic<AfterModelCreateTopicParams>;
+    onBeforeModelCreateFrom: Topic<BeforeModelCreateFromTopicParams>;
+    onAfterModelCreateFrom: Topic<AfterModelCreateFromTopicParams>;
     onBeforeModelUpdate: Topic<BeforeModelUpdateTopicParams>;
     onAfterModelUpdate: Topic<AfterModelUpdateTopicParams>;
     onBeforeModelDelete: Topic<BeforeModelDeleteTopicParams>;


### PR DESCRIPTION
## Changes
Added a GraphQL mutation to clone existing model.
Either new modelId can be given or it will be derived from new model name.
Added new events `onBeforeCreateFrom` and `onAfterCreateFrom` on `context.cms`.

## How Has This Been Tested?
Jest and manually.
