### PR TITLE
Webiny CLI - Print the Actual AWS Auth Error When in Debug Mode

### DIFF
--- a/packages/cwp-template-aws/cli/aws/checkCredentials.js
+++ b/packages/cwp-template-aws/cli/aws/checkCredentials.js
@@ -16,6 +16,10 @@ module.exports = {
         } catch (err) {
             console.log();
             context.error("Looks like your AWS credentials are not configured correctly!");
+
+            // Print the actual error if the debug mode has been enabled.
+            context.debug(err);
+
             context.info(
                 "To learn how to configure your AWS credentials, visit https://www.webiny.com/docs/how-to-guides/deployment/aws/configure-aws-credentials"
             );


### PR DESCRIPTION
## Changes

If an AWS auth error has been thrown upon deploying the project, with the `--debug` flag passed, users will be able to see the actual error that was thrown in the background by the AWS SDK:

![image](https://user-images.githubusercontent.com/5121148/195056519-ccdf3626-9e2f-4121-beaf-8c70de0756fe.png)

This will make it easier for users to debug these errors.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.