### PR TITLE
Prevent Deploy On Build Errors

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
@@ -119,6 +119,26 @@ module.exports = async ({ projectApplication, inputs, context }) => {
                     });
                 });
 
+                worker.on("exit", code => {
+                    if (code === 0) {
+                        return;
+                    }
+
+                    stats.error++;
+                    context.error(
+                        `An error occurred while building ${context.error.hl(
+                            current.name
+                        )} package.`
+                    );
+
+                    resolve({
+                        package: current,
+                        result: {
+                            message: `Process exited with a non-zero exit code.`
+                        }
+                    });
+                });
+
                 let enableLogs = inputs.logs;
                 if (typeof enableLogs === "undefined") {
                     enableLogs = !multipleBuilds;

--- a/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
@@ -108,7 +108,7 @@ module.exports = async ({ projectApplication, inputs, context }) => {
                     context.error(
                         `An unknown error occurred while building ${context.error.hl(
                             current.name
-                        )}:`
+                        )} package.`
                     );
 
                     resolve({

--- a/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy/buildPackages.js
@@ -138,10 +138,12 @@ module.exports = async ({ projectApplication, inputs, context }) => {
 
     console.log();
 
-    if (stats.error) {
-        throw new Error(
-            `Failed to build all packages (${context.error.hl(stats.error)} error(s) occurred).`
-        );
+    if (stats.error > 0) {
+        const errorsCount = context.error.hl(stats.error);
+        const errorsWord = stats.error === 1 ? "error" : "errors";
+        const errorsOccurred = `(${errorsCount} ${errorsWord} occurred)`;
+
+        throw new Error(`Failed to build all packages ${errorsOccurred}.`);
     }
 
     const duration = (new Date() - start) / 1000 + "s";


### PR DESCRIPTION
## Changes
Prior to this PR, upon deploying a project app, if an error occurred in the build phase, the deployment would still be continued, when in fact that should never happen.

This was happening because of a bug in the code that was dealing with spawning and monitoring separate package/app build processes. 

## How Has This Been Tested?
Manual.

## Documentation
Changelog.
