### PR TITLE
Add react-properties package

### DIFF
--- a/.adiorc.js
+++ b/.adiorc.js
@@ -35,6 +35,7 @@ module.exports = {
             "aws-sdk",
             "url",
             "worker_threads",
+            "~tests",
             "~"
         ],
         dependencies: [

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -22,6 +22,7 @@ module.exports = function ({ path }, presets = []) {
         },
         moduleDirectories: ["node_modules"],
         moduleNameMapper: {
+            "~tests/(.*)": `${path}/__tests__/$1`,
             "~/(.*)": `${path}/src/$1`
         },
         modulePathIgnorePatterns: [],

--- a/jest.config.js
+++ b/jest.config.js
@@ -161,5 +161,6 @@ if (projects.length === 0) {
 module.exports = {
     projects,
     modulePathIgnorePatterns: ["dist"],
-    testTimeout: 30000
+    testTimeout: 30000,
+    watchman: false
 };

--- a/packages/react-properties/.babelrc.js
+++ b/packages/react-properties/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("../../.babel.react")({ path: __dirname });

--- a/packages/react-properties/LICENSE
+++ b/packages/react-properties/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-properties/README.md
+++ b/packages/react-properties/README.md
@@ -1,0 +1,65 @@
+# React Properties
+
+[![](https://img.shields.io/npm/dw/@webiny/react-properties.svg)](https://www.npmjs.com/package/@webiny/react-properties)
+[![](https://img.shields.io/npm/v/@webiny/react-properties.svg)](https://www.npmjs.com/package/@webiny/react-properties)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+A tiny React properties framework, to build dynamic data objects using React components, which can be customized after initial creation. The usage is very similar to how you write XML data structures, but in this case you're using actual React.
+
+## Basic Example
+
+```jsx
+import React, { useCallback } from "react";
+import { Properties, Property, toObject } from "@webiny/react-properties";
+
+const View = () => {
+  const onChange = useCallback(properties => {
+    console.log(toObject(properties));
+  }, []);
+
+  return (
+    <Properties onChange={onChange}>
+      <Property name={"group"}>
+        <Property name={"name"} value={"layout"} />
+        <Property name={"label"} value={"Layout"} />
+        <Property name={"toolbar"}>
+          <Property name={"name"} value={"basic"} />
+        </Property>
+      </Property>
+      <Property name={"group"}>
+        <Property name={"name"} value={"heroes"} />
+        <Property name={"label"} value={"Heroes"} />
+        <Property name={"toolbar"}>
+          <Property name={"name"} value={"heroes"} />
+        </Property>
+      </Property>
+    </Properties>
+  );
+};
+```
+
+Output:
+
+```json
+{
+  "group": [
+    {
+      "name": "layout",
+      "label": "Layout",
+      "toolbar": {
+        "name": "basic"
+      }
+    },
+    {
+      "name": "heroes",
+      "label": "Heroes",
+      "toolbar": {
+        "name": "heroes"
+      }
+    }
+  ]
+}
+```
+
+For more examples, check out the test files.

--- a/packages/react-properties/__tests__/cases/dashboard/App.tsx
+++ b/packages/react-properties/__tests__/cases/dashboard/App.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import {
+    Compose,
+    HigherOrderComponent,
+    makeComposable,
+    CompositionProvider
+} from "@webiny/react-composition";
+import { Property, Properties } from "~/index";
+
+interface AddWidgetProps {
+    name: string;
+    type: string;
+}
+
+const AddWidget = <T extends Record<string, unknown>>(props: T & AddWidgetProps) => {
+    return (
+        <Property id={props.name} name={"widget"} array>
+            {Object.keys(props).map(name => (
+                <Property key={name} id={`${props.name}:${name}`} name={name} value={props[name]} />
+            ))}
+        </Property>
+    );
+};
+
+export interface CardWidget extends Record<string, unknown> {
+    title: string;
+    description: string;
+    button: React.ReactElement;
+}
+
+const createHOC =
+    (newChildren: React.ReactNode): HigherOrderComponent =>
+    BaseComponent => {
+        return function ConfigHOC({ children }) {
+            return (
+                <BaseComponent>
+                    {newChildren}
+                    {children}
+                </BaseComponent>
+            );
+        };
+    };
+
+const DashboardConfigApply = makeComposable("DashboardConfigApply", ({ children }) => {
+    return <>{children}</>;
+});
+
+interface DashboardConfig extends React.FC<unknown> {
+    AddWidget: typeof AddWidget;
+    DashboardRenderer: typeof DashboardRenderer;
+}
+
+export const DashboardConfig: DashboardConfig = ({ children }) => {
+    return <Compose component={DashboardConfigApply} with={createHOC(children)} />;
+};
+
+const DashboardRenderer = makeComposable("DashboardRenderer", () => {
+    return <div>Renderer not implemented!</div>;
+});
+
+DashboardConfig.AddWidget = AddWidget;
+DashboardConfig.DashboardRenderer = DashboardRenderer;
+
+interface ViewContext {
+    properties: Property[];
+}
+
+const defaultContext = { properties: [] };
+
+const ViewContext = React.createContext<ViewContext>(defaultContext);
+
+interface DashboardViewProps {
+    onProperties(properties: Property[]): void;
+}
+
+const DashboardView: React.FC<DashboardViewProps> = ({ onProperties }) => {
+    const [properties, setProperties] = useState<Property[]>([]);
+    const context = { properties };
+
+    useEffect(() => {
+        onProperties(properties);
+    }, [properties]);
+
+    const stateUpdater = (properties: Property[]) => {
+        setProperties(properties);
+    };
+
+    return (
+        <ViewContext.Provider value={context}>
+            <Properties onChange={stateUpdater}>
+                <DashboardConfigApply />
+                <DashboardRenderer />
+            </Properties>
+        </ViewContext.Provider>
+    );
+};
+
+export const App: React.FC<DashboardViewProps> = ({ onProperties, children }) => {
+    return (
+        <CompositionProvider>
+            <DashboardView onProperties={onProperties} />
+            <DashboardConfig>
+                <AddWidget<CardWidget>
+                    name="my-widget"
+                    type="card"
+                    title="My Widget"
+                    description="Custom widget that shows current weather."
+                    button={<button>Show Weather</button>}
+                />
+            </DashboardConfig>
+            {children}
+        </CompositionProvider>
+    );
+};

--- a/packages/react-properties/__tests__/cases/dashboard/dashboard.test.tsx
+++ b/packages/react-properties/__tests__/cases/dashboard/dashboard.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Compose, HigherOrderComponent } from "@webiny/react-composition";
+import { Property, toObject, useProperties } from "~/index";
+import { App, DashboardConfig } from "./App";
+import { getLastCall } from "~tests/utils";
+
+const { AddWidget, DashboardRenderer } = DashboardConfig;
+
+describe("Dashboard", () => {
+    it("should contain 2 widgets (the built-in one, and the custom one)", async () => {
+        const onChange = jest.fn();
+        /**
+         * <App/> contains the built-in widget, and we're using the <DashboardConfig/> component to register more widgets.
+         */
+        const view = (
+            <App onProperties={onChange}>
+                <DashboardConfig>
+                    <AddWidget<{ title: string; button: unknown }>
+                        name={"new-widget"}
+                        title={"Latest News"}
+                        type={"card"}
+                        button={<div />}
+                    />
+                </DashboardConfig>
+            </App>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toMatchObject({
+            widget: [
+                {
+                    name: "my-widget",
+                    title: "My Widget",
+                    type: "card",
+                    button: expect.anything()
+                },
+                {
+                    name: "new-widget",
+                    title: "Latest News",
+                    type: "card",
+                    button: <div />
+                }
+            ]
+        });
+    });
+
+    it("should contain the built-in widget with modified values", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <App onProperties={onChange}>
+                <DashboardConfig>
+                    <AddWidget<{ title: string; button: unknown }>
+                        name={"my-widget"}
+                        title={"My own title!"}
+                        type={"card"}
+                        button={null}
+                    />
+                </DashboardConfig>
+            </App>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toMatchObject({
+            widget: [
+                {
+                    name: "my-widget",
+                    title: "My own title!",
+                    type: "card",
+                    button: null
+                }
+            ]
+        });
+    });
+
+    it("should contain new custom properties", async () => {
+        /**
+         * Let's create a custom Dashboard renderer to render links (which are our custom property).
+         */
+        const CustomDashboard: HigherOrderComponent = () => {
+            return function CustomDashboard() {
+                const { getObject } = useProperties();
+                const { link } = getObject<{ link: { title: string; url: string }[] }>();
+
+                return (
+                    <ul>
+                        {link.map(item => (
+                            <li key={item.title}>
+                                {item.title}: {item.url}
+                            </li>
+                        ))}
+                    </ul>
+                );
+            };
+        };
+
+        /**
+         * This custom component will allow us to expose a user-friendly API to developers, hook into the existing
+         * data structure of the Dashboard, and add our new properties (links in this case).
+         */
+        interface LinkProps {
+            url: string;
+            title: string;
+        }
+
+        const Link: React.FC<LinkProps> = ({ url, title }) => {
+            return (
+                <Property name={"link"} array>
+                    <Property name={"url"} value={url} />
+                    <Property name={"title"} value={title} />
+                </Property>
+            );
+        };
+
+        const onChange = jest.fn();
+        const view = (
+            <App onProperties={onChange}>
+                <DashboardConfig>
+                    {/* Compose the renderer, to intercept the rendering process and render custom Links. */}
+                    <Compose component={DashboardRenderer} with={CustomDashboard} />
+                    {/* Register new properties. */}
+                    <Link title={"Webiny"} url={"www.webiny.com"} />
+                    <Link title={"Google"} url={"www.google.com"} />
+                </DashboardConfig>
+            </App>
+        );
+
+        const { container } = render(view);
+
+        // Verify the new data structure
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toMatchObject({
+            widget: [
+                {
+                    name: "my-widget",
+                    title: "My Widget",
+                    type: "card",
+                    button: expect.anything()
+                }
+            ],
+            link: [
+                { title: "Webiny", url: "www.webiny.com" },
+                { title: "Google", url: "www.google.com" }
+            ]
+        });
+
+        // Verify that our custom renderer is rendering the expected output.
+        expect(container.innerHTML).toEqual(
+            "<ul><li>Webiny: www.webiny.com</li><li>Google: www.google.com</li></ul>"
+        );
+    });
+});

--- a/packages/react-properties/__tests__/cases/pbEditorSettings/PbEditorSettingsView.tsx
+++ b/packages/react-properties/__tests__/cases/pbEditorSettings/PbEditorSettingsView.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback } from "react";
+import { createConfigurableView } from "./createConfigurableView";
+import { Property, useParentProperty } from "~/index";
+
+interface SettingsGroupProps {
+    name: string;
+    title?: string;
+    icon?: string;
+    remove?: boolean;
+    replace?: string;
+}
+
+type DynamicProps<T> = T & {
+    [key: string]: any;
+};
+
+const SettingsGroup: React.FC<SettingsGroupProps> = ({
+    children,
+    replace,
+    remove = false,
+    ...rest
+}) => {
+    const props: DynamicProps<typeof rest> = rest;
+    const id = `group:${props.name}`;
+    const toReplace = replace !== undefined ? `group:${replace}` : undefined;
+
+    return (
+        <Property id={id} name={"groups"} array remove={remove} replace={toReplace}>
+            {Object.keys(props).map(name => (
+                <Property
+                    key={name}
+                    id={`group:${props.name}:${name}`}
+                    name={name}
+                    value={props[name]}
+                />
+            ))}
+            {children}
+        </Property>
+    );
+};
+
+interface FormFieldProps extends Record<string, unknown> {
+    name: string;
+    component?: string;
+    after?: string;
+    remove?: boolean;
+    replace?: string;
+}
+
+const FormField: React.FC<FormFieldProps> = ({
+    children,
+    after,
+    before,
+    replace,
+    remove = false,
+    ...props
+}) => {
+    const parent = useParentProperty();
+    if (!parent) {
+        throw Error(`<FormField> must be a child of a <SettingsGroup> element.`);
+    }
+
+    const { id } = parent;
+
+    const getId = useCallback(
+        (suffix = undefined) => [id, "field", props.name, suffix].filter(Boolean).join(":"),
+        []
+    );
+
+    const toReplace = replace !== undefined ? `${id}:field:${replace}` : undefined;
+    const placeAfter = after !== undefined ? `${id}:field:${after}` : undefined;
+    const placeBefore = before !== undefined ? `${id}:field:${before}` : undefined;
+
+    return (
+        <Property
+            id={getId()}
+            name={"fields"}
+            array
+            replace={toReplace}
+            remove={remove}
+            after={placeAfter}
+            before={placeBefore}
+        >
+            {Object.keys(props).map(name => (
+                <Property key={name} id={getId(name)} name={name} value={props[name]} />
+            ))}
+            {children}
+        </Property>
+    );
+};
+
+// Base view components.
+const { View, Config } = createConfigurableView("PageSettings");
+
+// Create a named alias.
+const PageSettingsView = View;
+
+// Assign custom components
+const PageSettingsConfig = Object.assign(Config, { FormField, SettingsGroup });
+
+export { PageSettingsView, PageSettingsConfig };

--- a/packages/react-properties/__tests__/cases/pbEditorSettings/createConfigurableView.tsx
+++ b/packages/react-properties/__tests__/cases/pbEditorSettings/createConfigurableView.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import { Compose, HigherOrderComponent, makeComposable } from "@webiny/react-composition";
+import { Property, Properties } from "~/index";
+
+const createHOC =
+    (newChildren: React.ReactNode): HigherOrderComponent =>
+    BaseComponent => {
+        return function ConfigHOC({ children }) {
+            return (
+                <BaseComponent>
+                    {newChildren}
+                    {children}
+                </BaseComponent>
+            );
+        };
+    };
+
+export interface ViewProps {
+    onProperties?(properties: Property[]): void;
+}
+
+export function createConfigurableView(name: string) {
+    /**
+     * This component is used when we want to mount all composed configs.
+     */
+    const ConfigApply = makeComposable(`${name}ConfigApply`, ({ children }) => {
+        return <>{children}</>;
+    });
+
+    /**
+     * This component is used to configure the view (it can be mounted many times).
+     */
+    const Config: React.FC = ({ children }) => {
+        return <Compose component={ConfigApply} with={createHOC(children)} />;
+    };
+
+    const Renderer = makeComposable(`${name}Renderer`, () => {
+        return <div>{name}Renderer is not implemented!</div>;
+    });
+
+    interface ViewContext {
+        properties: Property[];
+    }
+
+    const defaultContext = { properties: [] };
+
+    const ViewContext = React.createContext<ViewContext>(defaultContext);
+
+    const View: React.FC<ViewProps> = ({ onProperties }) => {
+        const [properties, setProperties] = useState<Property[]>([]);
+        const context = { properties };
+
+        useEffect(() => {
+            if (typeof onProperties === "function") {
+                onProperties(properties);
+            }
+        }, [properties]);
+
+        const stateUpdater = (properties: Property[]) => {
+            setProperties(properties);
+        };
+
+        return (
+            <ViewContext.Provider value={context}>
+                <Properties onChange={stateUpdater}>
+                    <ConfigApply />
+                    <Renderer />
+                </Properties>
+            </ViewContext.Provider>
+        );
+    };
+
+    return {
+        View,
+        Config
+    };
+}

--- a/packages/react-properties/__tests__/cases/pbEditorSettings/pbEditorSettings.test.tsx
+++ b/packages/react-properties/__tests__/cases/pbEditorSettings/pbEditorSettings.test.tsx
@@ -1,0 +1,461 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { CompositionProvider } from "@webiny/react-composition";
+import { Property, toObject } from "~/index";
+import { PageSettingsView, PageSettingsConfig } from "./PbEditorSettingsView";
+import { getLastCall } from "~tests/utils";
+
+const { SettingsGroup, FormField } = PageSettingsConfig;
+
+const BaseConfig = () => {
+    return (
+        <>
+            <PageSettingsConfig>
+                <SettingsGroup name={"general"} title={"General Settings"} icon={"cog"}>
+                    <FormField name={"title"} label={"Title"} component={"input"} />
+                    <FormField name={"snippet"} label={"Snippet"} component={"textarea"} />
+                    <FormField name={"layout"} label={"Layout"} component={"select"} />
+                </SettingsGroup>
+            </PageSettingsConfig>
+        </>
+    );
+};
+
+describe("PB Editor", () => {
+    it("should contain 1 settings groups with 3 fields", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should contain a new settings group with 1 field", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"social"} title={"Social Media"} icon={"like"}>
+                        <FormField name={"ogImage"} label={"OG Image"} component={"input"} />
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                },
+                {
+                    name: "social",
+                    title: "Social Media",
+                    icon: "like",
+                    fields: [
+                        {
+                            name: "ogImage",
+                            label: "OG Image",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow group customization", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"} title={"Main Settings"} icon={"page"} />
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "Main Settings",
+                    icon: "page",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: "textarea"
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow group removal", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"} remove />
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject<{ groups?: Array<unknown> }>(properties);
+
+        expect(data.groups).toBe(undefined);
+    });
+
+    it("should allow field customization", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"}>
+                        {/* Add custom prop via component props. */}
+                        <FormField name={"title"} description={"Field #1"} />
+                        {/* Add custom prop via children. */}
+                        <FormField name={"snippet"}>
+                            <Property name={"description"} value={"Field #2"} />
+                        </FormField>
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything(),
+                            description: "Field #1"
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: expect.anything(),
+                            description: "Field #2"
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow adding fields after a specific field", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"}>
+                        <FormField
+                            name={"email"}
+                            label={"Email"}
+                            component={"email"}
+                            after={"title"}
+                        />
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "email",
+                            label: "Email",
+                            component: "email"
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow adding fields before a specific field", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"}>
+                        <FormField
+                            name={"email"}
+                            label={"Email"}
+                            component={"email"}
+                            before={"layout"}
+                        />
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "email",
+                            label: "Email",
+                            component: "email"
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow field removal", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"}>
+                        <FormField name={"title"} remove />
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "snippet",
+                            label: "Snippet",
+                            component: "textarea"
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow field replacement", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <CompositionProvider>
+                <PageSettingsView onProperties={onChange} />
+                <BaseConfig />
+                <PageSettingsConfig>
+                    <SettingsGroup name={"general"}>
+                        <FormField
+                            name={"description"}
+                            label={"Description"}
+                            component={"richtext"}
+                            replace={"snippet"}
+                        />
+                    </SettingsGroup>
+                </PageSettingsConfig>
+            </CompositionProvider>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+        const data = toObject(properties);
+
+        expect(data).toEqual({
+            groups: [
+                {
+                    name: "general",
+                    title: "General Settings",
+                    icon: "cog",
+                    fields: [
+                        {
+                            name: "title",
+                            label: "Title",
+                            component: expect.anything()
+                        },
+                        {
+                            name: "description",
+                            label: "Description",
+                            component: "richtext"
+                        },
+                        {
+                            name: "layout",
+                            label: "Layout",
+                            component: expect.anything()
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+});

--- a/packages/react-properties/__tests__/properties.test.tsx
+++ b/packages/react-properties/__tests__/properties.test.tsx
@@ -1,0 +1,432 @@
+import React, { useCallback } from "react";
+import { render } from "@testing-library/react";
+import { Properties, Property, useParentProperty, toObject } from "~/index";
+import { getLastCall } from "./utils";
+
+interface GroupProps {
+    name: string;
+    label?: string;
+}
+
+const Group: React.FC<GroupProps> = ({ name, label, children }) => {
+    return (
+        <Property id={`group:${name}`} name={"settingsGroup"} array={true}>
+            <Property id={`group:${name}:name`} name={"name"} value={name} />
+            {label ? <Property id={`group:${name}:label`} name={"label"} value={label} /> : null}
+            {children}
+        </Property>
+    );
+};
+
+interface FieldProps {
+    name: string;
+    label?: string;
+    remove?: boolean;
+    replace?: string;
+}
+
+const Field: React.FC<FieldProps> = ({ name, label, replace, remove = false }) => {
+    const parentProperty = useParentProperty();
+
+    const id = parentProperty ? parentProperty.id : undefined;
+
+    const getId = useCallback(
+        (suffix = undefined) => [id, "field", name, suffix].filter(Boolean).join(":"),
+        []
+    );
+    const toReplace = replace !== undefined ? `${id}:field:${replace}` : undefined;
+
+    return (
+        <Property id={getId()} name={"field"} array remove={remove} replace={toReplace}>
+            <Property id={getId("name")} name={"name"} value={name} />
+            {label ? <Property id={getId("label")} name={"label"} value={label} /> : null}
+        </Property>
+    );
+};
+
+describe("Test Properties", () => {
+    it("should create 2 properties", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <Properties onChange={onChange}>
+                <Property id={"label"} name={"label"} value={"Label"} />
+                <Property name={"name"} value={"basic"} />
+            </Properties>
+        );
+
+        render(view);
+
+        expect(onChange).toHaveBeenLastCalledWith([
+            { id: "label", name: "label", value: "Label", parent: "", array: false },
+            { id: expect.any(String), name: "name", value: "basic", parent: "", array: false }
+        ]);
+    });
+
+    it("should create nested properties", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <Properties onChange={onChange}>
+                <Property id="1" name={"group"}>
+                    <Property name={"name"} value={"layout"} />
+                    <Property name={"label"} value={"Layout"} />
+                    <Property id="2" name={"toolbar"}>
+                        <Property name={"name"} value={"basic"} />
+                    </Property>
+                </Property>
+            </Properties>
+        );
+
+        render(view);
+
+        expect(onChange).toHaveBeenLastCalledWith([
+            { id: expect.any(String), name: "name", value: "layout", parent: "1", array: false },
+            { id: expect.any(String), name: "label", value: "Layout", parent: "1", array: false },
+            { id: expect.any(String), name: "name", value: "basic", parent: "2", array: false },
+            {
+                id: expect.any(String),
+                name: "toolbar",
+                value: undefined,
+                parent: "1",
+                array: false
+            },
+            { id: "1", name: "group", value: undefined, parent: "", array: false }
+        ]);
+    });
+
+    it("should convert to a single object", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <Properties onChange={onChange}>
+                <Property name={"group"}>
+                    <Property name={"name"} value={"layout"} />
+                    <Property name={"label"} value={"Layout"} />
+                    <Property name={"toolbar"}>
+                        <Property name={"name"} value={"basic"} />
+                    </Property>
+                </Property>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            group: {
+                name: "layout",
+                label: "Layout",
+                toolbar: {
+                    name: "basic"
+                }
+            }
+        });
+    });
+
+    it("should treat a single object as an array (array prop)", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <Properties onChange={onChange}>
+                <Property name={"group"} array>
+                    <Property name={"name"} value={"layout"} />
+                    <Property name={"label"} value={"Layout"} />
+                    <Property name={"toolbar"}>
+                        <Property name={"name"} value={"basic"} />
+                    </Property>
+                </Property>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            group: [
+                {
+                    name: "layout",
+                    label: "Layout",
+                    toolbar: {
+                        name: "basic"
+                    }
+                }
+            ]
+        });
+    });
+
+    it("should convert to an array of objects", async () => {
+        const onChange = jest.fn();
+        const view = (
+            <Properties onChange={onChange}>
+                <Property name={"group"}>
+                    <Property name={"name"} value={"layout"} />
+                    <Property name={"label"} value={"Layout"} />
+                    <Property name={"toolbar"}>
+                        <Property name={"name"} value={"basic"} />
+                    </Property>
+                </Property>
+                <Property name={"group"}>
+                    <Property name={"name"} value={"heroes"} />
+                    <Property name={"label"} value={"Heroes"} />
+                    <Property name={"toolbar"}>
+                        <Property name={"name"} value={"heroes"} />
+                    </Property>
+                </Property>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            group: [
+                {
+                    name: "layout",
+                    label: "Layout",
+                    toolbar: {
+                        name: "basic"
+                    }
+                },
+                {
+                    name: "heroes",
+                    label: "Heroes",
+                    toolbar: {
+                        name: "heroes"
+                    }
+                }
+            ]
+        });
+    });
+
+    it("should convert to an array of objects using custom components", async () => {
+        interface GroupProps {
+            name: string;
+            label?: string;
+        }
+
+        const Group: React.FC<GroupProps> = ({ name, label, children }) => {
+            return (
+                <Property name={"group"}>
+                    <Property name={"name"} value={name} />
+                    {label ? <Property name={"label"} value={label} /> : null}
+                    {children}
+                </Property>
+            );
+        };
+
+        interface ToolbarProps {
+            name: string;
+        }
+
+        const Toolbar: React.FC<ToolbarProps> = ({ name }) => {
+            return (
+                <Property name={"toolbar"}>
+                    <Property name={"name"} value={name} />
+                </Property>
+            );
+        };
+
+        const onChange = jest.fn();
+
+        const view = (
+            <Properties onChange={onChange}>
+                <Group name={"layout"} label={"Layout"}>
+                    <Toolbar name={"basic"} />
+                </Group>
+                <Group name={"heroes"} label={"Heroes"}>
+                    <Toolbar name={"heroes"} />
+                </Group>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            group: [
+                {
+                    name: "layout",
+                    label: "Layout",
+                    toolbar: {
+                        name: "basic"
+                    }
+                },
+                {
+                    name: "heroes",
+                    label: "Heroes",
+                    toolbar: {
+                        name: "heroes"
+                    }
+                }
+            ]
+        });
+    });
+
+    it("should merge properties for matching 'name' prop", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <Properties onChange={onChange}>
+                <Group name={"styleSettings"} label={"Style Settings"}>
+                    <Field name={"color"} label={"Color"} />
+                    <Field name={"component"} label={"Component"} />
+                </Group>
+                <Group name={"elementSettings"} label={"Element Settings"}>
+                    <Field name={"url"} label={"URL"} />
+                    <Field name={"newTab"} label={"Open in new tab"} />
+                </Group>
+                <Group name={"styleSettings"} label={"Style"}>
+                    <Field name={"component"} label={"Render"} />
+                    <Field name={"url"} label={"Open URL"} />
+                </Group>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            settingsGroup: [
+                {
+                    name: "styleSettings",
+                    label: "Style",
+                    field: [
+                        {
+                            name: "color",
+                            label: "Color"
+                        },
+                        {
+                            name: "component",
+                            label: "Render"
+                        },
+                        { name: "url", label: "Open URL" }
+                    ]
+                },
+                {
+                    name: "elementSettings",
+                    label: "Element Settings",
+                    field: [
+                        { name: "url", label: "URL" },
+                        { name: "newTab", label: "Open in new tab" }
+                    ]
+                }
+            ]
+        });
+    });
+
+    it("should allow addition of custom properties to predefined components", async () => {
+        const onChange = jest.fn();
+
+        const Tutorial: React.FC<{ label: string }> = ({ label }) => {
+            return <Property name={"tutorial"} value={label} />;
+        };
+
+        const view = (
+            <Properties onChange={onChange}>
+                <Group name={"styleSettings"} label={"Style Settings"}>
+                    <Field name={"color"} label={"Color"} />
+                    <Field name={"component"} label={"Component"} />
+                </Group>
+                <Group name={"styleSettings"}>
+                    <Tutorial label={"Learn more"} />
+                </Group>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            settingsGroup: [
+                {
+                    name: "styleSettings",
+                    label: "Style Settings",
+                    field: [
+                        {
+                            name: "color",
+                            label: "Color"
+                        },
+                        {
+                            name: "component",
+                            label: "Component"
+                        }
+                    ],
+                    tutorial: "Learn more"
+                }
+            ]
+        });
+    });
+
+    it("should remove existing property by 'name' and add a new one", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <Properties onChange={onChange}>
+                {/* Define base properties */}
+                <Group name={"styleSettings"} label={"Style Settings"}>
+                    <Field name={"color"} label={"Color"} />
+                    <Field name={"component"} label={"Component"} />
+                </Group>
+                {/* Remove existing fields and add a new one */}
+                <Group name={"styleSettings"}>
+                    <Field name={"component"} remove />
+                    <Field name={"color"} remove />
+                    <Field name={"link"} label={"Link"} />
+                </Group>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(toObject(properties)).toEqual({
+            settingsGroup: [
+                {
+                    name: "styleSettings",
+                    label: "Style Settings",
+                    field: [{ name: "link", label: "Link" }]
+                }
+            ]
+        });
+    });
+
+    it("should replace existing property with a new one", async () => {
+        const onChange = jest.fn();
+
+        const view = (
+            <Properties onChange={onChange}>
+                {/* Define base properties */}
+                <Group name={"styleSettings"} label={"Style Settings"}>
+                    <Field name={"color"} label={"Color"} />
+                    <Field name={"component"} label={"Component"} />
+                </Group>
+                {/* Remove existing fields and add a new one */}
+                <Group name={"styleSettings"}>
+                    <Field name={"link"} label={"Link"} replace={"color"} />
+                </Group>
+            </Properties>
+        );
+
+        render(view);
+
+        const properties = getLastCall(onChange);
+
+        expect(properties.length).toBe(9);
+        expect(toObject(properties)).toEqual({
+            settingsGroup: [
+                {
+                    name: "styleSettings",
+                    label: "Style Settings",
+                    field: [
+                        { name: "link", label: "Link" },
+                        { name: "component", label: "Component" }
+                    ]
+                }
+            ]
+        });
+    });
+});

