### PR TITLE
Update the bug template with a default label "bug"

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,4 +1,5 @@
 name: "\U0001F41B Bug report"
+labels: "bug"
 description: Create a report to help us improve
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,6 @@
 name: "\U0001F680 Feature request"
 description: Suggest an idea for the project
+labels: "feature request"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Added a default label = bug for the bug template

## Changes
I am adding a line of code to add a default label"bug" to the bug template


## How Has This Been Tested?
Swapnil tested it by cloning Webiny repo it to his GitHub account and applying the change. Please refer to screenshot below for the actual result- as expected
<img width="1702" alt="image" src="https://user-images.githubusercontent.com/106819205/180233589-0e3cb289-95e1-4e7f-8f95-7469f09b2940.png">


Also roll back by deleting this line of code from the form:
labels:"bug"

## Documentation
NA

-->
