### PR TITLE
fix: fix long page title bleeds into control options

### DIFF
--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/Header.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/Header.tsx
@@ -1,32 +1,32 @@
 import React from "react";
-import { css } from "emotion";
+import styled from "@emotion/styled";
 import { renderPlugins } from "@webiny/app/plugins";
 import { Typography } from "@webiny/ui/Typography";
-import { Grid, Cell } from "@webiny/ui/Grid";
 import { PbPageData } from "~/types";
 
-const headerTitle = css({
-    "&.mdc-layout-grid": {
-        borderBottom: "1px solid var(--mdc-theme-on-background)",
-        color: "var(--mdc-theme-text-primary-on-background)",
-        background: "var(--mdc-theme-surface)",
-        paddingTop: 10,
-        paddingBottom: 9,
-        ".mdc-layout-grid__inner": {
-            alignItems: "center"
-        }
-    }
+const HeaderTitle = styled("div")({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderBottom: "1px solid var(--mdc-theme-on-background)",
+    color: "var(--mdc-theme-text-primary-on-background)",
+    background: "var(--mdc-theme-surface)",
+    paddingTop: 10,
+    paddingBottom: 9,
+    paddingLeft: 24,
+    paddingRight: 24
 });
 
-const pageTitle = css({
+const PageTitle = styled("div")({
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis"
 });
 
-const headerActions = css({
+const HeaderActions = styled("div")({
     justifyContent: "flex-end",
     marginRight: "-15px",
+    marginLeft: "10px",
     display: "flex",
     alignItems: "center"
 });
@@ -38,15 +38,15 @@ const Header: React.FC<HeaderProps> = props => {
     const { page } = props;
     return (
         <React.Fragment>
-            <Grid className={headerTitle}>
-                <Cell span={8} className={pageTitle}>
+            <HeaderTitle>
+                <PageTitle>
                     <Typography use="headline5">{page.title}</Typography>
-                </Cell>
-                <Cell span={4} className={headerActions}>
+                </PageTitle>
+                <HeaderActions>
                     {renderPlugins("pb-page-details-header-left", props)}
                     {renderPlugins("pb-page-details-header-right", props)}
-                </Cell>
-            </Grid>
+                </HeaderActions>
+            </HeaderTitle>
         </React.Fragment>
     );
 };

--- a/packages/app-page-builder/src/pageEditor/config/editorBar/Title/Styled.ts
+++ b/packages/app-page-builder/src/pageEditor/config/editorBar/Title/Styled.ts
@@ -40,7 +40,7 @@ export const PageTitle = styled("div")({
 });
 
 export const pageTitleWrapper = css({
-    maxWidth: "calc(100% - 50px)"
+    maxWidth: "calc(100% - 100px)"
 });
 
 export const PageVersion = styled("span")({


### PR DESCRIPTION
## Changes
Fix issue "UI issue - Page title bleeds into control options".
Also fixes same issue on Block Editor page:
![image](https://user-images.githubusercontent.com/77202393/200016641-b4dac816-d0c6-4a52-8da5-e93278a5002d.png)


Closes #2362

## How Has This Been Tested?
Manual

## Documentation
None