--- a/packages/react-properties/__tests__/utils.ts
+++ b/packages/react-properties/__tests__/utils.ts
@@ -1,0 +1,3 @@
+export function getLastCall(callable: jest.Mock) {
+    return callable.mock.calls[callable.mock.calls.length - 1][0];
+}

--- a/packages/react-properties/jest.config.js
+++ b/packages/react-properties/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/react-properties/package.json
+++ b/packages/react-properties/package.json
@@ -1,0 +1,33 @@
+{
+  "private": true,
+  "name": "@webiny/react-properties",
+  "version": "5.28.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "description": "Build pluggable data objects using React components.",
+  "author": "Webiny Ltd",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.16.3",
+    "@types/react": "^16.14.0",
+    "nanoid": "^3.3.4",
+    "react": "^16.14.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^12.1.5",
+    "@webiny/cli": "^5.28.0",
+    "@webiny/project-utils": "^5.28.0",
+    "@webiny/react-composition": "^5.28.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  }
+}

--- a/packages/react-properties/src/Properties.tsx
+++ b/packages/react-properties/src/Properties.tsx
@@ -1,0 +1,195 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { getUniqueId, toObject } from "./utils";
+
+export interface Property {
+    id: string;
+    parent: string;
+    name: string;
+    value: unknown;
+    array?: boolean;
+}
+
+function removeByParent(id: string, properties: Property[]): Property[] {
+    return properties
+        .filter(prop => prop.parent === id)
+        .reduce((acc, item) => {
+            return removeByParent(
+                item.id,
+                acc.filter(prop => prop.id !== item.id)
+            );
+        }, properties);
+}
+
+interface AddPropertyOptions {
+    after?: string;
+    before?: string;
+}
+
+interface PropertiesContext {
+    properties: Property[];
+    getObject<T = unknown>(): T;
+    addProperty(property: Property, options?: AddPropertyOptions): void;
+    removeProperty(id: string): void;
+    replaceProperty(id: string, property: Property): void;
+}
+
+const PropertiesContext = createContext<PropertiesContext | undefined>(undefined);
+
+interface PropertiesProps {
+    onChange?(properties: Property[]): void;
+}
+
+export const Properties: React.FC<PropertiesProps> = ({ onChange, children }) => {
+    const [properties, setProperties] = useState<Property[]>([]);
+
+    useEffect(() => {
+        if (onChange) {
+            onChange(properties);
+        }
+    }, [properties]);
+
+    const context: PropertiesContext = useMemo(
+        () => ({
+            properties,
+            getObject<T>() {
+                return toObject(properties) as T;
+            },
+            addProperty(property, options = {}) {
+                setProperties(properties => {
+                    // If a property with this ID already exists, merge the two properties.
+                    const index = properties.findIndex(prop => prop.id === property.id);
+                    if (index > -1) {
+                        return [
+                            ...properties.slice(0, index),
+                            { ...properties[index], ...property },
+                            ...properties.slice(index + 1)
+                        ];
+                    }
+
+                    if (options.after) {
+                        const index = properties.findIndex(prop => prop.id === options.after);
+                        if (index > -1) {
+                            return [
+                                ...properties.slice(0, index + 1),
+                                property,
+                                ...properties.slice(index + 1)
+                            ];
+                        }
+                    }
+
+                    if (options.before) {
+                        const index = properties.findIndex(prop => prop.id === options.before);
+                        if (index > -1) {
+                            return [
+                                ...properties.slice(0, index),
+                                property,
+                                ...properties.slice(index)
+                            ];
+                        }
+                    }
+
+                    return [...properties, property];
+                });
+            },
+            removeProperty(id) {
+                setProperties(properties => {
+                    return removeByParent(
+                        id,
+                        properties.filter(prop => prop.id !== id)
+                    );
+                });
+            },
+            replaceProperty(id, property) {
+                setProperties(properties => {
+                    const toReplace = properties.findIndex(prop => prop.id === id);
+
+                    if (toReplace > -1) {
+                        // Replace the property and remove all remaining child properties.
+                        return removeByParent(id, [
+                            ...properties.slice(0, toReplace),
+                            property,
+                            ...properties.slice(toReplace + 1)
+                        ]);
+                    }
+                    return properties;
+                });
+            }
+        }),
+        [properties]
+    );
+
+    return <PropertiesContext.Provider value={context}>{children}</PropertiesContext.Provider>;
+};
+
+export function useProperties() {
+    const properties = useContext(PropertiesContext);
+    if (!properties) {
+        throw Error("Properties context provider is missing!");
+    }
+
+    return properties;
+}
+
+interface PropertyProps {
+    id?: string;
+    name: string;
+    value?: unknown;
+    array?: boolean;
+    after?: string;
+    before?: string;
+    replace?: string;
+    remove?: boolean;
+}
+
+const PropertyContext = createContext<Property | undefined>(undefined);
+
+export function useParentProperty() {
+    return useContext(PropertyContext);
+}
+
+export const Property: React.FC<PropertyProps> = ({
+    id,
+    name,
+    value,
+    children,
+    after = undefined,
+    before = undefined,
+    replace = undefined,
+    remove = false,
+    array = false
+}) => {
+    const uniqueId = useMemo(() => id || getUniqueId(), []);
+    const parent = useParentProperty();
+    const properties = useProperties();
+
+    if (!properties) {
+        throw Error("<Properties> provider is missing higher in the hierarchy!");
+    }
+
+    const { addProperty, removeProperty, replaceProperty } = properties;
+    const property = { id: uniqueId, name, value, parent: parent ? parent.id : "", array };
+
+    useEffect(() => {
+        if (remove) {
+            removeProperty(uniqueId);
+            return;
+        }
+
+        if (replace) {
+            replaceProperty(replace, property);
+            return;
+        }
+
+        addProperty(property, { after, before });
+
+        return () => {
+            removeProperty(uniqueId);
+        };
+    }, []);
+
+    if (children) {
+        return <PropertyContext.Provider value={property}>{children}</PropertyContext.Provider>;
+    }
+
+    return null;
+};

