### PR TITLE
Webpack Config - Remove Environment Variables From `DefinePlugin`

### DIFF
--- a/packages/project-utils/bundling/function/webpack.config.js
+++ b/packages/project-utils/bundling/function/webpack.config.js
@@ -54,12 +54,6 @@ module.exports = options => {
             new webpack.DefinePlugin({
                 "process.env.WEBINY_IS_PRE_529": JSON.stringify(String(isPre529())),
                 "process.env.WEBINY_VERSION": JSON.stringify(process.env.WEBINY_VERSION || version),
-                "process.env.WEBINY_ENABLE_VERSION_HEADER": JSON.stringify(
-                    process.env.WEBINY_ENABLE_VERSION_HEADER || "false"
-                ),
-                "process.env.WEBINY_MULTI_TENANCY": JSON.stringify(
-                    process.env.WEBINY_MULTI_TENANCY || false
-                ),
                 ...definitions
             }),
             tsChecksEnabled &&


### PR DESCRIPTION
## Changes
This PR removes `WEBINY_ENABLE_VERSION_HEADER` and `WEBINY_MULTI_TENANCY` environment variables from the `DefinePlugin` used in [`packages/project-utils/bundling/function/webpack.config.js`](https://github.com/webiny/webiny-js/pull/2660/files#diff-d12dc5ce7a926be5b834864213dea12b956ded2edaf49f5d0599981327d414e7) file.

This is mainly because of the `@webiny/serverless-cms-aws` package and the fact that the packages (handlers) that are prebuilt within it must not be sensitive to environment variables while they are being bundled.

Environment variables must be read in actual runtime (AWS Lambda), and must not be baked as actual code in the final bundle.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.
