### PR TITLE
`@webiny/api-authentication-cognito` - `undefined undefined` Present In the `displayName` Property

### DIFF
--- a/packages/api-authentication-cognito/__tests__/getIdentity.test.ts
+++ b/packages/api-authentication-cognito/__tests__/getIdentity.test.ts
@@ -1,0 +1,80 @@
+import { getIdentity } from "@webiny/api-authentication-cognito";
+
+describe("getIdentity Test", () => {
+    test("full identity information should be returned correctly", async () => {
+        expect(
+            getIdentity({
+                token: {
+                    id: "xyz",
+                    family_name: "Family",
+                    given_name: "Given",
+                    email: "family@given.com"
+                },
+                identityType: "user"
+            })
+        ).toEqual({
+            displayName: "Given Family",
+            email: "family@given.com",
+            firstName: "Given",
+            id: "xyz",
+            lastName: "Family",
+            type: "user"
+        });
+    });
+
+    test(`we must not have "undefined" string in any of the identity properties`, async () => {
+        expect(
+            getIdentity({
+                token: {},
+                identityType: "user"
+            })
+        ).toEqual({
+            displayName: null,
+            email: null,
+            firstName: null,
+            id: null,
+            lastName: null,
+            type: "user"
+        });
+    });
+
+    test(`when constructing displayName, if lastName is missing, only use firstName and vice versa`, async () => {
+        // Last name (family_name) missing - use only first name (given_name).
+        expect(
+            getIdentity({
+                token: {
+                    id: "xyz",
+                    given_name: "Given",
+                    email: "family@given.com"
+                },
+                identityType: "user"
+            })
+        ).toEqual({
+            displayName: "Given",
+            email: "family@given.com",
+            firstName: "Given",
+            id: "xyz",
+            lastName: null,
+            type: "user"
+        });
+
+        // First name (given_name) missing - use only last name (family_name).
+        expect(
+            getIdentity({
+                token: {
+                    id: "xyz",
+                    family_name: "Family",
+                    email: "family@given.com"
+                },
+                identityType: "user"
+            })
+        ).toEqual({
+            displayName: "Family",
+            email: "family@given.com",
+            firstName: null,
+            id: "xyz",
+            lastName: "Family",
+            type: "user"
+        });
+    });
+});

--- a/packages/api-authentication-cognito/jest.config.js
+++ b/packages/api-authentication-cognito/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -15,17 +15,17 @@ export interface Config extends CognitoConfig {
 export const getIdentity: GetIdentity = ({ identityType, token }) => {
     // We ensure `undefined` doesn't end up in the `displayName` property.
     // If first name and last name is not present, we end up with an empty string.
-    const firstName = token.given_name || "";
-    const lastName = token.family_name || "";
-    const displayName = `${firstName} ${lastName}`.trim();
+    const { given_name = null, family_name = null, id = null, email = null } = token;
+
+    const displayName = [given_name, family_name].filter(Boolean).join(" ").trim() || null;
 
     return {
-        id: token.sub,
+        id,
         type: identityType,
         displayName,
-        email: token.email,
-        firstName,
-        lastName
+        email,
+        firstName: given_name,
+        lastName: family_name
     };
 };
 

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -12,6 +12,23 @@ export interface Config extends CognitoConfig {
     getIdentity?: GetIdentity;
 }
 
+export const getIdentity: GetIdentity = ({ identityType, token }) => {
+    // We ensure `undefined` doesn't end up in the `displayName` property.
+    // If first name and last name is not present, we end up with an empty string.
+    const firstName = token.given_name || "";
+    const lastName = token.family_name || "";
+    const displayName = `${firstName} ${lastName}`.trim();
+
+    return {
+        id: token.sub,
+        type: identityType,
+        displayName,
+        email: token.email,
+        firstName,
+        lastName
+    };
+};
+
 export default (config: Config) => {
     const cognitoAuthenticator = createAuthenticator({
         region: config.region,
@@ -30,20 +47,7 @@ export default (config: Config) => {
                 return config.getIdentity({ identityType: config.identityType, token: tokenObj });
             }
 
-            // We ensure `undefined` doesn't end up in the `displayName` property.
-            // If first name and last name is not present, we end up with an empty string.
-            const firstName = tokenObj.given_name || "";
-            const lastName = tokenObj.family_name || "";
-            const displayName = `${firstName} ${lastName}`.trim();
-
-            return {
-                id: tokenObj.sub,
-                type: config.identityType,
-                displayName,
-                email: tokenObj.email,
-                firstName,
-                lastName
-            };
+            return getIdentity({ identityType: config.identityType, token: tokenObj });
         });
     });
 };

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -28,13 +28,19 @@ export default (config: Config) => {
                 return config.getIdentity({ identityType: config.identityType, token: tokenObj });
             }
 
+            // We ensure `undefined` doesn't end up in the `displayName` property.
+            // If first name and last name is not present, we end up with an empty string.
+            const firstName = tokenObj.given_name || "";
+            const lastName = tokenObj.family_name || "";
+            const displayName = `${firstName} ${lastName}`.trim();
+
             return {
                 id: tokenObj.sub,
                 type: config.identityType,
-                displayName: `${tokenObj.given_name} ${tokenObj.family_name}`,
+                displayName,
                 email: tokenObj.email,
-                firstName: tokenObj.given_name,
-                lastName: tokenObj.family_name
+                firstName,
+                lastName
             };
         });
     });

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -15,7 +15,7 @@ export interface Config extends CognitoConfig {
 export const getIdentity: GetIdentity = ({ identityType, token }) => {
     // We ensure `undefined` doesn't end up in the `displayName` property.
     // If first name and last name is not present, we end up with an empty string.
-    const { given_name = null, family_name = null, id = null, email = null } = token;
+    const { given_name = null, family_name = null, sub: id = null, email = null } = token;
 
     const displayName = [given_name, family_name].filter(Boolean).join(" ").trim() || null;
 

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -2,12 +2,14 @@ import { AuthenticationContext, Identity } from "@webiny/api-authentication/type
 import { ContextPlugin } from "@webiny/handler";
 import { createAuthenticator, Config as CognitoConfig } from "@webiny/api-cognito-authenticator";
 
+export type GetIdentity<TIdentity extends Identity = Identity> = (params: {
+    identityType: string;
+    token: { [key: string]: any };
+}) => TIdentity;
+
 export interface Config extends CognitoConfig {
     identityType: string;
-    getIdentity?<TIdentity extends Identity = Identity>(params: {
-        identityType: string;
-        token: { [key: string]: any };
-    }): TIdentity;
+    getIdentity?: GetIdentity;
 }
 
 export default (config: Config) => {


### PR DESCRIPTION
## Changes
Prior to this PR, upon retrieving identity information within `packages/api-authentication-cognito/src/index.ts:46`, if `given_name` or `family_name` is missing, the `undefined` string ends up in the `displayName` property. For example:

```json
{
  "id": "xyz",
  "email": "abc@webiny.com",
  "displayName": "undefined undefined"
}
```

From now on, if both `given_name` and `family_name` is missing, the `displayName` will be `null`. 

Also, if only one of the two is present, only one will be used as `displayName`. For example, if only `given_name` is present, `displayName` will be equal to it.

## How Has This Been Tested?
Jest.

## Documentation
Changelog.