### PR TITLE
fix(pulumi-aws): assign proper Lambda execution roles in prod setup

### DIFF
--- a/packages/pulumi-aws/src/apps/lambdaUtils.ts
+++ b/packages/pulumi-aws/src/apps/lambdaUtils.ts
@@ -49,20 +49,20 @@ export function createLambdaRole(app: PulumiApp, params: LambdaRoleParams) {
                 policyArn: params.executionRole
             }
         });
-    } else {
-        // Fallback to default execution role.
-        const vpc = app.getModule(VpcConfig);
-
-        app.addResource(aws.iam.RolePolicyAttachment, {
-            name: `${params.name}-execution-role`,
-            config: {
-                role: role.output,
-                policyArn: vpc.enabled
-                    ? aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
-                    : aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
-            }
-        });
     }
+
+    // Add default execution role.
+    const vpc = app.getModule(VpcConfig);
+
+    app.addResource(aws.iam.RolePolicyAttachment, {
+        name: `${params.name}-default-execution-role`,
+        config: {
+            role: role.output,
+            policyArn: vpc.enabled
+                ? aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
+                : aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+        }
+    });
 
     return role;
 }

--- a/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
+++ b/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
@@ -90,8 +90,7 @@ function createRenderSubscriber(
 
     const role = createLambdaRole(app, {
         name: "ps-render-subscriber-role",
-        policy: policy,
-        executionRole: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+        policy: policy
     });
 
     const lambda = app.addResource(aws.lambda.Function, {
@@ -226,8 +225,7 @@ function createFlushService(
 
     const role = createLambdaRole(app, {
         name: "ps-flush-lambda-role",
-        policy: policy,
-        executionRole: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+        policy: policy
     });
 
     const lambda = app.addResource(aws.lambda.Function, {


### PR DESCRIPTION
## Changes
This PR fixes Prerendering Service Lambda functions configuration in `prod` environment. 
1) When `prod` environment is being deployed, we put all Lambda functions into a VPC.
2) `ps-render-subscriber` Lambda function needs to have 2 managed execution roles: `AWSLambdaSQSQueueExecutionRole` and `AWSLambdaVPCAccessExecutionRole`.

Closes #2580

## How Has This Been Tested?
Manually.