### PR TITLE
Pluginable content entries filters and sorters

### DIFF
--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -51,6 +51,7 @@
     "graphql-tag": "^2.12.6",
     "invariant": "^2.2.4",
     "lodash": "^4.17.10",
+    "nanoid": "^3.3.4",
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "raw.macro": "^0.4.2",

--- a/packages/app-headless-cms/src/HeadlessCMS.tsx
+++ b/packages/app-headless-cms/src/HeadlessCMS.tsx
@@ -5,6 +5,7 @@ import { ApolloClient } from "apollo-client";
 import { CmsProvider } from "./admin/contexts/Cms";
 import { CmsMenuLoader } from "~/admin/menus/CmsMenuLoader";
 import apiInformation from "./admin/plugins/apiInformation";
+import { ContentEntriesModule } from "./admin/views/contentEntries/experiment/ContentEntriesModule";
 
 const createHeadlessCMSProvider =
     (createApolloClient: CreateApolloClient) =>
@@ -34,6 +35,7 @@ const HeadlessCMSExtension = ({ createApolloClient }: HeadlessCMSProps) => {
 
     return (
         <Fragment>
+            <ContentEntriesModule />
             <Provider hoc={createHeadlessCMSProvider(createApolloClient)} />
             <Plugins>
                 <CmsMenuLoader />

--- a/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
+++ b/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
@@ -4,13 +4,13 @@ import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { config as appConfig } from "@webiny/app/config";
 
-export interface CmsContextValue {
+export interface CmsContext {
     getApolloClient(locale: string): ApolloClient<any>;
     createApolloClient: CmsProviderProps["createApolloClient"];
     apolloClient: ApolloClient<any>;
 }
 
-export const CmsContext = React.createContext<CmsContextValue>({
+export const CmsContext = React.createContext<CmsContext>({
     getApolloClient: () => {
         return null;
     },
@@ -21,7 +21,7 @@ export const CmsContext = React.createContext<CmsContextValue>({
     /**
      * Safe to cast.
      */
-} as unknown as CmsContextValue);
+} as unknown as CmsContext);
 
 interface ApolloClientsCache {
     [locale: string]: ApolloClient<any>;
@@ -39,14 +39,6 @@ export const CmsProvider: React.FC<CmsProviderProps> = props => {
     const { getCurrentLocale } = useI18N();
 
     const currentLocale = getCurrentLocale("content");
-    /**
-     * TODO @ts-refactor @pavel did you think about this?
-     */
-    // TODO: not sure why this was necessary :thinking:
-    // const hasPermission = identity.getPermission("cms.endpoint.manage");
-    // if (!hasPermission) {
-    //     return <CmsContext.Provider value={{}} {...props} />;
-    // }
 
     if (currentLocale && !apolloClientsCache[currentLocale]) {
         apolloClientsCache[currentLocale] = props.createApolloClient({

--- a/packages/app-headless-cms/src/admin/hooks/useCms.ts
+++ b/packages/app-headless-cms/src/admin/hooks/useCms.ts
@@ -1,8 +1,8 @@
 import { useContext } from "react";
-import { CmsContext, CmsContextValue } from "../contexts/Cms";
+import { CmsContext } from "../contexts/Cms";
 
 function useCms() {
-    const context = useContext<CmsContextValue>(CmsContext);
+    const context = useContext(CmsContext);
     if (!context) {
         throw new Error("useCms must be used within a CmsProvider");
     }

--- a/packages/app-headless-cms/src/admin/plugins/routes.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/routes.tsx
@@ -6,6 +6,7 @@ import { Route } from "@webiny/react-router";
 import { AdminLayout } from "@webiny/app-admin/components/AdminLayout";
 import { RoutePlugin } from "@webiny/app/types";
 import { i18n } from "@webiny/app/i18n";
+import { ContentEntriesView } from "../views/contentEntries/experiment/ContentEntriesViewConfig";
 
 const t = i18n.ns("app-headless-cms/admin/routes");
 
@@ -18,7 +19,6 @@ const Loader: React.FC = ({ children, ...props }) => (
 const ContentModelEditor = lazy(() => import("../views/contentModels/ContentModelEditor"));
 const ContentModelsView = lazy(() => import("../views/contentModels/ContentModels"));
 const ContentModelGroupsView = lazy(() => import("../views/contentModelGroups/ContentModelGroups"));
-const ContentEntiesView = lazy(() => import("../views/contentEntries/ContentEntries"));
 
 const plugins: RoutePlugin[] = [
     {
@@ -56,9 +56,7 @@ const plugins: RoutePlugin[] = [
                             <Helmet>
                                 <title>{t`Content`}</title>
                             </Helmet>
-                            <Loader>
-                                <ContentEntiesView />
-                            </Loader>
+                            <ContentEntriesView />
                         </AdminLayout>
                     </SecureRoute>
                 )}

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
@@ -2,6 +2,10 @@ import React, { useState, useMemo, Dispatch, SetStateAction } from "react";
 import { useSecurity } from "@webiny/app-security";
 import { i18n } from "@webiny/app/i18n";
 import { CmsEditorContentModel, CmsSecurityPermission } from "~/types";
+import {
+    useContentEntriesViewConfig,
+    ContentEntriesViewConfigSorter
+} from "./experiment/ContentEntriesViewConfig";
 
 const t = i18n.ns("app-headless-cms/admin/contents/entries");
 
@@ -9,16 +13,6 @@ export interface CmsEntriesSorter {
     label: string;
     value: string;
 }
-const SORTERS: CmsEntriesSorter[] = [
-    {
-        label: t`Newest to oldest`,
-        value: "savedOn_DESC"
-    },
-    {
-        label: t`Oldest to newest`,
-        value: "savedOn_ASC"
-    }
-];
 
 export interface ListQueryVariables {
     sort?: string[];
@@ -30,18 +24,18 @@ export interface ListQueryVariables {
 
 export interface ContentEntriesContext {
     contentModel: CmsEditorContentModel;
-    sorters: CmsEntriesSorter[];
     canCreate: boolean;
     listQueryVariables: ListQueryVariables;
+    sorters: CmsEntriesSorter[];
     setListQueryVariables: Dispatch<SetStateAction<ListQueryVariables>>;
     insideDialog?: boolean;
 }
 
 export const Context = React.createContext<ContentEntriesContext>({
     contentModel: null as unknown as CmsEditorContentModel,
-    sorters: [],
     canCreate: false,
     listQueryVariables: {},
+    sorters: [],
     setListQueryVariables: () => {
         return void 0;
     }
@@ -53,16 +47,17 @@ export interface ContentEntriesContextProviderProps {
     insideDialog?: boolean;
 }
 
+function toEntriesSorters(sorters: ContentEntriesViewConfigSorter[]) {
+    return sorters.map(s => ({ label: s.label, value: s.name }));
+}
+
 export const Provider: React.FC<ContentEntriesContextProviderProps> = ({
     contentModel,
     children,
     insideDialog
 }) => {
     const { identity, getPermission } = useSecurity();
-
-    const [listQueryVariables, setListQueryVariables] = useState<ListQueryVariables>({
-        sort: [SORTERS[0].value]
-    });
+    const viewConfig = useContentEntriesViewConfig();
 
     const canCreate = useMemo((): boolean => {
         const permission = getPermission<CmsSecurityPermission>("cms.contentEntry");
@@ -81,13 +76,14 @@ export const Provider: React.FC<ContentEntriesContextProviderProps> = ({
         const titleField = contentModel.fields.find(
             field => field.fieldId === contentModel.titleFieldId
         );
+
         const titleFieldLabel = titleField ? titleField.label : null;
         if (!titleFieldLabel) {
-            return SORTERS;
+            return toEntriesSorters(viewConfig.sorters);
         }
 
         return [
-            ...SORTERS,
+            ...toEntriesSorters(viewConfig.sorters),
             {
                 label: t`{titleFieldLabel} A-Z`({ titleFieldLabel }),
                 value: `${contentModel.titleFieldId}_ASC`
@@ -97,7 +93,12 @@ export const Provider: React.FC<ContentEntriesContextProviderProps> = ({
                 value: `${contentModel.titleFieldId}_DESC`
             }
         ];
-    }, [contentModel.modelId]);
+    }, [viewConfig.sorters, contentModel.modelId]);
+
+    const [listQueryVariables, setListQueryVariables] = useState<ListQueryVariables>({
+        sort: [sorters[0].value],
+        where: {}
+    });
 
     const value = {
         insideDialog,

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, Dispatch, SetStateAction } from "react";
+import React, { useState, useMemo, Dispatch, SetStateAction, useCallback } from "react";
 import { useSecurity } from "@webiny/app-security";
 import { i18n } from "@webiny/app/i18n";
 import { CmsEditorContentModel, CmsSecurityPermission } from "~/types";
@@ -59,6 +59,13 @@ export const Provider: React.FC<ContentEntriesContextProviderProps> = ({
     const { identity, getPermission } = useSecurity();
     const viewConfig = useContentEntriesViewConfig();
 
+    const appliesToContentModel = useCallback(
+        ({ modelIds }: ContentEntriesViewConfigSorter) => {
+            return modelIds.length === 0 || modelIds.includes(contentModel.modelId);
+        },
+        [contentModel]
+    );
+
     const canCreate = useMemo((): boolean => {
         const permission = getPermission<CmsSecurityPermission>("cms.contentEntry");
         if (!permission) {
@@ -79,11 +86,11 @@ export const Provider: React.FC<ContentEntriesContextProviderProps> = ({
 
         const titleFieldLabel = titleField ? titleField.label : null;
         if (!titleFieldLabel) {
-            return toEntriesSorters(viewConfig.sorters);
+            return toEntriesSorters(viewConfig.sorters.filter(appliesToContentModel));
         }
 
         return [
-            ...toEntriesSorters(viewConfig.sorters),
+            ...toEntriesSorters(viewConfig.sorters.filter(appliesToContentModel)),
             {
                 label: t`{titleFieldLabel} A-Z`({ titleFieldLabel }),
                 value: `${contentModel.titleFieldId}_ASC`

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
@@ -24,7 +24,10 @@ import { useCallback } from "react";
 import { useContentEntriesList } from "~/admin/views/contentEntries/hooks/useContentEntriesList";
 import { positionValues as PositionValues } from "react-custom-scrollbars";
 import { CmsEditorContentEntry } from "~/types";
-import { useContentEntriesViewConfig } from "./experiment/ContentEntriesViewConfig";
+import {
+    useContentEntriesViewConfig,
+    ContentEntriesViewConfigFilter
+} from "./experiment/ContentEntriesViewConfig";
 
 const t = i18n.ns("app-headless-cms/admin/contents/data-list");
 
@@ -87,6 +90,13 @@ const ContentEntriesList: React.FC = () => {
         sort: listQueryVariables.sort ? listQueryVariables.sort[0] : ""
     };
 
+    const appliesToContentModel = useCallback(
+        ({ modelIds }: ContentEntriesViewConfigFilter) => {
+            return modelIds.length === 0 || modelIds.includes(contentModel.modelId);
+        },
+        [contentModel]
+    );
+
     const entriesDataListModalOverlay = useMemo(
         () => (
             <UIList.DataListModalOverlay>
@@ -117,7 +127,7 @@ const ContentEntriesList: React.FC = () => {
                                     </Select>
                                 </Bind>
                             </Cell>
-                            {viewConfig.filters.map(filter => (
+                            {viewConfig.filters.filter(appliesToContentModel).map(filter => (
                                 <Cell span={12} key={filter.name}>
                                     {filter.element}
                                 </Cell>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/cache.ts
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/cache.ts
@@ -22,7 +22,7 @@ const sortEntries = (
     if (!sort) {
         return list;
     } else if (Array.isArray(sort) === false) {
-        console.log("Sort is not an Array of string.");
+        console.log("Sort is not an Array of strings.");
         return list;
     } else if (sort.length === 0) {
         return list;

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesModule.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Compose, Plugins } from "@webiny/app-admin";
+import { useBind } from "@webiny/form";
+import { Select } from "@webiny/ui/Select";
+import { ContentEntriesViewRenderer, ContentEntriesViewConfig } from "./ContentEntriesViewConfig";
+import { ContentEntriesRenderer } from "./ContentEntriesRenderer";
+
+const { Filter, Sorter } = ContentEntriesViewConfig;
+
+const FilterByStatus = () => {
+    const bind = useBind({
+        name: "status",
+        defaultValue: "all",
+        beforeChange(value, cb) {
+            cb(value === "all" ? undefined : value);
+        }
+    });
+
+    return (
+        <Select
+            {...bind}
+            label={"Filter by status"}
+            description={"Filter by a specific entry status."}
+        >
+            <option value={"all"}>All</option>
+            <option value={"draft"}>Draft</option>
+            <option value={"published"}>Published</option>
+            <option value={"unpublished"}>Unpublished</option>
+            <option value={"reviewRequested"}>Review requested</option>
+            <option value={"changesRequested"}>Changes requested</option>
+        </Select>
+    );
+};
+
+export const ContentEntriesModule = () => {
+    return (
+        <>
+            <Compose component={ContentEntriesViewRenderer} with={ContentEntriesRenderer} />
+            <Plugins>
+                <ContentEntriesViewConfig>
+                    <Filter name={"status"} element={<FilterByStatus />} />
+                    <Sorter name={"savedOn_DESC"} label={"Newest to oldest"} />
+                    <Sorter name={"savedOn_ASC"} label={"Oldest to newest"} />
+                </ContentEntriesViewConfig>
+            </Plugins>
+        </>
+    );
+};

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesRenderer.tsx
@@ -1,0 +1,15 @@
+import React, { Suspense, lazy } from "react";
+import { CircularProgress } from "@webiny/ui/Progress";
+import { HigherOrderComponent } from "@webiny/app-admin";
+
+const ContentEntriesView = lazy(() => import("../ContentEntries"));
+
+export const ContentEntriesRenderer: HigherOrderComponent = () => {
+    return function ContentEntriesRenderer() {
+        return (
+            <Suspense fallback={<CircularProgress />}>
+                <ContentEntriesView />
+            </Suspense>
+        );
+    };
+};

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesViewConfig.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesViewConfig.tsx
@@ -34,14 +34,21 @@ export const ContentEntriesViewConfig: ContentEntriesViewConfig = ({ children })
 export interface ContentEntriesViewConfigFilterProps {
     name: string;
     element?: React.ReactElement<unknown>;
+    modelIds?: string[];
     remove?: boolean;
 }
 
-const Filter: React.FC<ContentEntriesViewConfigFilterProps> = ({ name, element, remove }) => {
+const Filter: React.FC<ContentEntriesViewConfigFilterProps> = ({
+    name,
+    element,
+    modelIds = [],
+    remove = false
+}) => {
     return (
         <Property id={name} name={"filter"} merge={true} remove={remove}>
-            <Property id="name" name={"name"} value={name} />
-            {element ? <Property id="element" name={"element"} value={element} /> : null}
+            <Property id={"name"} name={"name"} value={name} />
+            <Property id={"modelIds"} name={"modelIds"} value={modelIds} />
+            {element ? <Property id={"element"} name={"element"} value={element} /> : null}
         </Property>
     );
 };
@@ -49,13 +56,21 @@ const Filter: React.FC<ContentEntriesViewConfigFilterProps> = ({ name, element, 
 export interface ContentEntriesViewConfigSorterProps {
     name: string;
     label: string;
+    modelIds?: string[];
+    remove?: boolean;
 }
 
-const Sorter: React.FC<ContentEntriesViewConfigSorterProps> = ({ name, label }) => {
+const Sorter: React.FC<ContentEntriesViewConfigSorterProps> = ({
+    name,
+    label,
+    modelIds = [],
+    remove = false
+}) => {
     return (
-        <Property id={name} name={"sorter"} merge={true}>
-            <Property name={"name"} value={name} />
-            <Property name={"label"} value={label} />
+        <Property id={name} name={"sorter"} merge={true} remove={remove}>
+            <Property id={"name"} name={"name"} value={name} />
+            <Property id={"label"} name={"label"} value={label} />
+            <Property id={"modelIds"} name={"modelIds"} value={modelIds} />
         </Property>
     );
 };
@@ -98,11 +113,13 @@ function byName(name: string) {
 export interface ContentEntriesViewConfigFilter {
     name: string;
     element: React.ReactElement;
+    modelIds: string[];
 }
 
 export interface ContentEntriesViewConfigSorter {
     name: string;
     label: string;
+    modelIds: string[];
 }
 
 export function useContentEntriesViewConfig(): {
@@ -118,6 +135,7 @@ export function useContentEntriesViewConfig(): {
     const sorters = properties
         .filter(byName("sorter"))
         .map(f => toObject<ContentEntriesViewConfigSorter>(f));
+
     return {
         filters,
         sorters

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesViewConfig.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/ContentEntriesViewConfig.tsx
@@ -1,0 +1,125 @@
+import { makeComposable, Compose, HigherOrderComponent } from "@webiny/app-admin";
+import React, { useContext, useState } from "react";
+import { Property, PropertyContainer, toObject } from "./Property";
+
+interface ContentEntriesViewConfig extends React.FC<unknown> {
+    Filter: React.FC<ContentEntriesViewConfigFilterProps>;
+    Sorter: React.FC<ContentEntriesViewConfigSorterProps>;
+}
+
+const ContentEntriesViewConfigApply = makeComposable(
+    "ContentEntriesViewConfigApply",
+    ({ children }) => {
+        return <>{children}</>;
+    }
+);
+
+const createHOC =
+    (newChildren: React.ReactNode): HigherOrderComponent =>
+    BaseComponent => {
+        return function ConfigHOC({ children }) {
+            return (
+                <BaseComponent>
+                    {newChildren}
+                    {children}
+                </BaseComponent>
+            );
+        };
+    };
+
+export const ContentEntriesViewConfig: ContentEntriesViewConfig = ({ children }) => {
+    return <Compose component={ContentEntriesViewConfigApply} with={createHOC(children)} />;
+};
+
+export interface ContentEntriesViewConfigFilterProps {
+    name: string;
+    element?: React.ReactElement<unknown>;
+    remove?: boolean;
+}
+
+const Filter: React.FC<ContentEntriesViewConfigFilterProps> = ({ name, element, remove }) => {
+    return (
+        <Property id={name} name={"filter"} merge={true} remove={remove}>
+            <Property id="name" name={"name"} value={name} />
+            {element ? <Property id="element" name={"element"} value={element} /> : null}
+        </Property>
+    );
+};
+
+export interface ContentEntriesViewConfigSorterProps {
+    name: string;
+    label: string;
+}
+
+const Sorter: React.FC<ContentEntriesViewConfigSorterProps> = ({ name, label }) => {
+    return (
+        <Property id={name} name={"sorter"} merge={true}>
+            <Property name={"name"} value={name} />
+            <Property name={"label"} value={label} />
+        </Property>
+    );
+};
+
+ContentEntriesViewConfig.Filter = Filter;
+ContentEntriesViewConfig.Sorter = Sorter;
+
+interface ViewContext {
+    properties: Property[];
+}
+
+const defaultContext = { properties: [] };
+
+const ViewContext = React.createContext<ViewContext>(defaultContext);
+
+export const ContentEntriesView = makeComposable("ContentEntriesView", () => {
+    const [properties, setProperties] = useState<Property[]>([]);
+    const context = { properties };
+
+    const stateUpdater = (properties: Property[]) => {
+        setProperties(properties);
+    };
+
+    return (
+        <ViewContext.Provider value={context}>
+            <PropertyContainer name={"view"} onChange={stateUpdater}>
+                <ContentEntriesViewConfigApply />
+                <ContentEntriesViewRenderer />
+            </PropertyContainer>
+        </ViewContext.Provider>
+    );
+});
+
+export const ContentEntriesViewRenderer = makeComposable("ContentEntriesViewRenderer");
+
+function byName(name: string) {
+    return (obj: Property) => obj.name === name;
+}
+
+export interface ContentEntriesViewConfigFilter {
+    name: string;
+    element: React.ReactElement;
+}
+
+export interface ContentEntriesViewConfigSorter {
+    name: string;
+    label: string;
+}
+
+export function useContentEntriesViewConfig(): {
+    filters: ContentEntriesViewConfigFilter[];
+    sorters: ContentEntriesViewConfigSorter[];
+} {
+    const { properties } = useContext(ViewContext);
+
+    const filters = properties
+        .filter(byName("filter"))
+        .map(f => toObject<ContentEntriesViewConfigFilter>(f));
+
+    const sorters = properties
+        .filter(byName("sorter"))
+        .map(f => toObject<ContentEntriesViewConfigSorter>(f));
+    return {
+        filters,
+        sorters
+    };
+}

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/Property.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/Property.tsx
@@ -1,0 +1,251 @@
+// @ts-nocheck
+/**
+ * Note by @pavel910:
+ *
+ * TS is disabled in this file, as this is a wild experiment, and I need to come back and fix some types, which are not very
+ * obvious. I don't have time to do it right now. If the experiment is successful, I'll come back and clean this up, and
+ * extract this whole logic into a separate package, as this is a tiny framework for building data objects using React, and
+ * we might want to use it in many more places (all views, Page Builder Editor, etc.).
+ *
+ * More on this a bit later, if the experiment is successful.
+ */
+import React, { createContext, FC, useContext, useMemo, useRef, useState } from "react";
+import { nanoid } from "nanoid";
+import useDeepCompareEffect from "use-deep-compare-effect";
+
+export function toObject<T = unknown>(property: Property): T {
+    if (property.value !== undefined) {
+        return { [property.name]: property.value };
+    }
+
+    const obj = {};
+    property.properties.forEach(prop => {
+        // Check if this is a single occurrence of this property
+        const isSingle = property.properties.filter(p => p.name === prop.name).length === 1;
+        if (prop.value !== undefined) {
+            obj[prop.name] = isSingle ? prop.value : [...(obj[prop.name] || []), prop.value];
+        } else {
+            const asObject = toObject(prop);
+
+            if (!isSingle) {
+                obj[prop.name] = [...(obj[prop.name] || []), asObject[prop.name]];
+            } else {
+                obj[prop.name] = asObject[prop.name];
+            }
+        }
+    });
+
+    return obj;
+}
+
+export function toArray(objects: Property[]) {
+    return objects.map(obj =>
+        obj.properties.reduce((acc, item) => {
+            return { ...acc, ...toObject(item) };
+        }, {})
+    );
+}
+
+function mergeProperties(properties1: Property[], properties2: Property[]) {
+    const temp: Property[] = [...properties1, ...properties2];
+
+    return Object.values(
+        temp.reduce((acc, item) => {
+            return { ...acc, [item.id]: item };
+        }, {})
+    );
+}
+
+interface PropertyContext {
+    removeProperty(id: string): void;
+    updateProperty(property: Property): void;
+}
+
+const PropertyContext = createContext<PropertyContext>(null);
+PropertyContext.displayName = "PropertyContext";
+
+const useProperty = () => {
+    return useContext(PropertyContext);
+};
+
+interface PropertyContainerContext {
+    updateContainer(update): void;
+}
+
+export interface Property<TValue = unknown> {
+    id?: string;
+    name: string;
+    value?: TValue;
+    properties?: Property[];
+}
+
+const PropertyContainerContext = createContext<PropertyContainerContext>();
+
+function cleanup(properties: Property[]): Property[] {
+    return properties
+        .map(property => {
+            if ("$remove" in property) {
+                return null;
+            }
+
+            return {
+                ...property,
+                properties: cleanup(property.properties)
+            };
+        })
+        .filter(Boolean);
+}
+
+const store = new Map<string, any>();
+
+interface PropertyContainerProps {
+    name: string;
+    // TODO: create a proper type
+    onChange: any;
+}
+
+export const PropertyContainer: FC<PropertyContainerProps> = ({ name, onChange, children }) => {
+    const ref = useRef(store);
+    const context = useMemo(
+        () => ({
+            updateContainer(updater) {
+                const current = store.get(name) || [];
+                const properties = cleanup(updater(current));
+                store.set(name, properties);
+                onChange(properties);
+            }
+        }),
+        [ref]
+    );
+
+    return (
+        <PropertyContainerContext.Provider value={context}>
+            {children}
+        </PropertyContainerContext.Provider>
+    );
+};
+
+interface PropertyProps {
+    id?: string;
+    name: string;
+    value?: unknown;
+    merge?: boolean;
+    replace?: boolean;
+    remove?: boolean;
+}
+
+export const Property: FC<PropertyProps> = ({ children, name, value, ...props }) => {
+    const id = useRef(props.id || nanoid());
+    const [properties, setProperties] = useState([]);
+    const { updateContainer } = useContext(PropertyContainerContext);
+    const parentProperty = useProperty();
+
+    const context: PropertyContext = {
+        removeProperty(id: string) {
+            setProperties(properties => {
+                const index = properties.findIndex(p => p.id === id);
+                if (index > -1) {
+                    return [
+                        ...properties.slice(0, index),
+                        { ...properties[index], $remove: true },
+                        ...properties.slice(index + 1)
+                    ];
+                }
+                return properties;
+            });
+        },
+        updateProperty(property) {
+            setProperties(properties => {
+                const index = properties.findIndex(p => p.id === property.id);
+                if (index > -1) {
+                    return [
+                        ...properties.slice(0, index),
+                        { ...properties[index], ...property },
+                        ...properties.slice(index + 1)
+                    ];
+                }
+                return [...properties, property];
+            });
+        }
+    };
+
+    const indexById = p => p.id === props.id;
+    const indexByName = p => p.name === name;
+
+    const updateParentContainer = property => {
+        updateContainer((properties: Property[]) => {
+            // Check if this property already exists in the parent container.
+            const index = properties.findIndex(props.id ? indexById : indexByName);
+
+            if (props.remove) {
+                if (index > -1) {
+                    return [
+                        ...properties.slice(0, index),
+                        { ...properties[index], $remove: true },
+                        ...properties.slice(index + 1)
+                    ];
+                }
+
+                return properties;
+            }
+
+            if (props.replace) {
+                if (index > -1) {
+                    return [
+                        ...properties.slice(0, index),
+                        { ...property },
+                        ...properties.slice(index + 1)
+                    ];
+                }
+
+                return [...properties, property];
+            }
+
+            if (props.merge) {
+                if (index > -1) {
+                    return [
+                        ...properties.slice(0, index),
+                        {
+                            ...properties[index],
+                            ...property,
+                            properties: mergeProperties(
+                                properties[index].properties,
+                                property.properties
+                            )
+                        },
+                        ...properties.slice(index + 1)
+                    ];
+                }
+            }
+
+            return [...properties, property];
+        });
+    };
+
+    useDeepCompareEffect(() => {
+        const property = { id: id.current, name, value, properties };
+
+        if (!parentProperty) {
+            return updateParentContainer(property);
+        }
+
+        parentProperty.updateProperty(property);
+    }, [properties]);
+
+    useDeepCompareEffect(() => {
+        // On mount, we need to report to our parent.
+        if (parentProperty) {
+            if (props.remove) {
+                parentProperty.removeProperty(id.current);
+            } else {
+                parentProperty.updateProperty({ id: id.current, name, value, properties });
+            }
+        }
+    }, [props.remove, properties]);
+
+    if (!children) {
+        return null;
+    }
+
+    return <PropertyContext.Provider value={context}>{children}</PropertyContext.Provider>;
+};

--- a/packages/app-headless-cms/src/admin/views/contentEntries/hooks/useContentEntriesList.ts
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/hooks/useContentEntriesList.ts
@@ -79,7 +79,7 @@ export function useContentEntriesList() {
     const { data, loading, fetchMore } = useQuery<
         CmsEntriesListQueryResponse,
         CmsEntriesListQueryVariables
-    >(LIST_QUERY, { variables: listQueryVariables });
+    >(LIST_QUERY, { variables: listQueryVariables, fetchPolicy: "network-only" });
 
     const onCreate = useCallback(() => {
         history.push(`/cms/content-entries/${contentModel.modelId}?new=true`);

--- a/packages/app-headless-cms/src/index.ts
+++ b/packages/app-headless-cms/src/index.ts
@@ -1,1 +1,15 @@
 export * from "./HeadlessCMS";
+/**
+ * DANGER!
+ * The following exports are experimental and can change in the future!
+ * You CAN use them, but the API may change in the future. Migration instructions will be included
+ * with the release that breaks them, so you won't be left alone in the dark :)
+ *
+ * These exports contain components to experiment with configurable views (currently only ContentEntries view).
+ */
+export { ContentEntriesViewConfig } from "./admin/views/contentEntries/experiment/ContentEntriesViewConfig";
+
+export type {
+    ContentEntriesViewConfigFilterProps,
+    ContentEntriesViewConfigSorterProps
+} from "./admin/views/contentEntries/experiment/ContentEntriesViewConfig";

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -31,7 +31,8 @@ export interface BindComponentRenderProp<T = any, F = Record<string, any>> {
 
 export interface BindComponentProps {
     name: string;
-    beforeChange?: (value: any, cb: (value: string | string[]) => void) => void;
+    // Form field value can be anything, so we just let it be `any`.
+    beforeChange?: (value: any, cb: (value: any) => void) => void;
     afterChange?: (value: any, form: FormAPI) => void;
     defaultValue?: any;
     validators?: Validator | Validator[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11727,6 +11727,7 @@ __metadata:
     graphql-tag: ^2.12.6
     invariant: ^2.2.4
     lodash: ^4.17.10
+    nanoid: ^3.3.4
     pluralize: ^8.0.0
     prop-types: ^15.7.2
     raw.macro: ^0.4.2
@@ -29455,6 +29456,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "nanoid@npm:3.3.4"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR adds the ability to configure the content entries view filters and sorters using an experimental API.

I'm using this opportunity to test an experiment I've been building on the side for some time now, which should allow us to make UI views configurable, by separating the view _definition_ from _presentation_. With that, we can modify the definition of each view using the view configuration component, and declarative React elements. The presentation then renders the view based on the configuration (view title, actions, fields, event handlers, filters, sorters, etc.).

## How Has This Been Tested?
This was tested by using this configuration system for the core content entry view setup, as well as manually testing the Admin app by creating a custom plugin, registering it, and observing the UI and GraphQL queries.

## Documentation
Since this is an experiment, I don't want to document it yet. Once we verify that this approach makes sense, we'll apply it to the rest of the view (Content Entries), as well as other apps. Then we'll have best practices to document, and potentially helper utils for better DX.

## Example usage

```tsx
import { ContentEntriesViewConfig } from "@webiny/app-headless-cms";

// Grab configuration components from the main view config component.
const { Filter, Sorter } = ContentEntriesViewConfig;

export const App = () => {
    return (
        <Admin>
            <Cognito />
            <ApwAdmin />
            <ContentEntriesViewConfig>
                <Filter name={"category"} element={<CategorySelect/>} />
                <Sorter name={"title_ASC"} label={"Title ASC"}/>
                <Sorter name={"title_DESC"} label={"Title DESC"}/>
            </ContentEntriesViewConfig>
        </Admin>
    );
};
```