### PR TITLE
feat: blocks list page changes

### DIFF
--- a/packages/app-page-builder/src/admin/utils/createBlockCategoryPlugin.tsx
+++ b/packages/app-page-builder/src/admin/utils/createBlockCategoryPlugin.tsx
@@ -8,7 +8,7 @@ interface IconProps {
     category: PbBlockCategory;
 }
 
-const Icon: React.FC<IconProps> = ({ category }) => {
+export const Icon: React.FC<IconProps> = ({ category }) => {
     return (
         <FontAwesomeIcon
             style={{ color: "var(--mdc-theme-text-secondary-on-background)", fontSize: "24px" }}

--- a/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesDataList.tsx
@@ -13,6 +13,7 @@ import {
     DataListModalOverlayAction,
     ScrollList,
     ListItem,
+    ListItemGraphic,
     ListItemText,
     ListItemMeta,
     ListActions,
@@ -28,6 +29,7 @@ import SearchUI from "@webiny/app-admin/components/SearchUI";
 import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18px.svg";
 import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/filter-24px.svg";
 import { PageBuilderSecurityPermission, PbBlockCategory } from "~/types";
+import { Icon } from "~/admin/utils/createBlockCategoryPlugin";
 
 const t = i18n.ns("app-page-builder/admin/block-categories/data-list");
 
@@ -205,12 +207,17 @@ const PageBuilderBlockCategoriesDataList = ({
             {({ data }: { data: PbBlockCategory[] }) => (
                 <ScrollList data-testid="default-data-list">
                     {data.map(item => (
-                        <ListItem key={item.slug} selected={item.slug === slug}>
-                            <ListItemText
-                                onClick={() =>
-                                    history.push(`/page-builder/block-categories?slug=${item.slug}`)
-                                }
-                            >
+                        <ListItem
+                            key={item.slug}
+                            selected={item.slug === slug}
+                            onClick={() =>
+                                history.push(`/page-builder/block-categories?slug=${item.slug}`)
+                            }
+                        >
+                            <ListItemGraphic>
+                                <Icon category={item} />
+                            </ListItemGraphic>
+                            <ListItemText>
                                 {item.name}
                                 <ListItemTextSecondary>
                                     {item.description || t`No description provided.`}

--- a/packages/app-page-builder/src/admin/views/PageBlocks/BlocksByCategoriesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/PageBlocks/BlocksByCategoriesDataList.tsx
@@ -6,7 +6,6 @@ import { useQuery, useApolloClient } from "@apollo/react-hooks";
 import orderBy from "lodash/orderBy";
 import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
-import { Icon } from "~/admin/utils/createBlockCategoryPlugin";
 
 import {
     DataList,
@@ -29,6 +28,7 @@ import { ButtonDefault, ButtonIcon, ButtonSecondary } from "@webiny/ui/Button";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/filter-24px.svg";
 import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18px.svg";
+import { Icon } from "~/admin/utils/createBlockCategoryPlugin";
 
 import { PbBlockCategory, PbPageBlock } from "~/types";
 import { LIST_PAGE_BLOCKS_AND_CATEGORIES, LIST_PAGE_BLOCKS, CREATE_PAGE_BLOCK } from "./graphql";
@@ -291,6 +291,9 @@ const BlocksByCategoriesDataList = ({ canCreate }: PageBuilderBlocksByCategories
                                         key={item.slug}
                                         onClick={() => onCreatePageBlock(item.slug)}
                                     >
+                                        <ListItemGraphic>
+                                            <Icon category={item} />
+                                        </ListItemGraphic>
                                         <ListItemText>
                                             <ListItemTextPrimary>{item.name}</ListItemTextPrimary>
                                             <ListItemTextSecondary>

--- a/packages/app-page-builder/src/admin/views/PageBlocks/BlocksByCategoriesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/PageBlocks/BlocksByCategoriesDataList.tsx
@@ -6,6 +6,7 @@ import { useQuery, useApolloClient } from "@apollo/react-hooks";
 import orderBy from "lodash/orderBy";
 import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
+import { Icon } from "~/admin/utils/createBlockCategoryPlugin";
 
 import {
     DataList,
@@ -14,6 +15,7 @@ import {
     ScrollList,
     List,
     ListItem,
+    ListItemGraphic,
     ListItemText,
     ListItemTextPrimary,
     ListItemTextSecondary
@@ -193,6 +195,14 @@ const BlocksByCategoriesDataList = ({ canCreate }: PageBuilderBlocksByCategories
         }
     };
 
+    const handleNewBlockClick = useCallback(() => {
+        if (selectedBlocksCategory) {
+            onCreatePageBlock(selectedBlocksCategory);
+        } else {
+            setIsNewPageBlockDialogOpen(true);
+        }
+    }, [selectedBlocksCategory]);
+
     return (
         <>
             <DataList
@@ -201,7 +211,7 @@ const BlocksByCategoriesDataList = ({ canCreate }: PageBuilderBlocksByCategories
                 data={categoryList}
                 actions={
                     canCreate ? (
-                        <ButtonSecondary onClick={() => setIsNewPageBlockDialogOpen(true)}>
+                        <ButtonSecondary onClick={handleNewBlockClick}>
                             <ButtonIcon icon={<AddIcon />} /> {t`New Block`}
                         </ButtonSecondary>
                     ) : null
@@ -237,14 +247,16 @@ const BlocksByCategoriesDataList = ({ canCreate }: PageBuilderBlocksByCategories
                                 <ListItem
                                     key={item.slug}
                                     selected={item.slug === selectedBlocksCategory}
+                                    onClick={() =>
+                                        history.push(
+                                            `/page-builder/page-blocks?category=${item.slug}`
+                                        )
+                                    }
                                 >
-                                    <ListItemText
-                                        onClick={() =>
-                                            history.push(
-                                                `/page-builder/page-blocks?category=${item.slug}`
-                                            )
-                                        }
-                                    >
+                                    <ListItemGraphic>
+                                        <Icon category={item} />
+                                    </ListItemGraphic>
+                                    <ListItemText>
                                         {item.name}
                                         <ListItemTextSecondary>{`${numberOfBlocks} ${
                                             numberOfBlocks === 1 ? "block" : "blocks"

--- a/packages/app-page-builder/src/admin/views/PageBlocks/PageBlocks.tsx
+++ b/packages/app-page-builder/src/admin/views/PageBlocks/PageBlocks.tsx
@@ -64,7 +64,7 @@ const PageBlocks: React.FC = () => {
                 <BlocksByCategoriesDataList canCreate={canCreate} />
             </LeftPanel>
             <RightPanel>
-                <PageBlocksDataList canEdit={canEdit} canDelete={canDelete} />
+                <PageBlocksDataList canCreate={canCreate} canEdit={canEdit} canDelete={canDelete} />
             </RightPanel>
         </SplitView>
     );


### PR DESCRIPTION
## Changes
Implements issues:
- In the blocks list view, where we have the block categories on the left side, we should also display the block icon next to the category name so it looks nicer visually. Do the same inside the Block categories list.
- In the blocks list view, if I’m inside a block category and click new block button → there is no need to ask the user to select a block category, let’s just use the category they are in currently.
- In the page editor - if I click on a block that’s linked, automatically position the right sidebar to the “Element” tab, instead of the “Style” tab.

## How Has This Been Tested?
Manual

## Documentation
None