### PR TITLE
fix(scripts): filter package for those that include package.json file

### DIFF
--- a/scripts/utils/getPackages.js
+++ b/scripts/utils/getPackages.js
@@ -14,7 +14,7 @@ module.exports.rootPackageJson = rootPackageJson;
 let packagesCache;
 
 const isFolder = p => fs.statSync(p).isDirectory();
-const hasPackageJson = p => fs.existsSync(p + "/package.json")
+const hasPackageJson = p => fs.existsSync(p + "/package.json");
 
 module.exports.getPackages = (args = {}) => {
     if (packagesCache) {

--- a/scripts/utils/getPackages.js
+++ b/scripts/utils/getPackages.js
@@ -14,6 +14,7 @@ module.exports.rootPackageJson = rootPackageJson;
 let packagesCache;
 
 const isFolder = p => fs.statSync(p).isDirectory();
+const hasPackageJson = p => fs.existsSync(p + "/package.json")
 
 module.exports.getPackages = (args = {}) => {
     if (packagesCache) {
@@ -22,6 +23,7 @@ module.exports.getPackages = (args = {}) => {
 
     packagesCache = getPackages()
         .filter(isFolder)
+        .filter(hasPackageJson)
         .map(path => {
             if (args.includes) {
                 if (!args.includes.some(p => path.includes(p))) {


### PR DESCRIPTION
## Changes
- Filters out packages folders that don't have a `package.json` file

## Problem solved
- When developers were creating new packages, then switching branches, the `build`  script would fail because the package had been deleted, but the folder was still there (as it has a `/dist/` folder)
- Now the script only attempts to build if there is a package.json file in the package folder