### PR TITLE
Update Headless CMS types

### DIFF
--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -88,7 +88,7 @@ export const createEntriesStorageOperations = (
                 model,
                 field,
                 value,
-                getStoragePlugin(fieldType: string): StorageTransformPlugin<any> {
+                getStoragePlugin(fieldType: string): StorageTransformPlugin {
                     return storageTransformPlugins[fieldType] || storageTransformPlugins["*"];
                 },
                 plugins

--- a/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
@@ -23,7 +23,9 @@ const baseGroup = new CmsGroupPlugin({
     tenant: "root",
     locale: "en-US",
     id: "group",
-    slug: "group"
+    slug: "group",
+    description: "",
+    icon: ""
 });
 
 const biography = crypto.randomBytes(65536).toString("hex");
@@ -84,6 +86,7 @@ export const createPersonModel = (): CmsModel => {
         layout: Object.values(personModelFields).map(field => {
             return [field.id];
         }),
+        description: "",
         webinyVersion
     };
 };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -138,7 +138,6 @@ const cleanUpdatedInputData = (
 interface DeleteEntryParams {
     model: CmsModel;
     entry: CmsEntry;
-    storageEntry: CmsStorageEntry;
 }
 
 interface EntryIdResult {
@@ -277,7 +276,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
      * A helper to delete the entire entry.
      */
     const deleteEntry = async (params: DeleteEntryParams): Promise<void> => {
-        const { model, entry, storageEntry } = params;
+        const { model, entry } = params;
         try {
             await onBeforeEntryDelete.publish({
                 entry,
@@ -285,8 +284,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             });
 
             await storageOperations.entries.delete(model, {
-                entry,
-                storageEntry
+                entry
             });
 
             await onAfterEntryDelete.publish({
@@ -962,8 +960,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             if (entryToDelete.id === latestEntryRevisionId && !previousStorageEntry) {
                 return await deleteEntry({
                     model,
-                    entry: entryToDelete,
-                    storageEntry: storageEntryToDelete
+                    entry: entryToDelete
                 });
             }
             /**
@@ -1025,8 +1022,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
             return await deleteEntry({
                 model,
-                entry,
-                storageEntry
+                entry
             });
         },
         publishEntry: async (model, id) => {

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModelGroup.crud.ts
@@ -218,10 +218,12 @@ export const createModelGroupsCrud = (params: CreateModelGroupsCrudParams): CmsG
 
             const createdData = new CreateContentModelGroupModel().populate({
                 ...inputData,
-                slug: inputData.slug ? utils.toSlug(inputData.slug) : ""
+                slug: inputData.slug ? utils.toSlug(inputData.slug) : "",
+                description: inputData.description || ""
             });
             await createdData.validate();
-            const input: CmsGroupCreateInput & { slug: string } = await createdData.toJSON();
+            const input: CmsGroupCreateInput & { slug: string; description: string } =
+                await createdData.toJSON();
 
             const identity = getIdentity();
 

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -832,7 +832,7 @@ export interface CmsGroup {
     /**
      * Description for the group.
      */
-    description?: string;
+    description: string;
     /**
      * Icon for the group. In a form of "ico/ico".
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2073,17 +2073,11 @@ export interface CmsEntryStorageOperationsDeleteRevisionParams<
     latestStorageEntry: T | null;
 }
 
-export interface CmsEntryStorageOperationsDeleteParams<
-    T extends CmsStorageEntry = CmsStorageEntry
-> {
+export interface CmsEntryStorageOperationsDeleteParams {
     /**
      * Entry that is going to be deleted.
      */
     entry: CmsEntry;
-    /**
-     * Entry that is going to be deleted, directly from storage.
-     */
-    storageEntry: T;
 }
 
 export interface CmsEntryStorageOperationsPublishParams<
@@ -2298,7 +2292,7 @@ export interface CmsEntryStorageOperations<T extends CmsStorageEntry = CmsStorag
     /**
      * Delete the entry.
      */
-    delete: (model: CmsModel, params: CmsEntryStorageOperationsDeleteParams<T>) => Promise<void>;
+    delete: (model: CmsModel, params: CmsEntryStorageOperationsDeleteParams) => Promise<void>;
     /**
      * Publish the entry.
      */


### PR DESCRIPTION
## Changes
This PR removes some unused parameters form TS types (`storageEntry` is not used in `delete` method), and also makes CmsGroup property `description` required.

## How Has This Been Tested?
Jest tests.
