### PR TITLE
Fix Tag Selection in File Manager

### DIFF
--- a/packages/app-admin/src/components/FileManager/FileDetails/Tags.tsx
+++ b/packages/app-admin/src/components/FileManager/FileDetails/Tags.tsx
@@ -255,11 +255,7 @@ const Tags: React.FC<TagsProps> = ({ file, canEdit }) => {
                                 {({ value, ...bindProps }) => (
                                     <MultiAutoComplete
                                         {...bindProps}
-                                        value={tagWithoutScopePrefix(value, queryParams.scope).map(
-                                            value => ({
-                                                name: value
-                                            })
-                                        )}
+                                        value={tagWithoutScopePrefix(value, queryParams.scope)}
                                         options={allTags}
                                         placeholder={"homepage asset"}
                                         description={"Type in a new tag or select an existing one."}

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -137,8 +137,8 @@ function paginateMultipleSelection(
 ) {
     // Assign a real index, so that later when we press delete, we know what is the actual index we're deleting.
     let data = Array.isArray(multipleSelection)
-        // @ts-ignore TODO: Will fix this in the following PR.
-        ? multipleSelection.map((item, index) => ({ ...item, index }))
+        ? // @ts-ignore TODO: Will fix this in the following PR.
+          multipleSelection.map((item, index) => ({ ...item, index }))
         : [];
 
     if (typeof search === "string" && search) {

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -137,6 +137,7 @@ function paginateMultipleSelection(
 ) {
     // Assign a real index, so that later when we press delete, we know what is the actual index we're deleting.
     let data = Array.isArray(multipleSelection)
+        // @ts-ignore TODO: Will fix this in the following PR.
         ? multipleSelection.map((item, index) => ({ ...item, index }))
         : [];
 

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -12,7 +12,6 @@ import { Typography } from "~/Typography";
 import { autoCompleteStyle, suggestionList } from "./styles";
 import { AutoCompleteBaseProps } from "./types";
 import { FormElementMessage } from "~/FormElementMessage";
-
 import { ReactComponent as BaselineCloseIcon } from "./icons/baseline-close-24px.svg";
 import { ReactComponent as PrevIcon } from "./icons/navigate_before-24px.svg";
 import { ReactComponent as NextIcon } from "./icons/navigate_next-24px.svg";
@@ -20,17 +19,18 @@ import { ReactComponent as PrevAllIcon } from "./icons/skip_previous-24px.svg";
 import { ReactComponent as NextAllIcon } from "./icons/skip_next-24px.svg";
 import { ReactComponent as DeleteIcon } from "./icons/baseline-close-24px.svg";
 import { ReactComponent as ReorderIcon } from "./icons/reorder_black_24dp.svg";
-
 import { css } from "emotion";
+import { ListItemGraphic } from "~/List";
+import { AutoCompleteProps } from "~/AutoComplete/AutoComplete";
 
 const listItemMetaClassName = css({
     display: "table"
 });
+
 const iconButtonClassName = css({
     display: "table-cell !important"
 });
-import { ListItemGraphic } from "~/List";
-import { AutoCompleteProps } from "~/AutoComplete/AutoComplete";
+
 const style = {
     pagination: {
         bar: css({
@@ -59,6 +59,7 @@ const style = {
         })
     }
 };
+
 const listStyles = css({
     "&.multi-autocomplete__options-list": {
         listStyle: "none",

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -72,7 +72,8 @@ const listStyles = css({
 interface SelectionItem {
     name: string;
 }
-type MultiAutoCompletePropsValue = SelectionItem[];
+
+type MultiAutoCompletePropsValue = SelectionItem[] | string[];
 
 export interface MultiAutoCompleteProps extends Omit<AutoCompleteBaseProps, "value"> {
     /**
@@ -261,11 +262,11 @@ export class MultiAutoComplete extends React.Component<
     getOptions() {
         const { unique, value, allowFreeInput, useSimpleValues, options } = this.props;
 
+        const values = Array.isArray(value) ? [...value] : [];
         const filtered = options.filter(item => {
             // We need to filter received options.
             // 1) If "unique" prop was passed, we don't want to show already picked options again.
             if (unique) {
-                const values = value;
                 if (Array.isArray(values)) {
                     if (
                         values.find(


### PR DESCRIPTION
## Changes
In the File Manager, when a user would try to add a tag to a file, a React error would be thrown. This was happening because of incorrectly passing the values to the `Tags` component.

This has been updated and adding tags now works as expected.

![Snipaste_2022-05-12_14-14-11](https://user-images.githubusercontent.com/5121148/168072290-acaad166-197f-400e-b024-0df0d8b8a7ca.png)

## How Has This Been Tested?
Cypress.

## Documentation
Changelog.