### PR TITLE
Use Handlers For `projectAppParams.pulumi` Parameter

### DIFF
--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -22,6 +22,12 @@ export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParam
         path: "apps/admin",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.pulumi) {
+                app.addHandler(() => {
+                    return projectAppParams.pulumi!(app as ReturnType<typeof createAdminPulumiApp>);
+                });
+            }
+
             const bucket = createPublicAppBucket(app, "admin-app");
 
             const cloudfront = app.addResource(aws.cloudfront.Distribution, {
@@ -76,10 +82,6 @@ export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParam
                 WbyProjectName: String(process.env["WEBINY_PROJECT_NAME"]),
                 WbyEnvironment: String(process.env["WEBINY_ENV"])
             });
-
-            if (projectAppParams.pulumi) {
-                await projectAppParams.pulumi(app as ReturnType<typeof createAdminPulumiApp>);
-            }
 
             return {
                 ...bucket,

--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -22,6 +22,8 @@ export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParam
         path: "apps/admin",
         config: projectAppParams,
         program: async app => {
+            // Overrides must be applied via a handler, registered at the very start of the program.
+            // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {
                 app.addHandler(() => {
                     return projectAppParams.pulumi!(app as ReturnType<typeof createAdminPulumiApp>);

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -34,6 +34,12 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
         path: "apps/api",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.pulumi) {
+                app.addHandler(() => {
+                    return projectAppParams.pulumi!(app as ReturnType<typeof createApiPulumiApp>);
+                });
+            }
+
             // Enables logs forwarding.
             // https://www.webiny.com/docs/how-to-guides/use-watch-command#enabling-logs-forwarding
             const WEBINY_LOGS_FORWARD_URL = String(process.env.WEBINY_LOGS_FORWARD_URL);
@@ -158,10 +164,6 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 WbyProjectName: String(process.env["WEBINY_PROJECT_NAME"]),
                 WbyEnvironment: String(process.env["WEBINY_ENV"])
             });
-
-            if (projectAppParams.pulumi) {
-                await projectAppParams.pulumi(app as ReturnType<typeof createApiPulumiApp>);
-            }
 
             return {
                 fileManager,

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -34,6 +34,8 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
         path: "apps/api",
         config: projectAppParams,
         program: async app => {
+            // Overrides must be applied via a handler, registered at the very start of the program.
+            // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {
                 app.addHandler(() => {
                     return projectAppParams.pulumi!(app as ReturnType<typeof createApiPulumiApp>);

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -48,6 +48,12 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         path: "apps/core",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.pulumi) {
+                app.addHandler(() => {
+                    return projectAppParams.pulumi!(app as ReturnType<typeof createCorePulumiApp>);
+                });
+            }
+
             const prod = app.params.run.env === "prod";
             const protect = app.getParam(projectAppParams.protect) || prod;
             const legacyConfig = app.getParam(projectAppParams.legacy) || {};
@@ -92,10 +98,6 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
                 WbyProjectName: String(process.env["WEBINY_PROJECT_NAME"]),
                 WbyEnvironment: String(process.env["WEBINY_ENV"])
             });
-
-            if (projectAppParams.pulumi) {
-                await projectAppParams.pulumi(app as ReturnType<typeof createCorePulumiApp>);
-            }
 
             return {
                 dynamoDbTable,

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -48,6 +48,8 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         path: "apps/core",
         config: projectAppParams,
         program: async app => {
+            // Overrides must be applied via a handler, registered at the very start of the program.
+            // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {
                 app.addHandler(() => {
                     return projectAppParams.pulumi!(app as ReturnType<typeof createCorePulumiApp>);

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -31,6 +31,8 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
         path: "apps/website",
         config: projectAppParams,
         program: async app => {
+            // Overrides must be applied via a handler, registered at the very start of the program.
+            // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {
                 app.addHandler(() => {
                     return projectAppParams.pulumi!(

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -31,6 +31,14 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
         path: "apps/website",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.pulumi) {
+                app.addHandler(() => {
+                    return projectAppParams.pulumi!(
+                        app as ReturnType<typeof createWebsitePulumiApp>
+                    );
+                });
+            }
+
             // Register core output as a module available for all other modules
             const core = app.addModule(CoreOutput);
 
@@ -183,10 +191,6 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 WbyProjectName: String(process.env["WEBINY_PROJECT_NAME"]),
                 WbyEnvironment: String(process.env["WEBINY_ENV"])
             });
-
-            if (projectAppParams.pulumi) {
-                await projectAppParams.pulumi(app as ReturnType<typeof createWebsitePulumiApp>);
-            }
 
             return {
                 prerendering,


### PR DESCRIPTION
## Changes
Prior to this PR, updating existing cloud infrastructure resources (via Pulumi / `webiny.application.ts`) would not work because of an internal bug located in Pulumi apps. 

By using a "handler" to, internally, propagate user's Pulumi overrides, we're resolving the above issue.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.
