### PR TITLE
fix(pulumi-sdk): set GODEBUG variable for M1

### DIFF
--- a/packages/pulumi-sdk/src/Pulumi.ts
+++ b/packages/pulumi-sdk/src/Pulumi.ts
@@ -104,6 +104,14 @@ export class Pulumi {
         set(args.execa, "env.PULUMI_SKIP_UPDATE_CHECK", "true");
         set(args.execa, "env.PULUMI_HOME", this.pulumiFolder);
 
+        if (os.arch() === "arm64") {
+            /**
+             * This variable is an attempt to resolve this issue:
+             * https://yaleman.org/post/2021/2021-01-01-apple-m1-terraform-and-golang/
+             */
+            set(args.execa, "env.GODEBUG", "asyncpreemptoff=1");
+        }
+
         // Use ";" when on Windows. For Mac and Linux, use ":".
         const PATH_SEPARATOR = os.platform() === "win32" ? ";" : ":";
 


### PR DESCRIPTION
## Changes
This PR sets `GODEBUG=asyncpreemptoff=1` when running `pulumi` as an attempt to solve the following issue with M1 processors: https://yaleman.org/post/2021/2021-01-01-apple-m1-terraform-and-golang/


## How Has This Been Tested?
Manually.
