### PR TITLE
feat(app-admin): send telemetry to GA on first install

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "lint:fix": "yarn eslint:fix && yarn prettier:fix",
     "setup-project": "node scripts/setupProject",
     "setup-env-files": "node scripts/setupEnvFiles",
-    "setup-ci-cypress": "node scripts/setupCiCypress",
     "setup-cypress": "node scripts/setupCypress",
     "test": "jest --config jest.config.js --runInBand --logHeapUsage",
     "test:unit": "cross-env TEST_TYPE=unit yarn test",

--- a/packages/app-admin-users-cognito/src/plugins/installation.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/installation.tsx
@@ -126,7 +126,7 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                             <View name={"adminUsers.installation.fields"} props={{ Bind, data }} />
                         </Grid>
 
-                        <Grid style={{ paddingTop: '0px' }}>
+                        <Grid style={{ paddingTop: "0px" }}>
                             <Cell span={12}>
                                 <Bind name="subscribed">
                                     <Checkbox
@@ -144,7 +144,10 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                     <SimpleFormFooter>
                         <Grid>
                             <Cell span={8}>
-                                <p style={{ textAlign: "left" }}>By submitting the form, you agree to our Terms of Service and acknowledge our {privacyPolicyLink}.</p>
+                                <p style={{ textAlign: "left" }}>
+                                    By submitting the form, you agree to our Terms of Service and
+                                    acknowledge our {privacyPolicyLink}.
+                                </p>
                             </Cell>
                             <Cell span={4}>
                                 <ButtonPrimary
@@ -157,7 +160,6 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                                 </ButtonPrimary>
                             </Cell>
                         </Grid>
-
                     </SimpleFormFooter>
                 </SimpleForm>
             )}

--- a/packages/app-admin-users-cognito/src/plugins/installation.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/installation.tsx
@@ -149,8 +149,8 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                             <Cell span={4}>
                                 <ButtonPrimary
                                     data-testid="install-security-button"
-                                    onClick={ev => {
-                                        submit(ev);
+                                    onClick={() => {
+                                        submit();
                                     }}
                                 >
                                     Create Admin User

--- a/packages/app-admin-users-cognito/src/plugins/installation.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/installation.tsx
@@ -126,15 +126,14 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                             <View name={"adminUsers.installation.fields"} props={{ Bind, data }} />
                         </Grid>
 
-                        <Grid>
+                        <Grid style={{ paddingTop: '0px' }}>
                             <Cell span={12}>
                                 <Bind name="subscribed">
                                     <Checkbox
                                         label={
                                             <span>
                                                 I want to receive updates on product improvements
-                                                and new features. Doing so I accept Webiny&apos;s{" "}
-                                                {privacyPolicyLink}.
+                                                and new features.
                                             </span>
                                         }
                                     />
@@ -143,14 +142,22 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                         </Grid>
                     </SimpleFormContent>
                     <SimpleFormFooter>
-                        <ButtonPrimary
-                            data-testid="install-security-button"
-                            onClick={ev => {
-                                submit(ev);
-                            }}
-                        >
-                            Create Admin User
-                        </ButtonPrimary>
+                        <Grid>
+                            <Cell span={8}>
+                                <p style={{ textAlign: "left" }}>By submitting the form, you agree to our Terms of Service and acknowledge our {privacyPolicyLink}.</p>
+                            </Cell>
+                            <Cell span={4}>
+                                <ButtonPrimary
+                                    data-testid="install-security-button"
+                                    onClick={ev => {
+                                        submit(ev);
+                                    }}
+                                >
+                                    Create Admin User
+                                </ButtonPrimary>
+                            </Cell>
+                        </Grid>
+
                     </SimpleFormFooter>
                 </SimpleForm>
             )}

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -48,17 +48,6 @@ export const AppInstaller: React.FC = ({ children }) => {
         skippingVersions
     } = useInstaller({ isInstalled: isInstallerCompleted() });
 
