### PR TITLE
feat(pulumi): allow custom ENV variables and resource customization

### DIFF
--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -43,7 +43,7 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
             // By doing this, we're ensuring user's adjustments are not applied too late.
             if (projectAppParams.pulumi) {
                 app.addHandler(() => {
-                    projectAppParams.pulumi!(app as ApiPulumiApp);
+                    return projectAppParams.pulumi!(app as ApiPulumiApp);
                 });
             }
 

--- a/packages/pulumi-aws/src/apps/lambdaUtils.ts
+++ b/packages/pulumi-aws/src/apps/lambdaUtils.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { PulumiApp } from "@webiny/pulumi";
+export * from "../utils/lambdaEnvVariables";
 
 import { VpcConfig } from "./common";
 

--- a/packages/pulumi-aws/src/apps/lambdaUtils.ts
+++ b/packages/pulumi-aws/src/apps/lambdaUtils.ts
@@ -65,27 +65,3 @@ export function createLambdaRole(app: PulumiApp, params: LambdaRoleParams) {
 
     return role;
 }
-
-export function getCommonLambdaEnvVariables() {
-    // Apart from a couple of basic environment variables like STAGED_ROLLOUTS_VARIANT and DEBUG,
-    // we also take into consideration variables that have `WEBINY_` and `WCP_` prefix in their names.
-    const envVars: Record<string, string> = Object.keys(process.env).reduce(
-        (current, environmentVariableName) => {
-            const startsWithWebiny = environmentVariableName.startsWith("WEBINY_");
-            const startsWithWcp = environmentVariableName.startsWith("WCP_");
-
-            if (startsWithWebiny || startsWithWcp) {
-                current[environmentVariableName] = process.env[environmentVariableName];
-            }
-            return current;
-        },
-        {
-            // STAGED_ROLLOUTS_VARIANT: app.ctx.variant || "",
-            // Among other things, this determines the amount of information we reveal on runtime errors.
-            // https://www.webiny.com/docs/how-to-guides/environment-variables/#debug-environment-variable
-            DEBUG: String(process.env.DEBUG)
-        } as Record<string, any>
-    );
-
-    return envVars;
-}

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -4,8 +4,8 @@ import { createPulumiApp, PulumiAppParamCallback, PulumiAppParam } from "@webiny
 import { createPublicAppBucket } from "../createAppBucket";
 import { applyCustomDomain, CustomDomainParams } from "../customDomain";
 import { createPrerenderingService } from "./WebsitePrerendering";
-import { CoreOutput, VpcConfig } from "../common";
-import { tagResources } from "~/utils";
+import { CoreOutput, VpcConfig } from "~/apps";
+import { tagResources, withCommonLambdaEnvVariables } from "~/utils";
 import { applyTenantRouter } from "~/apps/tenantRouter";
 
 export type WebsitePulumiApp = ReturnType<typeof createWebsitePulumiApp>;
