### PR TITLE
fix: add numbers to slug validator

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/blockCategories.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/blockCategories.test.ts
@@ -216,7 +216,7 @@ describe("Block Categories CRUD Test", () => {
                         code: "VALIDATION_FAILED_INVALID_FIELD",
                         data: null,
                         message:
-                            "Slug must consist of only 'a-z' and '-' and be max 100 characters long (for example: 'some-entry-slug')"
+                            "Slug must consist of only 'a-z', '0-9' and '-' and be max 100 characters long (for example: 'some-slug' or 'some-slug-2')"
                     }
                 }
             }

--- a/packages/validation/__tests__/slug.test.js
+++ b/packages/validation/__tests__/slug.test.js
@@ -7,7 +7,6 @@ describe("slug test", () => {
 
     it("should not get triggered if correct value was set", async () => {
         await expect(validation.validate("test-slug", "slug")).resolves.toBe(true);
-        await expect(validation.validate("test_slug", "slug")).resolves.toBe(true);
         await expect(validation.validate("test", "slug")).resolves.toBe(true);
         await expect(validation.validate("test-123", "slug")).resolves.toBe(true);
         await expect(validation.validate("123-test", "slug")).resolves.toBe(true);
@@ -24,6 +23,12 @@ describe("slug test", () => {
         await expect(validation.validate("-slug-", "slug")).rejects.toThrow(ValidationError);
         await expect(validation.validate("-slug", "slug")).rejects.toThrow(ValidationError);
         await expect(validation.validate("slug-", "slug")).rejects.toThrow(ValidationError);
+    });
+
+    it("should fail - underscores are not allowed", async () => {
+        await expect(validation.validate("test_slug", "slug")).rejects.toThrow(ValidationError);
+        await expect(validation.validate("_test-slug", "slug")).rejects.toThrow(ValidationError);
+        await expect(validation.validate("test-slug_", "slug")).rejects.toThrow(ValidationError);
     });
 
     it("should fail - uppercase letters are not allowed", async () => {

--- a/packages/validation/__tests__/slug.test.js
+++ b/packages/validation/__tests__/slug.test.js
@@ -6,9 +6,11 @@ describe("slug test", () => {
     });
 
     it("should not get triggered if correct value was set", async () => {
-        //await expect(validation.validate("test-slug-correct", "slug")).resolves.toBe(true);
         await expect(validation.validate("test-slug", "slug")).resolves.toBe(true);
+        await expect(validation.validate("test_slug", "slug")).resolves.toBe(true);
         await expect(validation.validate("test", "slug")).resolves.toBe(true);
+        await expect(validation.validate("test-123", "slug")).resolves.toBe(true);
+        await expect(validation.validate("123-test", "slug")).resolves.toBe(true);
     });
 
     it("should fail - wrong dash character usage", async () => {
@@ -31,24 +33,6 @@ describe("slug test", () => {
         await expect(validation.validate("tesT-sluG", "slug")).rejects.toThrow(ValidationError);
         await expect(validation.validate("Test", "slug")).rejects.toThrow(ValidationError);
         await expect(validation.validate("tEst", "slug")).rejects.toThrow(ValidationError);
-    });
-
-    it("should fail - numbers are not allowed", async () => {
-        await expect(validation.validate("test-slug-12345", "slug")).rejects.toThrow(
-            ValidationError
-        );
-        await expect(validation.validate("test-12345-slug", "slug")).rejects.toThrow(
-            ValidationError
-        );
-        await expect(validation.validate("12345-test-slug", "slug")).rejects.toThrow(
-            ValidationError
-        );
-        await expect(validation.validate("test123-slug", "slug")).rejects.toThrow(ValidationError);
-        await expect(validation.validate("test-slug123", "slug")).rejects.toThrow(ValidationError);
-        await expect(validation.validate("12345-slug", "slug")).rejects.toThrow(ValidationError);
-        await expect(validation.validate("slug-12345", "slug")).rejects.toThrow(ValidationError);
-
-        await expect(validation.validate("slug12345", "slug")).rejects.toThrow(ValidationError);
     });
 
     it("should fail - special chars are not allowed", async () => {

--- a/packages/validation/src/validators/slug.ts
+++ b/packages/validation/src/validators/slug.ts
@@ -6,11 +6,11 @@ export default (value: any) => {
     }
     value = value + "";
 
-    if (value.match(/^[a-z0-9]+([-_][a-z0-9]+)*$/) && value.length <= 100) {
+    if (value.match(/^[a-z0-9]+(-[a-z0-9]+)*$/) && value.length <= 100) {
         return;
     }
 
     throw new ValidationError(
-        "Slug must consist of only letters, numbers, dashes and underscores and be max 100 characters long (for example: 'some-slug' or 'some_slug-2')"
+        "Slug must consist of only 'a-z', '0-9' and '-' and be max 100 characters long (for example: 'some-slug' or 'some_slug-2')"
     );
 };

--- a/packages/validation/src/validators/slug.ts
+++ b/packages/validation/src/validators/slug.ts
@@ -11,6 +11,6 @@ export default (value: any) => {
     }
 
     throw new ValidationError(
-        "Slug must consist of only 'a-z', '0-9' and '-' and be max 100 characters long (for example: 'some-slug' or 'some_slug-2')"
+        "Slug must consist of only 'a-z', '0-9' and '-' and be max 100 characters long (for example: 'some-slug' or 'some-slug-2')"
     );
 };

--- a/packages/validation/src/validators/slug.ts
+++ b/packages/validation/src/validators/slug.ts
@@ -6,11 +6,11 @@ export default (value: any) => {
     }
     value = value + "";
 
-    if (value.match(/^[a-z]+(\-[a-z]+)*$/) && value.length <= 100) {
+    if (value.match(/^[a-z0-9]+([-_][a-z0-9]+)*$/) && value.length <= 100) {
         return;
     }
 
     throw new ValidationError(
-        "Slug must consist of only 'a-z' and '-' and be max 100 characters long (for example: 'some-entry-slug')"
+        "Slug must consist of only letters, numbers, dashes and underscores and be max 100 characters long (for example: 'some-slug' or 'some_slug-2')"
     );
 };


### PR DESCRIPTION
## Changes
With this PR we allow numbers for our slug validator package.

## How Has This Been Tested?
Jest

