### PR TITLE
feat: apw - filter content reviews by content type

### DIFF
--- a/packages/api-apw/src/plugins/cms/contentReviewModelFields.ts
+++ b/packages/api-apw/src/plugins/cms/contentReviewModelFields.ts
@@ -1,0 +1,30 @@
+import { ApwContext } from "~/types";
+import { CONTENT_REVIEW_MODEL_ID } from "~/storageOperations/models/contentReview.model";
+import { CmsEntryFieldFilterPathPlugin } from "@webiny/api-headless-cms-ddb/plugins/CmsEntryFieldFilterPathPlugin";
+
+export const createContentReviewModelFields = (context: ApwContext) => {
+    const plugins = [];
+    /**
+     * There is a possibility that this is Elasticsearch deployment.
+     * At that point add Elasticsearch fields.
+     * We are not using CmsEntryElasticsearchFieldPlugin because we would need to import @webiny/api-headless-cms-ddb-es.
+     * // TODO figure out how to push this plugin only on Elasticsearch deployment.
+     */
+    if ((context as any).elasticsearch) {
+        plugins.push({
+            type: "elasticsearch.fieldDefinition.cms.entry",
+            field: "appType",
+            modelId: CONTENT_REVIEW_MODEL_ID,
+            path: "content.type"
+        });
+    }
+    plugins.push(
+        new CmsEntryFieldFilterPathPlugin({
+            path: "content.type",
+            fieldId: ["appType"],
+            fieldType: "text"
+        })
+    );
+
+    context.plugins.register(plugins);
+};

--- a/packages/api-apw/src/plugins/cms/index.ts
+++ b/packages/api-apw/src/plugins/cms/index.ts
@@ -1,38 +1,34 @@
-import { AdvancedPublishingWorkflow } from "~/types";
+import { ApwContext } from "~/types";
 import { apwEntryPlugins } from "~/plugins/cms/apwEntryPlugins";
 import { linkContentReviewToEntry } from "~/plugins/cms/linkContentReviewToEntry";
 import { linkWorkflowToEntry } from "~/plugins/cms/linkWorkflowToEntry";
 import { triggerContentReview } from "~/plugins/cms/triggerContentReview";
 import { updateContentReviewStatus } from "~/plugins/cms/updateContentReviewStatus";
-import { HeadlessCms } from "@webiny/api-headless-cms/types";
-import { Security } from "@webiny/api-security/types";
-import { PluginsContainer } from "@webiny/plugins";
 import { CmsEntryApwSettingsGetterPlugin } from "~/plugins/cms/CmsEntryApwSettingsGetterPlugin";
+import { createContentReviewModelFields } from "~/plugins/cms/contentReviewModelFields";
 
