### PR TITLE
fix(project-utils): watch telemetry path

### DIFF
--- a/packages/project-utils/bundling/function/watchFunction.js
+++ b/packages/project-utils/bundling/function/watchFunction.js
@@ -3,6 +3,12 @@ const { getProject } = require("@webiny/cli/utils");
 const { injectHandlerTelemetry } = require("./utils");
 
 module.exports = async options => {
+    if (!options) {
+        options = {};
+    }
+    if (!options.cwd) {
+        options.cwd = process.cwd();
+    }
     const webpack = require("webpack");
 
     const { overrides } = options;
@@ -33,7 +39,9 @@ module.exports = async options => {
         });
     });
 
-    const project = getProject({ cwd });
+    const project = getProject({
+        cwd: options.cwd
+    });
 
     if (!project.config.id) {
         return result;
@@ -46,7 +54,7 @@ module.exports = async options => {
     const includesGraphQl = handlerFile.includes("wcp-telemetry-tracker");
 
     if (includesGraphQl) {
-        await injectHandlerTelemetry(cwd);
+        await injectHandlerTelemetry(options.cwd);
     }
 
     return result;


### PR DESCRIPTION
## Changes
Variable cwd was assigned wrong (there is no cwd variable).
Added checks to options param for the cwd. If its not defined, use the process.cwd().

Watch command is breaking due to missing variable.

## How Has This Been Tested?
Manually.
