### PR TITLE
docs: fixed the link of project organization and updated Node version information

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,12 +59,12 @@ Once you clone the repository, you will have a monorepo which consists of a bunc
 - `handler-*` are utility packages to create serverless function handlers
 - `cli-*` are packages that are use by Webiny CLI
 
-In the root of the project, you'll find the `api` and `apps` folders. You'll find an in-depth explanation of [project organization on our docs portal](https://docs.webiny.com/docs/key-topics/project-organization).
+In the root of the project, you'll find the `api` and `apps` folders. You'll find an in-depth explanation of [project organization on our docs portal](https://www.webiny.com/docs/core-development-concepts/project-organization/project-applications).
 The setup of our Github repo is identical to the one created by `create-webiny-project`.
 
 ## Prerequisites
 
-1. Node `12` or higher (to manage your Node versions we recommend [n](https://www.npmjs.com/package/n) for OSX/Linux, and [nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows)
+1. Node `14` or higher (to manage your Node versions we recommend [n](https://www.npmjs.com/package/n) for OSX/Linux, and [nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows)
 
 2. `yarn 1.22.*` or higher (because our project setup uses workspaces). We prefer using `yarn 2` as it's a lot faster and some issues from `yarn 1` are finally fixed. 
    If you don't already have `yarn`, visit https://yarnpkg.com/ to install it.


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
We recent docs migration, the project organization article link was changed, and updated it in the contribution guide and updated the Node version information

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
N/A

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
