### PR TITLE
fix: optimizeImage respects jpeg exif orientation

### DIFF
--- a/packages/api-file-manager/src/handlers/transform/optimizeImage.ts
+++ b/packages/api-file-manager/src/handlers/transform/optimizeImage.ts
@@ -17,6 +17,7 @@ export default async (buffer: Body, type: string): Promise<Body> => {
         case "image/jpeg":
         case "image/jpg": {
             return await sharp(buffer)
+                .rotate()
                 .resize({ width: 2560, withoutEnlargement: true, fit: "inside" })
                 .toFormat("jpeg", { quality: 90 })
                 .toBuffer();


### PR DESCRIPTION
## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->

Uploaded jpeg image with exif rotated orientation(eg. photo from mobile camera) was removed by `sharp.toFormat`. So the optimized image was rotated unintentionally.

`sharp.rotate()` will rotate the image according to exif orientation before the metadata is lost.

## How Has This Been Tested?
Manually.
