### PR TITLE
fix: page link creation on folder change

### DIFF
--- a/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
@@ -8,9 +8,6 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import useImportPage from "./hooks/useImportPage";
 import useCreatePage from "./hooks/useCreatePage";
 import { PageBuilderSecurityPermission } from "~/types";
-import { useRouter } from "@webiny/react-router";
-import { useLinks } from "@webiny/app-folders";
-import { FOLDER_ID_DEFAULT } from "~/admin/constants/folders";
 
 enum LoadingLabel {
     CREATING_PAGE = "Creating page...",
@@ -23,8 +20,6 @@ enum Operation {
 }
 
 const Pages: React.FC = () => {
-    const { history } = useRouter();
-    const { createLink } = useLinks(FOLDER_ID_DEFAULT);
     const [operation, setOperation] = useState<string>(Operation.CREATE);
     const [loadingLabel, setLoadingLabel] = useState<string | null>(null);
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
@@ -35,11 +30,7 @@ const Pages: React.FC = () => {
     const { createPageMutation } = useCreatePage({
         setLoadingLabel: () => setLoadingLabel(LoadingLabel.CREATING_PAGE),
         clearLoadingLabel: () => setLoadingLabel(null),
-        closeDialog,
-        onCreatePageSuccess: async id => {
-            await createLink({ id, folderId: FOLDER_ID_DEFAULT });
-            history.push(`/page-builder/editor/${encodeURIComponent(id)}`);
-        }
+        closeDialog
     });
 
     const { showDialog } = useImportPage({

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -14,7 +14,6 @@ import styled from "@emotion/styled";
 import { useCanCreatePage } from "~/admin/views/Pages/hooks/useCanCreate";
 import { FOLDER_ID_DEFAULT, FOLDER_TYPE } from "~/admin/constants/folders";
 import { Preview } from "~/admin/components/Table/Preview";
-import { useRouter } from "@webiny/react-router";
 import useDeepCompareEffect from "use-deep-compare-effect";
 
 interface Props {
@@ -45,14 +44,8 @@ const getCurrentFolderList = (
 };
 
 export const Main = ({ folderId }: Props) => {
-    const { history } = useRouter();
     const { folders = [], loading: foldersLoading } = useFolders(FOLDER_TYPE);
-    const {
-        links,
-        loading: linksLoading,
-        createLink,
-        deleteLink
-    } = useLinks(folderId || FOLDER_ID_DEFAULT);
+    const { links, loading: linksLoading, deleteLink } = useLinks(folderId || FOLDER_ID_DEFAULT);
     const { pages, loading: pagesLoading } = useGetPages(links);
     const [subFolders, setSubFolders] = useState<FolderItem[]>([]);
 
@@ -81,10 +74,7 @@ export const Main = ({ folderId }: Props) => {
         setLoadingLabel: () => setLoadingLabel(LoadingLabel.CREATING_PAGE),
         clearLoadingLabel: () => setLoadingLabel(null),
         closeDialog: closeCategoryDialog,
-        onCreatePageSuccess: async id => {
-            await createLink({ id, folderId: folderId || FOLDER_ID_DEFAULT });
-            history.push(`/page-builder/editor/${encodeURIComponent(id)}`);
-        }
+        folderId
     });
 
     return (

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/useCreatePage.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/useCreatePage.ts
@@ -3,49 +3,62 @@ import { useMutation } from "@apollo/react-hooks";
 import { CREATE_PAGE } from "~/admin/graphql/pages";
 import * as GQLCache from "~/admin/views/Pages/cache";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
+import { useLinks } from "@webiny/app-folders";
+import { useRouter } from "@webiny/react-router";
+
+import { FOLDER_ID_DEFAULT } from "~/admin/constants/folders";
 
 interface UseCreatePageParams {
     setLoadingLabel: () => void;
     clearLoadingLabel: () => void;
     closeDialog: () => void;
-    onCreatePageSuccess: (id: string) => Promise<void>;
+    folderId?: string;
 }
 const useCreatePage = ({
     setLoadingLabel,
     clearLoadingLabel,
     closeDialog,
-    onCreatePageSuccess
+    folderId = FOLDER_ID_DEFAULT
 }: UseCreatePageParams) => {
     const [create] = useMutation(CREATE_PAGE);
+    const { createLink } = useLinks(folderId);
+    const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
 
-    const createPageMutation = useCallback(async ({ slug: category }) => {
-        try {
-            setLoadingLabel();
-            const res = await create({
-                variables: { category },
-                update(cache, { data }) {
-                    if (data.pageBuilder.createPage.error) {
-                        return;
+    const createPageMutation = useCallback(
+        async ({ slug: category }) => {
+            try {
+                setLoadingLabel();
+                const res = await create({
+                    variables: { category },
+                    update(cache, { data }) {
+                        if (data.pageBuilder.createPage.error) {
+                            return;
+                        }
+
+                        GQLCache.addPageToListCache(cache, data.pageBuilder.createPage.data);
                     }
+                });
 
-                    GQLCache.addPageToListCache(cache, data.pageBuilder.createPage.data);
+                clearLoadingLabel();
+                closeDialog();
+
+                const { error, data } = res.data.pageBuilder.createPage;
+                if (error) {
+                    showSnackbar(error.message);
+                } else {
+                    /**
+                     * We create a new folder link to bind the page with the source folder.
+                     */
+                    await createLink({ id: data.pid, folderId });
+                    history.push(`/page-builder/editor/${encodeURIComponent(data.id)}`);
                 }
-            });
-
-            clearLoadingLabel();
-            closeDialog();
-
-            const { error, data } = res.data.pageBuilder.createPage;
-            if (error) {
-                showSnackbar(error.message);
-            } else {
-                await onCreatePageSuccess(data.pid);
+            } catch (e) {
+                showSnackbar(e.message);
             }
-        } catch (e) {
-            showSnackbar(e.message);
-        }
-    }, []);
+        },
+        [folderId]
+    );
 
     return {
         createPageMutation


### PR DESCRIPTION
## Changes
Fix the link creation into the `useCreatePage` hook: the folderId was persisting even after the user selected a different folder.
Closes [WEB-1942](https://webiny.atlassian.net/browse/WEB-1942) 

## How Has This Been Tested?
TBD

## Documentation
Inline