### PR TITLE
fix: fix corrupted undo state after deleting a block

### DIFF
--- a/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EventActionHandlerProvider.tsx
@@ -43,7 +43,7 @@ import {
     GetElementTreeProps
 } from "~/types";
 import { composeAsync, composeSync, AsyncProcessor, SyncProcessor } from "@webiny/utils/compose";
-import { UpdateElementTreeActionEvent } from "~/editor/recoil/actions";
+import { UpdateElementTreeActionEvent, UpdateDocumentActionEvent } from "~/editor/recoil/actions";
 
 type ListType = Map<symbol, EventActionCallable>;
 type RegistryType = Map<string, ListType>;
@@ -147,6 +147,14 @@ export const EventActionHandlerProvider = makeComposable<
     const updateElementTree = () => {
         setTimeout(() => {
             eventActionHandlerRef.current!.trigger(new UpdateElementTreeActionEvent());
+        }, 200);
+    };
+
+    const updateDocument = () => {
+        setTimeout(() => {
+            eventActionHandlerRef.current!.trigger(
+                new UpdateDocumentActionEvent({ history: false, debounce: true })
+            );
         }, 200);
     };
 
@@ -375,6 +383,7 @@ export const EventActionHandlerProvider = makeComposable<
                 goToSnapshot(previousSnapshot);
                 snapshotsHistory.current.busy = false;
                 updateElementTree();
+                updateDocument();
             },
             redo: () => {
                 if (snapshotsHistory.current.busy === true) {
@@ -394,6 +403,7 @@ export const EventActionHandlerProvider = makeComposable<
                 goToSnapshot(nextSnapshot);
                 snapshotsHistory.current.busy = false;
                 updateElementTree();
+                updateDocument();
             },
             startBatch: () => {
                 snapshotsHistory.current.isBatching = true;

--- a/packages/app-page-builder/src/editor/plugins/toolbar/undoRedo/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/undoRedo/index.tsx
@@ -6,7 +6,6 @@ import { PbEditorToolbarBottomPlugin } from "~/types";
 import Action from "../Action";
 import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { useActiveElement } from "~/editor/hooks/useActiveElement";
-import { UpdateDocumentActionEvent } from "~/editor/recoil/actions";
 
 const osFamily = platform.os ? platform.os.family : null;
 const metaKey = osFamily === "OS X" ? "CMD" : "CTRL";
@@ -15,13 +14,12 @@ export const undo: PbEditorToolbarBottomPlugin = {
     name: "pb-editor-toolbar-undo",
     type: "pb-editor-toolbar-bottom",
     renderAction() {
-        const { undo, trigger } = useEventActionHandler();
+        const { undo } = useEventActionHandler();
         const [, setActiveElement] = useActiveElement();
 
-        const onClick = async () => {
+        const onClick = () => {
             undo();
             setActiveElement(null);
-            await trigger(new UpdateDocumentActionEvent({ history: false, debounce: true }));
         };
         return (
             <Action
@@ -38,13 +36,12 @@ export const redo: PbEditorToolbarBottomPlugin = {
     name: "pb-editor-toolbar-redo",
     type: "pb-editor-toolbar-bottom",
     renderAction() {
-        const { redo, trigger } = useEventActionHandler();
+        const { redo } = useEventActionHandler();
         const [, setActiveElement] = useActiveElement();
 
-        const onClick = async () => {
+        const onClick = () => {
             setActiveElement(null);
             redo();
-            await trigger(new UpdateDocumentActionEvent({ history: false, debounce: true }));
         };
 
         return (


### PR DESCRIPTION
## Changes
Fix issue "The undo state gets corrupted when deleting a block"

## How Has This Been Tested?
Manual

## Documentation
None
