### PR TITLE
feat(app-headless-cms): make fieldId changeable

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -573,13 +573,13 @@ describe("content model test", () => {
             }
         });
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 updateContentModel: {
                     data: null,
                     error: {
                         code: "VALIDATION_ERROR",
-                        message: `Field does not exist in the model.`,
+                        message: `Field selected for the title field does not exist in the model.`,
                         data: {
                             fieldId: "nonExistingTitleFieldId",
                             fields: expect.any(Array)

--- a/packages/api-headless-cms/__tests__/contentAPI/lockedFields.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/lockedFields.test.ts
@@ -130,7 +130,7 @@ describe("Content model locked fields", () => {
             };
             const [removedFieldResponse] = await updateContentModelMutation(variables);
 
-            expect(removedFieldResponse).toEqual({
+            expect(removedFieldResponse).toMatchObject({
                 data: {
                     updateContentModel: {
                         data: null,

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -26,7 +26,6 @@ import {
     UpdateContentModelModel
 } from "./contentModel/models";
 import { createFieldModels } from "./contentModel/createFieldModels";
-import { validateLayout } from "./contentModel/validateLayout";
 import WebinyError from "@webiny/error";
 import { Tenant } from "@webiny/api-tenancy/types";
 import { I18NLocale } from "@webiny/api-i18n/types";
@@ -301,8 +300,6 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 webinyVersion: context.WEBINY_VERSION
             };
 
-            validateLayout(model, fields);
-
             await onBeforeModelCreate.publish({
                 input,
                 model
@@ -480,7 +477,6 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 fields,
                 savedOn: new Date().toISOString()
             };
-            validateLayout(model, fields);
 
             await onBeforeModelUpdate.publish({
                 input,

--- a/packages/api-headless-cms/src/crud/contentModel/beforeCreate.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/beforeCreate.ts
@@ -10,7 +10,8 @@ import {
 import { Topic } from "@webiny/pubsub/types";
 import { PluginsContainer } from "@webiny/plugins";
 import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
-import { validateModel } from "~/crud/contentModel/validateModel";
+import { validateModel } from "./validateModel";
+import { validateLayout } from "./validateLayout";
 
 const disallowedModelIdList: string[] = [
     "contentModel",
@@ -179,7 +180,11 @@ export const assignBeforeModelCreate = (params: AssignBeforeModelCreateParams) =
 
     onBeforeModelCreate.subscribe(async ({ model, input }) => {
         /**
-         * First we need to validate base data of the model.
+         * First the layout...
+         */
+        validateLayout(model.layout, model.fields);
+        /**
+         * then we run the shared create/createFrom methods.
          */
         const cb = createOnBeforeCb({
             storageOperations,
@@ -189,8 +194,9 @@ export const assignBeforeModelCreate = (params: AssignBeforeModelCreateParams) =
             model,
             input
         });
+
         /**
-         * Then we move onto fields...
+         * and then we move onto model and fields...
          */
         await validateModel({
             model,

--- a/packages/api-headless-cms/src/crud/contentModel/beforeUpdate.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/beforeUpdate.ts
@@ -2,6 +2,7 @@ import { Topic } from "@webiny/pubsub/types";
 import { BeforeModelUpdateTopicParams, HeadlessCmsStorageOperations } from "~/types";
 import { PluginsContainer } from "@webiny/plugins";
 import { validateModel } from "./validateModel";
+import { validateLayout } from "./validateLayout";
 
 interface AssignBeforeModelUpdateParams {
     onBeforeModelUpdate: Topic<BeforeModelUpdateTopicParams>;
@@ -12,9 +13,16 @@ interface AssignBeforeModelUpdateParams {
 export const assignBeforeModelUpdate = (params: AssignBeforeModelUpdateParams) => {
     const { onBeforeModelUpdate, plugins } = params;
 
-    onBeforeModelUpdate.subscribe(async params => {
+    onBeforeModelUpdate.subscribe(async ({ model }) => {
+        /**
+         * First we go through the layout...
+         */
+        validateLayout(model.layout, model.fields);
+        /**
+         * then the model and fields...
+         */
         await validateModel({
-            model: params.model,
+            model,
             plugins
         });
     });

--- a/packages/api-headless-cms/src/crud/contentModel/validateLayout.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateLayout.ts
@@ -1,7 +1,6 @@
 import { CmsModelField, CmsModel } from "~/types";
 
-export const validateLayout = (model: CmsModel, fields: CmsModelField[] = []): void => {
-    const layout = model.layout || [];
+export const validateLayout = (layout: CmsModel["layout"], fields: CmsModelField[] = []): void => {
     const flatLayoutIdList = layout.reduce((acc, id) => {
         return acc.concat(Array.isArray(id) ? id : [id]);
     }, []);

--- a/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
@@ -17,6 +17,12 @@ const allowedTitleFieldTypes = ["text", "number"];
 
 const getContentModelTitleFieldId = (fields: CmsModelField[], titleFieldId?: string): string => {
     /**
+     * If there are no fields defined, we will return the default field
+     */
+    if (fields.length === 0) {
+        return defaultTitleFieldId;
+    }
+    /**
      * if there is no title field defined either in input data or existing content model data
      * we will take first text field that has no multiple values enabled
      * or if initial titleFieldId is the default one also try to find first available text field
@@ -25,7 +31,7 @@ const getContentModelTitleFieldId = (fields: CmsModelField[], titleFieldId?: str
         const titleField = fields.find(field => {
             return field.type === "text" && !field.multipleValues;
         });
-        return titleField ? titleField.fieldId : defaultTitleFieldId;
+        return titleField?.fieldId || defaultTitleFieldId;
     }
     /**
      * check existing titleFieldId for existence in the model
@@ -34,10 +40,14 @@ const getContentModelTitleFieldId = (fields: CmsModelField[], titleFieldId?: str
      */
     const target = fields.find(f => f.fieldId === titleFieldId);
     if (!target) {
-        throw new WebinyError(`Field does not exist in the model.`, "VALIDATION_ERROR", {
-            fieldId: titleFieldId,
-            fields
-        });
+        throw new WebinyError(
+            `Field selected for the title field does not exist in the model.`,
+            "VALIDATION_ERROR",
+            {
+                fieldId: titleFieldId,
+                fields
+            }
+        );
     }
 
     if (allowedTitleFieldTypes.includes(target.type) === false) {

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -105,7 +105,7 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
                 label: String!
                 helpText: String
                 placeholderText: String
-                # should never use user input - this is here for backward compatibility
+                # we never use user input - this is here to the GraphQL does not break when posting from our UI
                 storageId: String
                 fieldId: String!
                 type: String!

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -106,6 +106,7 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
                 helpText: String
                 placeholderText: String
                 # we never use user input - this is here to the GraphQL does not break when posting from our UI
+                # used for debugging purposes
                 storageId: String
                 fieldId: String!
                 type: String!
@@ -188,6 +189,7 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
             type CmsContentModelField {
                 id: ID!
                 # auto-generated value
+                # used for debugging purposes
                 storageId: String!
                 fieldId: String!
                 label: String!

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -52,7 +52,6 @@
     "graphql-tag": "^2.12.6",
     "invariant": "^2.2.4",
     "lodash": "^4.17.10",
-    "nanoid": "^3.3.4",
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "raw.macro": "^0.4.2",
@@ -64,7 +63,6 @@
     "react-helmet": "^6.1.0",
     "react-hotkeyz": "^1.0.4",
     "react-virtualized": "^9.21.2",
-    "shortid": "^2.2.14",
     "timeago-react": "^2.0.0",
     "use-deep-compare-effect": "^1.6.1"
   },
@@ -79,7 +77,6 @@
     "babel-plugin-emotion": "^9.2.8",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^4.1.0",
-    "execa": "^5.0.0",
     "rimraf": "^3.0.2",
     "ttypescript": "^1.5.12",
     "typescript": "4.7.4"

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/GeneralTab.tsx
@@ -19,7 +19,7 @@ interface GeneralTabProps {
 const GeneralTab: React.FC<GeneralTabProps> = ({ field, form, fieldPlugin }) => {
     const { Bind, setValue } = form;
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const { data } = useContentModelEditor();
+    const { data: contentModel } = useContentModelEditor();
     const { getField } = useFieldEditor();
 
     // Had problems with auto-focusing the "label" field. A couple of comments on this.
@@ -76,7 +76,7 @@ const GeneralTab: React.FC<GeneralTabProps> = ({ field, form, fieldPlugin }) => 
             form,
             afterChangeLabel,
             uniqueFieldIdValidator,
-            contentModel: data
+            contentModel
         });
     }
 

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/GeneralTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/GeneralTab.tsx
@@ -120,7 +120,6 @@ const GeneralTab: React.FC<GeneralTabProps> = ({ field, form, fieldPlugin }) => 
                     >
                         <Input
                             label={"Field ID"}
-                            disabled={!!field.id}
                             data-testid={`cms.editor.field.settings.general.label-${field.id}`}
                         />
                     </Bind>

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
@@ -119,7 +119,12 @@ export const FieldEditorContext = React.createContext<FieldEditorContextValue>(
         field: null
     } as unknown as FieldEditorContextValue
 );
-
+/**
+ * We try to generate the random id string but with the check that it does not exist already.
+ * Chances that the same string exists are quite small, but let's check it anyway.
+ *
+ * In most cases, there will be no iterations anyway...
+ */
 const maxGenerateIdIterations = 100;
 const generateFieldId = (layout: string[]): string => {
     let id = generateAlphaNumericLowerCaseId(8);

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
@@ -13,7 +13,7 @@ import * as utils from "./utils";
 import { FieldEditorProps } from "./FieldEditor";
 import { DragObjectWithType, DragSourceMonitor } from "react-dnd";
 import { useFieldEditor } from "~/admin/components/FieldEditor/useFieldEditor";
-import { generateAlphaNumericId } from "@webiny/utils";
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
 
 interface DropTarget {
     row: number;
@@ -119,6 +119,21 @@ export const FieldEditorContext = React.createContext<FieldEditorContextValue>(
         field: null
     } as unknown as FieldEditorContextValue
 );
+
+const maxGenerateIdIterations = 100;
+const generateFieldId = (layout: string[]): string => {
+    let id = generateAlphaNumericLowerCaseId(8);
+
+    let iteration = 0;
+    while (layout.includes(id) || iteration < maxGenerateIdIterations) {
+        id = generateAlphaNumericLowerCaseId(8);
+        iteration++;
+    }
+    if (iteration >= maxGenerateIdIterations) {
+        throw new Error(`Could not generate field ID in ${maxGenerateIdIterations} iterations.`);
+    }
+    return id;
+};
 
 interface State {
     layout: CmsEditorFieldsLayout;
@@ -288,7 +303,7 @@ export const FieldEditorProvider: React.FC<FieldEditorProviderProps> = ({
      */
     const insertField: InsertFieldCallable = ({ field, position }) => {
         if (!field.id) {
-            field.id = generateAlphaNumericId(8);
+            field.id = generateFieldId(layout.flat());
         }
 
         if (!field.type) {

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 import dot from "dot-prop-immutable";
-import shortid from "shortid";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import {
     CmsEditorField,
@@ -14,6 +13,7 @@ import * as utils from "./utils";
 import { FieldEditorProps } from "./FieldEditor";
 import { DragObjectWithType, DragSourceMonitor } from "react-dnd";
 import { useFieldEditor } from "~/admin/components/FieldEditor/useFieldEditor";
+import { generateAlphaNumericId } from "@webiny/utils";
 
 interface DropTarget {
     row: number;
@@ -288,7 +288,7 @@ export const FieldEditorProvider: React.FC<FieldEditorProviderProps> = ({
      */
     const insertField: InsertFieldCallable = ({ field, position }) => {
         if (!field.id) {
-            field.id = shortid.generate();
+            field.id = generateAlphaNumericId(8);
         }
 
         if (!field.type) {

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
@@ -125,7 +125,7 @@ const generateFieldId = (layout: string[]): string => {
     let id = generateAlphaNumericLowerCaseId(8);
 
     let iteration = 0;
-    while (layout.includes(id) || iteration < maxGenerateIdIterations) {
+    while (layout.includes(id) && iteration < maxGenerateIdIterations) {
         id = generateAlphaNumericLowerCaseId(8);
         iteration++;
     }

--- a/packages/app-headless-cms/src/admin/graphql/contentModels.ts
+++ b/packages/app-headless-cms/src/admin/graphql/contentModels.ts
@@ -9,10 +9,11 @@ const ERROR_FIELDS = `
 export const FIELDS_FIELDS = `
     id
     fieldId
+    storageId
     type
     label
     placeholderText
-    helpText  
+    helpText
     predefinedValues {
         enabled
         values {
@@ -21,7 +22,7 @@ export const FIELDS_FIELDS = `
             selected
         }
     }
-    multipleValues 
+    multipleValues
     renderer {
         name
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -23,7 +23,7 @@ import {
     ItemHighLight,
     ObjectItem
 } from "./StyledComponents";
-import { generateAlphaNumericId } from "@webiny/utils";
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -46,7 +46,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
                     bind.field.moveValueDown(index);
                     setHighlightIndex(map => ({
                         ...map,
-                        [index + 1]: generateAlphaNumericId(8)
+                        [index + 1]: generateAlphaNumericLowerCaseId(12)
                     }));
                 }}
             />
@@ -57,7 +57,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
                     bind.field.moveValueUp(index);
                     setHighlightIndex(map => ({
                         ...map,
-                        [index - 1]: generateAlphaNumericId(8)
+                        [index - 1]: generateAlphaNumericLowerCaseId(12)
                     }));
                 }}
             />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -1,5 +1,4 @@
 import React, { Dispatch, SetStateAction, useState } from "react";
-import shortid from "shortid";
 import { i18n } from "@webiny/app/i18n";
 import { IconButton } from "@webiny/ui/Button";
 import { Cell } from "@webiny/ui/Grid";
@@ -24,6 +23,7 @@ import {
     ItemHighLight,
     ObjectItem
 } from "./StyledComponents";
+import { generateAlphaNumericId } from "@webiny/utils";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -46,7 +46,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
                     bind.field.moveValueDown(index);
                     setHighlightIndex(map => ({
                         ...map,
-                        [index + 1]: shortid.generate()
+                        [index + 1]: generateAlphaNumericId(8)
                     }));
                 }}
             />
@@ -57,7 +57,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
                     bind.field.moveValueUp(index);
                     setHighlightIndex(map => ({
                         ...map,
-                        [index - 1]: shortid.generate()
+                        [index - 1]: generateAlphaNumericId(8)
                     }));
                 }}
             />

--- a/packages/app-headless-cms/src/admin/views/contentEntries/experiment/Property.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/experiment/Property.tsx
@@ -10,8 +10,8 @@
  * More on this a bit later, if the experiment is successful.
  */
 import React, { createContext, FC, useContext, useMemo, useRef, useState } from "react";
-import { nanoid } from "nanoid";
 import useDeepCompareEffect from "use-deep-compare-effect";
+import { generateAlphaNumericId } from "@webiny/utils";
 
 export function toObject<T = unknown>(property: Property): T {
     if (property.value !== undefined) {
@@ -135,7 +135,7 @@ interface PropertyProps {
 }
 
 export const Property: FC<PropertyProps> = ({ children, name, value, ...props }) => {
-    const id = useRef(props.id || nanoid());
+    const id = useRef(props.id || generateAlphaNumericId(21));
     const [properties, setProperties] = useState([]);
     const { updateContainer } = useContext(PropertyContainerContext);
     const parentProperty = useProperty();

--- a/packages/utils/src/generateId.ts
+++ b/packages/utils/src/generateId.ts
@@ -3,11 +3,16 @@ import { nanoid, customAlphabet } from "nanoid";
  * Package nanoid-dictionary is missing types
  */
 // @ts-ignore
-import { lowercase, uppercase, alphanumeric } from "nanoid-dictionary";
+import { lowercase, uppercase, alphanumeric, numbers } from "nanoid-dictionary";
 
 const DEFAULT_SIZE = 21;
 
 export const generateAlphaNumericId = customAlphabet(alphanumeric, DEFAULT_SIZE);
+
+export const generateAlphaNumericLowerCaseId = customAlphabet(
+    `${lowercase}${numbers}`,
+    DEFAULT_SIZE
+);
 
 export const generateAlphaId = customAlphabet(`${lowercase}${uppercase}`, DEFAULT_SIZE);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11712,12 +11712,10 @@ __metadata:
     classnames: ^2.2.6
     dot-prop-immutable: ^2.1.0
     emotion: ^10.0.17
-    execa: ^5.0.0
     graphql: ^15.7.2
     graphql-tag: ^2.12.6
     invariant: ^2.2.4
     lodash: ^4.17.10
-    nanoid: ^3.3.4
     pluralize: ^8.0.0
     prop-types: ^15.7.2
     raw.macro: ^0.4.2
@@ -11730,7 +11728,6 @@ __metadata:
     react-hotkeyz: ^1.0.4
     react-virtualized: ^9.21.2
     rimraf: ^3.0.2
-    shortid: ^2.2.14
     timeago-react: ^2.0.0
     ttypescript: ^1.5.12
     typescript: 4.7.4


### PR DESCRIPTION
## Changes
UI changes to support the field alias. Basically we will make fieldId changeable and it will serve as the field alias (graphql identifier).

The `storageId` property cannot be customly created or updated - it is an autogenerated value.

## How Has This Been Tested?
Manually and cypress.
