### PR TITLE
React App Bundling/Webpack Overrides Not Working

### DIFF
--- a/packages/project-utils/bundling/app/buildApp.js
+++ b/packages/project-utils/bundling/app/buildApp.js
@@ -57,7 +57,7 @@ module.exports = async options => {
     // Generate configuration
     let config = configFactory("production", { paths, options });
 
-    if (typeof options.webpack === "function") {
+    if (typeof overrides.webpack === "function") {
         config = overrides.webpack(config);
     }
 


### PR DESCRIPTION
## Changes
This PR resolves a small issue (an incorrect if statement) that prevented the user to apply any Webpack config overrides, when it comes to building React apps. Watch mode worked fine.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.