### PR TITLE
Minor fixes of watch logs, CMS context, and PB lifecycle events.

### DIFF
--- a/packages/api-file-manager-s3/tsconfig.build.json
+++ b/packages/api-file-manager-s3/tsconfig.build.json
@@ -3,9 +3,9 @@
   "include": ["src"],
   "references": [
     { "path": "../api-file-manager/tsconfig.build.json" },
+    { "path": "../error/tsconfig.build.json" },
     { "path": "../handler-graphql/tsconfig.build.json" },
-    { "path": "../validation/tsconfig.build.json" },
-    { "path": "../error/tsconfig.build.json" }
+    { "path": "../validation/tsconfig.build.json" }
   ],
   "compilerOptions": {
     "rootDir": "./src",

--- a/packages/api-file-manager-s3/tsconfig.json
+++ b/packages/api-file-manager-s3/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src", "__tests__/**/*.ts"],
   "references": [
     { "path": "../api-file-manager" },
+    { "path": "../error" },
     { "path": "../handler-graphql" },
-    { "path": "../validation" },
-    { "path": "../error" }
+    { "path": "../validation" }
   ],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
@@ -15,12 +15,12 @@
       "~/*": ["./src/*"],
       "@webiny/api-file-manager/*": ["../api-file-manager/src/*"],
       "@webiny/api-file-manager": ["../api-file-manager/src"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
       "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],
       "@webiny/handler-graphql": ["../handler-graphql/src"],
       "@webiny/validation/*": ["../validation/src/*"],
-      "@webiny/validation": ["../validation/src"],
-      "@webiny/error/*": ["../error/src/*"],
-      "@webiny/error": ["../error/src"]
+      "@webiny/validation": ["../validation/src"]
     },
     "baseUrl": "."
   }

