### PR TITLE
Extract the Composition API into a standalone package

### DIFF
--- a/packages/app-admin-core/package.json
+++ b/packages/app-admin-core/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.14.0",
     "@webiny/app": "^5.27.0",
     "@webiny/plugins": "^5.27.0",
+    "@webiny/react-composition": "^5.27.0",
     "@webiny/react-router": "^5.27.0",
     "lodash.debounce": "^4.0.8",
     "react": "16.14.0",

--- a/packages/app-admin-core/src/index.ts
+++ b/packages/app-admin-core/src/index.ts
@@ -1,9 +1,11 @@
+// Composition - we re-export this for ease of use
+export * from "@webiny/react-composition";
+export type { HigherOrderComponent, ComposeProps, ComposableFC } from "@webiny/react-composition";
+
 // Admin framework
 export * from "./admin";
-export * from "./makeComposable";
-export type { AdminProps, HigherOrderComponent } from "./admin";
+export type { AdminProps } from "./admin";
 // Core components
-export * from "./components/core/Compose";
 export * from "./components/core/Plugins";
 export * from "./components/core/Provider";
 export * from "./components/core/Routes";

--- a/packages/app-admin-core/tsconfig.build.json
+++ b/packages/app-admin-core/tsconfig.build.json
@@ -4,7 +4,8 @@
   "references": [
     { "path": "../app/tsconfig.build.json" },
     { "path": "../plugins/tsconfig.build.json" },
-    { "path": "../react-router/tsconfig.build.json" }
+    { "path": "../react-router/tsconfig.build.json" },
+    { "path": "../react-composition/tsconfig.build.json" }
   ],
   "compilerOptions": {
     "rootDir": "./src",

--- a/packages/app-admin-core/tsconfig.json
+++ b/packages/app-admin-core/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__/**/*.ts"],
-  "references": [{ "path": "../app" }, { "path": "../plugins" }, { "path": "../react-router" }],
+  "references": [
+    { "path": "../app" },
+    { "path": "../plugins" },
+    { "path": "../react-composition" },
+    { "path": "../react-router" }
+  ],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",
@@ -12,6 +17,7 @@
       "@webiny/app": ["../app/src"],
       "@webiny/plugins/*": ["../plugins/src/*"],
       "@webiny/plugins": ["../plugins/src"],
+      "@webiny/react-composition": ["../react-composition/src/*"],
       "@webiny/react-router/*": ["../react-router/src/*"],
       "@webiny/react-router": ["../react-router/src"]
     },

--- a/packages/react-composition/.babelrc.js
+++ b/packages/react-composition/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.react")({ path: __dirname });

