### PR TITLE
fix: fix missing error message when deleting a Page Category that already has pages

### DIFF
--- a/packages/app-page-builder/src/admin/views/Categories/CategoriesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/Categories/CategoriesDataList.tsx
@@ -107,7 +107,7 @@ const PageBuilderCategoriesDataList = ({ canCreate }: PageBuilderCategoriesDataL
                     variables: item
                 });
 
-                const error = response?.data?.pageBuilder?.deletePageBuilderCategory?.error;
+                const error = response?.data?.pageBuilder?.deleteCategory?.error;
                 if (error) {
                     return showSnackbar(error.message);
                 }


### PR DESCRIPTION
## Changes
Fix issue "No Error Message When Deleting a Page Category That Already Has Pages"

## How Has This Been Tested?
Manual

## Documentation
None