### PR TITLE
Add PB Editor sandbox

### DIFF
--- a/apps/admin/code/package.json
+++ b/apps/admin/code/package.json
@@ -14,6 +14,7 @@
     "@webiny/app-form-builder": "^5.25.0",
     "@webiny/app-headless-cms": "^5.25.0",
     "@webiny/app-page-builder": "^5.25.0",
+    "@webiny/app-page-builder-editor": "^5.25.0",
     "@webiny/app-serverless-cms": "^5.25.0",
     "@webiny/cli": "^5.25.0",
     "@webiny/cli-plugin-deploy-pulumi": "^5.25.0",

--- a/apps/admin/code/src/App.editor.tsx
+++ b/apps/admin/code/src/App.editor.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Admin } from "@webiny/app-serverless-cms";
+import { Cognito } from "@webiny/app-admin-users-cognito";
+import { Editor } from "@webiny/app-page-builder-editor";
+import "./App.scss";
+
+export const App: React.FC = () => {
+    return (
+        <Admin>
+            <Cognito />
+            <Editor />
+        </Admin>
+    );
+};

--- a/packages/app-page-builder-editor/.babelrc.js
+++ b/packages/app-page-builder-editor/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.react")({ path: __dirname });

--- a/packages/app-page-builder-editor/LICENSE
+++ b/packages/app-page-builder-editor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/app-page-builder-editor/README.md
+++ b/packages/app-page-builder-editor/README.md
@@ -1,0 +1,18 @@
+# @webiny/app-page-builder-editor
+
+[![](https://img.shields.io/npm/dw/@webiny/app-page-builder-editor.svg)](https://www.npmjs.com/package/@webiny/app-page-builder-editor)
+[![](https://img.shields.io/npm/v/@webiny/app-page-builder-editor.svg)](https://www.npmjs.com/package/@webiny/app-page-builder-editor)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+Enables an alternative PB Editor in the Admin app.
+
+Use together with [@webiny/app-page-builder](../app-page-builder) package.
+
+#### Setup
+
+```
+import { Editor } from "@webiny/app-page-builder-editor";
+
+<Editor/>
+```

--- a/packages/app-page-builder-editor/package.json
+++ b/packages/app-page-builder-editor/package.json
@@ -1,0 +1,63 @@
+{
+  "private": true,
+  "name": "@webiny/app-page-builder-editor",
+  "version": "5.25.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "author": "Pavel Denisjuk",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.16.3",
+    "@emotion/core": "^10.0.17",
+    "@svgr/webpack": "^6.1.1",
+    "@types/react": "^16.14.0",
+    "@webiny/app": "^5.21.0",
+    "@webiny/app-admin": "^5.21.0",
+    "@webiny/app-page-builder": "^5.21.0",
+    "@webiny/ui": "^5.21.0",
+    "apollo-cache": "^1.3.5",
+    "apollo-client": "^2.6.10",
+    "apollo-link": "^1.2.14",
+    "apollo-utilities": "^1.3.4",
+    "classnames": "^2.2.6",
+    "dot-prop-immutable": "^2.1.0",
+    "emotion": "^10.0.17",
+    "graphql": "^15.7.2",
+    "lodash": "^4.17.10",
+    "nanoid": "^3.1.20",
+    "prop-types": "^15.7.2",
+    "react": "16.14.0",
+    "react-dnd": "^11.1.3",
+    "react-dnd-html5-backend": "^11.1.3",
+    "react-dom": "16.14.0",
+    "recoil": "^0.1.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.16.0",
+    "@babel/core": "^7.16.0",
+    "@babel/plugin-proposal-class-properties": "^7.16.0",
+    "@babel/preset-env": "^7.16.4",
+    "@babel/preset-react": "^7.16.0",
+    "@babel/preset-typescript": "^7.16.0",
+    "@types/medium-editor": "^5.0.3",
+    "@types/resize-observer-browser": "^0.1.4",
+    "@webiny/cli": "^5.21.0",
+    "@webiny/project-utils": "^5.21.0",
+    "babel-plugin-emotion": "^9.2.8",
+    "babel-plugin-lodash": "^3.3.4",
+    "rimraf": "^3.0.2",
+    "ttypescript": "^1.5.12",
+    "typescript": "^4.1.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  }
+}

--- a/packages/app-page-builder-editor/src/components/Editor/Bar.tsx
+++ b/packages/app-page-builder-editor/src/components/Editor/Bar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import DefaultEditorBar from "./DefaultEditorBar";
+// import { pluginsAtom } from "~/state";
+// import { plugins } from "@webiny/plugins";
+// import { useRecoilValue } from "recoil";
+// import { PbEditorBarPlugin } from "~/types";
+// import { useActiveElementId } from "~/hooks/useActiveElementId";
+
+const Bar: React.FC = () => {
+    // const activeElementId = useActiveElementId();
+    // const editorPlugins = useRecoilValue(pluginsAtom);
+    // const pluginsByType = plugins.byType<PbEditorBarPlugin>("pb-editor-bar");
+    // let pluginBar = null;
+    // for (const plugin of pluginsByType) {
+    //     if (plugin.shouldRender({ plugins: editorPlugins, activeElement: activeElementId })) {
+    //         pluginBar = plugin.render();
+    //         break;
+    //     }
+    // }
+
+    return (
+        <>
+            <DefaultEditorBar />
+        </>
+    );
+};
+export default React.memo(Bar);

--- a/packages/app-page-builder-editor/src/components/Editor/DefaultEditorBar.tsx
+++ b/packages/app-page-builder-editor/src/components/Editor/DefaultEditorBar.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { TopAppBar, TopAppBarSection } from "@webiny/ui/TopAppBar";
+import { renderPlugins } from "@webiny/app/plugins";
+import { css } from "emotion";
+
+const topBar = css({
+    boxShadow: "1px 0px 5px 0px rgba(128,128,128,1)"
+});
+
+const centerTopBar = css({
+    "&.mdc-top-app-bar__section": {
+        paddingTop: 0,
+        paddingBottom: 0
+    }
+});
+
+const DefaultEditorBar = () => {
+    return (
+        <TopAppBar className={topBar} fixed>
+            <TopAppBarSection style={{ width: "33%" }} alignStart>
+                {renderPlugins("pb-editor-default-bar-left")}
+            </TopAppBarSection>
+            <TopAppBarSection className={centerTopBar}>
+                {renderPlugins("pb-editor-default-bar-center")}
+            </TopAppBarSection>
+            <TopAppBarSection style={{ width: "33%" }} alignEnd>
+                {renderPlugins("pb-editor-default-bar-right")}
+            </TopAppBarSection>
+        </TopAppBar>
+    );
+};
+
+export default React.memo(DefaultEditorBar);

--- a/packages/app-page-builder-editor/src/components/Editor/Editor.scss
+++ b/packages/app-page-builder-editor/src/components/Editor/Editor.scss
@@ -1,0 +1,58 @@
+.pb-editor-dragging {
+  .pb-disable {
+    z-index: 10000000;
+    opacity: 0.5;
+    background-color: red;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+  /* Append this class to the DOM elements you want to disable during element dragging. */
+  .pb-editor-dragging--disabled {
+    &:before {
+      content: " ";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      z-index: 10;
+      background-color: #b0b0b0;
+    }
+    iframe {
+      pointer-events: none;
+    }
+  }
+}
+
+.pb-editor-resizing {
+  /* Append this class to the DOM elements you want to disable during element resizing. */
+  .pb-editor-resizing--disabled {
+    &:before {
+      content: " ";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      z-index: 10;
+      background-color: #b0b0b0;
+    }
+    iframe {
+      pointer-events: none;
+    }
+  }
+}
+
+.pb-editor {
+  &.pb-editor-no-highlight {
+    .type {
+      display: none !important;
+    }
+    .webiny-pb-page-element-container::after {
+      content: none;
+    }
+  }
+}

--- a/packages/app-page-builder-editor/src/components/Editor/Editor.tsx
+++ b/packages/app-page-builder-editor/src/components/Editor/Editor.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect } from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import classSet from "classnames";
+// import { useKeyHandler } from "~/hooks/useKeyHandler";
+import "./Editor.scss";
+// Components
+// import EditorBar from "./Bar";
+// import EditorToolbar from "./Toolbar";
+// import EditorContent from "./Content";
+// import DragPreview from "./DragPreview";
+// import Dialogs from "./Dialogs";
+// import ElementSideBar from "./ElementSideBar";
+import { PageAtomType, RevisionsAtomType } from "~/state";
+import { usePbEditor } from "~/hooks/usePbEditor";
+import { useUI } from "~/hooks/useUI";
+// import { useRevisions } from "~/hooks/useRevisions";
+// import { UndoStateChangeActionEvent } from "~/actions/undo";
+// import { RedoStateChangeActionEvent } from "~/actions/redo";
+// import { EditorPreviewContent } from "./EditorPreviewContent";
+
+type EditorPropsType = {
+    page: PageAtomType;
+    revisions: RevisionsAtomType;
+};
+
+export const Editor: React.FunctionComponent<EditorPropsType> = (/*{ revisions }*/) => {
+    const { editor } = usePbEditor();
+    // const { addKeyHandler, removeKeyHandler } = useKeyHandler();
+    const [{ isDragging, isResizing }] = useUI();
+
+    // const [, setRevisions] = useRevisions();
+    const rootElementId = editor.getRootElementId();
+
+    const firstRender = React.useRef<boolean>(true);
+
+    useEffect(() => {
+        // @ts-ignore
+        window["editor"] = editor;
+        // addKeyHandler("mod+z", e => {
+        //     e.preventDefault();
+        //     // app.dispatchEvent(new UndoStateChangeActionEvent());
+        // });
+        // addKeyHandler("mod+shift+z", e => {
+        //     e.preventDefault();
+        //     // app.dispatchEvent(new RedoStateChangeActionEvent());
+        // });
+        //
+        // setRevisions(revisions);
+        //
+        //
+        // return () => {
+        //     removeKeyHandler("mod+z");
+        //     removeKeyHandler("mod+shift+z");
+        // };
+    }, []);
+
+    useEffect(() => {
+        if (!rootElementId || firstRender.current === true) {
+            firstRender.current = false;
+            return;
+        }
+    }, [rootElementId]);
+
+    const classes = {
+        "pb-editor": true,
+        "pb-editor-dragging": isDragging,
+        "pb-editor-resizing": isResizing
+    };
+
+    return (
+        <DndProvider backend={HTML5Backend}>
+            <div className={classSet(classes)}>
+                <pre>{JSON.stringify(editor.getPage(), null, 4)}</pre>
+                {/*<EditorBar />*/}
+                {/*<EditorToolbar />*/}
+                {/*<EditorContent />*/}
+                {/*<EditorPreviewContent />*/}
+                {/*<ElementSideBar />*/}
+                {/*<Dialogs />*/}
+                {/*<DragPreview />*/}
+            </div>
+        </DndProvider>
+    );
+};

--- a/packages/app-page-builder-editor/src/components/Editor/index.ts
+++ b/packages/app-page-builder-editor/src/components/Editor/index.ts
@@ -1,0 +1,1 @@
+export * from "./Editor";

--- a/packages/app-page-builder-editor/src/components/RecoilExternal.ts
+++ b/packages/app-page-builder-editor/src/components/RecoilExternal.ts
@@ -1,0 +1,42 @@
+import { RecoilState, useRecoilCallback, RecoilValueReadOnly, SetterOrUpdater } from "recoil";
+
+export type ValueOrSetter<T> = SetterOrUpdater<T> | (T | ((prevValue: T) => T));
+
+interface GetState {
+    <T>(atom: RecoilState<T> | RecoilValueReadOnly<T>): T;
+}
+
+interface SetState {
+    <T>(state: RecoilState<T>, valueOrSetter: ValueOrSetter<T>): void;
+}
+
+interface Portal {
+    getState?: GetState;
+    setState?: SetState;
+}
+
+const portal: Portal = {};
+
+export default function RecoilExternal() {
+    // @ts-ignore
+    portal.getState = useRecoilCallback<[atom: RecoilState<any>], any>(
+        ({ snapshot }) =>
+            function <T>(atom: RecoilState<T>) {
+                return snapshot.getLoadable(atom).contents;
+            },
+        []
+    );
+
+    // @ts-ignore
+    portal.setState = useRecoilCallback(({ set }) => set, []);
+
+    return null;
+}
+
+export const getState: GetState = atom => {
+    return portal.getState!(atom);
+};
+
+export const setState: SetState = (atom, valueOrSetter) => {
+    portal.setState!(atom, valueOrSetter);
+};

--- a/packages/app-page-builder-editor/src/contexts/Editor.tsx
+++ b/packages/app-page-builder-editor/src/contexts/Editor.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { getState, setState } from "~/components/RecoilExternal";
+import { activeElementAtom, pageAtom, PageAtomType, rootElementAtom } from "~/state";
+
+export interface Editor {
+    activateElement(id: string): void;
+    deactivateElement(id: string): void;
+    getRootElementId(): string;
+    getPage(): PageAtomType;
+}
+
+export interface EditorContext {
+    editor: Editor;
+}
+
+export const EditorContext = React.createContext<EditorContext>({} as EditorContext);
+
+export const EditorProvider: React.FC = ({ children }) => {
+    const context: EditorContext = {
+        editor: {
+            getRootElementId(): string {
+                return getState(rootElementAtom) || "";
+            },
+            activateElement(id: string) {
+                setState(activeElementAtom, id);
+            },
+
+            deactivateElement() {
+                setState(activeElementAtom, undefined);
+            },
+            getPage() {
+                return getState(pageAtom);
+            }
+        }
+    };
+    return <EditorContext.Provider value={context}>{children}</EditorContext.Provider>;
+};

--- a/packages/app-page-builder-editor/src/contexts/EditorState.tsx
+++ b/packages/app-page-builder-editor/src/contexts/EditorState.tsx
@@ -1,0 +1,188 @@
+// @ts-nocheck
+/* eslint-disable */
+import React, { useEffect, useRef } from "react";
+import { PbEditorElement } from "~/types";
+import {
+    Snapshot,
+    useGotoRecoilSnapshot,
+    useRecoilCallback,
+    useRecoilSnapshot,
+    useSetRecoilState
+} from "recoil";
+import {
+    activeElementAtom,
+    highlightElementAtom,
+    elementsAtom,
+    pageAtom,
+    sidebarAtom,
+    uiAtom
+} from "~/state";
+import { usePbEditor } from "~/hooks/usePbEditor";
+// import { ApplyStateChangesActionEvent } from "../app/ApplyStateChangesActionEvent";
+import { PbState } from "~/state/types";
+// import { UndoStateChangeActionEvent } from "../actions/undo";
+// import { RedoStateChangeActionEvent } from "~/actions/redo";
+// import { SaveRevisionActionEvent } from "~/actions";
+
+interface SnapshotHistory {
+    past: Snapshot[];
+    future: Snapshot[];
+    busy: boolean;
+    present: Snapshot | null;
+    isBatching: boolean;
+    isDisabled: boolean;
+}
+
+const trackedAtoms = ["elements"];
+
+const isTrackedAtomChanged = (state: Partial<PbState>): boolean => {
+    for (const atom of trackedAtoms) {
+        if (!state[atom]) {
+            continue;
+        }
+        return true;
+    }
+    return false;
+};
+
+export const EditorState: React.FunctionComponent<any> = () => {
+    const { editor } = usePbEditor();
+    const setActiveElementId = useSetRecoilState(activeElementAtom);
+    const setHighlightElementId = useSetRecoilState(highlightElementAtom);
+    const setSidebarAtomValue = useSetRecoilState(sidebarAtom);
+    const setPageAtomValue = useSetRecoilState(pageAtom);
+    // const setPluginsAtomValue = useSetRecoilState(pluginsAtom);
+    const setUiAtomValue = useSetRecoilState(uiAtom);
+    const goToSnapshot = useGotoRecoilSnapshot();
+    const currentSnapshot = useRecoilSnapshot();
+
+    const snapshotsHistory = useRef<SnapshotHistory>({
+        past: [],
+        future: [],
+        present: currentSnapshot,
+        busy: false,
+        isBatching: false,
+        isDisabled: false
+    });
+
+    const takeSnapshot = useRecoilCallback(({ snapshot }) => () => {
+        // return snapshot.map(snap => {
+        //     We want to reset the `pluginsAtom` to avoid UI state being tracked in history.
+        // snap.set(pluginsAtom, currentSnapshot.getLoadable(pluginsAtom).contents);
+        // });
+    });
+
+    const createStateHistorySnapshot = (): void => {
+        if (snapshotsHistory.current.busy === true) {
+            return;
+        }
+        snapshotsHistory.current.busy = true;
+        // when saving new state history we must remove everything after the current one
+        // since this is the new starting point of the state history
+        snapshotsHistory.current.future = [];
+        snapshotsHistory.current.past.push(takeSnapshot());
+        snapshotsHistory.current.present = currentSnapshot;
+        snapshotsHistory.current.busy = false;
+    };
+
+    const updateElements = useRecoilCallback(({ set }) => (elements: PbEditorElement[] = []) => {
+        elements.forEach(item => {
+            set(elementsAtom(item.id), prevValue => {
+                return {
+                    ...prevValue,
+                    ...item,
+                    parent: item.parent !== undefined ? item.parent : prevValue.parent
+                };
+            });
+            return item.id;
+        });
+    });
+
+    useEffect(() => {
+        snapshotsHistory.current.present = currentSnapshot;
+    }, [currentSnapshot]);
+
+    useEffect(() => {
+        // app.addEventListener(ApplyStateChangesActionEvent, event => {
+        //     const { state } = event.getData();
+        //
+        //     if (Object.values(state).length === 0) {
+        //         return;
+        //     } else if (
+        //         snapshotsHistory.current.isBatching === false &&
+        //         snapshotsHistory.current.isDisabled === false &&
+        //         isTrackedAtomChanged(state)
+        //     ) {
+        //         createStateHistorySnapshot();
+        //     }
+        //
+        //     if (state.ui) {
+        //         setUiAtomValue(prev => ({ ...prev, ...state.ui }));
+        //     }
+        //
+        //     if (state.plugins) {
+        //         setPluginsAtomValue(state.plugins);
+        //     }
+        //
+        //     if (state.page) {
+        //         setPageAtomValue(prev => ({ ...prev, ...state.page }));
+        //     }
+        //
+        //     if (state.hasOwnProperty("activeElement")) {
+        //         setActiveElementId(state.activeElement);
+        //     }
+        //
+        //     if (state.hasOwnProperty("highlightElement")) {
+        //         setHighlightElementId(state.highlightElement);
+        //     }
+        //
+        //     if (state.elements) {
+        //         updateElements(Object.values(state.elements));
+        //     }
+        //
+        //     if (state.sidebar) {
+        //         setSidebarAtomValue(state.sidebar);
+        //     }
+        // });
+        // app.addEventListener(UndoStateChangeActionEvent, () => {
+        //     if (snapshotsHistory.current.busy === true) {
+        //         return;
+        //     }
+        //     snapshotsHistory.current.busy = true;
+        //     const previousSnapshot = snapshotsHistory.current.past.pop();
+        //     if (!previousSnapshot) {
+        //         snapshotsHistory.current.busy = false;
+        //         return;
+        //     }
+        //     const futureSnapshot = snapshotsHistory.current.present || currentSnapshot;
+        //     snapshotsHistory.current.future.unshift(futureSnapshot);
+        //
+        //     snapshotsHistory.current.present = previousSnapshot;
+        //
+        //     goToSnapshot(previousSnapshot);
+        //     snapshotsHistory.current.busy = false;
+        //
+        //     app.dispatchEvent(new SaveRevisionActionEvent());
+        // });
+        // app.addEventListener(RedoStateChangeActionEvent, () => {
+        //     if (snapshotsHistory.current.busy === true) {
+        //         return;
+        //     }
+        //     snapshotsHistory.current.busy = true;
+        //     const nextSnapshot = snapshotsHistory.current.future.shift();
+        //     if (!nextSnapshot) {
+        //         snapshotsHistory.current.busy = false;
+        //         return;
+        //     } else if (snapshotsHistory.current.present) {
+        //         snapshotsHistory.current.past.push(snapshotsHistory.current.present);
+        //     }
+        //     snapshotsHistory.current.present = nextSnapshot;
+        //
+        //     goToSnapshot(nextSnapshot);
+        //     snapshotsHistory.current.busy = false;
+        //     app.dispatchEvent(new SaveRevisionActionEvent());
+        // });
+    }, []);
+
+    return null;
+};

--- a/packages/app-page-builder-editor/src/contexts/compose.ts
+++ b/packages/app-page-builder-editor/src/contexts/compose.ts
@@ -1,0 +1,53 @@
+export const composeAsync = (functions: Array<Function> = []): Function => {
+    return (input: unknown): Promise<any> => {
+        if (!functions.length) {
+            return Promise.resolve();
+        }
+
+        // Create a clone of function chain to prevent modifying the original array with `shift()`
+        let index = -1;
+
+        const next = (input: unknown) => {
+            index++;
+
+            const fn = functions[index];
+            if (!fn) {
+                return Promise.resolve(input);
+            }
+
+            return new Promise(async (resolve, reject) => {
+                try {
+                    resolve(await fn(input, next));
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        };
+
+        return next(input);
+    };
+};
+
+export const composeSync = (functions: Array<Function> = []): Function => {
+    return (input: unknown) => {
+        if (!functions.length) {
+            return input;
+        }
+
+        // Create a clone of function chain to prevent modifying the original array with `shift()`
+        let index = -1;
+
+        const next = (input: unknown) => {
+            index++;
+
+            const fn = functions[index];
+            if (!fn) {
+                return input;
+            }
+
+            return fn(input, next);
+        };
+
+        return next(input);
+    };
+};

--- a/packages/app-page-builder-editor/src/helpers.ts
+++ b/packages/app-page-builder-editor/src/helpers.ts
@@ -1,0 +1,35 @@
+import { customAlphabet } from "nanoid";
+import { set } from "dot-prop-immutable";
+import omit from "lodash/omit";
+import { PbEditorElement } from "~/types";
+
+const ALPHANUMERIC = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+export const getNanoid = customAlphabet(ALPHANUMERIC, 10);
+
+type FlattenElementsType = {
+    [id: string]: PbEditorElement;
+};
+export const flattenElements = (
+    el: PbEditorElement,
+    parent: string | undefined = undefined
+): FlattenElementsType => {
+    const els: FlattenElementsType = {};
+    els[el.id] = set(
+        el,
+        "elements",
+        (el.elements || []).map(child => {
+            if (typeof child === "string") {
+                return child;
+            }
+            const children = flattenElements(child, el.id);
+            Object.keys(children).forEach(id => {
+                els[id] = omit(children[id], ["path"]) as PbEditorElement;
+            });
+            return child.id;
+        })
+    );
+
+    els[el.id].parent = parent;
+
+    return els;
+};

--- a/packages/app-page-builder-editor/src/hooks/useActiveElement.ts
+++ b/packages/app-page-builder-editor/src/hooks/useActiveElement.ts
@@ -1,0 +1,14 @@
+import { SetterOrUpdater, useRecoilState } from "recoil";
+import { activeElementAtom, ActiveElementAtomType } from "~/state";
+import { useElementById } from "./useElementById";
+import { PbEditorElement } from "~/types";
+
+export function useActiveElement(): [
+    PbEditorElement | undefined,
+    SetterOrUpdater<ActiveElementAtomType>
+] {
+    const [activeElementId, setActiveElement] = useRecoilState(activeElementAtom);
+    const [activeElement] = useElementById(activeElementId);
+
+    return [activeElement, setActiveElement];
+}

--- a/packages/app-page-builder-editor/src/hooks/useActiveElementId.ts
+++ b/packages/app-page-builder-editor/src/hooks/useActiveElementId.ts
@@ -1,0 +1,6 @@
+import { useRecoilState } from "recoil";
+import { activeElementAtom } from "~/state";
+
+export function useActiveElementId() {
+    return useRecoilState(activeElementAtom);
+}

--- a/packages/app-page-builder-editor/src/hooks/useElementById.ts
+++ b/packages/app-page-builder-editor/src/hooks/useElementById.ts
@@ -1,0 +1,6 @@
+import { useRecoilState } from "recoil";
+import { elementByIdSelector } from "~/state";
+
+export function useElementById(id: string | undefined) {
+    return useRecoilState(elementByIdSelector(id));
+}

--- a/packages/app-page-builder-editor/src/hooks/useElementSidebar.ts
+++ b/packages/app-page-builder-editor/src/hooks/useElementSidebar.ts
@@ -1,0 +1,6 @@
+import { useRecoilState } from "recoil";
+import { sidebarAtom } from "~/state";
+
+export function useElementSidebar() {
+    return useRecoilState(sidebarAtom);
+}

--- a/packages/app-page-builder-editor/src/hooks/useHighlightElement.ts
+++ b/packages/app-page-builder-editor/src/hooks/useHighlightElement.ts
@@ -1,0 +1,14 @@
+import { useRecoilState, SetterOrUpdater } from "recoil";
+import { highlightElementAtom, HighlightElementAtomType } from "~/state";
+import { useElementById } from "~/hooks/useElementById";
+import { PbEditorElement } from "~/types";
+
+export function useHighlightElement(): [
+    PbEditorElement | undefined,
+    SetterOrUpdater<HighlightElementAtomType>
+] {
+    const [highlightedElementId, setHighlightedElement] = useRecoilState(highlightElementAtom);
+    const [element] = useElementById(highlightedElementId);
+
+    return [element, setHighlightedElement];
+}

--- a/packages/app-page-builder-editor/src/hooks/usePbEditor.ts
+++ b/packages/app-page-builder-editor/src/hooks/usePbEditor.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { EditorContext } from "~/contexts/Editor";
+
+export function usePbEditor() {
+    return useContext(EditorContext);
+}

--- a/packages/app-page-builder-editor/src/hooks/useRevisions.ts
+++ b/packages/app-page-builder-editor/src/hooks/useRevisions.ts
@@ -1,0 +1,6 @@
+import { useRecoilState } from "recoil";
+import { revisionsAtom } from "~/state";
+
+export function useRevisions() {
+    return useRecoilState(revisionsAtom);
+}

--- a/packages/app-page-builder-editor/src/hooks/useUI.ts
+++ b/packages/app-page-builder-editor/src/hooks/useUI.ts
@@ -1,0 +1,6 @@
+import { useRecoilState } from "recoil";
+import { uiAtom } from "~/state";
+
+export function useUI() {
+    return useRecoilState(uiAtom);
+}

--- a/packages/app-page-builder-editor/src/index.tsx
+++ b/packages/app-page-builder-editor/src/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { RecoilRoot } from "recoil";
+import { Compose, HigherOrderComponent } from "@webiny/app-admin";
+import { EditorRenderer, EditorProps } from "@webiny/app-page-builder";
+import { EditorState } from "./contexts/EditorState";
+import { rootElementAtom, pageAtom, elementsAtom, PageAtomType } from "./state";
+import { flattenElements } from "./helpers";
+import RecoilExternal from "./components/RecoilExternal";
+import { Editor as EditorComponent } from "./components/Editor";
+import { EditorProvider } from "~/contexts/Editor";
+import { PbEditorElement } from "~/types";
+import omit from "lodash/omit";
+
+const EditorHOC: HigherOrderComponent<EditorProps> = () => {
+    return function Editor({ page, revisions }) {
+        return (
+            <EditorProvider>
+                <RecoilRoot
+                    initializeState={({ set }) => {
+                        /* Here we initialize elementsAtom and rootElement if it exists */
+                        set(rootElementAtom, page.content.id);
+
+                        // Type casting here because we know that data from API will always have a `content` object.
+                        const elements = flattenElements(page.content as PbEditorElement);
+                        Object.keys(elements).forEach(key => {
+                            set(elementsAtom(key), elements[key]);
+                        });
+
+                        // Unsetting the `content` object because content is reconstructed from a flat structure on each
+                        // save; thus, we don't need to store this massive object into our state.
+                        const pageData: PageAtomType = omit(page, ["content"]);
+                        set(pageAtom, pageData);
+                    }}
+                >
+                    <RecoilExternal />
+                    <EditorState />
+                    <EditorComponent page={page} revisions={revisions} />
+                </RecoilRoot>
+            </EditorProvider>
+        );
+    };
+};
+
+export const Editor = () => {
+    return <Compose component={EditorRenderer} with={EditorHOC} />;
+};

--- a/packages/app-page-builder-editor/src/state/elements/elementByIdSelector.ts
+++ b/packages/app-page-builder-editor/src/state/elements/elementByIdSelector.ts
@@ -1,0 +1,34 @@
+import { selectorFamily } from "recoil";
+import { PbEditorElement } from "~/types";
+import { elementsAtom } from "~/state";
+
+export const elementByIdSelector = selectorFamily<PbEditorElement | undefined, string | undefined>({
+    key: "elementByIdSelector",
+    get: id => {
+        return ({ get }) => {
+            if (!id) {
+                return undefined;
+            }
+            return get(elementsAtom(id));
+        };
+    },
+    set:
+        id =>
+        ({ set }, newValue) => {
+            if (!id) {
+                return;
+            }
+            /**
+             * We are positive that element exists, so we can set it
+             */
+            set(elementsAtom(id), prevState => {
+                if (!prevState) {
+                    return newValue;
+                }
+                return {
+                    ...prevState,
+                    ...newValue
+                };
+            });
+        }
+});

--- a/packages/app-page-builder-editor/src/state/elements/elementWithChildrenByIdSelector.ts
+++ b/packages/app-page-builder-editor/src/state/elements/elementWithChildrenByIdSelector.ts
@@ -1,0 +1,31 @@
+import { selectorFamily } from "recoil";
+import { elementByIdSelector } from "./elementByIdSelector";
+import { PbEditorElement } from "~/types";
+
+export const elementWithChildrenByIdSelector = selectorFamily<
+    PbEditorElement | null,
+    string | null
+>({
+    key: "elementWithChildrenByIdSelector",
+    get: id => {
+        return ({ get }): PbEditorElement | null => {
+            if (!id) {
+                return null;
+            }
+            const element = get(elementByIdSelector(id));
+            if (!element) {
+                return null;
+            }
+
+            return {
+                ...element,
+                /**
+                 * We are positive that we can cast element.elements as string[] here
+                 */
+                elements: (element.elements as string[])
+                    .map(id => get(elementByIdSelector(id)))
+                    .filter(Boolean) as PbEditorElement[]
+            };
+        };
+    }
+});

--- a/packages/app-page-builder-editor/src/state/elements/elementsAtom.ts
+++ b/packages/app-page-builder-editor/src/state/elements/elementsAtom.ts
@@ -1,0 +1,9 @@
+import { atomFamily } from "recoil";
+import { PbEditorElement } from "~/types";
+
+export type ElementsAtomType = PbEditorElement;
+
+export const elementsAtom = atomFamily<ElementsAtomType | undefined, string>({
+    key: "v2.elementsAtom",
+    default: () => undefined
+});

--- a/packages/app-page-builder-editor/src/state/elements/index.ts
+++ b/packages/app-page-builder-editor/src/state/elements/index.ts
@@ -1,0 +1,3 @@
+export * from "./elementsAtom";
+export * from "./elementByIdSelector";
+export * from "./elementWithChildrenByIdSelector";

--- a/packages/app-page-builder-editor/src/state/index.ts
+++ b/packages/app-page-builder-editor/src/state/index.ts
@@ -1,0 +1,5 @@
+export * from "./elements";
+export * from "./page";
+export * from "./ui";
+export * from "./rootElement";
+export * from "./revisions";

--- a/packages/app-page-builder-editor/src/state/page/elementsInContentTotalSelector.ts
+++ b/packages/app-page-builder-editor/src/state/page/elementsInContentTotalSelector.ts
@@ -1,0 +1,17 @@
+import { selector } from "recoil";
+import { elementsAtom, rootElementAtom } from "~/state";
+
+export const elementsInContentTotalSelector = selector({
+    key: "elementsInContentTotalSelector",
+    get: ({ get }): number => {
+        const rootElement = get(rootElementAtom);
+        if (!rootElement) {
+            return 0;
+        }
+        const editorElement = get(elementsAtom(rootElement));
+        if (!editorElement || !editorElement.elements) {
+            return 0;
+        }
+        return editorElement.elements.length;
+    }
+});

--- a/packages/app-page-builder-editor/src/state/page/index.ts
+++ b/packages/app-page-builder-editor/src/state/page/index.ts
@@ -1,0 +1,3 @@
+export * from "./pageAtom";
+export * from "./layoutSelector";
+export * from "./elementsInContentTotalSelector";

--- a/packages/app-page-builder-editor/src/state/page/layoutSelector.ts
+++ b/packages/app-page-builder-editor/src/state/page/layoutSelector.ts
@@ -1,0 +1,13 @@
+import { selector } from "recoil";
+import { pageAtom } from "~/state";
+
+export const layoutSelector = selector<string | undefined>({
+    key: "layoutSelector",
+    get: ({ get }) => {
+        const page = get(pageAtom);
+        if (!page) {
+            return undefined;
+        }
+        return page.settings?.general?.layout;
+    }
+});

--- a/packages/app-page-builder-editor/src/state/page/pageAtom.ts
+++ b/packages/app-page-builder-editor/src/state/page/pageAtom.ts
@@ -1,0 +1,46 @@
+import { atom } from "recoil";
+import { PbEditorElement } from "~/types";
+
+type PageCategoryType = {
+    slug: string;
+    name: string;
+    url: string;
+};
+
+export interface PageWithContent extends PageAtomType {
+    content: PbEditorElement;
+}
+
+export type PageAtomType = {
+    id?: string;
+    title?: string;
+    path?: string;
+    settings?: {
+        general?: {
+            layout?: string;
+        };
+    };
+    parent?: string;
+    version: number;
+    locked: boolean;
+    published: boolean;
+    savedOn?: Date;
+    snippet: string | null;
+    category?: PageCategoryType;
+    createdBy: {
+        id: string | null;
+    };
+};
+
+export const pageAtom = atom<PageAtomType>({
+    key: "v2.pageAtom",
+    default: {
+        locked: false,
+        version: 1,
+        published: false,
+        snippet: null,
+        createdBy: {
+            id: null
+        }
+    }
+});

--- a/packages/app-page-builder-editor/src/state/revisions/index.ts
+++ b/packages/app-page-builder-editor/src/state/revisions/index.ts
@@ -1,0 +1,1 @@
+export * from "./revisionsAtom";

--- a/packages/app-page-builder-editor/src/state/revisions/revisionsAtom.ts
+++ b/packages/app-page-builder-editor/src/state/revisions/revisionsAtom.ts
@@ -1,0 +1,17 @@
+import { atom } from "recoil";
+
+export type RevisionItemAtomType = {
+    id: string;
+    title: string;
+    path: string;
+    version: number;
+    parent?: string;
+    published: boolean;
+    locked: boolean;
+    savedOn?: Date;
+};
+export type RevisionsAtomType = RevisionItemAtomType[];
+export const revisionsAtom = atom<RevisionsAtomType>({
+    key: "v2.revisionsAtom",
+    default: []
+});

--- a/packages/app-page-builder-editor/src/state/rootElement/index.ts
+++ b/packages/app-page-builder-editor/src/state/rootElement/index.ts
@@ -1,0 +1,1 @@
+export * from "./rootElementAtom";

--- a/packages/app-page-builder-editor/src/state/rootElement/rootElementAtom.ts
+++ b/packages/app-page-builder-editor/src/state/rootElement/rootElementAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+export type RootElementAtom = string | undefined;
+
+export const rootElementAtom = atom<RootElementAtom>({
+    key: "v2.rootElementAtom",
+    default: undefined
+});

--- a/packages/app-page-builder-editor/src/state/types.ts
+++ b/packages/app-page-builder-editor/src/state/types.ts
@@ -1,0 +1,15 @@
+import { PageAtomType } from "./page";
+import { RevisionsAtomType } from "./revisions";
+import { ActiveElementAtomType, HighlightElementAtomType, SidebarAtomType, UiAtomType } from "./ui";
+import { PbEditorElement } from "~/types";
+
+export type PbState = {
+    activeElement?: ActiveElementAtomType;
+    highlightElement?: HighlightElementAtomType;
+    elements?: { [id: string]: PbEditorElement };
+    page: PageAtomType;
+    ui: UiAtomType;
+    rootElement: string;
+    revisions: RevisionsAtomType;
+    sidebar: SidebarAtomType;
+};

--- a/packages/app-page-builder-editor/src/state/ui/activeElementAtom.ts
+++ b/packages/app-page-builder-editor/src/state/ui/activeElementAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil";
+
+export type ActiveElementAtomType = string | undefined;
+export const activeElementAtom = atom<ActiveElementAtomType>({
+    key: "v2.activeElementAtom",
+    default: undefined
+});

--- a/packages/app-page-builder-editor/src/state/ui/highlightElementAtom.ts
+++ b/packages/app-page-builder-editor/src/state/ui/highlightElementAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+export type HighlightElementAtomType = string | undefined;
+
+export const highlightElementAtom = atom<HighlightElementAtomType>({
+    key: "v2.highlightElementAtom",
+    default: undefined
+});

--- a/packages/app-page-builder-editor/src/state/ui/index.ts
+++ b/packages/app-page-builder-editor/src/state/ui/index.ts
@@ -1,0 +1,4 @@
+export * from "./uiAtom";
+export * from "./highlightElementAtom";
+export * from "./activeElementAtom";
+export * from "./sidebarAtom";

--- a/packages/app-page-builder-editor/src/state/ui/sidebarAtom.ts
+++ b/packages/app-page-builder-editor/src/state/ui/sidebarAtom.ts
@@ -1,0 +1,13 @@
+import { atom } from "recoil";
+
+export type SidebarAtomType = {
+    activeTabIndex: number;
+    highlightTab: boolean;
+};
+export const sidebarAtom = atom<SidebarAtomType>({
+    key: "v2.sidebarAtom",
+    default: {
+        activeTabIndex: 0,
+        highlightTab: false
+    }
+});

--- a/packages/app-page-builder-editor/src/state/ui/uiAtom.ts
+++ b/packages/app-page-builder-editor/src/state/ui/uiAtom.ts
@@ -1,0 +1,28 @@
+import { atom } from "recoil";
+import { DisplayMode } from "~/types";
+
+export type PagePreviewDimension = {
+    width: number;
+    height: number;
+};
+
+export type UiAtomType = {
+    isDragging: boolean;
+    isResizing: boolean;
+    isSaving: boolean;
+    displayMode: DisplayMode;
+    pagePreviewDimension: PagePreviewDimension;
+};
+export const uiAtom = atom<UiAtomType>({
+    key: "v2.uiAtom",
+    default: {
+        isDragging: false,
+        isResizing: false,
+        isSaving: false,
+        displayMode: DisplayMode.DESKTOP,
+        pagePreviewDimension: {
+            width: 100,
+            height: 100
+        }
+    }
+});

--- a/packages/app-page-builder-editor/src/types.ts
+++ b/packages/app-page-builder-editor/src/types.ts
@@ -1,0 +1,307 @@
+import { ReactNode } from "react";
+import { Plugin } from "@webiny/app/types";
+
+export type PbElementDataSettingsSpacingValueType = {
+    all?: string;
+    top?: string;
+    right?: string;
+    bottom?: string;
+    left?: string;
+};
+export type PbElementDataSettingsBackgroundType = {
+    color?: string;
+    image?: {
+        scaling?: string;
+        position?: string;
+        file?: {
+            src?: string;
+        };
+    };
+};
+export type PbElementDataSettingsMarginType = {
+    advanced?: boolean;
+    mobile?: PbElementDataSettingsSpacingValueType;
+    desktop?: PbElementDataSettingsSpacingValueType;
+};
+export type PbElementDataSettingsPaddingType = {
+    advanced?: boolean;
+    mobile?: PbElementDataSettingsSpacingValueType;
+    desktop?: PbElementDataSettingsSpacingValueType;
+};
+export type PbElementDataSettingsBorderType = {
+    width?:
+        | number
+        | {
+              all?: number;
+              top?: number;
+              right?: number;
+              bottom?: number;
+              left?: number;
+          };
+    style?: "none" | "solid" | "dashed" | "dotted";
+    radius?:
+        | number
+        | {
+              all?: number;
+              topLeft?: number;
+              topRight?: number;
+              bottomLeft?: number;
+              bottomRight?: number;
+          };
+    borders?: {
+        top?: boolean;
+        right?: boolean;
+        bottom?: boolean;
+        left?: boolean;
+    };
+};
+
+export interface PbParagraphElementPerDeviceData {
+    type?: string;
+    color?: string;
+    alignment: string;
+    typography: string;
+    tag: string;
+}
+
+export interface PbElementDataTextType
+    extends PbPerDeviceSettings<PbParagraphElementPerDeviceData> {
+    data: {
+        text: string;
+    };
+}
+export type PbElementDataImageType = {
+    width?: string | number;
+    height?: string | number;
+    file?: {
+        id?: string;
+        src?: string;
+    };
+    title?: string;
+};
+export type PbElementDataIconType = {
+    id?: [string, string];
+    width?: number;
+    color?: string;
+    svg?: string;
+    position?: string;
+};
+export type PbElementDataSettingsFormType = {
+    parent?: string;
+    revision?: string;
+};
+export enum AlignmentTypesEnum {
+    HORIZONTAL_LEFT = "horizontalLeft",
+    HORIZONTAL_CENTER = "horizontalCenter",
+    HORIZONTAL_RIGHT = "horizontalRight",
+    VERTICAL_TOP = "verticalTop",
+    VERTICAL_CENTER = "verticalCenter",
+    VERTICAL_BOTTOM = "verticalBottom"
+}
+export interface PbElementDataSettingsType
+    extends PbPerDeviceSettings<{
+        alignment?: AlignmentTypesEnum;
+        horizontalAlign?: any; //"left" | "center" | "right" | "justify";
+        horizontalAlignFlex?: any; //"flex-start" | "center" | "flex-end";
+        verticalAlign?: "start" | "center" | "end";
+        margin?: PbElementDataSettingsMarginType;
+        padding?: PbElementDataSettingsPaddingType;
+        height?: {
+            value?: number;
+        };
+        background?: PbElementDataSettingsBackgroundType;
+        border?: PbElementDataSettingsBorderType;
+        grid?: {
+            cellsType?: string;
+            size?: number;
+        };
+        columnWidth?: {
+            value?: string;
+        };
+        width?: {
+            value?: string;
+        };
+        className?: string;
+        form?: PbElementDataSettingsFormType;
+    }> {
+    [key: string]: any;
+}
+
+export interface PbPerDeviceSettings<TData> {
+    [DisplayMode.DESKTOP]?: TData;
+    [DisplayMode.TABLET]?: TData;
+    [DisplayMode.MOBILE_PORTRAIT]?: TData;
+    [DisplayMode.MOBILE_LANDSCAPE]?: TData;
+}
+
+export type PbElementDataType = {
+    settings?: PbElementDataSettingsType;
+    text?: PbElementDataTextType;
+    image?: PbElementDataImageType;
+    buttonText?: string;
+    link?: {
+        href?: string;
+        newTab?: boolean;
+    };
+    type?: string;
+    icon?: PbElementDataIconType;
+    source?: {
+        url?: string;
+    };
+    oembed?: {
+        source?: {
+            url?: string;
+        };
+        html?: string;
+    };
+    width?: number;
+    [key: string]: any;
+};
+
+export type PbEditorElement = {
+    id: string;
+    type: string;
+    data: PbElementDataType;
+    parent?: string;
+    elements: (string | PbEditorElement)[];
+    // A helper value for React; not stored into DB.
+    isHighlighted?: boolean;
+    [key: string]: any;
+};
+
+export type PbElement = {
+    id: string;
+    type: string;
+    data: PbElementDataType;
+    elements: PbElement[];
+};
+
+export type PbPageData = {
+    id: string;
+    path: string;
+    title?: string;
+    content: any;
+    settings?: {
+        general?: {
+            layout?: string;
+        };
+        seo?: {
+            title: string;
+            description: string;
+            meta: { name: string; content: string }[];
+        };
+        social?: {
+            title: string;
+            description: string;
+            meta: { property: string; content: string }[];
+            image: {
+                src: string;
+            };
+        };
+    };
+};
+
+// export type PbEditorPageElementPlugin = Plugin & {
+//     type: "pb-editor-page-element";
+//     elementType: string;
+//     toolbar?: {
+//         // Element title in the toolbar.
+//         title?: string | PbEditorPageElementTitle;
+//         // Element group this element belongs to.
+//         group?: string;
+//         // A function to render an element preview in the toolbar.
+//         preview?: React.ReactElement;
+//     };
+//     // Help link
+//     help?: string;
+//     // Whitelist elements that can accept this element (for drag&drop interaction)
+//     target?: string[];
+//     // Array of element settings plugin names.
+//     settings?: Array<string | Array<string | any>>;
+//     // A function to create an element data structure.
+//     create: (
+//         options: { [key: string]: any },
+//         parent?: PbEditorElement
+//     ) => Omit<PbEditorElement, "id">;
+//     // A function to render an element in the editor.
+//     render: (params: { theme?: PbTheme; element: PbEditorElement; isActive: boolean }) => ReactNode;
+//     // A function to check if an element can be deleted.
+//     canDelete?: (params: { element: PbEditorElement }) => boolean;
+//     // Executed when another element is dropped on the drop zones of current element.
+//     onReceived?: (params: { event: DropElementActionEvent }) => void;
+//     // Executed when an immediate child element is deleted
+//     onChildDeleted?: (params: {
+//         element: PbEditorElement;
+//         child: PbEditorElement;
+//     }) => PbEditorElement | undefined;
+//     // Executed after element was created
+//     onCreate?: string;
+//     // Render element preview (used when creating element screenshots; not all elements have a simple DOM representation
+//     // so this callback is used to customize the look of the element in a PNG image)
+//     renderElementPreview?: (params: {
+//         element: PbEditorElement;
+//         width: number;
+//         height: number;
+//     }) => ReactElement;
+// };
+
+// export type PbEditorPageElementActionPlugin = Plugin & {
+//     type: "pb-editor-page-element-action";
+//     render: (params: { element: PbEditorElement; plugin: PbEditorPageElementPlugin }) => ReactNode;
+// };
+
+export type PbPageDetailsPlugin = Plugin & {
+    render: (params: { [key: string]: any }) => ReactNode;
+};
+//
+// export type PbEditorPageSettingsPlugin = Plugin & {
+//     type: "pb-editor-page-settings";
+//     /* Settings group title */
+//     title: string;
+//     /* Settings group description */
+//     description: string;
+//     /* Settings group icon */
+//     icon: ReactNode;
+//     /* Render function that handles the specified `fields` */
+//     render: (params: {
+//         data: Record<string, any>;
+//         setValue: FormSetValue;
+//         form: Form;
+//         Bind: BindComponent;
+//     }) => ReactNode;
+// };
+
+// export type PbEditorBlockPlugin = Plugin & {
+//     type: "pb-editor-block";
+//     title: string;
+//     category: string;
+//     tags: string[];
+//     image: {
+//         src?: string;
+//         meta: {
+//             width: number;
+//             height: number;
+//             aspectRatio: number;
+//         };
+//     };
+//     create(): PbEditorElement;
+//     preview(): ReactElement;
+// };
+
+export enum DisplayMode {
+    DESKTOP = "desktop",
+    TABLET = "tablet",
+    MOBILE_LANDSCAPE = "mobile-landscape",
+    MOBILE_PORTRAIT = "mobile-portrait"
+}
+
+// export type PbEditorElementPluginArgs = {
+//     create?: (defaultValue) => Record<string, any>;
+//     settings?: (defaultValue) => Array<string | Array<string | any>>;
+//     toolbar?: (defaultValue) => Record<string, any>;
+//     elementType?: string;
+// };
+//
+// export type PbRenderElementPluginArgs = {
+//     elementType?: string;
+// };

--- a/packages/app-page-builder-editor/tsconfig.build.json
+++ b/packages/app-page-builder-editor/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../app/tsconfig.build.json" },
+    { "path": "../app-admin/tsconfig.build.json" },
+    { "path": "../app-page-builder/tsconfig.build.json" },
+    { "path": "../ui/tsconfig.build.json" }
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": { "~/*": ["./src/*"] },
+    "baseUrl": "."
+  }
+}

--- a/packages/app-page-builder-editor/tsconfig.json
+++ b/packages/app-page-builder-editor/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__/**/*.ts"],
+  "references": [
+    { "path": "../app" },
+    { "path": "../app-admin" },
+    { "path": "../app-page-builder" },
+    { "path": "../ui" }
+  ],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "@webiny/app/*": ["../app/src/*"],
+      "@webiny/app": ["../app/src"],
+      "@webiny/app-admin/*": ["../app-admin/src/*"],
+      "@webiny/app-admin": ["../app-admin/src"],
+      "@webiny/app-page-builder/*": ["../app-page-builder/src/*"],
+      "@webiny/app-page-builder": ["../app-page-builder/src"],
+      "@webiny/ui/*": ["../ui/src/*"],
+      "@webiny/ui": ["../ui/src"]
+    },
+    "baseUrl": "."
+  }
+}

--- a/packages/app-page-builder-editor/webiny.config.js
+++ b/packages/app-page-builder-editor/webiny.config.js
@@ -1,0 +1,8 @@
+const { createWatchPackage, createBuildPackage } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: createBuildPackage({ cwd: __dirname }),
+        watch: createWatchPackage({ cwd: __dirname })
+    }
+};

--- a/packages/app-page-builder/src/PageBuilder.tsx
+++ b/packages/app-page-builder/src/PageBuilder.tsx
@@ -15,6 +15,9 @@ import { DefaultOnPagePublish } from "~/admin/plugins/pageDetails/pageRevisions/
 import { DefaultOnPageDelete } from "~/admin/plugins/pageDetails/pageRevisions/DefaultOnPageDelete";
 import { EditorProps, EditorRenderer } from "./admin/components/Editor";
 
+export type { EditorProps };
+export { EditorRenderer };
+
 const PageBuilderProviderHOC = (Component: React.FC): React.FC => {
     return function PageBuilderProvider({ children }) {
         return (
@@ -86,15 +89,12 @@ const EditorRendererHOC: HigherOrderComponent<EditorProps> = () => {
         return <EditorLoader {...props} />;
     };
 };
-/**
- * TODO @ts-refactor @pavel
- * as any in hoc and provider
- */
+
 export const PageBuilder: React.FC = () => {
     return (
         <Fragment>
             <Provider hoc={PageBuilderProviderHOC} />
-            <Compose component={EditorRenderer as any} with={EditorRendererHOC as any} />
+            <Compose component={EditorRenderer} with={EditorRendererHOC} />
             <Plugins>
                 <PageBuilderMenu />
                 <WebsiteSettings />

--- a/packages/app-page-builder/src/admin/components/Editor.tsx
+++ b/packages/app-page-builder/src/admin/components/Editor.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { makeComposable } from "@webiny/app-admin";
-import { PageAtomType, RevisionsAtomType } from "~/editor/recoil/modules";
-import { PbEditorElement } from "~/types";
+import { PageWithContent, RevisionsAtomType } from "~/editor/recoil/modules";
 
 export type EditorProps = {
-    page: PageAtomType & PbEditorElement;
+    page: PageWithContent;
     revisions: RevisionsAtomType;
 };
 

--- a/packages/app-page-builder/src/admin/views/Pages/Editor.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Editor.tsx
@@ -22,11 +22,11 @@ import {
 import createElementPlugin from "~/admin/utils/createElementPlugin";
 import createBlockPlugin from "~/admin/utils/createBlockPlugin";
 import dotProp from "dot-prop-immutable";
-import { PbEditorElement, PbErrorResponse } from "~/types";
-import { PageAtomType, RevisionsAtomType } from "~/editor/recoil/modules";
+import { PbErrorResponse } from "~/types";
+import { PageWithContent, RevisionsAtomType } from "~/editor/recoil/modules";
 
 interface PageDataAndRevisionsState {
-    page: (PageAtomType & PbEditorElement) | null;
+    page: PageWithContent | null;
     revisions: RevisionsAtomType;
 }
 
@@ -98,7 +98,7 @@ const Editor: React.FC = () => {
                 }
 
                 const { revisions = [], content, ...restOfPageData } = extractPageData(data);
-                const page: PageAtomType & PbEditorElement = {
+                const page: PageWithContent = {
                     ...restOfPageData,
                     content: content || createElement("document")
                 };
@@ -142,7 +142,7 @@ const Editor: React.FC = () => {
     return (
         <React.Suspense fallback={<EditorLoadingScreen />}>
             <LoadData>
-                <PbEditor page={page as PageAtomType & PbEditorElement} revisions={revisions} />
+                <PbEditor page={page as PageWithContent} revisions={revisions} />
             </LoadData>
         </React.Suspense>
     );

--- a/packages/app-page-builder/src/editor/index.tsx
+++ b/packages/app-page-builder/src/editor/index.tsx
@@ -7,13 +7,14 @@ import {
     RevisionsAtomType,
     pageAtom,
     elementsAtom,
-    PageAtomType
+    PageAtomType,
+    PageWithContent
 } from "./recoil/modules";
 import { flattenElements } from "./helpers";
-import { PbEditorElement } from "~/types";
+import omit from "lodash/omit";
 
 interface EditorPropsType {
-    page: PageAtomType & PbEditorElement;
+    page: PageWithContent;
     revisions: RevisionsAtomType;
 }
 
@@ -31,8 +32,8 @@ export const Editor: React.FC<EditorPropsType> = ({ page, revisions }) => {
                 /**
                  * We always unset the content because we are not using it via the page atom.
                  */
-                const pageData = { ...page };
-                delete pageData.content;
+                const pageData: PageAtomType = omit(page, ["content"]);
+
                 set(pageAtom, pageData);
             }}
         >

--- a/packages/app-page-builder/src/editor/recoil/modules/page/pageAtom.ts
+++ b/packages/app-page-builder/src/editor/recoil/modules/page/pageAtom.ts
@@ -1,4 +1,5 @@
 import { atom } from "recoil";
+import { PbEditorElement } from "~/types";
 
 interface PageCategoryType {
     slug: string;
@@ -6,8 +7,12 @@ interface PageCategoryType {
     url: string;
 }
 
+export interface PageWithContent extends PageAtomType {
+    content: PbEditorElement;
+}
+
 export interface PageAtomType {
-    id?: string;
+    id: string;
     title?: string;
     pid?: string;
     path?: string;
@@ -32,6 +37,7 @@ export interface PageAtomType {
 export const pageAtom = atom<PageAtomType>({
     key: "pageAtom",
     default: {
+        id: "",
         locked: false,
         version: 1,
         published: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11378,7 +11378,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-admin@^5.25.0, @webiny/app-admin@workspace:packages/app-admin":
+"@webiny/app-admin@^5.21.0, @webiny/app-admin@^5.25.0, @webiny/app-admin@workspace:packages/app-admin":
   version: 0.0.0-use.local
   resolution: "@webiny/app-admin@workspace:packages/app-admin"
   dependencies:
@@ -11818,6 +11818,52 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/app-page-builder-editor@^5.25.0, @webiny/app-page-builder-editor@workspace:packages/app-page-builder-editor":
+  version: 0.0.0-use.local
+  resolution: "@webiny/app-page-builder-editor@workspace:packages/app-page-builder-editor"
+  dependencies:
+    "@babel/cli": ^7.16.0
+    "@babel/core": ^7.16.0
+    "@babel/plugin-proposal-class-properties": ^7.16.0
+    "@babel/preset-env": ^7.16.4
+    "@babel/preset-react": ^7.16.0
+    "@babel/preset-typescript": ^7.16.0
+    "@babel/runtime": ^7.16.3
+    "@emotion/core": ^10.0.17
+    "@svgr/webpack": ^6.1.1
+    "@types/medium-editor": ^5.0.3
+    "@types/react": ^16.14.0
+    "@types/resize-observer-browser": ^0.1.4
+    "@webiny/app": ^5.21.0
+    "@webiny/app-admin": ^5.21.0
+    "@webiny/app-page-builder": ^5.21.0
+    "@webiny/cli": ^5.21.0
+    "@webiny/project-utils": ^5.21.0
+    "@webiny/ui": ^5.21.0
+    apollo-cache: ^1.3.5
+    apollo-client: ^2.6.10
+    apollo-link: ^1.2.14
+    apollo-utilities: ^1.3.4
+    babel-plugin-emotion: ^9.2.8
+    babel-plugin-lodash: ^3.3.4
+    classnames: ^2.2.6
+    dot-prop-immutable: ^2.1.0
+    emotion: ^10.0.17
+    graphql: ^15.7.2
+    lodash: ^4.17.10
+    nanoid: ^3.1.20
+    prop-types: ^15.7.2
+    react: 16.14.0
+    react-dnd: ^11.1.3
+    react-dnd-html5-backend: ^11.1.3
+    react-dom: 16.14.0
+    recoil: ^0.1.2
+    rimraf: ^3.0.2
+    ttypescript: ^1.5.12
+    typescript: ^4.1.3
+  languageName: unknown
+  linkType: soft
+
 "@webiny/app-page-builder-elements@^5.25.0, @webiny/app-page-builder-elements@workspace:packages/app-page-builder-elements":
   version: 0.0.0-use.local
   resolution: "@webiny/app-page-builder-elements@workspace:packages/app-page-builder-elements"
@@ -11846,7 +11892,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app-page-builder@^5.25.0, @webiny/app-page-builder@workspace:packages/app-page-builder":
+"@webiny/app-page-builder@^5.21.0, @webiny/app-page-builder@^5.25.0, @webiny/app-page-builder@workspace:packages/app-page-builder":
   version: 0.0.0-use.local
   resolution: "@webiny/app-page-builder@workspace:packages/app-page-builder"
   dependencies:
@@ -12208,7 +12254,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/app@^5.25.0, @webiny/app@workspace:packages/app":
+"@webiny/app@^5.21.0, @webiny/app@^5.25.0, @webiny/app@workspace:packages/app":
   version: 0.0.0-use.local
   resolution: "@webiny/app@workspace:packages/app"
   dependencies:
@@ -12555,7 +12601,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/cli@^5.25.0, @webiny/cli@workspace:packages/cli":
+"@webiny/cli@^5.21.0, @webiny/cli@^5.25.0, @webiny/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@webiny/cli@workspace:packages/cli"
   dependencies:
@@ -13041,7 +13087,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/project-utils@^5.24.0, @webiny/project-utils@^5.25.0, @webiny/project-utils@workspace:packages/project-utils":
+"@webiny/project-utils@^5.21.0, @webiny/project-utils@^5.24.0, @webiny/project-utils@^5.25.0, @webiny/project-utils@workspace:packages/project-utils":
   version: 0.0.0-use.local
   resolution: "@webiny/project-utils@workspace:packages/project-utils"
   dependencies:
@@ -13309,7 +13355,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/ui@^5.25.0, @webiny/ui@workspace:packages/ui":
+"@webiny/ui@^5.21.0, @webiny/ui@^5.25.0, @webiny/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@webiny/ui@workspace:packages/ui"
   dependencies:
@@ -13787,6 +13833,7 @@ __metadata:
     "@webiny/app-form-builder": ^5.25.0
     "@webiny/app-headless-cms": ^5.25.0
     "@webiny/app-page-builder": ^5.25.0
+    "@webiny/app-page-builder-editor": ^5.25.0
     "@webiny/app-serverless-cms": ^5.25.0
     "@webiny/cli": ^5.25.0
     "@webiny/cli-plugin-deploy-pulumi": ^5.25.0


### PR DESCRIPTION
## Changes
This PR introduces a new package, `@webiny/app-page-builder-editor`, which contains only the PB Editor itself, and for the time being, serves as a playground/sandbox for various Editor PoCs. The package is set to `private: true`, so it will not be published to `npm` on every release.

The goal of this package is to have a sandbox within the repo that is up-to-date with the main branch, and one that can be quickly enabled by the developer working on it. We'll use this package to test different approaches on how to improve the PB editor for developers, and make it a lot easier to extend, comparing to the current plugin system.

Currently, the package only contains data fetching logic (page loading), and no UI at all. I have several PoCs sitting in various projects on my hard drive, which I want to try in the real context, and see if those PoCs make sense in reality.
