### PR TITLE
Fix: JWT types version

### DIFF
--- a/api/code/graphql/package.json
+++ b/api/code/graphql/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@webiny/api-admin-users-cognito": "^5.21.0",
     "@webiny/api-admin-users-cognito-so-ddb": "^5.21.0",
-    "@webiny/api-apw": "^5.21.0",
     "@webiny/api-file-manager": "^5.21.0",
     "@webiny/api-file-manager-ddb": "^5.21.0",
     "@webiny/api-file-manager-s3": "^5.21.0",

--- a/api/code/graphql/src/index.ts
+++ b/api/code/graphql/src/index.ts
@@ -33,7 +33,6 @@ import tenantManager from "@webiny/api-tenant-manager";
 
 // Imports plugins created via scaffolding utilities.
 import scaffoldsPlugins from "./plugins/scaffolds";
-import { createApwContext, createApwGraphQL } from "@webiny/api-apw";
 
 const debug = process.env.DEBUG === "true";
 
@@ -91,8 +90,6 @@ export const handler = createHandler({
                 modelFieldToGraphQLPlugins: headlessCmsModelFieldToGraphQLPlugins()
             })
         }),
-        createApwContext(),
-        createApwGraphQL(),
         scaffoldsPlugins()
     ],
     http: { debug }

--- a/api/code/graphql/tsconfig.json
+++ b/api/code/graphql/tsconfig.json
@@ -4,7 +4,6 @@
   "references": [
     { "path": "../../../packages/api-admin-users-cognito/tsconfig.build.json" },
     { "path": "../../../packages/api-admin-users-cognito-so-ddb/tsconfig.build.json" },
-    { "path": "../../../packages/api-apw/tsconfig.build.json" },
     { "path": "../../../packages/api-file-manager/tsconfig.build.json" },
     { "path": "../../../packages/api-file-manager-ddb/tsconfig.build.json" },
     { "path": "../../../packages/api-file-manager-s3/tsconfig.build.json" },
@@ -45,8 +44,6 @@
       "@webiny/api-admin-users-cognito-so-ddb": [
         "../../../packages/api-admin-users-cognito-so-ddb/src"
       ],
-      "@webiny/api-apw/*": ["../../../packages/api-apw/src/*"],
-      "@webiny/api-apw": ["../../../packages/api-apw/src"],
       "@webiny/api-file-manager/*": ["../../../packages/api-file-manager/src/*"],
       "@webiny/api-file-manager": ["../../../packages/api-file-manager/src"],
       "@webiny/api-file-manager-ddb/*": ["../../../packages/api-file-manager-ddb/src/*"],

--- a/packages/api-admin-users-cognito/package.json
+++ b/packages/api-admin-users-cognito/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
-    "@types/jsonwebtoken": "^8.5.1",
+    "@types/jsonwebtoken": "8.5.7",
     "@webiny/api-security-so-ddb": "^5.17.0-beta.1",
     "@webiny/api-tenancy-so-ddb": "^5.17.0-beta.1",
     "@webiny/cli": "^5.21.0",

--- a/packages/api-cognito-authenticator/package.json
+++ b/packages/api-cognito-authenticator/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
-    "@types/jsonwebtoken": "^8.5.1",
+    "@types/jsonwebtoken": "8.5.7",
     "@webiny/cli": "^5.21.0",
     "@webiny/project-utils": "^5.21.0",
     "rimraf": "^3.0.2",

--- a/packages/api-security-cognito/package.json
+++ b/packages/api-security-cognito/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
-    "@types/jsonwebtoken": "^8.5.1",
+    "@types/jsonwebtoken": "8.5.7",
     "@webiny/cli": "^5.21.0",
     "@webiny/project-utils": "^5.21.0",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7536,7 +7536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:^8.3.3, @types/jsonwebtoken@npm:^8.5.1":
+"@types/jsonwebtoken@npm:8.5.7, @types/jsonwebtoken@npm:^8.3.3":
   version: 8.5.7
   resolution: "@types/jsonwebtoken@npm:8.5.7"
   dependencies:
@@ -8486,7 +8486,7 @@ __metadata:
     "@babel/cli": ^7.16.0
     "@babel/core": ^7.16.0
     "@commodo/fields": ^1.2.1
-    "@types/jsonwebtoken": ^8.5.1
+    "@types/jsonwebtoken": 8.5.7
     "@webiny/api-security": ^5.21.0
     "@webiny/api-security-so-ddb": ^5.17.0-beta.1
     "@webiny/api-tenancy": ^5.21.0
@@ -8599,7 +8599,7 @@ __metadata:
   dependencies:
     "@babel/cli": ^7.16.0
     "@babel/core": ^7.16.0
-    "@types/jsonwebtoken": ^8.5.1
+    "@types/jsonwebtoken": 8.5.7
     "@webiny/cli": ^5.21.0
     "@webiny/project-utils": ^5.21.0
     jsonwebtoken: ^8.5.1
@@ -9454,7 +9454,7 @@ __metadata:
   dependencies:
     "@babel/cli": ^7.16.0
     "@babel/core": ^7.16.0
-    "@types/jsonwebtoken": ^8.5.1
+    "@types/jsonwebtoken": 8.5.7
     "@webiny/api-cognito-authenticator": ^5.21.0
     "@webiny/api-security": ^5.21.0
     "@webiny/cli": ^5.21.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8514,7 +8514,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/api-apw@^5.21.0, @webiny/api-apw@workspace:packages/api-apw":
+"@webiny/api-apw@workspace:packages/api-apw":
   version: 0.0.0-use.local
   resolution: "@webiny/api-apw@workspace:packages/api-apw"
   dependencies:
@@ -12443,7 +12443,6 @@ __metadata:
   dependencies:
     "@webiny/api-admin-users-cognito": ^5.21.0
     "@webiny/api-admin-users-cognito-so-ddb": ^5.21.0
-    "@webiny/api-apw": ^5.21.0
     "@webiny/api-file-manager": ^5.21.0
     "@webiny/api-file-manager-ddb": ^5.21.0
     "@webiny/api-file-manager-s3": ^5.21.0


### PR DESCRIPTION
## Changes
This PR introduces the following changes:
- lock `"@types/jsonwebtoken"` version to `8.5.7`
- remove usage of `@webiny/api-apw` from `api/code/graphql` (we need to sort installer for this application first)

## How Has This Been Tested?
Manually
