### PR TITLE
Watch Command - Add `hook-before-watch` Hook

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/deploy.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/deploy.js
@@ -1,5 +1,5 @@
 const buildPackages = require("./deploy/buildPackages");
-const { createPulumiCommand, processHooks, login, notify } = require("../utils");
+const { createPulumiCommand, runHook, login, notify } = require("../utils");
 
 module.exports = (params, context) => {
     const command = createPulumiCommand({
@@ -126,13 +126,3 @@ module.exports = (params, context) => {
 
     return command(params, context);
 };
-
-async function runHook({ hook, skip, args, context }) {
-    if (skip) {
-        context.info(`Skipped "${hook}" hook.`);
-    } else {
-        context.info(`Running "${hook}" hook...`);
-        await processHooks(hook, args);
-        context.success(`Hook "${hook}" completed.`);
-    }
-}

--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -14,7 +14,7 @@ const simpleOutput = require("./watch/output/simpleOutput");
 const minimatch = require("minimatch");
 const glob = require("fast-glob");
 const watchPackages = require("./watch/watchPackages");
-const { login, getPulumi, getRandomColorForString, loadEnvVariables } = require("../utils");
+const { login, getPulumi, getRandomColorForString, loadEnvVariables, runHook } = require("../utils");
 
 // Do not allow watching "prod" and "production" environments. On the Pulumi CLI side, the command
 // is still in preview mode, so it's definitely not wise to use it on production environments.
@@ -82,6 +82,14 @@ module.exports = async (inputs, context) => {
             inputs.remoteRuntimeLogs = "*";
         }
     }
+
+    const hookArgs = { context, env: inputs.env, inputs, projectApplication };
+
+    await runHook({
+        hook: "hook-before-watch",
+        args: hookArgs,
+        context
+    });
 
     // 1.1. Check if the project application and Pulumi stack exist.
     let PULUMI_SECRETS_PROVIDER = process.env.PULUMI_SECRETS_PROVIDER;

--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -14,7 +14,13 @@ const simpleOutput = require("./watch/output/simpleOutput");
 const minimatch = require("minimatch");
 const glob = require("fast-glob");
 const watchPackages = require("./watch/watchPackages");
-const { login, getPulumi, getRandomColorForString, loadEnvVariables, runHook } = require("../utils");
+const {
+    login,
+    getPulumi,
+    getRandomColorForString,
+    loadEnvVariables,
+    runHook
+} = require("../utils");
 
 // Do not allow watching "prod" and "production" environments. On the Pulumi CLI side, the command
 // is still in preview mode, so it's definitely not wise to use it on production environments.

--- a/packages/cli-plugin-deploy-pulumi/utils/index.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/index.js
@@ -4,6 +4,7 @@ const getStackOutput = require("./getStackOutput");
 const createPulumiCommand = require("./createPulumiCommand");
 const loadEnvVariables = require("./loadEnvVariables");
 const processHooks = require("./processHooks");
+const runHook = require("./runHook");
 const notify = require("./notify");
 const login = require("./login");
 const mapStackOutput = require("./mapStackOutput");
@@ -16,6 +17,7 @@ module.exports = {
     loadEnvVariables,
     mapStackOutput,
     processHooks,
+    runHook,
     notify,
     login,
     getRandomColorForString,

--- a/packages/cli-plugin-deploy-pulumi/utils/runHook.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/runHook.js
@@ -1,4 +1,4 @@
-const { processHooks } = require("./index");
+const processHooks = require("./processHooks");
 
 module.exports = async function runHook({ hook, skip, args, context }) {
     if (skip) {
@@ -8,4 +8,4 @@ module.exports = async function runHook({ hook, skip, args, context }) {
         await processHooks(hook, args);
         context.success(`Hook "${hook}" completed.`);
     }
-}
+};

--- a/packages/cli-plugin-deploy-pulumi/utils/runHook.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/runHook.js
@@ -1,0 +1,11 @@
+const { processHooks } = require("./index");
+
+module.exports = async function runHook({ hook, skip, args, context }) {
+    if (skip) {
+        context.info(`Skipped "${hook}" hook.`);
+    } else {
+        context.info(`Running "${hook}" hook...`);
+        await processHooks(hook, args);
+        context.success(`Hook "${hook}" completed.`);
+    }
+}


### PR DESCRIPTION
## Changes
This PR introduces a new `hook-before-watch` hook to the watch command.

The main incentive to add [this is a WCP-related](https://github.com/webiny/webiny-js/pull/2609) bug. If you deploy your WCP-enabled project, all of the WCP-related env variables are correctly assigned. On the other hand, the moment you start development with the watch command, all of the WCP-related env variables disappear. This is because, when running the watch command, the code that assigns these variables does not get executed. It only gets executed with the deploy command.

This PR ensures we have a way to run code before the watch command starts.

## How Has This Been Tested?
Manual testing.

## Documentation
Changelog.