### PR TITLE
refactor(headless-cms): date time field

### DIFF
--- a/packages/api-elasticsearch/src/plugins/operator/equal.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/equal.ts
@@ -13,6 +13,15 @@ export class ElasticsearchQueryBuilderOperatorEqualPlugin extends ElasticsearchQ
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, path, basePath } = params;
+
+        if (value === null) {
+            query.must_not.push({
+                exists: {
+                    field: path
+                }
+            });
+            return;
+        }
         /**
          * In case we are searching for a string, use regular path.
          * Otherwise use base path

--- a/packages/api-elasticsearch/src/plugins/operator/not.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/not.ts
@@ -14,6 +14,15 @@ export class ElasticsearchQueryBuilderOperatorNotPlugin extends ElasticsearchQue
     ): void {
         const { value, path, basePath } = params;
 
+        if (value === null) {
+            query.must.push({
+                exists: {
+                    field: path
+                }
+            });
+            return;
+        }
+
         const useBasePath = typeof value !== "string";
         query.must_not.push({
             term: {

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -303,12 +303,7 @@ const models: CmsModel[] = [
                 settings: {
                     type: "date"
                 },
-                validation: [
-                    {
-                        name: "required",
-                        message: "Please enter a date"
-                    }
-                ],
+                validation: [],
                 listValidation: [],
                 placeholderText: "placeholder text",
                 predefinedValues: {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -70,7 +70,7 @@ export default /* GraphQL */ `
         price: Number!
         inStock: Boolean
         itemsInStock: Number
-        availableOn: Date!
+        availableOn: Date
         color: String!
         availableSizes: [String]!
         image: String!

--- a/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
@@ -202,7 +202,7 @@ export const useProductManageHandler = (
                 headers
             });
         },
-        async listProducts(variables, headers: Record<string, any> = {}) {
+        async listProducts(variables = {}, headers: Record<string, any> = {}) {
             return await contentHandler.invoke({
                 body: { query: listProductsQuery, variables },
                 headers

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { Input, TrailingIcon } from "./Input";
+import { CmsEditorField } from "~/types";
+import { getFieldValue } from "~/admin/plugins/fieldRenderers/dateTime/utils";
+
+export interface Props {
+    field: CmsEditorField;
+    bind: any;
+    trailingIcon?: TrailingIcon;
+}
+
+export const DateOnly: React.FC<Props> = props => {
+    const { field, bind, trailingIcon } = props;
+    const initialDate = getFieldValue(field, bind, () => {
+        return new Date().toISOString().substr(0, 10);
+    });
+
+    const [date, setDate] = useState<string>("");
+
+    useEffect(() => {
+        if (!initialDate) {
+            return;
+        }
+        setDate(initialDate);
+        bind.onChange(initialDate);
+    }, []);
+
+    return (
+        <Input
+            bind={{
+                ...bind,
+                value: date,
+                onChange: (value: string) => {
+                    if (!value && initialDate) {
+                        value = initialDate;
+                    }
+                    return bind.onChange(value);
+                }
+            }}
+            field={field}
+            type={field.settings.type}
+            trailingIcon={trailingIcon}
+        />
+    );
+};

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Input, TrailingIcon } from "./Input";
 import { CmsEditorField } from "~/types";
-import { getFieldValue } from "~/admin/plugins/fieldRenderers/dateTime/utils";
+import {
+    getCurrentDate,
+    getDefaultFieldValue
+} from "~/admin/plugins/fieldRenderers/dateTime/utils";
 
 export interface Props {
     field: CmsEditorField;
@@ -11,19 +14,18 @@ export interface Props {
 
 export const DateOnly: React.FC<Props> = props => {
     const { field, bind, trailingIcon } = props;
-    const initialDate = getFieldValue(field, bind, () => {
-        return new Date().toISOString().substr(0, 10);
+    const date = getDefaultFieldValue(field, bind, () => {
+        return getCurrentDate(new Date());
     });
 
-    const [date, setDate] = useState<string>("");
+    const bindValue = bind.value || "";
 
     useEffect(() => {
-        if (!initialDate) {
+        if (!date || bindValue === date) {
             return;
         }
-        setDate(initialDate);
-        bind.onChange(initialDate);
-    }, []);
+        bind.onChange(date);
+    }, [bindValue]);
 
     return (
         <Input
@@ -31,8 +33,11 @@ export const DateOnly: React.FC<Props> = props => {
                 ...bind,
                 value: date,
                 onChange: (value: string) => {
-                    if (!value && initialDate) {
-                        value = initialDate;
+                    if (!value) {
+                        if (!bindValue) {
+                            return;
+                        }
+                        return bind.onChange("");
                     }
                     return bind.onChange(value);
                 }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -3,20 +3,20 @@ import { CmsEditorField } from "~/types";
 import { BindComponentRenderProp } from "@webiny/form";
 import { Input as UiInput } from "@webiny/ui/Input";
 
-type TrailingIconType = {
+export interface TrailingIcon {
     icon: React.ReactNode;
     onClick: any;
-};
+}
 
-type Props = {
+export interface Props {
     step?: number;
     type?: string;
     bind: BindComponentRenderProp;
     field: CmsEditorField;
-    trailingIcon?: TrailingIconType;
-};
+    trailingIcon?: TrailingIcon;
+}
 
-const Input = ({ bind, ...props }: Props) => {
+export const Input: React.FC<Props> = ({ bind, ...props }) => {
     return (
         <UiInput
             {...props}
@@ -35,5 +35,3 @@ const Input = ({ bind, ...props }: Props) => {
         />
     );
 };
-
-export default Input;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Select.tsx
@@ -1,7 +1,15 @@
 import * as React from "react";
-import { Select as UiSelect } from "@webiny/ui/Select";
+import { Select as UiSelect, SelectProps } from "@webiny/ui/Select";
 
-const Select = props => {
+export interface Option {
+    value: string;
+    label: string;
+}
+
+export interface Props extends SelectProps {
+    options: Option[];
+}
+export const Select: React.FC<Props> = props => {
     return (
         <UiSelect {...props}>
             {props.options.map(t => {
@@ -14,5 +22,3 @@ const Select = props => {
         </UiSelect>
     );
 };
-
-export default Select;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -1,9 +1,37 @@
-import React from "react";
-import Input from "./Input";
+import React, { useState, useEffect } from "react";
+import { Input, Props } from "./Input";
+import { getFieldValue } from "~/admin/plugins/fieldRenderers/dateTime/utils";
 
-const Time = props => {
+export const Time: React.FC<Props> = props => {
+    const initialTime = getFieldValue(props.field, props.bind, () => {
+        return new Date().toISOString().substr(11, 8);
+    });
+
+    const [time, setTime] = useState<string>("");
+
+    useEffect(() => {
+        if (!initialTime) {
+            return;
+        }
+        setTime(initialTime);
+        props.bind.onChange(initialTime);
+    }, []);
+
     // "09:00:00"
-    return <Input {...props} type={"time"} step={5} trailingIcon={props.trailingIcon} />;
+    return (
+        <Input
+            {...props}
+            bind={{
+                ...props.bind,
+                value: time,
+                onChange: (value: string) => {
+                    if (!value) {
+                    }
+                    return props.bind.onChange(value);
+                }
+            }}
+            type={"time"}
+            step={5}
+        />
+    );
 };
-
-export default Time;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -1,33 +1,39 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { Input, Props } from "./Input";
-import { getFieldValue } from "~/admin/plugins/fieldRenderers/dateTime/utils";
+import {
+    getCurrentLocalTime,
+    getDefaultFieldValue
+} from "~/admin/plugins/fieldRenderers/dateTime/utils";
 
 export const Time: React.FC<Props> = props => {
-    const initialTime = getFieldValue(props.field, props.bind, () => {
-        return new Date().toISOString().substr(11, 8);
+    const { field, bind } = props;
+    const time = getDefaultFieldValue(field, bind, () => {
+        return getCurrentLocalTime(new Date());
     });
 
-    const [time, setTime] = useState<string>("");
+    const bindValue = bind.value || "";
 
     useEffect(() => {
-        if (!initialTime) {
+        if (!time || bindValue === time) {
             return;
         }
-        setTime(initialTime);
-        props.bind.onChange(initialTime);
-    }, []);
+        bind.onChange(time);
+    }, [bindValue]);
 
-    // "09:00:00"
     return (
         <Input
             {...props}
             bind={{
-                ...props.bind,
+                ...bind,
                 value: time,
                 onChange: (value: string) => {
                     if (!value) {
+                        if (bind.value) {
+                            return;
+                        }
+                        return bind.onChange("");
                     }
-                    return props.bind.onChange(value);
+                    return bind.onChange(value);
                 }
             }}
             type={"time"}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeField.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import get from "lodash/get";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import { i18n } from "@webiny/app/i18n";
-import DateTimeWithoutTimezone from "./DateTimeWithoutTimezone";
-import DateTimeWithTimezone from "./DateTimeWithTimezone";
-import Time from "./Time";
-import Input from "./Input";
+import { DateOnly } from "./DateOnly";
+import { DateTimeWithoutTimezone } from "./DateTimeWithoutTimezone";
+import { DateTimeWithTimezone } from "./DateTimeWithTimezone";
+import { Time } from "./Time";
 
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 
@@ -31,14 +31,12 @@ const plugin: CmsEditorFieldRendererPlugin = {
                     {bind => {
                         if (field.settings.type === "dateTimeWithoutTimezone") {
                             return <DateTimeWithoutTimezone field={field} bind={bind} />;
-                        }
-                        if (field.settings.type === "dateTimeWithTimezone") {
+                        } else if (field.settings.type === "dateTimeWithTimezone") {
                             return <DateTimeWithTimezone field={field} bind={bind} />;
-                        }
-                        if (field.settings.type === "time") {
+                        } else if (field.settings.type === "time") {
                             return <Time field={field} bind={bind} />;
                         }
-                        return <Input bind={bind} field={field} type={field.settings.type} />;
+                        return <DateOnly bind={bind} field={field} />;
                     }}
                 </Bind>
             );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import get from "lodash/get";
+import DynamicSection from "../DynamicSection";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import { i18n } from "@webiny/app/i18n";
 import { ReactComponent as DeleteIcon } from "~/admin/icons/close.svg";
-import DynamicSection from "../DynamicSection";
-import DateTimeWithoutTimezone from "./DateTimeWithoutTimezone";
-import DateTimeWithTimezone from "./DateTimeWithTimezone";
-import Time from "./Time";
-import Input from "./Input";
+import { DateTimeWithoutTimezone } from "./DateTimeWithoutTimezone";
+import { DateTimeWithTimezone } from "./DateTimeWithTimezone";
+import { DateOnly } from "./DateOnly";
+import { Time } from "./Time";
 
 const t = i18n.ns("app-headless-cms/admin/fields/date-time");
 
@@ -64,14 +64,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                             t` Value {number}`({ number: index + 1 })
                                     }}
                                     bind={bind.index}
-                                    label={t`Value {number}`({ number: index + 1 })}
                                     trailingIcon={trailingIcon}
                                 />
                             );
                         }
 
                         return (
-                            <Input
+                            <DateOnly
                                 bind={bind.index}
                                 field={{
                                     ...props.field,
@@ -79,7 +78,6 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                         props.field.label +
                                         t` Value {number}`({ number: index + 1 })
                                 }}
-                                type={field.settings.type}
                                 trailingIcon={trailingIcon}
                             />
                         );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -162,31 +162,59 @@ export const UTC_TIMEZONES = [
         label: "UTC+14:00"
     }
 ];
-/**
- * @returns Current date string in format `YYYY-MM-DD`
- */
-export const getCurrentDateString = () => {
-    const today = new Date().toISOString();
-    return today.substr(0, 10);
-};
 
-export const DEFAULT_TIME = "00:00:00";
-export const DEFAULT_DATE = getCurrentDateString();
 export const DEFAULT_TIMEZONE = "+01:00";
 
-export const getFieldValue = (
+export const getDefaultFieldValue = (
     field: CmsEditorField,
-    bind: { value: any },
+    bind: {
+        value: string | null | undefined;
+    },
     getCurrent: () => string
-) => {
-    if (bind.value) {
-        return bind.value;
-    }
+): string => {
     const def = field.settings ? field.settings.defaultSetValue || "null" : "null";
-    if (def === "current") {
-        return getCurrent();
+    if (bind.value || def === "null") {
+        return bind.value || "";
     }
-    return null;
+    return getCurrent();
+};
+
+export const getCurrentTimeZone = (date?: Date): string => {
+    if (!date) {
+        date = new Date();
+    }
+    const value = date.toTimeString();
+
+    const matches = value.match(/GMT([+-][0-9]{4})/);
+    if (!matches) {
+        return null;
+    }
+    const timezone = matches[1];
+    return `${timezone.substr(0, 3)}:${timezone.substr(3)}`;
+};
+
+export const getCurrentLocalTime = (date?: Date): string => {
+    if (!date) {
+        date = new Date();
+    }
+    const value = date.toTimeString();
+
+    const [time] = value.split(" ");
+    if (!time || time.match(/^([0-9]{2}):([0-9]{2}):([0-9]{2})$/) === null) {
+        return "00:00:00";
+    }
+    return time;
+};
+
+export const getCurrentDate = (date?: Date): string => {
+    if (!date) {
+        date = new Date();
+    }
+    const year = String(date.getFullYear()).padStart(4, "0");
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${day}`;
 };
 
 const deleteIconStyles = css({

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -173,7 +173,7 @@ export const getDefaultFieldValue = (
     getCurrent: () => string
 ): string => {
     const def = field.settings ? field.settings.defaultSetValue || "null" : "null";
-    if (bind.value || def === "null") {
+    if (bind.value || def !== "current") {
         return bind.value || "";
     }
     return getCurrent();

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { css } from "emotion";
 import { Cell } from "@webiny/ui/Grid";
 import { IconButton } from "@webiny/ui/Button";
+import { CmsEditorField } from "~/types";
 
 export const UTC_TIMEZONES = [
     {
@@ -172,6 +173,21 @@ export const getCurrentDateString = () => {
 export const DEFAULT_TIME = "00:00:00";
 export const DEFAULT_DATE = getCurrentDateString();
 export const DEFAULT_TIMEZONE = "+01:00";
+
+export const getFieldValue = (
+    field: CmsEditorField,
+    bind: { value: any },
+    getCurrent: () => string
+) => {
+    if (bind.value) {
+        return bind.value;
+    }
+    const def = field.settings ? field.settings.defaultSetValue || "null" : "null";
+    if (def === "current") {
+        return getCurrent();
+    }
+    return null;
+};
 
 const deleteIconStyles = css({
     width: "100% !important",

--- a/packages/app-headless-cms/src/admin/plugins/fieldValidators/date/createDateInputField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldValidators/date/createDateInputField.tsx
@@ -1,19 +1,17 @@
 import React from "react";
-import DateTimeWithoutTimezone from "../../fieldRenderers/dateTime/DateTimeWithoutTimezone";
-import DateTimeWithTimezone from "../../fieldRenderers/dateTime/DateTimeWithTimezone";
-import Time from "../../fieldRenderers/dateTime/Time";
-import Input from "../../fieldRenderers/dateTime/Input";
+import { DateTimeWithoutTimezone } from "../../fieldRenderers/dateTime/DateTimeWithoutTimezone";
+import { DateTimeWithTimezone } from "../../fieldRenderers/dateTime/DateTimeWithTimezone";
+import { Time } from "../../fieldRenderers/dateTime/Time";
 import { CmsEditorField } from "~/types";
+import { DateOnly } from "~/admin/plugins/fieldRenderers/dateTime/DateOnly";
 
 export const createInputField = (field: CmsEditorField, bind: any) => {
     if (field.settings.type === "dateTimeWithoutTimezone") {
         return <DateTimeWithoutTimezone field={field} bind={bind} />;
-    }
-    if (field.settings.type === "dateTimeWithTimezone") {
+    } else if (field.settings.type === "dateTimeWithTimezone") {
         return <DateTimeWithTimezone field={field} bind={bind} />;
-    }
-    if (field.settings.type === "time") {
+    } else if (field.settings.type === "time") {
         return <Time field={field} bind={bind} />;
     }
-    return <Input bind={bind} field={field} type={field.settings.type} />;
+    return <DateOnly bind={bind} field={field} />;
 };

--- a/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dateTime.tsx
@@ -43,34 +43,49 @@ const plugin: CmsEditorFieldTypePlugin = {
             }>;
 
             return (
-                <Grid>
-                    <Cell span={12}>
-                        <Bind name={"placeholderText"}>
-                            <Input
-                                label={t`Placeholder text`}
-                                description={t`Placeholder text (optional)`}
-                            />
-                        </Bind>
-                    </Cell>
-                    <Cell span={12}>
-                        <Bind name={"settings.type"}>
-                            <Select
-                                label={t`Format`}
-                                description={t`Cannot be changed later`}
-                                disabled={lockedField && Boolean(lockedField.formatType)}
-                            >
-                                <option value={t`date`}>{t`Date only`}</option>
-                                <option value={t`time`}>{t`Time only`}</option>
-                                <option
-                                    value={t`dateTimeWithTimezone`}
-                                >{t`Date and time with timezone`}</option>
-                                <option
-                                    value={t`dateTimeWithoutTimezone`}
-                                >{t`Date and time without timezone`}</option>
-                            </Select>
-                        </Bind>
-                    </Cell>
-                </Grid>
+                <>
+                    <Grid>
+                        <Cell span={12}>
+                            <Bind name={"placeholderText"}>
+                                <Input
+                                    label={t`Placeholder text`}
+                                    description={t`Placeholder text (optional)`}
+                                />
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                    <Grid>
+                        <Cell span={6}>
+                            <Bind name={"settings.type"}>
+                                <Select
+                                    label={t`Format`}
+                                    description={t`Cannot be changed later`}
+                                    disabled={lockedField && Boolean(lockedField.formatType)}
+                                >
+                                    <option value={t`date`}>{t`Date only`}</option>
+                                    <option value={t`time`}>{t`Time only`}</option>
+                                    <option
+                                        value={t`dateTimeWithTimezone`}
+                                    >{t`Date and time with timezone`}</option>
+                                    <option
+                                        value={t`dateTimeWithoutTimezone`}
+                                    >{t`Date and time without timezone`}</option>
+                                </Select>
+                            </Bind>
+                        </Cell>
+                        <Cell span={6}>
+                            <Bind name={"settings.defaultSetValue"}>
+                                <Select
+                                    label={t`Default Admin UI value`}
+                                    description={"Affects the Admin UI only"}
+                                >
+                                    <option value={t`null`}>{t`Leave empty (null value)`}</option>
+                                    <option value={t`current`}>{t`Current date/time`}</option>
+                                </Select>
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                </>
             );
         }
     }

--- a/packages/app-headless-cms/src/admin/plugins/transformers/dateTransformer.ts
+++ b/packages/app-headless-cms/src/admin/plugins/transformers/dateTransformer.ts
@@ -17,7 +17,8 @@ const throwTransformError = (params: ThrowTransformErrorParams): void => {
 
 const dateOnly = (value?: string): string => {
     if (!value) {
-        return new Date().toISOString().substr(0, 10);
+        return null;
+        // return new Date().toISOString().substr(0, 10);
     }
     try {
         const date = new Date(value).toISOString();
@@ -54,7 +55,8 @@ const extractTimeZone = (value?: string): [string, string] => {
 
 const extractTime = (value?: string): string => {
     if (!value) {
-        return "00:00:00";
+        return null;
+        // return "00:00:00";
     } else if (value.includes(":") === false) {
         throw new WebinyError("Time value is missing : separators.", "TIME_ERROR", {
             value
@@ -70,8 +72,9 @@ const extractTime = (value?: string): string => {
 
 const dateTimeWithTimezone = (value?: string): string => {
     if (!value) {
-        const date = new Date().toISOString();
-        return date.replace(/\.([0-9]+)Z/, "+00:00");
+        return null;
+        // const date = new Date().toISOString();
+        // return date.replace(/\.([0-9]+)Z/, "+00:00");
     } else if (value.includes("T") === false) {
         return value;
     }
@@ -103,7 +106,8 @@ const dateTimeWithTimezone = (value?: string): string => {
 
 const dateTimeWithoutTimezone = (value?: string): string => {
     if (!value) {
-        return new Date().toISOString();
+        return null;
+        // return new Date().toISOString();
     } else if (value.includes(" ") === false) {
         return value;
     }
@@ -120,7 +124,8 @@ const dateTimeWithoutTimezone = (value?: string): string => {
 
 const time = (value?: string) => {
     if (!value) {
-        return "00:00:00";
+        return null;
+        // return "00:00:00";
     }
     return extractTime(value);
 };

--- a/packages/app-headless-cms/src/admin/plugins/transformers/dateTransformer.ts
+++ b/packages/app-headless-cms/src/admin/plugins/transformers/dateTransformer.ts
@@ -56,7 +56,6 @@ const extractTimeZone = (value?: string): [string, string] => {
 const extractTime = (value?: string): string => {
     if (!value) {
         return null;
-        // return "00:00:00";
     } else if (value.includes(":") === false) {
         throw new WebinyError("Time value is missing : separators.", "TIME_ERROR", {
             value
@@ -73,8 +72,6 @@ const extractTime = (value?: string): string => {
 const dateTimeWithTimezone = (value?: string): string => {
     if (!value) {
         return null;
-        // const date = new Date().toISOString();
-        // return date.replace(/\.([0-9]+)Z/, "+00:00");
     } else if (value.includes("T") === false) {
         return value;
     }
@@ -107,7 +104,6 @@ const dateTimeWithTimezone = (value?: string): string => {
 const dateTimeWithoutTimezone = (value?: string): string => {
     if (!value) {
         return null;
-        // return new Date().toISOString();
     } else if (value.includes(" ") === false) {
         return value;
     }
@@ -125,7 +121,6 @@ const dateTimeWithoutTimezone = (value?: string): string => {
 const time = (value?: string) => {
     if (!value) {
         return null;
-        // return "00:00:00";
     }
     return extractTime(value);
 };

--- a/packages/db-dynamodb/src/plugins/definitions/DateTimeTransformPlugin.ts
+++ b/packages/db-dynamodb/src/plugins/definitions/DateTimeTransformPlugin.ts
@@ -2,8 +2,11 @@ import { ValueTransformPlugin, Params, TransformParams } from "./ValueTransformP
 import WebinyError from "@webiny/error";
 import { parseISO } from "date-fns";
 
-const transformDateTime = (params: TransformParams): number => {
+const transformDateTime = (params: TransformParams): number | null => {
     const { value } = params;
+    if (value === null) {
+        return null;
+    }
     if (value && typeof (value as any).getTime === "function") {
         /**
          * In this case we assume this is a date object and we just get the time.

--- a/packages/ui/src/Select/Select.tsx
+++ b/packages/ui/src/Select/Select.tsx
@@ -5,7 +5,7 @@ import { FormComponentProps } from "./../types";
 import { css } from "emotion";
 import classNames from "classnames";
 
-type SelectProps = FormComponentProps &
+export type SelectProps = FormComponentProps &
     RmwcSelectProps & {
         // Component label.
         label?: string;


### PR DESCRIPTION
## Changes
Closes #2170 
User can now select if they want datetime field populated in the UI or left empty.
If user chose to populate the datetime field, the value is populated as the form is getting initialized.

Closes #2063 
In the Elasticsearch project use `exists` method than match to determine if the filtered field value is null.

## How Has This Been Tested?
Manually and Jest.