-interface ApwCmsHooksParams {
-    apw: AdvancedPublishingWorkflow;
-    cms: HeadlessCms;
-    plugins: PluginsContainer;
-    security: Security;
-}
-export const apwCmsHooks = (params: ApwCmsHooksParams) => {
+export const apwCmsHooks = (context: ApwContext) => {
     /**
      * We do not need to assign anything if no apw or cms in the context.
      * This might happen on options request.
      */
-    if (!params.apw || !params.cms) {
+    if (!context.apw || !context.cms) {
         return;
     }
 
-    params.plugins.register(new CmsEntryApwSettingsGetterPlugin());
+    context.plugins.register(new CmsEntryApwSettingsGetterPlugin());
 
-    apwEntryPlugins(params);
+    apwEntryPlugins(context);
 
-    linkContentReviewToEntry(params);
+    linkContentReviewToEntry(context);
 
-    linkWorkflowToEntry(params);
+    linkWorkflowToEntry(context);
 
-    triggerContentReview(params);
+    triggerContentReview(context);
 
-    updateContentReviewStatus(params);
+    updateContentReviewStatus(context);
+    /**
+     * Add fields that will help with filtering.
+     */
+    createContentReviewModelFields(context);
 };

--- a/packages/api-apw/src/plugins/graphql/contentReview.gql.ts
+++ b/packages/api-apw/src/plugins/graphql/contentReview.gql.ts
@@ -172,7 +172,7 @@ const contentReviewSchema = new GraphQLSchemaPlugin<ApwContext>({
             status: ApwContentReviewStatus
             title: String
             title_contains: String
-            app_type: ApwContentReviewContentTypes
+            appType: ApwContentReviewContentTypes
         }
 
         type ApwProvideSignOffResponse {

--- a/packages/api-apw/src/plugins/graphql/contentReview.gql.ts
+++ b/packages/api-apw/src/plugins/graphql/contentReview.gql.ts
@@ -172,6 +172,7 @@ const contentReviewSchema = new GraphQLSchemaPlugin<ApwContext>({
             status: ApwContentReviewStatus
             title: String
             title_contains: String
+            app_type: ApwContentReviewContentTypes
         }
 
         type ApwProvideSignOffResponse {

--- a/packages/app-apw/src/hooks/useContentReviewsList.ts
+++ b/packages/app-apw/src/hooks/useContentReviewsList.ts
@@ -72,7 +72,7 @@ export const useContentReviewsList: UseContentReviewsListHook = (config: Config)
     const where = {
         status: status === "all" ? undefined : status,
         title_contains: title ? title : undefined,
-        app_type: type && type !== "all" ? type : undefined
+        appType: type && type !== "all" ? type : undefined
     };
 
     const {
@@ -84,7 +84,7 @@ export const useContentReviewsList: UseContentReviewsListHook = (config: Config)
         {
             variables: {
                 where,
-                sort: [sort as string]
+                sort: sort ? [sort] : undefined
             },
             /**
              * We're using "network-only" fetchPolicy here because, we need to update the cache result for this query after creating a content review,

--- a/packages/app-apw/src/hooks/useContentReviewsList.ts
+++ b/packages/app-apw/src/hooks/useContentReviewsList.ts
@@ -7,7 +7,12 @@ import {
     ListContentReviewsQueryResponse,
     ListContentReviewsQueryVariables
 } from "~/graphql/contentReview.gql";
-import { ApwContentReview, ApwContentReviewListItem, ApwContentReviewStatus } from "~/types";
+import {
+    ApwContentReview,
+    ApwContentReviewListItem,
+    ApwContentReviewStatus,
+    ApwContentTypes
+} from "~/types";
 
 const BASE_URL = "/apw/content-reviews";
 
@@ -31,6 +36,8 @@ interface UseContentReviewsListHook {
         fetchMore: () => Promise<void>;
         fetchMoreLoading: boolean;
         setFilter: (filter: string) => void;
+        type: ApwContentTypes | "all";
+        setType: (value: ApwContentTypes | "all") => void;
         sort: string | null;
         setSort: (sort: string) => void;
         serializeSorters: (data: Record<string, string>) => string;
@@ -46,6 +53,7 @@ export const useContentReviewsList: UseContentReviewsListHook = (config: Config)
     const [title, setTitle] = useState<string>("");
     const [sort, setSort] = useState<string | null>(defaultSorter);
     const [status, setStatus] = useState<ApwContentReviewStatus | "all">("all");
+    const [type, setType] = useState<ApwContentTypes | "all">("all");
     const navigate = useNavigate();
 
     const [lastLoadedCursor, setLastLoadedCursor] = useState<string | null>(null);
@@ -63,7 +71,8 @@ export const useContentReviewsList: UseContentReviewsListHook = (config: Config)
 
     const where = {
         status: status === "all" ? undefined : status,
-        title_contains: title ? title : undefined
+        title_contains: title ? title : undefined,
+        app_type: type && type !== "all" ? type : undefined
     };
 
     const {
@@ -145,6 +154,8 @@ export const useContentReviewsList: UseContentReviewsListHook = (config: Config)
         setFilter,
         fetchMore,
         fetchMoreLoading,
+        type,
+        setType,
         sort,
         setSort,
         serializeSorters,

--- a/packages/app-apw/src/views/contentReviewDashboard/ContentReviewDataList.tsx
+++ b/packages/app-apw/src/views/contentReviewDashboard/ContentReviewDataList.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 import { DataList, List, DataListModalOverlayAction, ListItem } from "@webiny/ui/List";
 import { i18n } from "@webiny/app/i18n";
 import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/filter-24px.svg";
-import { ApwContentReviewListItem } from "~/types";
+import { ApwContentReviewListItem, ApwContentTypes } from "~/types";
 import { ContentReviewListItem } from "./components/ContentReviewItem";
 import { useContentReviewsList } from "~/hooks/useContentReviewsList";
 import { ContentReviewsFilterModal } from "./components/ContentReviewsFilterOverlay";
@@ -39,6 +39,21 @@ const SORTERS = [
     }
 ];
 
+const TYPES = [
+    {
+        label: t`All`,
+        value: "all"
+    },
+    {
+        label: t`Page`,
+        value: ApwContentTypes.PAGE
+    },
+    {
+        label: t`CMS Entry`,
+        value: ApwContentTypes.CMS_ENTRY
+    }
+];
+
 const InlineLoaderWrapper = styled("div")({
     position: "absolute",
     bottom: 0,
@@ -57,6 +72,8 @@ export const ContentReviewDataList: React.FC = () => {
         loading,
         editContentReview,
         fetchMoreLoading,
+        type,
+        setType,
         sort,
         setSort,
         status,
@@ -96,6 +113,9 @@ export const ContentReviewDataList: React.FC = () => {
                     setStatus={setStatus}
                     sort={sort}
                     setSort={setSort}
+                    type={type}
+                    types={TYPES}
+                    setType={setType}
                     sorters={SORTERS}
                 />
             }

--- a/packages/app-apw/src/views/contentReviewDashboard/components/ContentReviewsFilterOverlay.tsx
+++ b/packages/app-apw/src/views/contentReviewDashboard/components/ContentReviewsFilterOverlay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Select } from "@webiny/ui/Select";
 import { DataListModalOverlay } from "@webiny/ui/List";
-import { ApwContentReviewStatus } from "~/types";
+import { ApwContentReviewStatus, ApwContentTypes } from "~/types";
 import { i18n } from "@webiny/app/i18n";
 
 const t = i18n.ns("app-apw/admin/content-reviews/datalist/modal");
@@ -15,10 +15,13 @@ interface ContentReviewsFilterModalProps {
     sort: string | null;
     setSort: (value: any) => void;
     sorters: { label: string; value: string }[];
+    type: ApwContentTypes | "all";
+    setType: (value: ApwContentTypes | "all") => void;
+    types: { label: string; value: string }[];
 }
 
 export const ContentReviewsFilterModal = (props: ContentReviewsFilterModalProps) => {
-    const { status, setStatus, sort, setSort, sorters } = props;
+    const { status, setStatus, sort, setSort, sorters, types, type, setType } = props;
 
     return (
         <DataListModalOverlay>
@@ -49,6 +52,22 @@ export const ContentReviewsFilterModal = (props: ContentReviewsFilterModalProps)
                         description={t`Sort reviews by.`}
                     >
                         {sorters.map(({ label, value }) => {
+                            return (
+                                <option key={label} value={value}>
+                                    {label}
+                                </option>
+                            );
+                        })}
+                    </Select>
+                </Cell>
+                <Cell span={12}>
+                    <Select
+                        value={type}
+                        onChange={setType}
+                        label={t`Content type`}
+                        description={t`Show only selected content type.`}
+                    >
+                        {types.map(({ label, value }) => {
                             return (
                                 <option key={label} value={value}>
                                     {label}


### PR DESCRIPTION
## Changes
This PR adds filter by content type in the content reviews so user can select if they want to see only page or cms entries in the content review dashboard.

## How Has This Been Tested?
Jest and manually.
