### PR TITLE
feat(app-tenancy): add support for tenantId query parameter

### DIFF
--- a/packages/api-tenant-manager/__tests__/crud.test.ts
+++ b/packages/api-tenant-manager/__tests__/crud.test.ts
@@ -80,4 +80,87 @@ describe(`Test "Tenant Manager"`, () => {
         const tenants3 = listResponse3.data.tenancy.listTenants.data;
         expect(tenants3).toEqual([tenant2]);
     });
+
+    test(`should enforce security rules`, async () => {
+        const anonHandler = useGqlHandler({ identity: null });
+        const authHandler = useGqlHandler();
+
+        const notAuthorizedResponse = {
+            data: null,
+            error: {
+                code: "SECURITY_NOT_AUTHORIZED",
+                message: "Not authorized!",
+                data: null
+            }
+        };
+
+        await anonHandler.install();
+
+        const tenant1Data = {
+            name: "Tenant #1",
+            description: "The first sub-tenant",
+            settings: {
+                domains: [{ fqdn: "domain1.com" }]
+            }
+        };
+
+        // Create
+        {
+            const [response1] = await anonHandler.createTenant({ data: tenant1Data });
+            const tenant1 = response1.data.tenancy.createTenant;
+            expect(tenant1).toEqual(notAuthorizedResponse);
+        }
+
+        // Create a tenant using a valid identity
+        const [response1] = await authHandler.createTenant({ data: tenant1Data });
+        const tenant1 = response1.data.tenancy.createTenant.data;
+
+        // List with anonymous identity
+        {
+            const [listResponse1] = await anonHandler.listTenants();
+            const tenants1 = listResponse1.data.tenancy.listTenants;
+            expect(tenants1).toEqual(notAuthorizedResponse);
+        }
+
+        // List with a valid identity
+        {
+            const [listResponse1] = await authHandler.listTenants();
+            const tenants1 = listResponse1.data.tenancy.listTenants.data;
+            expect(tenants1).toEqual([tenant1]);
+        }
+
+        // Update with anonymous identity
+        {
+            const [updateResponse] = await anonHandler.updateTenant({
+                id: tenant1.id,
+                data: {
+                    name: "Updated #1",
+                    description: "Updated desc",
+                    settings: tenant1.settings
+                }
+            });
+
+            const updatedTenant1 = updateResponse.data.tenancy.updateTenant;
+            expect(updatedTenant1).toEqual(notAuthorizedResponse);
+        }
+
+        // Update with a valid identity
+        const [updateResponse] = await authHandler.updateTenant({
+            id: tenant1.id,
+            data: { name: "Updated #1", description: "Updated desc", settings: tenant1.settings }
+        });
+
+        const tenant1a = updateResponse.data.tenancy.updateTenant.data;
+        expect(tenant1a).toEqual({
+            id: expect.any(String),
+            name: "Updated #1",
+            description: "Updated desc",
+            parent: "root",
+            settings: tenant1.settings
+        });
+
+        // Delete using anonymous identity
+        const [deleteResponse] = await anonHandler.deleteTenant({ id: tenant1.id });
+        expect(deleteResponse.data.tenancy.deleteTenant).toEqual(notAuthorizedResponse);
+    });
 });

