### PR TITLE
Fix composition API types

### DIFF
--- a/packages/app-admin-core/src/admin.tsx
+++ b/packages/app-admin-core/src/admin.tsx
@@ -4,6 +4,7 @@ import React, {
     useMemo,
     useState,
     useCallback,
+    FC,
     FunctionComponentElement,
     ComponentType,
     ReactElement
@@ -13,14 +14,11 @@ import { Routes as SortRoutes } from "./components/utils/Routes";
 import { DebounceRender } from "./components/utils/DebounceRender";
 import { PluginsProvider } from "./components/core/Plugins";
 
-/**
- * TODO: Determine the exact type
- */
-const compose = (...fns: any[]) => {
-    return (Base: any) => {
+function compose(...fns: HigherOrderComponent[]) {
+    return function ComposedComponent(Base: FC<unknown>): FC<unknown> {
         return fns.reduceRight((Component, hoc) => hoc(Component), Base);
     };
-};
+}
 
 interface Wrapper {
     component: ComponentType<unknown>;
@@ -67,8 +65,13 @@ export const useAdmin = () => {
     return useContext(AdminContext);
 };
 
-export interface HigherOrderComponent<TInputProps = unknown, TOutputProps = TInputProps> {
-    (Component: React.FC<TInputProps>): React.FC<TOutputProps>;
+/**
+ * IMPORTANT: TInputProps default type is `any` because this interface is use as a prop type in the `Compose` component.
+ * You can pass any HigherOrderComponent as a prop, regardless of its TInputProps type. The only way to allow that is
+ * to let it be `any` in this interface.
+ */
+export interface HigherOrderComponent<TInputProps = any, TOutputProps = TInputProps> {
+    (Component: FC<TInputProps>): FC<TOutputProps>;
 }
 
 export interface AdminProps {

--- a/packages/app-admin-core/src/components/core/Compose.tsx
+++ b/packages/app-admin-core/src/components/core/Compose.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect } from "react";
 import { HigherOrderComponent, useAdmin } from "~/admin";
 
+export interface ComposableFC<TProps> extends React.FC<TProps> {
+    original: React.FC<TProps>;
+    originalName: string;
+}
+
 export interface ComposeProps {
-    component: React.FC<unknown> & {
-        original: React.FC<unknown>;
-        originalName?: string;
-    };
+    /**
+     * Component to compose.
+     * NOTE: ComposableFC<TProps> use `any` because the type of the component props is irrelevant.
+     */
+    component: ComposableFC<any>;
     with: HigherOrderComponent | HigherOrderComponent[];
 }
 

--- a/packages/app-admin-core/src/makeComposable.tsx
+++ b/packages/app-admin-core/src/makeComposable.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo } from "react";
 import debounce from "lodash.debounce";
 import { useAdmin } from "./admin";
 import { ComponentType } from "react";
+import { ComposableFC } from "./components/core/Compose";
 
 const useComponent = (Component: ComponentType<any>): ComponentType<any> => {
     const { wrappers } = useAdmin();
@@ -45,11 +46,6 @@ const createEmptyRenderer = (name: string): React.FC => {
         return null;
     };
 };
-
-export interface ComposableFC<TProps> extends React.FC<TProps> {
-    original: React.FC<TProps>;
-    originalName: string;
-}
 
 export function makeComposable<TProps>(name: string, Component?: React.FC<TProps>) {
     if (!Component) {


### PR DESCRIPTION
## Changes
This PR fixes some TS issues with the `Compose` component and `makeComposable` utility.

## How Has This Been Tested?
By using the `<Compose/>` component in the Admin  app.