### PR TITLE
fix: fix pasting into paragraph/text editor component

### DIFF
--- a/packages/app-page-builder/src/editor/components/Text/PbText.tsx
+++ b/packages/app-page-builder/src/editor/components/Text/PbText.tsx
@@ -59,7 +59,10 @@ const PbText: React.FC<TextElementProps> = ({ elementId, mediumEditorOptions, ro
         return null;
     }
 
-    const textContent = variableValue || get(element, `${DATA_NAMESPACE}.data.text`);
+    // only used to set initial value, so no reason to update it every time
+    const textContent = useMemo(() => {
+        return variableValue || get(element, `${DATA_NAMESPACE}.data.text`);
+    }, []);
     const tag = get(value, "tag");
     const typography = get(value, "typography");
 

--- a/packages/app-page-builder/src/editor/components/Text/PbText.tsx
+++ b/packages/app-page-builder/src/editor/components/Text/PbText.tsx
@@ -38,6 +38,11 @@ const PbText: React.FC<TextElementProps> = ({ elementId, mediumEditorOptions, ro
         [displayMode]
     );
 
+    const initialText = useMemo(
+        () => variableValue || get(element, `${DATA_NAMESPACE}.data.text`),
+        []
+    );
+
     const value = get(element, `${DATA_NAMESPACE}.${displayMode}`, fallbackValue);
 
     const onChange = useCallback(
@@ -59,10 +64,6 @@ const PbText: React.FC<TextElementProps> = ({ elementId, mediumEditorOptions, ro
         return null;
     }
 
-    // only used to set initial value, so no reason to update it every time
-    const textContent = useMemo(() => {
-        return variableValue || get(element, `${DATA_NAMESPACE}.data.text`);
-    }, []);
     const tag = get(value, "tag");
     const typography = get(value, "typography");
 
@@ -74,7 +75,7 @@ const PbText: React.FC<TextElementProps> = ({ elementId, mediumEditorOptions, ro
             <ReactMediumEditor
                 elementId={elementId}
                 tag={tag}
-                value={textContent}
+                value={initialText}
                 onChange={onChange}
                 options={mediumEditorOptions}
                 onSelect={onSelect}


### PR DESCRIPTION
## Changes
Fix "Pasting function pastes text at the beginning of the paragraph instead of new row" bug.
Closes #2346

## How Has This Been Tested?
Manual

## Documentation
None
