### PR TITLE
feat(api-headless-cms): endpoint and locale plugin

### DIFF
--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -133,7 +133,7 @@ export const graphQLHandlerFactory = (
             async handle(context: CmsContext, next) {
                 const { http } = context;
 
-                if (!http || !http.request || !http.request.path || !http.request.path.parameters) {
+                if (!http || !http.request) {
                     return next();
                 }
 

--- a/packages/api-headless-cms/src/content/parameterPlugins.ts
+++ b/packages/api-headless-cms/src/content/parameterPlugins.ts
@@ -1,0 +1,87 @@
+import WebinyError from "@webiny/error";
+import {
+    CmsParametersPlugin,
+    CmsParametersPluginResponse
+} from "~/content/plugins/CmsParametersPlugin";
+
+export interface CreateParametersPluginsParams {
+    endpointType?: CmsParametersPluginResponse["type"];
+    locale?: CmsParametersPluginResponse["locale"];
+}
+
+const createRequestPlugin = () => {
+    return new CmsParametersPlugin(async context => {
+        /**
+         * If any of the properties is not defined, just ignore this plugin
+         */
+        if (
+            !context.http ||
+            !context.http.request ||
+            !context.http.request.path ||
+            !context.http.request.path.parameters
+        ) {
+            return null;
+        }
+
+        const { key } = context.http.request.path.parameters;
+        if (typeof key !== "string") {
+            throw new WebinyError(
+                "The key property in context.http.request.path.parameters is not a string.",
+                "MALFORMED_KEY",
+                {
+                    key
+                }
+            );
+        }
+        const [type, locale] = key.split("/");
+        if (!type) {
+            throw new WebinyError(
+                `Missing context.http.request.path.parameters.key parameter "type".`
+            );
+        } else if (!locale) {
+            throw new WebinyError(`Missing context.http.request.path.parameters.key "locale".`);
+        }
+
+        return {
+            type,
+            locale
+        };
+    });
+};
+
+const createManualPlugin = (params: CreateParametersPluginsParams): CmsParametersPlugin => {
+    return new CmsParametersPlugin(async () => {
+        /**
+         * if both of parameters are not existing, just skip this plugin.
+         */
+        if (!params.endpointType && !params.locale) {
+            return null;
+        } else if (!params.endpointType) {
+            throw new WebinyError(
+                `There is defined locale CMS parameter but no endpointType.`,
+                "MALFORMED_ENDPOINT_TYPE",
+                {
+                    ...params
+                }
+            );
+        } else if (!params.locale) {
+            throw new WebinyError(
+                `There is defined endpointType CMS parameter but no locale.`,
+                "MALFORMED_LOCALE_TYPE",
+                {
+                    ...params
+                }
+            );
+        }
+
+        return {
+            type: params.endpointType,
+            locale: params.locale
+        };
+    });
+};
+export const createParametersPlugins = (
+    params: CreateParametersPluginsParams
+): CmsParametersPlugin[] => {
+    return [createManualPlugin(params), createRequestPlugin()];
+};

--- a/packages/api-headless-cms/src/content/plugins/CmsParametersPlugin.ts
+++ b/packages/api-headless-cms/src/content/plugins/CmsParametersPlugin.ts
@@ -1,0 +1,27 @@
+import { Plugin } from "@webiny/plugins";
+import { CmsContext } from "~/types";
+
+export interface CmsParametersPluginResponse {
+    type: "read" | "manage" | "preview" | string;
+    locale: string;
+}
+
+export interface CmsParametersPluginCallable {
+    (context: CmsContext): Promise<CmsParametersPluginResponse>;
+}
+
+export class CmsParametersPlugin extends Plugin {
+    public static readonly type: string = "cms-parameters-plugin";
+
+    private readonly callable: CmsParametersPluginCallable;
+
+    public constructor(callable: CmsParametersPluginCallable) {
+        super();
+
+        this.callable = callable;
+    }
+
+    public async getParameters(context: CmsContext): Promise<CmsParametersPluginResponse | null> {
+        return this.callable(context);
+    }
+}

--- a/packages/api-headless-cms/src/index.ts
+++ b/packages/api-headless-cms/src/index.ts
@@ -15,6 +15,8 @@ import {
 } from "~/content/graphQLHandlerFactory";
 
 import { StorageTransformPlugin } from "~/content/plugins/storage/StorageTransformPlugin";
+import { createParametersPlugins, CreateParametersPluginsParams } from "~/content/parameterPlugins";
+import { CmsParametersPlugin } from "./content/plugins/CmsParametersPlugin";
 
 export type AdminContextParams = CreateAdminCrudsParams;
 
@@ -26,9 +28,12 @@ export const createAdminHeadlessCmsGraphQL = () => {
     return createGraphQLPlugin();
 };
 
-export type ContentContextParams = CreateContentCrudsParams;
+export interface ContentContextParams
+    extends CreateContentCrudsParams,
+        CreateParametersPluginsParams {}
 export const createContentHeadlessCmsContext = (params: ContentContextParams) => {
     return [
+        createParametersPlugins(params),
         contextSetup(),
         modelManager(),
         createContentCruds(params),
@@ -45,4 +50,4 @@ export const createContentHeadlessCmsGraphQL = (params?: ContentGraphQLParams) =
     return graphQLHandlerFactory(params);
 };
 
-export { StorageTransformPlugin };
+export { StorageTransformPlugin, CmsParametersPlugin };

--- a/packages/api-headless-cms/src/index.ts
+++ b/packages/api-headless-cms/src/index.ts
@@ -13,10 +13,11 @@ import {
     CreateGraphQLHandlerOptions,
     graphQLHandlerFactory
 } from "~/content/graphQLHandlerFactory";
-
 import { StorageTransformPlugin } from "~/content/plugins/storage/StorageTransformPlugin";
 import { createParametersPlugins, CreateParametersPluginsParams } from "~/content/parameterPlugins";
-import { CmsParametersPlugin } from "./content/plugins/CmsParametersPlugin";
+import { CmsParametersPlugin } from "~/content/plugins/CmsParametersPlugin";
+import { CmsGroupPlugin } from "~/content/plugins/CmsGroupPlugin";
+import { CmsModelPlugin } from "~/content/plugins/CmsModelPlugin";
 
 export type AdminContextParams = CreateAdminCrudsParams;
 
@@ -50,4 +51,4 @@ export const createContentHeadlessCmsGraphQL = (params?: ContentGraphQLParams) =
     return graphQLHandlerFactory(params);
 };
 
-export { StorageTransformPlugin, CmsParametersPlugin };
+export { StorageTransformPlugin, CmsParametersPlugin, CmsGroupPlugin, CmsModelPlugin };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -985,6 +985,7 @@ export interface CmsModelFieldInput {
     type: string;
     /**
      * A unique ID for the field. Values will be mapped via this value.
+     * This field MUST be in range of "a-zA-Z".
      */
     fieldId: string;
     /**


### PR DESCRIPTION
## Changes
Add plugin `CmsParametersPlugin` which determines the locale and type for use in the Headless CMS.
Built-in plugins are manual and request:
* manual - user passes the parameters `endpointType` and `locale` when creating the CMS context.
* request - type and locale are automatically determined from `context.http.request.parameters.key` value.

## Usage
For example, if user wants to determine the endpoint type and locale from headers, they would need to implement `CmsParametersPlugin` which takes those parameters from the headers and return them from the `getParameters` method.

## How Has This Been Tested?
Jest testing.
