### PR TITLE
feat(api-elasticsearch): optimize operators

### DIFF
--- a/packages/api-elasticsearch/__tests__/plugins/operators/between.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/between.test.ts
@@ -8,6 +8,7 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
     it("should apply between correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: [100, 110],
             path: "id",
             basePath: "id",
@@ -16,7 +17,8 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -26,7 +28,6 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 
@@ -36,6 +37,7 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
     it("should apply multiple between correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: [100, 110],
             path: "id",
             basePath: "id",
@@ -46,7 +48,8 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
         const to = new Date();
         to.setTime(from.getTime() + 1000000);
         plugin.apply(query, {
-            value: [from, to],
+            name: "id",
+            value: [from.toISOString(), to.toISOString()],
             path: "date",
             basePath: "date",
             keyword: false
@@ -54,7 +57,8 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -66,13 +70,12 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
                 {
                     range: {
                         date: {
-                            lte: to as any,
-                            gte: from as any
+                            lte: to.toISOString(),
+                            gte: from.toISOString()
                         }
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);
@@ -83,6 +86,7 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
 
         expect(() => {
             plugin.apply(query, {
+                name: "id",
                 value: "notAnArray",
                 path: "id",
                 basePath: "id",
@@ -102,6 +106,7 @@ describe("ElasticsearchQueryBuilderOperatorBetweenPlugin", () => {
 
             expect(() => {
                 plugin.apply(query, {
+                    name: "id",
                     value,
                     path: "id",
                     basePath: "id",

--- a/packages/api-elasticsearch/__tests__/plugins/operators/contains.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/contains.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorContainsPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "John",
@@ -16,6 +17,7 @@ describe("ElasticsearchQueryBuilderOperatorContainsPlugin", () => {
         });
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "Doe",

--- a/packages/api-elasticsearch/__tests__/plugins/operators/equal.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/equal.test.ts
@@ -5,10 +5,11 @@ import { ElasticsearchQueryBuilderOperatorEqualPlugin } from "~/plugins/operator
 describe("ElasticsearchQueryBuilderOperatorEqualPlugin", () => {
     const plugin = new ElasticsearchQueryBuilderOperatorEqualPlugin();
 
-    it("should apply must correctly", () => {
+    it("should apply equal correctly", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             basePath: "name",
             path: "name.keyword",
             value: "John",
@@ -16,6 +17,7 @@ describe("ElasticsearchQueryBuilderOperatorEqualPlugin", () => {
         });
 
         plugin.apply(query, {
+            name: "name",
             basePath: "name",
             path: "name.keyword",
             value: "Doe",
@@ -24,7 +26,8 @@ describe("ElasticsearchQueryBuilderOperatorEqualPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     term: {
                         "name.keyword": "John"
@@ -36,7 +39,6 @@ describe("ElasticsearchQueryBuilderOperatorEqualPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 

--- a/packages/api-elasticsearch/__tests__/plugins/operators/gt.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/gt.test.ts
@@ -8,6 +8,7 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
     it("should apply gt correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
@@ -16,7 +17,8 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -25,7 +27,6 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 
@@ -35,14 +36,16 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
     it("should apply multiple gt correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
             keyword: false
         });
 
-        const from = new Date();
+        const from = new Date().toISOString();
         plugin.apply(query, {
+            name: "id",
             value: from,
             path: "date",
             basePath: "date",
@@ -51,7 +54,8 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -62,12 +66,11 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanPlugin", () => {
                 {
                     range: {
                         date: {
-                            gt: from as any
+                            gt: from
                         }
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/plugins/operators/gte.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/gte.test.ts
@@ -8,6 +8,7 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
     it("should apply gte correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
@@ -16,7 +17,8 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -25,7 +27,6 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 
@@ -35,14 +36,16 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
     it("should apply multiple gte correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
             keyword: false
         });
 
-        const from = new Date();
+        const from = new Date().toISOString();
         plugin.apply(query, {
+            name: "id",
             value: from,
             path: "date",
             basePath: "date",
@@ -51,7 +54,8 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -62,12 +66,11 @@ describe("ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin", () => {
                 {
                     range: {
                         date: {
-                            gte: from as any
+                            gte: from
                         }
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/plugins/operators/in.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/in.test.ts
@@ -5,10 +5,11 @@ import { ElasticsearchQueryBuilderOperatorInPlugin } from "~/plugins/operator";
 describe("ElasticsearchQueryBuilderOperatorInPlugin", () => {
     const plugin = new ElasticsearchQueryBuilderOperatorInPlugin();
 
-    it("should apply must in correctly", () => {
+    it(`should apply in operator`, () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "id",
             path: "name.keyword",
             basePath: "name",
             value: ["John", "Johnny"],
@@ -17,14 +18,14 @@ describe("ElasticsearchQueryBuilderOperatorInPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     terms: {
                         ["name.keyword"]: ["John", "Johnny"]
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/plugins/operators/lt.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/lt.test.ts
@@ -8,6 +8,7 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
     it("should apply lt correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
@@ -16,7 +17,8 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -25,7 +27,6 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 
@@ -35,14 +36,16 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
     it("should apply multiple lt correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
             keyword: false
         });
 
-        const to = new Date();
+        const to = new Date().toISOString();
         plugin.apply(query, {
+            name: "id",
             value: to,
             path: "date",
             basePath: "date",
@@ -51,7 +54,8 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -62,12 +66,11 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanPlugin", () => {
                 {
                     range: {
                         date: {
-                            lt: to as any
+                            lt: to
                         }
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/plugins/operators/lte.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/lte.test.ts
@@ -8,6 +8,7 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
     it("should apply lte correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
@@ -16,7 +17,8 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -25,7 +27,6 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
 
@@ -35,14 +36,16 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
     it("should apply multiple lte correctly", () => {
         const query = createBlankQuery();
         plugin.apply(query, {
+            name: "id",
             value: 100,
             path: "id",
             basePath: "id",
             keyword: false
         });
 
-        const to = new Date();
+        const to = new Date().toISOString();
         plugin.apply(query, {
+            name: "id",
             value: to,
             path: "date",
             basePath: "date",
@@ -51,7 +54,8 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     range: {
                         id: {
@@ -62,12 +66,11 @@ describe("ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin", () => {
                 {
                     range: {
                         date: {
-                            lte: to as any
+                            lte: to
                         }
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/plugins/operators/not.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/not.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorNotPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "John",

--- a/packages/api-elasticsearch/__tests__/plugins/operators/notBetween.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/notBetween.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorNotBetweenPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "id",
             path: "id",
             basePath: "id",
             value: [100, 200],

--- a/packages/api-elasticsearch/__tests__/plugins/operators/notContains.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/notContains.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorNotContainsPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "John",

--- a/packages/api-elasticsearch/__tests__/plugins/operators/notIn.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/notIn.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorNotInPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             basePath: "name",
             path: "name.keyword",
             value: ["John", "Doe", "P."],
@@ -34,13 +35,14 @@ describe("ElasticsearchQueryBuilderOperatorNotInPlugin", () => {
 
         expect(() => {
             plugin.apply(query, {
+                name: "name",
                 basePath: "name",
                 path: "name.keyword",
                 value: "somethingString",
                 keyword: true
             });
         }).toThrow(
-            `You cannot filter field path "name" with not_in and not send an array of values.`
+            `You cannot filter field "name" with "not_in" operator and not send an array of values.`
         );
     });
 
@@ -49,6 +51,7 @@ describe("ElasticsearchQueryBuilderOperatorNotInPlugin", () => {
 
         expect(() => {
             plugin.apply(query, {
+                name: "name",
                 basePath: "name",
                 path: "name.keyword",
                 value: {
@@ -57,7 +60,7 @@ describe("ElasticsearchQueryBuilderOperatorNotInPlugin", () => {
                 keyword: true
             });
         }).toThrow(
-            `You cannot filter field path "name" with not_in and not send an array of values.`
+            `You cannot filter field "name" with "not_in" operator and not send an array of values.`
         );
     });
 });

--- a/packages/api-elasticsearch/__tests__/plugins/operators/notStartsWith.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/notStartsWith.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorNotStartsWithPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "John",
@@ -16,6 +17,7 @@ describe("ElasticsearchQueryBuilderOperatorNotStartsWithPlugin", () => {
         });
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "Doe",

--- a/packages/api-elasticsearch/__tests__/plugins/operators/startsWith.test.ts
+++ b/packages/api-elasticsearch/__tests__/plugins/operators/startsWith.test.ts
@@ -9,6 +9,7 @@ describe("ElasticsearchQueryBuilderOperatorStartsWithPlugin", () => {
         const query = createBlankQuery();
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "John",
@@ -16,6 +17,7 @@ describe("ElasticsearchQueryBuilderOperatorStartsWithPlugin", () => {
         });
 
         plugin.apply(query, {
+            name: "name",
             path: "name.keyword",
             basePath: "name",
             value: "Doe",
@@ -24,7 +26,8 @@ describe("ElasticsearchQueryBuilderOperatorStartsWithPlugin", () => {
 
         const expected: ElasticsearchBoolQueryConfig = {
             must_not: [],
-            must: [
+            must: [],
+            filter: [
                 {
                     match_phrase_prefix: {
                         name: "John"
@@ -36,7 +39,6 @@ describe("ElasticsearchQueryBuilderOperatorStartsWithPlugin", () => {
                     }
                 }
             ],
-            filter: [],
             should: []
         };
         expect(query).toEqual(expected);

--- a/packages/api-elasticsearch/__tests__/search/japanese.test.ts
+++ b/packages/api-elasticsearch/__tests__/search/japanese.test.ts
@@ -236,6 +236,7 @@ describe("Japanese search", () => {
             };
 
             searchPlugin.apply(query, {
+                name: "title",
                 basePath: "title",
                 path: "title",
                 value: search,

--- a/packages/api-elasticsearch/__tests__/where.test.ts
+++ b/packages/api-elasticsearch/__tests__/where.test.ts
@@ -1,7 +1,7 @@
-import { parseWhereKey } from "~/where";
+import { parseWhereKey, ParseWhereKeyResult } from "~/where";
 
 describe("where", () => {
-    const whereKeys = [
+    const whereKeys: [string, ParseWhereKeyResult][] = [
         [
             "id",
             {
@@ -25,13 +25,16 @@ describe("where", () => {
         ]
     ];
 
-    test.each(whereKeys)("parse should result in field and operator values", (key, expected) => {
-        const result = parseWhereKey(key as unknown as string);
+    test.each(whereKeys)(
+        "parse should result in field and operator values - %s",
+        (key, expected) => {
+            const result = parseWhereKey(key as unknown as string);
 
-        expect(result).toEqual(expected);
-    });
+            expect(result).toEqual(expected);
+        }
+    );
 
-    const malformedWhereKeys = [["_a"], ["_"], ["__"], ["a_"]];
+    const malformedWhereKeys: string[][] = [["_a"], ["_"], ["__"], ["a_"]];
 
     test.each(malformedWhereKeys)(
         `should throw error when malformed key is passed "%s"`,

--- a/packages/api-elasticsearch/src/cursors.ts
+++ b/packages/api-elasticsearch/src/cursors.ts
@@ -1,3 +1,5 @@
+import { PrimitiveValue } from "~/types";
+
 /**
  * Encode a received cursor value into something that can be passed on to the user.
  */
@@ -19,14 +21,17 @@ export const encodeCursor = (cursor?: string | string[] | null): string | undefi
  * Decode a received value into a Elasticsearch cursor.
  * If no value is received or is not decodable, return undefined.
  */
-export const decodeCursor = (cursor?: string | null): string[] | string | undefined => {
+export const decodeCursor = (cursor?: string | null): PrimitiveValue[] | undefined => {
     if (!cursor) {
         return undefined;
     }
     try {
         const value = JSON.parse(Buffer.from(cursor, "base64").toString("ascii"));
-
-        return Array.isArray(value) ? value.map(decodeURIComponent) : decodeURIComponent(value);
+        if (Array.isArray(value)) {
+            return value.map(decodeURIComponent);
+        }
+        const decoded = decodeURIComponent(value);
+        return decoded ? [decoded] : undefined;
     } catch (ex) {
         console.error(ex.message);
     }

--- a/packages/api-elasticsearch/src/normalize.ts
+++ b/packages/api-elasticsearch/src/normalize.ts
@@ -3,38 +3,36 @@
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
  */
 
-const RESERVED_CHARACTERS = {
-    // These characters need to be escaped with backslash ("\").
-    escape: [
-        "\\\\",
-        "\\/",
-        "\\+",
-        "\\-",
-        "\\=",
-        "\\&\\&",
-        "\\|\\|",
-        "\\!",
-        "\\(",
-        "\\)",
-        "\\{",
-        "\\}",
-        "\\[",
-        "\\]",
-        "\\^",
-        '\\"',
-        "\\~",
-        "\\*",
-        "\\?",
-        "\\:",
-        "\\>",
-        "\\<"
-    ]
-};
+const specialCharacters = [
+    "\\+",
+    "\\-",
+    "\\=",
+    "\\&\\&",
+    "\\|\\|",
+    ">",
+    "<",
+    "\\!",
+    "\\(",
+    "\\)",
+    "\\{",
+    "\\}",
+    "\\[",
+    "\\]",
+    "\\^",
+    '\\"',
+    "\\~",
+    "\\*",
+    "\\?",
+    "\\:",
+    "\\\\",
+    "\\/",
+    "\\#"
+];
 
 export const normalizeValue = (value: string) => {
     let result = value;
-    for (const character of RESERVED_CHARACTERS.escape) {
-        result = result.replace(new RegExp(`${character}`, "g"), ` `);
+    for (const character of specialCharacters) {
+        result = result.replace(new RegExp(character, "g"), `\\${character}`);
     }
 
     return result ? `*${result}*` : "";

--- a/packages/api-elasticsearch/src/plugins/operator/andIn.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/andIn.ts
@@ -30,7 +30,7 @@ export class ElasticsearchQueryBuilderOperatorAndInPlugin extends ElasticsearchQ
         }
 
         for (const value of values) {
-            query.must.push({
+            query.filter.push({
                 term: {
                     [useBasePath ? basePath : path]: value
                 }

--- a/packages/api-elasticsearch/src/plugins/operator/between.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/between.ts
@@ -12,20 +12,20 @@ export class ElasticsearchQueryBuilderOperatorBetweenPlugin extends Elasticsearc
         query: ElasticsearchBoolQueryConfig,
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
-        const { value, basePath } = params;
+        const { value, basePath, name } = params;
         if (Array.isArray(value) === false) {
             throw new Error(
-                `You cannot filter field path "${basePath}" with between query and not send an array of values.`
+                `You cannot filter field path "${name}" with between query and not send an array of values.`
             );
         } else if (value.length !== 2) {
             throw new Error(
-                `You must pass 2 values in the array for field path "${basePath}" filtering.`
+                `You must pass 2 values in the array for field path "${name}" filtering.`
             );
         }
         // we take gte first because it should be a lesser value than lte, eg [5, 10]
         // 6 >= gte && 6 <= lte
         const [gte, lte] = value;
-        query.must.push({
+        query.filter.push({
             range: {
                 [basePath]: {
                     lte,

--- a/packages/api-elasticsearch/src/plugins/operator/equal.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/equal.ts
@@ -22,14 +22,30 @@ export class ElasticsearchQueryBuilderOperatorEqualPlugin extends ElasticsearchQ
             });
             return;
         }
+        const typeOf = typeof value;
+        /**
+         * If value is a number or boolean, use filtering instead of must/term
+         */
+        if (typeOf === "number" || typeOf === "boolean") {
+            query.filter.push({
+                term: {
+                    [basePath]: value
+                }
+            });
+            return;
+        }
         /**
          * In case we are searching for a string, use regular path.
-         * Otherwise use base path
+         * Otherwise use base path.
          */
-        const useBasePath = typeof value !== "string";
-        query.must.push({
+        const useBasePath = typeOf !== "string";
+        const valuePath = useBasePath ? basePath : path;
+        /**
+         * String or something else.
+         */
+        query.filter.push({
             term: {
-                [useBasePath ? basePath : path]: value
+                [valuePath]: value
             }
         });
     }

--- a/packages/api-elasticsearch/src/plugins/operator/gt.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/gt.ts
@@ -13,7 +13,7 @@ export class ElasticsearchQueryBuilderOperatorGreaterThanPlugin extends Elastics
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
-        query.must.push({
+        query.filter.push({
             range: {
                 [basePath]: {
                     gt: value

--- a/packages/api-elasticsearch/src/plugins/operator/gte.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/gte.ts
@@ -13,7 +13,7 @@ export class ElasticsearchQueryBuilderOperatorGreaterThanOrEqualToPlugin extends
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
-        query.must.push({
+        query.filter.push({
             range: {
                 [basePath]: {
                     gte: value

--- a/packages/api-elasticsearch/src/plugins/operator/in.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/in.ts
@@ -12,24 +12,20 @@ export class ElasticsearchQueryBuilderOperatorInPlugin extends ElasticsearchQuer
         query: ElasticsearchBoolQueryConfig,
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
-        const { value: values, path, basePath } = params;
+        const { value: values, path, basePath, name } = params;
         const isArray = Array.isArray(values);
         if (isArray === false || values.length === 0) {
             throw new Error(
-                `You cannot filter field "${path}" with "in" operator and not send an array of values.`
+                `You cannot filter field "${name}" with "in" operator and not send an array of values.`
             );
         }
 
-        let useBasePath = false;
         // Only use ".keyword" if all of the provided values are strings.
-        for (const value of values) {
-            if (typeof value !== "string") {
-                useBasePath = true;
-                break;
-            }
-        }
+        const useBasePath = values.some(
+            (value: string | number | boolean | null | undefined) => typeof value !== "string"
+        );
 
-        query.must.push({
+        query.filter.push({
             terms: {
                 [useBasePath ? basePath : path]: values
             }

--- a/packages/api-elasticsearch/src/plugins/operator/lt.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/lt.ts
@@ -13,7 +13,7 @@ export class ElasticsearchQueryBuilderOperatorLesserThanPlugin extends Elasticse
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
-        query.must.push({
+        query.filter.push({
             range: {
                 [basePath]: {
                     lt: value

--- a/packages/api-elasticsearch/src/plugins/operator/lte.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/lte.ts
@@ -13,7 +13,7 @@ export class ElasticsearchQueryBuilderOperatorLesserThanOrEqualToPlugin extends 
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
-        query.must.push({
+        query.filter.push({
             range: {
                 [basePath]: {
                     lte: value

--- a/packages/api-elasticsearch/src/plugins/operator/not.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/not.ts
@@ -15,7 +15,7 @@ export class ElasticsearchQueryBuilderOperatorNotPlugin extends ElasticsearchQue
         const { value, path, basePath } = params;
 
         if (value === null) {
-            query.must.push({
+            query.filter.push({
                 exists: {
                     field: path
                 }
@@ -23,10 +23,22 @@ export class ElasticsearchQueryBuilderOperatorNotPlugin extends ElasticsearchQue
             return;
         }
 
-        const useBasePath = typeof value !== "string";
+        const typeOf = typeof value;
+
+        if (typeOf === "boolean") {
+            query.filter.push({
+                term: {
+                    [basePath]: !value
+                }
+            });
+            return;
+        }
+
+        const useBasePath = typeOf !== "string";
+        const valuePath = useBasePath ? basePath : path;
         query.must_not.push({
             term: {
-                [useBasePath ? basePath : path]: value
+                [valuePath]: value
             }
         });
     }

--- a/packages/api-elasticsearch/src/plugins/operator/notBetween.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/notBetween.ts
@@ -12,14 +12,14 @@ export class ElasticsearchQueryBuilderOperatorNotBetweenPlugin extends Elasticse
         query: ElasticsearchBoolQueryConfig,
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
-        const { value, basePath } = params;
+        const { value, basePath, name } = params;
         if (Array.isArray(value) === false) {
             throw new Error(
-                `You cannot filter field path "${basePath}" with between query and not send an array of values.`
+                `You cannot filter field path "${name}" with "not_between" query and not send an array of values.`
             );
         } else if (value.length !== 2) {
             throw new Error(
-                `You must pass 2 values in the array for field path "${basePath}" filtering.`
+                `You must pass 2 values in the array for field path "${name}" filtering.`
             );
         }
         // we take gte first because it should be a lesser value than lte, eg [5, 10]

--- a/packages/api-elasticsearch/src/plugins/operator/notIn.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/notIn.ts
@@ -12,11 +12,11 @@ export class ElasticsearchQueryBuilderOperatorNotInPlugin extends ElasticsearchQ
         query: ElasticsearchBoolQueryConfig,
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
-        const { value: values, path, basePath } = params;
+        const { value: values, path, basePath, name } = params;
         const isArray = Array.isArray(values);
         if (isArray === false || values.length === 0) {
             throw new Error(
-                `You cannot filter field path "${basePath}" with not_in and not send an array of values.`
+                `You cannot filter field "${name}" with "not_in" operator and not send an array of values.`
             );
         }
 

--- a/packages/api-elasticsearch/src/plugins/operator/startsWith.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/startsWith.ts
@@ -13,7 +13,7 @@ export class ElasticsearchQueryBuilderOperatorStartsWithPlugin extends Elasticse
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
-        query.must.push({
+        query.filter.push({
             match_phrase_prefix: {
                 [basePath]: value
             }

--- a/packages/api-elasticsearch/src/sort.ts
+++ b/packages/api-elasticsearch/src/sort.ts
@@ -1,15 +1,11 @@
 import WebinyError from "@webiny/error";
-import { FieldSortOptions, SortType, SortOrder } from "./types";
-import { ElasticsearchFieldPlugin } from "./plugins/definition/ElasticsearchFieldPlugin";
+import { FieldSortOptions, SortType, SortOrder } from "~/types";
+import { ElasticsearchFieldPlugin } from "~/plugins";
 
 const sortRegExp = new RegExp(/^([a-zA-Z-0-9_@]+)_(ASC|DESC)$/);
 
-interface SortOption {
-    path: string;
-    order: "ASC" | "DESC" | "asc" | "desc";
-}
 interface CreateSortParams {
-    sort: string[] | SortOption[];
+    sort: string[];
     defaults?: {
         field?: string;
         order?: SortOrder;
@@ -17,7 +13,7 @@ interface CreateSortParams {
     };
     fieldPlugins: Record<string, ElasticsearchFieldPlugin>;
 }
-// TODO refactor so the sort input is of SortOption type
+
 export const createSort = (params: CreateSortParams): SortType => {
     const { sort, defaults, fieldPlugins } = params;
     if (!sort || sort.length === 0) {
@@ -35,8 +31,7 @@ export const createSort = (params: CreateSortParams): SortType => {
     /**
      * Cast as string because nothing else should be allowed yet.
      */
-    // @ts-refactor
-    return (sort as string[]).reduce((acc, value) => {
+    return sort.reduce((acc, value) => {
         if (typeof value !== "string") {
             throw new WebinyError(`Sort as object is not supported..`);
         }

--- a/packages/api-elasticsearch/src/types.ts
+++ b/packages/api-elasticsearch/src/types.ts
@@ -1,5 +1,4 @@
-import { Client } from "@elastic/elasticsearch";
-import { ApiResponse } from "@elastic/elasticsearch/lib/Transport";
+import { Client, ApiResponse } from "@elastic/elasticsearch";
 import { BoolQueryConfig as esBoolQueryConfig, Query as esQuery } from "elastic-ts";
 import { Context } from "@webiny/api/types";
 /**
@@ -40,7 +39,8 @@ export type ElasticsearchQueryOperator =
     | "gt"
     | "gte"
     | "lt"
-    | "lte";
+    | "lte"
+    | string;
 
 /**
  * Definition for arguments of the ElasticsearchQueryBuilderOperatorPlugin.apply method.
@@ -51,6 +51,10 @@ export type ElasticsearchQueryOperator =
  * @category Elasticsearch
  */
 export interface ElasticsearchQueryBuilderArgsPlugin {
+    /**
+     * Name of the field.
+     */
+    name: string;
     /**
      * A full path to the field. Including the ".keyword" if it is added.
      */

--- a/packages/api-elasticsearch/src/where.ts
+++ b/packages/api-elasticsearch/src/where.ts
@@ -91,6 +91,7 @@ export const applyWhere = (params: ApplyWhereParams): void => {
         });
 
         operatorPlugin.apply(query, {
+            name: field,
             value,
             path,
             basePath,

--- a/packages/api-headless-cms-ddb-es/src/helpers/createElasticsearchQueryBody.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/createElasticsearchQueryBody.ts
@@ -356,6 +356,7 @@ const applyFiltering = (params: ApplyFilteringParams) => {
 
     const keyword = hasKeyword(modelField);
     plugin.apply(query, {
+        name: modelField.field.fieldId,
         basePath: fieldPathFactory({
             plugin: fieldSearchPlugin,
             modelField,


### PR DESCRIPTION
## Changes
This PR optimizes operators (for example: not to use must when really not necessary), improves types and simplifies imports from external packages.

## How Has This Been Tested?
Jest.

## Documentation
Not required.