### PR TITLE
Fix PB import/export private file handling

### DIFF
--- a/packages/api-page-builder-import-export/src/exportPages/combine/index.ts
+++ b/packages/api-page-builder-import-export/src/exportPages/combine/index.ts
@@ -73,7 +73,7 @@ export default () => {
                     data: {
                         message: `Finish uploading page export.`,
                         key: pageExportUpload.Key,
-                        url: pageExportUpload.Location
+                        url: s3Stream.getPresignedUrl(pageExportUpload.Key)
                     }
                 });
 
@@ -94,7 +94,7 @@ export default () => {
                         name: e.name,
                         message: e.message,
                         stack: e.stack,
-                        code: "IMPORT_FAILED"
+                        code: "EXPORT_FAILED"
                     }
                 });
 

--- a/packages/api-page-builder-import-export/src/exportPages/process/index.ts
+++ b/packages/api-page-builder-import-export/src/exportPages/process/index.ts
@@ -156,7 +156,7 @@ export default (configuration: Configuration) => {
                                 name: e.name,
                                 message: e.message,
                                 stack: e.stack,
-                                code: "IMPORT_FAILED"
+                                code: "EXPORT_FAILED"
                             }
                         }
                     );

--- a/packages/api-page-builder-import-export/src/exportPages/s3Stream.ts
+++ b/packages/api-page-builder-import-export/src/exportPages/s3Stream.ts
@@ -14,6 +14,14 @@ class S3Stream {
         this.bucket = process.env.S3_BUCKET as string;
     }
 
