### PR TITLE
Feat: CMS Create Ref Field Entry

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
@@ -173,7 +173,7 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
                     GQLCache.addRevisionToRevisionsCache(contentModel, cache, newRevision);
 
                     showSnackbar("A new revision was created!");
-                    goToRevision(revision.id);
+                    goToRevision(newRevision.id);
                 }
             });
             setLoading(false);

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
@@ -40,6 +40,7 @@ export interface UseContentEntryFormParams {
     entry?: { [key: string]: any };
     onChange?: FormOnSubmit;
     onSubmit?: FormOnSubmit;
+    addEntryToListCache: boolean;
 }
 
 export function useContentEntryForm(params: UseContentEntryFormParams): UseContentEntryForm {
@@ -97,7 +98,7 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
                         return;
                     }
                     resetInvalidFieldValues();
-                    if (typeof params.onSubmit !== "function") {
+                    if (params.addEntryToListCache) {
                         GQLCache.addEntryToListCache(
                             contentModel,
                             cache,
@@ -124,7 +125,7 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
             }
             return entry;
         },
-        [contentModel.modelId, listQueryVariables]
+        [contentModel.modelId, listQueryVariables, params.onSubmit, params.addEntryToListCache]
     );
 
     const updateContent = useCallback(
@@ -172,7 +173,7 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
                     GQLCache.addRevisionToRevisionsCache(contentModel, cache, newRevision);
 
                     showSnackbar("A new revision was created!");
-                    goToRevision(newRevision.id);
+                    goToRevision(revision.id);
                 }
             });
             setLoading(false);

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
@@ -3,9 +3,11 @@ import debounce from "lodash/debounce";
 import { AutoComplete } from "@webiny/ui/AutoComplete";
 import { i18n } from "@webiny/app/i18n";
 import { Link } from "@webiny/react-router";
+import { useNewRefEntry } from "../hooks/useNewRefEntry";
 import { useReference } from "./useReference";
 import { renderItem } from "./renderItem";
 import { createEntryUrl } from "./createEntryUrl";
+import NewRefEntryFormDialog, { NewEntryButton } from "./NewRefEntryFormDialog";
 
 const t = i18n.ns("app-headless-cms/admin/fields/ref");
 
@@ -28,6 +30,34 @@ function ContentEntriesAutocomplete({ bind, field }) {
             here: <Link to={link}>{t`here`}</Link>
         });
     }
+    const { renderNewEntryModal, refModelId, helpText } = useNewRefEntry({ field });
+
+    /*
+     * Wrap AutoComplete input in NewRefEntry modal.
+     */
+    if (renderNewEntryModal) {
+        return (
+            <NewRefEntryFormDialog modelId={refModelId} onChange={entry => onChange(entry, entry)}>
+                <AutoComplete
+                    {...bind}
+                    renderItem={renderItem}
+                    onChange={onChange}
+                    loading={loading}
+                    value={value ? value.id : null}
+                    options={options}
+                    label={field.label}
+                    description={
+                        <>
+                            {field.helpText}
+                            {entryInfo}
+                        </>
+                    }
+                    onInput={debounce(search => setSearch(search), 250)}
+                    noResultFound={<NewEntryButton />}
+                />
+            </NewRefEntryFormDialog>
+        );
+    }
 
     return (
         <AutoComplete
@@ -45,6 +75,7 @@ function ContentEntriesAutocomplete({ bind, field }) {
                 </>
             }
             onInput={debounce(search => setSearch(search), 250)}
+            noResultFound={helpText}
         />
     );
 }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
@@ -10,12 +10,20 @@ const t = i18n.ns("app-headless-cms/admin/fields/ref");
 const missingEntryLabel = t`If you can't find the intended reference value in the target model,
          please close this dialog and populate the {newEntryLink} in the target model first.`;
 
+const referenceMultipleModelsLabel = t`The creation of reference values from within this view is only supported
+ when a single reference model is selected. To reference values from multiple models
+ please make sure the referenced values exist before setting the reference`;
+
 const HelpTextTypography = styled(Typography)`
     & {
         display: inline-block;
         color: var(--mdc-theme-text-secondary-on-background) !important;
     }
 `;
