### PR TITLE
fix: remove padding from selected grid cells

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elements/block/Block.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/block/Block.tsx
@@ -8,7 +8,6 @@ import { ElementRoot } from "~/render/components/ElementRoot";
 const BlockStyle = styled("div")({
     position: "relative",
     color: "#666",
-    padding: 5,
     boxSizing: "border-box"
 });
 interface BlockType {

--- a/packages/app-page-builder/src/editor/plugins/elements/grid/GridContainer.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/grid/GridContainer.tsx
@@ -11,7 +11,6 @@ import { elementWithChildrenByIdSelector, uiAtom } from "~/editor/recoil/modules
 const GridContainerStyle = styled("div")({
     position: "relative",
     color: "#666",
-    padding: 5,
     boxSizing: "border-box",
     display: "flex"
 });


### PR DESCRIPTION
## Changes
Fix issue "Let’s remove the padding the element selector adds".
Closes #2696

## How Has This Been Tested?
Manual

## Documentation
None
