### PR TITLE
feat(api-mailer): add security permissions and checks

### DIFF
--- a/packages/api-mailer/__tests__/context/helpers.ts
+++ b/packages/api-mailer/__tests__/context/helpers.ts
@@ -1,13 +1,8 @@
-import { SecurityIdentity } from "@webiny/api-security/types";
 export { until } from "@webiny/project-utils/testing/helpers/until";
 export { sleep } from "@webiny/project-utils/testing/helpers/sleep";
 
 export interface PermissionsArg {
     name: string;
-    locales?: string[];
-    rwd?: string;
-    pw?: string | null;
-    own?: boolean;
 }
 
 export const identity = {
@@ -16,53 +11,13 @@ export const identity = {
     type: "admin"
 };
 
-const getSecurityIdentity = () => {
-    return identity;
-};
-
 export const createPermissions = (permissions?: PermissionsArg[]): PermissionsArg[] => {
     if (permissions) {
         return permissions;
     }
     return [
         {
-            name: "cms.settings"
-        },
-        {
-            name: "cms.contentModel",
-            rwd: "rwd"
-        },
-        {
-            name: "cms.contentModelGroup",
-            rwd: "rwd"
-        },
-        {
-            name: "cms.contentEntry",
-            rwd: "rwd",
-            pw: "rcpu"
-        },
-        {
-            name: "cms.endpoint.read"
-        },
-        {
-            name: "cms.endpoint.manage"
-        },
-        {
-            name: "cms.endpoint.preview"
-        },
-        {
-            name: "content.i18n",
-            locales: ["en-US"]
-        },
-        {
-            name: "apw.publishingWorkflows"
+            name: "mailer.settings"
         }
     ];
-};
-
-export const createIdentity = (identity?: SecurityIdentity) => {
-    if (!identity) {
-        return getSecurityIdentity();
-    }
-    return identity;
 };

--- a/packages/api-mailer/__tests__/settings.graphql.test.ts
+++ b/packages/api-mailer/__tests__/settings.graphql.test.ts
@@ -181,4 +181,36 @@ describe("Mailer Settings GraphQL", () => {
             }
         });
     });
+
+    it("should not have access to saving settings", async () => {
+        const noAccessHandler = createGraphQLHandler({
+            permissions: []
+        });
+        const [response] = await noAccessHandler.saveSettings({
+            data: {
+                host: "dummy-host.webiny",
+                user: "user",
+                password: "password",
+                from: "from@dummy-host.webiny",
+                replyTo: "replyTo@dummy-host.webiny"
+            }
+        });
+
+        expect(response).toEqual({
+            data: {
+                mailer: {
+                    saveSettings: {
+                        data: null,
+                        error: {
+                            code: "SECURITY_NOT_AUTHORIZED",
+                            data: {
+                                reason: "Not allowed to update the mailer settings."
+                            },
+                            message: "Not authorized!"
+                        }
+                    }
+                }
+            }
+        });
+    });
 });

--- a/packages/app-mailer/src/plugins/Module.tsx
+++ b/packages/app-mailer/src/plugins/Module.tsx
@@ -35,22 +35,20 @@ export const Module: React.FC = () => {
                     />
                 </Menu>
             </Menu>
-            {
-                <AddRoute
-                    exact
-                    path={"/mailer/settings"}
-                    render={() => (
-                        <SecureRoute permission={"mailer.settings"}>
-                            <AdminLayout>
-                                <Helmet title={"Mailer - Settings"} />
-                                <Loader>
-                                    <Settings />
-                                </Loader>
-                            </AdminLayout>
-                        </SecureRoute>
-                    )}
-                />
-            }
+            <AddRoute
+                exact
+                path={"/mailer/settings"}
+                render={() => (
+                    <SecureRoute permission={"mailer.settings"}>
+                        <AdminLayout>
+                            <Helmet title={"Mailer - Settings"} />
+                            <Loader>
+                                <Settings />
+                            </Loader>
+                        </AdminLayout>
+                    </SecureRoute>
+                )}
+            />
         </>
     );
 };

--- a/packages/cwp-template-aws/template/common/types/env/index.d.ts
+++ b/packages/cwp-template-aws/template/common/types/env/index.d.ts
@@ -45,5 +45,13 @@ declare namespace NodeJS {
         APW_SCHEDULER_SCHEDULE_ACTION_HANDLER?: string;
         ELASTIC_SEARCH_ENDPOINT?: string;
         EVENT_BUS?: string;
+        /**
+         * api-mailer
+         */
+        WEBINY_MAILER_HOST?: string;
+        WEBINY_MAILER_USER?: string;
+        WEBINY_MAILER_PASSWORD?: string;
+        WEBINY_MAILER_REPLY_TO?: string;
+        WEBINY_MAILER_FROM?: string;
     }
 }

--- a/typings/env/index.d.ts
+++ b/typings/env/index.d.ts
@@ -47,5 +47,13 @@ declare namespace NodeJS {
         STAGED_ROLLOUTS_VARIANT?: string;
         ELASTIC_SEARCH_ENDPOINT?: string;
         EVENT_BUS?: string;
+        /**
+         * api-mailer
+         */
+        WEBINY_MAILER_HOST?: string;
+        WEBINY_MAILER_USER?: string;
+        WEBINY_MAILER_PASSWORD?: string;
+        WEBINY_MAILER_REPLY_TO?: string;
+        WEBINY_MAILER_FROM?: string;
     }
 }


### PR DESCRIPTION
## Changes
Add security permissions and checks to the api-mailer packages.

We need to make sure that users with no permissions for CMS can actually access mailer settings data.

## How Has This Been Tested?
Jest.