### PR TITLE
fix(serverless-cms-aws): disable cache control on website preview index.html

### DIFF
--- a/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
+++ b/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
@@ -24,14 +24,14 @@ function getFileChecksum(file: string): Promise<string> {
     });
 }
 
-import { BucketName, ObjectCannedACL, CacheControl } from "aws-sdk/clients/s3";
+import { BucketName, CacheControl } from "aws-sdk/clients/s3";
 
 export interface Paths {
     full: string;
     relative: string;
 }
 
-type CacheControls = Array<{ pattern: RegExp; value: CacheControl }>;
+export type CacheControls = Array<{ pattern: RegExp; value: CacheControl }>;
 
 export interface UploadFolderToS3Params {
     // Path to the folder that needs to be uploaded.
@@ -46,8 +46,10 @@ export interface UploadFolderToS3Params {
     // A callback that gets called every time a file upload has been skipped.
     onFileUploadSkip: (params: { paths: Paths }) => void;
 
+    // Target bucket
     bucket: BucketName;
-    acl?: ObjectCannedACL;
+
+    // Cache control to apply to each uploaded file
     cacheControl?: CacheControl | CacheControls;
 }
 

--- a/packages/serverless-cms-aws/src/createWebsiteApp.ts
+++ b/packages/serverless-cms-aws/src/createWebsiteApp.ts
@@ -7,7 +7,7 @@ export interface CreateWebsiteAppParams extends CreateWebsitePulumiAppParams {
 }
 
 export function createWebsiteApp(projectAppParams: CreateWebsiteAppParams = {}) {
-    const builtInPlugins = [uploadAppToS3, generateCommonHandlers, renderWebsite];
+    const builtInPlugins = [uploadAppToS3(), generateCommonHandlers, renderWebsite];
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];
 
     return {

--- a/packages/serverless-cms-aws/src/index.ts
+++ b/packages/serverless-cms-aws/src/index.ts
@@ -5,4 +5,8 @@ export * from "./createAdminAppConfig";
 export * from "./createReactApp";
 export * from "./createReactAppConfig";
 export * from "./createWebsiteApp";
+export {
+    uploadAppToS3 as uploadWebsiteAppToS3,
+    UploadAppToS3Config
+} from "./website/plugins/uploadAppToS3";
 export * from "./createWebsiteAppConfig";

--- a/packages/serverless-cms-aws/src/website/plugins/uploadAppToS3.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/uploadAppToS3.ts
@@ -1,8 +1,15 @@
 import { getStackOutput } from "@webiny/cli-plugin-deploy-pulumi/utils";
-import { uploadFolderToS3 } from "@webiny/pulumi-aws";
+import { uploadFolderToS3, UploadFolderToS3Params } from "@webiny/pulumi-aws";
 import { CliContext } from "@webiny/cli/types";
 import * as path from "path";
 import * as fs from "fs";
+
+export type UploadAppToS3Config = Partial<
+    Pick<
+        UploadFolderToS3Params,
+        "path" | "cacheControl" | "onFileUploadSuccess" | "onFileUploadSkip" | "onFileUploadError"
+    >
+>;
 
 /**
  * This plugin uploads the Website React application to the deployed Amazon S3 bucket.
@@ -10,12 +17,11 @@ import * as fs from "fs";
  * and relevant cloud infrastructure resources have been deployed (via `webiny deploy` command).
  * https://www.webiny.com/docs/how-to-guides/deployment/deploy-your-project/
  */
-export const uploadAppToS3 = {
+export const uploadAppToS3 = (config: UploadAppToS3Config = {}) => ({
     type: "hook-after-deploy",
     name: "hook-after-deploy-upload-app-to-s3",
     async hook(params: Record<string, any>, context: CliContext) {
         const { projectApplication } = params;
-
         context.info("Uploading React application...");
 
         const buildFolderPath = path.join(projectApplication.paths.absolute, "build");
@@ -32,6 +38,16 @@ export const uploadAppToS3 = {
         await uploadFolderToS3({
             path: buildFolderPath,
             bucket: websiteOutput.appStorage,
+            cacheControl: [
+                {
+                    pattern: /index\.html/,
+                    value: "no-cache, no-store, must-revalidate"
+                },
+                {
+                    pattern: /.*/,
+                    value: "max-age=31536000"
+                }
+            ],
             onFileUploadSuccess: ({ paths }) => {
                 context.success(paths.relative);
             },
@@ -41,7 +57,8 @@ export const uploadAppToS3 = {
             },
             onFileUploadSkip: ({ paths }) => {
                 context.info(`Skipping ${context.info.hl(paths.relative)}, already exists.`);
-            }
+            },
+            ...config
         });
 
         const duration = (new Date().getTime() - start) / 1000;
@@ -50,4 +67,4 @@ export const uploadAppToS3 = {
             `React application successfully uploaded in ${context.success.hl(duration)}s.`
         );
     }
-};
+});


### PR DESCRIPTION
## Changes
This PR disables cache-control header for `index.html` file of the `website` app, by setting the `Cache-Control` to `no-cache, no-store, must-revalidate`. Previous cache control settings were causing issues in the prerendering service, as the changes were not being served to the browser. By disabling the cache only on `index.html`, we are now getting the latest changes immediately visible in the browser. Other files can remain cached for a much longer period of time, because they contain content hashes anyway.

We're now also exposing an `uploadWebsiteAppToS3` plugin factory, which can be used to override the default cache controls:

![image](https://user-images.githubusercontent.com/3920893/183954392-1daf85bd-87aa-4b7a-afac-7ea08ae136c3.png)


Closes #2573 

## How Has This Been Tested?
Manually.