@@ -28,7 +28,7 @@ export interface CreateWebsitePulumiAppParams {
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {
-    return createPulumiApp({
+    const app = createPulumiApp({
         name: "website",
         path: "apps/website",
         config: projectAppParams,
@@ -207,4 +207,6 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
             };
         }
     });
+
+    return withCommonLambdaEnvVariables(app);
 };

--- a/packages/pulumi-aws/src/utils/index.ts
+++ b/packages/pulumi-aws/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./tagResources";
 export * from "./uploadFolderToS3";
+export { withCommonLambdaEnvVariables, getCommonLambdaEnvVariables } from "./lambdaEnvVariables";

--- a/packages/pulumi-aws/src/utils/lambdaEnvVariables.ts
+++ b/packages/pulumi-aws/src/utils/lambdaEnvVariables.ts
@@ -1,0 +1,87 @@
+import * as pulumi from "@pulumi/pulumi";
+import { PulumiApp } from "@webiny/pulumi";
+
+type EnvVariables = Record<string, string>;
+
+const variablesRegistry: EnvVariables = {};
+
+export let sealEnvVariables: () => void;
+
+const variablesPromise = new Promise<EnvVariables>(resolve => {
+    sealEnvVariables = () => {
+        // Apart from a couple of basic environment variables like STAGED_ROLLOUTS_VARIANT and DEBUG,
+        // we also take into consideration variables that have `WEBINY_` and `WCP_` prefix in their names.
+        const baseVariables = Object.keys(process.env).reduce<EnvVariables>(
+            (current, environmentVariableName) => {
+                const startsWithWebiny = environmentVariableName.startsWith("WEBINY_");
+                const startsWithWcp = environmentVariableName.startsWith("WCP_");
+
+                if (
+                    (startsWithWebiny || startsWithWcp) &&
+                    process.env[environmentVariableName] !== undefined
+                ) {
+                    current[environmentVariableName] = String(process.env[environmentVariableName]);
+                }
+                return current;
+            },
+            {
+                // STAGED_ROLLOUTS_VARIANT: app.ctx.variant || "",
+                // Among other things, this determines the amount of information we reveal on runtime errors.
+                // https://www.webiny.com/docs/how-to-guides/environment-variables/#debug-environment-variable
+                DEBUG: String(process.env.DEBUG)
+            }
+        );
+
+        resolve(Object.assign({}, baseVariables, variablesRegistry));
+    };
+});
+
+export function getCommonLambdaEnvVariables(): pulumi.Output<EnvVariables> {
+    return pulumi.output(variablesPromise);
+}
+
+function setCommonLambdaEnvVariables(variables: EnvVariables) {
+    Object.assign(variablesRegistry, variables);
+}
+
+export interface SetCommonLambdaEnvVariables {
+    (variables: EnvVariables): void;
+}
+
+export interface WithCommonLambdaEnvVariables {
+    /**
+     * Set ENV variables that wil be assigned to all Lambda functions in the current Pulumi app.
+     */
+    setCommonLambdaEnvVariables: SetCommonLambdaEnvVariables;
+}
+
+/**
+ * Augment the given app with `setCommonLambdaEnvVariables` functionality.
+ * @param {PulumiApp} app
+ */
+export function withCommonLambdaEnvVariables<T extends PulumiApp>(
+    app: T
+): T & WithCommonLambdaEnvVariables {
+    const originalProgram = app.program;
+    app.program = async app => {
+        // We must first execute the original program, and pass in the augmented app.
+        const resources = await originalProgram({
+            ...app,
+            // @ts-ignore because currently, we don't have a way of passing in a custom app type.
+            setCommonLambdaEnvVariables
+        });
+
+        // Once the program is executed, we need to seal the variables (this will resolve the pulumi.output promise).
+        app.addHandler(() => {
+            sealEnvVariables();
+        });
+
+        return resources;
+    };
+
+    // Augment the original PulumiApp.
+    return {
+        ...app,
+        setCommonLambdaEnvVariables
+    };
+}

--- a/packages/pulumi/src/PulumiAppResource.ts
+++ b/packages/pulumi/src/PulumiAppResource.ts
@@ -31,6 +31,7 @@ export type PulumiAppResourceConfigProxy<T extends object> = {
 
 export interface PulumiAppResource<T extends PulumiAppResourceConstructor> {
     name: string;
+    type: T;
     readonly config: PulumiAppResourceConfigProxy<PulumiAppResourceArgs<T>>;
     readonly opts: pulumi.CustomResourceOptions;
     readonly output: pulumi.Output<pulumi.Unwrap<PulumiAppResourceType<T>>>;

--- a/packages/pulumi/src/createPulumiApp.ts
+++ b/packages/pulumi/src/createPulumiApp.ts
@@ -95,18 +95,19 @@ export function createPulumiApp<TResources extends Record<string, unknown>>(
 
             const promise = new Promise<PulumiAppResourceType<T>>(resolve => {
                 app.handlers.push(() => {
+                    app.resourceHandlers.forEach(handler => handler(resource));
+
                     resolve(new resourceConstructor(resource.name, config, opts));
                 });
             });
 
             const resource: PulumiAppResource<T> = {
                 name: params.name,
+                type: resourceConstructor,
                 config: createPulumiAppResourceConfigProxy(config),
                 opts,
                 output: pulumi.output(promise)
             };
-
-            app.resourceHandlers.forEach(handler => handler(resource));
 
             return resource;
         },

--- a/packages/pulumi/src/index.ts
+++ b/packages/pulumi/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./createPulumiApp";
+export * from "./isResourceOfType";
 export * from "./PulumiAppModule";
 export * from "./PulumiAppResource";
 export * from "./PulumiAppRemoteResource";

--- a/packages/pulumi/src/isResourceOfType.ts
+++ b/packages/pulumi/src/isResourceOfType.ts
@@ -1,0 +1,8 @@
+import { PulumiAppResource, PulumiAppResourceConstructor } from "~/PulumiAppResource";
+
+export function isResourceOfType<T extends PulumiAppResourceConstructor>(
+    resource: PulumiAppResource<PulumiAppResourceConstructor>,
+    type: T
+): resource is PulumiAppResource<T> {
+    return resource.type === type;
+}


### PR DESCRIPTION
## Changes
This PR adds two features to Pulumi apps:

## 1) Custom ENV variables
This allows developers to assign custom ENV variables to all Lambda functions within the `api` and `website` Pulumi apps.
An example usage looks like this:

```ts
import { createApiApp } from "@webiny/serverless-cms-aws";

export default createApiApp({
    pulumi(app) {
        app.setCommonLambdaEnvVariables({
            MY_CUSTOM_VAR: "any-value",
            OKTA_ISSUER: "dev-123",
            AUTH0_TENANT: "6352"
        });
    }
});
```

## 2) Customize resources based on a type
This allows developers to hook into the instantiation process of each infrastructure resource, and modify it before deployments starts. A utility function `isResourceOfType` is added to improve DX and make conditional checks a breeze:

![image](https://user-images.githubusercontent.com/3920893/179531309-8ef333fb-a35b-405f-8a8d-6ce06c09341b.png)
![image](https://user-images.githubusercontent.com/3920893/179531338-f88e61ba-c8a9-4734-a515-120acf4760c7.png)


## How Has This Been Tested?
Manually.
