### PR TITLE
Ensure `hook-before-deploy` Hook Is Invoked Before Pulumi

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/deploy.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy.js
@@ -69,6 +69,15 @@ module.exports = async (inputs, context) => {
         return;
     }
 
+
+    await runHook({
+        hookName: "hook-before-deploy",
+        hookFn: application.onBeforeDeploy,
+        skip: inputs.preview,
+        args: hookArgs,
+        context
+    });
+
     await login(projectApplication);
 
     const pulumi = await getPulumi({
@@ -93,14 +102,6 @@ module.exports = async (inputs, context) => {
             await login(projectApplication);
         });
     }
-
-    await runHook({
-        hookName: "hook-before-deploy",
-        hookFn: application.onBeforeDeploy,
-        skip: inputs.preview,
-        args: hookArgs,
-        context
-    });
 
     console.log();
     const continuing = inputs.preview ? `Previewing deployment...` : `Deploying...`;

--- a/packages/cli-plugin-deploy-pulumi/commands/deploy.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy.js
@@ -69,7 +69,6 @@ module.exports = async (inputs, context) => {
         return;
     }
 
-
     await runHook({
         hookName: "hook-before-deploy",
         hookFn: application.onBeforeDeploy,


### PR DESCRIPTION
## Changes
As the title says, this PR ensures that, within the `webiny deploy` command, the `hook-before-deploy` hook is invoked **before** Pulumi starts executing the cloud infra code.

The main reason behind this change is the fact that within the new WCP-related CLI hooks we are setting some environment variables ([`WCP_PROJECT_ENVIRONMENT`](https://github.com/webiny/webiny-js/blob/wcpls-06-before-deploy-hook-move/packages/cli/commands/wcp/hooks.js#L73)). Prior to this PR, these environments would be set too late and would not be available while Pulumi is executing the cloud infra code.

## How Has This Been Tested?
Manually.

## Documentation
N/A (internal fix)