### PR TITLE
Disable Experimental WCP-related Webiny CLI Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lodash": "^4.17.11",
     "longest": "^2.0.1",
     "minimatch": "^3.0.4",
+    "node-fetch": "^2.6.1",
     "pm2": "^4.5.4",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",

--- a/packages/project-utils/__tests__/bundling/function/telemetry.test.ts
+++ b/packages/project-utils/__tests__/bundling/function/telemetry.test.ts
@@ -2,7 +2,8 @@ const { updateTelemetryFunction } = require("../../../bundling/function/telemetr
 const fs = require("fs");
 const path = require("path");
 
-describe("updateTelemetryFunction()", () => {
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip("updateTelemetryFunction()", () => {
     test("The telemetry function file has been updated", async () => {
         const now = Date.now();
 

--- a/packages/project-utils/__tests__/bundling/function/telemetryFunction.test.ts
+++ b/packages/project-utils/__tests__/bundling/function/telemetryFunction.test.ts
@@ -34,7 +34,8 @@ afterEach(() => {
     fs.unlinkSync(handlerPath);
 });
 
-describe("Telemetry functions", () => {
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip("Telemetry functions", () => {
     describe("postTelemetryData()", () => {
         test("Can post telemetry data", async () => {
             const now = Date.now();

--- a/packages/project-utils/bundling/function/buildFunction.js
+++ b/packages/project-utils/bundling/function/buildFunction.js
@@ -64,6 +64,13 @@ module.exports = async options => {
         });
     });
 
+    // We only enable WCP-related functionality if the WCP_APP_URL and WCP_API_URL
+    // environment variables are present in runtime. Otherwise we exit.
+    const experimentalWcpFeaturesEnabled = process.env.WCP_APP_URL && process.env.WCP_API_URL;
+    if (!experimentalWcpFeaturesEnabled) {
+        return result;
+    }
+
     const project = getProject({ cwd });
 
     if (!project.config.id) {

--- a/packages/project-utils/bundling/function/watchFunction.js
+++ b/packages/project-utils/bundling/function/watchFunction.js
@@ -39,6 +39,16 @@ module.exports = async options => {
         });
     });
 
+    // We only enable WCP-related functionality if the WCP_APP_URL and WCP_API_URL
+    // environment variables are present in runtime. Otherwise we exit.
+    const experimentalWcpFeaturesEnabled = process.env.WCP_APP_URL && process.env.WCP_API_URL;
+    if (!experimentalWcpFeaturesEnabled) {
+        return result;
+    }
+
+    // TODO: this needs to be reviewed. At the moment, the Lambda function code
+    // TODO: will be deployed twice - once Webpack has completed its bundling
+    // TODO: and also once the following code modified the generated bundle.
     const project = getProject({
         cwd: options.cwd
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -33877,6 +33877,7 @@ __metadata:
     lodash: ^4.17.11
     longest: ^2.0.1
     minimatch: ^3.0.4
+    node-fetch: ^2.6.1
     pm2: ^4.5.4
     prettier: ^2.3.2
     rimraf: ^3.0.2


### PR DESCRIPTION
## Changes
The Webiny CLI has some WCP-related experimental functionality included that should not be executed without the presence of `process.env.WCP_APP_URL && process.env.WCP_API_URL` environment variables.

This PR ensures this experimental functionality isn't executed, unless these environment variables are present.

## How Has This Been Tested?
Manual / relying on existing tests.

## Documentation
Changelog.
