### PR TITLE
fix(handler-http): add cache to options response

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
@@ -20,6 +20,7 @@ describe("HTTP Options request", () => {
                     "Access-Control-Allow-Methods": "OPTIONS,POST",
                     "Access-Control-Allow-Origin": "*",
                     "Content-Type": "application/json",
+                    "Access-Control-Max-Age": `30758400`,
                     "Cache-Control": "public, max-age=30758400"
                 },
                 isBase64Encoded: undefined,

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -29,7 +29,7 @@ interface ParsedBody {
     operationName: string;
 }
 
-const DEFAULT_HEADERS = {
+const DEFAULT_HEADERS: Record<string, string> = {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Headers": "*",
     "Access-Control-Allow-Methods": "OPTIONS,POST",
@@ -38,6 +38,11 @@ const DEFAULT_HEADERS = {
 };
 
 const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
+
+const OPTIONS_HEADERS: Record<string, string> = {
+    "Access-Control-Max-Age": `${DEFAULT_CACHE_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${DEFAULT_CACHE_MAX_AGE}`
+};
 
 const respond = (http, result: unknown) => {
     return http.response({
@@ -137,7 +142,7 @@ export const graphQLHandlerFactory = (
                         statusCode: 204,
                         headers: {
                             ...DEFAULT_HEADERS,
-                            "Cache-Control": "public, max-age=" + DEFAULT_CACHE_MAX_AGE
+                            ...OPTIONS_HEADERS
                         }
                     });
                 }

--- a/packages/handler-http/__tests__/handler.test.ts
+++ b/packages/handler-http/__tests__/handler.test.ts
@@ -20,11 +20,15 @@ describe("handler response", () => {
                 }
             };
         });
-        const handlerPlugin = new HandlerPlugin(async context => {
+        const handlerPlugin = new HandlerPlugin<HttpContext>(async context => {
             ctx.value = context;
-            return {
-                ok: true
-            };
+            return context.http.response({
+                body: JSON.stringify({
+                    ok: true
+                }),
+                statusCode: 200,
+                headers: {}
+            });
         });
 
         const handler = createHandler(
@@ -38,7 +42,11 @@ describe("handler response", () => {
         const result = await handler();
 
         expect(result).toEqual({
-            ok: true
+            body: JSON.stringify({
+                ok: true
+            }),
+            statusCode: 200,
+            headers: {}
         });
         expect(ctx.value).toMatchObject({
             invocationArgs: {

--- a/packages/handler-http/__tests__/handler.test.ts
+++ b/packages/handler-http/__tests__/handler.test.ts
@@ -1,0 +1,100 @@
+import { ContextPlugin, createHandler, HandlerPlugin } from "@webiny/handler";
+import plugins from "~/index";
+import { HttpContext } from "~/types";
+
+describe("handler response", () => {
+    it("should have http object attached to context", async () => {
+        const ctx = {
+            value: null
+        };
+        const contextPlugin = new ContextPlugin<HttpContext>(async context => {
+            context.invocationArgs = {
+                method: "POST",
+                body: "",
+                headers: {},
+                cookies: {},
+                path: {
+                    base: "base",
+                    parameters: {},
+                    query: {}
+                }
+            };
+        });
+        const handlerPlugin = new HandlerPlugin(async context => {
+            ctx.value = context;
+            return {
+                ok: true
+            };
+        });
+
+        const handler = createHandler(
+            contextPlugin,
+            handlerPlugin,
+            plugins({
+                debug: true
+            })
+        );
+
+        const result = await handler();
+
+        expect(result).toEqual({
+            ok: true
+        });
+        expect(ctx.value).toMatchObject({
+            invocationArgs: {
+                method: "POST",
+                body: "",
+                headers: {},
+                cookies: {},
+                path: {
+                    base: "base",
+                    parameters: {},
+                    query: {}
+                }
+            },
+            http: {
+                request: {
+                    method: "POST",
+                    body: "",
+                    headers: {},
+                    cookies: {},
+                    path: {
+                        base: "base",
+                        parameters: {},
+                        query: {}
+                    }
+                },
+                response: expect.any(Function)
+            }
+        });
+    });
+
+    it("should output proper options headers with caching", async () => {
+        const context = new ContextPlugin<HttpContext>(async context => {
+            context.invocationArgs = {
+                method: "OPTIONS"
+            };
+        });
+        const handler = createHandler(
+            context,
+            plugins({
+                debug: true
+            })
+        );
+
+        const result = await handler();
+
+        expect(result).toEqual({
+            body: "",
+            statusCode: 200,
+            headers: {
+                "Cache-Control": "public, max-age=86400",
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Headers": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,POST",
+                "Access-Control-Max-Age": "86400"
+            }
+        });
+    });
+});

--- a/packages/handler-http/__tests__/handler.test.ts
+++ b/packages/handler-http/__tests__/handler.test.ts
@@ -94,7 +94,7 @@ describe("handler response", () => {
 
         expect(result).toEqual({
             body: "",
-            statusCode: 200,
+            statusCode: 204,
             headers: {
                 "Cache-Control": "public, max-age=86400",
                 "Content-Type": "application/json",

--- a/packages/handler-http/jest.config.js
+++ b/packages/handler-http/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/handler-http/src/index.ts
+++ b/packages/handler-http/src/index.ts
@@ -18,6 +18,8 @@ const OPTIONS_HEADERS: Record<string, string> = {
     "Cache-Control": "public, max-age=86400"
 };
 
+const OPTION_STATUS_CODE = 204;
+
 const lowercaseKeys = obj => {
     return Object.keys(obj).reduce((acc, key) => {
         acc[key.toLowerCase()] = obj[key];
@@ -34,7 +36,7 @@ export default (options: HandlerHttpOptions = {}) => [
 
         if (invocationArgs.method.toLowerCase() === "options") {
             context.setResult({
-                statusCode: 200,
+                statusCode: OPTION_STATUS_CODE,
                 body: "",
                 headers: {
                     ...DEFAULT_HEADERS,

--- a/packages/handler-http/src/index.ts
+++ b/packages/handler-http/src/index.ts
@@ -4,13 +4,17 @@ import { boolean } from "boolean";
 import { getWebinyVersionHeaders } from "@webiny/utils";
 import { ContextPlugin } from "@webiny/handler";
 
-const DEFAULT_HEADERS = {
+const DEFAULT_HEADERS: Record<string, string> = {
     "Cache-Control": "no-store",
     "Content-Type": "application/json",
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Headers": "*",
     "Access-Control-Allow-Methods": "OPTIONS,POST",
     ...getWebinyVersionHeaders()
+};
+
+const OPTIONS_HEADERS: Record<string, string> = {
+    "Access-Control-Max-Age": "86400"
 };
 
 const lowercaseKeys = obj => {
@@ -31,7 +35,10 @@ export default (options: HandlerHttpOptions = {}) => [
             context.setResult({
                 statusCode: 204,
                 body: "",
-                headers: DEFAULT_HEADERS
+                headers: {
+                    ...DEFAULT_HEADERS,
+                    ...OPTIONS_HEADERS
+                }
             });
             return;
         }

--- a/packages/handler-http/src/index.ts
+++ b/packages/handler-http/src/index.ts
@@ -14,7 +14,8 @@ const DEFAULT_HEADERS: Record<string, string> = {
 };
 
 const OPTIONS_HEADERS: Record<string, string> = {
-    "Access-Control-Max-Age": "86400"
+    "Access-Control-Max-Age": "86400",
+    "Cache-Control": "public, max-age=86400"
 };
 
 const lowercaseKeys = obj => {
@@ -33,7 +34,7 @@ export default (options: HandlerHttpOptions = {}) => [
 
         if (invocationArgs.method.toLowerCase() === "options") {
             context.setResult({
-                statusCode: 204,
+                statusCode: 200,
                 body: "",
                 headers: {
                     ...DEFAULT_HEADERS,

--- a/packages/handler-http/src/types.ts
+++ b/packages/handler-http/src/types.ts
@@ -1,13 +1,13 @@
 import { ArgsContext } from "@webiny/handler-args/types";
 import { Context } from "@webiny/handler/types";
 
-type ResponseArgs = {
+interface ResponseArgs {
     statusCode?: number;
     headers?: {};
     body?: string;
-};
+}
 
-export type HttpRequestObject = {
+export interface HttpRequestObject {
     method: "POST" | "GET" | "PUT" | "DELETE" | "OPTIONS" | string;
     body: string;
     headers: { [key: string]: any };
@@ -17,17 +17,17 @@ export type HttpRequestObject = {
         parameters: { [key: string]: any };
         query: { [key: string]: any };
     };
-};
+}
 
-export type HttpObject = {
+export interface HttpObject {
     response: (args: ResponseArgs) => { [key: string]: any };
     request: HttpRequestObject;
-};
+}
 
 export interface HttpContext extends Context, ArgsContext {
     http: HttpObject;
 }
 
-export type HandlerHttpOptions = {
+export interface HandlerHttpOptions {
     debug?: boolean;
-};
+}

--- a/packages/handler/src/createHandler.ts
+++ b/packages/handler/src/createHandler.ts
@@ -59,7 +59,13 @@ async function handle(context: Context) {
         }
 
         const handlers = context.plugins.byType<HandlerPlugin>(HandlerPlugin.type);
-        const handler = middleware(handlers.map(pl => pl.handle));
+        const handler = middleware(
+            handlers.map(pl => {
+                return (context: Context, next: Function) => {
+                    return pl.handle(context, next);
+                };
+            })
+        );
         const result = await handler(context);
         if (!result) {
             throw new Error(`No result was returned from registered handlers.`);
@@ -70,7 +76,13 @@ async function handle(context: Context) {
         // Log error to cloud, as these can be extremely annoying to debug!
         console.log(error);
         const handlers = context.plugins.byType<HandlerErrorPlugin>(HandlerErrorPlugin.type);
-        const handler = middleware(handlers.map(pl => pl.handle));
+        const handler = middleware(
+            handlers.map(pl => {
+                return (context: Context, error: Error, next: Function) => {
+                    return pl.handle(context, error, next);
+                };
+            })
+        );
         return handler(context, error);
     }
 }

--- a/packages/handler/src/plugins/BeforeHandlerPlugin.ts
+++ b/packages/handler/src/plugins/BeforeHandlerPlugin.ts
@@ -1,15 +1,15 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
-interface Callable<T extends Context = Context> {
+export interface BeforeHandlerCallable<T extends Context = Context> {
     (context: T): void | Promise<void>;
 }
 
 export class BeforeHandlerPlugin<T extends Context = Context> extends Plugin {
     public static readonly type: string = "before-handler";
-    private readonly _callable: Callable<T>;
+    private readonly _callable: BeforeHandlerCallable<T>;
 
-    constructor(callable?: Callable<T>) {
+    constructor(callable?: BeforeHandlerCallable<T>) {
         super();
         this._callable = callable;
     }

--- a/packages/handler/src/plugins/ContextPlugin.ts
+++ b/packages/handler/src/plugins/ContextPlugin.ts
@@ -1,15 +1,15 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
-interface Callable<T extends Context = Context> {
+export interface ContextCallable<T extends Context = Context> {
     (context: T): void | Promise<void>;
 }
 
 export class ContextPlugin<T extends Context = Context> extends Plugin {
     public static readonly type = "context";
-    private readonly _callable: Callable<T>;
+    private readonly _callable: ContextCallable<T>;
 
-    constructor(callable?: Callable<T>) {
+    constructor(callable?: ContextCallable<T>) {
         super();
         this._callable = callable;
     }

--- a/packages/handler/src/plugins/HandlerErrorPlugin.ts
+++ b/packages/handler/src/plugins/HandlerErrorPlugin.ts
@@ -1,21 +1,21 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
-export interface HandleError<T extends Context = Context> {
+export interface HandlerErrorCallable<T extends Context = Context> {
     (context: T, error: Error, next: Function): Promise<any>;
 }
 
 export class HandlerErrorPlugin<T extends Context = Context> extends Plugin {
     public static readonly type: string = "handler-error";
 
-    private readonly _handle: HandleError;
+    private readonly _callable: HandlerErrorCallable<T>;
 
-    public constructor(handle: HandleError) {
+    public constructor(callable: HandlerErrorCallable<T>) {
         super();
-        this._handle = handle;
+        this._callable = callable;
     }
 
     async handle(context: T, error: Error, next: Function): Promise<any> {
-        return this._handle(context, error, next);
+        return this._callable(context, error, next);
     }
 }

--- a/packages/handler/src/plugins/HandlerPlugin.ts
+++ b/packages/handler/src/plugins/HandlerPlugin.ts
@@ -1,21 +1,21 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
-export interface Handle<T extends Context = Context> {
+export interface HandlerCallable<T extends Context = Context> {
     (context: T, next: Function): Promise<any>;
 }
 
 export class HandlerPlugin<T extends Context = Context> extends Plugin {
     public static readonly type: string = "handler";
 
-    private readonly _handle: Handle;
+    private readonly _callable: HandlerCallable<T>;
 
-    public constructor(handle: Handle) {
+    public constructor(callable: HandlerCallable<T>) {
         super();
-        this._handle = handle;
+        this._callable = callable;
     }
 
     async handle(context: T, next: Function): Promise<any> {
-        return this._handle(context, next);
+        return this._callable(context, next);
     }
 }

--- a/packages/handler/src/plugins/HandlerResultPlugin.ts
+++ b/packages/handler/src/plugins/HandlerResultPlugin.ts
@@ -1,21 +1,21 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
-export interface HandleResult<T extends Context = Context> {
+export interface HandlerResultCallable<T extends Context = Context> {
     (context: T, result: any): Promise<any>;
 }
 
 export class HandlerResultPlugin<T extends Context = Context> extends Plugin {
     public static readonly type: string = "handler-result";
 
-    private readonly _handle: HandleResult;
+    private readonly _callable: HandlerResultCallable<T>;
 
-    public constructor(handle: HandleResult) {
+    public constructor(callable: HandlerResultCallable<T>) {
         super();
-        this._handle = handle;
+        this._callable = callable;
     }
 
     async handle(context: T, result: any): Promise<any> {
-        return this._handle(context, result);
+        return this._callable(context, result);
     }
 }


### PR DESCRIPTION
## Changes
Add cache to OPTIONS response.

Added missing `Access-Control-Max-Age` to Headless CMS options response.

## How Has This Been Tested?
Jest and manually.

Added tests for `@webiny/handler-http` package.