### PR TITLE
Fix setup-project script

### DIFF
--- a/packages/cli/commands/index.js
+++ b/packages/cli/commands/index.js
@@ -1,10 +1,16 @@
 const run = require("./run");
 const telemetry = require("./telemetry");
-const wcp = require("./wcp");
 const upgrade = require("./upgrade");
 
 module.exports.createCommands = async (yargs, context) => {
-    context.plugins.register(run, telemetry, upgrade, wcp);
+    context.plugins.register(run, telemetry, upgrade);
+
+    try {
+        const wcp = require("./wcp");
+        context.plugins.register(wcp);
+    } catch {
+        // Skip WCP command
+    }
 
     await context.loadUserPlugins();
 

--- a/scripts/setupProject.js
+++ b/scripts/setupProject.js
@@ -12,7 +12,7 @@ const execa = require("execa");
     // Build all packages in the "packages" workspace.
     console.log(`🏗  Building packages...`);
     try {
-        await execa("yarn", ["webiny", "workspaces", "run", "build", "--folder", "packages"], {
+        await execa("yarn", ["build"], {
             stdio: "inherit"
         });
         console.log(`✅️ Packages were built successfully!`);


### PR DESCRIPTION
## Changes
This PR fixes the `setup-project` script, which is used by our contributors and core developers:

1) `@webiny/cli` will attempt to require the `@webiny/wcp` command, and if it's not available, it will simply skip that command. This solves the chicken/egg problem when packages are not yet built.

2) `setup-project` script now uses `buildWithCache` script internally, and by doing so, the build is now executed by directly importing `webiny.config.js` file and executing the command within the same node process, instead of spawning a new process for every package.

Closes #2559.

## How Has This Been Tested?
Manually.

## Documentation
Not needed; the setup process is the same, only some internals were changed.