### PR TITLE
fix: only forward Host header if tenant router is configured

### DIFF
--- a/packages/pulumi-aws/src/apps/customDomain.ts
+++ b/packages/pulumi-aws/src/apps/customDomain.ts
@@ -12,18 +12,6 @@ export function applyCustomDomain(
     cloudfront: PulumiAppResource<typeof aws.cloudfront.Distribution>,
     params: CustomDomainParams
 ) {
-    cloudfront.config.defaultCacheBehavior(value => {
-        return {
-            ...value,
-            forwardedValues: {
-                ...value.forwardedValues,
-                queryString: value.forwardedValues?.queryString || false,
-                cookies: value.forwardedValues?.cookies || { forward: "none" },
-                headers: [...(value.forwardedValues?.headers || []), "Host"]
-            }
-        };
-    });
-
     cloudfront.config.aliases(params.domains);
 
     cloudfront.config.viewerCertificate({

--- a/packages/pulumi-aws/src/apps/tenantRouter.ts
+++ b/packages/pulumi-aws/src/apps/tenantRouter.ts
@@ -112,6 +112,13 @@ export function applyTenantRouter(
     cloudfront.config.defaultCacheBehavior(value => {
         return {
             ...value,
+            // We need to forward the `Host` header so the Lambda@Edge knows what custom domain was requested.
+            forwardedValues: {
+                ...value.forwardedValues,
+                queryString: value.forwardedValues?.queryString || false,
+                cookies: value.forwardedValues?.cookies || { forward: "none" },
+                headers: [...(value.forwardedValues?.headers || []), "Host"]
+            },
             lambdaFunctionAssociations: [
                 ...(value.lambdaFunctionAssociations || []),
                 {


### PR DESCRIPTION
## Changes
This PR moves Host header forwarding from "custom domain" application, to "tenant router" configuration. We only need to forward the Host header when we have multi-tenancy enabled, which in turn deploys a tenant router Lambda@Edge function.

## How Has This Been Tested?
Manually.

## Documentation
Not needed, this is an internal behavior.