### PR TITLE
test: add API test for resolved ref blocks, remove not required ref block manipulation

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -7,8 +7,19 @@ jest.setTimeout(100000);
 describe("CRUD Test", () => {
     const handler = useGqlHandler();
 
-    const { createCategory, createPage, deletePage, listPages, getPage, updatePage, until } =
-        handler;
+    const {
+        createBlockCategory,
+        createCategory,
+        createPage,
+        createPageBlock,
+        createPageElement,
+        deletePage,
+        listPages,
+        getPage,
+        updatePage,
+        updatePageBlock,
+        until
+    } = handler;
 
     test("create, read, update and delete pages", async () => {
         const [createPageUnknownResponse] = await createPage({ category: "unknown" });
@@ -370,6 +381,106 @@ describe("CRUD Test", () => {
                     }
                 }
             }
+        });
+    });
+
+    test("get page with resolved reference block", async () => {
+        // Create page block and add element inside of it
+        await createBlockCategory({
+            data: {
+                slug: "block-category",
+                name: "block-category-name",
+                icon: "block-category-icon",
+                description: "block-category-description"
+            }
+        });
+
+        const [createPageBlockResponse] = await createPageBlock({
+            data: {
+                name: "block-name",
+                blockCategory: "block-category",
+                preview: { src: "https://test.com/src.jpg" },
+                content: { data: {}, elements: [], type: "block" }
+            }
+        });
+
+        const blockData = createPageBlockResponse.data.pageBuilder.createPageBlock.data;
+
+        const [createPageElementResponse] = await createPageElement({
+            data: {
+                name: "element-name",
+                type: "element",
+                category: "element-category",
+                preview: { src: "https://test.com/element/src.jpg" },
+                content: { some: "element-content" }
+            }
+        });
+
+        const pageElementData = createPageElementResponse.data.pageBuilder.createPageElement.data;
+
+        await updatePageBlock({
+            id: blockData.id,
+            data: {
+                content: {
+                    ...blockData.content,
+                    elements: [...blockData.content.elements, pageElementData]
+                }
+            }
+        });
+
+        // Create page
+        await createCategory({
+            data: {
+                slug: "category-slug",
+                name: "category-name",
+                url: "/category-url/",
+                layout: "category-layout"
+            }
+        });
+
+        const [createPageResponse] = await createPage({
+            category: "category-slug"
+        });
+
+        const pageId = createPageResponse.data.pageBuilder.createPage.data.id;
+
+        // Add block to the page as reference (without elements)
+        await updatePage({
+            id: pageId,
+            data: {
+                content: {
+                    data: {},
+                    elements: [
+                        { data: { blockId: blockData.id }, elements: [], path: [], type: "block" }
+                    ],
+                    path: [],
+                    type: "document"
+                }
+            }
+        });
+
+        // Get page with resolved block (with elements)
+        const [getPageWithReferenceBlockResponse] = await getPage({ id: pageId });
+
+        const resolvedBlockData =
+            getPageWithReferenceBlockResponse.data.pageBuilder.getPage.data.content.elements[0];
+
+        expect(resolvedBlockData).toMatchObject({
+            data: { blockId: blockData.id },
+            elements: [
+                {
+                    id: pageElementData.id,
+                    category: "element-category",
+                    preview: { src: "https://test.com/element/src.jpg" },
+                    name: "element-name",
+                    content: { some: "element-content" },
+                    type: "element",
+                    createdOn: expect.stringMatching(/^20/),
+                    createdBy: defaultIdentity
+                }
+            ],
+            path: [],
+            type: "block"
         });
     });
 });

--- a/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
+++ b/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
@@ -5,7 +5,6 @@ import { SaveRevisionActionArgsType } from "./types";
 import { ToggleSaveRevisionStateActionEvent } from "./event";
 import { PageAtomType } from "~/pageEditor/state";
 import { PageEventActionCallable } from "~/pageEditor/types";
-import { PbEditorElement } from "~/types";
 
 interface PageRevisionType extends Pick<PageAtomType, "title" | "snippet" | "path" | "settings"> {
     category: string;
@@ -27,21 +26,6 @@ const triggerOnFinish = (args?: SaveRevisionActionArgsType): void => {
 // TODO @ts-refactor not worth it
 let debouncedSave: any = null;
 
-const removeElementsFromReferences = (content: any) => {
-    const elements = content.elements.map((element: PbEditorElement) => {
-        if (element.data.blockId) {
-            return {
-                ...element,
-                elements: []
-            };
-        } else {
-            return element;
-        }
-    });
-
-    return { ...content, elements };
-};
-
 export const saveRevisionAction: PageEventActionCallable<SaveRevisionActionArgsType> = async (
     state,
     meta,
@@ -53,14 +37,12 @@ export const saveRevisionAction: PageEventActionCallable<SaveRevisionActionArgsT
         };
     }
 
-    const content = await state.getElementTree();
-
     const data: PageRevisionType = {
         title: state.page.title,
         snippet: state.page.snippet,
         path: state.page.path,
         settings: state.page.settings,
-        content: removeElementsFromReferences(content),
+        content: await state.getElementTree(),
         category: state.page.category ? state.page.category.slug : ""
     };
 


### PR DESCRIPTION
## Changes
Add API tests
Removed not required anymore block manipulation on save (we already remove elements for ref blocks inside getElementTree)

## How Has This Been Tested?
Manual

## Documentation
None