+
+export const ReferenceMultipleModelsHelpText = () => {
+    return <HelpTextTypography use={"caption"}>{referenceMultipleModelsLabel}</HelpTextTypography>;
+};
 
 const MissingEntryHelpText: React.FC<{ refModelId: string }> = ({ refModelId }) => {
     return (

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
@@ -11,8 +11,8 @@ const missingEntryLabel = t`If you can't find the intended reference value in th
          please close this dialog and populate the {newEntryLink} in the target model first.`;
 
 const referenceMultipleModelsLabel = t`The creation of reference values from within this view is only supported
- when a single reference model is selected. To reference values from multiple models
- please make sure the referenced values exist before setting the reference`;
+ when a single reference model is selected. To reference values from multiple models,
+ please make sure the referenced values exist before setting the reference.`;
 
 const HelpTextTypography = styled(Typography)`
     & {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/NewRefEntryFormDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/NewRefEntryFormDialog.tsx
@@ -52,6 +52,7 @@ const EntryForm = ({ onCreate }) => {
             onSubmit={onCreate}
             onForm={form => setFormRef(form)}
             entry={{}}
+            addEntryToListCache={false}
         />
     );
 };
@@ -109,13 +110,21 @@ const NewRefEntryFormDialog: React.FC<NewRefEntryProps> = ({ modelId, children, 
 
     const onCreate = useCallback(
         entry => {
-            onChange(entry);
+            onChange({
+                ...entry,
+                /*
+                 * Format data for AutoComplete.
+                 */
+                published: get(entry, "meta.status") === "published",
+                modelId: contentModel.modelId,
+                modelName: contentModel.name
+            });
             /* 
             Close the modal
              */
             setOpen(false);
         },
-        [modelId, onChange]
+        [onChange, contentModel]
     );
 
     if (!contentModel) {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/useReference.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/useReference.ts
@@ -11,6 +11,7 @@ interface ValueEntry {
     published: boolean;
     name: string;
 }
+
 interface DataEntry {
     id: string;
     model: {
@@ -20,10 +21,12 @@ interface DataEntry {
     status: "published" | "draft";
     title: string;
 }
+
 interface UseReferenceHookArgs {
     bind: any;
     field: CmsEditorField;
 }
+
 interface UseReferenceHookValue {
     onChange: (value: any, entry: ValueEntry) => void;
     setSearch: (value: string) => void;
@@ -31,6 +34,7 @@ interface UseReferenceHookValue {
     loading: boolean;
     options: ValueEntry[];
 }
+
 type UseReferenceHook = (args: UseReferenceHookArgs) => UseReferenceHookValue;
 
 type EntryCollection = Record<string, DataEntry>;
@@ -118,7 +122,12 @@ export const useReference: UseReferenceHook = ({ bind, field }) => {
                     modelIds: models.map(m => m.modelId),
                     query: "__latest__",
                     limit: 10
-                }
+                },
+                /**
+                 * We cannot update this query response in cache after a reference entry being created/deleted,
+                 * which result in cached response being stale, therefore, we're setting the fetchPolicy to "network-only" to by passing cache.
+                 */
+                fetchPolicy: "network-only"
             })
             .then(({ data }) => {
                 const latestEntryData = convertQueryDataToEntryList(data.content.data);

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/useReferences.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/useReferences.ts
@@ -57,7 +57,12 @@ export const useReferences = ({ bind, field }) => {
                     modelIds: models.map(m => m.modelId),
                     query: "__latest__",
                     limit: 10
-                }
+                },
+                /**
+                 * We cannot update this query response in cache after a reference entry being created/deleted,
+                 * which result in cached response being stale, therefore, we're setting the fetchPolicy to "network-only" to by passing cache.
+                 */
+                fetchPolicy: "network-only"
             })
             .then(({ data }) => {
                 setLatestEntries(data.content.data);

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/hooks/useNewRefEntry.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/hooks/useNewRefEntry.tsx
@@ -1,6 +1,9 @@
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { Context as ContentEntriesContext } from "~/admin/views/contentEntries/ContentEntriesContext";
 import { CmsEditorField } from "~/types";
+import MissingEntryHelpText, {
+    ReferenceMultipleModelsHelpText
+} from "../components/MissingEntryHelpText";
 
 interface UseNewRefEntryParams {
     field: CmsEditorField;
@@ -8,12 +11,13 @@ interface UseNewRefEntryParams {
 
 interface UseNewRefEntry {
     renderNewEntryModal: boolean;
-    renderedInPreviewTab: boolean;
     refModelId: string;
+    helpText: React.ReactElement;
 }
 
 export const useNewRefEntry = ({ field }: UseNewRefEntryParams): UseNewRefEntry => {
-    const refModelId = field.settings.models[0].modelId;
+    const [{ modelId: refModelId }] = field.settings.models;
+    const referenceMultipleModels = field.settings.models.length > 1;
 
     const contentEntriesContextValue = useContext(ContentEntriesContext);
 
@@ -26,18 +30,32 @@ export const useNewRefEntry = ({ field }: UseNewRefEntryParams): UseNewRefEntry 
      */
     const renderedInPreviewTab = contentEntriesContextValue === null;
 
+    /**
+     * Set "renderNewEntryModal" value.
+     */
     let renderNewEntryModal;
 
     if (renderedInPreviewTab) {
+        renderNewEntryModal = false;
+    } else if (referenceMultipleModels) {
         renderNewEntryModal = false;
     } else {
         const { insideDialog } = contentEntriesContextValue;
         renderNewEntryModal = !insideDialog;
     }
+    /**
+     * Set "helpText" value.
+     */
+    let helpText = null;
+    if (referenceMultipleModels) {
+        helpText = <ReferenceMultipleModelsHelpText />;
+    } else {
+        helpText = <MissingEntryHelpText refModelId={refModelId} />;
+    }
 
     return {
         renderNewEntryModal,
-        renderedInPreviewTab,
-        refModelId
+        refModelId,
+        helpText
     };
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/refInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/refInput.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import { i18n } from "@webiny/app/i18n";
 import ContentEntriesAutocomplete from "./components/ContentEntriesAutocomplete";
+import { NewRefEntryDialogContextProvider } from "./hooks/useNewRefEntryDialog";
 
 const t = i18n.ns("app-headless-cms/admin/fields/ref");
 
@@ -17,7 +18,15 @@ const plugin: CmsEditorFieldRendererPlugin = {
         },
         render(props) {
             const Bind = props.getBind();
-            return <Bind>{bind => <ContentEntriesAutocomplete {...props} bind={bind} />}</Bind>;
+            return (
+                <Bind>
+                    {bind => (
+                        <NewRefEntryDialogContextProvider>
+                            <ContentEntriesAutocomplete {...props} bind={bind} />
+                        </NewRefEntryDialogContextProvider>
+                    )}
+                </Bind>
+            );
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/refInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/refInputs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import ContentEntriesMultiAutocomplete from "./components/ContentEntriesMultiAutoComplete";
+import { NewRefEntryDialogContextProvider } from "./hooks/useNewRefEntryDialog";
 
 import { i18n } from "@webiny/app/i18n";
 
@@ -25,11 +26,13 @@ const plugin: CmsEditorFieldRendererPlugin = {
             return (
                 <Bind>
                     {bind => (
-                        <ContentEntriesMultiAutocomplete
-                            key={getKey(props.field, bind)}
-                            {...props}
-                            bind={bind}
-                        />
+                        <NewRefEntryDialogContextProvider>
+                            <ContentEntriesMultiAutocomplete
+                                key={getKey(props.field, bind)}
+                                {...props}
+                                bind={bind}
+                            />
+                        </NewRefEntryDialogContextProvider>
                     )}
                 </Bind>
             );

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
@@ -95,6 +95,7 @@ const ContentEntry = () => {
                                     contentModel={contentModel}
                                     entry={entry}
                                     onForm={form => setFormRef(form)}
+                                    addEntryToListCache={true}
                                 />
                             </Elevation>
                         </RenderBlock>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -35,16 +35,16 @@ export interface ContentEntryContext extends ContentEntriesContext {
 
 export const Context = React.createContext<ContentEntryContext>(null);
 
-export interface ContentEntryContextProviderProps extends GetContentEntryFormType {
+export interface ContentEntryContextProviderProps extends UseContentEntryProviderProps {
     children: React.ReactNode;
 }
 
-interface GetContentEntryFormType {
+interface UseContentEntryProviderProps {
     getContentId?: () => string | null;
     isNewEntry?: () => boolean;
 }
 
-export const useContentEntryProviderProps = (): GetContentEntryFormType => {
+export const useContentEntryProviderProps = (): UseContentEntryProviderProps => {
     const { location } = useRouter();
     const query = new URLSearchParams(location.search);
 

--- a/packages/ui/src/AutoComplete/AutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/AutoComplete.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Downshift, { ControllerStateAndHelpers } from "downshift";
+import Downshift, { ControllerStateAndHelpers, PropGetters } from "downshift";
 import { Input } from "~/Input";
 import classNames from "classnames";
 import { Elevation } from "~/Elevation";
@@ -59,6 +59,29 @@ interface RenderOptionsParams
     options: Props["options"];
     placement: Props["placement"];
 }
+
+interface OptionsListProps {
+    placement: Placement;
+    getMenuProps: PropGetters<Record<string, any>>["getMenuProps"];
+}
+
+const OptionsList: React.FC<OptionsListProps> = ({ placement, getMenuProps, children }) => {
+    return (
+        <Elevation
+            z={1}
+            className={classNames({
+                [menuStyles]: placement === Placement.top
+            })}
+        >
+            <ul
+                className={classNames("autocomplete__options-list", listStyles)}
+                {...getMenuProps()}
+            >
+                {children}
+            </ul>
+        </Elevation>
+    );
+};
 
 class AutoComplete extends React.Component<Props, State> {
     static defaultProps = {
@@ -125,6 +148,18 @@ class AutoComplete extends React.Component<Props, State> {
         if (!isOpen) {
             return null;
         }
+        /**
+         * Suggest user to start typing when there are no options available to choose from.
+         */
+        if (!this.state.inputValue && !options.length) {
+            return (
+                <OptionsList placement={placement} getMenuProps={getMenuProps}>
+                    <li>
+                        <Typography use={"body2"}>Start typing to find entry</Typography>
+                    </li>
+                </OptionsList>
+            );
+        }
 
         const { renderItem } = this.props;
 
@@ -145,65 +180,47 @@ class AutoComplete extends React.Component<Props, State> {
 
         if (!filtered.length) {
             return (
-                <Elevation
-                    z={1}
-                    className={classNames({
-                        [menuStyles]: placement === Placement.top
-                    })}
-                >
-                    <ul
-                        className={classNames("autocomplete__options-list", listStyles)}
-                        {...getMenuProps()}
-                    >
-                        <li>
-                            <Typography use={"body2"}>No results.</Typography>
-                            {this.props.noResultFound}
-                        </li>
-                    </ul>
-                </Elevation>
+                <OptionsList placement={placement} getMenuProps={getMenuProps}>
+                    <li>
+                        <Typography use={"body2"}>No results.</Typography>
+                        {this.props.noResultFound}
+                    </li>
+                </OptionsList>
             );
         }
 
         return (
-            <Elevation z={1} className={classNames({ [menuStyles]: placement === Placement.top })}>
-                <ul
-                    className={classNames("autocomplete__options-list", listStyles)}
-                    {...getMenuProps()}
-                >
-                    {filtered.map((item, index) => {
-                        const itemValue = getOptionValue(item, this.props);
+            <OptionsList placement={placement} getMenuProps={getMenuProps}>
+                {filtered.map((item, index) => {
+                    const itemValue = getOptionValue(item, this.props);
 
-                        // Base classes.
-                        const itemClassNames = {
-                            [suggestionList]: true,
-                            highlighted: highlightedIndex === index,
-                            selected: false
-                        };
+                    // Base classes.
+                    const itemClassNames = {
+                        [suggestionList]: true,
+                        highlighted: highlightedIndex === index,
+                        selected: false
+                    };
 
-                        // Add "selected" class if the item is selected.
-                        if (
-                            selectedItem &&
-                            getOptionValue(selectedItem, this.props) === itemValue
-                        ) {
-                            itemClassNames.selected = true;
-                        }
+                    // Add "selected" class if the item is selected.
+                    if (selectedItem && getOptionValue(selectedItem, this.props) === itemValue) {
+                        itemClassNames.selected = true;
+                    }
 
-                        // Render the item.
-                        return (
-                            <li
-                                key={itemValue}
-                                {...getItemProps({
-                                    index,
-                                    item,
-                                    className: classNames(itemClassNames)
-                                })}
-                            >
-                                {renderItem.call(this, item, index)}
-                            </li>
-                        );
-                    })}
-                </ul>
-            </Elevation>
+                    // Render the item.
+                    return (
+                        <li
+                            key={itemValue}
+                            {...getItemProps({
+                                index,
+                                item,
+                                className: classNames(itemClassNames)
+                            })}
+                        >
+                            {renderItem.call(this, item, index)}
+                        </li>
+                    );
+                })}
+            </OptionsList>
         );
     }
 

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Downshift, { ControllerStateAndHelpers } from "downshift";
+import Downshift, { ControllerStateAndHelpers, PropGetters } from "downshift";
 import MaterialSpinner from "react-spinner-material";
 import { Input } from "~/Input";
 import { Chips, Chip } from "../Chips";
@@ -105,6 +105,7 @@ function Spinner() {
 }
 
 const DEFAULT_PER_PAGE = 10;
+
 function paginateMultipleSelection(multipleSelection, limit, page, search) {
     // Assign a real index, so that later when we press delete, we know what is the actual index we're deleting.
     let data = Array.isArray(multipleSelection)
@@ -153,6 +154,23 @@ interface RenderOptionsParams
     options: Props["options"];
     unique: boolean;
 }
+
+interface OptionsListProps {
+    getMenuProps: PropGetters<Record<string, any>>["getMenuProps"];
+}
+
+const OptionsList: React.FC<OptionsListProps> = ({ getMenuProps, children }) => {
+    return (
+        <Elevation z={1}>
+            <ul
+                className={classNames("multi-autocomplete__options-list", listStyles)}
+                {...getMenuProps()}
+            >
+                {children}
+            </ul>
+        </Elevation>
+    );
+};
 
 export class MultiAutoComplete extends React.Component<MultiAutoCompleteProps, State> {
     static defaultProps = {
@@ -268,6 +286,19 @@ export class MultiAutoComplete extends React.Component<MultiAutoCompleteProps, S
         const { options, isOpen, highlightedIndex, getMenuProps, getItemProps } = params;
         if (!isOpen) {
             return null;
+        }
+
+        /**
+         * Suggest user to start typing when there are no options available to choose from.
+         */
+        if (!this.state.inputValue && !options.length) {
+            return (
+                <OptionsList getMenuProps={getMenuProps}>
+                    <li>
+                        <Typography use={"body2"}>Start typing to find entry</Typography>
+                    </li>
+                </OptionsList>
+            );
         }
 
         if (!options.length) {


### PR DESCRIPTION
This PR introduces a new feature in `app-headless-cms` whereby users can create a new reference field entry(if not found) right from a content entry form without having to go back to the reference model entry form to create one. In other words,
users now have the ability to generate reference field entries on the fly.

## Changes
- updated both `refField` and `refFields` components to support the new feature
- updated `AutoComplete` and `MultiAutoComplete` components prop
- remove duplicate `helpText` from `fileField` component

## How Has This Been Tested?
Manually 

---

https://user-images.githubusercontent.com/13612227/149706459-06591e24-a040-4c84-be69-05464d42b968.mov