--- a/packages/api-tenant-manager/__tests__/tenancySecurity.ts
+++ b/packages/api-tenant-manager/__tests__/tenancySecurity.ts
@@ -20,7 +20,7 @@ const documentClient = new DocumentClient({
 
 interface Config {
     permissions?: SecurityPermission[];
-    identity?: SecurityIdentity;
+    identity?: SecurityIdentity | null;
 }
 
 export const defaultIdentity = {
@@ -55,7 +55,8 @@ export const createTenancyAndSecurity = ({ permissions, identity }: Config = {})
             } as any);
 
             context.security.addAuthenticator(async () => {
-                return identity || defaultIdentity;
+                // `undefined` results in the default identity being set; `null` means "anonymous request".
+                return identity === undefined ? defaultIdentity : identity;
             });
 
             context.security.addAuthorizer(async () => {

--- a/packages/api-tenant-manager/__tests__/useGqlHandler.ts
+++ b/packages/api-tenant-manager/__tests__/useGqlHandler.ts
@@ -1,6 +1,7 @@
 import { createWcpContext, createWcpGraphQL } from "@webiny/api-wcp";
 import { createHandler } from "@webiny/handler-aws/gateway";
 import graphqlHandler from "@webiny/handler-graphql";
+import { SecurityIdentity } from "@webiny/api-security/types";
 import tenantManagerPlugins from "../src";
 import {
     CREATE_TENANT,
@@ -15,17 +16,18 @@ import { createTenancyAndSecurity } from "./tenancySecurity";
 
 type UseGqlHandlerParams = {
     plugins?: any;
+    identity?: SecurityIdentity | null;
 };
 
 export default (params: UseGqlHandlerParams = {}) => {
-    const { plugins: extraPlugins } = params;
+    const { plugins: extraPlugins, identity } = params;
 
     // Creates the actual handler. Feel free to add additional plugins if needed.
     const handler = createHandler({
         plugins: [
             createWcpContext(),
             createWcpGraphQL(),
-            ...createTenancyAndSecurity(),
+            ...createTenancyAndSecurity({ identity }),
             graphqlHandler(),
             tenantManagerPlugins(),
             extraPlugins || []

--- a/packages/api-tenant-manager/src/graphql/tenants.ts
+++ b/packages/api-tenant-manager/src/graphql/tenants.ts
@@ -125,8 +125,15 @@ export default new GraphQLSchemaPlugin<Context>({
                         });
                     }
 
-                    // You can only update a tenant if it's a child of the current tenant.
-                    if (currentTenant.id !== tenantToUpdate.parent) {
+                    const canUpdate = [
+                        // You can update a tenant if it's a child of the current tenant.
+                        currentTenant.id === tenantToUpdate.parent,
+                        // Root tenant can update itself
+                        currentTenant.id === "root" && tenantToUpdate.id === "root"
+                    ];
+
+                    // If not a single `true` is present in the array...
+                    if (!canUpdate.some(Boolean)) {
                         throw new NotAuthorizedError();
                     }
 

--- a/packages/api-tenant-manager/src/graphql/tenants.ts
+++ b/packages/api-tenant-manager/src/graphql/tenants.ts
@@ -5,10 +5,18 @@
 import mdbid from "mdbid";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins";
 import { ErrorResponse, Response, ListResponse } from "@webiny/handler-graphql";
+import { NotAuthorizedError } from "@webiny/api-security";
 import { SecurityContext } from "@webiny/api-security/types";
 import { TenancyContext } from "@webiny/api-tenancy/types";
 
 type Context = TenancyContext & SecurityContext;
+
+const checkPermissions = (context: SecurityContext) => {
+    const identity = context.security.getIdentity();
+    if (!identity) {
+        throw new NotAuthorizedError();
+    }
+};
 
 export default new GraphQLSchemaPlugin<Context>({
     typeDefs: /* GraphQL */ `
@@ -55,67 +63,103 @@ export default new GraphQLSchemaPlugin<Context>({
     resolvers: {
         TenancyQuery: {
             getTenant: async (_, { where }, context) => {
-                // TODO: add permission checks
-                const tenant = await context.tenancy.getTenantById(where.id);
+                try {
+                    await checkPermissions(context);
+                    const tenant = await context.tenancy.getTenantById(where.id);
+                    const currentTenant = context.tenancy.getCurrentTenant();
+                    const selfOrParent = [tenant.id, tenant.parent];
 
-                // Maybe move this logic into the `tenancy` app, but use storage ops for initializing the `root` tenant?
-                const currentTenant = context.tenancy.getCurrentTenant();
+                    // Make sure the requested tenant is either the current tenant itself, or one of its children.
+                    if (selfOrParent.includes(currentTenant.id)) {
+                        return new Response(tenant);
+                    }
 
-                // Make sure current tenant is allowed to access the requested tenant.
-                if (currentTenant.id !== tenant.parent && currentTenant.id !== tenant.id) {
-                    return undefined;
+                    throw new NotAuthorizedError();
+                } catch (e) {
+                    return new ErrorResponse(e);
                 }
-
-                return new Response(tenant);
             },
             listTenants: async (_, __, context) => {
-                // TODO: add permission checks
-                const tenant = context.tenancy.getCurrentTenant();
-                const tenants = await context.tenancy.listTenants({ parent: tenant.id });
-                return new ListResponse(tenants);
+                // This lists tenants that are subtenants of the current tenant.
+                try {
+                    await checkPermissions(context);
+                    const tenant = context.tenancy.getCurrentTenant();
+                    const tenants = await context.tenancy.listTenants({ parent: tenant.id });
+                    return new ListResponse(tenants);
+                } catch (e) {
+                    return new ErrorResponse(e);
+                }
             }
         },
         TenancyMutation: {
             createTenant: async (_, args: any, context) => {
-                // TODO: add permission checks
-                const tenant = context.tenancy.getCurrentTenant();
-                const newTenant = await context.tenancy.createTenant({
-                    id: mdbid(),
-                    name: args.data.name,
-                    description: args.data.description,
-                    parent: tenant.id,
-                    settings: args.data.settings
-                });
+                /**
+                 * This method creates a subtenant of the current tenant.
+                 */
+                try {
+                    await checkPermissions(context);
+                    const tenant = context.tenancy.getCurrentTenant();
+                    const newTenant = await context.tenancy.createTenant({
+                        id: mdbid(),
+                        name: args.data.name,
+                        description: args.data.description,
+                        parent: tenant.id,
+                        settings: args.data.settings
+                    });
 
-                return new Response(newTenant);
+                    return new Response(newTenant);
+                } catch (e) {
+                    return new ErrorResponse(e);
+                }
             },
             updateTenant: async (_, args: any, context) => {
-                // TODO: add permission checks
-                const tenantToUpdate = await context.tenancy.getTenantById(args.id);
-                if (!tenantToUpdate) {
-                    return new ErrorResponse({
-                        message: `Tenant "${args.id}" was not found!`,
-                        code: "TENANT_NOT_FOUND"
-                    });
+                try {
+                    await checkPermissions(context);
+                    const tenantToUpdate = await context.tenancy.getTenantById(args.id);
+                    const currentTenant = context.tenancy.getCurrentTenant();
+
+                    if (!tenantToUpdate) {
+                        return new ErrorResponse({
+                            message: `Tenant "${args.id}" was not found!`,
+                            code: "TENANT_NOT_FOUND"
+                        });
+                    }
+
+                    // You can only update a tenant if it's a child of the current tenant.
+                    if (currentTenant.id !== tenantToUpdate.parent) {
+                        throw new NotAuthorizedError();
+                    }
+
+                    const updatedTenant = await context.tenancy.updateTenant(args.id, args.data);
+
+                    return new Response(updatedTenant);
+                } catch (e) {
+                    return new ErrorResponse(e);
                 }
-
-                const updatedTenant = await context.tenancy.updateTenant(args.id, args.data);
-
-                return new Response(updatedTenant);
             },
             deleteTenant: async (_, args: any, context) => {
-                // TODO: add permission checks
-                const tenantToUpdate = await context.tenancy.getTenantById(args.id);
-                if (!tenantToUpdate) {
-                    return new ErrorResponse({
-                        message: `Tenant "${args.id}" was not found!`,
-                        code: "TENANT_NOT_FOUND"
-                    });
+                try {
+                    await checkPermissions(context);
+                    const tenantToDelete = await context.tenancy.getTenantById(args.id);
+                    if (!tenantToDelete) {
+                        return new ErrorResponse({
+                            message: `Tenant "${args.id}" was not found!`,
+                            code: "TENANT_NOT_FOUND"
+                        });
+                    }
+
+                    // You can only delete a tenant if it's a child of the current tenant.
+                    const currentTenant = context.tenancy.getCurrentTenant();
+                    if (currentTenant.id !== tenantToDelete.parent) {
+                        throw new NotAuthorizedError();
+                    }
+
+                    await context.tenancy.deleteTenant(args.id);
+
+                    return new Response(true);
+                } catch (e) {
+                    return new ErrorResponse(e);
                 }
-
-                await context.tenancy.deleteTenant(args.id);
-
-                return new Response(true);
             }
         }
     }

--- a/packages/app-admin/src/components/FileManager.tsx
+++ b/packages/app-admin/src/components/FileManager.tsx
@@ -61,7 +61,6 @@ export type MultipleProps =
 export type FileManagerProps = {
     accept?: Array<string>;
     images?: boolean;
-    imagesMimeTypes?: Array<string>;
     maxSize?: number | string;
     /**
      * @deprecated This prop is no longer used. The file structure was reduced to a bare minimum so picking is no longer necessary.
@@ -106,23 +105,23 @@ const formatFileItem = ({ id, src, ...rest }: FileItem): FileManagerFileItem => 
     };
 };
 
+/**
+ * If `accept` prop is not passed, and `images` prop is set, use these default mime types.
+ * Defaults can be overridden using the `createComponentPlugin` and `FileManagerRenderer` component.
+ */
+const imagesAccept = [
+    "image/jpg",
+    "image/jpeg",
+    "image/tiff",
+    "image/gif",
+    "image/png",
+    "image/webp",
+    "image/bmp",
+    "image/svg+xml"
+];
+
 const DefaultFileManagerRenderer: React.FC<FileManagerRendererProps> = props => {
-    const {
-        onChange,
-        images,
-        accept,
-        imagesMimeTypes = [
-            "image/jpg",
-            "image/jpeg",
-            "image/tiff",
-            "image/gif",
-            "image/png",
-            "image/webp",
-            "image/bmp",
-            "image/svg+xml"
-        ],
-        ...forwardProps
-    } = props;
+    const { onChange, images, accept, ...forwardProps } = props;
 
     const handleFileOnChange = (value?: FileItem[] | FileItem) => {
         if (!onChange || !value || (Array.isArray(value) && !value.length)) {
@@ -141,11 +140,16 @@ const DefaultFileManagerRenderer: React.FC<FileManagerRendererProps> = props => 
     const viewProps: FileManagerViewProps = {
         ...forwardProps,
         onChange: typeof onChange === "function" ? handleFileOnChange : undefined,
-        accept: images ? imagesMimeTypes : accept || []
+        accept: images ? accept || imagesAccept : accept || []
     };
 
     return (
-        <FileManagerProvider {...props}>
+        <FileManagerProvider
+            accept={viewProps.accept}
+            tags={viewProps.tags || []}
+            own={viewProps.own}
+            scope={viewProps.scope}
+        >
             <FileManagerView {...viewProps} />
         </FileManagerProvider>
     );

--- a/packages/app-admin/src/components/FileManager/FileManagerContext.tsx
+++ b/packages/app-admin/src/components/FileManager/FileManagerContext.tsx
@@ -25,18 +25,20 @@ export const getWhere = (scope: string | undefined) => {
 interface InitParams {
     accept: string[];
     tags: string[];
-    scope: string;
-    own: boolean;
+    scope?: string;
+    own?: boolean;
     identity: any;
 }
+
 interface StateQueryParams {
     types: string[];
     limit: number;
     sort: number;
     tags: string[];
-    scope: string;
+    scope?: string;
     where: Record<string, any>;
 }
+
 interface State {
     showingFileDetails: string | null;
     selected: FileItem[];
@@ -45,6 +47,7 @@ interface State {
     dragging: boolean;
     uploading: boolean;
 }
+
 const init = ({ accept, tags, scope, own, identity }: InitParams): State => {
     const initialWhere = own ? { createdBy: identity.id } : {};
     return {
@@ -130,13 +133,16 @@ const fileManagerReducer: Reducer = (state: State, action) => {
 
 const FileManagerContext = React.createContext({});
 
-const FileManagerProvider: React.FC = ({ children, ...props }) => {
+export interface FileManagerProviderProps {
+    accept: string[];
+    tags: string[];
+    scope?: string;
+    own?: boolean;
+}
+
+const FileManagerProvider: React.FC<FileManagerProviderProps> = ({ children, ...props }) => {
     const { identity } = useSecurity();
-    /**
-     * TODO @ts-refactor
-     * Figure out how to type the rest of the types.
-     */
-    // @ts-ignore
+
     const [state, dispatch] = React.useReducer(fileManagerReducer, { ...props, identity }, init);
 
     const value = React.useMemo(() => {
@@ -146,11 +152,7 @@ const FileManagerProvider: React.FC = ({ children, ...props }) => {
         };
     }, [state]);
 
-    return (
-        <FileManagerContext.Provider value={value} {...props}>
-            {children}
-        </FileManagerContext.Provider>
-    );
+    return <FileManagerContext.Provider value={value}>{children}</FileManagerContext.Provider>;
 };
 
 function useFileManager() {

--- a/packages/app-tenancy/src/contexts/Tenancy.tsx
+++ b/packages/app-tenancy/src/contexts/Tenancy.tsx
@@ -34,8 +34,15 @@ function storeState(state: string) {
 }
 
 const getInitialTenant = (): string | null => {
-    const currentTenant = loadState();
-    plugins.register(new TenantHeaderLinkPlugin(currentTenant || "root"));
+    // Check if `tenantId` query parameter is set. If it is, it takes precedence over any other source.
+    const searchParams = new URLSearchParams(location.search);
+    const tenantId = searchParams.get("tenantId");
+    if (tenantId) {
+        storeState(tenantId);
+    }
+
+    const currentTenant = loadState() || "root";
+    plugins.register(new TenantHeaderLinkPlugin(currentTenant));
     return currentTenant;
 };
 


### PR DESCRIPTION
## Changes
This PR adds support for the `tenantId` query parameter, which can be used in multi-tenant systems to point a user to a specific tenant (for example, when sharing a link with colleagues, or mapping custom domains).

## How Has This Been Tested?
Manually.
