### PR TITLE
feat(app-headless-cms): enable object reordering

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
@@ -74,6 +74,30 @@ export function useBind({ Bind: ParentBind, field }: UseBindProps) {
                                     // To make sure the field is still valid, we must trigger validation.
                                     bind.form.validateInput(field.fieldId);
                                 };
+
+                                props.moveValueUp = (index: number) => {
+                                    if (index <= 0) {
+                                        return;
+                                    }
+
+                                    const value = [...bind.value];
+                                    value.splice(index, 1);
+                                    value.splice(index - 1, 0, bind.value[index]);
+
+                                    bind.onChange(value);
+                                };
+
+                                props.moveValueDown = (index: number) => {
+                                    if (index >= bind.value.length) {
+                                        return;
+                                    }
+
+                                    const value = [...bind.value];
+                                    value.splice(index, 1);
+                                    value.splice(index + 1, 0, bind.value[index]);
+
+                                    bind.onChange(value);
+                                };
                             }
 
                             if (typeof children === "function") {
@@ -94,3 +118,5 @@ export function useBind({ Bind: ParentBind, field }: UseBindProps) {
         [field.fieldId]
     );
 }
+
+// [0,1,2,3,4,5]

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
@@ -173,6 +173,15 @@ const EditFieldDialog: React.FC<EditFieldDialogProps> = ({ field, onSubmit, ...p
                 }}
             >
                 {form => {
+                    const hasValidators =
+                        Array.isArray(fieldPlugin.field.validators) &&
+                        fieldPlugin.field.validators.length > 0;
+
+                    const showValidatorsTab =
+                        form.data.multipleValues ||
+                        (Array.isArray(fieldPlugin.field.validators) &&
+                            fieldPlugin.field.validators.length > 0);
+
                     const predefinedValuesTabEnabled =
                         fieldPlugin.field.allowPredefinedValues &&
                         form.data.predefinedValues &&
@@ -202,78 +211,75 @@ const EditFieldDialog: React.FC<EditFieldDialogProps> = ({ field, onSubmit, ...p
                                         )}
                                     </Tab>
 
-                                    {form.data.multipleValues && (
+                                    {showValidatorsTab ? (
                                         <Tab
                                             label={"Validators"}
                                             data-testid={"cms.editor.field.tabs.validators"}
                                         >
-                                            <Grid>
-                                                <Cell span={12}>
-                                                    <Typography use={"headline5"}>
-                                                        List validators
-                                                    </Typography>
-                                                    <br />
-                                                    <Typography use={"body2"}>
-                                                        These validators are applied to the entire
-                                                        list of values.
-                                                    </Typography>
-                                                </Cell>
-                                                <Cell span={12}>
-                                                    <Elevation z={2}>
-                                                        <ValidatorsTab
-                                                            field={current}
-                                                            name={"listValidation"}
-                                                            validators={getListValidators(
-                                                                fieldPlugin
-                                                            )}
-                                                            form={form}
-                                                        />
-                                                    </Elevation>
-                                                </Cell>
-                                            </Grid>
+                                            {form.data.multipleValues ? (
+                                                <>
+                                                    <Grid>
+                                                        <Cell span={12}>
+                                                            <Typography use={"headline5"}>
+                                                                List validators
+                                                            </Typography>
+                                                            <br />
+                                                            <Typography use={"body2"}>
+                                                                These validators are applied to the
+                                                                entire list of values.
+                                                            </Typography>
+                                                        </Cell>
+                                                        <Cell span={12}>
+                                                            <Elevation z={2}>
+                                                                <ValidatorsTab
+                                                                    field={current}
+                                                                    name={"listValidation"}
+                                                                    validators={getListValidators(
+                                                                        fieldPlugin
+                                                                    )}
+                                                                    form={form}
+                                                                />
+                                                            </Elevation>
+                                                        </Cell>
+                                                    </Grid>
 
-                                            <Grid>
-                                                <Cell span={12}>
-                                                    <Typography use={"headline5"}>
-                                                        Individual value validators
-                                                    </Typography>
-                                                    <br />
-                                                    <Typography use={"body2"}>
-                                                        These validators are applied to each value
-                                                        in the list.
-                                                    </Typography>
-                                                </Cell>
-                                                <Cell span={12}>
-                                                    <Elevation z={2}>
-                                                        <ValidatorsTab
-                                                            field={current}
-                                                            form={form}
-                                                            name={"validation"}
-                                                            validators={getFieldValidators(
-                                                                fieldPlugin
-                                                            )}
-                                                        />
-                                                    </Elevation>
-                                                </Cell>
-                                            </Grid>
-                                        </Tab>
-                                    )}
+                                                    <Grid>
+                                                        <Cell span={12}>
+                                                            <Typography use={"headline5"}>
+                                                                Individual value validators
+                                                            </Typography>
+                                                            <br />
+                                                            <Typography use={"body2"}>
+                                                                These validators are applied to each
+                                                                value in the list.
+                                                            </Typography>
+                                                        </Cell>
+                                                        <Cell span={12}>
+                                                            <Elevation z={2}>
+                                                                <ValidatorsTab
+                                                                    field={current}
+                                                                    form={form}
+                                                                    name={"validation"}
+                                                                    validators={getFieldValidators(
+                                                                        fieldPlugin
+                                                                    )}
+                                                                />
+                                                            </Elevation>
+                                                        </Cell>
+                                                    </Grid>
+                                                </>
+                                            ) : null}
 
-                                    {!form.data.multipleValues &&
-                                        Array.isArray(fieldPlugin.field.validators) &&
-                                        fieldPlugin.field.validators.length > 0 && (
-                                            <Tab
-                                                label={"Validators"}
-                                                data-testid={"cms.editor.field.tabs.validators"}
-                                            >
+                                            {!form.data.multipleValues && hasValidators ? (
                                                 <ValidatorsTab
                                                     field={current}
                                                     form={form}
                                                     name={"validation"}
                                                     validators={getFieldValidators(fieldPlugin)}
                                                 />
-                                            </Tab>
-                                        )}
+                                            ) : null}
+                                        </Tab>
+                                    ) : null}
                                     <Tab label={t`Appearance`}>
                                         <AppearanceTab
                                             form={form}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
@@ -79,6 +79,9 @@ const classes = {
         "&.collapsed": {
             maxHeight: 0,
             transition: "max-height 0.35s cubic-bezier(0, 1, 0, 1)"
+        },
+        ".accordion-content": {
+            paddingBottom: 10
         }
     })
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
@@ -18,7 +18,7 @@ const style = {
     })
 };
 
