### PR TITLE
fix(app-page-builder): resurrect "click-to-add" element

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/cell/CellContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/cell/CellContainer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Cell from "./Cell";
-import DropZone from "../../../components/DropZone";
+import DropZone from "~/editor/components/DropZone";
 import styled from "@emotion/styled";
 import { IconButton } from "@webiny/ui/Button";
 import { css } from "emotion";

--- a/packages/app-page-builder/src/editor/plugins/toolbar/addElement/AddElement.tsx
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/addElement/AddElement.tsx
@@ -1,26 +1,26 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
-import * as Styled from "./StyledComponents";
-import { activePluginParamsByNameSelector } from "../../../recoil/modules";
-import { useEventActionHandler } from "../../../hooks/useEventActionHandler";
-import {
-    DeactivatePluginActionEvent,
-    DragEndActionEvent,
-    DragStartActionEvent,
-    DropElementActionEvent
-} from "../../../recoil/actions";
-import { DropElementActionArgsType } from "../../../recoil/actions/dropElement/types";
-import Draggable from "../../../components/Draggable";
-import { plugins } from "@webiny/plugins";
-import { usePageBuilder } from "../../../../hooks/usePageBuilder";
 import { useRecoilValue } from "recoil";
 import { css } from "emotion";
 import { List, ListItem, ListItemMeta } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
 import { Typography } from "@webiny/ui/Typography";
 import { ButtonFloating } from "@webiny/ui/Button";
-import { ReactComponent as AddIcon } from "../../../assets/icons/add.svg";
-import { PbEditorPageElementGroupPlugin, PbEditorPageElementPlugin } from "../../../../types";
-import { useKeyHandler } from "../../../hooks/useKeyHandler";
+import * as Styled from "./StyledComponents";
+import { activePluginParamsByNameSelector } from "~/editor/recoil/modules";
+import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
+import {
+    DeactivatePluginActionEvent,
+    DragEndActionEvent,
+    DragStartActionEvent,
+    DropElementActionEvent
+} from "~/editor/recoil/actions";
+import Draggable from "~/editor/components/Draggable";
+import { plugins } from "@webiny/plugins";
+import { usePageBuilder } from "~/hooks/usePageBuilder";
+import { ReactComponent as AddIcon } from "~/editor/assets/icons/add.svg";
+import { PbEditorPageElementGroupPlugin, PbEditorPageElementPlugin } from "~/types";
+import { useKeyHandler } from "~/editor/hooks/useKeyHandler";
+import { DropElementActionArgsType } from "~/editor/recoil/actions/dropElement/types";
 
 const ADD_ELEMENT = "pb-editor-toolbar-add-element";
 
@@ -45,8 +45,7 @@ const categoriesList = css({
 
 const AddElement: React.FC = () => {
     const handler = useEventActionHandler();
-    const plugin = useRecoilValue(activePluginParamsByNameSelector(ADD_ELEMENT));
-    const { params } = plugin || {};
+    const params = useRecoilValue(activePluginParamsByNameSelector(ADD_ELEMENT));
     const { removeKeyHandler, addKeyHandler } = useKeyHandler();
 
     const dragStart = useCallback(() => {
@@ -158,7 +157,7 @@ const AddElement: React.FC = () => {
                 () => {
                     dropElement({
                         source: { type: plugin.elementType } as any,
-                        target: { ...params }
+                        target: params as DropElementActionArgsType["target"]
                     });
                     deactivatePlugin();
                 },

--- a/packages/app-page-builder/src/editor/plugins/toolbar/addElement/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/addElement/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { PbEditorToolbarTopPlugin } from "~/types";
 import Action from "../Action";
 import AddElement from "./AddElement";
-import { ReactComponent as AddIcon } from "../../../assets/icons/add_circle_outline.svg";
+import { ReactComponent as AddIcon } from "~/editor/assets/icons/add_circle_outline.svg";
 
 export default {
     name: "pb-editor-toolbar-add-element",

--- a/packages/app-page-builder/src/editor/recoil/actions/togglePlugin/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/togglePlugin/action.ts
@@ -12,7 +12,7 @@ export const togglePluginAction: EventActionCallable<TogglePluginActionArgsType>
             actions: []
         };
     }
-    const { name, params = {}, closeOtherInGroup = false } = args;
+    const { name, params, closeOtherInGroup = false } = args;
     const plugin = plugins.byName(name);
     if (!plugin) {
         throw new Error(`There is no plugin with name "${name}".`);


### PR DESCRIPTION
## Changes
This PR fixes an existing feature that was broken at some point along the way. The feature allows you to activate a dropzone, and then simply select an element in the sidebar to insert, without using drag&drop.

https://user-images.githubusercontent.com/3920893/178733864-adddcf74-b9f1-4d61-92e9-b61765550269.mp4

## How Has This Been Tested?
Manually.
