### PR TITLE
fix(api-file-manager): handle download of large files

### DIFF
--- a/packages/api-file-manager/src/handlers/transform/loaders/imageLoader.ts
+++ b/packages/api-file-manager/src/handlers/transform/loaders/imageLoader.ts
@@ -26,6 +26,7 @@ const callImageTransformerLambda = async ({ key, transformations, context }: Tra
 interface File {
     extension: string;
     name: string;
+    contentLength: number;
 }
 interface Options {
     width?: string;


### PR DESCRIPTION
## Changes
This PR improves the way of handling files in the `download` Lambda function. We now always do an `s3.headObject` request to get file metadata, and depending on its `ContentLength` and loaders, we decide if the file should be downloaded and served from the Lambda function, or if a 301 redirect needs to be issued.

Closes #2570

## How Has This Been Tested?
I used a `video/mp4` file ~540MB large, and a binary file ~1GB large.