--- a/packages/react-properties/src/index.ts
+++ b/packages/react-properties/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./utils";
+export * from "./Properties";

--- a/packages/react-properties/src/utils.ts
+++ b/packages/react-properties/src/utils.ts
@@ -1,0 +1,33 @@
+import { customAlphabet } from "nanoid";
+const nanoid = customAlphabet("1234567890abcdef", 6);
+import { Property } from "./Properties";
+
+function buildRoots(roots: Property[], properties: Property[]) {
+    const obj: Record<string, unknown> = roots.reduce((acc, item) => {
+        const isArray = item.array === true || roots.filter(r => r.name === item.name).length > 1;
+        return { ...acc, [item.name]: isArray ? [] : {} };
+    }, {});
+
+    roots.forEach(root => {
+        const isArray = root.array === true || Array.isArray(obj[root.name]);
+        if (root.value !== undefined) {
+            obj[root.name] = isArray ? [...(obj[root.name] as Array<any>), root.value] : root.value;
+            return;
+        }
+
+        const nextRoots = properties.filter(p => p.parent === root.id);
+        const value = buildRoots(nextRoots, properties);
+        obj[root.name] = isArray ? [...(obj[root.name] as Property[]), value] : value;
+    });
+
+    return obj;
+}
+
+export function toObject<T = unknown>(properties: Property[]): T {
+    const roots = properties.filter(prop => prop.parent === "");
+    return buildRoots(roots, properties) as T;
+}
+
+export function getUniqueId() {
+    return nanoid();
+}

