### PR TITLE
fix: fix breaking page rendering if main menu absent

### DIFF
--- a/apps/theme/pageBuilder/components/Menu.tsx
+++ b/apps/theme/pageBuilder/components/Menu.tsx
@@ -19,7 +19,7 @@ declare global {
 export const hasMenuItems = (data: GetPublishMenuQueryResponse): boolean => {
     return Boolean(
         data &&
-            Array.isArray(data.pageBuilder.getPublicMenu.data.items) &&
+            Array.isArray(data.pageBuilder.getPublicMenu.data?.items) &&
             data.pageBuilder.getPublicMenu.data.items.length
     );
 };

--- a/packages/cwp-template-aws/template/common/apps/theme/pageBuilder/components/Menu.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/pageBuilder/components/Menu.tsx
@@ -19,7 +19,7 @@ declare global {
 export const hasMenuItems = (data: GetPublishMenuQueryResponse): boolean => {
     return Boolean(
         data &&
-            Array.isArray(data.pageBuilder.getPublicMenu.data.items) &&
+            Array.isArray(data.pageBuilder.getPublicMenu.data?.items) &&
             data.pageBuilder.getPublicMenu.data.items.length
     );
 };


### PR DESCRIPTION
## Changes
Fix issue "Default Page Builder theme breaks page rendering if main menu is not present"
Closes #2579

## How Has This Been Tested?
Manual

## Documentation
None