### PR TITLE
feat(app-headless-cms): block navigation on cms entry form error

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
@@ -8,6 +8,8 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import { CmsContentFormRendererPlugin } from "~/types";
 import { useContentEntryForm, UseContentEntryFormParams } from "./useContentEntryForm";
 import { Fields } from "./Fields";
+import { Prompt } from "@webiny/react-router";
+import { useSnackbar } from "@webiny/app-admin";
 
 const FormWrapper = styled("div")({
     height: "calc(100vh - 260px)",
@@ -21,6 +23,19 @@ interface ContentEntryFormProps extends UseContentEntryFormParams {
 export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...props }) => {
     const { contentModel } = props;
     const { loading, data, onChange, onSubmit, invalidFields } = useContentEntryForm(props);
+
+    const [isDirty, setIsDirty] = React.useState<boolean>(false);
+    /**
+     * Reset isDirty when the loaded data changes.
+     */
+    useEffect(() => {
+        if (!isDirty) {
+            return;
+        }
+        setIsDirty(false);
+    }, [data]);
+
+    const { showSnackbar } = useSnackbar();
 
     const ref = useRef<FormAPI | null>(null);
 
@@ -72,27 +87,44 @@ export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...p
     return (
         <Form
             onChange={onChange}
-            onSubmit={onSubmit}
+            onSubmit={(data, form) => {
+                setIsDirty(false);
+                return onSubmit(data, form);
+            }}
             data={data}
             ref={ref}
             invalidFields={invalidFields}
+            onInvalid={() => {
+                setIsDirty(true);
+                showSnackbar(
+                    "You have fields that did not pass the validation. Please check the form!"
+                );
+            }}
         >
-            {formProps => (
-                <FormWrapper data-testid={"cms-content-form"}>
-                    {loading && <CircularProgress />}
-                    {formRenderer ? (
-                        renderCustomLayout(formProps)
-                    ) : (
-                        <Fields
-                            contentModel={contentModel}
-                            fields={contentModel.fields || []}
-                            layout={contentModel.layout || []}
-                            {...formProps}
-                            Bind={formProps.Bind as any}
+            {formProps => {
+                return (
+                    <>
+                        <Prompt
+                            when={isDirty}
+                            message={"Form has changed, please discard if not applicable."}
                         />
-                    )}
-                </FormWrapper>
-            )}
+                        <FormWrapper data-testid={"cms-content-form"}>
+                            {loading && <CircularProgress />}
+                            {formRenderer ? (
+                                renderCustomLayout(formProps)
+                            ) : (
+                                <Fields
+                                    contentModel={contentModel}
+                                    fields={contentModel.fields || []}
+                                    layout={contentModel.layout || []}
+                                    {...formProps}
+                                    Bind={formProps.Bind as any}
+                                />
+                            )}
+                        </FormWrapper>
+                    </>
+                );
+            }}
         </Form>
     );
 };

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
@@ -86,7 +86,10 @@ export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...p
 
     return (
         <Form
-            onChange={onChange}
+            onChange={(data, form) => {
+                setIsDirty(true);
+                return onChange(data, form);
+            }}
             onSubmit={(data, form) => {
                 setIsDirty(false);
                 return onSubmit(data, form);
@@ -97,7 +100,7 @@ export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...p
             onInvalid={() => {
                 setIsDirty(true);
                 showSnackbar(
-                    "You have fields that did not pass the validation. Please check the form!"
+                    "You have fields that did not pass the validation. Please check the form."
                 );
             }}
         >
@@ -106,7 +109,9 @@ export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...p
                     <>
                         <Prompt
                             when={isDirty}
-                            message={"Form has changed, please discard if not applicable."}
+                            message={
+                                "There are some unsaved changes! Are you sure you want to navigate away and discard all changes?"
+                            }
                         />
                         <FormWrapper data-testid={"cms-content-form"}>
                             {loading && <CircularProgress />}

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useContentEntryForm.ts
@@ -50,7 +50,7 @@ interface UseContentEntryForm {
     loading: boolean;
     setLoading: Dispatch<SetStateAction<boolean>>;
     onChange: FormOnSubmit;
-    onSubmit: (data: Record<string, any>) => void;
+    onSubmit: FormOnSubmit;
     invalidFields: Record<string, string>;
     renderPlugins: CmsEditorFieldRendererPlugin[];
 }
@@ -254,6 +254,13 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
         [contentModel.modelId, listQueryVariables]
     );
 
+    const onChange: FormOnSubmit = (data, form) => {
+        if (!params.onChange) {
+            return;
+        }
+        return params.onChange(data, form);
+    };
+
     const onSubmit = async (data: Record<string, any>) => {
         const fieldsIds = contentModel.fields.map(item => item.fieldId);
         const formData = pick(data, [...fieldsIds]);
@@ -333,11 +340,7 @@ export function useContentEntryForm(params: UseContentEntryFormParams): UseConte
         data: entry && entry.id ? entry : getDefaultValues(),
         loading,
         setLoading,
-        onChange:
-            params.onChange ||
-            (() => {
-                return void 0;
-            }),
+        onChange,
         onSubmit,
         invalidFields,
         renderPlugins

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/boolean/booleanSwitch.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/boolean/booleanSwitch.tsx
@@ -25,7 +25,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
             return (
                 <Bind>
-                    {(bindProps: any) => (
+                    {bindProps => (
                         <Switch {...bindProps} label={field.label} description={field.helpText} />
                     )}
                 </Bind>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInput.tsx
@@ -25,7 +25,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
             return (
                 <Bind>
-                    {(bindProps: any) => {
+                    {bindProps => {
                         return (
                             <Input
                                 {...bindProps}

--- a/packages/react-router/src/usePrompt.ts
+++ b/packages/react-router/src/usePrompt.ts
@@ -7,7 +7,7 @@
  * Thanks to https://github.com/rmorse
  */
 import { useContext, useEffect, useCallback } from "react";
-import { UNSAFE_NavigationContext as NavigationContext } from "react-router-dom";
+import { UNSAFE_NavigationContext as NavigationContext, useLocation } from "react-router-dom";
 import { History, Transition } from "history";
 
 type Navigator = Pick<History, "go" | "push" | "replace" | "createHref" | "block">;
@@ -23,7 +23,13 @@ interface BlockerCallable {
  */
 const useBlocker = (blocker: BlockerCallable, when = true) => {
     const ctx = useContext(NavigationContext);
-
+    /**
+     * We must use the location values because it is possible for a component which uses Prompt is not unmounted.
+     * Example, when switching from CMS entry to another one, if blocker was removed, a new one will not appear because
+     * useEffect will not rerun.
+     */
+    const location = useLocation();
+    const url = `${location.pathname}${location.search}`;
     const navigator = ctx.navigator as unknown as Navigator;
 
     useEffect(() => {
@@ -48,7 +54,7 @@ const useBlocker = (blocker: BlockerCallable, when = true) => {
         });
 
         return unblock;
-    }, [navigator, blocker, when]);
+    }, [url, navigator, blocker, when]);
 };
 
 /**


### PR DESCRIPTION
## Issue
Closes #2135

## Changes
Blocks navigating from the CMS entry form when there are errors on form submit or entry was changes but not saved.

## How Has This Been Tested?
Manually and jest.