### PR TITLE
Enable Multi-tenancy If `WEBINY_MULTI_TENANCY` Environment Variable Is Present

### DIFF
--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -186,7 +186,10 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 applyCustomDomain(deliveryCloudfront, domains);
             }
 
-            if (process.env.WCP_PROJECT_ENVIRONMENT) {
+            if (
+                process.env.WCP_PROJECT_ENVIRONMENT ||
+                process.env.WEBINY_MULTI_TENANCY === "true"
+            ) {
                 applyTenantRouter(app, deliveryCloudfront);
             }
 


### PR DESCRIPTION
## Changes
This PR fixes ensures that multi-tenancy is enabled not only if the user is using WCP, but also if there's `WEBINY_MULTI_TENANCY=true` environment variable defined in the runtime.

The support for `WEBINY_MULTI_TENANCY` environment variable exists because of backwards compatibility (old systems that used multi-tenancy and that still want to use it, without WCP).

## How Has This Been Tested?
Manually.

## Documentation
Changelog.