+    getPresignedUrl(key: string) {
+        return this.s3.getSignedUrl("getObject", {
+            Bucket: this.bucket,
+            Key: key,
+            Expires: 604800 // 1 week
+        });
+    }
+
     /**
      * We're checking if the file is accessible on S3 by getting object meta data.
      * It help us to filter files that we need to download as part of export data.
@@ -48,7 +56,7 @@ class S3Stream {
         const streamPassThrough = new Stream.PassThrough();
 
         const params: S3.PutObjectRequest = {
-            ACL: "public-read",
+            ACL: "private",
             Body: streamPassThrough,
             Bucket: this.bucket,
             ContentType: contentType,

--- a/packages/api-page-builder-import-export/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder-import-export/src/graphql/crud/pages.crud.ts
@@ -21,7 +21,7 @@ const IMPORT_PAGES_CREATE_HANDLER = process.env.IMPORT_PAGES_CREATE_HANDLER as s
 
 export default new ContextPlugin<PbPageImportExportContext>(context => {
     const importExportCrud: PagesImportExportCrud = {
-        async importPages({ category: categorySlug, zipFileKey, zipFileUrl }) {
+        async importPages({ category: categorySlug, zipFileUrl }) {
             await checkBasePermissions(context, PERMISSION_NAME, {
                 rwd: "w"
             });
@@ -37,7 +37,6 @@ export default new ContextPlugin<PbPageImportExportContext>(context => {
                 status: PageImportExportTaskStatus.PENDING,
                 input: {
                     category: categorySlug,
-                    zipFileKey,
                     zipFileUrl
                 }
             });
@@ -51,7 +50,6 @@ export default new ContextPlugin<PbPageImportExportContext>(context => {
                 name: IMPORT_PAGES_CREATE_HANDLER,
                 payload: {
                     category: categorySlug,
-                    zipFileKey,
                     zipFileUrl,
                     task,
                     identity: context.security.getIdentity()

--- a/packages/api-page-builder-import-export/src/graphql/graphql/pages.gql.ts
+++ b/packages/api-page-builder-import-export/src/graphql/graphql/pages.gql.ts
@@ -43,7 +43,6 @@ const plugin: GraphQLSchemaPlugin<PbPageImportExportContext> = {
                 # Import pages
                 importPages(
                     category: String!
-                    zipFileKey: String
                     zipFileUrl: String
                 ): PbImportPageResponse
             }

--- a/packages/api-page-builder-import-export/src/graphql/graphql/pages.gql.ts
+++ b/packages/api-page-builder-import-export/src/graphql/graphql/pages.gql.ts
@@ -41,10 +41,7 @@ const plugin: GraphQLSchemaPlugin<PbPageImportExportContext> = {
                 ): PbExportPageResponse
 
                 # Import pages
-                importPages(
-                    category: String!
-                    zipFileUrl: String
-                ): PbImportPageResponse
+                importPages(category: String!, zipFileUrl: String): PbImportPageResponse
             }
         `,
         resolvers: {

--- a/packages/api-page-builder-import-export/src/graphql/types.ts
+++ b/packages/api-page-builder-import-export/src/graphql/types.ts
@@ -22,8 +22,7 @@ export interface ExportPagesParams {
 
 export interface ImportPagesParams {
     category: string;
-    zipFileKey?: string;
-    zipFileUrl?: string;
+    zipFileUrl: string;
 }
 
 export type PagesImportExportCrud = {

--- a/packages/api-page-builder-import-export/src/importPages/create/index.ts
+++ b/packages/api-page-builder-import-export/src/importPages/create/index.ts
@@ -19,8 +19,7 @@ interface Configuration {
 
 export interface Payload {
     category: string;
-    zipFileKey?: string;
-    zipFileUrl?: string;
+    zipFileUrl: string;
     task: PageImportExportTask;
     identity: SecurityIdentity;
 }
@@ -38,26 +37,22 @@ export default (configuration: Configuration) => {
             const log = console.log;
 
             const { pageBuilder } = context;
-            const { task, category, zipFileKey, zipFileUrl, identity } = payload;
+            const { task, category, zipFileUrl, identity } = payload;
             try {
                 log("RUNNING Import Pages Create");
-                if (!zipFileKey && !zipFileUrl) {
+                if (!zipFileUrl) {
                     return {
                         data: null,
                         error: {
-                            message:
-                                "Missing zipFileKey and zipFileUrl parameters. One must be defined."
+                            message: `Missing "zipFileUrl"!`
                         }
                     };
                 }
                 mockSecurity(identity, context);
                 // Step 1: Read the zip file
-                const pageImportDataList = await readExtractAndUploadZipFileContents(
-                    zipFileKey || (zipFileUrl as string)
-                );
-                // Once we have map we can start processing each page
+                const pageImportDataList = await readExtractAndUploadZipFileContents(zipFileUrl);
 
-                // For each page create a sub task and invoke the process handler
+                // For each page create a subtask and invoke the process handler
                 for (let i = 0; i < pageImportDataList.length; i++) {
                     const pagesDirMap = pageImportDataList[i];
                     // Create sub task
@@ -69,7 +64,6 @@ export default (configuration: Configuration) => {
                             data: {
                                 pageKey: pagesDirMap.key,
                                 category,
-                                zipFileKey,
                                 zipFileUrl,
                                 input: {
                                     fileUploadsData: pagesDirMap

--- a/packages/app-page-builder/src/admin/graphql/pageImportExport.gql.ts
+++ b/packages/app-page-builder/src/admin/graphql/pageImportExport.gql.ts
@@ -21,13 +21,11 @@ stats {
 export const IMPORT_PAGES = gql`
     mutation PbImportPage(
         $category: String!,
-        $zipFileKey: String,
         $zipFileUrl: String
     ) {
         pageBuilder {
             importPages(
                 category: $category,
-                zipFileKey: $zipFileKey,
                 zipFileUrl: $zipFileUrl
             ) {
                 data {

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/useImportPage.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/useImportPage.ts
@@ -21,13 +21,13 @@ const useImportPage = ({
     const { showImportPageDialog } = useImportPageDialog();
     const { showImportPageLoadingDialog } = useImportPageLoadingDialog();
 
-    const importPageMutation = useCallback(async ({ slug: category }, fileKey) => {
+    const importPageMutation = useCallback(async ({ slug: category }, zipFileUrl) => {
         try {
             setLoadingLabel();
             const res = await importPage({
                 variables: {
                     category,
-                    [fileKey.startsWith("http") ? "zipFileUrl" : "zipFileKey"]: fileKey
+                    zipFileUrl
                 }
             });
 
@@ -47,14 +47,9 @@ const useImportPage = ({
     }, []);
 
     const showDialog = useCallback(category => {
-        showImportPageDialog(
-            async key => {
-                await importPageMutation(category, key);
-            },
-            async url => {
-                await importPageMutation(category, url);
-            }
-        );
+        showImportPageDialog(async url => {
+            await importPageMutation(category, url);
+        });
     }, []);
 
     return {

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/ExportPageLoadingDialogContent.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/ExportPageLoadingDialogContent.tsx
@@ -119,7 +119,7 @@ const ExportPageLoadingDialogContent: React.FC<ExportPageLoadingDialogContent> =
                         <LoadingDialog.ProgressContainer>
                             <LoadingDialog.StatusTitle use={"subtitle2"}>
                                 {t`{completed} of {total} completed`({
-                                    completed: stats.completedz,
+                                    completed: stats.completed,
                                     total: stats.total
                                 })}
                             </LoadingDialog.StatusTitle>

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/ExportPageLoadingDialogContent.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/ExportPageLoadingDialogContent.tsx
@@ -119,7 +119,7 @@ const ExportPageLoadingDialogContent: React.FC<ExportPageLoadingDialogContent> =
                         <LoadingDialog.ProgressContainer>
                             <LoadingDialog.StatusTitle use={"subtitle2"}>
                                 {t`{completed} of {total} completed`({
-                                    completed: stats.completed,
+                                    completed: stats.completedz,
                                     total: stats.total
                                 })}
                             </LoadingDialog.StatusTitle>

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/useExportPageDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/useExportPageDialog.tsx
@@ -25,9 +25,8 @@ const linkWrapper = css`
 
     & .link-text {
         padding: 8px 0 8px 16px;
-    }
-
-    & .copy-button__wrapper {
+        width: 100%;
+        overflow: hidden;
     }
 `;
 
@@ -93,7 +92,7 @@ const ExportPageDialogMessage: React.FC<ExportPageDialogProps> = ({ exportUrl })
                         <Typography use={"body2"} className={"link-text"}>
                             {exportUrl}
                         </Typography>
-                        <span className={"copy-button__wrapper"}>
+                        <span>
                             <CopyButton
                                 data-testid={"export-pages.export-ready-dialog.copy-button"}
                                 value={exportUrl}

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ImportPageButton/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ImportPageButton/index.tsx
@@ -18,8 +18,7 @@ export const WrapperWithFileUpload: React.FC<WrapperWithFileUploadProps> = ({
                 if (!uploadedFiles || uploadedFiles.length === 0) {
                     return;
                 }
-                const zipKey = uploadedFiles[0].src;
-                onSelect(zipKey);
+                onSelect(uploadedFiles[0].src);
             }}
             accept={["application/zip"]}
         >

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ImportPageButton/useImportPageDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ImportPageButton/useImportPageDialog.tsx
@@ -35,14 +35,10 @@ const separator = css`
 export const importPageDialogTitle = t`Import page`;
 
 interface ImportPageDialogContentProps {
-    onUploadFile: (file: string) => void;
-    onPasteFileLink: (url: string) => void;
+    onFileLink: (url: string) => void;
 }
 
-export const ImportPageDialogContent: React.FC<ImportPageDialogContentProps> = ({
-    onUploadFile,
-    onPasteFileLink
-}) => {
+export const ImportPageDialogContent: React.FC<ImportPageDialogContentProps> = ({ onFileLink }) => {
     const ui = useUi();
     const [showLink, setShowLink] = useState<boolean>(false);
 
@@ -67,11 +63,8 @@ export const ImportPageDialogContent: React.FC<ImportPageDialogContentProps> = (
                 <Form
                     data={{ url: "" }}
                     onSubmit={data => {
-                        if (typeof onPasteFileLink !== "function") {
-                            return;
-                        }
                         closeDialog();
-                        onPasteFileLink(data["url"]);
+                        onFileLink(data["url"]);
                     }}
                 >
                     {({ Bind, submit }) => (
@@ -99,7 +92,7 @@ export const ImportPageDialogContent: React.FC<ImportPageDialogContentProps> = (
                 </Form>
             ) : (
                 <div className={contentContainer}>
-                    <WrapperWithFileUpload onSelect={onUploadFile}>
+                    <WrapperWithFileUpload onSelect={onFileLink}>
                         {({ showFileManager }) => (
                             <ButtonSecondary
                                 onClick={() => {
@@ -130,23 +123,14 @@ const useImportPageDialog = () => {
     const { showDialog } = useDialog();
 
     return {
-        showImportPageDialog: (
-            onUploadFile?: (file: string) => void,
-            onPasteFileLink?: (url: string) => void
-        ) => {
+        showImportPageDialog: (onFileLink?: (url: string) => void) => {
             showDialog(
                 <ImportPageDialogContent
-                    onUploadFile={file => {
-                        if (!onUploadFile) {
+                    onFileLink={url => {
+                        if (!onFileLink) {
                             return;
                         }
-                        onUploadFile(file);
-                    }}
-                    onPasteFileLink={url => {
-                        if (!onPasteFileLink) {
-                            return;
-                        }
-                        onPasteFileLink(url);
+                        onFileLink(url);
                     }}
                 />,
                 {

--- a/packages/pulumi-aws/src/apps/common/VpcConfig.ts
+++ b/packages/pulumi-aws/src/apps/common/VpcConfig.ts
@@ -16,7 +16,7 @@ export const VpcConfig = createAppModule({
                 securityGroupIds: []
             };
 
-            const enabled = params.enabled !== false;
+            const enabled = Boolean(params.enabled);
 
             if (enabled) {
                 // If VPC is not manually disabled we extract details from core.

--- a/packages/pulumi-aws/src/apps/lambdaUtils.ts
+++ b/packages/pulumi-aws/src/apps/lambdaUtils.ts
@@ -58,9 +58,11 @@ export function createLambdaRole(app: PulumiApp, params: LambdaRoleParams) {
         name: `${params.name}-default-execution-role`,
         config: {
             role: role.output,
-            policyArn: vpc.enabled
-                ? aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
-                : aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+            policyArn: vpc.enabled.apply(enabled =>
+                enabled
+                    ? aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole
+                    : aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole
+            )
         }
     });
 


### PR DESCRIPTION
## Changes
This  PR is related to #2664 in a sense that we no longer have a `file.key` property, so we can't use S3 bucket keys in the export logic. The process was simplified to always use ZIP file URLs, instead of S3 bucket keys.

Additionally, interaction with S3 was fixed, and `public-read` ACL was replaced with a `private` one, which also required changing the URL from simple S3 file URL to a presigned URL.

## How Has This Been Tested?
Manually.

## Documentation
Not necessary, these are internal changes.