### PR TITLE
Core Pulumi App - Only Use `AWSLambdaVPCAccessExecutionRole` Policy If VPC Feature Is Enabled

### DIFF
--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -167,15 +167,23 @@ export const ElasticSearch = createAppModule({
         });
 
         // Only use `AWSLambdaVPCAccessExecutionRole` policy if VPC feature is enabled.
-        let policyArn: aws.iam.ManagedPolicy = aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole;
         if (vpc) {
-            policyArn = aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole;
+            app.addResource(aws.iam.RolePolicyAttachment, {
+                name: `${roleName}-AWSLambdaVPCAccessExecutionRole`,
+                config: {
+                    role: role.output,
+                    policyArn: aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
+                }
+            });
+        } else {
+            app.addResource(aws.iam.RolePolicyAttachment, {
+                name: `${roleName}-AWSLambdaBasicExecutionRole`,
+                config: {
+                    role: role.output,
+                    policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+                }
+            });
         }
-
-        app.addResource(aws.iam.RolePolicyAttachment, {
-            name: `${roleName}-AWSLambdaVPCAccessExecutionRole`,
-            config: { role: role.output, policyArn }
-        });
 
         app.addResource(aws.iam.RolePolicyAttachment, {
             name: `${roleName}-AWSLambdaDynamoDBExecutionRole`,

--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -166,12 +166,15 @@ export const ElasticSearch = createAppModule({
             }
         });
 
+        // Only use `AWSLambdaVPCAccessExecutionRole` policy if VPC feature is enabled.
+        let policyArn: aws.iam.ManagedPolicy = aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole;
+        if (vpc) {
+            policyArn = aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole;
+        }
+
         app.addResource(aws.iam.RolePolicyAttachment, {
             name: `${roleName}-AWSLambdaVPCAccessExecutionRole`,
-            config: {
-                role: role.output,
-                policyArn: aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
-            }
+            config: { role: role.output, policyArn }
         });
 
         app.addResource(aws.iam.RolePolicyAttachment, {


### PR DESCRIPTION
## Changes
This PR ensures `AWSLambdaVPCAccessExecutionRole` policy is used only when `VPC` feature is enabled. It doesn't make sense to use it if VPC are not in use.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.