### PR TITLE
Deprecate `init` CLI Command and Introduce `link`

### DIFF
--- a/packages/cli/commands/wcp/login.js
+++ b/packages/cli/commands/wcp/login.js
@@ -183,7 +183,7 @@ module.exports.command = () => ({
                     context.project.config.id || process.env.WCP_PROJECT_ID
                 );
 
-                // If we have `orgId` and `projectId` in PAT's meta data, let's immediately activate the project.
+                // If we have `orgId` and `projectId` in PAT's metadata, let's immediately link the project.
                 if (pat.meta && pat.meta.orgId && pat.meta.projectId) {
                     await sleep();
 

--- a/packages/cli/commands/wcp/login.js
+++ b/packages/cli/commands/wcp/login.js
@@ -192,7 +192,7 @@ module.exports.command = () => ({
                     const { orgId, projectId } = pat.meta;
 
                     const id = `${orgId}/${projectId}`;
-                    console.log(`Project ${chalk.green(id)} detected. Initializing...`);
+                    console.log(`Project ${chalk.green(id)} detected. Linking...`);
 
                     await sleep();
 
@@ -202,7 +202,7 @@ module.exports.command = () => ({
                         projectId
                     });
 
-                    console.log(`Project ${context.success.hl(id)} initialized successfully.`);
+                    console.log(`Project ${context.success.hl(id)} linked successfully.`);
                     projectInitialized = true;
                 }
 
@@ -213,8 +213,8 @@ module.exports.command = () => ({
 
                 if (!projectInitialized) {
                     console.log(
-                        `‣ initialize your project via the ${chalk.green(
-                            "yarn webiny project init"
+                        `‣ link your project via the ${chalk.green(
+                            "yarn webiny project link"
                         )} command`
                     );
                 }

--- a/packages/cli/commands/wcp/project.js
+++ b/packages/cli/commands/wcp/project.js
@@ -13,24 +13,6 @@ module.exports.command = () => [
                 `Webiny project-related commands`,
                 projectCommand => {
                     projectCommand.command(
-                        "init",
-                        `Initialize a Webiny project (deprecated, please use the link command instead)`,
-                        command => {
-                            yargs.option("debug", {
-                                describe: `Turn on debug logs`,
-                                type: "boolean"
-                            });
-                            yargs.option("debug-level", {
-                                default: 1,
-                                describe: `Set the debug logs verbosity level`,
-                                type: "number"
-                            });
-                            command.example("$0 project init");
-                        },
-                        () => handler({ context })
-                    );
-
-                    projectCommand.command(
                         "link",
                         `Link a Webiny project with Webiny Control Panel (WCP)`,
                         command => {
@@ -44,6 +26,24 @@ module.exports.command = () => [
                                 type: "number"
                             });
                             command.example("$0 project link");
+                        },
+                        () => handler({ context })
+                    );
+
+                    projectCommand.command(
+                        "init",
+                        `Initialize a Webiny project (deprecated, please use the link command instead)`,
+                        command => {
+                            yargs.option("debug", {
+                                describe: `Turn on debug logs`,
+                                type: "boolean"
+                            });
+                            yargs.option("debug-level", {
+                                default: 1,
+                                describe: `Set the debug logs verbosity level`,
+                                type: "number"
+                            });
+                            command.example("$0 project init");
                         },
                         () => handler({ context })
                     );

--- a/packages/cli/commands/wcp/project.js
+++ b/packages/cli/commands/wcp/project.js
@@ -57,13 +57,13 @@ const handler = async ({ context }) => {
     // Check login.
     const user = await getUser();
 
-    // User already initialized a project?
+    // User already linked a project?
     const { id: orgProjectId } = context.project.config;
     if (orgProjectId) {
         const [, projectId] = orgProjectId.split("/");
         const project = user.projects.find(item => item.id === projectId);
         if (project) {
-            console.log(`Your ${chalk.green(orgProjectId)} project has already been initialized.`);
+            console.log(`Your ${chalk.green(orgProjectId)} project has already been linked.`);
 
             const prompt = inquirer.createPromptModule();
             const { proceed } = await prompt({
@@ -188,7 +188,7 @@ const handler = async ({ context }) => {
     console.log(
         `${chalk.green("✔")} Project ${context.success.hl(
             selectedProject.name
-        )} initialized successfully.`
+        )} linked successfully.`
     );
 
     await sleep();

--- a/packages/cli/commands/wcp/project.js
+++ b/packages/cli/commands/wcp/project.js
@@ -50,7 +50,7 @@ module.exports.command = () => [
                 }
             );
         }
-    },
+    }
 ];
 
 const handler = async ({ context }) => {

--- a/packages/cli/commands/wcp/project.js
+++ b/packages/cli/commands/wcp/project.js
@@ -14,7 +14,7 @@ module.exports.command = () => [
                 projectCommand => {
                     projectCommand.command(
                         "init",
-                        `Initialize a Webiny project`,
+                        `Initialize a Webiny project (deprecated, please use the link command instead)`,
                         command => {
                             yargs.option("debug", {
                                 describe: `Turn on debug logs`,
@@ -29,10 +29,28 @@ module.exports.command = () => [
                         },
                         () => handler({ context })
                     );
+
+                    projectCommand.command(
+                        "link",
+                        `Link a Webiny project with Webiny Control Panel (WCP)`,
+                        command => {
+                            yargs.option("debug", {
+                                describe: `Turn on debug logs`,
+                                type: "boolean"
+                            });
+                            yargs.option("debug-level", {
+                                default: 1,
+                                describe: `Set the debug logs verbosity level`,
+                                type: "number"
+                            });
+                            command.example("$0 project link");
+                        },
+                        () => handler({ context })
+                    );
                 }
             );
         }
-    }
+    },
 ];
 
 const handler = async ({ context }) => {


### PR DESCRIPTION
## Changes
This PR deprecates the `webiny project init` command and introduces the `webiny project link` command.

![image](https://user-images.githubusercontent.com/5121148/194899138-a1efcdd6-7994-42ec-9cba-b57af4adafbe.png)

This is because the word "link" is simply clearer then "init".

> **NOTE**
> We still left the `init` method in the Webiny CLI, for backwards compatibility.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.