### PR TITLE
Add the Ability To Assign WCP Project ID via Environment Variable

### DIFF
--- a/example.env
+++ b/example.env
@@ -19,15 +19,18 @@ PULUMI_CONFIG_PASSPHRASE={PULUMI_CONFIG_PASSPHRASE}
 # Overrides the default `https://app.webiny.com` app URL.
 # WCP_APP_URL=...
 
+# Besides having it in `webiny.project.ts`, we can also set the WCP project ID via this variable.
+# WCP_PROJECT_ID=...
+
 # You can paste a WCP CI/CD environment API key via this variable.
-WCP_PROJECT_ENVIRONMENT_API_KEY=...
+# WCP_PROJECT_ENVIRONMENT_API_KEY=...
 
 # Thresholds for sending telemetry logs can be modified via these variables.
 # Send logs to WCP once there are two logs to be sent.
-WCP_TELEMETRY_CLIENT_SEND_LOGS_MAX_COUNT=2
+# WCP_TELEMETRY_CLIENT_SEND_LOGS_MAX_COUNT=2
 
 # Send logs to WCP once the last recorded log is more than 10 seconds old.
-WCP_TELEMETRY_CLIENT_SEND_LOGS_MAX_TIME=10
+# WCP_TELEMETRY_CLIENT_SEND_LOGS_MAX_TIME=10
 
 
 

