### PR TITLE
feat(project-utils): use retries to delete indexes on snapshot errors

### DIFF
--- a/packages/project-utils/testing/elasticsearch/client.ts
+++ b/packages/project-utils/testing/elasticsearch/client.ts
@@ -21,6 +21,33 @@ if (!!esEndpoint) {
     defaultOptions.auth = undefined;
 }
 
+const wait = (ms: number): Promise<void> => {
+    return new Promise((resolve: (value?: any) => void) => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+};
+
+const SNAPSHOT_ERROR = "snapshot_in_progress_exception";
+
+const isSnapshotError = (ex: any): boolean => {
+    const rootCauseType = ex.meta?.body?.error?.type;
+    if (rootCauseType === SNAPSHOT_ERROR) {
+        return true;
+    }
+    const rootCauses = ex.meta?.body?.error?.root_cause;
+    if (Array.isArray(rootCauses) === false) {
+        return false;
+    }
+    for (const rc of rootCauses) {
+        if (rc.type === SNAPSHOT_ERROR) {
+            return true;
+        }
+    }
+    return false;
+};
+
 const createDeleteIndexCallable = (client: Client) => {
     const max = 10;
     return async (index: string): Promise<void> => {
@@ -52,8 +79,17 @@ const createDeleteIndexCallable = (client: Client) => {
             } catch (ex) {
                 console.log(`Could not delete index: ${index}`);
                 console.log(JSON.stringify(ex));
-                return;
+                /**
+                 * In case of snapshot error - we will retry.
+                 */
+                if (isSnapshotError(ex) === false) {
+                    return;
+                }
             }
+            /**
+             * Let's retry deleting index again...
+             */
+            await wait(1000);
             counter++;
         }
     };

--- a/packages/project-utils/testing/elasticsearch/createClient.js
+++ b/packages/project-utils/testing/elasticsearch/createClient.js
@@ -15,7 +15,37 @@ if (!!esEndpoint) {
     defaultOptions.auth = undefined;
 }
 
+const wait = ms => {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+};
+
+const SNAPSHOT_ERROR = "snapshot_in_progress_exception";
+
+const isSnapshotError = ex => {
+    const rootCauseType = ex.meta?.body?.error?.type;
+    if (rootCauseType === SNAPSHOT_ERROR) {
+        return true;
+    }
+    const rootCauses = ex.meta?.body?.error?.root_cause;
+    if (Array.isArray(rootCauses) === false) {
+        return false;
+    }
+    for (const rc of rootCauses) {
+        if (rc.type === SNAPSHOT_ERROR) {
+            return true;
+        }
+    }
+    return false;
+};
+
 const createDeleteIndexCallable = client => {
+    /**
+     * The amount of retries in case of snapshot error.
+     */
     const max = 10;
     return async index => {
         for (let counter = 0; counter <= max; counter++) {
@@ -36,18 +66,28 @@ const createDeleteIndexCallable = client => {
                 return;
             }
             /**
-             * Then we delete it.
+             * Then we delete it, or at least try.
              */
             try {
                 await client.indices.delete({
                     index,
                     ignore_unavailable: true
                 });
+                return;
             } catch (ex) {
                 console.log(`Could not delete index: ${index}`);
                 console.log(JSON.stringify(ex));
-                return;
+                /**
+                 * In case of snapshot error - we will retry.
+                 */
+                if (isSnapshotError(ex) === false) {
+                    return;
+                }
             }
+            /**
+             * Let's retry deleting index again...
+             */
+            await wait(1000);
             counter++;
         }
     };

--- a/scripts/listPackagesWithTests.js
+++ b/scripts/listPackagesWithTests.js
@@ -20,31 +20,31 @@ const CUSTOM_HANDLERS = {
     // Split "api-file-manager" tests.
     "api-file-manager": () => {
         return [
-            "packages/api-file-manager/* --keyword=fm:ddb --keyword=fm:base"
-            // "packages/api-file-manager/* --keyword=fm:ddb-es --keyword=fm:base"
+            "packages/api-file-manager/* --keyword=fm:ddb --keyword=fm:base",
+            "packages/api-file-manager/* --keyword=fm:ddb-es --keyword=fm:base"
         ];
     },
 
     // Split "api-form-builder" tests.
     "api-form-builder": () => {
         return [
-            "packages/api-form-builder/* --keyword=fb:ddb --keyword=fb:base"
-            // "packages/api-form-builder/* --keyword=fb:ddb-es --keyword=fb:base"
+            "packages/api-form-builder/* --keyword=fb:ddb --keyword=fb:base",
+            "packages/api-form-builder/* --keyword=fb:ddb-es --keyword=fb:base"
         ];
     },
 
     // Split "api-page-builder" tests.
     "api-page-builder": () => {
         return [
-            "packages/api-page-builder/* --keyword=pb:ddb --keyword=pb:base"
-            // "packages/api-page-builder/* --keyword=pb:ddb-es --keyword=pb:base"
+            "packages/api-page-builder/* --keyword=pb:ddb --keyword=pb:base",
+            "packages/api-page-builder/* --keyword=pb:ddb-es --keyword=pb:base"
         ];
     },
     // Split "api-headless-cms" tests.
     "api-headless-cms": () => {
         return [
-            "packages/api-headless-cms/* --keyword=cms:ddb --keyword=cms:base"
-            // "packages/api-headless-cms/* --keyword=cms:ddb-es --keyword=cms:base"
+            "packages/api-headless-cms/* --keyword=cms:ddb --keyword=cms:base",
+            "packages/api-headless-cms/* --keyword=cms:ddb-es --keyword=cms:base"
         ];
     },
     // Split "api-apw" tests.


### PR DESCRIPTION
## Changes
This PR adds retries to deletion of the indexes after tests - when snapshot error happens.

## How Has This Been Tested?
Jest.