### PR TITLE
fix(api-headless-cms): long text field decompression

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/dynamoDb/storage/longText.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/dynamoDb/storage/longText.test.ts
@@ -85,4 +85,63 @@ describe("long text storage plugin", () => {
         });
         expect(decompressResult).toEqual(value);
     });
+
+    it("should do nothing when decompressing a non-compressed value - string", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = "some text which is going to get compressed";
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should do nothing when decompressing a non-compressed value - number", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = 1234567890;
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should do nothing when decompressing a non-compressed value - array", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = ["some text which is going to get compressed"];
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should fail with decompression because no compression definition value exists", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        let error: any = undefined;
+        try {
+            await plugin.fromStorage({
+                ...defaultArgs,
+                value: {} as any
+            });
+        } catch (ex: any) {
+            error = {
+                message: ex.message,
+                code: ex.code,
+                data: ex.data
+            };
+        }
+        expect(error).toEqual({
+            message: `Missing compression in "fromStorage" function in field "longTextStorageFieldId" - longTextFieldId.": {}.`,
+            code: "MISSING_COMPRESSION",
+            data: expect.any(Object)
+        });
+    });
 });

--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
@@ -1,3 +1,7 @@
+/**
+ * File is @internal
+ */
+
 import WebinyError from "@webiny/error";
 import { compress as gzip, decompress as ungzip } from "@webiny/utils/compression/gzip";
 import { StorageTransformPlugin } from "@webiny/api-headless-cms";
@@ -30,8 +34,8 @@ export const createLongTextStorageTransformPlugin = () => {
                 typeOf === "number" ||
                 Array.isArray(storageValue) === true
             ) {
-                return storageValue as unknown as string;
-            } else if (typeof storageValue !== "object") {
+                return storageValue as unknown as string | string[];
+            } else if (typeOf !== "object") {
                 throw new WebinyError(
                     `LongText value received in "fromStorage" function is not an object in field "${field.storageId}" - ${field.fieldId}.`
                 );
@@ -43,8 +47,8 @@ export const createLongTextStorageTransformPlugin = () => {
             if (!compression) {
                 throw new WebinyError(
                     `Missing compression in "fromStorage" function in field "${
-                        field.fieldId
-                    }": ${JSON.stringify(storageValue)}.`,
+                        field.storageId
+                    }" - ${field.fieldId}.": ${JSON.stringify(storageValue)}.`,
                     "MISSING_COMPRESSION",
                     {
                         value: storageValue

--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
@@ -24,7 +24,12 @@ export const createLongTextStorageTransformPlugin = () => {
         fieldType: "long-text",
         fromStorage: async ({ field, value: storageValue }) => {
             const typeOf = typeof storageValue;
-            if (!storageValue || typeOf === "string" || typeOf === "number") {
+            if (
+                !storageValue ||
+                typeOf === "string" ||
+                typeOf === "number" ||
+                Array.isArray(storageValue) === true
+            ) {
                 return storageValue as unknown as string;
             } else if (typeof storageValue !== "object") {
                 throw new WebinyError(

--- a/packages/api-headless-cms-ddb/__tests__/plugins/dynamoDb/storage/longText.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/plugins/dynamoDb/storage/longText.test.ts
@@ -85,4 +85,63 @@ describe("long text storage plugin", () => {
         });
         expect(decompressResult).toEqual(value);
     });
+
+    it("should do nothing when decompressing a non-compressed value - string", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = "some text which is going to get compressed";
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should do nothing when decompressing a non-compressed value - number", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = 1234567890;
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should do nothing when decompressing a non-compressed value - array", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: any = ["some text which is going to get compressed"];
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value
+        });
+        expect(decompressResult).toEqual(value);
+    });
+
+    it("should fail with decompression because no compression definition value exists", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        let error: any = undefined;
+        try {
+            await plugin.fromStorage({
+                ...defaultArgs,
+                value: {} as any
+            });
+        } catch (ex: any) {
+            error = {
+                message: ex.message,
+                code: ex.code,
+                data: ex.data
+            };
+        }
+        expect(error).toEqual({
+            message: `Missing compression in "fromStorage" function in field "longTextStorageFieldId" - longTextFieldId.": {}.`,
+            code: "MISSING_COMPRESSION",
+            data: expect.any(Object)
+        });
+    });
 });

