### PR TITLE
fix: login screen logo

### DIFF
--- a/packages/app-admin-cognito/package.json
+++ b/packages/app-admin-cognito/package.json
@@ -16,6 +16,7 @@
     "@aws-amplify/auth": "^4.3.10",
     "@emotion/styled": "^10.0.27",
     "@webiny/app": "^5.21.0",
+    "@webiny/app-admin": "^5.21.0",
     "@webiny/app-cognito-authenticator": "^5.21.0",
     "@webiny/app-security": "^5.21.0",
     "@webiny/form": "^5.21.0",

--- a/packages/app-admin-cognito/src/views/StateContainer.tsx
+++ b/packages/app-admin-cognito/src/views/StateContainer.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
-import { LoginContent, Logo, Wrapper } from "./StyledComponents";
-import logoOrange from "./webiny-orange-logo.svg";
+import { Logo } from "@webiny/app-admin";
+import { LoginContent, LogoWrapper, Wrapper } from "./StyledComponents";
 
 const StateContainer = ({ children }) => (
     <Wrapper>
-        <Logo src={logoOrange} />
+        <LogoWrapper>
+            <Logo />
+        </LogoWrapper>
         <LoginContent>{children}</LoginContent>
     </Wrapper>
 );

--- a/packages/app-admin-cognito/src/views/StyledComponents.ts
+++ b/packages/app-admin-cognito/src/views/StyledComponents.ts
@@ -9,10 +9,9 @@ export const Wrapper = styled("section")({
     color: "var(--mdc-theme-on-surface)"
 });
 
