### PR TITLE
feat(headless-cms): ability to delete locked field

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,8 @@ module.exports = {
         // Sometimes we have to use expect() inside try/catch clause (for async calls).
         // This rule raises an error when you do that, so we disabled it.
         "jest/no-conditional-expect": 0,
-        "jest/no-commented-out-tests": 0
+        "jest/no-commented-out-tests": 0,
+        "jest/no-disabled-tests": 0
     },
     settings: {
         react: {

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -913,11 +913,6 @@ describe("filtering", () => {
             sort: ["title_ASC"]
         });
 
-        delete daciaProduct["deletedTextField"];
-        delete teslaProduct["deletedTextField"];
-        delete bananaProduct["deletedTextField"];
-        delete plumProduct["deletedTextField"];
-
         expect(equalReaderResponse).toEqual({
             data: {
                 listProducts: {

--- a/packages/api-headless-cms/__tests__/contentAPI/lockedFields.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/lockedFields.test.ts
@@ -56,7 +56,10 @@ describe("Content model locked fields", () => {
         return update.data.updateContentModel.data;
     };
 
-    test("must mark fields as used and prevent changes on it, as soon as the first entry is saved", async () => {
+    /**
+     * Removed in 5.33.0 because users can now remove fields whenever they want to.
+     */
+    test.skip("must mark fields as used and prevent changes on it, as soon as the first entry is saved", async () => {
         const { createCategory } = useCategoryManageHandler({
             ...manageOpts
         });
@@ -144,8 +147,10 @@ describe("Content model locked fields", () => {
             });
         }
     });
-
-    it("should allow deleting fields when no entries are present", async () => {
+    /**
+     * Removed in 5.33.0 because users can now remove fields whenever they want to.
+     */
+    it.skip("should allow deleting fields when no entries are present", async () => {
         const { createCategory, deleteCategory, listCategories, until } = useCategoryManageHandler({
             ...manageOpts
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -49,7 +49,6 @@ const ids = {
     field219: generateAlphaNumericLowerCaseId(8),
     field220: generateAlphaNumericLowerCaseId(8),
     field221: generateAlphaNumericLowerCaseId(8),
-    field222: `${generateAlphaNumericLowerCaseId(8)}_deleted`,
     // product review
     field31: generateAlphaNumericLowerCaseId(8),
     field32: generateAlphaNumericLowerCaseId(8),
@@ -186,8 +185,7 @@ const models: CmsModel[] = [
             [ids.field209],
             [ids.field210],
             [ids.field211],
-            [ids.field221],
-            [ids.field222]
+            [ids.field221]
         ],
         fields: [
             {
@@ -665,27 +663,6 @@ const models: CmsModel[] = [
                                         renderer: {
                                             name: "renderer"
                                         }
-                                    },
-                                    {
-                                        id: ids.field221,
-                                        multipleValues: true,
-                                        helpText: "",
-                                        label: "Long Text List - Deleted",
-                                        storageId: "longTextDeletedStorageId",
-                                        fieldId: "longTextDeleted",
-                                        type: "long-text",
-                                        validation: [],
-                                        listValidation: [],
-                                        settings: {},
-                                        placeholderText: "placeholder text",
-                                        predefinedValues: {
-                                            enabled: false,
-                                            values: []
-                                        },
-                                        renderer: {
-                                            name: "renderer"
-                                        },
-                                        isDeleted: true
                                     }
                                 ]
                             },
@@ -760,26 +737,6 @@ const models: CmsModel[] = [
                 renderer: {
                     name: "renderer"
                 }
-            },
-            {
-                id: ids.field222,
-                multipleValues: false,
-                helpText: "",
-                label: "Deleted text field",
-                storageId: "deletedTextFieldStorageId",
-                fieldId: "deletedTextField",
-                type: "text",
-                validation: [],
-                listValidation: [],
-                placeholderText: "",
-                predefinedValues: {
-                    enabled: false,
-                    values: []
-                },
-                renderer: {
-                    name: "renderer"
-                },
-                isDeleted: true
             }
         ],
         tenant: "root",

--- a/packages/api-headless-cms/__tests__/contentAPI/multipleValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/multipleValues.test.ts
@@ -175,8 +175,10 @@ describe("multiple values in field", () => {
             }
         });
     });
-
-    test("should not allow to change or removal of locked multiple values field", async () => {
+    /**
+     * Removed in 5.33.0 because users can now remove fields whenever they want to.
+     */
+    test.skip("should not allow to change or removal of locked multiple values field", async () => {
         const { createCategory } = useCategoryManageHandler({
             ...manageOpts
         });
@@ -274,7 +276,6 @@ describe("multiple values in field", () => {
                                 value: "some text"
                             }
                         ],
-                        deletedTextField: null,
                         meta: {
                             locked: false,
                             modelId: "product",

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -1157,8 +1157,7 @@ describe("MANAGE - Resolvers", () => {
                                     id: vegetables.id
                                 }
                             ],
-                            longText: [null],
-                            longTextDeleted: []
+                            longText: [null]
                         },
                         {
                             name: "Option 2",
@@ -1173,8 +1172,7 @@ describe("MANAGE - Resolvers", () => {
                                     id: vegetables.id
                                 }
                             ],
-                            longText: ["long text"],
-                            longTextDeleted: []
+                            longText: ["long text"]
                         }
                     ]
                 }
@@ -1200,7 +1198,6 @@ describe("MANAGE - Resolvers", () => {
                         inStock: true,
                         itemsInStock: 101,
                         image: "image.png",
-                        deletedTextField: null,
                         richText: [
                             {
                                 type: "p"
@@ -1236,8 +1233,7 @@ describe("MANAGE - Resolvers", () => {
                                             entryId: vegetables.entryId
                                         }
                                     ],
-                                    longText: [null],
-                                    longTextDeleted: []
+                                    longText: [null]
                                 },
                                 {
                                     name: "Option 2",
@@ -1254,8 +1250,7 @@ describe("MANAGE - Resolvers", () => {
                                             entryId: vegetables.entryId
                                         }
                                     ],
-                                    longText: ["long text"],
-                                    longTextDeleted: []
+                                    longText: ["long text"]
                                 }
                             ]
                         }

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
@@ -122,12 +122,12 @@ describe("READ - Resolvers", () => {
 
         if (update.errors) {
             console.error(`[beforeEach] ${update.errors[0].message}`);
-            process.exit(1);
+            process.exit(update.errors[0].message);
         }
 
         if (update.data.updateContentModel.error) {
             console.error(`[beforeEach] ${update.data.updateContentModel.error.message}`);
-            process.exit(1);
+            process.exit(update.data.updateContentModel.error.message);
         }
         return targetModel;
     };

--- a/packages/api-headless-cms/__tests__/contentAPI/richTextField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/richTextField.test.ts
@@ -140,8 +140,7 @@ describe("richTextField", () => {
                     modelId: "category",
                     id: category.id
                 },
-                richText: richTextMock,
-                deletedTextField: "Deleted! Yes!"
+                richText: richTextMock
             }
         });
 
@@ -173,7 +172,6 @@ describe("richTextField", () => {
                         inStock: null,
                         itemsInStock: null,
                         variant: null,
-                        deletedTextField: "Deleted! Yes!",
                         meta: {
                             locked: false,
                             modelId: "product",
@@ -267,8 +265,7 @@ describe("richTextField", () => {
             category: {
                 modelId: "category",
                 id: category.id
-            },
-            deletedTextField: "Deleted!"
+            }
         };
         /**
          * First we create the product without the rich text populated.
@@ -302,7 +299,6 @@ describe("richTextField", () => {
             inStock: null,
             itemsInStock: null,
             variant: null,
-            deletedTextField: "Deleted!",
             meta: {
                 locked: false,
                 modelId: "product",

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -10,7 +10,6 @@ export default /* GraphQL */ `
         category: RefField
         categories: [RefField!]
         longText: [String]
-        longTextDeleted: [String]
     }
     
     type Product_Variant {
@@ -45,7 +44,6 @@ export default /* GraphQL */ `
         richText: JSON
         variant: Product_Variant
         fieldsObject: Product_FieldsObject
-        deletedTextField: String
     }
 
     type ProductMeta {
@@ -67,7 +65,6 @@ export default /* GraphQL */ `
         category: RefFieldInput!
         categories: [RefFieldInput]
         longText: [String]
-        longTextDeleted: [String]
     }
     
     input Product_VariantInput {
@@ -95,7 +92,7 @@ export default /* GraphQL */ `
         richText: JSON
         variant: Product_VariantInput
         fieldsObject: Product_FieldsObjectInput
-        deletedTextField: String
+        
     }
 
     input ProductGetWhereInput {
@@ -108,7 +105,7 @@ export default /* GraphQL */ `
         availableOn: Date
         color: String
         availableSizes: String
-        deletedTextField: String
+        
     }
     
     input ProductListWhereInput {
@@ -196,13 +193,6 @@ export default /* GraphQL */ `
         availableSizes_not_in: [String]
         availableSizes_contains: String
         availableSizes_not_contains: String
-
-        deletedTextField: String
-        deletedTextField_not: String
-        deletedTextField_in: [String]
-        deletedTextField_not_in: [String]
-        deletedTextField_contains: String
-        deletedTextField_not_contains: String
     }
 
     type ProductResponse {
@@ -242,8 +232,6 @@ export default /* GraphQL */ `
         color_DESC
         availableSizes_ASC
         availableSizes_DESC
-        deletedTextField_ASC
-        deletedTextField_DESC
     }
 
     extend type Query {

--- a/packages/api-headless-cms/__tests__/helpers/filterModelFields.test.ts
+++ b/packages/api-headless-cms/__tests__/helpers/filterModelFields.test.ts
@@ -1,3 +1,6 @@
+/**
+ * We will leave the test for isDeleted because it might come back later on.
+ */
 import { CmsModelField } from "~/types";
 
 import { filterModelsDeletedFields } from "~/utils/filterModelFields";
@@ -82,7 +85,7 @@ const fields: Field[] = [
     }
 ];
 
-describe("Filter model fields", () => {
+describe.skip("Filter model fields", () => {
     it("should filter deleted fields in case of not being manage endpoint", () => {
         const models = filterModelsDeletedFields({
             models: [

--- a/packages/api-headless-cms/__tests__/helpers/renderSortEnum.test.ts
+++ b/packages/api-headless-cms/__tests__/helpers/renderSortEnum.test.ts
@@ -1,0 +1,90 @@
+import models from "../contentAPI/mocks/contentModels";
+import { renderSortEnum } from "~/utils/renderSortEnum";
+import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
+import { CmsFieldTypePlugins, CmsModel, CmsModelFieldToGraphQLPlugin } from "~/types";
+import { filterModelsDeletedFields } from "~/utils/filterModelFields";
+
+describe("Render GraphQL sort enum", () => {
+    const { plugins } = useGraphQLHandler();
+
+    const fieldTypePlugins = plugins
+        .byType<CmsModelFieldToGraphQLPlugin>("cms-model-field-to-graphql")
+        .reduce<CmsFieldTypePlugins>((collection, plugin) => {
+            collection[plugin.fieldType] = plugin;
+            return collection;
+        }, {});
+
+    it("should render non-deleted fields sorts - read API", () => {
+        const [model] = filterModelsDeletedFields({
+            models: [models.find(model => model.modelId === "product") as CmsModel],
+            type: "read"
+        });
+
+        const result = renderSortEnum({
+            model,
+            fieldTypePlugins
+        });
+
+        expect(result).toEqual(
+            [
+                "id_ASC",
+                "id_DESC",
+                "savedOn_ASC",
+                "savedOn_DESC",
+                "createdOn_ASC",
+                "createdOn_DESC",
+                "title_ASC",
+                "title_DESC",
+                "price_ASC",
+                "price_DESC",
+                "inStock_ASC",
+                "inStock_DESC",
+                "itemsInStock_ASC",
+                "itemsInStock_DESC",
+                "availableOn_ASC",
+                "availableOn_DESC",
+                "color_ASC",
+                "color_DESC",
+                "availableSizes_ASC",
+                "availableSizes_DESC"
+            ].join("\n")
+        );
+    });
+
+    it("should render non-deleted fields sorts - manage API", () => {
+        const [model] = filterModelsDeletedFields({
+            models: [models.find(model => model.modelId === "product") as CmsModel],
+            type: "manage"
+        });
+
+        const result = renderSortEnum({
+            model,
+            fieldTypePlugins
+        });
+
+        expect(result).toEqual(
+            [
+                "id_ASC",
+                "id_DESC",
+                "savedOn_ASC",
+                "savedOn_DESC",
+                "createdOn_ASC",
+                "createdOn_DESC",
+                "title_ASC",
+                "title_DESC",
+                "price_ASC",
+                "price_DESC",
+                "inStock_ASC",
+                "inStock_DESC",
+                "itemsInStock_ASC",
+                "itemsInStock_DESC",
+                "availableOn_ASC",
+                "availableOn_DESC",
+                "color_ASC",
+                "color_DESC",
+                "availableSizes_ASC",
+                "availableSizes_DESC"
+            ].join("\n")
+        );
+    });
+});

--- a/packages/api-headless-cms/__tests__/testHelpers/useProductManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useProductManageHandler.ts
@@ -59,10 +59,8 @@ const productFields = `
                 id
             }
             longText
-            longTextDeleted
         }
     }
-    deletedTextField
 `;
 
 const errorFields = `

--- a/packages/api-headless-cms/src/crud/contentModel/models.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/models.ts
@@ -62,11 +62,11 @@ export const ContentModelFieldModel = withFields({
             settings: object({ value: {} })
         })()
     }),
-    settings: object({ value: {} }),
+    settings: object({ value: {} })
     /**
      * By the default, field is not deleted.
      */
-    isDeleted: boolean({ value: false })
+    // isDeleted: boolean({ value: false })
 })();
 
 export const CreateContentModelModel = withFields({

--- a/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
@@ -287,19 +287,25 @@ export const validateModelFields = (params: ValidateModelFieldsParams) => {
 
     /**
      * We must not allow removal or changes in fields that are already in use in content entries.
+     * Locked fields still have fieldId (should be storageId) because of the old existing locked fields in the models.
      */
     for (const lockedField of lockedFields) {
         const existingField = fields.find(item => item.storageId === lockedField.fieldId);
 
+        /**
+         * Starting with 5.33.0 fields can be deleted.
+         * Our UI gives a warning upon locked field deletion, but if user is managing fields through API directly - we cannot do anything.
+         */
         if (!existingField) {
-            throw new WebinyError(
-                `Cannot remove the field "${lockedField.fieldId}" because it's already in use in created content.`,
-                "ENTRY_FIELD_USED",
-                {
-                    lockedField,
-                    fields
-                }
-            );
+            continue;
+            // throw new WebinyError(
+            //     `Cannot remove the field "${lockedField.fieldId}" because it's already in use in created content.`,
+            //     "ENTRY_FIELD_USED",
+            //     {
+            //         lockedField,
+            //         fields
+            //     }
+            // );
         }
 
         if (lockedField.multipleValues !== existingField.multipleValues) {

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -116,7 +116,6 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
                 validation: [CmsFieldValidationInput]
                 listValidation: [CmsFieldValidationInput]
                 settings: JSON
-                isDeleted: Boolean
             }
 
             input CmsContentModelCreateInput {

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -214,11 +214,6 @@ export interface CmsModelField {
          */
         [key: string]: any;
     };
-    /**
-     * Is this field marked as deleted?
-     * Note that we are actually never deleting any of the fields.
-     */
-    isDeleted?: boolean;
 }
 
 /**

--- a/packages/api-headless-cms/src/utils/filterModelFields.ts
+++ b/packages/api-headless-cms/src/utils/filterModelFields.ts
@@ -1,3 +1,7 @@
+/**
+ * We are leaving this file because isDeleted might come back later
+ */
+// @ts-nocheck
 import { ApiEndpoint, CmsModel, CmsModelField } from "~/types";
 
 /**

--- a/packages/api-headless-cms/src/utils/renderSortEnum.ts
+++ b/packages/api-headless-cms/src/utils/renderSortEnum.ts
@@ -5,7 +5,7 @@ interface RenderSortEnum {
 }
 
 export const renderSortEnum: RenderSortEnum = ({ model, fieldTypePlugins }): string => {
-    const sorters = [
+    const sorters: string[] = [
         `id_ASC`,
         `id_DESC`,
         "savedOn_ASC",
@@ -15,11 +15,11 @@ export const renderSortEnum: RenderSortEnum = ({ model, fieldTypePlugins }): str
     ];
 
     for (const field of model.fields) {
-        if (!fieldTypePlugins[field.type]) {
+        const plugin = fieldTypePlugins[field.type];
+        if (!plugin) {
             continue;
         }
-        const isSortable = fieldTypePlugins[field.type].isSortable;
-        if (!isSortable) {
+        if (!plugin.isSortable) {
             continue;
         }
         sorters.push(`${field.fieldId}_ASC`);

--- a/packages/app-headless-cms/src/types.ts
+++ b/packages/app-headless-cms/src/types.ts
@@ -261,6 +261,7 @@ export type CmsEditorField<T = unknown> = T & {
     id: string;
     type: string;
     fieldId: CmsEditorFieldId;
+    storageId?: string;
     label?: string;
     helpText?: string;
     placeholderText?: string;


### PR DESCRIPTION
## Changes
In the `api-headless-cms` we do not check for locked fields anymore.
In the `app-headless-cms` we show confirmation to the user when deleting a locked field.

## How Has This Been Tested?
Jest, manually and Cypress.