--- a/packages/react-properties/tsconfig.build.json
+++ b/packages/react-properties/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~tests/*": ["./__tests__/*"],
+      "~/*": ["./src/*"]
+    },
+    "baseUrl": "."
+  }
+}

--- a/packages/react-properties/tsconfig.build.json
+++ b/packages/react-properties/tsconfig.build.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__"],
-  "references": [
-    { "path": "../react-composition/tsconfig.build.json" }
-  ],
+  "references": [{ "path": "../react-composition/tsconfig.build.json" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",

--- a/packages/react-properties/tsconfig.build.json
+++ b/packages/react-properties/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__"],
-  "references": [],
+  "references": [
+    { "path": "../react-composition/tsconfig.build.json" }
+  ],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",

--- a/packages/react-properties/tsconfig.json
+++ b/packages/react-properties/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~tests/*": ["./__tests__/*"],
+      "~/*": ["./src/*"]
+    },
+    "baseUrl": "."
+  }
+}

--- a/packages/react-properties/tsconfig.json
+++ b/packages/react-properties/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__"],
-  "references": [],
+  "references": [{ "path": "../react-composition" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",

--- a/packages/react-properties/webiny.config.js
+++ b/packages/react-properties/webiny.config.js
@@ -1,0 +1,8 @@
+const { createWatchPackage, createBuildPackage } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: createBuildPackage({ cwd: __dirname }),
+        watch: createWatchPackage({ cwd: __dirname })
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13264,6 +13264,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/react-properties@workspace:packages/react-properties":
+  version: 0.0.0-use.local
+  resolution: "@webiny/react-properties@workspace:packages/react-properties"
+  dependencies:
+    "@babel/runtime": ^7.16.3
+    "@testing-library/react": ^12.1.5
+    "@types/react": ^16.14.0
+    "@webiny/cli": ^5.28.0
+    "@webiny/project-utils": ^5.28.0
+    "@webiny/react-composition": ^5.28.0
+    nanoid: ^3.3.4
+    react: ^16.14.0
+  languageName: unknown
+  linkType: soft
+
 "@webiny/react-rich-text-renderer@^5.28.0, @webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer":
   version: 0.0.0-use.local
   resolution: "@webiny/react-rich-text-renderer@workspace:packages/react-rich-text-renderer"


### PR DESCRIPTION
## Changes
This PR introduces a new `@webiny/react-properties` package. It is currently marked as `private`, and it will not be released in this upcoming release. However, this package will serve as a base for customizable UI in combination with the `@webiny/react-composition`.

## How Has This Been Tested?
Jest tests. Lots of them 😎 

## Documentation
The best way to learn how this package works is to look at the test files. This is an internal package, so no user docs are necessary at this stage.