### PR TITLE
fix(api-headless-cms): report invalid part of the schema

### DIFF
--- a/packages/api-headless-cms/package.json
+++ b/packages/api-headless-cms/package.json
@@ -37,6 +37,7 @@
     "@webiny/pubsub": "^5.33.2",
     "@webiny/utils": "^5.33.2",
     "@webiny/validation": "^5.33.2",
+    "code-frame": "^5.0.0",
     "commodo-fields-object": "^1.0.6",
     "dataloader": "^2.0.0",
     "dot-prop": "^6.0.1",

--- a/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
@@ -10,6 +10,9 @@ import { buildSchemaPlugins } from "./buildSchemaPlugins";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins";
 import { GraphQLRequestBody } from "@webiny/handler-graphql/types";
 import { RoutePlugin } from "@webiny/handler";
+import WebinyError from "@webiny/error";
+// @ts-ignore `code-frame` has no types
+import codeFrame from "code-frame";
 
 interface SchemaCache {
     key: string;
@@ -64,13 +67,27 @@ const getSchema = async (params: GetSchemaParams): Promise<GraphQLSchema> => {
 
     const cacheKey = await generateCacheKey(params);
     if (!schemaList.has(id)) {
-        const schema = await generateSchema(params);
+        try {
+            const schema = await generateSchema(params);
+            schemaList.set(id, {
+                key: cacheKey,
+                schema
+            });
+            return schema;
+        } catch (err) {
+            const [location] = err.locations;
+            const invalidSegment = codeFrame(err.source.body, location.line, location.column, {
+                frameSize: 15
+            });
 
-        schemaList.set(id, {
-            key: cacheKey,
-            schema
-        });
-        return schema;
+            throw new WebinyError({
+                code: "INVALID_GRAPHQL_SCHEMA",
+                message: err.message,
+                data: {
+                    invalidSegment
+                }
+            });
+        }
     }
     /**
      * Safe to cast because check was done few lines up.
@@ -118,14 +135,29 @@ const cmsRoutes = new RoutePlugin<CmsContext>(({ onPost, onOptions, context }) =
             });
         }
 
-        const schema = await getSchema({
-            context,
-            locale: context.cms.getLocale(),
-            type: context.cms.type as ApiEndpoint
-        });
-        const body: GraphQLRequestBody | GraphQLRequestBody[] = request.body as any;
-        const result = await processRequestBody(body, schema, context);
-        return reply.code(200).send(result);
+        try {
+            const schema = await getSchema({
+                context,
+                locale: context.cms.getLocale(),
+                type: context.cms.type as ApiEndpoint
+            });
+            const body: GraphQLRequestBody | GraphQLRequestBody[] = request.body as any;
+            const result = await processRequestBody(body, schema, context);
+            return reply.code(200).send(result);
+        } catch (ex) {
+            if (ex instanceof WebinyError) {
+                return reply.code(500).send({
+                    data: null,
+                    error: {
+                        message: ex.message,
+                        code: ex.code,
+                        data: ex.data
+                    }
+                });
+            }
+
+            return reply.code(500).send();
+        }
     });
 
     onOptions("/cms/:type(^manage|preview|read$)/:locale", async (_, reply) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10586,6 +10586,7 @@ __metadata:
     "@webiny/utils": ^5.33.2
     "@webiny/validation": ^5.33.2
     apollo-graphql: ^0.9.5
+    code-frame: ^5.0.0
     commodo-fields-object: ^1.0.6
     dataloader: ^2.0.0
     dot-prop: ^6.0.1
@@ -17646,6 +17647,15 @@ __metadata:
   version: 10.1.1
   resolution: "code-block-writer@npm:10.1.1"
   checksum: e048037acbcbda19fca62a3a63e4a64226ea6b5dc0fad7632d34a88c1165b29a357e5e19f0497811e9911472e824ab85f68176f40e439da87e051908956eb47c
+  languageName: node
+  linkType: hard
+
+"code-frame@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "code-frame@npm:5.0.0"
+  dependencies:
+    left-pad: ^1.1.3
+  checksum: cf47b3f1aa7b052cf0117a6ae8be3da700afb803e96c89c468006e2bf6735f3b752391a50242623f08ebd05ba21e866561164507239f9822f780c60d8a3be11d
   languageName: node
   linkType: hard
 
@@ -27536,6 +27546,13 @@ __metadata:
   dependencies:
     readable-stream: ^2.0.5
   checksum: 822c54c6b87701a6491c70d4fabc4cafcf0f87d6b656af168ee7bb3c45de9128a801cb612e6eeeefc64d298a7524a698dd49b13b0121ae50c2ae305f0dcc5310
+  languageName: node
+  linkType: hard
+
+"left-pad@npm:^1.1.3":
+  version: 1.3.0
+  resolution: "left-pad@npm:1.3.0"
+  checksum: 13fa96e17b70a54836490de22d4bab706e2ed508338bbabecfac72ecce445a74139c5b009a8112252cab8fc4ab7ac4ebd870e5b35bd236b443b12be96f8745ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR adds error handling to Headless CMS schema construction and extracts a human readable schema segment which caused the error, which is then returned as part of the 500 response.

## How Has This Been Tested?
Manually.