### PR TITLE
Ensure any error within deploy hooks stops the deploy process

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/processHooks.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/processHooks.js
@@ -1,5 +1,3 @@
-const { green } = require("chalk");
-
 module.exports = async (hook, { context, ...options }) => {
     const plugins = context.plugins.byType(hook);
 
@@ -7,7 +5,10 @@ module.exports = async (hook, { context, ...options }) => {
         try {
             await plugins[i].hook(options, context);
         } catch (err) {
-            context.error(`Hook ${green(plugins[i].name)} encountered an error: ${err.message}`);
+            err.message = `An error occurred while processing ${context.error.hl(
+                plugins[i].name
+            )} plugin: ${err.message}`;
+            throw err;
         }
     }
 };


### PR DESCRIPTION
## Changes
Prior to this PR, if one of the [deploy hooks](https://www.webiny.com/docs/how-to-guides/deployment/build-and-deploy-hooks) threw an error, the deploy process would not be stopped, which is incorrect.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.