### PR TITLE
Watch Command - Fix Glob (Paths to Watch) Generation For `pulumi watch`

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -117,8 +117,6 @@ module.exports = async (inputs, context) => {
     }
 
     let output = terminalOutput;
-    if (inputs.output === "browser") {
-    }
 
     switch (inputs.output) {
         case "browser":

--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -204,11 +204,17 @@ module.exports = async (inputs, context) => {
                 message: chalk.green("Watching cloud infrastructure resources...")
             });
 
-            const buildFoldersGlob = [
-                projectApplication.project.workspace,
-                inputs.folder,
-                "**/build"
-            ].join("/");
+            let buildFoldersGlob = [projectApplication.paths.workspace, "**/build/*.js"].join("/");
+
+            // For non-workspaces projects, we still want to be watching `**/build/*.js` files located
+            // in user's project (for example `api/graphql/code/build/handler.js`).
+            if (projectApplication.type !== "v5-workspaces") {
+                buildFoldersGlob = [
+                    projectApplication.paths.absolute,
+                    inputs.folder,
+                    "**/build/*.js"
+                ].join("/");
+            }
 
             const buildFolders = glob.sync(buildFoldersGlob, { onlyFiles: false });
 
@@ -241,7 +247,6 @@ module.exports = async (inputs, context) => {
 
             const pulumi = await getPulumi({ projectApplication });
 
-            // We only watch "code/**/build" and "pulumi" folders.
             const watchCloudInfrastructure = pulumi.run({
                 command: "watch",
                 args: {


### PR DESCRIPTION
## Changes
This PR fixes the [glob generation step](https://github.com/webiny/webiny-js/pull/2538/files#diff-8bd62af183cdab9d2c9ab4aea4f63dfb691cb1b81e38017c9784f0b6e07785ffR207-R217), via which we get the list of all paths that the Pulumi CLI (`pulumi watch` command) needs to watch. 

Additionally, with the previous glob pattern, the `pulumi watch` command would trigger redeploy twice on every app source code change, which should not happen. This PR also addresses this.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.