### PR TITLE
fix: fix not refreshed Navigator tree for editors

### DIFF
--- a/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
@@ -133,7 +133,7 @@ export const EventActionHandlerProvider = makeComposable<
         pluginsAtomValueRef.current = pluginsAtomValue;
         uiAtomValueRef.current = uiAtomValue;
         snapshotRef.current = snapshot;
-    }, [sidebarAtomValue, rootElementAtomValue, pluginsAtomValue, uiAtomValue]);
+    }, [sidebarAtomValue, rootElementAtomValue, pluginsAtomValue, uiAtomValue, snapshot]);
 
     const registry = useRef<RegistryType>(new Map());
 


### PR DESCRIPTION
## Changes
Fix useEffect dependency, so now Navigator side panel is refreshed properly.
But as a side effect this effect is called much more often (on element on hover for example)
But if I understand it properly we are using refs here exactly to keep performance impact minimal

PS: we may split this useEffect in separate... but I don't thing it will improve performance much

## How Has This Been Tested?
Manual

## Documentation
None
