### PR TITLE
feat(api-headless-cms): upgrade for all tenants

### DIFF
--- a/packages/api-headless-cms/__tests__/upgrades/upgrade.5330.test.ts
+++ b/packages/api-headless-cms/__tests__/upgrades/upgrade.5330.test.ts
@@ -1,6 +1,8 @@
 import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
 import models from "../contentAPI/mocks/contentModels";
-import { CmsModelField } from "~/types";
+import { CmsContext, CmsModel, CmsModelField } from "~/types";
+import { ContextPlugin } from "@webiny/api";
+import { Tenant } from "@webiny/api-tenancy/types";
 
 const clearStorageId = (fields: CmsModelField[]): CmsModelField[] => {
     return fields.map(field => {
@@ -62,6 +64,65 @@ const expectModelFieldsAfterUpgrade = (fields: CmsModelField[]): Partial<CmsMode
         return result;
     });
 };
+const locales: string[] = ["en-US", "de-DE"];
+const tenants: string[] = ["root", "webiny", "admin"];
+const createTestTenantsContextPlugin = () => {
+    return new ContextPlugin<CmsContext>(async context => {
+        for (const tenant of tenants) {
+            const tenantObj: Tenant = {
+                id: tenant,
+                createdOn: new Date().toISOString(),
+                savedOn: new Date().toISOString(),
+                name: `${tenant} name`,
+                settings: {
+                    domains: []
+                },
+                description: `${tenant} description`,
+                status: "active",
+                parent: null
+            };
+            await context.tenancy.getStorageOperations().createTenant(tenantObj);
+
+            for (const locale of locales) {
+                await context.i18n.locales.storageOperations.create({
+                    locale: {
+                        code: locale,
+                        default: true,
+                        createdOn: new Date().toISOString(),
+                        createdBy: {
+                            id: "admin",
+                            displayName: "admin",
+                            type: "admin"
+                        },
+                        tenant,
+                        webinyVersion: context.WEBINY_VERSION
+                    }
+                });
+            }
+        }
+    });
+};
+
+const extractFieldsFromModels = (models: CmsModel[]): CmsModelField[] => {
+    const getFields = (input?: CmsModelField[]): CmsModelField[] => {
+        if (!input) {
+            return [];
+        }
+        return input.reduce<CmsModelField[]>((fields, field) => {
+            if (field.settings?.fields) {
+                fields.push(...getFields(field.settings.fields));
+            }
+            fields.push(field);
+            return fields;
+        }, []);
+    };
+
+    return models.reduce<CmsModelField[]>((fields, model) => {
+        fields.push(...getFields(model.fields));
+
+        return fields;
+    }, []);
+};
 
 describe("upgrade for 5.33.0", () => {
     const { listContentModelsQuery } = useGraphQLHandler({
@@ -72,12 +133,15 @@ describe("upgrade for 5.33.0", () => {
         process.env.WEBINY_VERSION = "5.33.0";
     });
 
-    const { storageOperations, upgradeMutation } = useGraphQLHandler({});
+    const { storageOperations, upgradeMutation } = useGraphQLHandler({
+        plugins: [createTestTenantsContextPlugin()]
+    });
 
-    it("should add storageId to all the models", async () => {
+    const insertModels = async (tenant: string) => {
         const clearedModelsToInsert = models.map(model => {
             return {
                 ...model,
+                tenant,
                 fields: clearStorageId(model.fields),
                 createdBy: {
                     id: "adminId",
@@ -98,7 +162,7 @@ describe("upgrade for 5.33.0", () => {
         /**
          * These are the models, sorted by name, which we are getting back from the GraphQL API.
          */
-        const sortedModels = clearedModelsToInsert.sort((a, b) => {
+        const sortedModels: CmsModel[] = clearedModelsToInsert.sort((a, b) => {
             if (a.modelId < b.modelId) {
                 return -1;
             } else if (a.modelId > b.modelId) {
@@ -114,27 +178,103 @@ describe("upgrade for 5.33.0", () => {
                 });
             } catch (ex) {
                 console.log(ex.message);
-                return;
+                throw new Error(ex.message);
             }
         }
 
-        const [listContentModelsBeforeUpgradeResult] = await listContentModelsQuery();
+        return {
+            sortedModels
+        };
+    };
 
-        const expectedModelsBeforeUpgrade = sortedModels.map(model => {
-            return {
-                modelId: model.modelId,
-                fields: expectModelFieldsBeforeUpgrade(model.fields)
-            };
-        });
-        expect(listContentModelsBeforeUpgradeResult).toMatchObject({
-            data: {
-                listContentModels: {
-                    data: expectedModelsBeforeUpgrade,
-                    error: null
-                }
+    it("should add storageId to all the models", async () => {
+        const { sortedModels: sortedRootModel } = await insertModels("root");
+        await insertModels("webiny");
+        await insertModels("admin");
+        /**
+         * Each of the tenants must have 2x sortedModels
+         */
+        for (const tenant of tenants) {
+            let total = 0;
+            for (const locale of locales) {
+                const listModelResponse = await storageOperations.models.list({
+                    where: {
+                        tenant,
+                        locale
+                    }
+                });
+                total = total + listModelResponse.length;
             }
-        });
+            expect(total).toEqual(sortedRootModel.length * 2);
+        }
 
+        const fields: CmsModelField[] = [];
+
+        /**
+         * First we need to test that everything is fine before the upgrade.
+         */
+        for (const tenant of tenants) {
+            /**
+             * In the list of models from query we expect it to have the storageId
+             * as we attach on in listing in the crud
+             */
+            const [listContentModelsBeforeUpgradeResult] = await listContentModelsQuery();
+
+            const expectedModelsBeforeUpgradeViaQuery = sortedRootModel.map(model => {
+                return {
+                    modelId: model.modelId,
+                    fields: expectModelFieldsAfterUpgrade(model.fields)
+                };
+            });
+            expect(listContentModelsBeforeUpgradeResult).toMatchObject({
+                data: {
+                    listContentModels: {
+                        data: expectedModelsBeforeUpgradeViaQuery,
+                        error: null
+                    }
+                }
+            });
+
+            /**
+             * In the list of models from storage operations listing we expect models not to have storageId.
+             */
+            const expectedModelsBeforeUpgrade = sortedRootModel.map(model => {
+                return {
+                    modelId: model.modelId,
+                    fields: expectModelFieldsBeforeUpgrade(model.fields)
+                };
+            });
+
+            const listEnModelsResponse = await storageOperations.models.list({
+                where: {
+                    tenant,
+                    locale: "en-US"
+                }
+            });
+
+            expect(listEnModelsResponse).toMatchObject(expectedModelsBeforeUpgrade);
+
+            const listDeModelsResponse = await storageOperations.models.list({
+                where: {
+                    tenant,
+                    locale: "de-DE"
+                }
+            });
+
+            expect(listDeModelsResponse).toMatchObject(
+                expectedModelsBeforeUpgrade.map(model => {
+                    return {
+                        ...model,
+                        tenant,
+                        locale: "de-DE"
+                    };
+                })
+            );
+        }
+
+        /**
+         * Then we do the upgrade...
+         */
         const [upgradeResponse] = await upgradeMutation("5.33.0");
 
         expect(upgradeResponse).toMatchObject({
@@ -147,41 +287,77 @@ describe("upgrade for 5.33.0", () => {
                 }
             }
         });
-
-        const expectedModelsAfterUpgrade = sortedModels.map(model => {
-            return {
-                modelId: model.modelId,
-                fields: expectModelFieldsAfterUpgrade(model.fields)
-            };
-        });
-
-        const [listContentModelsAfterUpgradeResult] = await listContentModelsQuery();
-
-        expect(listContentModelsAfterUpgradeResult).toMatchObject({
-            data: {
-                listContentModels: {
-                    data: expectedModelsAfterUpgrade,
-                    error: null
-                }
-            }
-        });
         /**
-         * Also, if we go to fetch the models in de-DE locale via storage operations, they should also have their fields updated.
+         * Then we go and test everything again, after the upgrade...
          */
-        const deModels = await storageOperations.models.list({
-            where: {
-                tenant: "root",
-                locale: "de-DE"
-            }
-        });
-
-        expect(deModels).toMatchObject(
-            expectedModelsAfterUpgrade.map(model => {
+        for (const tenant of tenants) {
+            const expectedModelsAfterUpgrade = sortedRootModel.map(model => {
                 return {
-                    ...model,
-                    locale: "de-DE"
+                    modelId: model.modelId,
+                    fields: expectModelFieldsAfterUpgrade(model.fields)
                 };
-            })
-        );
+            });
+
+            const [listContentModelsAfterUpgradeResult] = await listContentModelsQuery();
+
+            expect(listContentModelsAfterUpgradeResult).toMatchObject({
+                data: {
+                    listContentModels: {
+                        data: expectedModelsAfterUpgrade,
+                        error: null
+                    }
+                }
+            });
+            /**
+             * We need to check models we get via the storage operations.
+             */
+            const listEnModelsViaStorageOperationsResponse = await storageOperations.models.list({
+                where: {
+                    tenant,
+                    locale: "en-US"
+                }
+            });
+
+            expect(listEnModelsViaStorageOperationsResponse).toMatchObject(
+                expectedModelsAfterUpgrade
+            );
+            /**
+             * Also, if we go to fetch the models in de-DE locale via storage operations, they should also have their fields updated.
+             */
+            const listDeModelsViaStorageOperationsResponse = await storageOperations.models.list({
+                where: {
+                    tenant,
+                    locale: "de-DE"
+                }
+            });
+
+            expect(listDeModelsViaStorageOperationsResponse).toMatchObject(
+                expectedModelsAfterUpgrade.map(model => {
+                    return {
+                        ...model,
+                        locale: "de-DE"
+                    };
+                })
+            );
+            /**
+             * We will have one last test for the field definitions, but we need all the fields for that.
+             */
+            fields.push(
+                ...extractFieldsFromModels(
+                    listContentModelsAfterUpgradeResult.data.listContentModels.data
+                )
+            );
+            fields.push(...extractFieldsFromModels(listEnModelsViaStorageOperationsResponse));
+            fields.push(...extractFieldsFromModels(listDeModelsViaStorageOperationsResponse));
+        }
+        /**
+         * All collected fields MUST have storageId properly defined.
+         */
+        for (const field of fields) {
+            expect(field.storageId).toBeDefined();
+            expect(field.storageId).toMatch(/^([a-zA-Z]+)$/);
+            expect(field.storageId.length).toBeGreaterThan(2);
+            expect(field.storageId).toEqual(field.fieldId);
+        }
     });
 });

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -15,7 +15,8 @@ import {
     AfterModelCreateFromTopicParams,
     CmsModelCreateInput,
     CmsModelUpdateInput,
-    CmsModelCreateFromInput
+    CmsModelCreateFromInput,
+    CmsModelField
 } from "~/types";
 import DataLoader from "dataloader";
 import { NotFoundError } from "@webiny/handler-graphql";
@@ -44,6 +45,40 @@ import { filterAsync } from "~/utils/filterAsync";
 import { checkOwnership, validateOwnership } from "~/utils/ownership";
 import { checkModelAccess, validateModelAccess } from "~/utils/access";
 import { validateModelFields } from "~/crud/contentModel/validateModelFields";
+import semver, { SemVer } from "semver";
+
+/**
+ * TODO: remove for 5.34.0
+ * Required because of the 5.33.0 upgrade.
+ * Until the upgrade is done, API will break because there is no storageId assigned.
+ */
+const featureVersion = semver.coerce("5.33.0") as SemVer;
+
+const attachStorageIdToFields = (fields: CmsModelField[]): CmsModelField[] => {
+    return fields.map(field => {
+        if (field.settings?.fields) {
+            field.settings.fields = attachStorageIdToFields(field.settings.fields);
+        }
+        if (!field.storageId) {
+            field.storageId = field.fieldId;
+        }
+        return field;
+    });
+};
+
+const attachStorageIdToModelFields = (model: CmsModel): CmsModelField[] => {
+    if (!model.webinyVersion) {
+        return model.fields;
+    }
+    const version = semver.coerce(model.webinyVersion);
+    if (!version) {
+        return model.fields;
+    }
+    if (semver.compare(version, featureVersion) >= 0) {
+        return model.fields;
+    }
+    return attachStorageIdToFields(model.fields);
+};
 
 export interface CreateModelsCrudParams {
     getTenant: () => Tenant;
@@ -67,6 +102,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 models.map(model => {
                     return {
                         ...model,
+                        fields: attachStorageIdToModelFields(model),
                         tenant: model.tenant || getTenant().id,
                         locale: model.locale || getLocale().code
                     };

--- a/packages/api-headless-cms/src/upgrades/5.33.0/index.ts
+++ b/packages/api-headless-cms/src/upgrades/5.33.0/index.ts
@@ -1,22 +1,8 @@
 import WebinyError from "@webiny/error";
 import { UpgradePlugin } from "@webiny/api-upgrade";
-import { CmsContext, CmsModelField } from "~/types";
-
-// const clearStorageId = (fields: CmsModelField[]): CmsModelField[] => {
-//     return fields.map(field => {
-//         const settings = {
-//             ...(field.settings || {})
-//         };
-//         if (settings.fields && Array.isArray(settings.fields) === true) {
-//             settings.fields = clearStorageId(settings.fields);
-//         }
-//         return {
-//             ...field,
-//             storageId: null as any,
-//             settings
-//         };
-//     });
-// };
+import { CmsContext, CmsModelField, HeadlessCms } from "~/types";
+import { Tenant } from "@webiny/api-tenancy/types";
+import { I18NContextObject } from "@webiny/api-i18n/types";
 
 const assignStorageId = (fields: CmsModelField[]): CmsModelField[] => {
     return fields.map(field => {
@@ -33,6 +19,107 @@ const assignStorageId = (fields: CmsModelField[]): CmsModelField[] => {
         };
     });
 };
+/**
+ * If at least one field does not have storageId define, we should definitely update the model.
+ */
+const shouldUpdate = (fields: CmsModelField[]): boolean => {
+    return fields.some(field => {
+        if (field.settings?.fields) {
+            return shouldUpdate(field.settings.fields);
+        }
+        return !field.storageId;
+    });
+};
+
+interface UpgradeTenantModelsParams {
+    tenant: Tenant;
+    cms: HeadlessCms;
+    i18n: I18NContextObject;
+}
+
+const upgradeTenantModels = async (params: UpgradeTenantModelsParams): Promise<void> => {
+    const { tenant, cms, i18n } = params;
+    /**
+     * We need all locales for this tenant, so we can go and find all models for all the locales.
+     */
+    const [locales] = await i18n.locales.storageOperations.list({
+        where: {
+            tenant: tenant.id
+        },
+        limit: 100
+    });
+    if (locales.length === 0) {
+        console.log(`There are no locales under the tenant "${tenant.id}".`);
+        return;
+    }
+    for (const locale of locales) {
+        /**
+         * We need all the models that are not plugin models.
+         */
+        const models = await cms.storageOperations.models.list({
+            where: {
+                tenant: tenant.id,
+                locale: locale.code
+            }
+        });
+        if (models.length === 0) {
+            console.log(
+                `No models in tenant "${tenant.id}" and locale "${locale.code}" combination.`
+            );
+            continue;
+        }
+
+        /**
+         * Then we need to go into each of the model fields and add the storageId, which is the same as the fieldId
+         */
+        const updatedModels = models
+            .filter(model => {
+                /**
+                 * If model has at least one field with no storageId, continue with the update.
+                 */
+                const toUpdate = shouldUpdate(model.fields);
+
+                /**
+                 * If not updating the model, lets log it - just in case...
+                 */
+                if (!toUpdate) {
+                    console.log(
+                        `Skipping update of model "${model.modelId} - ${tenant.id} - ${locale.code}".`
+                    );
+                    return false;
+                }
+                return true;
+            })
+            .map(model => {
+                return {
+                    ...model,
+                    fields: assignStorageId(model.fields)
+                };
+            });
+        /**
+         * And update all the models
+         */
+        for (const model of updatedModels) {
+            try {
+                await cms.storageOperations.models.update({
+                    model
+                });
+            } catch (ex) {
+                throw new WebinyError(
+                    `Could not update CMS model ${model.modelId}`,
+                    "MODEL_UPGRADE_ERROR",
+                    {
+                        model
+                    }
+                );
+            }
+        }
+    }
+    /**
+     * In the end we need to write the new cms system version.
+     */
+    await cms.setSystemVersion("5.33.0");
+};
 
 export const createUpgrade = (): UpgradePlugin<CmsContext> => {
     return {
@@ -46,63 +133,34 @@ export const createUpgrade = (): UpgradePlugin<CmsContext> => {
              * We need to be able to access all data.
              */
             security.disableAuthorization();
-            try {
-                const tenant = tenancy.getCurrentTenant();
-                /**
-                 * We need all locales for this tenant, so we can go and find all models for all the locales.
-                 */
-                const [locales] = await i18n.locales.listLocales();
-                if (locales.length === 0) {
-                    throw new WebinyError(
-                        "There are no locales in the system. Is that possible? Please contact the Webiny team.",
-                        "MISSING_LOCALES",
-                        {
-                            tenant
-                        }
-                    );
-                }
-                for (const locale of locales) {
-                    /**
-                     * We need all the models that are not plugin models.
-                     */
-                    const models = await cms.storageOperations.models.list({
-                        where: {
-                            tenant: tenant.id,
-                            locale: locale.code
-                        }
-                    });
-                    if (models.length === 0) {
-                        continue;
-                    }
 
-                    /**
-                     * Then we need to go into each of the model fields and add the storageId, which is the same as the fieldId
-                     */
-                    const updatedModels = models.map(model => {
-                        return {
-                            ...model,
-                            fields: assignStorageId(model.fields)
-                        };
+            const initialTenant = tenancy.getCurrentTenant();
+
+            const tenants = await tenancy.listTenants();
+            try {
+                for (const tenant of tenants) {
+                    tenancy.setCurrentTenant(tenant);
+                    await upgradeTenantModels({
+                        tenant,
+                        cms,
+                        i18n
                     });
-                    /**
-                     * And update all the models
-                     */
-                    for (const model of updatedModels) {
-                        await cms.storageOperations.models.update({
-                            model
-                        });
-                    }
                 }
             } catch (ex) {
+                console.log(
+                    `Upgrade error: ${JSON.stringify({
+                        message: ex.message,
+                        code: ex.code,
+                        data: ex.data
+                    })}`
+                );
                 throw new WebinyError(
                     `Could not finish the 5.33.0 upgrade. Please contact Webiny team on Slack and share the error.`,
                     "UPGRADE_ERROR",
                     {
-                        ex: {
-                            message: ex.message,
-                            code: ex.code,
-                            data: ex.data
-                        }
+                        message: ex.message,
+                        code: ex.code,
+                        data: ex.data
                     }
                 );
             } finally {
@@ -110,6 +168,7 @@ export const createUpgrade = (): UpgradePlugin<CmsContext> => {
                  * Always enable the security after all the code runs.
                  */
                 security.enableAuthorization();
+                tenancy.setCurrentTenant(initialTenant);
             }
         }
     };

--- a/packages/api-i18n/src/graphql/crud/system.crud.ts
+++ b/packages/api-i18n/src/graphql/crud/system.crud.ts
@@ -14,6 +14,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCRUD => 
     };
 
     return {
+        storageOperations,
         async getSystemVersion() {
             const system = await storageOperations.get();
 

--- a/packages/api-i18n/src/types.ts
+++ b/packages/api-i18n/src/types.ts
@@ -49,6 +49,7 @@ export interface SystemInstallParams {
  * Definition for the system part crud of the i18n.
  */
 export interface SystemCRUD {
+    storageOperations: I18NSystemStorageOperations;
     /**
      * Get the current version of the i18n.
      */
@@ -140,6 +141,7 @@ export interface OnAfterDeleteLocaleTopicParams {
  * Definition for the locales part crud of the i18n.
  */
 export interface LocalesCRUD {
+    storageOperations: I18NLocalesStorageOperations;
     /**
      * Lifecycle events.
      */
@@ -177,8 +179,18 @@ export interface LocalesCRUD {
     deleteLocale: (code: string) => Promise<I18NLocaleData>;
 }
 
+export interface I18NLocalesStorageOperationsGetDefaultParams {
+    tenant: string;
+}
+
+export interface I18NLocalesStorageOperationsGetParams {
+    code: string;
+    tenant: string;
+}
+
 export interface I18NLocalesStorageOperationsListParams {
-    where?: {
+    where: {
+        tenant: string;
         code?: string;
         default?: boolean;
         createdBy?: string;
@@ -226,8 +238,10 @@ export interface I18NLocalesStorageOperationsDeleteParams {
 }
 
 export interface I18NLocalesStorageOperations {
-    getDefault: () => Promise<I18NLocaleData | null>;
-    get: (code: string) => Promise<I18NLocaleData | null>;
+    getDefault: (
+        params: I18NLocalesStorageOperationsGetDefaultParams
+    ) => Promise<I18NLocaleData | null>;
+    get: (params: I18NLocalesStorageOperationsGetParams) => Promise<I18NLocaleData | null>;
     list: (
         params: I18NLocalesStorageOperationsListParams
     ) => Promise<I18NLocalesStorageOperationsListResponse>;


### PR DESCRIPTION
## Changes
Update fields in all tenants models at same time.

Also, attach storageId to the models listed by CMS model crud - otherwise API would break on deployment.

## How Has This Been Tested?
Jest and manually.