### PR TITLE
feat: editor sidebar changes

### DIFF
--- a/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/ElementNotLinked.tsx
+++ b/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/ElementNotLinked.tsx
@@ -10,7 +10,7 @@ export const ElementLinkStatusWrapper = styled("div")({
     rowGap: "16px",
     justifyContent: "center",
     alignItems: "center",
-    margin: "16px",
+    margin: "auto 16px 16px 16px",
     textAlign: "center",
     backgroundColor: "var(--mdc-theme-background)",
     border: "3px dashed var(--webiny-theme-color-border)",
@@ -18,6 +18,7 @@ export const ElementLinkStatusWrapper = styled("div")({
     "& .info-wrapper": {
         display: "flex",
         alignItems: "center",
+        textAlign: "start",
         fontSize: "10px",
         "& svg": {
             width: "18px",
@@ -34,7 +35,7 @@ const ElementNotLinked = () => {
             a variable.
             <div>
                 <CreateVariableAction>
-                    <ButtonPrimary>Create variable</ButtonPrimary>
+                    <ButtonPrimary>Link element</ButtonPrimary>
                 </CreateVariableAction>
             </div>
             <div className="info-wrapper">

--- a/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariableSettings.tsx
+++ b/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariableSettings.tsx
@@ -112,8 +112,8 @@ const VariableSettings = ({ element }: { element: PbEditorElement }) => {
             </FormWrapper>
             <ElementLinkStatusWrapper>
                 <strong>Element is linked</strong>
-                To prevent users to change the value of this element inside a page, you need to
-                unlink it from variables.
+                To prevent users from changing the value of this element, you need to unlink it from
+                a variable.
                 <ButtonPrimary onClick={onRemove}>Unlink Element</ButtonPrimary>
                 <div className="info-wrapper">
                     <InfoIcon /> Click here to learn more about how block variables work

--- a/packages/app-page-builder/src/editor/components/Editor/Sidebar/ElementSettingsTabContent.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/Sidebar/ElementSettingsTabContent.tsx
@@ -8,7 +8,9 @@ import { COLORS } from "~/editor/plugins/elementSettings/components/StyledCompon
 import useElementSettings from "~/editor/plugins/elementSettings/hooks/useElementSettings";
 import { ElementSettings } from "~/editor/plugins/elementSettings/advanced/ElementSettings";
 
-const RootElement = styled("div")({
+export const RootElement = styled("div")({
+    display: "flex",
+    flexDirection: "column",
     height: "calc(100vh - 65px - 48px)", // Subtract top-bar and tab-header height
     overflowY: "auto",
     // Style scrollbar
@@ -58,7 +60,6 @@ const ElementSettingsTabContent: React.FC = () => {
                     );
                 })}
             </SidebarActions>
-            <ElementSettings />
         </RootElement>
     );
 };
@@ -66,7 +67,12 @@ const ElementSettingsTabContent: React.FC = () => {
 export const SidebarActions = makeComposable(
     "ElementSettingsTabContent",
     ({ children, ...props }) => {
-        return <SidebarActionsWrapper {...props}>{children}</SidebarActionsWrapper>;
+        return (
+            <>
+                <SidebarActionsWrapper {...props}>{children}</SidebarActionsWrapper>
+                <ElementSettings />
+            </>
+        );
     }
 );
 

--- a/packages/app-page-builder/src/pageEditor/config/BlockElementSidebarPlugin.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/BlockElementSidebarPlugin.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "@emotion/styled";
 import { EditorSidebarTab } from "~/editor";
 import { createComponentPlugin } from "@webiny/app-admin";
@@ -6,6 +6,9 @@ import { useActiveElement } from "~/editor/hooks/useActiveElement";
 import { ButtonPrimary } from "@webiny/ui/Button";
 import UnlinkBlockAction from "~/pageEditor/plugins/elementSettings/UnlinkBlockAction";
 import { ReactComponent as InfoIcon } from "@webiny/app-admin/assets/icons/info.svg";
+import { useElementSidebar } from "~/editor/hooks/useElementSidebar";
+import { updateSidebarActiveTabIndexMutation } from "~/editor/recoil/modules";
+import { RootElement } from "~/editor/components/Editor/Sidebar/ElementSettingsTabContent";
 
 const UnlinkBlockWrapper = styled("div")({
     padding: "16px",
@@ -13,7 +16,7 @@ const UnlinkBlockWrapper = styled("div")({
     rowGap: "16px",
     justifyContent: "center",
     alignItems: "center",
-    margin: "16px",
+    margin: "auto 16px 16px 16px",
     textAlign: "center",
     backgroundColor: "var(--mdc-theme-background)",
     border: "3px dashed var(--webiny-theme-color-border)",
@@ -31,28 +34,39 @@ const UnlinkBlockWrapper = styled("div")({
 
 const UnlinkTab = () => {
     return (
-        <UnlinkBlockWrapper>
-            This is a block element - to change it you need to unlink it first. By unlinking it, any
-            changes made to the block will no longer automatically reflect to this page.
-            <div>
-                <UnlinkBlockAction>
-                    <ButtonPrimary>Unlink block</ButtonPrimary>
-                </UnlinkBlockAction>
-            </div>
-            <div className="info-wrapper">
-                <InfoIcon /> Click here to learn more about how block work
-            </div>
-        </UnlinkBlockWrapper>
+        <RootElement>
+            <UnlinkBlockWrapper>
+                This is a block element - to change it you need to unlink it first. By unlinking it,
+                any changes made to the block will no longer automatically reflect to this page.
+                <div>
+                    <UnlinkBlockAction>
+                        <ButtonPrimary>Unlink block</ButtonPrimary>
+                    </UnlinkBlockAction>
+                </div>
+                <div className="info-wrapper">
+                    <InfoIcon /> Click here to learn more about how block work
+                </div>
+            </UnlinkBlockWrapper>
+        </RootElement>
     );
 };
 
 export const BlockElementSidebarPlugin = createComponentPlugin(EditorSidebarTab, Tab => {
     return function ElementTab({ children, ...props }) {
         const [element] = useActiveElement();
+        const [sidebar, setSidebar] = useElementSidebar();
 
         const isReferenceBlock =
-            element !== null && element.type === "block" && element.data?.blockId;
+            element !== null && element.type === "block" && !!element.data?.blockId;
         const isStyleTab = props?.label === "Style";
+
+        useEffect(() => {
+            if (isReferenceBlock) {
+                setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, 1));
+            } else if (sidebar.activeTabIndex === 1) {
+                setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, 0));
+            }
+        }, [element?.id]);
 
         return <Tab {...props}>{isReferenceBlock && isStyleTab ? <UnlinkTab /> : children}</Tab>;
     };


### PR DESCRIPTION
## Changes
Implement issues:
- In the page editor - if I click on a block that’s linked, automatically position the right sidebar to the “Element” tab, instead of the “Style” tab.
- In the block editor, the style for “unlink the variable” should be updated.

## How Has This Been Tested?
Manual

## Documentation
None