-    const openWelcomeScreen = () => {
-        if (!isRootTenant) {
-            return;
-        }
-        if (!isFirstInstall) {
-            window.location.href = `https://site.webiny.com/thank-you/upgrade?version=${wbyVersion}&returnUrl=${window.location.href}`;
-            return;
-        }
-        window.location.href = `https://site.webiny.com/thank-you/installation?returnUrl=${window.location.href}`;
-    };
-
     useEffect(() => {
         if (identity) {
             onUser();
@@ -171,12 +160,20 @@ export const AppInstaller: React.FC = ({ children }) => {
             <Elevation z={1}>
                 <SuccessDialog>
                     <p>You have successfully installed all new applications!</p>
+                    {isRootTenant && isFirstInstall ? (
+                        <iframe
+                            height="0"
+                            width="0"
+                            frameBorder="0"
+                            style={{ opacity: "0" }}
+                            src="https://www.webiny.com/thank-you/new-install"
+                        ></iframe>
+                    ) : null}
                     <ButtonPrimary
                         data-testid={"open-webiny-cms-admin-button"}
                         onClick={() => {
                             markInstallerAsCompleted();
                             setFinished(true);
-                            openWelcomeScreen();
                         }}
                     >
                         {isFirstInstall ? "Finish install" : "Finish upgrade"}

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -22,10 +22,10 @@ import { config as appConfig } from "@webiny/app/config";
 
 export const AppInstaller: React.FC = ({ children }) => {
     const tenantId = localStorage.get("webiny_tenant") || "root";
-
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
     const isRootTenant = tenantId === "root";
+    const isCypressTest = window && window.Cypress
 
     const markInstallerAsCompleted = () => {
         localStorage.set(lsKey, wbyVersion);
@@ -160,7 +160,7 @@ export const AppInstaller: React.FC = ({ children }) => {
             <Elevation z={1}>
                 <SuccessDialog>
                     <p>You have successfully installed all new applications!</p>
-                    {isRootTenant && isFirstInstall ? (
+                    {!isCypressTest && isRootTenant && isFirstInstall ? (
                         <iframe
                             height="0"
                             width="0"

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -32,11 +32,11 @@ export const AppInstaller: React.FC = ({ children }) => {
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
     const isRootTenant = tenantId === "root";
-    /* 
-    * This flag allows us to avoid rendering the <iframe> when the app is tested with Cypress
-    * (Cypress doesn't work with cross domains because of security-related implications).
-    * @see https://docs.cypress.io/guides/guides/web-security#Insecure-Content 
-    */
+    /*
+     * This flag allows us to avoid rendering the <iframe> when the app is tested with Cypress
+     * (Cypress doesn't work with cross domains because of security-related implications).
+     * @see https://docs.cypress.io/guides/guides/web-security#Insecure-Content
+     */
     const isCypressTest = window && window.Cypress;
 
     const markInstallerAsCompleted = () => {

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -25,6 +25,11 @@ export const AppInstaller: React.FC = ({ children }) => {
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
     const isRootTenant = tenantId === "root";
+    /* Cypress doesn't work with cross domains because of
+    * security issues. This setting allows us to avoid rendering
+    * the <iframe> without disabling chrome web security
+    * reference: https://docs.cypress.io/guides/guides/web-security#Insecure-Content 
+    */
     const isCypressTest = window && window.Cypress
 
     const markInstallerAsCompleted = () => {

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -25,10 +25,10 @@ export const AppInstaller: React.FC = ({ children }) => {
     const lsKey = `webiny_installation_${tenantId}`;
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
     const isRootTenant = tenantId === "root";
-    /* Cypress doesn't work with cross domains because of
-    * security issues. This setting allows us to avoid rendering
-    * the <iframe> without disabling chrome web security
-    * reference: https://docs.cypress.io/guides/guides/web-security#Insecure-Content 
+    /* 
+    * This flag allows us to avoid rendering the <iframe> when the app is tested with Cypress
+    * (Cypress doesn't work with cross domains because of security-related implications).
+    * @see https://docs.cypress.io/guides/guides/web-security#Insecure-Content 
     */
     const isCypressTest = window && window.Cypress
 

--- a/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
+++ b/packages/app-admin/src/components/AppInstaller/AppInstaller.tsx
@@ -10,6 +10,13 @@ import { Typography } from "@webiny/ui/Typography";
 import { Elevation } from "@webiny/ui/Elevation";
 import { useInstaller } from "./useInstaller";
 import Sidebar from "./Sidebar";
+
+declare global {
+    interface Window {
+        Cypress: any;
+    }
+}
+
 import {
     Wrapper,
     alertClass,
@@ -30,7 +37,7 @@ export const AppInstaller: React.FC = ({ children }) => {
     * (Cypress doesn't work with cross domains because of security-related implications).
     * @see https://docs.cypress.io/guides/guides/web-security#Insecure-Content 
     */
-    const isCypressTest = window && window.Cypress
+    const isCypressTest = window && window.Cypress;
 
     const markInstallerAsCompleted = () => {
         localStorage.set(lsKey, wbyVersion);

--- a/scripts/setupCypress.js
+++ b/scripts/setupCypress.js
@@ -78,6 +78,7 @@ const args = {
             env: args.env,
             cwd: args.projectFolder
         });
+
         cypressConfig.baseUrl = adminOutput.appUrl;
         cypressConfig.env.ADMIN_URL = adminOutput.appUrl;
         cypressConfig.env.WEBSITE_URL = websiteOutput.deliveryUrl;


### PR DESCRIPTION
## Changes
- Added iframe to AppInstaller
- Added `isFirstInstall` boolean to `useInstaller()` hook

## How Has This Been Tested?
- Cypress
- Locally

## Screenshots

1. Update to install screen repositioning ToS & Privacy link: 
![Screen Shot 2022-05-05 at 15 14 31](https://user-images.githubusercontent.com/2216344/166955336-8e40a983-0026-4596-adfa-b72f9294f010.png)
 
2. IFrame on successful install screen
![Screen Shot 2022-05-05 at 16 09 00](https://user-images.githubusercontent.com/2216344/166955445-afef7943-6e6f-4701-9f17-fe563adc949f.png)

3. Cookies from www.webiny.com showing `_ga` cookie
![Screen Shot 2022-04-29 at 15 15 08](https://user-images.githubusercontent.com/2216344/166955585-fed706dc-aa4d-4d4f-9539-ebb65f8e1467.png)

