### PR TITLE
Enable preferred_username alias in Cognito user pools

### DIFF
--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -15,7 +15,13 @@ export interface Config extends CognitoConfig {
 export const getIdentity: GetIdentity = ({ identityType, token }) => {
     // We ensure `undefined` doesn't end up in the `displayName` property.
     // If first name and last name is not present, we end up with an empty string.
-    const { given_name = null, family_name = null, sub: id = null, email = null } = token;
+    const {
+        given_name = null,
+        family_name = null,
+        sub: id = null,
+        email = null,
+        preferred_username = null
+    } = token;
 
     const displayName = [given_name, family_name].filter(Boolean).join(" ").trim() || null;
 
@@ -23,7 +29,7 @@ export const getIdentity: GetIdentity = ({ identityType, token }) => {
         id,
         type: identityType,
         displayName,
-        email,
+        email: preferred_username || email,
         firstName: given_name,
         lastName: family_name
     };

--- a/packages/cwp-template-aws/template/ddb-es/api/pulumi/dev/cognito.ts
+++ b/packages/cwp-template-aws/template/ddb-es/api/pulumi/dev/cognito.ts
@@ -25,7 +25,7 @@ class Cognito {
             userPoolAddOns: {
                 advancedSecurityMode: "OFF" /* required */
             },
-            usernameAttributes: ["email"],
+            aliasAttributes: ["preferred_username"],
             verificationMessageTemplate: {
                 defaultEmailOption: "CONFIRM_WITH_CODE"
             },

--- a/packages/cwp-template-aws/template/ddb-es/api/pulumi/prod/cognito.ts
+++ b/packages/cwp-template-aws/template/ddb-es/api/pulumi/prod/cognito.ts
@@ -27,7 +27,7 @@ class Cognito {
                 userPoolAddOns: {
                     advancedSecurityMode: "OFF" /* required */
                 },
-                usernameAttributes: ["email"],
+                aliasAttributes: ["preferred_username"],
                 verificationMessageTemplate: {
                     defaultEmailOption: "CONFIRM_WITH_CODE"
                 },

--- a/packages/cwp-template-aws/template/ddb/api/pulumi/dev/cognito.ts
+++ b/packages/cwp-template-aws/template/ddb/api/pulumi/dev/cognito.ts
@@ -25,7 +25,7 @@ class Cognito {
             userPoolAddOns: {
                 advancedSecurityMode: "OFF" /* required */
             },
-            usernameAttributes: ["email"],
+            aliasAttributes: ["preferred_username"],
             verificationMessageTemplate: {
                 defaultEmailOption: "CONFIRM_WITH_CODE"
             },

--- a/packages/cwp-template-aws/template/ddb/api/pulumi/prod/cognito.ts
+++ b/packages/cwp-template-aws/template/ddb/api/pulumi/prod/cognito.ts
@@ -27,7 +27,7 @@ class Cognito {
                 userPoolAddOns: {
                     advancedSecurityMode: "OFF" /* required */
                 },
-                usernameAttributes: ["email"],
+                aliasAttributes: ["preferred_username"],
                 verificationMessageTemplate: {
                     defaultEmailOption: "CONFIRM_WITH_CODE"
                 },


### PR DESCRIPTION
## Changes
This PR enables `preferred_username` alias for Cognito login.

## How Has This Been Tested?
Manually.

## Documentation
This doesn't require any documentation; this will be configured with every new project automatically.