### PR TITLE
Tools Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "watch:apps": "yarn webiny ws run watch --scope='@webiny/app*'",
     "watch:api": "yarn webiny ws run watch --scope='@webiny/api*'",
     "clear-dist": "yarn rimraf packages/*/dist",
+    "delete-empty-package-folders": "node scripts/deleteEmptyPackageFolders.js",
     "contributors:add": "contreebutors add --username",
     "contributors:generate": "contreebutors render",
     "commit": "node ./scripts/commitizen.js",

--- a/packages/project-utils/workspaces/index.js
+++ b/packages/project-utils/workspaces/index.js
@@ -1,12 +1,12 @@
 const fs = require("fs");
 const { linkWorkspaces } = require("./linkWorkspaces");
 
-const isFolder = p => fs.statSync(p).isDirectory();
+const hasPackageJson = p => fs.existsSync(p + "/package.json");
 
 const allWorkspaces = () => {
     const path = require("path");
     return require("get-yarn-workspaces")()
-        .filter(isFolder)
+        .filter(hasPackageJson)
         .map(pkg => pkg.replace(/\//g, path.sep));
 };
 

--- a/scripts/deleteEmptyPackageFolders.js
+++ b/scripts/deleteEmptyPackageFolders.js
@@ -1,0 +1,44 @@
+const fs = require("fs");
+const getPackages = require("get-yarn-workspaces");
+const { argv } = require("yargs");
+
+const isMissingPackageJson = p => !fs.existsSync(p + "/package.json");
+
+const args = {
+    preview: argv.preview
+};
+
+/**
+ * Deletes empty package folders. Useful when switching branches and when left with empty package folders.
+ * Pass "--preview" to prevent any actual deletions from happening. Will only return a list of packages.
+ */
+
+(async () => {
+    const packagesWithoutPackageJson = getPackages().filter(isMissingPackageJson);
+
+    if (packagesWithoutPackageJson.length) {
+        console.log(`Found ${packagesWithoutPackageJson.length} empty package folder(s).`);
+        console.log("The following folder(s) will be deleted:");
+        for (let i = 0; i < packagesWithoutPackageJson.length; i++) {
+            const pkg = packagesWithoutPackageJson[i];
+            console.log(`${i + 1}. ${pkg}`);
+        }
+    } else {
+        console.log("There are no empty package folders to delete. Exiting...");
+        process.exit(0);
+    }
+
+    console.log();
+    if (args.preview === false) {
+        for (let i = 0; i < packagesWithoutPackageJson.length; i++) {
+            const pkg = packagesWithoutPackageJson[i];
+            fs.rmdirSync(pkg, { recursive: true });
+        }
+
+        console.log("Empty package folders deleted.");
+    } else {
+        console.log(
+            "Note: in order to actually delete these folders, run the command again, with the --no-preview flag."
+        );
+    }
+})();


### PR DESCRIPTION
## Changes

#### 1. Introduced `delete-empty-package-folders`

When switching branches, I often get left with empty folders in `packages` folder. Then I have to manually delete them, because otherwise, different "invalid package" errors start to occur within various tools. For example:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/5121148/170073980-6c06c47e-7f5a-48c2-a033-2ade7b35cc33.png">


This PR introduces a simple `delete-empty-package-folders` command that will quickly clear all folders that are empty (leftovers from the previous branch).

#### 2. `webiny workspaces` - Improve Package Validity Check

As per comments below, the thing that pushed me to create a cleanup script was an error that I received when running `webiny watch` command ([see](https://github.com/webiny/webiny-js/pull/2426#issuecomment-1136266299)). But after further investigation, I found out that [this simple fix](https://github.com/webiny/webiny-js/pull/2426/commits/8ea1e83f5a94ec8dcb0da36326a981884da18889) was only thing that was needed to resolve it. 

So, from now on, these scripts will work even when there are leftover folders in dev's project.

## How Has This Been Tested?
Manual testing.

## Documentation
None. Internal tooling. Script added to `package.json`.