### PR TITLE
fix(app-admin): register and sort file type plugins in the correct order

### DIFF
--- a/packages/app-admin/src/base/Base.tsx
+++ b/packages/app-admin/src/base/Base.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
 import { Plugins } from "@webiny/app-admin-core";
-import { AddMenu, AddRoute, Dashboard, Layout, NotFound } from "~/index";
+import { AddMenu, AddRoute, Dashboard, FileManagerFileTypePlugin, Layout, NotFound } from "~/index";
 import { plugins } from "@webiny/plugins";
 import { ReactComponent as DocsIcon } from "~/assets/icons/icon-documentation.svg";
 import { ReactComponent as SlackIcon } from "~/assets/icons/slack-logo.svg";
@@ -9,10 +9,31 @@ import { ReactComponent as FileIcon } from "~/assets/icons/insert_drive_file-24p
 import { ReactComponent as SettingsIcon } from "~/assets/icons/round-settings-24px.svg";
 import { FileManager } from "~/components";
 
-import adminPlugins from "../plugins";
+import { defaultFileTypePlugin, imageFileTypePlugin } from "~/plugins/fileManager";
+import { globalSearchHotkey } from "~/plugins/globalSearch";
+
+function registerFileTypePlugins() {
+    // This is an ugly hack, which we will replace when we implement file thumbnail rendering via the Composition API.
+    const fileTypePlugins = plugins.byType(FileManagerFileTypePlugin.type);
+
+    // First we need to unregister already registered plugins.
+    fileTypePlugins.forEach(pl => plugins.unregister(pl.name as string));
+
+    // Then, we need to register the default plugins first, then register user's plugins again, to generate new names.
+    plugins.register([
+        defaultFileTypePlugin,
+        imageFileTypePlugin,
+        ...fileTypePlugins.map(pl => {
+            pl.name = undefined;
+            return pl;
+        })
+    ]);
+}
 
 const BaseExtension: React.FC = () => {
-    plugins.register(adminPlugins());
+    plugins.register(globalSearchHotkey);
+
+    registerFileTypePlugins();
 
     return (
         <Plugins>

--- a/packages/app-admin/src/index.ts
+++ b/packages/app-admin/src/index.ts
@@ -27,6 +27,8 @@ export type { ViewCompositionContext, ViewElement } from "./base/providers/ViewC
 
 // Plugins
 export * from "./base/plugins/AddGraphQLQuerySelection";
+export * from "./plugins/FileManagerFileTypePlugin";
+export * from "./plugins/PermissionRendererPlugin";
 
 // Components
 export { AppInstaller } from "./components/AppInstaller";

--- a/packages/app-admin/src/plugins/fileManager/fileDefault.tsx
+++ b/packages/app-admin/src/plugins/fileManager/fileDefault.tsx
@@ -12,7 +12,7 @@ const style = {
     })
 };
 
-export default new FileManagerFileTypePlugin({
+export const defaultFileTypePlugin = new FileManagerFileTypePlugin({
     types: ["*/*"],
     render(): React.ReactNode {
         return (

--- a/packages/app-admin/src/plugins/fileManager/fileImage/index.tsx
+++ b/packages/app-admin/src/plugins/fileManager/fileImage/index.tsx
@@ -15,7 +15,7 @@ const styles = css({
     transform: "translateX(-50%) translateY(-50%)"
 });
 
-export default new FileManagerFileTypePlugin({
+export const imageFileTypePlugin = new FileManagerFileTypePlugin({
     types: ["image/*"],
     actions: [EditAction],
     render({ file }) {

--- a/packages/app-admin/src/plugins/fileManager/index.ts
+++ b/packages/app-admin/src/plugins/fileManager/index.ts
@@ -1,4 +1,2 @@
-import fileDefault from "./fileDefault";
-import fileImage from "./fileImage";
-
-export default [fileDefault, fileImage];
+export { defaultFileTypePlugin } from "./fileDefault";
+export { imageFileTypePlugin } from "./fileImage";

--- a/packages/app-admin/src/plugins/index.ts
+++ b/packages/app-admin/src/plugins/index.ts
@@ -1,5 +1,0 @@
-import fileManager from "./fileManager";
-import uiLayoutRenderer from "./uiLayoutRenderer";
-import { globalSearchHotkey } from "./globalSearch";
-
-export default () => [fileManager, globalSearchHotkey, uiLayoutRenderer];

--- a/packages/app-admin/src/types.ts
+++ b/packages/app-admin/src/types.ts
@@ -69,7 +69,7 @@ export interface AdminFileManagerFileTypePluginRenderParams {
 }
 export type AdminFileManagerFileTypePlugin = Plugin & {
     type: "admin-file-manager-file-type";
-    types?: string[];
+    types: string[];
     render(params: AdminFileManagerFileTypePluginRenderParams): React.ReactNode;
     fileDetails?: {
         actions: Array<React.FC | React.Component>;


### PR DESCRIPTION
## Changes
This PR addresses an issue with custom file type renderers for the File Manager. The issue appeared when we switched from  object plugins to the new [Admin app framework](https://www.webiny.com/docs/admin-area/basics/framework). At that point, we unknowingly changed the order of plugin registration. The Admin app preset registers default thumbnail renderers, which, because of the new architecture, happens _after_ user plugin registration. This means that user's plugins never get a chance to execute, because the built-in ones take precedence.

The issue has two parts: first one is the order of plugin registration, and the second one is the logic that sorts plugins at runtime, when thumbnails are rendered. 

Thanks to @DasRed, this bug was uncovered, and a sorting solution was implemented in [this PR](https://github.com/webiny/webiny-js/pull/2515). However, we unfortunately lost touch and were unable to finalize the original PR. So this PR is a continuation of the work done by @DasRed, with some other tweaks to make it work the way it was meant to.

## How Has This Been Tested?
Manually.

## Other Thoughts
This implementation is still lacking on many fronts feature-wise, and we will replace the old object plugins approach with the new approach, using our [Composition API](https://www.webiny.com/docs/admin-area/basics/framework#the-compose-component). This will give us the flexibility to customize rendering not only based on mime types, but also on file size, file tags, even user's security permissions.