### PR TITLE
feat: make getElementTree composable

### DIFF
--- a/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/saveBlockAction.ts
+++ b/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/saveBlockAction.ts
@@ -7,6 +7,7 @@ import { BlockWithContent } from "~/blockEditor/state";
 import { UPDATE_PAGE_BLOCK } from "~/admin/views/PageBlocks/graphql";
 import getPreviewImage from "./getPreviewImage";
 import { removeElementId } from "~/editor/helpers";
+import { PbElement } from "~/types";
 
 // TODO: add more properties here
 type BlockType = Pick<BlockWithContent, "name" | "content" | "blockCategory">;
@@ -27,7 +28,7 @@ export const saveBlockAction: BlockEventActionCallable<SaveBlockActionArgsType> 
 ) => {
     // TODO: make sure the API call is not sent if the data was not changed since the last invocation of this event.
     // See `pageEditor` for an example and feel free to copy that same logic over here.
-    const element = await state.getElementTree();
+    const element = (await state.getElementTree()) as PbElement;
     // We need to grab the first block from the "document" element.
     const createdImage = await getPreviewImage(element.elements[0], meta);
 

--- a/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
@@ -92,7 +92,7 @@ export type GetElementTreeResult = {
     path?: string[];
 } | void;
 
-export type GetElementTree = AsyncProcessor<GetElementTreeResult>;
+export type GetElementTree = AsyncProcessor<GetElementTreeResult, PbEditorElement>;
 export type GetCallableState = SyncProcessor<Partial<EventActionHandlerCallableState>>;
 export type SaveCallableResults<TState = Partial<PbState>> = SyncProcessor<{
     state: TState & Partial<PbState>;

--- a/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
@@ -41,7 +41,7 @@ import {
     EventActionHandlerTarget,
     EventActionHandlerCallableState
 } from "~/types";
-import { composeSync, SyncProcessor } from "@webiny/utils/compose";
+import { composeAsync, composeSync, AsyncProcessor, SyncProcessor } from "@webiny/utils/compose";
 import { UpdateElementTreeActionEvent } from "~/editor/recoil/actions";
 
 type ListType = Map<symbol, EventActionCallable>;
@@ -87,6 +87,12 @@ const isTrackedAtomChanged = (state: Partial<PbState>): boolean => {
     return false;
 };
 
+export type GetElementTreeResult = {
+    element?: PbEditorElement;
+    path?: string[];
+} | void;
+
+export type GetElementTree = AsyncProcessor<GetElementTreeResult>;
 export type GetCallableState = SyncProcessor<Partial<EventActionHandlerCallableState>>;
 export type SaveCallableResults<TState = Partial<PbState>> = SyncProcessor<{
     state: TState & Partial<PbState>;
@@ -94,6 +100,7 @@ export type SaveCallableResults<TState = Partial<PbState>> = SyncProcessor<{
 }>;
 
 export interface EventActionHandlerProviderProps<TState> {
+    getElementTree?: Array<GetElementTree>;
     getCallableState?: Array<GetCallableState>;
     saveCallablesResults?: Array<SaveCallableResults<TState>>;
 }
@@ -170,33 +177,43 @@ export const EventActionHandlerProvider = makeComposable<
         return snapshot;
     });
 
-    const getElementTree = async (
-        element?: PbEditorElement,
-        path: string[] = []
-    ): Promise<PbEditorElement> => {
-        if (!element) {
-            element = (await getElementById(rootElementAtomValue)) as PbEditorElement;
-        }
-        if (element.parent) {
-            path.push(element.parent);
-        }
-        return {
-            id: element.id,
-            type: element.type,
-            data: element.data,
-            elements: await Promise.all(
-                /**
-                 * We are positive that element.elements is array of strings.
-                 */
-                (element.elements as string[]).map(async child => {
-                    return getElementTree((await getElementById(child)) as PbEditorElement, [
-                        ...path
-                    ]);
-                })
-            ),
-            path
-        };
-    };
+    const defaultGetElementTree = useCallback<GetElementTree>(
+        () =>
+            async function getChildElement(props: GetElementTreeResult): Promise<PbEditorElement> {
+                let element = props?.element;
+                if (!element) {
+                    element = (await getElementById(rootElementAtomValue)) as PbEditorElement;
+                }
+
+                const path = props?.path || [];
+                if (element.parent) {
+                    path.push(element.parent);
+                }
+
+                return {
+                    id: element.id,
+                    type: element.type,
+                    data: element.data,
+                    elements: await Promise.all(
+                        /**
+                         * We are positive that element.elements is array of strings.
+                         */
+                        (element.elements as string[]).map(async child => {
+                            return await getChildElement({
+                                element: (await getElementById(child)) as PbEditorElement,
+                                path: [...path]
+                            });
+                        })
+                    ),
+                    path
+                };
+            },
+        []
+    );
+
+    const getElementTree = useMemo(() => {
+        return composeAsync([...(props.getElementTree || []), defaultGetElementTree]);
+    }, [props.getElementTree]);
 
     const get = (name: string): ListType => {
         const list = registry.current.get(name);

--- a/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
@@ -39,7 +39,8 @@ import {
     PbEditorElement,
     EventActionHandler,
     EventActionHandlerTarget,
-    EventActionHandlerCallableState
+    EventActionHandlerCallableState,
+    GetElementTreeProps
 } from "~/types";
 import { composeAsync, composeSync, AsyncProcessor, SyncProcessor } from "@webiny/utils/compose";
 import { UpdateElementTreeActionEvent } from "~/editor/recoil/actions";
@@ -87,12 +88,7 @@ const isTrackedAtomChanged = (state: Partial<PbState>): boolean => {
     return false;
 };
 
-export type GetElementTreeResult = {
-    element?: PbEditorElement;
-    path?: string[];
-} | void;
-
-export type GetElementTree = AsyncProcessor<GetElementTreeResult, PbEditorElement>;
+export type GetElementTree = AsyncProcessor<GetElementTreeProps, PbEditorElement>;
 export type GetCallableState = SyncProcessor<Partial<EventActionHandlerCallableState>>;
 export type SaveCallableResults<TState = Partial<PbState>> = SyncProcessor<{
     state: TState & Partial<PbState>;
@@ -179,7 +175,7 @@ export const EventActionHandlerProvider = makeComposable<
 
     const defaultGetElementTree = useCallback<GetElementTree>(
         () =>
-            async function getChildElement(props: GetElementTreeResult): Promise<PbEditorElement> {
+            async function getChildElement(props: GetElementTreeProps): Promise<PbEditorElement> {
                 let element = props?.element;
                 if (!element) {
                     element = (await getElementById(rootElementAtomValue)) as PbEditorElement;

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveAction.tsx
@@ -78,7 +78,7 @@ const SaveAction: React.FC = ({ children }) => {
     const client = useApolloClient();
 
     const onSubmit = async (formData: PbDocumentElement) => {
-        const pbElement = (await getElementTree(element)) as PbElement;
+        const pbElement = (await getElementTree({ element })) as PbElement;
         formData.content = pluginOnSave(removeElementId(pbElement));
 
         const meta = await getDataURLImageDimensions(formData.preview);

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -688,11 +688,16 @@ export type PbRenderElementPluginArgs = {
     elementType?: string;
 };
 
+export type GetElementTreeProps = {
+    element?: PbEditorElement;
+    path?: string[];
+} | void;
+
 // ============== EVENT ACTION HANDLER ================= //
 // TODO: at some point, convert this into an interface, and use module augmentation to add new properties.
 export type EventActionHandlerCallableState<TState = PbState> = PbState<TState> & {
     getElementById(id: string): Promise<PbEditorElement>;
-    getElementTree(props?: { element?: PbEditorElement }): Promise<PbEditorElement>;
+    getElementTree(props: GetElementTreeProps): Promise<PbEditorElement>;
 };
 
 export interface EventActionHandler<TCallableState = unknown> {
@@ -709,7 +714,7 @@ export interface EventActionHandler<TCallableState = unknown> {
     endBatch: () => void;
     enableHistory: () => void;
     disableHistory: () => void;
-    getElementTree: (props?: { element?: PbEditorElement }) => Promise<PbEditorElement>;
+    getElementTree: (props: GetElementTreeProps) => Promise<PbEditorElement>;
 }
 
 export interface EventActionHandlerTarget {

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -692,7 +692,7 @@ export type PbRenderElementPluginArgs = {
 // TODO: at some point, convert this into an interface, and use module augmentation to add new properties.
 export type EventActionHandlerCallableState<TState = PbState> = PbState<TState> & {
     getElementById(id: string): Promise<PbEditorElement>;
-    getElementTree(props?: { element?: PbEditorElement }): Promise<any>;
+    getElementTree(props?: { element?: PbEditorElement }): Promise<PbEditorElement>;
 };
 
 export interface EventActionHandler<TCallableState = unknown> {
@@ -709,7 +709,7 @@ export interface EventActionHandler<TCallableState = unknown> {
     endBatch: () => void;
     enableHistory: () => void;
     disableHistory: () => void;
-    getElementTree: (props?: { element?: PbEditorElement }) => Promise<any>;
+    getElementTree: (props?: { element?: PbEditorElement }) => Promise<PbEditorElement>;
 }
 
 export interface EventActionHandlerTarget {

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -692,7 +692,7 @@ export type PbRenderElementPluginArgs = {
 // TODO: at some point, convert this into an interface, and use module augmentation to add new properties.
 export type EventActionHandlerCallableState<TState = PbState> = PbState<TState> & {
     getElementById(id: string): Promise<PbEditorElement>;
-    getElementTree(element?: PbEditorElement): Promise<any>;
+    getElementTree(props?: { element?: PbEditorElement }): Promise<any>;
 };
 
 export interface EventActionHandler<TCallableState = unknown> {
@@ -709,7 +709,7 @@ export interface EventActionHandler<TCallableState = unknown> {
     endBatch: () => void;
     enableHistory: () => void;
     disableHistory: () => void;
-    getElementTree: (element?: PbEditorElement) => Promise<PbEditorElement>;
+    getElementTree: (props?: { element?: PbEditorElement }) => Promise<any>;
 }
 
 export interface EventActionHandlerTarget {


### PR DESCRIPTION
## Changes
Make getElementTree  composable. Filter out ref blocks from Navigator tree.

## How Has This Been Tested?
Manual

## Documentation
None