### PR TITLE
Feat(app-admin): open thankyou page on new install or upgrade

### DIFF
--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -54,6 +54,7 @@ export const AppInstaller: React.FC = ({ children }) => {
         }
         if (!isFirstInstall) {
             window.location.href = `https://site.webiny.com/thank-you/upgrade?version=${wbyVersion}&returnUrl=${window.location.href}`;
+            return;
         }
         window.location.href = `https://site.webiny.com/thank-you/installation?returnUrl=${window.location.href}`;
     };
@@ -178,7 +179,7 @@ export const AppInstaller: React.FC = ({ children }) => {
                             openWelcomeScreen();
                         }}
                     >
-                        Finish install
+                        {isFirstInstall ? "Finish install" : "Finish upgrade"}
                     </ButtonPrimary>
                 </SuccessDialog>
             </Elevation>

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -26,6 +26,18 @@ export const AppInstaller: React.FC = ({ children }) => {
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
 
+    const openWelcomeScreen = () => {
+        if (localStorage.get(lsKey)) {
+            // new version welcome screen
+            window.open(
+                `https://site.webiny.com/thank-you/upgrade?version=${wbyVersion}`,
+                "_blank"
+            );
+        }
+        // new installation welcome screen
+        window.open(`https://site.webiny.com/thank-you/installation`, "_blank");
+    };
+
     const markInstallerAsCompleted = () => {
         localStorage.set(lsKey, wbyVersion);
     };
@@ -161,6 +173,7 @@ export const AppInstaller: React.FC = ({ children }) => {
                     <ButtonPrimary
                         data-testid={"open-webiny-cms-admin-button"}
                         onClick={() => {
+                            openWelcomeScreen();
                             markInstallerAsCompleted();
                             setFinished(true);
                         }}

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -25,18 +25,7 @@ export const AppInstaller: React.FC = ({ children }) => {
 
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
-
-    const openWelcomeScreen = () => {
-        if (localStorage.get(lsKey)) {
-            // new version welcome screen
-            window.open(
-                `https://site.webiny.com/thank-you/upgrade?version=${wbyVersion}`,
-                "_blank"
-            );
-        }
-        // new installation welcome screen
-        window.open(`https://site.webiny.com/thank-you/installation`, "_blank");
-    };
+    const isRootTenant = tenantId === "root";
 
     const markInstallerAsCompleted = () => {
         localStorage.set(lsKey, wbyVersion);
@@ -52,11 +41,22 @@ export const AppInstaller: React.FC = ({ children }) => {
         loading,
         installers,
         installer,
+        isFirstInstall,
         showNextInstaller,
         showLogin,
         onUser,
         skippingVersions
     } = useInstaller({ isInstalled: isInstallerCompleted() });
+
+    const openWelcomeScreen = () => {
+        if (!isRootTenant) {
+            return;
+        }
+        if (!isFirstInstall) {
+            window.location.href = `https://site.webiny.com/thank-you/upgrade?version=${wbyVersion}&returnUrl=${window.location.href}`;
+        }
+        window.location.href = `https://site.webiny.com/thank-you/installation?returnUrl=${window.location.href}`;
+    };
 
     useEffect(() => {
         if (identity) {
@@ -173,12 +173,12 @@ export const AppInstaller: React.FC = ({ children }) => {
                     <ButtonPrimary
                         data-testid={"open-webiny-cms-admin-button"}
                         onClick={() => {
-                            openWelcomeScreen();
                             markInstallerAsCompleted();
                             setFinished(true);
+                            openWelcomeScreen();
                         }}
                     >
-                        Open Admin Area
+                        Finish install
                     </ButtonPrimary>
                 </SuccessDialog>
             </Elevation>

--- a/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/useInstaller.tsx
@@ -242,9 +242,12 @@ export const useInstaller = (params: UseInstallerParams) => {
         })();
     }, []);
 
+    const isFirstInstall = installers.some(installer => installer.installed);
+
     return {
         loading,
         installers,
+        isFirstInstall,
         installer: installers[installerIndex],
         showNextInstaller,
         showLogin,


### PR DESCRIPTION
## Changes
- Add `isFirstInstall` check to `useInstaller()` hook
- Change text in installer completed button
- Add `openWelcomeScreen()` function to the above button
- Only redirect if we are on the root tenant

## How has this been tested?
- Run install script on a new install