--- a/packages/cli/commands/wcp/hooks.js
+++ b/packages/cli/commands/wcp/hooks.js
@@ -7,6 +7,18 @@ const { getUser, getProjectEnvironment, updateUserLastActiveOn } = require("./ut
  * - WCP_PROJECT_ENVIRONMENT_API_KEY - for easier access, we also set the API key
  */
 
+/**
+ * There are multiple ways the hooks below prepare the WCP-enabled project for deployment.
+ * 1. If `WCP_PROJECT_ENVIRONMENT` metadata env var is defined, we decrypt it, retrieve the
+ *    API key from it, and assign it as the `WCP_PROJECT_ENVIRONMENT_API_KEY` env var.
+ * 2. If `WCP_PROJECT_ENVIRONMENT_API_KEY` env var is defined, then we use that as the
+ *    project environment API key. We use that to load the project environment data
+ *    and to also assign the `WCP_PROJECT_ENVIRONMENT` metadata env var.
+ * 3. If none of the above is defined, we retrieve (or create) the project environment,
+ *    retrieve its API key and again assign it as `WCP_PROJECT_ENVIRONMENT_API_KEY` env var.
+ *    As in 2), we also assign the `WCP_PROJECT_ENVIRONMENT` metadata env var.
+ */
+
 let projectEnvironment;
 
 module.exports = () => [
@@ -14,32 +26,29 @@ module.exports = () => [
         type: "hook-before-deploy",
         name: "hook-before-deploy-environment-get-environment",
         async hook(args, context) {
+            // For development purposes, we allow setting the WCP_PROJECT_ENVIRONMENT env var directly.
+            if (process.env.WCP_PROJECT_ENVIRONMENT) {
+                // If we have WCP_PROJECT_ENVIRONMENT env var, we set the WCP_PROJECT_ENVIRONMENT_API_KEY too.
+                const decryptedProjectEnvironment = decrypt(process.env.WCP_PROJECT_ENVIRONMENT);
+                process.env.WCP_PROJECT_ENVIRONMENT_API_KEY = decryptedProjectEnvironment.apiKey;
+                return;
+            }
+
+            // If the project isn't activated, do nothing.
+            const wcpProjectId = context.project.config.id || process.env.WCP_PROJECT_ID;
+            if (!wcpProjectId) {
+                return;
+            }
+
+            // The `id` has the orgId/projectId structure, for example `my-org-x/my-project-y`.
+            const [orgId, projectId] = wcpProjectId.split("/");
+
             const apiKey = process.env.WCP_PROJECT_ENVIRONMENT_API_KEY;
+
+            let projectEnvironment;
             if (apiKey) {
                 projectEnvironment = await getProjectEnvironment({ apiKey });
             } else {
-                // If the project isn't activated, do nothing.
-                const wcpProjectId = context.project.config.id || process.env.WCP_PROJECT_ID;
-                if (!wcpProjectId) {
-                    return;
-                }
-
-                // For development purposes, we allow setting the WCP_PROJECT_ENVIRONMENT env var directly.
-                // TODO: discuss this, do we really want to have this feature? Maybe we can remove it?
-                if (process.env.WCP_PROJECT_ENVIRONMENT) {
-                    // If we have WCP_PROJECT_ENVIRONMENT env var, we set the WCP_PROJECT_ENVIRONMENT_API_KEY too.
-                    const decryptedProjectEnvironment = decrypt(
-                        process.env.WCP_PROJECT_ENVIRONMENT
-                    );
-                    process.env.WCP_PROJECT_ENVIRONMENT_API_KEY =
-                        decryptedProjectEnvironment.apiKey;
-
-                    return;
-                }
-
-                // The `id` has the orgId/projectId structure, for example `my-org-x/my-project-y`.
-                const [orgId, projectId] = wcpProjectId.split("/");
-
                 const isValidId = orgId && projectId;
                 if (!isValidId) {
                     throw new Error(
@@ -64,24 +73,25 @@ module.exports = () => [
                 });
             }
 
+            if (projectEnvironment.org.id !== orgId) {
+                throw new Error(
+                    `Cannot proceed with the deployment because the "${projectEnvironment.name}" project environment doesn't belong to the "${orgId}" organization. Please check your WCP project ID (currently set to "${wcpProjectId}").`
+                );
+            }
+
+            if (projectEnvironment.project.id !== projectId) {
+                throw new Error(
+                    `Cannot proceed with the deployment because the "${projectEnvironment.name}" project environment doesn't belong to the "${wcpProjectId}" project. Please check your WCP project ID (currently set to "${wcpProjectId}").`
+                );
+            }
+
             if (projectEnvironment && projectEnvironment.status !== "enabled") {
                 throw new Error(
                     `Cannot proceed with the deployment because the "${projectEnvironment.name}" project environment has been disabled.`
                 );
             }
-        }
-    },
-    // Within this hook, we're setting the `WCP_PROJECT_ENVIRONMENT` env variable, which can then be used in
-    // build / deploy steps. For example, we pass it to GraphQL and Headless CMS Lambda functions.
-    {
-        type: "hook-before-deploy",
-        name: "hook-before-deploy-project-environment",
-        async hook() {
-            if (!projectEnvironment) {
-                return;
-            }
 
-            // Ensure the correct API key is set into environment variable.
+            // Assign `WCP_PROJECT_ENVIRONMENT` and `WCP_PROJECT_ENVIRONMENT_API_KEY`
             const wcpProjectEnvironment = {
                 id: projectEnvironment.id,
                 apiKey: projectEnvironment.apiKey,
@@ -93,7 +103,6 @@ module.exports = () => [
             process.env.WCP_PROJECT_ENVIRONMENT_API_KEY = projectEnvironment.apiKey;
         }
     },
-    // Within this hook, we're updating user's "last active" field.
     {
         type: "hook-before-deploy",
         name: "hook-before-deploy-update-last-active-on",

--- a/packages/cli/commands/wcp/login.js
+++ b/packages/cli/commands/wcp/login.js
@@ -179,7 +179,9 @@ module.exports.command = () => ({
                     `${chalk.green("✔")} You've successfully logged in to Webiny Control Panel.`
                 );
 
-                let projectInitialized = Boolean(context.project.config.id || process.env.WCP_PROJECT_ID);
+                let projectInitialized = Boolean(
+                    context.project.config.id || process.env.WCP_PROJECT_ID
+                );
 
                 // If we have `orgId` and `projectId` in PAT's meta data, let's immediately activate the project.
                 if (pat.meta && pat.meta.orgId && pat.meta.projectId) {

--- a/packages/cli/commands/wcp/login.js
+++ b/packages/cli/commands/wcp/login.js
@@ -179,7 +179,7 @@ module.exports.command = () => ({
                     `${chalk.green("✔")} You've successfully logged in to Webiny Control Panel.`
                 );
 
-                let projectInitialized = Boolean(context.project.config.id);
+                let projectInitialized = Boolean(context.project.config.id || process.env.WCP_PROJECT_ID);
 
                 // If we have `orgId` and `projectId` in PAT's meta data, let's immediately activate the project.
                 if (pat.meta && pat.meta.orgId && pat.meta.projectId) {

--- a/packages/project-utils/bundling/app/utils.js
+++ b/packages/project-utils/bundling/app/utils.js
@@ -12,8 +12,9 @@ module.exports.applyDefaults = () => {
         telemetry = isEnabled();
     }
 
-    if (config.id) {
-        process.env.REACT_APP_WCP_PROJECT_ID = config.id;
+    const wcpProjectId = config.id || process.env.WCP_PROJECT_ID;
+    if (wcpProjectId) {
+        process.env.REACT_APP_WCP_PROJECT_ID = wcpProjectId;
     }
 
     if (!("REACT_APP_USER_ID" in process.env)) {

--- a/packages/wcp/src/encryption.ts
+++ b/packages/wcp/src/encryption.ts
@@ -4,10 +4,18 @@
  */
 
 export const encrypt = <T = Record<string, any>>(rawObject: T): string => {
-    return Buffer.from(JSON.stringify(rawObject), "utf-8").toString("base64");
+    try {
+        return Buffer.from(JSON.stringify(rawObject), "utf-8").toString("base64");
+    } catch {
+        throw new Error("Could not encrypt given data.");
+    }
 };
 
 export const decrypt = <T = Record<string, any>>(encryptedString: string): T => {
-    const decryptedString = Buffer.from(encryptedString, "base64").toString("utf-8");
-    return JSON.parse(decryptedString) as T;
+    try {
+        const decryptedString = Buffer.from(encryptedString, "base64").toString("utf-8");
+        return JSON.parse(decryptedString) as T;
+    } catch {
+        throw new Error(`Could not decrypt the given string (${encryptedString}).`);
+    }
 };

--- a/webiny.project.ts
+++ b/webiny.project.ts
@@ -1,8 +1,5 @@
 // @ts-nocheck
 export default {
-    id: "adrian/test",
-    // Uncomment this to test WCP-related functionality.
-    // id: "webiny/webiny-js",
     name: "webiny-js",
     cli: {
         // No need to track anything when developing Webiny.


### PR DESCRIPTION
## Changes
Usually, the WCP project ID is set via `webiny.project.ts`, but, for dev/testing purposes, we want to be able to set the WCP project ID via an env var too.

## How Has This Been Tested?
Manual.

## Documentation
None for now.