### PR TITLE
Remove Redundant `console.log` Call

### DIFF
--- a/packages/handler-logs/__tests__/plugin.test.ts
+++ b/packages/handler-logs/__tests__/plugin.test.ts
@@ -23,7 +23,7 @@ const testHandler = createHandler({
         createHttpLogsHandlerResultPlugin(),
         new RoutePlugin(context => {
             context.onGet("/test", () => {
-                console.log(forwardUrl)
+                console.log(forwardUrl);
                 return null;
             });
         })

--- a/packages/handler-logs/__tests__/plugin.test.ts
+++ b/packages/handler-logs/__tests__/plugin.test.ts
@@ -15,21 +15,24 @@ jest.mock("node-fetch", () => {
     };
 });
 
-import createPlugin from "~/index";
-import { HandlerResultPlugin } from "@webiny/handler";
+import { createHandler, RoutePlugin } from "@webiny/handler-aws/gateway";
+import createHttpLogsHandlerResultPlugin from "~/index";
+
+const testHandler = createHandler({
+    plugins: [
+        createHttpLogsHandlerResultPlugin(),
+        new RoutePlugin(context => {
+            context.onGet("/test", () => {
+                console.log(forwardUrl)
+                return null;
+            });
+        })
+    ]
+});
 
 describe("logs plugin", () => {
     it("should send data to given url", async () => {
-        const plugin = createPlugin();
-
-        expect(plugin).toBeInstanceOf(HandlerResultPlugin);
-
-        const context = {} as any;
-        const output = {} as any;
-
-        const result = await plugin.handle(context, output);
-
-        expect(result).toEqual(undefined);
+        await testHandler({ path: "/test" } as any, {} as any);
 
         expect(mockResult.url).toEqual(forwardUrl);
         expect(mockResult.opts).toEqual({

--- a/packages/handler-logs/package.json
+++ b/packages/handler-logs/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-typescript": "^7.16.0",
     "@types/node-fetch": "^2.6.1",
     "@webiny/cli": "^5.31.0",
+    "@webiny/handler-aws": "^5.31.0",
     "@webiny/project-utils": "^5.31.0",
     "rimraf": "^3.0.2",
     "typescript": "4.7.4"

--- a/packages/handler-logs/src/index.ts
+++ b/packages/handler-logs/src/index.ts
@@ -17,7 +17,6 @@ export default () => {
 
     return new HandlerResultPlugin(async () => {
         const url = process.env.WEBINY_LOGS_FORWARD_URL;
-        console.log(url);
         if (logs.length && typeof url === "string" && url.startsWith("http")) {
             try {
                 await fetch(url, {

--- a/packages/handler-logs/tsconfig.build.json
+++ b/packages/handler-logs/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
-  "references": [{ "path": "../handler/tsconfig.build.json" }],
+  "references": [
+    { "path": "../handler/tsconfig.build.json" },
+    { "path": "../handler-aws/tsconfig.build.json" }
+  ],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/handler-logs/tsconfig.json
+++ b/packages/handler-logs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__/**/*.ts"],
-  "references": [{ "path": "../handler" }],
+  "references": [{ "path": "../handler" }, { "path": "../handler-aws" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",
@@ -9,7 +9,9 @@
     "paths": {
       "~/*": ["./src/*"],
       "@webiny/handler/*": ["../handler/src/*"],
-      "@webiny/handler": ["../handler/src"]
+      "@webiny/handler": ["../handler/src"],
+      "@webiny/handler-aws/*": ["../handler/src/*"],
+      "@webiny/handler-aws": ["../handler/src"]
     },
     "baseUrl": "."
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12907,6 +12907,7 @@ __metadata:
     "@types/node-fetch": ^2.6.1
     "@webiny/cli": ^5.31.0
     "@webiny/handler": ^5.31.0
+    "@webiny/handler-aws": ^5.31.0
     "@webiny/project-utils": ^5.31.0
     node-fetch: ^2.6.1
     rimraf: ^3.0.2


### PR DESCRIPTION
## Changes
This PR removes the redundant `console.log` call, which would cause the following issue (notice the forward URLs being logged too):

![image](https://user-images.githubusercontent.com/5121148/188469779-ee7c33c3-5073-47e6-9cc9-5cc4c5970aab.png)


## How Has This Been Tested?
Manual.

## Documentation
Changelog.