### PR TITLE
fix(app-headless-cms): ensure value is an array

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -38,7 +38,7 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
                 const { onChange } = bind;
 
                 // We need to make sure the value is an array, since this is a multi-value component.
-                const value = bind.value || [];
+                const value = (Array.isArray(bind.value) ? bind.value : [bind.value]).filter(Boolean);
 
                 return (
                     <FileUploadWrapper className={imageWrapperStyles}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -38,7 +38,9 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
                 const { onChange } = bind;
 
                 // We need to make sure the value is an array, since this is a multi-value component.
-                const value = (Array.isArray(bind.value) ? bind.value : [bind.value]).filter(Boolean);
+                const value: string[] = (
+                    Array.isArray(bind.value) ? bind.value : [bind.value]
+                ).filter(Boolean);
 
                 return (
                     <FileUploadWrapper className={imageWrapperStyles}>
@@ -71,18 +73,20 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
                                             <Label>{field.label}</Label>
                                         </Cell>
 
-                                        {value.map((url: string, index: number) => (
-                                            <Cell span={3} key={url}>
-                                                <File
-                                                    url={url}
-                                                    showFileManager={() => selectFiles(index)}
-                                                    onRemove={() =>
-                                                        onChange(dotProp.delete(value, index))
-                                                    }
-                                                    placeholder={t`Select a file"`}
-                                                />
-                                            </Cell>
-                                        ))}
+                                        <>
+                                            {value.map((url: string, index: number) => (
+                                                <Cell span={3} key={url}>
+                                                    <File
+                                                        url={url}
+                                                        showFileManager={() => selectFiles(index)}
+                                                        onRemove={() =>
+                                                            onChange(dotProp.delete(value, index))
+                                                        }
+                                                        placeholder={t`Select a file"`}
+                                                    />
+                                                </Cell>
+                                            ))}
+                                        </>
 
                                         <Cell span={3}>
                                             <File

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -35,7 +35,11 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
     return (
         <Bind>
             {bind => {
-                const { value, onChange } = bind;
+                const { onChange } = bind;
+
+                // We need to make sure the value is an array, since this is a multi-value component.
+                const value = bind.value || [];
+
                 return (
                     <FileUploadWrapper className={imageWrapperStyles}>
                         <FileManager multiple={true} images={imagesOnly}>
@@ -51,7 +55,7 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
 
                                         const urls = files.map(f => f.src);
                                         if (index === -1) {
-                                            onChange([...(value || []), ...urls]);
+                                            onChange([...value, ...urls]);
                                         } else {
                                             onChange([
                                                 ...value.slice(0, index),

--- a/scripts/listPackagesWithTests.js
+++ b/scripts/listPackagesWithTests.js
@@ -56,8 +56,9 @@ const CUSTOM_HANDLERS = {
     }
 };
 
-/**
+const testFilePattern = /test\.j?t?sx?$/;
 
+/**
  * @param folder
  * @returns boolean
  */
@@ -74,8 +75,8 @@ function hasTestFiles(folder) {
             if (hasTFiles) {
                 return true;
             }
-        } else if (filepath.endsWith("test.js") || filepath.endsWith("test.ts")) {
-            return true;
+        } else {
+            return testFilePattern.test(filepath);
         }
     }
     return false;


### PR DESCRIPTION
## Changes
This PR ensures that `file` field renderer value defaults to an array when configured as `multipleValues=true`.

Closes #2452 

## How Has This Been Tested?
Manually.
