### PR TITLE
fix: remove the utf8 encoding parameter from the call to fs.readFile

### DIFF
--- a/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
+++ b/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
@@ -139,7 +139,7 @@ export const uploadFolderToS3 = async ({
                                 ...fields,
                                 "Content-Type": contentType || "",
                                 "X-Amz-Meta-Checksum": checksum,
-                                file: fs.readFileSync(path, "utf8")
+                                file: fs.readFileSync(path)
                             };
 
                             if (cacheControl) {

--- a/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
+++ b/packages/pulumi-aws/src/utils/uploadFolderToS3.ts
@@ -135,7 +135,7 @@ export const uploadFolderToS3 = async ({
                                 cacheControl: cacheControl ? cacheControl.value : undefined
                             });
 
-                            const data: Record<string, string> = {
+                            const data: Record<string, string | Buffer> = {
                                 ...fields,
                                 "Content-Type": contentType || "",
                                 "X-Amz-Meta-Checksum": checksum,


### PR DESCRIPTION
## Related Issue
#2629

## Changes
I remove the utf8 encoding parameter from the call to fs.readFileSync which caused the static non-text assets (images, videos) to be broken/inaccessible.

## How Has This Been Tested?
Manually.

