### PR TITLE
fix(react-router): explicitly re-export all types from react-router-dom

### DIFF
--- a/packages/react-router/src/Route.tsx
+++ b/packages/react-router/src/Route.tsx
@@ -1,6 +1,6 @@
 /**
- * TODO remove at some point and use the one from react-router-dom directly.
- * This component for our old code to work without much changes.
+ * TODO: remove at some point and use the one from react-router-dom directly.
+ * This component is for backwards compatibility with react-router v5, to avoid codemods on existing Webiny projects.
  */
 import React from "react";
 import { Route as BaseRoute, RouteProps as BaseRouteProps, useLocation } from "react-router-dom";
@@ -9,9 +9,19 @@ import { Location } from "history";
 interface RoutePropsRenderParams {
     location: Location;
 }
+
 export interface RouteProps extends BaseRouteProps {
+    /**
+     * @deprecated This prop is here for backwards compatibility with react-router v5 routes.
+     */
     exact?: boolean;
+    /**
+     * @deprecated This prop is here for backwards compatibility with react-router v5 routes.
+     */
     render?: (params: RoutePropsRenderParams) => React.ReactNode;
+    /**
+     * @deprecated This prop is here for backwards compatibility with react-router v5 routes.
+     */
     component?: React.ComponentType;
 }
 

--- a/packages/react-router/src/context/RouterContext.tsx
+++ b/packages/react-router/src/context/RouterContext.tsx
@@ -4,11 +4,11 @@ import { useApolloClient } from "@apollo/react-hooks";
 import { ReactRouterOnLinkPlugin } from "~/types";
 import ApolloClient from "apollo-client";
 
-export type ReactRouterContextValue = {
+export interface ReactRouterContext {
     onLink(link: string): void;
-};
+}
 
-export const RouterContext = React.createContext<ReactRouterContextValue>({
+export const RouterContext = React.createContext<ReactRouterContext>({
     onLink: () => {
         return void 0;
     }

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -8,9 +8,11 @@ import {
     Location
 } from "react-router-dom";
 import { StaticRouter as RStaticRouter, StaticRouterProps } from "react-router-dom/server";
-import { RouterContext, ReactRouterContextValue } from "./context/RouterContext";
+import { RouterContext, ReactRouterContext } from "./context/RouterContext";
 
-// Re-export types from react-router-dom
+/**
+ * Re-export types from react-router-dom.
+ */
 export type {
     // "react-router" types
     Hash,
@@ -37,9 +39,10 @@ export type {
     ParamKeyValuePair,
     URLSearchParamsInit
 } from "react-router-dom";
-import type { } from "react-router-dom";
-//
 
+/**
+ * Webiny enhancements and backwards compatibility with react-router v5.
+ */
 import enhancer from "./routerEnhancer";
 import { useHistory, UseHistory } from "~/useHistory";
 
@@ -64,7 +67,7 @@ export type { UseHistory } from "./useHistory";
 
 export { usePrompt } from "./usePrompt";
 
-export interface UseRouter extends RouteProps, ReactRouterContextValue {
+export interface UseRouter extends RouteProps, ReactRouterContext {
     history: UseHistory;
     location: Location;
     params: Record<string, any>;
@@ -81,6 +84,10 @@ export function useRouter(): UseRouter {
     };
 }
 
+/**
+ * For Webiny, we only need a BrowserRouter, and we also export a StaticRouter, if we ever
+ * need to do SSR. Right now, StaticRouter is not being used at all.
+ */
 export const BrowserRouter: React.FC<BrowserRouterProps> = enhancer(RBrowserRouter);
 export type { BrowserRouterProps };
 

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from "react";
 import {
     BrowserRouter as RBrowserRouter,
     BrowserRouterProps,
-    RouteProps as RouteChildrenProps,
     UNSAFE_RouteContext as __RouterContext,
     useLocation,
     useParams,
@@ -10,6 +9,36 @@ import {
 } from "react-router-dom";
 import { StaticRouter as RStaticRouter, StaticRouterProps } from "react-router-dom/server";
 import { RouterContext, ReactRouterContextValue } from "./context/RouterContext";
+
+// Re-export types from react-router-dom
+export type {
+    // "react-router" types
+    Hash,
+    Location,
+    Path,
+    To,
+    MemoryRouterProps,
+    NavigateFunction,
+    NavigateOptions,
+    NavigateProps,
+    Navigator,
+    OutletProps,
+    Params,
+    PathMatch,
+    RouteMatch,
+    RouteObject,
+    PathRouteProps,
+    LayoutRouteProps,
+    IndexRouteProps,
+    RouterProps,
+    Pathname,
+    Search,
+    // "react-router-dom" types
+    ParamKeyValuePair,
+    URLSearchParamsInit
+} from "react-router-dom";
+import type { } from "react-router-dom";
+//
 
 import enhancer from "./routerEnhancer";
 import { useHistory, UseHistory } from "~/useHistory";
@@ -20,6 +49,7 @@ export { Link } from "./Link";
 export type { LinkProps } from "./Link";
 
 export { Route } from "./Route";
+import { RouteProps } from "./Route";
 export type { RouteProps } from "./Route";
 
 export { Prompt } from "./Prompt";
@@ -34,7 +64,7 @@ export type { UseHistory } from "./useHistory";
 
 export { usePrompt } from "./usePrompt";
 
-export interface UseRouter extends RouteChildrenProps, ReactRouterContextValue {
+export interface UseRouter extends RouteProps, ReactRouterContextValue {
     history: UseHistory;
     location: Location;
     params: Record<string, any>;
@@ -52,4 +82,6 @@ export function useRouter(): UseRouter {
 }
 
 export const BrowserRouter: React.FC<BrowserRouterProps> = enhancer(RBrowserRouter);
+export type { BrowserRouterProps };
+
 export const StaticRouter: React.FC<StaticRouterProps> = enhancer(RStaticRouter);


### PR DESCRIPTION
## Changes
This PR re-exports types from `react-router-dom` in the `@webiny/react-router` package to make them available for import in the user's projects.

Issue: https://webiny-community.slack.com/archives/C014Y0HGJ0Y/p1651063802796489

## How Has This Been Tested?
Manually.
