### PR TITLE
Page builder blocks v2: variables for other elements

### DIFF
--- a/packages/app-page-builder/src/blockEditor/config/ElementSettingsTabContentPlugin.tsx
+++ b/packages/app-page-builder/src/blockEditor/config/ElementSettingsTabContentPlugin.tsx
@@ -6,12 +6,14 @@ import ElementNotLinked from "~/blockEditor/components/elementSettingsTab/Elemen
 import VariableSettings from "~/blockEditor/components/elementSettingsTab/VariableSettings";
 import VariablesList from "~/blockEditor/components/elementSettingsTab/VariablesList";
 
+const elementTypes = ["heading", "paragraph", "image", "images-list", "quote", "list", "button"];
+
 export const ElementSettingsTabContentPlugin = createComponentPlugin(
     SidebarActions,
     SidebarActionsWrapper => {
         return function SettingsTabContent({ children, ...props }) {
             const [element] = useActiveElement();
-            const canHaveVariable = element && element.type === "heading";
+            const canHaveVariable = element && elementTypes.some(type => type === element.type);
             const hasVariable = element && element.data?.variableId;
             const isBlock = element && element.type === "block";
 

--- a/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/saveBlockAction.ts
+++ b/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/saveBlockAction.ts
@@ -30,10 +30,28 @@ const syncBlockVariables = (block: PbElement) => {
         variable: PbBlockVariable
     ) {
         const dataObject = findNestedObj(block.elements, "variableId", variable.id);
+        const isTextVariable =
+            variable.type === "heading" ||
+            variable.type === "paragraph" ||
+            variable.type === "quote" ||
+            variable.type === "list";
 
-        if (dataObject) {
+        if (dataObject && isTextVariable) {
             result.push({ ...variable, value: dataObject?.text?.data?.text });
         }
+        if (dataObject && variable.type === "image") {
+            result.push({ ...variable, value: dataObject?.image?.file });
+        }
+        if (dataObject && variable.type === "images-list") {
+            result.push({ ...variable, value: dataObject?.images });
+        }
+        if (dataObject && variable.type === "button") {
+            result.push({
+                ...variable,
+                value: { label: dataObject?.buttonText, url: dataObject?.action?.href }
+            });
+        }
+
         return result;
     },
     []);

--- a/packages/app-page-builder/src/blockEditor/plugins/elementSettings/CreateVariableAction.ts
+++ b/packages/app-page-builder/src/blockEditor/plugins/elementSettings/CreateVariableAction.ts
@@ -28,6 +28,7 @@ const CreateVariableAction: React.FC<CreateVariableActionPropsType> = ({ childre
                         ...(block.data?.variables || []),
                         {
                             id: element.id,
+                            type: element.type,
                             label: startCase(camelCase(element.type))
                         }
                     ]

--- a/packages/app-page-builder/src/editor/index.tsx
+++ b/packages/app-page-builder/src/editor/index.tsx
@@ -17,3 +17,5 @@ export { SidebarActions } from "./components/Editor/Sidebar/ElementSettingsTabCo
 export { ElementSettingsRenderer } from "./plugins/elementSettings/advanced/ElementSettings";
 export * from "../render/components/ElementRoot";
 export { default as DropZone } from "../editor/components/DropZone";
+export { default as ImageContainer } from "./plugins/elements/image/ImageContainer";
+export { default as ImagesList } from "./plugins/elements/imagesList/ImagesList";

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/variable/MultipleImageUpload.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/variable/MultipleImageUpload.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { css } from "emotion";
+/**
+ * Package react-sortable does not have types.
+ */
+// @ts-ignore
+import { sortable } from "react-sortable";
+import { cloneDeep } from "lodash";
+import { FileManager } from "@webiny/app-admin/components";
+import File from "~/editor/plugins/elements/imagesList/File";
+import {
+    SimpleButton,
+    ButtonContainer
+} from "~/editor/plugins/elementSettings/components/StyledComponents";
+
+const style = {
+    addImagesButton: css({ clear: "both", padding: "20px 10px", textAlign: "center" }),
+    liItem: {
+        display: "inline-block"
+    }
+};
+
+class Item extends React.Component {
+    public override render() {
+        return (
+            <li style={style.liItem} {...this.props}>
+                {this.props.children}
+            </li>
+        );
+    }
+}
+
+const SortableItem = sortable(Item);
+
+interface MultipleImageUploadProps {
+    value: FileItem[];
+    onChange: (value: FileItem[]) => void;
+    [key: string]: any;
+}
+
+const MultipleImageUpload: React.FC<MultipleImageUploadProps> = ({ value, onChange }) => {
+    return (
+        <FileManager
+            images
+            multiple
+            onChange={files => {
+                const filesArray = Array.isArray(files) ? files : [files];
+                Array.isArray(value)
+                    ? onChange([...value, ...filesArray])
+                    : onChange([...filesArray]);
+            }}
+        >
+            {({ showFileManager }) => (
+                <>
+                    <ul className="sortable-list">
+                        {Array.isArray(value) &&
+                            value.map((item, i) => (
+                                <SortableItem
+                                    key={i}
+                                    onSortItems={onChange}
+                                    // Clone item so lib can modify it
+                                    items={cloneDeep(value)}
+                                    sortId={i}
+                                >
+                                    <File
+                                        file={item}
+                                        onRemove={() => {
+                                            // Remove the image at index i
+                                            const updatedValue = [
+                                                ...value.slice(0, i),
+                                                ...value.slice(i + 1)
+                                            ];
+                                            onChange(updatedValue);
+                                        }}
+                                    />
+                                </SortableItem>
+                            ))}
+                    </ul>
+                    <ButtonContainer>
+                        <SimpleButton onClick={() => showFileManager()}>Add images...</SimpleButton>
+                    </ButtonContainer>
+                </>
+            )}
+        </FileManager>
+    );
+};
+
+export default MultipleImageUpload;

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/variable/RichInput.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/variable/RichInput.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { CoreOptions } from "medium-editor";
+import ReactMediumEditor from "~/editor/components/MediumEditor";
+
+const InputWrapper = styled("div")({
+    padding: "20px 16px",
+    backgroundColor: "rgba(212, 212, 212, 0.5)",
+    borderBottom: "1px solid",
+
+    "&:hover": {
+        backgroundColor: "rgba(212, 212, 212, 0.7)"
+    },
+
+    "&>p": {
+        minHeight: "auto",
+        lineHeight: "normal"
+    }
+});
+
+const DEFAULT_EDITOR_OPTIONS: CoreOptions = {
+    toolbar: {
+        buttons: ["bold", "italic", "underline", "anchor"]
+    },
+    anchor: {
+        targetCheckbox: true,
+        targetCheckboxText: "Open in a new tab"
+    }
+};
+
+interface RichInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    onSelect: (value: string) => void;
+    [key: string]: any;
+}
+
+const RichInput: React.FC<RichInputProps> = ({ value, onChange, onSelect }) => {
+    const [initialValue] = useState(value);
+
+    return (
+        <InputWrapper className="webiny-pb-page-element-text">
+            <ReactMediumEditor
+                tag="p"
+                value={initialValue}
+                onChange={onChange}
+                onSelect={onSelect}
+                options={DEFAULT_EDITOR_OPTIONS}
+            />
+        </InputWrapper>
+    );
+};
+
+export default RichInput;

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/variable/TextInput.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/variable/TextInput.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Input } from "@webiny/ui/Input";
+
+interface TextInputProps {
+    label?: string;
+    value: string;
+    onChange: (value: string) => void;
+    onBlur: () => void;
+}
+
+const TextInput: React.FC<TextInputProps> = ({ label, value, onChange, onBlur }) => {
+    const [localValue, setLocalValue] = useState(value);
+
+    useEffect(() => {
+        if (localValue !== value) {
+            setLocalValue(value);
+        }
+    }, [value]);
+
+    return (
+        <Input
+            label={label}
+            value={localValue}
+            onChange={value => {
+                onChange(value);
+                setLocalValue(value);
+            }}
+            onBlur={onBlur}
+        />
+    );
+};
+
+export default TextInput;

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/variable/VariableSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/variable/VariableSettings.tsx
@@ -1,22 +1,46 @@
 import React, { useCallback } from "react";
-import styled from "@emotion/styled";
+import { css } from "emotion";
 import { useUpdateElement } from "~/editor/hooks/useUpdateElement";
 import { useActiveElement } from "~/editor/hooks/useActiveElement";
-import { Input } from "@webiny/ui/Input";
+import { Typography } from "@webiny/ui/Typography";
+import SingleImageUpload from "@webiny/app-admin/components/SingleImageUpload";
 import { PbBlockVariable } from "~/types";
+import RichInput from "~/editor/plugins/elementSettings/variable/RichInput";
+import TextInput from "~/editor/plugins/elementSettings/variable/TextInput";
+import MultipleImageUpload from "~/editor/plugins/elementSettings/variable/MultipleImageUpload";
 
-const VariableSettingsWrapper = styled("div")({
+const wrapperStyle = css({
     padding: "16px",
     display: "grid",
-    rowGap: "16px"
+    rowGap: "20px"
 });
+
+const labelStyle = css({
+    marginBottom: "8px",
+    "& span": {
+        color: "var(--mdc-theme-text-primary-on-background)"
+    }
+});
+
+const buttonInputsWrapperStyle = css({
+    display: "grid",
+    rowGap: "8px"
+});
+
+const textToBlockQuote = (text: string) => {
+    return `<blockquote><q>${text}</q></blockquote>`;
+};
+
+const blockQuoteToText = (text: string) => {
+    return text.replace("<blockquote><q>", "").replace("</q></blockquote>", "");
+};
 
 const VariableSettings: React.FC = () => {
     const [element] = useActiveElement();
     const updateElement = useUpdateElement();
 
     const onChange = useCallback(
-        (value: string, variableId: string) => {
+        (value: any, variableId: string, history = false) => {
             if (element) {
                 const newVariables = element?.data?.variables?.map((variable: PbBlockVariable) => {
                     if (variable?.id === variableId) {
@@ -24,9 +48,9 @@ const VariableSettings: React.FC = () => {
                             ...variable,
                             value
                         };
-                    } else {
-                        return variable;
                     }
+
+                    return variable;
                 });
                 updateElement(
                     {
@@ -37,7 +61,7 @@ const VariableSettings: React.FC = () => {
                         }
                     },
                     {
-                        history: false
+                        history
                     }
                 );
             }
@@ -52,17 +76,68 @@ const VariableSettings: React.FC = () => {
     }, [element, updateElement]);
 
     return (
-        <VariableSettingsWrapper>
+        <div className={wrapperStyle}>
             {element?.data?.variables?.map((variable: PbBlockVariable, index: number) => (
-                <Input
-                    key={index}
-                    label={variable?.label}
-                    value={variable?.value}
-                    onChange={value => onChange(value, variable.id)}
-                    onBlur={onBlur}
-                />
+                <div key={index}>
+                    <div className={labelStyle}>
+                        <Typography use={"subtitle2"}>{variable.label}</Typography>
+                    </div>
+                    {variable.type === "heading" && (
+                        <TextInput
+                            value={variable?.value}
+                            onChange={value => onChange(value, variable.id)}
+                            onBlur={onBlur}
+                        />
+                    )}
+                    {(variable.type === "paragraph" || variable.type === "list") && (
+                        <RichInput
+                            value={variable?.value}
+                            onSelect={value => onChange(value, variable.id)}
+                            onChange={onBlur}
+                        />
+                    )}
+                    {variable.type === "image" && (
+                        <SingleImageUpload
+                            onChange={(value: File) => onChange(value, variable.id, true)}
+                            value={{ src: variable?.value?.src || "" }}
+                        />
+                    )}
+                    {variable.type === "images-list" && (
+                        <MultipleImageUpload
+                            value={variable?.value}
+                            onChange={value => onChange(value, variable.id, true)}
+                        />
+                    )}
+                    {variable.type === "quote" && (
+                        <TextInput
+                            value={blockQuoteToText(variable?.value)}
+                            onChange={value => onChange(textToBlockQuote(value), variable.id)}
+                            onBlur={onBlur}
+                        />
+                    )}
+                    {variable.type === "button" && (
+                        <div className={buttonInputsWrapperStyle}>
+                            <TextInput
+                                label="Label"
+                                value={variable?.value?.label}
+                                onChange={value =>
+                                    onChange({ ...variable.value, label: value }, variable.id)
+                                }
+                                onBlur={onBlur}
+                            />
+                            <TextInput
+                                label="URL"
+                                value={variable?.value?.url}
+                                onChange={value =>
+                                    onChange({ ...variable.value, url: value }, variable.id)
+                                }
+                                onBlur={onBlur}
+                            />
+                        </div>
+                    )}
+                </div>
             ))}
-        </VariableSettingsWrapper>
+        </div>
     );
 };
 

--- a/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/ButtonContainer.tsx
@@ -10,6 +10,7 @@ import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { UpdateElementActionEvent } from "~/editor/recoil/actions";
 import { elementByIdSelector, uiAtom } from "~/editor/recoil/modules";
 import SimpleEditableText from "./SimpleEditableText";
+import { useElementVariableValue } from "~/editor/hooks/useElementVariableValue";
 
 const buttonEditStyle = css({
     "&.button__content--empty": {
@@ -37,6 +38,7 @@ const ButtonContainer: React.FC<ButtonContainerPropsType> = ({
     const uiAtomValue = useRecoilValue(uiAtom);
     const element = useRecoilValue(elementByIdSelector(elementId)) as PbEditorElement;
     const { type = "default", icon = {}, buttonText } = element.data || {};
+    const variableValue = useElementVariableValue(element);
     const defaultValue = typeof buttonText === "string" ? buttonText : "Click me";
     const value = useRef<string>(defaultValue);
 
@@ -101,6 +103,7 @@ const ButtonContainer: React.FC<ButtonContainerPropsType> = ({
                         "button__content--empty": !value.current
                     })}
                     value={value.current}
+                    variableValue={variableValue?.label}
                     onChange={onChange}
                     onBlur={onBlur}
                 />

--- a/packages/app-page-builder/src/editor/plugins/elements/button/SimpleEditableText.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/SimpleEditableText.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from "react";
 
 interface SimpleTextPropsType {
     value?: string;
+    variableValue?: string;
     onFocus?: () => void;
     onBlur?: () => void;
     onChange: (value: string) => void;
@@ -12,6 +13,7 @@ interface SimpleTextPropsType {
 }
 const SimpleEditableText: React.FC<SimpleTextPropsType> = ({
     value: defaultValue = "",
+    variableValue,
     onFocus,
     onBlur,
     onChange,
@@ -60,7 +62,7 @@ const SimpleEditableText: React.FC<SimpleTextPropsType> = ({
         onBlur: onBlurHandler,
         onFocus: onFocusHandler,
         dangerouslySetInnerHTML: {
-            __html: value.current
+            __html: variableValue || value.current
         },
         ref: inputRef,
         ...options

--- a/packages/app-page-builder/src/editor/plugins/elements/image/ImageContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/ImageContainer.tsx
@@ -11,6 +11,7 @@ import {
 import { uiAtom } from "~/editor/recoil/modules";
 import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { UpdateElementActionEvent } from "~/editor/recoil/actions";
+import { makeComposable } from "@webiny/react-composition";
 
 const AlignImage = styled("div")((props: any) => ({
     img: {
@@ -87,4 +88,9 @@ const ImageContainer: React.FC<ImageContainerType> = ({ element }) => {
     );
 };
 
-export default React.memo(ImageContainer);
+export default makeComposable(
+    "ImageContainer",
+    React.memo(({ element }: { element: PbEditorElement }) => {
+        return <ImageContainer element={element} />;
+    })
+);

--- a/packages/app-page-builder/src/editor/plugins/elements/imagesList/ImagesList.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/imagesList/ImagesList.tsx
@@ -1,18 +1,15 @@
 import * as React from "react";
 import { usePageBuilder } from "~/hooks/usePageBuilder";
 import { plugins } from "@webiny/plugins";
-import { PbPageElementImagesListComponentPlugin } from "~/types";
-import { Image } from "react-images";
+import { PbEditorElement, PbPageElementImagesListComponentPlugin } from "~/types";
+import { makeComposable } from "@webiny/react-composition";
 
 interface ImagesListProps {
-    data: {
-        component: string;
-        images: Image[];
-    };
+    element: PbEditorElement;
 }
-const ImagesList: React.FC<ImagesListProps> = ({ data }) => {
+const ImagesList: React.FC<ImagesListProps> = ({ element }) => {
     const { theme } = usePageBuilder();
-    const { component, images } = data;
+    const { component, images } = element.data;
     const components = plugins.byType<PbPageElementImagesListComponentPlugin>(
         "pb-page-element-images-list-component"
     );
@@ -30,4 +27,9 @@ const ImagesList: React.FC<ImagesListProps> = ({ data }) => {
     return <ListComponent data={images} theme={theme} />;
 };
 
-export default React.memo(ImagesList);
+export default makeComposable(
+    "ImagesList",
+    React.memo(({ element }: { element: PbEditorElement }) => {
+        return <ImagesList element={element} />;
+    })
+);

--- a/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/imagesList/index.tsx
@@ -76,8 +76,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
                 return typeof args.create === "function" ? args.create(defaultValue) : defaultValue;
             },
             render({ element }) {
-                // TODO @ts-refactor
-                return <ImagesList data={element.data as any} />;
+                return <ImagesList element={element} />;
             }
         } as PbEditorPageElementPlugin,
         {

--- a/packages/app-page-builder/src/pageEditor/config/PageEditorConfig.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/PageEditorConfig.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { EventActionPlugins, EventActionHandlerPlugin } from "./eventActions";
+import { ImageContainerPlugin, ImagesListPlugin } from "./elements";
 import { EditorBarPlugins } from "./editorBar";
 import { BlockEditingPlugin } from "./blockEditing";
 import { BlockElementPlugin } from "./BlockElementPlugin";
@@ -16,6 +17,8 @@ export const PageEditorConfig = React.memo(() => {
             <BlockElementPlugin />
             <BlockElementSidebarPlugin />
             <ElementSettingsTabContentPlugin />
+            <ImageContainerPlugin />
+            <ImagesListPlugin />
         </>
     );
 });

--- a/packages/app-page-builder/src/pageEditor/config/elements/ImageContainerPlugin.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/elements/ImageContainerPlugin.tsx
@@ -1,0 +1,29 @@
+import React, { useMemo } from "react";
+import { ImageContainer } from "~/editor";
+import { createComponentPlugin } from "@webiny/app-admin";
+import { useElementVariableValue } from "~/editor/hooks/useElementVariableValue";
+
+export const ImageContainerPlugin = createComponentPlugin(
+    ImageContainer,
+    ImageContainerComponent => {
+        return function ImageContainerWithVariables({ element }) {
+            const variableValue = useElementVariableValue(element);
+
+            const elementWithVariable = useMemo(() => {
+                if (variableValue) {
+                    return {
+                        ...element,
+                        data: {
+                            ...element.data,
+                            image: { ...element.data.image, file: variableValue }
+                        }
+                    };
+                }
+
+                return element;
+            }, [element, variableValue]);
+
+            return <ImageContainerComponent element={elementWithVariable} />;
+        };
+    }
+);

--- a/packages/app-page-builder/src/pageEditor/config/elements/ImagesListPlugin.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/elements/ImagesListPlugin.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from "react";
+import { ImagesList } from "~/editor";
+import { createComponentPlugin } from "@webiny/app-admin";
+import { useElementVariableValue } from "~/editor/hooks/useElementVariableValue";
+
+export const ImagesListPlugin = createComponentPlugin(ImagesList, ImagesListComponent => {
+    return function ImageListWithVariables({ element }) {
+        const variableValue = useElementVariableValue(element);
+
+        const elementWithVariable = useMemo(() => {
+            if (variableValue) {
+                return {
+                    ...element,
+                    data: {
+                        ...element.data,
+                        images: variableValue
+                    }
+                };
+            }
+
+            return element;
+        }, [element, variableValue]);
+
+        return <ImagesListComponent element={elementWithVariable} />;
+    };
+});

--- a/packages/app-page-builder/src/pageEditor/config/elements/index.ts
+++ b/packages/app-page-builder/src/pageEditor/config/elements/index.ts
@@ -1,0 +1,2 @@
+export { ImageContainerPlugin } from "./ImageContainerPlugin";
+export { ImagesListPlugin } from "./ImagesListPlugin";

--- a/packages/app-page-builder/src/pageEditor/plugins/blocks/emptyBlock.tsx
+++ b/packages/app-page-builder/src/pageEditor/plugins/blocks/emptyBlock.tsx
@@ -8,7 +8,7 @@ const height = 117;
 const aspectRatio = width / height;
 
 const plugin: PbEditorBlockPlugin = {
-    name: "pb-editor-empty-block",
+    name: "pb-editor-block-empty",
     type: "pb-editor-block",
     blockCategory: "general",
     title: "Empty block",

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -208,8 +208,9 @@ export interface PbElement {
 
 export interface PbBlockVariable {
     id: string;
+    type: string;
     label: string;
-    value?: string;
+    value?: any;
 }
 
 /**


### PR DESCRIPTION
## Changes
Add support of other variable types

Notes:
1) [MediumEditor](https://github.com/webiny/webiny-js/compare/page-builder-blocks-v2...page-builder-blocks-v2-variables-for-other-elements?expand=1#diff-31cbe1d931f4cbfca68a1338baf8fe2ce156bff1c43d5b224291954ff1957949) changes are due to "cached" initial state of the rich text editor (it was stored in scope on initial subscribe, and was not updated after that)
2) I have tried to use a makeComposable for image/imageList components (but I not sure if it worth it, please take a look)
3) I have added a "type" property to the variables (as different elements are storing their element value in different places). And now value is "any" (not "string")
4) I have wrapped right panel inputs with local state (otherwise, on edit in the middle of the string a cursor was jumping to the end of it... do not why, but I have not investigated it deeply)

## How Has This Been Tested?
Manual

## Documentation
None
