### PR TITLE
Add `CmsContext` In GraphQL Packages

### DIFF
--- a/apps/api/graphql/src/types.ts
+++ b/apps/api/graphql/src/types.ts
@@ -4,6 +4,7 @@ import { PbContext } from "@webiny/api-page-builder/graphql/types";
 import { PrerenderingServiceClientContext } from "@webiny/api-prerendering-service/client/types";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { FormBuilderContext } from "@webiny/api-form-builder/types";
+import { CmsContext } from "@webiny/api-headless-cms/types";
 
 // When working with the `context` object (for example while defining a new GraphQL resolver function),
 // you can import this interface and assign it to it. This will give you full autocomplete functionality
@@ -17,4 +18,5 @@ export interface Context
         PbContext,
         PrerenderingServiceClientContext,
         FileManagerContext,
+        CmsContext,
         FormBuilderContext {}

--- a/packages/cwp-template-aws/template/ddb-es/apps/api/graphql/src/types.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/api/graphql/src/types.ts
@@ -8,6 +8,7 @@ import { PbContext } from "@webiny/api-page-builder/graphql/types";
 import { PrerenderingServiceClientContext } from "@webiny/api-prerendering-service/client/types";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { FormBuilderContext } from "@webiny/api-form-builder/types";
+import { CmsContext } from "@webiny/api-headless-cms/types";
 
 // When working with the `context` object (for example while defining a new GraphQL resolver function),
 // you can import this interface and assign it to it. This will give you full autocomplete functionality
@@ -25,4 +26,5 @@ export interface Context
         PbContext,
         PrerenderingServiceClientContext,
         FileManagerContext,
-        FormBuilderContext {}
+        FormBuilderContext,
+        CmsContext {}

--- a/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/types.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/types.ts
@@ -7,6 +7,7 @@ import { PbContext } from "@webiny/api-page-builder/graphql/types";
 import { PrerenderingServiceClientContext } from "@webiny/api-prerendering-service/client/types";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { FormBuilderContext } from "@webiny/api-form-builder/types";
+import { CmsContext } from "@webiny/api-headless-cms/types";
 
 // When working with the `context` object (for example while defining a new GraphQL resolver function),
 // you can import this interface and assign it to it. This will give you full autocomplete functionality
@@ -23,4 +24,5 @@ export interface Context
         PbContext,
         PrerenderingServiceClientContext,
         FileManagerContext,
-        FormBuilderContext {}
+        FormBuilderContext,
+        CmsContext {}


### PR DESCRIPTION
## Changes
This PR adds the missing `CmsContext` interface to the main `Context` interface, located in both default GraphQL and Headless CMS GraphQL packages.

## How Has This Been Tested?
Manual, relying on TypeScript.

## Documentation
Changelog.
