### PR TITLE
Better behavior of Webpack Define Plugin

### DIFF
--- a/packages/project-utils/bundling/app/config/env.js
+++ b/packages/project-utils/bundling/app/config/env.js
@@ -48,13 +48,14 @@ function getClientEnvironment(publicUrl) {
             }
         );
 
-    // Stringify all values so we can feed into Webpack DefinePlugin
-    const stringified = {
-        "process.env": Object.keys(raw).reduce((env, key) => {
-            env[key] = JSON.stringify(raw[key]);
-            return env;
-        }, {})
-    };
+    // Stringify all values so we can feed into Webpack DefinePlugin.
+    // Provide values one by one, not as a single process.env object,
+    // because otherwise plugin will put a big JSON object every time process.env is used in code.
+    // This way minifier also removes reduntant code on prod (like if(process.env.NODE_ENV === 'development')).
+    const stringified = {};
+    for (const key of Object.keys(raw)) {
+        stringified[`process.env.${key}`] = JSON.stringify(raw[key]);
+    }
 
     return { raw, stringified };
 }


### PR DESCRIPTION
## Changes
Our current configuration of `WebpackDefinePlugin` is that we provide a full `process.env` object.

This causes, that when you compile the code you would see, that a statement like:
```
if(process.env.NODE_ENV !== "development") {
   // some code
}
```

... is compiled to:
```
if({ NODE_ENV: "production", OTHER_VAR: "foo", ... }.NODE_ENV !== "development") {
   // some code
}
```

... and should be:
```
if("production" !== "development") {
   // some code
}
```

Basically, the plugin replaces all `process.env` calls with a rather big JSON object.
This is unnecessary and causes, that the minifier is unable to remove that kind of unreachable code.

Instead of providing a whole object, I provided every single env variable as a separate value.

## How Has This Been Tested?
Built & deployed admin app.
I need to better check what is happening if there is no env variable defined. Maybe will require some more changes.