### PR TITLE
fix(app-admin): use <Brand/> component in the installer view

### DIFF
--- a/packages/app-admin-rmwc/src/modules/Brand/index.tsx
+++ b/packages/app-admin-rmwc/src/modules/Brand/index.tsx
@@ -15,10 +15,15 @@ const BrandImpl: HigherOrderComponent = () => {
     return function BrandRenderer() {
         const { location } = useTags();
         const { setVisible } = useNavigation();
+        const inApp = ["appBar", "navigation"].includes(String(location));
 
         const onClick = useCallback(() => {
             location === "navigation" ? setVisible(false) : null;
         }, []);
+
+        if (!inApp) {
+            return <Logo />;
+        }
 
         return (
             <Link to={"/"} onClick={onClick}>
@@ -32,15 +37,17 @@ const WebinyLogo: React.FC = () => {
     const { location } = useTags();
     const isLoginScreen = location === "loginScreen";
     const isAppBar = location === "appBar";
+    const isInstaller = location === "installer";
+    const inApp = !isInstaller && !isLoginScreen;
 
     const color = isAppBar ? "white" : "var(--mdc-theme-primary)";
 
     return (
         <LogoIcon
             style={{
-                width: isLoginScreen ? 125 : 100,
-                height: isLoginScreen ? "auto" : 30,
-                paddingLeft: isLoginScreen ? 0 : 20,
+                width: !inApp ? 125 : 100,
+                height: !inApp ? "auto" : 30,
+                paddingLeft: !inApp ? 0 : 20,
                 color
             }}
         />

--- a/packages/app-admin-rmwc/src/modules/Navigation/Hamburger.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/Hamburger.tsx
@@ -8,6 +8,10 @@ const Hamburger: React.FC = () => {
     const { location } = useTags();
     const { visible, setVisible } = useNavigation();
 
+    if (location === "installer") {
+        return null;
+    }
+
     return (
         <IconButton
             icon={<MenuIcon style={{ color: location === "navigation" ? undefined : "white" }} />}

--- a/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
+++ b/packages/app-admin/src/components/AppInstaller/Sidebar.tsx
@@ -1,22 +1,16 @@
 import React, { Fragment } from "react";
+import classSet from "classnames";
 import styled from "@emotion/styled";
 import { Typography } from "@webiny/ui/Typography";
-import classSet from "classnames";
-
-import webinyLogo from "../../assets/images/webiny-orange-logo.svg";
-import signInDivider from "./assets/sign-in-divider.svg";
 import { config as appConfig } from "@webiny/app/config";
+import signInDivider from "./assets/sign-in-divider.svg";
 import { Installer } from "./useInstaller";
-
-const SidebarWrapper = styled("div")({});
+import { Brand } from "~/base/ui/Brand";
+import { Tags } from "~/base/ui/Tags";
 
 const Logo = styled("div")({
     padding: 15,
-    borderBottom: "1px solid var(--mdc-theme-background)",
-    img: {
-        width: "100px",
-        height: "auto"
-    }
+    borderBottom: "1px solid var(--mdc-theme-background)"
 });
 
 const List = styled("ul")({
@@ -128,16 +122,16 @@ interface SidebarProps {
     installer: Installer;
     showLogin: boolean;
 }
+
 const Sidebar: React.FC<SidebarProps> = ({ allInstallers, installer, showLogin }) => {
     const upgrades = allInstallers.filter(installer => installer.type === "upgrade");
     const installations = allInstallers.filter(installer => installer.type === "install");
-
     const wbyVersion = appConfig.getKey("WEBINY_VERSION", process.env.REACT_APP_WEBINY_VERSION);
 
     return (
-        <SidebarWrapper>
+        <Tags tags={{ location: "installer" }}>
             <Logo>
-                <img src={webinyLogo} alt="Webiny CMS" />
+                <Brand />
             </Logo>
             {upgrades.length > 0 ? (
                 <Installations
@@ -159,7 +153,7 @@ const Sidebar: React.FC<SidebarProps> = ({ allInstallers, installer, showLogin }
                     showLogin={upgrades.length > 0 ? false : showLogin}
                 />
             )}
-        </SidebarWrapper>
+        </Tags>
     );
 };
 export default Sidebar;


### PR DESCRIPTION
## Changes
This PR updates the installer view to use the <Brand/> component. This was the last place where Webiny logo was used without the possibility to replace it, and by using the common <Brand/> component, which is composable, this is now resolved.

## How Has This Been Tested?
Manually.
