### PR TITLE
Update Apollo Cache When Updating FM Settings

### DIFF
--- a/packages/app-file-manager/src/admin/views/FileManagerSettings.tsx
+++ b/packages/app-file-manager/src/admin/views/FileManagerSettings.tsx
@@ -46,6 +46,21 @@ const FileManagerSettings: React.FC = () => {
                                         uploadMaxFileSize: parseFloat(data.uploadMaxFileSize),
                                         srcPrefix: data.srcPrefix
                                     }
+                                },
+                                update: (cache, result) => {
+                                    const data = structuredClone(
+                                        cache.readQuery({ query: graphql.GET_SETTINGS })
+                                    );
+
+                                    data.fileManager.getSettings.data = {
+                                        ...data.fileManager.getSettings.data,
+                                        ...result.data.fileManager.updateSettings.data
+                                    };
+
+                                    cache.writeQuery({
+                                        query: graphql.GET_SETTINGS,
+                                        data
+                                    });
                                 }
                             });
                             showSnackbar("Settings updated successfully.");


### PR DESCRIPTION
## Changes
When a user would update the FM settings, for some parts of the Admin Area app, the changes would take effect only if the user would refresh the screen. A simple example is:

1. user uploads a file, and "max file exceeded" error is shown to the user
2. user navigates to FM's settings, updates the "Maximum file upload size" 
3. user navigates back to FM, tries to upload the same file again, and still, the "max file exceeded" error would be shown to the user
4. only after refreshing the screen, the user would be able to upload the file

<img width="874" alt="image" src="https://user-images.githubusercontent.com/5121148/167284117-309007cf-989f-4ca4-9395-c144f2aacc0f.png">

This is because the Apollo cache would not get updated with new values (after the form has been submitted and the underlying GraphQL mutation has been successfully completed).

So, once the GraphQL mutation has been completed, now we make sure the Apollo cache is updated with the new values.

## How Has This Been Tested?
Manual (will add Cypress).

## Documentation
Changelog.