--- a/packages/react-composition/LICENSE
+++ b/packages/react-composition/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-composition/README.md
+++ b/packages/react-composition/README.md
@@ -1,0 +1,8 @@
+# Validation
+[![](https://img.shields.io/npm/dw/@webiny/react-composition.svg)](https://www.npmjs.com/package/@webiny/react-composition) 
+[![](https://img.shields.io/npm/v/@webiny/react-composition.svg)](https://www.npmjs.com/package/@webiny/react-composition)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+A tiny composition framework for React components which makes it possible to compose components anywhere in your application. 
+

--- a/packages/react-composition/jest.config.js
+++ b/packages/react-composition/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/react-composition/package.json
+++ b/packages/react-composition/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@webiny/react-composition",
+  "version": "5.27.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "description": "A tiny composition framework for React components.",
+  "contributors": [
+    "Pavel Denisjuk <pavel@webiny.com>",
+    "Sven Al Hamad <sven@webiny.com>",
+    "Adrian Smijulj <adrian@webiny.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.16.3",
+    "@types/react": "^16.14.0",
+    "lodash.debounce": "^4.0.8",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.16.0",
+    "@babel/core": "^7.16.0",
+    "@babel/preset-env": "^7.16.4",
+    "@babel/preset-typescript": "^7.16.0",
+    "@webiny/cli": "^5.27.0",
+    "@webiny/project-utils": "^5.27.0",
+    "jest": "^26.6.3",
+    "merge": "^1.2.1",
+    "rimraf": "^3.0.2",
+    "ttypescript": "^1.5.13",
+    "typescript": "4.5.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  }
+}

--- a/packages/react-composition/package.json
+++ b/packages/react-composition/package.json
@@ -27,9 +27,6 @@
     "@babel/preset-typescript": "^7.16.0",
     "@webiny/cli": "^5.27.0",
     "@webiny/project-utils": "^5.27.0",
-    "jest": "^26.6.3",
-    "merge": "^1.2.1",
-    "rimraf": "^3.0.2",
     "ttypescript": "^1.5.13",
     "typescript": "4.5.5"
   },

--- a/packages/react-composition/src/Compose.tsx
+++ b/packages/react-composition/src/Compose.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { HigherOrderComponent, useAdmin } from "~/admin";
+import { HigherOrderComponent, useComposition } from "./Context";
 
 export interface ComposableFC<TProps> extends React.FC<TProps> {
     original: React.FC<TProps>;
@@ -16,7 +16,7 @@ export interface ComposeProps {
 }
 
 export const Compose: React.FC<ComposeProps> = props => {
-    const { addComponentWrappers } = useAdmin();
+    const { composeComponent } = useComposition();
 
     useEffect(() => {
         if (typeof props.component.original === "undefined") {
@@ -28,7 +28,7 @@ export const Compose: React.FC<ComposeProps> = props => {
         }
 
         const hocs = Array.isArray(props.with) ? props.with : [props.with];
-        return addComponentWrappers(props.component.original, hocs);
+        return composeComponent(props.component.original, hocs);
     }, [props.with]);
 
     return null;

--- a/packages/react-composition/src/Context.tsx
+++ b/packages/react-composition/src/Context.tsx
@@ -1,0 +1,139 @@
+import React, {
+    FC,
+    ComponentType,
+    useState,
+    useCallback,
+    createContext,
+    useContext,
+    useMemo
+} from "react";
+
+export function compose(...fns: HigherOrderComponent[]) {
+    return function ComposedComponent(Base: FC<unknown>): FC<unknown> {
+        return fns.reduceRight((Component, hoc) => hoc(Component), Base);
+    };
+}
+
+interface ComposedComponent {
+    /**
+     * Ready to use React component.
+     */
+    component: ComponentType<unknown>;
+    /**
+     * HOCs used to compose the original component.
+     */
+    hocs: HigherOrderComponent[];
+}
+
+/**
+ * IMPORTANT: TInputProps default type is `any` because this interface is use as a prop type in the `Compose` component.
+ * You can pass any HigherOrderComponent as a prop, regardless of its TInputProps type. The only way to allow that is
+ * to let it be `any` in this interface.
+ */
+export interface HigherOrderComponent<TInputProps = any, TOutputProps = TInputProps> {
+    (Component: FC<TInputProps>): FC<TOutputProps>;
+}
+
+type ComposedComponents = Map<ComponentType<unknown>, ComposedComponent>;
+
+interface CompositionContext {
+    components: ComposedComponents;
+    getComponent(component: ComponentType<unknown>): ComponentType<unknown> | undefined;
+    composeComponent(component: ComponentType<unknown>, hocs: HigherOrderComponent[]): void;
+}
+
+const CompositionContext = createContext<CompositionContext | undefined>(undefined);
+
+export const CompositionProvider: React.FC = ({ children }) => {
+    const [components, setComponents] = useState<ComposedComponents>(new Map());
+
+    const composeComponent = useCallback(
+        (component, hocs) => {
+            setComponents(prevComponents => {
+                const components = new Map(prevComponents);
+                const recipe = components.get(component) || { component: null, hocs: [] };
+
+                const newHocs = [...(recipe.hocs || []), ...hocs];
+
+                components.set(component, {
+                    component: compose(...[...newHocs].reverse())(component),
+                    hocs: newHocs
+                });
+
+                return components;
+            });
+
+            // Return a function that will remove the added HOCs.
+            return () => {
+                setComponents(prevComponents => {
+                    const components = new Map(prevComponents);
+                    const recipe = components.get(component) || {
+                        component: null,
+                        hocs: []
+                    };
+
+                    const newHOCs = [...recipe.hocs].filter(hoc => !hocs.includes(hoc));
+                    const NewComponent = compose(...[...newHOCs].reverse())(component);
+
+                    components.set(component, {
+                        component: NewComponent,
+                        hocs: newHOCs
+                    });
+
+                    return components;
+                });
+            };
+        },
+        [setComponents]
+    );
+
+    const getComponent: CompositionContext["getComponent"] = useCallback(
+        Component => {
+            const composedComponent = components.get(Component);
+            return composedComponent ? composedComponent.component : undefined;
+        },
+        [components]
+    );
+
+    const context: CompositionContext = useMemo(
+        () => ({
+            getComponent,
+            composeComponent,
+            components
+        }),
+        [components, composeComponent]
+    );
+
+    return <CompositionContext.Provider value={context}>{children}</CompositionContext.Provider>;
+};
+
+export function useComponent(Component: ComponentType<any>) {
+    const context = useOptionalComposition();
+
+    if (!context) {
+        return Component;
+    }
+
+    return context.getComponent(Component) || Component;
+}
+
+/**
+ * This hook will throw an error if composition context doesn't exist.
+ */
+export function useComposition() {
+    const context = useContext(CompositionContext);
+    if (!context) {
+        throw new Error(
+            `You're missing a <CompositionProvider> higher up in your component hierarchy!`
+        );
+    }
+
+    return context;
+}
+
+/**
+ * This hook will not throw an error if composition context doesn't exist.
+ */
+export function useOptionalComposition() {
+    return useContext(CompositionContext);
+}

--- a/packages/react-composition/src/index.ts
+++ b/packages/react-composition/src/index.ts
@@ -1,5 +1,3 @@
 export * from "./Context";
-// export type { HigherOrderComponent } from "./Context";
 export * from "./Compose";
-// export type { ComposeProps, ComposableFC } from "./Compose";
 export * from "./makeComposable";

--- a/packages/react-composition/src/index.ts
+++ b/packages/react-composition/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./Context";
+// export type { HigherOrderComponent } from "./Context";
+export * from "./Compose";
+// export type { ComposeProps, ComposableFC } from "./Compose";
+export * from "./makeComposable";

--- a/packages/react-composition/src/makeComposable.tsx
+++ b/packages/react-composition/src/makeComposable.tsx
@@ -1,19 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 import debounce from "lodash.debounce";
-import { useAdmin } from "./admin";
-import { ComponentType } from "react";
-import { ComposableFC } from "./components/core/Compose";
-
-const useComponent = (Component: ComponentType<any>): ComponentType<any> => {
-    const { wrappers } = useAdmin();
-    const recipe = wrappers.get(Component) as { component: ComponentType };
-
-    if (!recipe) {
-        return Component;
-    }
-
-    return recipe.component;
-};
+import { ComposableFC } from "./Compose";
+import { useComponent } from "./Context";
 
 const ComposableContext = createContext<string[]>([]);
 ComposableContext.displayName = "ComposableContext";
@@ -51,15 +39,16 @@ export function makeComposable<TProps>(name: string, Component?: React.FC<TProps
     if (!Component) {
         Component = createEmptyRenderer(name);
     }
+
     const Composable: ComposableFC<TProps> = props => {
         const parents = useComposableParents();
-        const WrappedComponent = useComponent(Component as React.FC<TProps>);
+        const ComposedComponent = useComponent(Component as React.FC<TProps>);
 
         const context = useMemo(() => [...parents, name], [parents, name]);
 
         return (
             <ComposableContext.Provider value={context}>
-                <WrappedComponent {...props}>{props.children}</WrappedComponent>
+                <ComposedComponent {...props}>{props.children}</ComposedComponent>
             </ComposableContext.Provider>
         );
     };

--- a/packages/react-composition/tsconfig.build.json
+++ b/packages/react-composition/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": { "~/*": ["./src/*"] },
+    "baseUrl": "."
+  }
+}

--- a/packages/react-composition/tsconfig.json
+++ b/packages/react-composition/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": { "~/*": ["./src/*"] },
+    "baseUrl": "."
+  }
+}

--- a/packages/react-composition/webiny.config.js
+++ b/packages/react-composition/webiny.config.js
@@ -1,0 +1,8 @@
+const { createWatchPackage, createBuildPackage } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: createBuildPackage({ cwd: __dirname }),
+        watch: createWatchPackage({ cwd: __dirname })
+    }
+};

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -17,6 +17,7 @@
     "@apollo/react-hooks": "^3.1.5",
     "@babel/runtime": "^7.16.3",
     "@webiny/plugins": "^5.27.0",
+    "@webiny/react-composition": "^5.27.0",
     "apollo-client": "^2.6.10",
     "graphql": "^15.7.2",
     "history": "^5.3.0",

--- a/packages/react-router/src/Link.tsx
+++ b/packages/react-router/src/Link.tsx
@@ -1,10 +1,11 @@
 import React, { useContext, useEffect } from "react";
 import { Link as RouterLink, LinkProps as RouterLinkProps } from "react-router-dom";
+import { makeComposable } from "@webiny/react-composition";
 import { RouterContext } from "./context/RouterContext";
 
 export type LinkProps = RouterLinkProps;
 
-const Link: React.FC<LinkProps> = ({ children, ...props }) => {
+const Link = makeComposable<LinkProps>("Link", ({ children, ...props }) => {
     const { onLink } = useContext(RouterContext);
 
     let { to } = props;
@@ -25,6 +26,6 @@ const Link: React.FC<LinkProps> = ({ children, ...props }) => {
     };
 
     return <LinkComponent {...componentProps}>{children}</LinkComponent>;
-};
+});
 
 export { Link };

--- a/packages/react-router/tsconfig.build.json
+++ b/packages/react-router/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
-  "references": [{ "path": "../plugins/tsconfig.build.json" }],
+  "references": [
+    { "path": "../plugins/tsconfig.build.json" },
+    { "path": "../react-composition/tsconfig.build.json" }
+  ],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__/**/*.ts"],
-  "references": [{ "path": "../plugins" }],
+  "references": [{ "path": "../plugins" }, { "path": "../react-composition" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",
@@ -9,7 +9,8 @@
     "paths": {
       "~/*": ["./src/*"],
       "@webiny/plugins/*": ["../plugins/src/*"],
-      "@webiny/plugins": ["../plugins/src"]
+      "@webiny/plugins": ["../plugins/src"],
+      "@webiny/react-composition": ["../react-composition/src"]
     },
     "baseUrl": "."
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13427,12 +13427,9 @@ __metadata:
     "@types/react": ^16.14.0
     "@webiny/cli": ^5.27.0
     "@webiny/project-utils": ^5.27.0
-    jest: ^26.6.3
     lodash.debounce: ^4.0.8
-    merge: ^1.2.1
     react: ^16.14.0
     react-dom: ^16.14.0
-    rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.5.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -11391,6 +11391,7 @@ __metadata:
     "@webiny/cli": ^5.27.0
     "@webiny/plugins": ^5.27.0
     "@webiny/project-utils": ^5.27.0
+    "@webiny/react-composition": ^5.27.0
     "@webiny/react-router": ^5.27.0
     babel-plugin-named-asset-import: ^1.0.0-next.3e165448
     lodash.debounce: ^4.0.8
@@ -13414,6 +13415,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/react-composition@^5.27.0, @webiny/react-composition@workspace:packages/react-composition":
+  version: 0.0.0-use.local
+  resolution: "@webiny/react-composition@workspace:packages/react-composition"
+  dependencies:
+    "@babel/cli": ^7.16.0
+    "@babel/core": ^7.16.0
+    "@babel/preset-env": ^7.16.4
+    "@babel/preset-typescript": ^7.16.0
+    "@babel/runtime": ^7.16.3
+    "@types/react": ^16.14.0
+    "@webiny/cli": ^5.27.0
+    "@webiny/project-utils": ^5.27.0
+    jest: ^26.6.3
+    lodash.debounce: ^4.0.8
+    merge: ^1.2.1
+    react: ^16.14.0
+    react-dom: ^16.14.0
+    rimraf: ^3.0.2
+    ttypescript: ^1.5.13
+    typescript: 4.5.5
+  languageName: unknown
+  linkType: soft
+
 "@webiny/react-rich-text-renderer@^5.27.0, @webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
   version: 0.0.0-use.local
   resolution: "@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer"
@@ -13448,6 +13472,7 @@ __metadata:
     "@webiny/cli": ^5.27.0
     "@webiny/plugins": ^5.27.0
     "@webiny/project-utils": ^5.27.0
+    "@webiny/react-composition": ^5.27.0
     apollo-client: ^2.6.10
     graphql: ^15.7.2
     history: ^5.3.0


### PR DESCRIPTION
## Changes
This PR extracts the Composition APi from `@webiny/app-admin-core` into a dedicated package, `@webiny/react-composition`, so it can be used outside of the Admin app, and even outside of Webiny. It's just a cool little composition framework.

This PR also makes `@webiny/react-router` `<Link>` component composable, using this composition package. It's a very useful addition, that can help us with implementation of, for example, analytics, data preloading (on the website), and even prefixing all Admin links with tenant IDs in a multi-tenant setup without thinking about it. It simply makes it super easy to compose all links in your app (website and admin).

## How Has This Been Tested?
Manually. Jest tests pending for `react-composition` package.

## Documentation
Not necessary at the moment; this package is used internally, and it's re-exported from `@webiny/app-admin`, so it's already covered by our existing docs.