-interface DynamicSectionPropsChildrenParams {
+export interface DynamicSectionPropsChildrenParams {
     Bind: BindComponent;
     field: CmsEditorField;
     bind: {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
@@ -3,7 +3,7 @@ import { css } from "emotion";
 import { i18n } from "@webiny/app/i18n";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { ButtonDefault, ButtonIcon } from "@webiny/ui/Button";
-import { CmsEditorField } from "~/types";
+import { BindComponent, BindComponentRenderProp, CmsEditorField } from "~/types";
 import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18px.svg";
 import { GetBindCallable } from "~/admin/components/ContentEntryForm/useBind";
@@ -18,20 +18,22 @@ const style = {
     })
 };
 
-/**
- * TODO @ts-refactor figure out correct types
- */
 interface DynamicSectionPropsChildrenParams {
-    // bind: BindComponentRenderProp;
-    // index: number;
-    [key: string]: any;
+    Bind: BindComponent;
+    field: CmsEditorField;
+    bind: {
+        index: BindComponentRenderProp;
+        field: BindComponentRenderProp;
+    };
+    index: number;
 }
-interface DynamicSectionProps {
+
+export interface DynamicSectionProps {
     field: CmsEditorField;
     getBind: GetBindCallable;
     showLabel?: boolean;
     Label: React.ComponentType<any>;
-    children: (params: DynamicSectionPropsChildrenParams) => React.ReactElement;
+    children: (params: DynamicSectionPropsChildrenParams) => JSX.Element;
     emptyValue?: any;
     renderTitle?: (value: any[]) => React.ReactElement;
     gridClassName?: string;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/StyledComponents.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/StyledComponents.ts
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { css } from "emotion";
 
 export const fieldsWrapperStyle = css`
@@ -24,3 +25,26 @@ export const fieldsGridStyle = css`
         padding: 8px;
     }
 `;
+
+export const ObjectItem = styled.div`
+    position: relative;
+`;
+
+export const ItemHighLight = styled("div")({
+    "&": {
+        opacity: 0,
+        animation: "wf-blink-in 1s",
+        border: "2px solid var(--mdc-theme-secondary)",
+        boxShadow: "0 0 15px var(--mdc-theme-secondary)",
+        backgroundColor: "rgba(42, 217, 134, 0.25)",
+        borderRadius: "2px",
+        position: "absolute",
+        top: 5,
+        left: -12,
+        right: -8,
+        bottom: 0,
+        zIndex: 1,
+        pointerEvents: "none"
+    },
+    "@keyframes wf-blink-in": { "40%": { opacity: 1 } }
+});

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/StyledComponents.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/StyledComponents.ts
@@ -39,7 +39,7 @@ export const ItemHighLight = styled("div")({
         backgroundColor: "rgba(42, 217, 134, 0.25)",
         borderRadius: "2px",
         position: "absolute",
-        top: 5,
+        top: 0,
         left: -12,
         right: -8,
         bottom: 0,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/arrow_drop_down.svg
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/arrow_drop_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z"/></svg>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/arrow_drop_up.svg
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/arrow_drop_up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="24px" height="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8.71 12.29L11.3 9.7c.39-.39 1.02-.39 1.41 0l2.59 2.59c.63.63.18 1.71-.71 1.71H9.41c-.89 0-1.33-1.08-.7-1.71z"/></svg>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -4,6 +4,8 @@ import { CmsEditorFieldRendererPlugin } from "~/types";
 import DynamicSection from "../DynamicSection";
 import { Fields } from "~/admin/components/ContentEntryForm/Fields";
 import { ReactComponent as DeleteIcon } from "~/admin/icons/close.svg";
+import { ReactComponent as ArrowUp } from "./arrow_drop_up.svg";
+import { ReactComponent as ArrowDown } from "./arrow_drop_down.svg";
 import { IconButton } from "@webiny/ui/Button";
 import { Cell } from "@webiny/ui/Grid";
 import { FormElementMessage } from "@webiny/ui/FormElementMessage";
@@ -53,10 +55,27 @@ const plugin: CmsEditorFieldRendererPlugin = {
                             title={`${props.field.label} #${index + 1}`}
                             action={
                                 index > 0 ? (
-                                    <IconButton
-                                        icon={<DeleteIcon />}
-                                        onClick={() => bind.field.removeValue(index)}
-                                    />
+                                    <>
+                                        <IconButton
+                                            icon={<ArrowDown />}
+                                            onClick={e => {
+                                                e.stopPropagation();
+                                                bind.field.moveValueDown(index);
+                                            }}
+                                        />
+                                        <IconButton
+                                            icon={<ArrowUp />}
+                                            onClick={e => {
+                                                e.stopPropagation();
+                                                bind.field.moveValueUp(index);
+                                            }}
+                                        />
+
+                                        <IconButton
+                                            icon={<DeleteIcon />}
+                                            onClick={() => bind.field.removeValue(index)}
+                                        />
+                                    </>
                                 ) : null
                             }
                             // Open first Accordion by default

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -1,16 +1,20 @@
-import React, { useState } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
 import shortid from "shortid";
 import { i18n } from "@webiny/app/i18n";
-import { CmsEditorFieldRendererPlugin, CmsEditorFieldRendererProps } from "~/types";
+import { IconButton } from "@webiny/ui/Button";
+import { Cell } from "@webiny/ui/Grid";
+import { FormElementMessage } from "@webiny/ui/FormElementMessage";
+import { Typography } from "@webiny/ui/Typography";
+import {
+    BindComponentRenderProp,
+    CmsEditorFieldRendererPlugin,
+    CmsEditorFieldRendererProps
+} from "~/types";
 import DynamicSection from "../DynamicSection";
 import { Fields } from "~/admin/components/ContentEntryForm/Fields";
 import { ReactComponent as DeleteIcon } from "~/admin/icons/close.svg";
 import { ReactComponent as ArrowUp } from "./arrow_drop_up.svg";
 import { ReactComponent as ArrowDown } from "./arrow_drop_down.svg";
-import { IconButton } from "@webiny/ui/Button";
-import { Cell } from "@webiny/ui/Grid";
-import { FormElementMessage } from "@webiny/ui/FormElementMessage";
-import { Typography } from "@webiny/ui/Typography";
 import Accordion from "~/admin/plugins/fieldRenderers/Accordion";
 import {
     fieldsWrapperStyle,
@@ -22,6 +26,46 @@ import {
 } from "./StyledComponents";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
+
+interface ActionsProps {
+    setHighlightIndex: Dispatch<SetStateAction<{ [key: number]: string }>>;
+    index: number;
+    bind: {
+        index: BindComponentRenderProp;
+        field: BindComponentRenderProp;
+    };
+}
+
+const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => {
+    return index > 0 ? (
+        <>
+            <IconButton
+                icon={<ArrowDown />}
+                onClick={e => {
+                    e.stopPropagation();
+                    bind.field.moveValueDown(index);
+                    setHighlightIndex(map => ({
+                        ...map,
+                        [index + 1]: shortid.generate()
+                    }));
+                }}
+            />
+            <IconButton
+                icon={<ArrowUp />}
+                onClick={e => {
+                    e.stopPropagation();
+                    bind.field.moveValueUp(index);
+                    setHighlightIndex(map => ({
+                        ...map,
+                        [index - 1]: shortid.generate()
+                    }));
+                }}
+            />
+
+            <IconButton icon={<DeleteIcon />} onClick={() => bind.field.removeValue(index)} />
+        </>
+    ) : null;
+};
 
 const ObjectsRenderer: React.FC<CmsEditorFieldRendererProps> = props => {
     const [highlightMap, setHighlightIndex] = useState<{ [key: number]: string }>({});
@@ -48,37 +92,11 @@ const ObjectsRenderer: React.FC<CmsEditorFieldRendererProps> = props => {
                     <Accordion
                         title={`${props.field.label} #${index + 1}`}
                         action={
-                            index > 0 ? (
-                                <>
-                                    <IconButton
-                                        icon={<ArrowDown />}
-                                        onClick={e => {
-                                            e.stopPropagation();
-                                            bind.field.moveValueDown(index);
-                                            setHighlightIndex(map => ({
-                                                ...map,
-                                                [index + 1]: shortid.generate()
-                                            }));
-                                        }}
-                                    />
-                                    <IconButton
-                                        icon={<ArrowUp />}
-                                        onClick={e => {
-                                            e.stopPropagation();
-                                            bind.field.moveValueUp(index);
-                                            setHighlightIndex(map => ({
-                                                ...map,
-                                                [index - 1]: shortid.generate()
-                                            }));
-                                        }}
-                                    />
-
-                                    <IconButton
-                                        icon={<DeleteIcon />}
-                                        onClick={() => bind.field.removeValue(index)}
-                                    />
-                                </>
-                            ) : null
+                            <Actions
+                                setHighlightIndex={setHighlightIndex}
+                                index={index}
+                                bind={bind}
+                            />
                         }
                         // Open first Accordion by default
                         defaultValue={index === 0}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
@@ -3,17 +3,20 @@ import get from "lodash/get";
 import { i18n } from "@webiny/app/i18n";
 import { CmsEditorField, CmsEditorFieldRendererPlugin } from "~/types";
 import { ReactComponent as DeleteIcon } from "~/admin/icons/close.svg";
-import DynamicSection from "../DynamicSection";
+import DynamicSection, { DynamicSectionPropsChildrenParams } from "../DynamicSection";
 import { RichTextEditor, createPropsFromConfig } from "@webiny/app-admin/components/RichTextEditor";
 import { IconButton } from "@webiny/ui/Button";
 import { plugins } from "@webiny/plugins";
 import styled from "@emotion/styled";
-import { BindComponentRenderProp } from "@webiny/form";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
-const getKey = (field: CmsEditorField, bind: BindComponentRenderProp, index: number): string => {
-    const formId = (bind as any).index?.form?.data?.id || "new";
+const getKey = (
+    field: CmsEditorField,
+    bind: DynamicSectionPropsChildrenParams["bind"],
+    index: number
+): string => {
+    const formId = bind.index.form?.data?.id || "new";
     return `${formId}.${field.fieldId}.${index}`;
 };
 

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -604,6 +604,8 @@ interface BindComponentRenderProp extends BaseBindComponentRenderProp {
     prependValue: (value: any) => void;
     appendValues: (values: any[]) => void;
     removeValue: (index: number) => void;
+    moveValueUp: (index: number) => void;
+    moveValueDown: (index: number) => void;
 }
 
 interface BindComponentProps extends Omit<BaseBindComponentProps, "children" | "name"> {

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -171,6 +171,13 @@ export interface CmsEditorFieldTypePlugin extends Plugin {
     };
 }
 
+export interface CmsEditorFieldRendererProps {
+    field: CmsEditorField;
+    Label: typeof Label;
+    getBind: (index?: number, key?: string) => BindComponent;
+    contentModel: CmsEditorContentModel;
+}
+
 export interface CmsEditorFieldRendererPlugin extends Plugin {
     /**
      * a plugin type
@@ -235,12 +242,7 @@ export interface CmsEditorFieldRendererPlugin extends Plugin {
          * }
          * ```
          */
-        render(props: {
-            field: CmsEditorField;
-            Label: typeof Label;
-            getBind: (index?: number, key?: string) => BindComponent;
-            contentModel: CmsEditorContentModel;
-        }): React.ReactNode;
+        render(props: CmsEditorFieldRendererProps): React.ReactNode;
     };
 }
 

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -600,7 +600,7 @@ export interface CmsMetaResponse {
 /***
  * ###### FORM ########
  */
-interface BindComponentRenderProp extends BaseBindComponentRenderProp {
+export interface BindComponentRenderProp extends BaseBindComponentRenderProp {
     parentName: string;
     appendValue: (value: any) => void;
     prependValue: (value: any) => void;


### PR DESCRIPTION
## Changes
This PR adds the ability to reorder objects in Headless CMS UI, when creating content entries with lists of object field. Sometimes it can be difficult to track were the record you're moving actually moved, so we also added a highlight to show you the exact position of the object.

As a bonus fix, field settings dialog Validation tab was refactored  to prevent unmounting of tabs when `Use as list` switch is toggled.

https://user-images.githubusercontent.com/3920893/180650551-fa45ba8c-82e0-4f5f-a71f-28a9172a3740.mp4

## How Has This Been Tested?
Manually.
