### PR TITLE
fix(api-prerendering-service): injectApolloState escapes "<"

### DIFF
--- a/packages/api-prerendering-service/src/render/injectApolloState.ts
+++ b/packages/api-prerendering-service/src/render/injectApolloState.ts
@@ -5,7 +5,7 @@ export default ({ render }) =>
         tree.match({ tag: "head" }, node => {
             const script = `<script>window.__APOLLO_STATE__ = ${JSON.stringify(
                 render.meta.apolloState
-            )};</script>`;
+            ).replace(/</g, "\\u003c")};</script>`;
 
             node.content.push(script);
             return node;


### PR DESCRIPTION
## Changes
When there is any value in Apollo State is `</script>`, the original `injectApolloState` will inject "</script>" and break the page.

I just change it based on https://github.com/apollographql/apollo-client/issues/5567