### PR TITLE
refactor(api-file-manager-ddb-es): add try catch around index creation

### DIFF
--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -397,7 +397,7 @@ describe("Files CRUD test", () => {
      * Testing the search locally and on deployed system shows that searching works.
      */
     // eslint-disable-next-line
-    it("should find files by name", async () => {
+    it.skip("should find files by name", async () => {
         const [createResponse] = await createFiles({
             data: [fileAData, fileBData, fileCData]
         });

--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -397,7 +397,7 @@ describe("Files CRUD test", () => {
      * Testing the search locally and on deployed system shows that searching works.
      */
     // eslint-disable-next-line
-    it.skip("should find files by name", async () => {
+    it("should find files by name", async () => {
         const [createResponse] = await createFiles({
             data: [fileAData, fileBData, fileCData]
         });


### PR DESCRIPTION
## Changes
File installer is failing on the DynamoDB+Elasticsearch so added try/catch around index creation and added a bit more error information.

## How Has This Been Tested?
Jest and manually.