--- a/packages/api-headless-cms-ddb/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb/src/dynamoDb/storage/longText.ts
@@ -28,9 +28,14 @@ export const createLongTextStorageTransformPlugin = () => {
         fieldType: "long-text",
         fromStorage: async ({ field, value: storageValue }) => {
             const typeOf = typeof storageValue;
-            if (!storageValue || typeOf === "string" || typeOf === "number") {
-                return storageValue as unknown as string;
-            } else if (typeof storageValue !== "object") {
+            if (
+                !storageValue ||
+                typeOf === "string" ||
+                typeOf === "number" ||
+                Array.isArray(storageValue) === true
+            ) {
+                return storageValue as unknown as string | string[];
+            } else if (typeOf !== "object") {
                 throw new WebinyError(
                     `LongText value received in "fromStorage" function is not an object in field "${field.storageId}" - ${field.fieldId}.`
                 );
@@ -42,8 +47,8 @@ export const createLongTextStorageTransformPlugin = () => {
             if (!compression) {
                 throw new WebinyError(
                     `Missing compression in "fromStorage" function in field "${
-                        field.fieldId
-                    }": ${JSON.stringify(storageValue)}.`,
+                        field.storageId
+                    }" - ${field.fieldId}.": ${JSON.stringify(storageValue)}.`,
                     "MISSING_COMPRESSION",
                     {
                         value: storageValue

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -643,6 +643,26 @@ const models: CmsModel[] = [
                                         renderer: {
                                             name: "renderer"
                                         }
+                                    },
+                                    {
+                                        id: ids.field220,
+                                        multipleValues: true,
+                                        helpText: "",
+                                        label: "Long Text List",
+                                        storageId: "longTextStorageId",
+                                        fieldId: "longText",
+                                        type: "long-text",
+                                        validation: [],
+                                        listValidation: [],
+                                        settings: {},
+                                        placeholderText: "placeholder text",
+                                        predefinedValues: {
+                                            enabled: false,
+                                            values: []
+                                        },
+                                        renderer: {
+                                            name: "renderer"
+                                        }
                                     }
                                 ]
                             },

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -1123,7 +1123,14 @@ describe("MANAGE - Resolvers", () => {
                 price: 99.9,
                 availableOn: "2020-12-25",
                 color: "white",
+                inStock: true,
+                itemsInStock: 101,
                 image: "image.png",
+                richText: [
+                    {
+                        type: "p"
+                    }
+                ],
                 availableSizes: ["s", "m"],
                 category: {
                     modelId: "category",
@@ -1149,7 +1156,8 @@ describe("MANAGE - Resolvers", () => {
                                     modelId: "category",
                                     id: vegetables.id
                                 }
-                            ]
+                            ],
+                            longText: [null]
                         },
                         {
                             name: "Option 2",
@@ -1163,22 +1171,38 @@ describe("MANAGE - Resolvers", () => {
                                     modelId: "category",
                                     id: vegetables.id
                                 }
-                            ]
+                            ],
+                            longText: ["long text"]
                         }
                     ]
                 }
             }
         });
 
-        expect(potatoResponse).toMatchObject({
+        expect(potatoResponse.errors).toBeUndefined();
+
+        expect(potatoResponse).toEqual({
             data: {
                 createProduct: {
                     data: {
                         id: expect.any(String),
+                        entryId: expect.any(String),
                         title: "Potato",
                         price: 99.9,
+                        createdBy: expect.any(Object),
+                        meta: expect.any(Object),
+                        createdOn: expect.stringMatching(/^20/),
+                        savedOn: expect.stringMatching(/^20/),
                         availableOn: "2020-12-25",
                         color: "white",
+                        inStock: true,
+                        itemsInStock: 101,
+                        image: "image.png",
+                        richText: [
+                            {
+                                type: "p"
+                            }
+                        ],
                         availableSizes: ["s", "m"],
                         category: {
                             modelId: "category",
@@ -1201,7 +1225,15 @@ describe("MANAGE - Resolvers", () => {
                                         modelId: "category",
                                         id: vegetables.id,
                                         entryId: vegetables.entryId
-                                    }
+                                    },
+                                    categories: [
+                                        {
+                                            modelId: "category",
+                                            id: vegetables.id,
+                                            entryId: vegetables.entryId
+                                        }
+                                    ],
+                                    longText: [null]
                                 },
                                 {
                                     name: "Option 2",
@@ -1210,7 +1242,15 @@ describe("MANAGE - Resolvers", () => {
                                         modelId: "category",
                                         id: vegetables.id,
                                         entryId: vegetables.entryId
-                                    }
+                                    },
+                                    categories: [
+                                        {
+                                            modelId: "category",
+                                            id: vegetables.id,
+                                            entryId: vegetables.entryId
+                                        }
+                                    ],
+                                    longText: ["long text"]
                                 }
                             ]
                         }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -9,6 +9,7 @@ export default /* GraphQL */ `
         price: Number
         category: RefField
         categories: [RefField!]
+        longText: [String]
     }
     
     type Product_Variant {
@@ -63,6 +64,7 @@ export default /* GraphQL */ `
         price: Number
         category: RefFieldInput!
         categories: [RefFieldInput]
+        longText: [String]
     }
     
     input Product_VariantInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -7,6 +7,7 @@ export default /* GraphQL */ `
         price: Number
         category: Category
         categories: [Category]
+        longText: [String]
     }
 
     type Product_Variant {

--- a/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/utils/useProductManageHandler.ts
@@ -58,6 +58,7 @@ const productFields = `
                 entryId
                 id
             }
+            longText
         }
     }
 `;


### PR DESCRIPTION
## Changes
When decompressing long-text field value more than once there is an error rather than the early return.
We should not even try to decompress the field if no compression value is found or value is not decompressable (string, number, array...)

## How Has This Been Tested?
Jest and manually.