### PR TITLE
Fix URI handling in the tenant router

### DIFF
--- a/packages/pulumi-aws/src/components/tenantRouter/functions/origin/request.js
+++ b/packages/pulumi-aws/src/components/tenantRouter/functions/origin/request.js
@@ -1,5 +1,7 @@
 const { DocumentClient } = require("aws-sdk/clients/dynamodb");
 
+// Since Lambda@Edge doesn't support ENV variables, the easiest way to pass
+// config values to it is to inject them into the source code before deploy.
 const DB_TABLE_NAME = "{DB_TABLE_NAME}";
 const DB_TABLE_REGION = "{DB_TABLE_REGION}";
 
@@ -9,26 +11,36 @@ const documentClient = new DocumentClient({
 });
 
 function sanitizeRequestURI(uri) {
-    // Make sure that / is not appended to index.html, or any path with extension.
+    // Make sure that `/` is not appended to index.html, or any path with extension.
+    // We remove all slashes, filter out empty values, and reconstruct the path following
+    // the fact that every page (slug) has a dedicated folder in the S3 bucket, and an `index.html`
+    // file with the actual page HTML.
     const parts = uri.split("/").filter(Boolean);
 
+    // This means that a `/` (homepage) was requested. When the homepage is prerendered, we place its files
+    // into the root of the tenant subfolder, e.g., `/root/index.html`.
     if (!parts.length) {
         return "/index.html";
     }
 
     const lastPart = parts[parts.length - 1];
 
+    // If there's a `.` in the last part of the path, we assume it's a file extension.
+    // In this case, we can reconstruct the path by joining parts with slashes.
     if (lastPart.includes(".")) {
         return ["", ...parts].join("/");
-    } // Otherwise, construct a valid S3 bucket path to an HTML file.
+    }
 
+    // Otherwise, we assume it's a page slug, which needs to point to page's subfolder.
+    // We construct a valid S3 bucket path to an HTML file.
     return ["", ...parts, "index.html"].join("/");
 }
 
 async function handleOriginRequest(request) {
     const requestedDomain = request.headers.host[0].value;
-    const originDomain = request.origin.custom.domainName; // Find tenant by domain
+    const originDomain = request.origin.custom.domainName;
 
+    // Find tenant by domain. This record is stored to the DB using the Tenant Manager app.
     const params = {
         TableName: DB_TABLE_NAME,
         Key: {
@@ -41,20 +53,24 @@ async function handleOriginRequest(request) {
     if (Item) {
         const uri = sanitizeRequestURI(request.uri);
 
+        // To be on the safe side, make sure the requested uri doesn't already include the tenant ID.
         if (uri.startsWith(`/${Item.tenant}/`)) {
-            // Don't include tenant ID twice.
             request.uri = uri;
         } else {
-            // Append tenant ID to point to the correct S3 bucket folder.
+            // Prepend the tenant ID, to point to the correct S3 bucket folder.
             request.uri = `/${Item.tenant}${uri}`;
         }
 
         console.log(`Rewriting request from "${uri}" to "${request.uri}"`);
     } else {
         console.log(`Failed to find a tenant for domain "${requestedDomain}"`);
-    } // Restore the Host header
+    }
 
+    // At this point, the value of the `Host` header is set to the custom domain.
+    // Before forwarding the request to the S3 bucket, we need to set the `Host` header
+    // to the value of the origin (S3 bucket URL).
     request.headers.host[0].value = originDomain;
+
     return request;
 }
 

--- a/packages/pulumi-aws/src/components/tenantRouter/functions/origin/request.js
+++ b/packages/pulumi-aws/src/components/tenantRouter/functions/origin/request.js
@@ -8,14 +8,27 @@ const documentClient = new DocumentClient({
     region: DB_TABLE_REGION
 });
 
-exports.handler = async event => {
-    const request = event.Records[0].cf.request;
-    // console.log(JSON.stringify(event.Records[0].cf, null, 2));
+function sanitizeRequestURI(uri) {
+    // Make sure that / is not appended to index.html, or any path with extension.
+    const parts = uri.split("/").filter(Boolean);
 
+    if (!parts.length) {
+        return "/index.html";
+    }
+
+    const lastPart = parts[parts.length - 1];
+
+    if (lastPart.includes(".")) {
+        return ["", ...parts].join("/");
+    } // Otherwise, construct a valid S3 bucket path to an HTML file.
+
+    return ["", ...parts, "index.html"].join("/");
+}
+
+async function handleOriginRequest(request) {
     const requestedDomain = request.headers.host[0].value;
-    const originDomain = request.origin.custom.domainName;
+    const originDomain = request.origin.custom.domainName; // Find tenant by domain
 
-    // Find tenant by domain
     const params = {
         TableName: DB_TABLE_NAME,
         Key: {
@@ -23,19 +36,34 @@ exports.handler = async event => {
             SK: "A"
         }
     };
-
     const { Item } = await documentClient.get(params).promise();
 
     if (Item) {
-        const from = request.uri.endsWith("/") ? request.uri : request.uri + "/";
-        request.uri = `/${Item.tenant}${from}`;
+        const uri = sanitizeRequestURI(request.uri);
 
-        console.log(`Rewriting request from "${from}" to "${request.uri}"`);
+        if (uri.startsWith(`/${Item.tenant}/`)) {
+            // Don't include tenant ID twice.
+            request.uri = uri;
+        } else {
+            // Append tenant ID to point to the correct S3 bucket folder.
+            request.uri = `/${Item.tenant}${uri}`;
+        }
+
+        console.log(`Rewriting request from "${uri}" to "${request.uri}"`);
     } else {
         console.log(`Failed to find a tenant for domain "${requestedDomain}"`);
-    }
-    // Restore the Host header
+    } // Restore the Host header
+
     request.headers.host[0].value = originDomain;
+    return request;
+}
+
+exports.handler = async event => {
+    const { request, config } = event.Records[0].cf;
+
+    if (config.eventType === "origin-request") {
+        return handleOriginRequest(request);
+    }
 
     return request;
 };


### PR DESCRIPTION
## Changes
This PR fixes URI construction in the tenant router Lambda@Edge function. The bug was discovered on a multi-tenant setup, when a requested page did not exist. That resulted in an error being thrown by the S3 bucket, and triggered CloudFront's `customErrorResponses` configuration, which invoked the tenant router again, with a `_NOT_FOUND_PAGE_/index.html` URI, which then ran into a bug in URI handling.

## How Has This Been Tested?
Manually.

## Documentation
User docs are not necessary, and the tenant router function now contains extensive code comments to cover the entire routing logic.