### PR TITLE
fix: do not allow to change content model registered by plugin on content entries page

### DIFF
--- a/packages/app-headless-cms/src/admin/graphql/contentModels.ts
+++ b/packages/app-headless-cms/src/admin/graphql/contentModels.ts
@@ -54,6 +54,7 @@ export const MODEL_FIELDS = `
     fields {
         ${FIELDS_FIELDS}
     }
+    plugin
 `;
 /**
  * ############################

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
@@ -58,6 +58,11 @@ const listItemMinHeight = css({
     minHeight: "66px !important"
 });
 
+const disabled = css({
+    color: "rgba(0, 0, 0, 0.54)",
+    cursor: "default"
+});
+
 const ContentEntriesList: React.FC = () => {
     const {
         contentModel,
@@ -158,7 +163,9 @@ const ContentEntriesList: React.FC = () => {
                                     content={t`Content model is registered via a plugin.`}
                                     placement={"top"}
                                 >
-                                    {contentModel.modelId}
+                                    <Link to="#" className={disabled}>
+                                        {contentModel.modelId}
+                                    </Link>
                                 </Tooltip>
                             ) : (
                                 <Tooltip content={t`Edit content model`} placement={"top"}>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
@@ -16,6 +16,7 @@ import { ButtonIcon, ButtonSecondary } from "@webiny/ui/Button";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Scrollbar } from "@webiny/ui/Scrollbar";
 import { Select } from "@webiny/ui/Select";
+import { Tooltip } from "@webiny/ui/Tooltip";
 import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18px.svg";
 import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/filter-24px.svg";
 import SearchUI from "@webiny/app-admin/components/SearchUI";
@@ -152,9 +153,20 @@ const ContentEntriesList: React.FC = () => {
                     <Typography use={"subtitle1"}>
                         <ModelId>
                             Model ID:{" "}
-                            <Link to={`/cms/content-models/${contentModel.modelId}`}>
-                                {contentModel.modelId}
-                            </Link>
+                            {contentModel.plugin ? (
+                                <Tooltip
+                                    content={t`Content model is registered via a plugin.`}
+                                    placement={"top"}
+                                >
+                                    {contentModel.modelId}
+                                </Tooltip>
+                            ) : (
+                                <Tooltip content={t`Edit content model`} placement={"top"}>
+                                    <Link to={`/cms/content-models/${contentModel.modelId}`}>
+                                        {contentModel.modelId}
+                                    </Link>
+                                </Tooltip>
+                            )}
                         </ModelId>
                     </Typography>
                 </span>


### PR DESCRIPTION
## Changes
Make sure you cannot edit a content model registered via plugin on the content entries page.
Closes #2704 

## How Has This Been Tested?
Manual check

<img width="353" alt="Schermafbeelding 2022-11-11 om 14 36 08" src="https://user-images.githubusercontent.com/53557527/201352189-b8207585-dd2c-4078-9a36-21fc618f2f86.png">

