### PR TITLE
feat(api-headless-cms): clear scheme cache after model clone

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -601,6 +601,67 @@ describe("content model test", () => {
         });
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreate")).toEqual(true);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterCreate")).toEqual(true);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreateFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterCreateFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterUpdate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeDelete")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterDelete")).toEqual(false);
+    });
+
+    test("should execute hooks on create from", async () => {
+        const { createContentModelMutation, createContentModelFromMutation } = useContentGqlHandler(
+            {
+                ...manageHandlerOpts,
+                plugins: [assignModelEvents()]
+            }
+        );
+
+        const [createResponse] = await createContentModelMutation({
+            data: {
+                name: "Test Content model",
+                modelId: "test-content-model",
+                group: contentModelGroup.id
+            }
+        });
+        const { modelId } = createResponse.data.createContentModel.data;
+        // need to reset because hooks for create have been fired
+        pubSubTracker.reset();
+
+        const [response] = await createContentModelFromMutation({
+            modelId,
+            data: {
+                name: "Cloned model",
+                modelId: "clonedTestModel",
+                description: "Cloned model description",
+                group: contentModelGroup.id
+            }
+        });
+
+        expect(response).toMatchObject({
+            data: {
+                createContentModelFrom: {
+                    data: {
+                        name: "Cloned model",
+                        description: "Cloned model description",
+                        modelId: "clonedTestModel",
+                        group: {
+                            id: contentModelGroup.id,
+                            name: contentModelGroup.name
+                        },
+                        fields: [],
+                        layout: [],
+                        plugin: false
+                    },
+                    error: null
+                }
+            }
+        });
+
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreateFrom")).toEqual(true);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterCreateFrom")).toEqual(true);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeUpdate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterUpdate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeDelete")).toEqual(false);
@@ -644,6 +705,8 @@ describe("content model test", () => {
 
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreateFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterCreateFrom")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeUpdate")).toEqual(true);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterUpdate")).toEqual(true);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeDelete")).toEqual(false);
@@ -682,6 +745,8 @@ describe("content model test", () => {
 
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterCreate")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:beforeCreateFrom")).toEqual(false);
+        expect(pubSubTracker.isExecutedOnce("contentModel:afterCreateFrom")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeUpdate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:afterUpdate")).toEqual(false);
         expect(pubSubTracker.isExecutedOnce("contentModel:beforeDelete")).toEqual(true);

--- a/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
@@ -6,12 +6,8 @@ describe("HTTP Options request", () => {
     const manageOpts = {
         path: "manage/en-US",
         plugins: [
-            new ContextPlugin(async context => {
-                context.waitFor<CmsContext>(["cms"], ctx => {
-                    ctx.cms.onBeforeGroupCreate.subscribe(async () => {
-                        throw new Error("This should not fire or register.");
-                    });
-                });
+            new ContextPlugin<CmsContext>(async () => {
+                throw new Error("This should not register.");
             })
         ]
     };

--- a/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/httpOptions.test.ts
@@ -1,7 +1,20 @@
+import { ContextPlugin } from "@webiny/handler";
+import { CmsContext } from "~/types";
 import { useCategoryManageHandler } from "../utils/useCategoryManageHandler";
 
 describe("HTTP Options request", () => {
-    const manageOpts = { path: "manage/en-US" };
+    const manageOpts = {
+        path: "manage/en-US",
+        plugins: [
+            new ContextPlugin(async context => {
+                context.waitFor<CmsContext>(["cms"], ctx => {
+                    ctx.cms.onBeforeGroupCreate.subscribe(async () => {
+                        throw new Error("This should not fire or register.");
+                    });
+                });
+            })
+        ]
+    };
 
     test(`http options`, async () => {
         const { invoke } = useCategoryManageHandler(manageOpts);

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/lifecycleHooks.ts
@@ -37,6 +37,12 @@ export const assignModelEvents = () => {
         context.cms.onAfterModelCreate.subscribe(async () => {
             pubSubTracker.track("contentModel:afterCreate");
         });
+        context.cms.onBeforeModelCreateFrom.subscribe(async () => {
+            pubSubTracker.track("contentModel:beforeCreateFrom");
+        });
+        context.cms.onAfterModelCreateFrom.subscribe(async () => {
+            pubSubTracker.track("contentModel:afterCreateFrom");
+        });
         context.cms.onBeforeModelUpdate.subscribe(async () => {
             pubSubTracker.track("contentModel:beforeUpdate");
         });

--- a/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/content/graphQLHandlerFactory.ts
@@ -139,7 +139,11 @@ export const graphQLHandlerFactory = (
                 return next();
             }
 
-            if (http.request.method === "OPTIONS") {
+            const method = (http.request.method || "").toLowerCase();
+            /**
+             * In case of OPTIONS method we just return the headers since there is no need to go further.
+             */
+            if (method.toLowerCase() === "options") {
                 return http.response({
                     statusCode: 204,
                     headers: {
@@ -148,8 +152,10 @@ export const graphQLHandlerFactory = (
                     }
                 });
             }
-
-            if (http.request.method !== "POST") {
+            /**
+             * We expect, and allow, only POST method to access our GraphQL
+             */
+            if (method !== "post") {
                 return next();
             }
 

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel.crud.ts
@@ -40,6 +40,7 @@ import { assignBeforeModelDelete } from "./contentModel/beforeDelete";
 import { assignAfterModelCreate } from "./contentModel/afterCreate";
 import { assignAfterModelUpdate } from "./contentModel/afterUpdate";
 import { assignAfterModelDelete } from "./contentModel/afterDelete";
+import { assignAfterModelCreateFrom } from "~/content/plugins/crud/contentModel/afterCreateFrom";
 
 export interface CreateModelsCrudParams {
     getTenant: () => Tenant;
@@ -215,6 +216,10 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
         context,
         onAfterModelUpdate
     });
+    assignAfterModelCreateFrom({
+        context,
+        onAfterModelCreateFrom
+    });
     assignBeforeModelDelete({
         onBeforeModelDelete,
         plugins: context.plugins,
@@ -384,8 +389,8 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                     displayName: identity.displayName,
                     type: identity.type
                 },
-                createdOn: new Date().toISOString() as any,
-                savedOn: new Date().toISOString() as any,
+                createdOn: new Date().toISOString(),
+                savedOn: new Date().toISOString(),
                 lockedFields: [],
                 webinyVersion: context.WEBINY_VERSION
             };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreateFrom.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/afterCreateFrom.ts
@@ -1,0 +1,14 @@
+import { AfterModelCreateFromTopicParams, CmsContext } from "~/types";
+import { Topic } from "@webiny/pubsub/types";
+
+interface AssignAfterModelCreateFromParams {
+    onAfterModelCreateFrom: Topic<AfterModelCreateFromTopicParams>;
+    context: CmsContext;
+}
+export const assignAfterModelCreateFrom = (params: AssignAfterModelCreateFromParams) => {
+    const { onAfterModelCreateFrom, context } = params;
+
+    onAfterModelCreateFrom.subscribe(async () => {
+        await context.cms.updateModelLastChange();
+    });
+};

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -371,11 +371,11 @@ export interface CmsModel {
     /**
      * Date created
      */
-    createdOn?: Date;
+    createdOn?: string;
     /**
      * Date saved. Changes on both save and create.
      */
-    savedOn?: Date;
+    savedOn?: string;
     /**
      * CreatedBy object wrapper. Contains id, name and type of the user.
      */


### PR DESCRIPTION
## Changes
Closes #2270

GraphQL scheme cache was not clearead after content model was cloned and it did not exist in the current scheme.

Stop execution of the context plugin if the request is OPTIONS.

## How Has This Been Tested?
Jest.