### PR TITLE
Disable ripple effect and minor UI optimizations

### DIFF
--- a/packages/app-admin-rmwc/package.json
+++ b/packages/app-admin-rmwc/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.5.5",
     "@emotion/styled": "^10.0.27",
     "@rmwc/base": "7.0.3",
+    "@rmwc/provider": "7.0.3",
     "@types/react": "17.0.39",
     "@webiny/app": "^5.33.2",
     "@webiny/app-admin": "^5.33.2",

--- a/packages/app-admin-rmwc/src/index.tsx
+++ b/packages/app-admin-rmwc/src/index.tsx
@@ -1,4 +1,6 @@
 import React, { Fragment } from "react";
+import { createProviderPlugin } from "@webiny/app-admin";
+import { RMWCProvider } from "@rmwc/provider";
 
 import { Layout } from "./modules/Layout";
 import { Navigation } from "./modules/Navigation";
@@ -9,9 +11,20 @@ import { Overlays } from "./modules/Overlays";
 import { NotFound } from "./modules/NotFound";
 import { Dashboard } from "./modules/Dashboard";
 
+const RMWCProviderPlugin = createProviderPlugin(Component => {
+    return function RMWCThemeProvider({ children }) {
+        return (
+            <RMWCProvider ripple={false}>
+                <Component>{children}</Component>
+            </RMWCProvider>
+        );
+    };
+});
+
 export const RMWC: React.FC = () => {
     return (
         <Fragment>
+            <RMWCProviderPlugin />
             <Layout />
             <Dashboard />
             <NotFound />

--- a/packages/app-form-builder/src/admin/plugins/editor/defaultBar/Name/Name.tsx
+++ b/packages/app-form-builder/src/admin/plugins/editor/defaultBar/Name/Name.tsx
@@ -27,7 +27,7 @@ declare global {
 
 export const Name: React.FC = () => {
     const { state, setData } = useFormEditor();
-    const [localName, setLocalName] = useState<string | null>(null);
+    const [localName, setLocalName] = useState("");
     const [editingEnabled, setEditing] = useState<boolean>(false);
 
     const cancelChanges = useCallback(() => {

--- a/packages/ui/src/Accordion/Accordion.tsx
+++ b/packages/ui/src/Accordion/Accordion.tsx
@@ -9,7 +9,10 @@ export interface AccordionProps {
     /**
      * Element displayed when accordion is expanded.
      */
-    children: React.ReactElement<typeof ListItem>[] | React.ReactElement<typeof AccordionItem>[];
+    children:
+        | React.ReactElement<typeof ListItem>[]
+        | React.ReactElement<typeof AccordionItem>
+        | React.ReactElement<typeof AccordionItem>[];
 
     /**
      * Elevation number, default set to 2

--- a/packages/ui/src/Accordion/AccordionItem.tsx
+++ b/packages/ui/src/Accordion/AccordionItem.tsx
@@ -19,9 +19,10 @@ const Content = styled("div")({
 });
 
 const listItem = css({
-    padding: "15px 20px",
+    padding: "0 16px",
     cursor: "pointer",
     borderBottom: "1px solid var(--mdc-theme-background)",
+    height: 48,
     "&:last-child": {
         borderBottom: "none"
     },
@@ -64,20 +65,20 @@ const transitionStyles = {
     entering: {
         opacity: 0,
         height: 0,
-        padding: "20px 20px 20px 65px",
+        padding: "20px",
         pointerEvents: "auto" as any,
         overflow: "initial"
     },
     entered: {
         opacity: 1,
         height: "auto",
-        padding: "20px 20px 20px 65px",
+        padding: "20px",
         pointerEvents: "auto" as any,
         overflow: "initial"
     },
     exiting: {
         height: "auto",
-        padding: "20px 20px 20px 65px",
+        padding: "20px",
         pointerEvents: "auto" as any,
         overflow: "initial"
     }

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -35,7 +35,7 @@ export interface ButtonProps {
  * Shows a default button, used typically when action is not of high priority.
  */
 export const ButtonDefault: React.FC<ButtonProps> = props => {
-    const { disabled, onClick, children, small, ripple = true, className = "", style } = props;
+    const { disabled, onClick, children, small, ripple, className = "", style } = props;
 
     return (
         <RmwcButton.Button
@@ -62,7 +62,7 @@ export const ButtonPrimary: React.FC<ButtonProps> = props => {
         children,
         small = false,
         flat = false,
-        ripple = true,
+        ripple,
         style = {},
         className = null
     } = props;
@@ -92,7 +92,7 @@ export const ButtonSecondary: React.FC<ButtonProps> = props => {
         onClick,
         children,
         small = false,
-        ripple = true,
+        ripple,
         className = null,
         style = {}
     } = props;
@@ -135,7 +135,7 @@ export const ButtonFloating: React.FC<ButtonFloatingProps> = props => {
         onClick,
         small = false,
         label = null,
-        ripple = true,
+        ripple,
         className = null,
         ...rest
     } = props;

--- a/packages/ui/src/Button/IconButton/IconButton.tsx
+++ b/packages/ui/src/Button/IconButton/IconButton.tsx
@@ -44,7 +44,7 @@ export interface IconButtonProps extends Omit<FormComponentProps, "onChange">, R
  * Shows the icon button.
  */
 const IconButton: React.FC<IconButtonProps> = props => {
-    const { id, icon, label, onClick, className, disabled, ripple = true } = props;
+    const { id, icon, label, onClick, className, disabled, ripple } = props;
 
     return (
         <RIconButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -7277,7 +7277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rmwc/provider@npm:^7.0.3":
+"@rmwc/provider@npm:7.0.3, @rmwc/provider@npm:^7.0.3":
   version: 7.0.3
   resolution: "@rmwc/provider@npm:7.0.3"
   dependencies:
@@ -11389,6 +11389,7 @@ __metadata:
     "@babel/runtime": ^7.5.5
     "@emotion/styled": ^10.0.27
     "@rmwc/base": 7.0.3
+    "@rmwc/provider": 7.0.3
     "@types/react": 17.0.39
     "@types/react-helmet": ^6.1.5
     "@webiny/app": ^5.33.2


### PR DESCRIPTION
## Changes
This PR disables the Material Design ripple effect globally. Other minor improvements include:
- Input component is refactored from class component to a functional component with better callback memoizations
- AccordionItem height is enforced in both local development and production builds
- Accordion now allows a single AccordionItem as a child
- ripple prop no longer has a default `true` value in individual UI components

## How Has This Been Tested?
Manually
