### PR TITLE
Pulumi App Params - Add Ability To Return `undefined`

### DIFF
--- a/packages/pulumi/src/types.ts
+++ b/packages/pulumi/src/types.ts
@@ -11,7 +11,7 @@ export interface ResourceHandler {
     (resource: PulumiAppResource<PulumiAppResourceConstructor>): void;
 }
 
-export type PulumiAppParamCallback<T> = (app: PulumiApp) => T;
+export type PulumiAppParamCallback<T> = (app: PulumiApp) => T | undefined;
 export type PulumiAppParam<T> = T | PulumiAppParamCallback<T>;
 
 export type PulumiProgram<TResources = Record<string, any>> = (
@@ -75,5 +75,5 @@ export interface PulumiApp<TResources = Record<string, unknown>> {
 
     addHandler<T>(handler: () => Promise<T> | T): pulumi.Output<pulumi.Unwrap<T>>;
 
-    getParam<T>(param: T | ((app: PulumiApp) => T)): T;
+    getParam<T>(param: T | ((app: PulumiApp) => T)): T | undefined;
 }


### PR DESCRIPTION
## Changes
Sometimes, developers have the need to either assign a value to a specific Pulumi app parameter, or leave it blank (`undefined`). Consider the following example:

```ts
import { createWebsiteApp } from "@webiny/serverless-cms-aws";

export default createWebsiteApp({
    domains: () => {
        const customDomainAliases = process.env["CUSTOM_WEBSITE_DOMAIN_ALIASES"];
        const viewerCertificateArn = process.env["VIEWER_CERTIFICATE_ARN"];
        const usingCustomDomain = customDomainAliases && viewerCertificateArn;

        // If using a custom domain, return required object.
        if (usingCustomDomain) {
            const aliases = customDomainAliases.split(",");
            return {
                domains: aliases,
                acmCertificateArn: viewerCertificateArn,
                sslSupportMethod: "sni-only"
            };
        }

        // If not using custom domains, don't do anything. Return `undefined`.
        return undefined;
    },

});
```

In this example, if a custom domain is being used (depending on env vars), we return the required object from the `domains` callback function. Otherwise, we return undefined, to signal no custom domain needs to be used.

At the moment, returning `undefined` results in an error, but with this PR, not anymore. Returning `undefined` is now allowed for all parameters.

## How Has This Been Tested?
Manual, TypeScript checks.

## Documentation
Changelog.