### PR TITLE
fix(api-page-builder-import-export): handle error in stream pipeline

### DIFF
--- a/packages/api-page-builder-import-export/src/importPages/utils.ts
+++ b/packages/api-page-builder-import-export/src/importPages/utils.ts
@@ -482,7 +482,9 @@ function extractZipToDisk(exportFileZipPath: string): Promise<string[]> {
                             zipFile.readEntry();
                         });
 
-                        streamPipeline(readStream, createWriteStream(filePath));
+                        streamPipeline(readStream, createWriteStream(filePath)).catch(error => {
+                            reject(error);
+                        });
                     });
                 }
             });
@@ -559,9 +561,13 @@ function extractZipAndUploadToS3(
                         const { streamPassThrough, streamPassThroughUploadPromise: promise } =
                             s3Stream.writeStream(newKey, FILE_CONTENT_TYPE);
 
-                        streamPipeline(readStream, streamPassThrough).then(() => {
-                            fileUploadPromises.push(promise);
-                        });
+                        streamPipeline(readStream, streamPassThrough)
+                            .then(() => {
+                                fileUploadPromises.push(promise);
+                            })
+                            .catch(error => {
+                                reject(error);
+                            });
                     });
                 }
             });


### PR DESCRIPTION
With this PR, we now catch and send back the error associated with the uploaded export zip file.
That is we report the issue back to the user if the page export file is modified in any way.

## Changes
Closes #2225 

## How Has This Been Tested?
Manually


