### PR TITLE
feat(app-headless-cms): edit entry with entryId

### DIFF
--- a/packages/app-headless-cms/src/admin/graphql/contentEntries.ts
+++ b/packages/app-headless-cms/src/admin/graphql/contentEntries.ts
@@ -37,15 +37,18 @@ export interface CmsEntryGetQueryResponse {
 }
 
 export interface CmsEntryGetQueryVariables {
-    revision: string;
+    revision?: string;
+    entryId?: string;
 }
 
 export const createReadQuery = (model: CmsEditorContentModel) => {
     const ucFirstModelId = upperFirst(model.modelId);
-
+    /**
+     * This query now accepts both revision or entryId as we can load exact revision or latest (if entryId was sent).
+     */
     return gql`
-        query CmsEntriesGet${ucFirstModelId}($revision: ID!) {
-            content: get${ucFirstModelId}(revision: $revision) {
+        query CmsEntriesGet${ucFirstModelId}($revision: ID, $entryId: ID) {
+            content: get${ucFirstModelId}(revision: $revision, entryId: $entryId) {
                 data {
                     id
                     createdBy {

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -101,9 +101,11 @@ export const Provider: React.FC<ContentEntryContextProviderProps> = ({
 
     const revisionId = contentId ? decodeURIComponent(contentId) : null;
     let entryId: string | null = null;
+    let version: number | null = null;
     if (revisionId) {
         const result = parseIdentifier(revisionId);
-        entryId = result ? result.id : null;
+        entryId = result.id;
+        version = result.version;
     }
 
     const tabsRef = useRef<TabsImperativeApi>();
@@ -131,10 +133,19 @@ export const Provider: React.FC<ContentEntryContextProviderProps> = ({
         history.push(`/cms/content-entries/${contentModel.modelId}?new=true`);
     }, [contentModel.modelId]);
 
+    let variables: CmsEntryGetQueryVariables | undefined = undefined;
+    if (version === null && entryId) {
+        variables = {
+            entryId
+        };
+    } else {
+        variables = {
+            revision: revisionId as string
+        };
+    }
+
     const getEntry = useQuery<CmsEntryGetQueryResponse, CmsEntryGetQueryVariables>(READ_CONTENT, {
-        variables: {
-            revision: revisionId || ""
-        },
+        variables,
         skip: !revisionId,
         onCompleted: data => {
             if (!data) {


### PR DESCRIPTION
## Changes
A possibility to edit CMS entry in Admin UI, just by sending the entryId, without the version. In that case, latest version is loaded.

## How Has This Been Tested?
Manually and jest.