### PR TITLE
fix(app-page-builder): add missing useCallback dependency

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/app-page-builder/src/editor/plugins/breadcrumbs/Breadcrumbs.tsx
@@ -65,25 +65,28 @@ const Breadcrumbs: React.FC = () => {
         setActiveElementId(id);
     }, []);
 
-    const createBreadCrumbs = useCallback(async (activeElement: PbEditorElement) => {
-        const list: ItemsState[] = [];
-        let element = activeElement;
-        while (element) {
-            list.push({
-                id: element.id,
-                type: element.type
-            });
+    const createBreadCrumbs = useCallback(
+        async (activeElement: PbEditorElement) => {
+            const list: ItemsState[] = [];
+            let element = activeElement;
+            while (element) {
+                list.push({
+                    id: element.id,
+                    type: element.type
+                });
 
-            if (!element.parent) {
-                break;
+                if (!element.parent) {
+                    break;
+                }
+
+                element = (await snapshot.getPromise(
+                    elementByIdSelector(element.parent)
+                )) as PbEditorElement;
             }
-
-            element = (await snapshot.getPromise(
-                elementByIdSelector(element.parent)
-            )) as PbEditorElement;
-        }
-        setItems(list.reverse());
-    }, []);
+            setItems(list.reverse());
+        },
+        [snapshot]
+    );
 
     useEffect(() => {
         if (!element) {


### PR DESCRIPTION
## Changes
Closes #2397

This PR fixes the PB editor breadcrumbs not being correctly generated when an empty block is created for the first time.

https://user-images.githubusercontent.com/3920893/174149717-6ceb1c54-c238-438f-8710-c928bcc8f200.mp4


## How Has This Been Tested?
Manually.