--- a/packages/api-headless-cms/src/content/plugins/crud/index.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/index.ts
@@ -15,6 +15,10 @@ export interface CreateContentCrudsParams {
 export const createContentCruds = (params: CreateContentCrudsParams) => {
     const { storageOperations } = params;
     return new ContextPlugin<CmsContext>(async context => {
+        if (context.http?.request?.method === "OPTIONS") {
+            return;
+        }
+
         /**
          * This should never happen in the actual project.
          * It is to make sure that we load setup context before the CRUD init in our internal code.
@@ -26,6 +30,7 @@ export const createContentCruds = (params: CreateContentCrudsParams) => {
                 );
             return;
         }
+
         const getLocale = () => {
             return context.cms.getLocale();
         };

--- a/packages/api-headless-cms/src/plugins/crud/index.ts
+++ b/packages/api-headless-cms/src/plugins/crud/index.ts
@@ -15,6 +15,10 @@ export interface CreateAdminCrudsParams {
 export const createAdminCruds = (params: CreateAdminCrudsParams) => {
     const { storageOperations } = params;
     return new ContextPlugin<CmsContext>(async context => {
+        if (context.http?.request?.method === "OPTIONS") {
+            return;
+        }
+
         /**
          * This should never happen in the actual project.
          * It is to make sure that we load setup context before the CRUD init in our internal code.

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -493,7 +493,7 @@ export const createPageCrud = (params: CreatePageCrudParams): PagesCrud => {
                     page
                 });
 
-                await onBeforePageUpdate.publish({
+                await onAfterPageUpdate.publish({
                     original,
                     page: result,
                     input

--- a/packages/app-admin-rmwc/src/modules/Dashboard/Welcome.tsx
+++ b/packages/app-admin-rmwc/src/modules/Dashboard/Welcome.tsx
@@ -194,7 +194,7 @@ const Welcome: React.FC = () => {
                         style={{ margin: "1rem 1rem 1rem 0rem" }}
                     >
                         <Link
-                            to="https://docs.webiny.com/"
+                            to="https://www.webiny.com/docs"
                             className={linkStyle}
                             target={"_blank"}
                             rel={"noopener noreferrer"}
@@ -261,7 +261,7 @@ const Welcome: React.FC = () => {
                     </Cell>
                     <Cell span={1} className={iconTextStyle} align="middle">
                         <Link
-                            to="https://twitter.com/WebinyPlatform"
+                            to="https://twitter.com/WebinyCMS"
                             className={linkStyle}
                             target={"_blank"}
                             rel={"noopener noreferrer"}

--- a/packages/app-admin-rmwc/tsconfig.build.json
+++ b/packages/app-admin-rmwc/tsconfig.build.json
@@ -4,11 +4,11 @@
   "references": [
     { "path": "../app/tsconfig.build.json" },
     { "path": "../app-admin/tsconfig.build.json" },
+    { "path": "../app-plugin-admin-welcome-screen/tsconfig.build.json" },
     { "path": "../app-security/tsconfig.build.json" },
     { "path": "../plugins/tsconfig.build.json" },
     { "path": "../react-router/tsconfig.build.json" },
-    { "path": "../ui/tsconfig.build.json" },
-    { "path": "../app-plugin-admin-welcome-screen/tsconfig.build.json" }
+    { "path": "../ui/tsconfig.build.json" }
   ],
   "compilerOptions": {
     "rootDir": "./src",

--- a/packages/app-admin-rmwc/tsconfig.json
+++ b/packages/app-admin-rmwc/tsconfig.json
@@ -4,11 +4,11 @@
   "references": [
     { "path": "../app" },
     { "path": "../app-admin" },
+    { "path": "../app-plugin-admin-welcome-screen" },
     { "path": "../app-security" },
     { "path": "../plugins" },
     { "path": "../react-router" },
-    { "path": "../ui" },
-    { "path": "../app-plugin-admin-welcome-screen" }
+    { "path": "../ui" }
   ],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
@@ -20,6 +20,8 @@
       "@webiny/app": ["../app/src"],
       "@webiny/app-admin/*": ["../app-admin/src/*"],
       "@webiny/app-admin": ["../app-admin/src"],
+      "@webiny/app-plugin-admin-welcome-screen/*": ["../app-plugin-admin-welcome-screen/src/*"],
+      "@webiny/app-plugin-admin-welcome-screen": ["../app-plugin-admin-welcome-screen/src"],
       "@webiny/app-security/*": ["../app-security/src/*"],
       "@webiny/app-security": ["../app-security/src"],
       "@webiny/plugins/*": ["../plugins/src/*"],
@@ -27,9 +29,7 @@
       "@webiny/react-router/*": ["../react-router/src/*"],
       "@webiny/react-router": ["../react-router/src"],
       "@webiny/ui/*": ["../ui/src/*"],
-      "@webiny/ui": ["../ui/src"],
-      "@webiny/app-plugin-admin-welcome-screen/*": ["../app-plugin-admin-welcome-screen/src/*"],
-      "@webiny/app-plugin-admin-welcome-screen": ["../app-plugin-admin-welcome-screen/src"]
+      "@webiny/ui": ["../ui/src"]
     },
     "baseUrl": "."
   }

--- a/packages/app-admin/src/base/Base.tsx
+++ b/packages/app-admin/src/base/Base.tsx
@@ -33,7 +33,7 @@ const BaseExtension: React.FC = () => {
                 name={"documentation"}
                 label={"Documentation"}
                 icon={<DocsIcon />}
-                path={"https://docs.webiny.com/"}
+                path={"https://www.webiny.com/docs"}
                 rel={"noopener noreferrer"}
                 target={"_blank"}
                 tags={["footer"]}

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -38,7 +38,7 @@ yargs
     .recommendCommands()
     .scriptName("webiny")
     .epilogue(
-        `To find more information, docs and tutorials, see ${blue("https://docs.webiny.com")}.`
+        `To find more information, docs and tutorials, see ${blue("https://www.webiny.com/docs")}.`
     )
     .epilogue(`Want to contribute? ${blue("https://github.com/webiny/webiny-js")}.`)
     .fail(function (msg, error, yargs) {

--- a/packages/cwp-template-aws/cli/deploy/deploy.js
+++ b/packages/cwp-template-aws/cli/deploy/deploy.js
@@ -111,7 +111,7 @@ module.exports = async (inputs, context) => {
                 `To finish the setup, please open your ${green("Admin")} app (${green(
                     outputs.apps.admin.appUrl
                 )}) and complete the installation wizard. To learn more, visit ${green(
-                    "https://docs.webiny.com"
+                    "https://www.webiny.com/docs"
                 )}.`
             ].join("\n")
         );

--- a/packages/handler-graphql/src/debugPlugins.ts
+++ b/packages/handler-graphql/src/debugPlugins.ts
@@ -1,5 +1,5 @@
 import { interceptConsole } from "./interceptConsole";
-import { GraphQLAfterQueryPlugin, GraphQLBeforeQueryPlugin } from "./types";
+import { GraphQLAfterQueryPlugin } from "./types";
 import { Context, ContextPlugin } from "@webiny/handler/types";
 
 interface Log {
@@ -19,21 +19,15 @@ export default () => [
             if (!context.debug) {
                 context.debug = {};
             }
-            if (!context.debug.logs) {
-                context.debug.logs = [];
-            }
+
+            // Reset logs.
+            context.debug.logs = [];
+
             interceptConsole((method, args) => {
                 (context.debug.logs as Log[]).push({ method, args });
             });
         }
     } as ContextPlugin<DebugContext>,
-    {
-        type: "graphql-before-query",
-        apply({ context }) {
-            // Empty logs
-            context.debug.logs = [];
-        }
-    } as GraphQLBeforeQueryPlugin<DebugContext>,
     {
         type: "graphql-after-query",
         apply({ result, context }) {

--- a/packages/handler-graphql/src/debugPlugins.ts
+++ b/packages/handler-graphql/src/debugPlugins.ts
@@ -1,5 +1,5 @@
 import { interceptConsole } from "./interceptConsole";
-import { GraphQLAfterQueryPlugin } from "./types";
+import { GraphQLAfterQueryPlugin, GraphQLBeforeQueryPlugin } from "./types";
 import { Context, ContextPlugin } from "@webiny/handler/types";
 
 interface Log {
@@ -28,6 +28,13 @@ export default () => [
             });
         }
     } as ContextPlugin<DebugContext>,
+    {
+        type: "graphql-before-query",
+        apply({ context }) {
+            // Empty logs
+            context.debug.logs = [];
+        }
+    } as GraphQLBeforeQueryPlugin<DebugContext>,
     {
         type: "graphql-after-query",
         apply({ result, context }) {

--- a/packages/handler-graphql/src/debugPlugins.ts
+++ b/packages/handler-graphql/src/debugPlugins.ts
@@ -1,5 +1,5 @@
 import { interceptConsole } from "./interceptConsole";
-import { GraphQLAfterQueryPlugin, GraphQLBeforeQueryPlugin } from "./types";
+import { GraphQLAfterQueryPlugin } from "./types";
 import { Context, ContextPlugin } from "@webiny/handler/types";
 
 interface Log {
@@ -20,8 +20,9 @@ export default () => [
                 context.debug = {};
             }
 
-            // Reset logs.
-            context.debug.logs = [];
+            if (!context.debug.logs) {
+                context.debug.logs = [];
+            }
 
             interceptConsole((method, args) => {
                 (context.debug.logs as Log[]).push({ method, args });
@@ -29,16 +30,12 @@ export default () => [
         }
     } as ContextPlugin<DebugContext>,
     {
-        type: "graphql-before-query",
-        apply({ context }) {
-            // Empty logs
-            context.debug.logs = [];
-        }
-    } as GraphQLBeforeQueryPlugin<DebugContext>,
-    {
         type: "graphql-after-query",
         apply({ result, context }) {
-            result["extensions"] = { console: context.debug.logs || [] };
+            result["extensions"] = { console: [...(context.debug.logs || [])] };
+            if (context.debug.logs) {
+                context.debug.logs.length = 0;
+            }
         }
     } as GraphQLAfterQueryPlugin<DebugContext>
 ];

--- a/packages/handler-logs/package.json
+++ b/packages/handler-logs/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.16.3",
+    "@webiny/handler": "^5.25.0-beta.3",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {

--- a/packages/handler-logs/tsconfig.build.json
+++ b/packages/handler-logs/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
-  "references": [],
+  "references": [{ "path": "../handler/tsconfig.build.json" }],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/handler-logs/tsconfig.json
+++ b/packages/handler-logs/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__/**/*.ts"],
-  "references": [],
+  "references": [{ "path": "../handler" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",
     "declarationDir": "./dist",
-    "paths": { "~/*": ["./src/*"] },
+    "paths": {
+      "~/*": ["./src/*"],
+      "@webiny/handler/*": ["../handler/src/*"],
+      "@webiny/handler": ["../handler/src"]
+    },
     "baseUrl": "."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11852,6 +11852,7 @@ __metadata:
     "@babel/preset-typescript": ^7.16.0
     "@babel/runtime": ^7.16.3
     "@webiny/cli": ^5.25.0-beta.3
+    "@webiny/handler": ^5.25.0-beta.3
     "@webiny/project-utils": ^5.25.0-beta.3
     node-fetch: ^2.6.1
     rimraf: ^3.0.2


### PR DESCRIPTION
## Changes
Closes #2296

### Logging
This PR fixes console.log aggregation and forwarding to the browser/terminal.
> NOTE: `localtunnel` is glitchy and it can occasionally fail to send the message to your local listener. There's nothing we can do here; I think it's best to ditch it and only have the browser-based logs (in the Dev Tools).

### Other
- fix execution of the `onAfterPageUpdate` lifecycle event in the Page Builder. 
- prevent Headless CMS context construction on OPTIONS request (@brunozoric not sure why this is not handled by your recent addition of request abortion on OPTIONS requests; please check it out during PR review)


## How Has This Been Tested?
Manually.
