### PR TITLE
feat(handler): wait for context property

### DIFF
--- a/packages/handler/__tests__/plugins/Context.test.ts
+++ b/packages/handler/__tests__/plugins/Context.test.ts
@@ -1,4 +1,11 @@
 import { Context } from "~/index";
+import { Context as ContextInterface } from "~/types";
+
+interface DummyContextInterface extends ContextInterface {
+    cms: any;
+    pageBuilder: any;
+    formBuilder: any;
+}
 
 describe("Context", () => {
     it("should construct a base context", () => {
@@ -27,7 +34,7 @@ describe("Context", () => {
     it("should wait for a variable to be defined on context and then trigger the callable", async () => {
         const context = new Context({
             WEBINY_VERSION: "test"
-        });
+        }) as unknown as DummyContextInterface;
 
         const tester = {
             cms: false,
@@ -35,15 +42,15 @@ describe("Context", () => {
             pageBuilder: false
         };
 
-        context.waitFor<Context>("cms", () => {
+        context.waitFor("cms", () => {
             tester.cms = true;
         });
-        expect((context as any).cms).toBeUndefined();
+        expect(context.cms).toBeUndefined();
 
-        (context as any).cms = {
+        context.cms = {
             loaded: true
         };
-        expect((context as any).cms).toEqual({
+        expect(context.cms).toEqual({
             loaded: true
         });
 
@@ -52,17 +59,17 @@ describe("Context", () => {
             tester.formBuilder = true;
         });
 
-        (context as any).pageBuilder = {
+        context.pageBuilder = {
             loaded: true
         };
-        (context as any).formBuilder = {
+        context.formBuilder = {
             loaded: true
         };
 
-        expect((context as any).pageBuilder).toEqual({
+        expect(context.pageBuilder).toEqual({
             loaded: true
         });
-        expect((context as any).formBuilder).toEqual({
+        expect(context.formBuilder).toEqual({
             loaded: true
         });
     });

--- a/packages/handler/__tests__/plugins/Context.test.ts
+++ b/packages/handler/__tests__/plugins/Context.test.ts
@@ -37,34 +37,58 @@ describe("Context", () => {
         }) as unknown as DummyContextInterface;
 
         const tester = {
-            cms: false,
-            formBuilder: false,
-            pageBuilder: false
+            cms: 0,
+            formBuilder: 0,
+            pageBuilder: 0
         };
 
         context.waitFor("cms", () => {
-            tester.cms = true;
+            tester.cms++;
         });
         expect(context.cms).toBeUndefined();
 
         context.cms = {
-            loaded: true
+            loaded: 1
         };
+
+        expect(tester).toEqual({
+            cms: 1,
+            pageBuilder: 0,
+            formBuilder: 0
+        });
+
         expect(context.cms).toEqual({
-            loaded: true
+            loaded: 1
         });
 
         context.waitFor(["pageBuilder", "formBuilder"], () => {
-            tester.pageBuilder = true;
-            tester.formBuilder = true;
+            tester.pageBuilder++;
+            tester.formBuilder++;
         });
 
         context.pageBuilder = {
             loaded: true
         };
+
+        expect(tester).toEqual({
+            cms: 1,
+            pageBuilder: 0,
+            formBuilder: 0
+        });
+
         context.formBuilder = {
             loaded: true
         };
+
+        context.formBuilder = {
+            loaded: true
+        };
+
+        expect(tester).toEqual({
+            cms: 1,
+            pageBuilder: 1,
+            formBuilder: 1
+        });
 
         expect(context.pageBuilder).toEqual({
             loaded: true

--- a/packages/handler/__tests__/plugins/Context.test.ts
+++ b/packages/handler/__tests__/plugins/Context.test.ts
@@ -1,0 +1,33 @@
+import { Context } from "~/index";
+
+describe("Context", () => {
+    it("should construct a base context", () => {
+        const context = new Context({
+            WEBINY_VERSION: "test"
+        });
+
+        expect(context).toBeInstanceOf(Context);
+        expect(context).toEqual({
+            plugins: {
+                _byTypeCache: {},
+                plugins: {}
+            },
+            _version: "test",
+            _args: []
+        });
+        expect(context.plugins).toEqual({
+            _byTypeCache: {},
+            plugins: {}
+        });
+        expect(context.args).toEqual([]);
+        expect(context.WEBINY_VERSION).toEqual("test");
+    });
+
+    it("should wait for a variable to be defined on context and then trigger the callable", async () => {
+        const context = new Context({
+            WEBINY_VERSION: "test"
+        });
+
+        context.waitFor<Context>("cms", ctx => {});
+    });
+});

--- a/packages/handler/__tests__/plugins/Context.test.ts
+++ b/packages/handler/__tests__/plugins/Context.test.ts
@@ -12,8 +12,9 @@ describe("Context", () => {
                 _byTypeCache: {},
                 plugins: {}
             },
-            _version: "test",
-            _args: []
+            WEBINY_VERSION: "test",
+            args: [],
+            waiters: []
         });
         expect(context.plugins).toEqual({
             _byTypeCache: {},
@@ -28,6 +29,20 @@ describe("Context", () => {
             WEBINY_VERSION: "test"
         });
 
-        context.waitFor<Context>("cms", ctx => {});
+        const tester = {
+            cms: false
+        };
+
+        context.waitFor<Context>("cms", () => {
+            tester.cms = true;
+        });
+        expect((context as any).cms).toBeUndefined();
+
+        (context as any).cms = {
+            loaded: true
+        };
+        expect((context as any).cms).toEqual({
+            loaded: true
+        });
     });
 });

--- a/packages/handler/__tests__/plugins/Context.test.ts
+++ b/packages/handler/__tests__/plugins/Context.test.ts
@@ -30,7 +30,9 @@ describe("Context", () => {
         });
 
         const tester = {
-            cms: false
+            cms: false,
+            formBuilder: false,
+            pageBuilder: false
         };
 
         context.waitFor<Context>("cms", () => {
@@ -42,6 +44,25 @@ describe("Context", () => {
             loaded: true
         };
         expect((context as any).cms).toEqual({
+            loaded: true
+        });
+
+        context.waitFor(["pageBuilder", "formBuilder"], () => {
+            tester.pageBuilder = true;
+            tester.formBuilder = true;
+        });
+
+        (context as any).pageBuilder = {
+            loaded: true
+        };
+        (context as any).formBuilder = {
+            loaded: true
+        };
+
+        expect((context as any).pageBuilder).toEqual({
+            loaded: true
+        });
+        expect((context as any).formBuilder).toEqual({
             loaded: true
         });
     });

--- a/packages/handler/src/plugins/Context.ts
+++ b/packages/handler/src/plugins/Context.ts
@@ -44,28 +44,59 @@ export class Context implements ContextInterface {
     ): void {
         const initialTargets = Array.isArray(obj) ? obj : [obj];
         const targets: string[] = [];
+        /**
+         * We go only through the first level properties
+         */
         for (const target of initialTargets) {
+            /**
+             * If property already exists, there is no need to wait for it, so we just continue the loop.
+             */
             if (this[target]) {
                 continue;
             }
+            /**
+             * Since there is no property, we must define it with its setter and getter.
+             * We could not know when it got defined otherwise.
+             */
             Object.defineProperty(this, target, {
+                /**
+                 * Setter sets the given value to this object.
+                 * We cannot set it on exact property name it is defined because it would go into loop of setting itself.
+                 * And that is why we add __ around the property name.
+                 */
                 set: value => {
                     this[`__${target}__`] = value;
+                    /**
+                     * WWhen the property is set, we will go through all the waiters and, if any of them include currently set property, act on it.
+                     */
                     for (const waiter of this.waiters) {
                         if (waiter.targets.includes(target) === false) {
                             continue;
                         }
+                        /**
+                         * Remove currently set property so we know if there are any more to be waited for.
+                         */
                         waiter.targets = waiter.targets.filter(t => t !== target);
+                        /**
+                         * If there are more to be waited, eg. user added [cms, pageBuilder] as waited properties, we just continue the loop.
+                         */
                         if (waiter.targets.length > 0) {
                             continue;
                         }
+                        /**
+                         * And if there is nothing more to be waited for, we execute the callable.
+                         * Note that this callable is not async.
+                         */
                         waiter.cb(this);
                     }
                 },
+                /**
+                 * As we have set property with __ around it, we must get it as well.
+                 */
                 get: () => {
                     return this[`__${target}__`];
                 },
-                configurable: true
+                configurable: false
             });
             targets.push(target);
         }

--- a/packages/handler/src/plugins/Context.ts
+++ b/packages/handler/src/plugins/Context.ts
@@ -98,12 +98,21 @@ export class Context implements ContextInterface {
                 },
                 configurable: false
             });
+            /**
+             * We add the target to be awaited.
+             */
             targets.push(target);
         }
+        /**
+         * If there are no targets to be awaited, just fire the callable.
+         */
         if (targets.length === 0) {
             cb(this as any);
             return;
         }
+        /**
+         * Otherwise add the waiter for the target properties.
+         */
         this.waiters.push({
             targets,
             cb

--- a/packages/handler/src/plugins/Context.ts
+++ b/packages/handler/src/plugins/Context.ts
@@ -1,6 +1,11 @@
 import { Context as ContextInterface, HandlerArgs } from "~/types";
 import { PluginsContainer } from "@webiny/plugins";
 
+interface Waiter {
+    targets: string[];
+    cb: (context: ContextInterface) => void;
+}
+
 export interface Params {
     args?: HandlerArgs;
     plugins?: Plugin | Plugin[] | Plugin[][] | PluginsContainer;
@@ -9,22 +14,16 @@ export interface Params {
 export class Context implements ContextInterface {
     public _result: any;
     public readonly plugins: PluginsContainer;
-    private readonly _args: HandlerArgs;
-    private readonly _version: string;
+    public readonly args: HandlerArgs;
+    public readonly WEBINY_VERSION: string;
 
-    public get args(): HandlerArgs {
-        return this._args;
-    }
-
-    public get WEBINY_VERSION(): string {
-        return this._version;
-    }
+    private readonly waiters: Waiter[] = [];
 
     public constructor(params: Params) {
         const { plugins, args, WEBINY_VERSION } = params;
         this.plugins = new PluginsContainer(plugins || []);
-        this._args = args || [];
-        this._version = WEBINY_VERSION;
+        this.args = args || [];
+        this.WEBINY_VERSION = WEBINY_VERSION;
     }
 
     public getResult(): any {
@@ -39,22 +38,44 @@ export class Context implements ContextInterface {
         this._result = value;
     }
 
-    public waitFor(
+    public waitFor<T extends ContextInterface = ContextInterface>(
         obj: string | string[],
-        cb: <T extends ContextInterface = ContextInterface>(context: T) => void
+        cb: (context: T) => void
     ): void {
-        const targets = Array.isArray(obj) ? obj : [obj];
-        for (const target of targets) {
-            if (!this[target]) {
-                Object.defineProperty(this, target, {
-                    set: value => {
-                        this[target] = value;
-                        cb(this);
-                    }
-                });
+        const initialTargets = Array.isArray(obj) ? obj : [obj];
+        const targets: string[] = [];
+        for (const target of initialTargets) {
+            if (this[target]) {
                 continue;
             }
-            cb(this);
+            Object.defineProperty(this, target, {
+                set: value => {
+                    this[`__${target}__`] = value;
+                    for (const waiter of this.waiters) {
+                        if (waiter.targets.includes(target) === false) {
+                            continue;
+                        }
+                        waiter.targets = waiter.targets.filter(t => t !== target);
+                        if (waiter.targets.length > 0) {
+                            continue;
+                        }
+                        waiter.cb(this);
+                    }
+                },
+                get: () => {
+                    return this[`__${target}__`];
+                },
+                configurable: true
+            });
+            targets.push(target);
         }
+        if (targets.length === 0) {
+            cb(this as any);
+            return;
+        }
+        this.waiters.push({
+            targets,
+            cb
+        });
     }
 }

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -37,6 +37,14 @@ export interface Context {
      * @internal
      */
     getResult: () => void;
+    /**
+     * Wait for property to be defined on the object and then execute the callable.
+     * In case of multiple objects defined, wait for all of them.
+     */
+    waitFor: <T extends Context = Context>(
+        obj: string[] | string,
+        cb: (context: T) => void
+    ) => void;
 }
 
 /**


### PR DESCRIPTION
## Changes
A possibility to wait for the context property to be defined and then trigger a callback.

## How Has This Been Tested?
Jest