### PR TITLE
Fix validation for empty string slug value

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/blockCategories.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/blockCategories.test.ts
@@ -147,15 +147,47 @@ describe("Block Categories CRUD Test", () => {
         });
     });
 
-    test("cannot create a block category with invalid slug", async () => {
-        const [errorResponse] = await createBlockCategory({
+    test("cannot create a block category with empty or invalid slug", async () => {
+        const [emptySlugErrorResponse] = await createBlockCategory({
+            data: {
+                slug: ``,
+                name: `empty-slug-category`
+            }
+        });
+
+        const emptySlugError: ErrorOptions = {
+            code: "VALIDATION_FAILED_INVALID_FIELDS",
+            message: "Validation failed.",
+            data: {
+                invalidFields: {
+                    slug: {
+                        code: "VALIDATION_FAILED_INVALID_FIELD",
+                        data: null,
+                        message: "Value is required."
+                    }
+                }
+            }
+        };
+
+        expect(emptySlugErrorResponse).toEqual({
+            data: {
+                pageBuilder: {
+                    createBlockCategory: {
+                        data: null,
+                        error: emptySlugError
+                    }
+                }
+            }
+        });
+
+        const [invalidSlugErrorResponse] = await createBlockCategory({
             data: {
                 slug: `invalid--slug--category`,
                 name: `invalid--slug--category`
             }
         });
 
-        const error: ErrorOptions = {
+        const invalidSlugError: ErrorOptions = {
             code: "VALIDATION_FAILED_INVALID_FIELDS",
             message: "Validation failed.",
             data: {
@@ -170,10 +202,55 @@ describe("Block Categories CRUD Test", () => {
             }
         };
 
-        expect(errorResponse).toEqual({
+        expect(invalidSlugErrorResponse).toEqual({
             data: {
                 pageBuilder: {
                     createBlockCategory: {
+                        data: null,
+                        error: invalidSlugError
+                    }
+                }
+            }
+        });
+    });
+
+    test("cannot get a block category by empty slug", async () => {
+        const [errorResponse] = await getBlockCategory({ slug: `` });
+
+        const error: ErrorOptions = {
+            code: "GET_BLOCK_CATEGORY_ERROR",
+            data: null,
+            message: "Could not load block category by empty slug."
+        };
+
+        expect(errorResponse).toEqual({
+            data: {
+                pageBuilder: {
+                    getBlockCategory: {
+                        data: null,
+                        error
+                    }
+                }
+            }
+        });
+    });
+
+    test("cannot update a block category by empty slug", async () => {
+        const [errorResponse] = await updateBlockCategory({
+            slug: ``,
+            data: { slug: ``, name: `empty-slug-category` }
+        });
+
+        const error: ErrorOptions = {
+            code: "GET_BLOCK_CATEGORY_ERROR",
+            data: null,
+            message: "Could not load block category by empty slug."
+        };
+
+        expect(errorResponse).toEqual({
+            data: {
+                pageBuilder: {
+                    updateBlockCategory: {
                         data: null,
                         error
                     }

--- a/packages/api-page-builder/src/graphql/crud/blockCategories.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/blockCategories.crud.ts
@@ -75,6 +75,13 @@ export const createBlockCategoriesCrud = (
         async getBlockCategory(slug, options = { auth: true }) {
             const { auth } = options;
 
+            if (slug === "") {
+                throw new WebinyError(
+                    "Could not load block category by empty slug.",
+                    "GET_BLOCK_CATEGORY_ERROR"
+                );
+            }
+
             const params: BlockCategoryStorageOperationsGetParams = {
                 where: {
                     slug,
@@ -166,15 +173,15 @@ export const createBlockCategoriesCrud = (
         async createBlockCategory(this: PageBuilderContextObject, input) {
             await checkBasePermissions(context, PERMISSION_NAME, { rwd: "w" });
 
+            const createDataModel = new CreateDataModel().populate(input);
+            await createDataModel.validate();
+
             const existingBlockCategory = await this.getBlockCategory(input.slug, {
                 auth: false
             });
             if (existingBlockCategory) {
                 throw new NotFoundError(`Category with slug "${input.slug}" already exists.`);
             }
-
-            const createDataModel = new CreateDataModel().populate(input);
-            await createDataModel.validate();
 
             const identity = context.security.getIdentity();
 


### PR DESCRIPTION
## Changes
Fix for Page Block Categories API: usage of empty string as a slug value caused and error about invalid DynamoDB query

## How Has This Been Tested?
Manual testing

## Documentation
No updates in documentation
