### PR TITLE
fix(app-headless-cms): set field as title

### DIFF
--- a/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
@@ -86,7 +86,7 @@ const Field: React.FC<FieldProps> = props => {
             return { ...data, titleFieldId: field.fieldId };
         });
 
-        if (response.error) {
+        if (response && response.error) {
             return showSnackbar(response.error.message);
         }
 


### PR DESCRIPTION
## Changes
Setting field as title produced an error because of no response from setData.

## How Has This Been Tested?
Manually.
