### PR TITLE
Clear Apollo Cache when content model is deleted

### DIFF
--- a/packages/app-headless-cms/src/HeadlessCMS.tsx
+++ b/packages/app-headless-cms/src/HeadlessCMS.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, memo } from "react";
 import { plugins } from "@webiny/plugins";
 import { Plugins, Provider } from "@webiny/app-admin";
+import { ApolloCacheObjectIdPlugin } from "@webiny/app";
 import { ApolloClient } from "apollo-client";
 import { CmsProvider } from "./admin/contexts/Cms";
 import { CmsMenuLoader } from "~/admin/menus/CmsMenuLoader";
@@ -34,6 +35,16 @@ export interface HeadlessCMSProps {
 
 const HeadlessCMSExtension = ({ createApolloClient }: HeadlessCMSProps) => {
     plugins.register(apiInformation);
+
+    plugins.register(
+        new ApolloCacheObjectIdPlugin(obj => {
+            if (obj.__typename === "CmsContentModelField") {
+                return null;
+            }
+
+            return undefined;
+        })
+    );
 
     return (
         <Fragment>

--- a/packages/app-headless-cms/src/admin/plugins/getObjectId.ts
+++ b/packages/app-headless-cms/src/admin/plugins/getObjectId.ts
@@ -1,15 +1,10 @@
-import { CacheGetObjectIdPlugin } from "@webiny/app/types";
+import { ApolloCacheObjectIdPlugin } from "@webiny/app";
 
-const plugin: CacheGetObjectIdPlugin = {
-    type: "cache-get-object-id",
-    getObjectId(obj): string | undefined {
-        switch (obj.__typename) {
-            case "CmsContentModel":
-                return obj.modelId;
-            default:
-                return undefined;
-        }
+export default new ApolloCacheObjectIdPlugin(obj => {
+    switch (obj.__typename) {
+        case "CmsContentModel":
+            return `${obj.__typename}:${obj.modelId}`;
+        default:
+            return undefined;
     }
-};
-
-export default plugin;
+});

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -17,7 +17,7 @@ import { ButtonIcon, ButtonSecondary, IconButton } from "@webiny/ui/Button";
 import { Tooltip } from "@webiny/ui/Tooltip";
 import { i18n } from "@webiny/app/i18n";
 import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
-import { removeModelFromGroupCache, removeModelFromListCache } from "./cache";
+import { removeModelFromGroupCache, removeModelFromListCache, removeModelFromCache } from "./cache";
 import * as GQL from "../../viewsGraphql";
 import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18px.svg";
 import SearchUI from "@webiny/app-admin/components/SearchUI";
@@ -130,6 +130,7 @@ const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
 
                     removeModelFromListCache(cache, item);
                     removeModelFromGroupCache(cache, item);
+                    removeModelFromCache(client, item);
 
                     showSnackbar(
                         t`Content model {name} deleted successfully!.`({ name: item.name })

--- a/packages/app-headless-cms/src/admin/views/contentModels/cache.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/cache.ts
@@ -1,7 +1,8 @@
 import dotProp from "dot-prop-immutable";
+import { DataProxy } from "apollo-cache";
+import ApolloClient from "apollo-client";
 import { LIST_CONTENT_MODELS, LIST_MENU_CONTENT_GROUPS_MODELS } from "../../viewsGraphql";
 import { CmsEditorContentModel } from "~/types";
-import { DataProxy } from "apollo-cache";
 import { ListCmsModelsQueryResponse, ListMenuCmsGroupsQueryResponse } from "../../viewsGraphql";
 
 export const addModelToListCache = (cache: DataProxy, model: CmsEditorContentModel): void => {
@@ -43,6 +44,29 @@ export const addModelToGroupCache = (cache: DataProxy, model: CmsEditorContentMo
                 `data.${groupIndex}.contentModels.${newGroupModelIndex}`,
                 model
             )
+        }
+    });
+};
+
+/**
+ * This function is an ugly hack, but I don't know a better way to remove items from cache in Apollo Client v2.
+ * When a Content Model is deleted, we need to remove it from cache, because a model can be recreated with the same
+ * modelId, and it will cause problems, because Apollo will think that the data in cache belongs to this new model.
+ */
+export const removeModelFromCache = (
+    client: ApolloClient<any>,
+    model: CmsEditorContentModel
+): void => {
+    const id = `CmsContentModel:${model.modelId}`;
+
+    // @ts-ignore
+    client.cache.data.delete(id);
+
+    // @ts-ignore
+    Object.keys(client.cache.data.data).forEach(key => {
+        if (key.startsWith(`${id}.`) || key.startsWith(`$${id}.`)) {
+            // @ts-ignore
+            client.cache.data.delete(key);
         }
     });
 };

--- a/packages/app-page-builder/src/render/plugins/apolloCacheObjectId.ts
+++ b/packages/app-page-builder/src/render/plugins/apolloCacheObjectId.ts
@@ -7,9 +7,10 @@ export interface PageBuilderObject extends ApolloCacheObject {
     id: string;
 }
 
-export default new ApolloCacheObjectIdPlugin<PageBuilderObject>((obj): string | null => {
+export default new ApolloCacheObjectIdPlugin<PageBuilderObject>(obj => {
     if (obj.__typename === "PbPage" || obj.__typename === "PbPageListItem") {
         return obj.__typename + obj.id;
     }
-    return null;
+
+    return undefined;
 });

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,0 +1,4 @@
+export { AddQuerySelectionPlugin } from "./plugins/AddQuerySelectionPlugin";
+export { ApolloLinkPlugin } from "./plugins/ApolloLinkPlugin";
+export { RoutePlugin } from "./plugins/RoutePlugin";
+export { ApolloCacheObjectIdPlugin } from "./plugins/ApolloCacheObjectIdPlugin";

--- a/packages/app/src/plugins/ApolloCacheObjectIdPlugin.ts
+++ b/packages/app/src/plugins/ApolloCacheObjectIdPlugin.ts
@@ -6,7 +6,8 @@ export interface ApolloCacheObject {
 }
 
 interface ApolloCacheObjectIdPluginCallable<T> {
-    (data: T): string | null;
+    // A value for `id`, null to prevent normalization, or undefined to continue with defaults.
+    (data: T): string | null | undefined;
 }
 
 export class ApolloCacheObjectIdPlugin<

--- a/packages/app/src/plugins/ApolloLinkPlugin.ts
+++ b/packages/app/src/plugins/ApolloLinkPlugin.ts
@@ -2,7 +2,7 @@ import { ApolloLink } from "apollo-link";
 import { nanoid } from "nanoid";
 import { Plugin } from "@webiny/plugins";
 
-interface ApolloLinkFactory {
+export interface ApolloLinkFactory {
     (): ApolloLink;
 }
 

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -18,11 +18,6 @@ export interface FileItem {
     [key: string]: any;
 }
 
-export type WebinyInitPlugin = Plugin & {
-    type: "webiny-init";
-    init(): void;
-};
-
 export type UploadOptions = {
     apolloClient: ApolloClient<object>;
 };
@@ -80,14 +75,4 @@ export type ImageComponentPlugin = Plugin & {
 export type RoutePlugin = Plugin & {
     type: "route";
     route: React.ReactElement;
-};
-
-interface CacheGetObjectIdPluginObj {
-    __typename: string;
-    modelId: string;
-    [key: string]: any;
-}
-export type CacheGetObjectIdPlugin = Plugin & {
-    type: "cache-get-object-id";
-    getObjectId(obj: CacheGetObjectIdPluginObj): string | undefined;
 };


### PR DESCRIPTION
## Changes
This PR adds logic to remove a content model from Apollo Cache when a model is deleted. Since we use `modelId` as a cache id, if a model is _not_ removed from cache, and is then recreated with the same modelId, there are problems with the new model because Apollo thinks that the data in the cache (which remains after model is deleted) belongs to this new model.

In the process I also switched all usages of `cache-get-object-id` plugin to use the proper class plugin, and added a re-export of useful plugins from `@webiny/app` package root.

## How Has This Been Tested?
Manually.