### PR TITLE
fix(api-security-so-ddb): add GSI key on API key update

### DIFF
--- a/packages/api-security-so-ddb/src/index.ts
+++ b/packages/api-security-so-ddb/src/index.ts
@@ -361,7 +361,11 @@ export const createStorageOperations = (
             return cleanupItems(entities.tenantLinks, links);
         },
         async updateApiKey({ apiKey }): Promise<ApiKey> {
-            const keys = createApiKeyKeys(apiKey);
+            const keys = {
+                ...createApiKeyKeys(apiKey),
+                GSI1_PK: `T#${apiKey.tenant}#API_KEYS`,
+                GSI1_SK: apiKey.token
+            };
 
             try {
                 await entities.apiKeys.put({

--- a/packages/api-security/__tests__/apiKeys.test.ts
+++ b/packages/api-security/__tests__/apiKeys.test.ts
@@ -100,6 +100,28 @@ describe("Security API Key Test", () => {
             }
         });
 
+        // List again to make sure that an updated token is accessible.
+        const [listResponse2] = await securityApiKeys.list();
+
+        expect(listResponse2).toEqual({
+            data: {
+                security: {
+                    listApiKeys: {
+                        data: [
+                            {
+                                id: token.id,
+                                name: "Renamed token",
+                                token: token.token,
+                                description: "Updated description",
+                                permissions: []
+                            }
+                        ],
+                        error: null
+                    }
+                }
+            }
+        });
+
         // Delete token
         const [deleteResponse] = await securityApiKeys.delete({
             id: token.id


### PR DESCRIPTION
## Changes
This PR adds the missing GSI keys on API key update, which makes it disappear from the `listApiKeys` results. 

Closes #2206 

## How Has This Been Tested?
Added a Jest test to verify the update->list scenario.

## Documentation
Not required, it's an internal bug fix.