### PR TITLE
Ensure `WCP_PROJECT_ENVIRONMENT_API_KEY` Doesn't Run PAT Auth

### DIFF
--- a/packages/cli/commands/wcp/hooks.js
+++ b/packages/cli/commands/wcp/hooks.js
@@ -22,7 +22,7 @@ const { getUser, getProjectEnvironment, updateUserLastActiveOn } = require("./ut
 let projectEnvironment;
 
 const getEnvironmentHookHandler = async (args, context) => {
-    // If the project isn't activated, do nothing.
+    // If the project isn't linked with WCP, do nothing.
     const wcpProjectId = context.project.config.id || process.env.WCP_PROJECT_ID;
     if (!wcpProjectId) {
         return;

--- a/packages/cli/commands/wcp/hooks.js
+++ b/packages/cli/commands/wcp/hooks.js
@@ -22,17 +22,17 @@ const { getUser, getProjectEnvironment, updateUserLastActiveOn } = require("./ut
 let projectEnvironment;
 
 const getEnvironmentHookHandler = async (args, context) => {
+    // If the project isn't activated, do nothing.
+    const wcpProjectId = context.project.config.id || process.env.WCP_PROJECT_ID;
+    if (!wcpProjectId) {
+        return;
+    }
+
     // For development purposes, we allow setting the WCP_PROJECT_ENVIRONMENT env var directly.
     if (process.env.WCP_PROJECT_ENVIRONMENT) {
         // If we have WCP_PROJECT_ENVIRONMENT env var, we set the WCP_PROJECT_ENVIRONMENT_API_KEY too.
         const decryptedProjectEnvironment = decrypt(process.env.WCP_PROJECT_ENVIRONMENT);
         process.env.WCP_PROJECT_ENVIRONMENT_API_KEY = decryptedProjectEnvironment.apiKey;
-        return;
-    }
-
-    // If the project isn't activated, do nothing.
-    const wcpProjectId = context.project.config.id || process.env.WCP_PROJECT_ID;
-    if (!wcpProjectId) {
         return;
     }
 

--- a/packages/cli/commands/wcp/utils/getProjectEnvironment.js
+++ b/packages/cli/commands/wcp/utils/getProjectEnvironment.js
@@ -69,6 +69,16 @@ module.exports.getProjectEnvironment = async ({
     environmentId,
     apiKey
 }) => {
+    if (apiKey) {
+        return request(getWcpGqlApiUrl(), GET_ENVIRONMENT, { apiKey })
+            .then(response => response.projects.getEnvironment)
+            .catch(() => {
+                throw new Error(
+                    `It seems the API key you provided is incorrect or disabled. Please double check the API key and try again.`
+                );
+            });
+    }
+
     const pat = localStorage().get("wcpPat");
     if (!pat) {
         throw new Error(


### PR DESCRIPTION
## Changes
Before this PR, even in the presence of the `WCP_PROJECT_ENVIRONMENT_API_KEY` environment variable, the authentication via user's PAT (obtained when logging in via `webiny login` command) would still be performed.

This is not needed. When an API key is present, the auth should be completely done using it. This PR ensures that is the case.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.