### PR TITLE
Require node >=14 to create a Webiny project

### DIFF
--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -7,14 +7,14 @@ const semver = require("semver");
 const currentNodeVersion = process.versions.node;
 
 (async () => {
-    if (!semver.satisfies(currentNodeVersion, "^12 || ^14")) {
+    if (!semver.satisfies(currentNodeVersion, ">=14")) {
         console.error(
             chalk.red(
-                "You are running Node " +
-                    currentNodeVersion +
-                    ".\n" +
-                    "Webiny requires Node ^12 or ^14. \n" +
-                    "Please update your version of Node."
+                [
+                    `You are running Node.js ${currentNodeVersion}, but Webiny requires version 14 or higher.`,
+                    `Please switch to one of the required versions and try again.`,
+                    `For more information, please visit https://docs.webiny.com/docs/tutorials/install-webiny#prerequisites.`
+                ].join(" ")
             )
         );
         process.exit(1);
@@ -22,13 +22,15 @@ const currentNodeVersion = process.versions.node;
 
     try {
         const { stdout } = await execa("yarn", ["--version"]);
-        if (!semver.satisfies(stdout, "^2||^3")) {
-            console.error(chalk.red(`"@webiny/cli" requires yarn ^2 or ^3 to be installed!`));
+        if (!semver.satisfies(stdout, ">=2")) {
+            console.error(chalk.red(`"@webiny/cli" requires yarn >=2!`));
             process.exit(1);
         }
     } catch (err) {
-        console.error(chalk.red(`"@webiny/cli" requires yarn ^2 or ^3 to be installed!`));
-        console.log(`Please visit https://yarnpkg.com/ to install "yarn".`);
+        console.error(chalk.red(`"@webiny/cli" requires yarn >=2!`));
+        console.log(
+            `Run ${chalk.blue("yarn set version berry")} to install a compatible version of yarn.`
+        );
         process.exit(1);
     }
 

--- a/packages/create-webiny-project/bin.js
+++ b/packages/create-webiny-project/bin.js
@@ -8,12 +8,12 @@ const verifyConfig = require("./utils/verifyConfig");
 
 (async () => {
     const nodeVersion = process.versions.node;
-    if (!semver.satisfies(nodeVersion, "^12 || ^14")) {
+    if (!semver.satisfies(nodeVersion, ">=14")) {
         console.error(
             chalk.red(
                 [
-                    `You are running Node.js ${nodeVersion}, but Webiny requires version 12 or 14.`,
-                    `Please switch to one of the two versions and try again.`,
+                    `You are running Node.js ${nodeVersion}, but Webiny requires version 14 or higher.`,
+                    `Please switch to one of the required versions and try again.`,
                     "For more information, please visit https://docs.webiny.com/docs/tutorials/install-webiny#prerequisites."
                 ].join(" ")
             )
@@ -23,7 +23,7 @@ const verifyConfig = require("./utils/verifyConfig");
 
     try {
         const yarnVersion = await getYarnVersion();
-        if (!semver.satisfies(yarnVersion, "^1.22.0 || ^2 || ^3")) {
+        if (!semver.satisfies(yarnVersion, ">=1.22.0")) {
             console.error(
                 chalk.red(
                     [


### PR DESCRIPTION
## Changes
`create-webiny-project` and `@webiny/cli` will now require node >=14.

## How Has This Been Tested?
Manually.

## Documentation
TODO