### PR TITLE
fix(handler-aws): add default content type and encoding

### DIFF
--- a/packages/handler-aws/src/gateway/index.ts
+++ b/packages/handler-aws/src/gateway/index.ts
@@ -40,17 +40,23 @@ const defaultCharset = "utf-8";
  * We need to attach default headers to the request, so it does not break if there is none sent.
  */
 const attachRequiredProperties = (event: APIGatewayEvent): void => {
+    /**
+     * A possibility that headers are not defined?
+     * Maybe during testing?
+     */
     if (!event.headers) {
         event.headers = {};
     }
     const contentType = getHeader(event.headers, "content-type");
+    /**
+     * We check the existing content type and add the default one if it does not exist.
+     *
+     * Also, if the content-type is the application/json, and the body is not sent, we add it.
+     */
     if (!contentType) {
         event.headers["content-type"] = [defaultContentType, `charset=${defaultCharset}`].join(";");
-    }
-    /**
-     * If the content type is
-     */
-    if (!event.body && event.headers["content-type"]!.startsWith(defaultContentType)) {
+        event.body = "{}";
+    } else if (!event.body && contentType.startsWith(defaultContentType)) {
         event.body = "{}";
     }
 };


### PR DESCRIPTION
## Changes
When using a GraphQL client, and it does not send the content type and/or charset automatically, we now set the defaults onto the request.

Default content type headers are: `application/json; charset=utf-8`

## How Has This Been Tested?
Jest.