### PR TITLE
test(api-headless-cms): check for reference on read api

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/references.test.ts
@@ -88,10 +88,7 @@ const createArticleItem = async ({ manager, from = null, publish, data }: any) =
 /**
  * We need only certain values from the article data when created.
  */
-const extractReadArticle = (
-    item: Record<string, any>,
-    category?: Record<string, any>
-): Record<string, any> => {
+const extractReadArticle = (item: any, category?: any): Record<string, any> => {
     return {
         id: item.id,
         entryId: item.entryId,
@@ -374,6 +371,20 @@ describe("entry references", () => {
                 return entries.every(entry => {
                     return !!entry.meta.publishedOn;
                 });
+            },
+            {
+                name: "list all published articles"
+            }
+        );
+        /**
+         * And that we can see it on read api.
+         */
+        await until(
+            () => articleRead.listArticles().then(([data]) => data),
+            ({ data }: any) => {
+                const entries: any[] = data?.listArticles?.data || [];
+
+                return entries.length === 1;
             },
             {
                 name: "list all published articles"


### PR DESCRIPTION
## Changes
Added another check for the flaky test in references.test.ts. Sometimes Elasticsearch does not index the reference fast enough.

## How Has This Been Tested?
Jest.
