### PR TITLE
fix(api-headless-cms): storage operations generate pk out of model

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -109,12 +109,14 @@ export const createEntriesStorageOperations = (
 
     const create = async (model: CmsModel, params: CmsEntryStorageOperationsCreateParams) => {
         const { entry, storageEntry } = params;
+        const isPublished = entry.status === "published";
+        const locked = isPublished ? true : entry.locked;
 
         const esEntry = prepareEntryToIndex({
             plugins,
             model,
-            entry: lodashCloneDeep(entry),
-            storageEntry: lodashCloneDeep(storageEntry)
+            entry: lodashCloneDeep({ ...entry, locked }),
+            storageEntry: lodashCloneDeep({ ...storageEntry, locked })
         });
 
         const { index: esIndex } = configurations.es({
@@ -122,29 +124,60 @@ export const createEntriesStorageOperations = (
         });
 
         const esLatestData = await getESLatestEntryData(plugins, esEntry);
+        const esPublishedData = await getESPublishedEntryData(plugins, esEntry);
 
         const revisionKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createRevisionSortKey(entry)
         };
 
         const latestKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createLatestSortKey()
+        };
+
+        const publishedKeys = {
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
+            SK: createPublishedSortKey()
         };
 
         const items = [
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 ...revisionKeys,
                 TYPE: createType()
             }),
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 ...latestKeys,
                 TYPE: createLatestType()
             })
         ];
