### PR TITLE
feat(api-headless-cms): remove unnecessary entry passed into so

### DIFF
--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -150,7 +150,7 @@ export const createEntriesStorageOperations = (
         model: CmsModel,
         params: CmsEntryStorageOperationsCreateRevisionFromParams
     ) => {
-        const { entry, storageEntry, latestEntry } = params;
+        const { entry, storageEntry } = params;
 
         const partitionKey = createPartitionKey(entry);
         /**
@@ -190,7 +190,6 @@ export const createEntriesStorageOperations = (
                 ex.code || "CREATE_REVISION_ERROR",
                 {
                     error: ex,
-                    latestEntry,
                     entry,
                     storageEntry
                 }

--- a/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentEntry.crud.ts
@@ -660,10 +660,6 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
             utils.checkOwnership(context, permission, originalEntry);
 
-            const latestEntry = latestStorageEntry
-                ? await entryFromStorageTransform(context, model, latestStorageEntry)
-                : null;
-
             const identity = context.security.getIdentity();
 
             const latestId = latestStorageEntry ? latestStorageEntry.id : sourceId;
@@ -700,9 +696,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
                 const result = await storageOperations.entries.createRevisionFrom(model, {
                     entry,
-                    storageEntry,
-                    latestEntry,
-                    latestStorageEntry
+                    storageEntry
                 });
 
                 await onAfterEntryCreateRevision.publish({

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2024,14 +2024,6 @@ export interface CmsEntryStorageOperationsCreateRevisionFromParams<
     T extends CmsStorageEntry = CmsStorageEntry
 > {
     /**
-     * Latest entry, used to calculate the new version.
-     */
-    latestEntry: CmsEntry | null;
-    /**
-     * Latest entry, used to calculate the new version, directly from storage, with transformations.
-     */
-    latestStorageEntry: T | null;
-    /**
      * Real entry, with no transformations on it.
      */
     entry: CmsEntry;


### PR DESCRIPTION
## Changes
Remove unnecessary latestEntry and latestStorageEntry passed into createRevisionFrom storage operation.

## How Has This Been Tested?
Jest.

## Documentation
Write in the doc that the parameter has been removed.