### PR TITLE
fix: advanced element settings onSave execution

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/ElementSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/advanced/ElementSettings.tsx
@@ -14,18 +14,20 @@ export const ElementSettings: React.FC = () => {
     const updateElement = useUpdateElement();
 
     const onSubmit = async (formData: FormData) => {
-        const plugin = plugins
+        const settingsPlugins = plugins
             .byType<PbEditorPageElementAdvancedSettingsPlugin>(
                 "pb-editor-page-element-advanced-settings"
             )
-            .find(pl => pl.elementType === element?.type && typeof pl?.onSave === "function");
+            .filter(pl => pl.elementType === element?.type);
 
-        let modifiedFormData = null;
-        if (typeof plugin?.onSave === "function") {
-            modifiedFormData = await plugin.onSave(formData);
+        let modifiedFormData = formData;
+        for (const plugin of settingsPlugins) {
+            if (typeof plugin?.onSave === "function") {
+                modifiedFormData = await plugin.onSave(modifiedFormData);
+            }
         }
 
-        updateElement(merge(element, "data", modifiedFormData || formData));
+        updateElement(merge(element, "data", modifiedFormData));
     };
 
     if (!element) {

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -612,7 +612,7 @@ export type PbEditorPageElementAdvancedSettingsPlugin = Plugin & {
     type: "pb-editor-page-element-advanced-settings";
     elementType: string;
     render(params: { Bind: BindComponent; data: any; submit: () => void }): ReactElement;
-    onSave?: (data: FormData) => FormData;
+    onSave?: (data: FormData) => Promise<FormData>;
 };
 
 export type PbEditorEventActionPlugin = Plugin & {


### PR DESCRIPTION
## Changes
Fix issue "PageBuilder - onSave callback on advanced element settings plugins is not executed".
Closes #2776

## How Has This Been Tested?
Manual

## Documentation
None