+
+        if (isPublished) {
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    locked,
+                    ...publishedKeys,
+                    TYPE: createPublishedType()
+                })
+            );
+        }
 
         try {
             await batchWriteAll({
@@ -166,11 +199,27 @@ export const createEntriesStorageOperations = (
             );
         }
 
-        try {
-            await esEntity.put({
+        const esItems = [
+            esEntity.putBatch({
                 ...latestKeys,
                 index: esIndex,
                 data: esLatestData
+            })
+        ];
+        if (isPublished) {
+            esItems.push(
+                esEntity.putBatch({
+                    ...publishedKeys,
+                    index: esIndex,
+                    data: esPublishedData
+                })
+            );
+        }
+
+        try {
+            await batchWriteAll({
+                table: esEntity.table,
+                items: esItems
             });
         } catch (ex) {
             throw new WebinyError(
@@ -193,11 +242,19 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry, storageEntry } = params;
         const revisionKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createRevisionSortKey(entry)
         };
         const latestKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createLatestSortKey()
         };
 
@@ -272,13 +329,34 @@ export const createEntriesStorageOperations = (
 
     const update = async (model: CmsModel, params: CmsEntryStorageOperationsUpdateParams) => {
         const { entry, storageEntry } = params;
+
+        const isPublished = entry.status === "published";
+        const locked = isPublished ? true : entry.locked;
+
         const revisionKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createRevisionSortKey(entry)
         };
         const latestKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createLatestSortKey()
+        };
+
+        const publishedKeys = {
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
+            SK: createPublishedSortKey()
         };
 
         /**
@@ -289,18 +367,40 @@ export const createEntriesStorageOperations = (
             ids: [entry.id]
         });
 
+        const [publishedStorageEntry] = await dataLoaders.getPublishedRevisionByEntryId({
+            model,
+            ids: [entry.id]
+        });
+
         const items = [
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 ...revisionKeys,
                 TYPE: createType()
             })
         ];
+        if (isPublished) {
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    locked,
+                    ...publishedKeys,
+                    TYPE: createPublishedType()
+                })
+            );
+        }
+
+        const esItems = [];
+
+        const { index: esIndex } = configurations.es({
+            model
+        });
         /**
          * If the latest entry is the one being updated, we need to create a new latest entry records.
          */
-        let elasticsearchLatestData = null;
-        if (latestStorageEntry.id === entry.id) {
+        let elasticsearchLatestData: any = null;
+        if (latestStorageEntry && latestStorageEntry.id === entry.id) {
             /**
              * First we update the regular DynamoDB table
              */
@@ -317,11 +417,61 @@ export const createEntriesStorageOperations = (
             const esEntry = prepareEntryToIndex({
                 plugins,
                 model,
-                entry: lodashCloneDeep(entry),
-                storageEntry: lodashCloneDeep(storageEntry)
+                entry: lodashCloneDeep({
+                    ...entry,
+                    locked
+                }),
+                storageEntry: lodashCloneDeep({
+                    ...storageEntry,
+                    locked
+                })
             });
 
             elasticsearchLatestData = await getESLatestEntryData(plugins, esEntry);
+
+            esItems.push(
+                esEntity.putBatch({
+                    ...latestKeys,
+                    index: esIndex,
+                    data: elasticsearchLatestData
+                })
+            );
+        }
+        let elasticsearchPublishedData = null;
+        if (isPublished && publishedStorageEntry && publishedStorageEntry.id === entry.id) {
+            if (!elasticsearchLatestData) {
+                /**
+                 * And then update the Elasticsearch table to propagate changes to the Elasticsearch
+                 */
+                const esEntry = prepareEntryToIndex({
+                    plugins,
+                    model,
+                    entry: lodashCloneDeep({
+                        ...entry,
+                        locked
+                    }),
+                    storageEntry: lodashCloneDeep({
+                        ...storageEntry,
+                        locked
+                    })
+                });
+                elasticsearchPublishedData = await getESPublishedEntryData(plugins, esEntry);
+            } else {
+                elasticsearchPublishedData = {
+                    ...elasticsearchLatestData,
+                    published: true,
+                    TYPE: createPublishedType(),
+                    __type: createPublishedType()
+                };
+                delete elasticsearchPublishedData.latest;
+            }
+            esItems.push(
+                esEntity.putBatch({
+                    ...publishedKeys,
+                    index: esIndex,
+                    data: elasticsearchPublishedData
+                })
+            );
         }
         try {
             await batchWriteAll({
@@ -342,21 +492,18 @@ export const createEntriesStorageOperations = (
                 }
             );
         }
-        if (!elasticsearchLatestData) {
+        if (esItems.length === 0) {
             return storageEntry;
         }
-        const { index: esIndex } = configurations.es({
-            model
-        });
+
         try {
-            await esEntity.put({
-                ...latestKeys,
-                index: esIndex,
-                data: elasticsearchLatestData
+            await batchWriteAll({
+                table: esEntity.table,
+                items: esItems
             });
         } catch (ex) {
             throw new WebinyError(
-                ex.message || "Could not update entry DynamoDB Elasticsearch record.",
+                ex.message || "Could not update entry DynamoDB Elasticsearch records.",
                 ex.code || "UPDATE_ES_ENTRY_ERROR",
                 {
                     error: ex,
@@ -370,7 +517,11 @@ export const createEntriesStorageOperations = (
     const deleteEntry = async (model: CmsModel, params: CmsEntryStorageOperationsDeleteParams) => {
         const { entry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         const items = await queryAll<CmsEntry>({
             entity,
@@ -444,7 +595,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry, latestEntry, latestStorageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         const { index } = configurations.es({
             model
@@ -664,15 +819,27 @@ export const createEntriesStorageOperations = (
         });
 
         const revisionKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createRevisionSortKey(entry)
         };
         const latestKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createLatestSortKey()
         };
         const publishedKeys = {
-            PK: createPartitionKey(entry),
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             SK: createPublishedSortKey()
         };
 
@@ -866,7 +1033,11 @@ export const createEntriesStorageOperations = (
             ids: [entry.id]
         });
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         const items = [
             entity.deleteBatch({
@@ -970,7 +1141,11 @@ export const createEntriesStorageOperations = (
             ids: [entry.id]
         });
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         /**
          * If we updated the latest version, then make sure the changes are propagated to ES too.
@@ -1054,7 +1229,11 @@ export const createEntriesStorageOperations = (
             ids: [entry.id]
         });
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         const items = [
             entity.putBatch({

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -99,7 +99,15 @@ export const createEntriesStorageOperations = (
     const create = async (model: CmsModel, args: CmsEntryStorageOperationsCreateParams) => {
         const { entry, storageEntry } = args;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
+
+        const isPublished = entry.status === "published";
+
+        const locked = isPublished ? true : entry.locked;
         /**
          * We need to:
          *  - create new main entry item
@@ -108,6 +116,7 @@ export const createEntriesStorageOperations = (
         const items = [
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 PK: partitionKey,
                 SK: createRevisionSortKey(entry),
                 TYPE: createType(),
@@ -116,6 +125,7 @@ export const createEntriesStorageOperations = (
             }),
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 PK: partitionKey,
                 SK: createLatestSortKey(),
                 TYPE: createLatestType(),
@@ -123,6 +133,23 @@ export const createEntriesStorageOperations = (
                 GSI1_SK: createGSISortKey(storageEntry)
             })
         ];
+
+        /**
+         * We need to create published entry if
+         */
+        if (isPublished) {
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    locked,
+                    PK: partitionKey,
+                    SK: createPublishedSortKey(),
+                    TYPE: createLatestType(),
+                    GSI1_PK: createGSIPartitionKey(model, "P"),
+                    GSI1_SK: createGSISortKey(storageEntry)
+                })
+            );
+        }
 
         try {
             await batchWriteAll({
@@ -152,7 +179,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry, storageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
         /**
          * We need to:
          *  - create the main entry item
@@ -203,7 +234,14 @@ export const createEntriesStorageOperations = (
 
     const update = async (model: CmsModel, params: CmsEntryStorageOperationsUpdateParams) => {
         const { entry, storageEntry } = params;
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
+
+        const isPublished = entry.status === "published";
+        const locked = isPublished ? true : entry.locked;
 
         const items = [];
         /**
@@ -214,6 +252,7 @@ export const createEntriesStorageOperations = (
         items.push(
             entity.putBatch({
                 ...storageEntry,
+                locked,
                 PK: partitionKey,
                 SK: createRevisionSortKey(storageEntry),
                 TYPE: createType(),
@@ -221,6 +260,20 @@ export const createEntriesStorageOperations = (
                 GSI1_SK: createGSISortKey(storageEntry)
             })
         );
+
+        if (isPublished) {
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    locked,
+                    PK: partitionKey,
+                    SK: createPublishedSortKey(),
+                    TYPE: createPublishedType(),
+                    GSI1_PK: createGSIPartitionKey(model, "P"),
+                    GSI1_SK: createGSISortKey(storageEntry)
+                })
+            );
+        }
 
         /**
          * We need the latest entry to update it as well if neccessary.
@@ -231,6 +284,7 @@ export const createEntriesStorageOperations = (
             items.push(
                 entity.putBatch({
                     ...storageEntry,
+                    locked,
                     PK: partitionKey,
                     SK: createLatestSortKey(),
                     TYPE: createLatestType(),
@@ -267,7 +321,11 @@ export const createEntriesStorageOperations = (
 
         const queryAllParams: QueryAllParams = {
             entity,
-            partitionKey: createPartitionKey(entry),
+            partitionKey: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
             options: {
                 gte: " "
             }
@@ -319,7 +377,11 @@ export const createEntriesStorageOperations = (
         params: CmsEntryStorageOperationsDeleteRevisionParams
     ) => {
         const { entry, latestEntry, latestStorageEntry } = params;
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         const items = [
             entity.deleteBatch({
@@ -443,13 +505,12 @@ export const createEntriesStorageOperations = (
         model: CmsModel,
         params: CmsEntryStorageOperationsGetPreviousRevisionParams
     ) => {
-        const { tenant, locale } = model;
         const { entryId, version } = params;
         const queryParams: QueryOneParams = {
             entity,
             partitionKey: createPartitionKey({
-                tenant,
-                locale,
+                tenant: model.tenant,
+                locale: model.locale,
                 id: entryId
             }),
             options: {
@@ -600,7 +661,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry, storageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         /**
          * We need to:
@@ -662,7 +727,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry, storageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
         /**
          * We need to:
          *  - update existing entry
@@ -721,7 +790,11 @@ export const createEntriesStorageOperations = (
     const publish = async (model: CmsModel, params: CmsEntryStorageOperationsPublishParams) => {
         const { entry, storageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
 
         /**
          * We need the latest and published entries to see if something needs to be updated along side the publishing one.
@@ -804,7 +877,11 @@ export const createEntriesStorageOperations = (
     const unpublish = async (model: CmsModel, params: CmsEntryStorageOperationsUnpublishParams) => {
         const { entry, storageEntry } = params;
 
-        const partitionKey = createPartitionKey(entry);
+        const partitionKey = createPartitionKey({
+            id: entry.id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
         /**
          * We need to:
          *  - delete currently published entry

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -574,7 +574,8 @@ describe("content model test", () => {
                         code: "VALIDATION_ERROR",
                         message: `Field does not exist in the model.`,
                         data: {
-                            fieldId: "nonExistingTitleFieldId"
+                            fieldId: "nonExistingTitleFieldId",
+                            fields: expect.any(Array)
                         }
                     }
                 }

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -112,7 +112,9 @@ describe("filtering", () => {
         // If this `until` resolves successfully, we know entry is accessible via the "read" API
         await until(
             () => listFruits({}).then(([data]: any) => data),
-            ({ data }: any) => data.listFruits.data.length === 3,
+            ({ data }: any) => {
+                return data.listFruits.data.length === 3;
+            },
             { name: `list all fruits - ${name}` }
         );
     };

--- a/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeUpdate.ts
+++ b/packages/api-headless-cms/src/content/plugins/crud/contentModel/beforeUpdate.ts
@@ -34,7 +34,8 @@ const getContentModelTitleFieldId = (fields: CmsModelField[], titleFieldId?: str
     const target = fields.find(f => f.fieldId === titleFieldId);
     if (!target) {
         throw new WebinyError(`Field does not exist in the model.`, "VALIDATION_ERROR", {
-            fieldId: titleFieldId
+            fieldId: titleFieldId,
+            fields
         });
     }
 

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
@@ -91,7 +91,7 @@ const Field: React.FC<FieldProps> = props => {
         }
 
         showSnackbar(t`Title field set successfully.`);
-    }, [field.fieldId]);
+    }, [field.fieldId, setData]);
 
     const fieldPlugin = getFieldPlugin(field.type);
     const editorFieldOptionPlugins =


### PR DESCRIPTION
## Changes
Storage operations for the Headless CMS were taking locale and tenant out of entries - now it is switched to a model.
Fix for `Use as title` in app-headless-cms - bug happens when user adds new field and sets it as title and then tries to save the model.-

## How Has This Been Tested?
Jest and manually.