-export const Logo = styled("img")({
+export const LogoWrapper = styled("div")({
     margin: "0 auto",
-    marginBottom: 30,
-    width: 125
+    marginBottom: 30
 });
 
 export const LoginContent = styled("div")({

--- a/packages/app-admin-cognito/tsconfig.build.json
+++ b/packages/app-admin-cognito/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "references": [
     { "path": "../app/tsconfig.build.json" },
+    { "path": "../app-admin/tsconfig.build.json" },
     { "path": "../app-cognito-authenticator/tsconfig.build.json" },
     { "path": "../app-security/tsconfig.build.json" },
     { "path": "../form/tsconfig.build.json" },

--- a/packages/app-admin-cognito/tsconfig.json
+++ b/packages/app-admin-cognito/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "__tests__/**/*.ts"],
   "references": [
     { "path": "../app" },
+    { "path": "../app-admin" },
     { "path": "../app-cognito-authenticator" },
     { "path": "../app-security" },
     { "path": "../form" },
@@ -18,6 +19,8 @@
       "~/*": ["./src/*"],
       "@webiny/app/*": ["../app/src/*"],
       "@webiny/app": ["../app/src"],
+      "@webiny/app-admin/*": ["../app-admin/src/*"],
+      "@webiny/app-admin": ["../app-admin/src"],
       "@webiny/app-cognito-authenticator/*": ["../app-cognito-authenticator/src/*"],
       "@webiny/app-cognito-authenticator": ["../app-cognito-authenticator/src"],
       "@webiny/app-security/*": ["../app-security/src/*"],

--- a/packages/app-admin-rmwc/src/modules/Brand/index.tsx
+++ b/packages/app-admin-rmwc/src/modules/Brand/index.tsx
@@ -30,14 +30,18 @@ const BrandImpl: HigherOrderComponent = () => {
 
 const WebinyLogo = () => {
     const { location } = useTags();
+    const isLoginScreen = location === "loginScreen";
+    const isAppBar = location === "appBar";
+
+    const color = isAppBar ? "white" : "var(--mdc-theme-primary)";
 
     return (
         <LogoIcon
             style={{
-                width: 100,
-                height: 30,
-                paddingLeft: 20,
-                color: location === "navigation" ? "var(--mdc-theme-primary)" : "white"
+                width: isLoginScreen ? 125 : 100,
+                height: isLoginScreen ? "auto" : 30,
+                paddingLeft: isLoginScreen ? 0 : 20,
+                color
             }}
         />
     );

--- a/packages/app-admin-rmwc/src/modules/Layout.tsx
+++ b/packages/app-admin-rmwc/src/modules/Layout.tsx
@@ -8,7 +8,8 @@ import {
     Search,
     LocaleSelector,
     UserMenu,
-    Navigation
+    Navigation,
+    Tags
 } from "@webiny/app-admin";
 import { TopAppBarPrimary, TopAppBarSection } from "@webiny/ui/TopAppBar";
 
@@ -17,18 +18,20 @@ const RMWCLayout = () => {
         return (
             <Fragment>
                 {title ? <Helmet title={title} /> : null}
-                <TopAppBarPrimary fixed>
-                    <TopAppBarSection style={{ width: "25%" }} alignStart>
-                        <Brand />
-                    </TopAppBarSection>
-                    <TopAppBarSection style={{ width: "50%" }}>
-                        <Search />
-                    </TopAppBarSection>
-                    <TopAppBarSection style={{ width: "25%" }} alignEnd>
-                        <LocaleSelector />
-                        <UserMenu />
-                    </TopAppBarSection>
-                </TopAppBarPrimary>
+                <Tags tags={{ location: "appBar" }}>
+                    <TopAppBarPrimary fixed>
+                        <TopAppBarSection style={{ width: "25%" }} alignStart>
+                            <Brand />
+                        </TopAppBarSection>
+                        <TopAppBarSection style={{ width: "50%" }}>
+                            <Search />
+                        </TopAppBarSection>
+                        <TopAppBarSection style={{ width: "25%" }} alignEnd>
+                            <LocaleSelector />
+                            <UserMenu />
+                        </TopAppBarSection>
+                    </TopAppBarPrimary>
+                </Tags>
                 <div style={{ paddingTop: 67 }}>{children}</div>
                 <Navigation />
             </Fragment>

--- a/packages/app-admin/src/base/ui/LoginScreen.tsx
+++ b/packages/app-admin/src/base/ui/LoginScreen.tsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { makeComposable } from "@webiny/app-admin-core";
+import { Tags } from "./Tags";
 
 export interface LoginScreenProps {
     children: React.ReactNode;
 }
 
 export const LoginScreen = ({ children }: LoginScreenProps) => {
-    return <LoginScreenRenderer>{children}</LoginScreenRenderer>;
+    return (
+        <Tags tags={{ location: "loginScreen" }}>
+            <LoginScreenRenderer>{children}</LoginScreenRenderer>
+        </Tags>
+    );
 };
 
 export const LoginScreenRenderer = makeComposable<LoginScreenProps>("LoginScreenRenderer");

--- a/packages/app-serverless-cms/src/index.tsx
+++ b/packages/app-serverless-cms/src/index.tsx
@@ -11,6 +11,8 @@ export {
     AddMenu,
     AddRoute,
     AddUserMenuItem,
+    Dashboard,
+    DashboardRenderer,
     Layout,
     LayoutRenderer,
     LoginScreen,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9699,6 +9699,7 @@ __metadata:
     "@babel/preset-typescript": ^7.8.3
     "@emotion/styled": ^10.0.27
     "@webiny/app": ^5.21.0
+    "@webiny/app-admin": ^5.21.0
     "@webiny/app-cognito-authenticator": ^5.21.0
     "@webiny/app-security": ^5.21.0
     "@webiny/cli": ^5.21.0


### PR DESCRIPTION
## Changes
This PR updates the Cognito login screen to use the `Logo` component from `@webiny/app-admin` package. This way, the logo will be customizable using the `<AddLogo/>` plugin component.

However, to make it work properly, I also had to add a new `<Tags/>` element around the `LoginScreen` and `TopAppBar` in the Admin app layout, to be able to identify the location of the logo from the context. The logo is now rendered in 3 locations: `appBar`, `navigation`, and `loginScreen`. These values are accessible via `const { location } = useTags();`, and this allows conditional rendering and styling based on the location of your Logo component.

And the last thing to make `<AddLogo/>` affect the LoginScreen is to use it without the `<Plugins>` wrapper. The reason is that `<Plugins>` component(s) are mounted as children of all the composed Context Providers. This is kind of a problem, because, `<LoginScreen/>` is mounted in the Provider hierarchy, so those plugins are not yet mounted at that point in time.
See https://www.webiny.com/docs/how-to-guides/webiny-applications/admin-area/framework#overview for more details.

Since AddLogo is a plugin that just uses the Compose component, we can render it without the Plugins wrapper, and it will immediately affect the Logo.

Closes #2186 @econtentmaps 

This PR also exports the `Dashboard` and `DashboardRenderer` components from `app-serverless-cms`.

## How Has This Been Tested?
Manually.

## Documentation
Not needed.
