### PR TITLE
Ensure VPC Is Used for Production Environments (API Project Application)

### DIFF
--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -47,6 +47,8 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 });
             }
 
+            const prod = app.params.run.env === "prod";
+
             // Enables logs forwarding.
             // https://www.webiny.com/docs/how-to-guides/use-watch-command#enabling-logs-forwarding
             const WEBINY_LOGS_FORWARD_URL = String(process.env.WEBINY_LOGS_FORWARD_URL);
@@ -54,10 +56,9 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
             // Register core output as a module available to all the other modules
             const core = app.addModule(CoreOutput);
 
-            // Register VPC config module to be available to other modules
-            app.addModule(VpcConfig, {
-                enabled: app.getParam(projectAppParams.vpc)
-            });
+            // Register VPC config module to be available to other modules.
+            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? prod;
+            app.addModule(VpcConfig, { enabled: vpcEnabled });
 
             const pageBuilder = app.addModule(ApiPageBuilder, {
                 env: {

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -49,13 +49,14 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 });
             }
 
+            const prod = app.params.run.env === "prod";
+
             // Register core output as a module available for all other modules
             const core = app.addModule(CoreOutput);
 
-            // Register VPC config module to be available to other modules
-            app.addModule(VpcConfig, {
-                enabled: app.getParam(projectAppParams.vpc)
-            });
+            // Register VPC config module to be available to other modules.
+            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? prod;
+            app.addModule(VpcConfig, { enabled: vpcEnabled });
 
             const appBucket = createPrivateAppBucket(app, "app");
 


### PR DESCRIPTION
## Changes
When deploying `apps/api` into the production environment (`--env prod`), AWS Lambda functions should be deployed into a VPC that was deployed as part of the `apps/core` deployment. But, at the moment, this is not the case, because of an incorrect if statement in the Pulumi code (check changes).

This PR addresses this issue.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.