### PR TITLE
fix(react-rich-text-renderer): Compile to commonJS

### DIFF
--- a/packages/react-rich-text-renderer/.babelrc.js
+++ b/packages/react-rich-text-renderer/.babelrc.js
@@ -1,1 +1,8 @@
-module.exports = require("../../.babel.react")({ path: __dirname });
+const defaults = require("../../.babel.react")({
+    path: __dirname
+});
+
+module.exports = {
+    ...defaults,
+    plugins: [...defaults.plugins, "@babel/plugin-transform-modules-commonjs"]
+};

--- a/packages/react-rich-text-renderer/package.json
+++ b/packages/react-rich-text-renderer/package.json
@@ -9,6 +9,7 @@
   "author": "Webiny Ltd",
   "license": "MIT",
   "dependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
     "@babel/runtime": "^7.16.3",
     "@editorjs/editorjs": "^2.20.1",
     "@types/react": "^16.14.0",

--- a/packages/react-rich-text-renderer/package.json
+++ b/packages/react-rich-text-renderer/package.json
@@ -9,7 +9,6 @@
   "author": "Webiny Ltd",
   "license": "MIT",
   "dependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
     "@babel/runtime": "^7.16.3",
     "@editorjs/editorjs": "^2.20.1",
     "@types/react": "^16.14.0",
@@ -19,6 +18,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11900,6 +11900,7 @@ __metadata:
   dependencies:
     "@babel/cli": ^7.16.0
     "@babel/core": ^7.16.0
+    "@babel/plugin-transform-modules-commonjs": ^7.16.8
     "@babel/preset-env": ^7.16.4
     "@babel/preset-react": ^7.16.0
     "@babel/preset-typescript": ^7.16.0


### PR DESCRIPTION
## Benefits:
We can use this package outside the Webiny ecosystem (eg. for using the HeadlessCMS to build a
NextJS application)

## Changes
Closes #2261

## How Has This Been Tested?
I tested the build with a NextJS application and it works.

## Documentation
I'll add this to the Changelog
