### PR TITLE
fix: protect installers from unauthorized run

### DIFF
--- a/packages/api-file-manager/src/plugins/crud/system.crud.ts
+++ b/packages/api-file-manager/src/plugins/crud/system.crud.ts
@@ -81,6 +81,10 @@ const systemCrudContextPlugin = new ContextPlugin<FileManagerContext>(async cont
             }
         },
         async install({ srcPrefix }) {
+            const identity = context.security.getIdentity();
+            if (!identity) {
+                throw new NotAuthorizedError();
+            }
             const { fileManager } = context;
             const version = await fileManager.system.getVersion();
 

--- a/packages/api-form-builder/src/plugins/crud/system.crud.ts
+++ b/packages/api-form-builder/src/plugins/crud/system.crud.ts
@@ -86,6 +86,10 @@ export const createSystemCrud = (params: Params): SystemCRUD => {
             }
         },
         async installSystem(this: FormBuilder, { domain }) {
+            const identity = context.security.getIdentity();
+            if (!identity) {
+                throw new NotAuthorizedError();
+            }
             const version = await this.getSystemVersion();
             if (version) {
                 throw new WebinyError(

--- a/packages/api-i18n/src/graphql/crud/system.crud.ts
+++ b/packages/api-i18n/src/graphql/crud/system.crud.ts
@@ -1,5 +1,6 @@
 import { I18NContext, I18NSystem, I18NSystemStorageOperations, SystemCRUD } from "~/types";
 import WebinyError from "@webiny/error";
+import { NotAuthorizedError } from "@webiny/api-security";
 
 export interface Params {
     context: I18NContext;
@@ -59,6 +60,10 @@ export const createSystemCrud = (params: Params): SystemCRUD => {
             }
         },
         async installSystem(this: SystemCRUD, { code }) {
+            const identity = context.security.getIdentity();
+            if (!identity) {
+                throw new NotAuthorizedError();
+            }
             const { i18n } = context;
             const version = await this.getSystemVersion();
             if (version) {

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -95,6 +95,11 @@ export const createSystemCrud = (params: Params): SystemCrud => {
             }
         },
         async installSystem(this: PageBuilderContextObject, { name, insertDemoData }) {
+            const identity = context.security.getIdentity();
+            if (!identity) {
+                throw new NotAuthorizedError();
+            }
+
             const { fileManager } = context;
 
             // Check whether the PB app is already installed


### PR DESCRIPTION
## Changes
Some installers could be ran without being logged in.

## How Has This Been Tested?
Jest and manually.

## Documentation
Not required.
