### PR TITLE
fix(cli-plugin-deploy-pulumi): allow finer control of cache settings

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.d.ts
@@ -5,6 +5,10 @@ export interface Paths {
     relative: string;
 }
 
+type CacheControlMap = {
+    [key: string]: CacheControl
+}
+
 export default function uploadFolderToS3(params: {
     // Path to the folder that needs to be uploaded.
     path: string;
@@ -20,5 +24,5 @@ export default function uploadFolderToS3(params: {
 
     bucket: BucketName;
     acl: ObjectCannedACL;
-    cacheControl: CacheControl;
+    cacheControl: CacheControl | CacheControlMap;
 }): Promise<void>;

--- a/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/aws/uploadFolderToS3.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const fs = require("fs");
 const S3Client = require("aws-sdk/clients/s3");
 const mime = require("mime");
@@ -44,6 +45,10 @@ module.exports = async ({
 
     const pathsChunks = chunk(paths, 20);
 
+    if (_.isString(cacheControl)) {
+        cacheControl = [{ pattern: /.*/, value: cacheControl }];
+    }
+
     for (let i = 0; i < pathsChunks.length; i++) {
         const chunk = pathsChunks[i];
 
@@ -86,7 +91,7 @@ module.exports = async ({
                                     Bucket: bucket,
                                     Key: key,
                                     ACL: acl,
-                                    CacheControl: cacheControl,
+                                    CacheControl: cacheControl.find(x => x.pattern.test(key)).value,
                                     ContentType: mime.getType(path) || undefined,
                                     Body: fs.readFileSync(path),
                                     Metadata: {


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #2179

Allow uploadFolderToS3 to take a list of patterns and cache settings in addition to a simple cache setting string.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manual test.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
