### PR TITLE
feat(api-mailer): change transport settings input name

### DIFF
--- a/packages/api-mailer/src/graphql/settings.ts
+++ b/packages/api-mailer/src/graphql/settings.ts
@@ -20,16 +20,16 @@ export const createSettingsGraphQL = () => {
                 replyTo: String
             }
             
-            type MailerSettingsResponse {
+            type MailerTransportSettingsResponse {
                 data: MailerTransportSettings
                 error: MailerTransportSettingsError
             }
         
             type MailerQuery {
-                getSettings: MailerSettingsResponse!
+                getSettings: MailerTransportSettingsResponse!
             }
             
-            input TransportSettingsInput {
+            input MailerTransportSettingsInput {
                 host: String!
                 port: Number
                 user: String!
@@ -39,7 +39,7 @@ export const createSettingsGraphQL = () => {
             }
             
             type MailerMutation {
-                saveSettings(data: TransportSettingsInput!): MailerSettingsResponse!
+                saveSettings(data: MailerTransportSettingsInput!): MailerTransportSettingsResponse!
             }
             
             extend type Query {
@@ -60,7 +60,7 @@ export const createSettingsGraphQL = () => {
                         /**
                          * We want to remove the password from the response
                          */
-                        if (settings) {
+                        if (settings?.password) {
                             // @ts-ignore
                             delete settings.password;
                         }

--- a/packages/api-mailer/src/graphql/settings.ts
+++ b/packages/api-mailer/src/graphql/settings.ts
@@ -58,7 +58,7 @@ export const createSettingsGraphQL = () => {
                     try {
                         const settings = await context.mailer.getSettings();
                         /**
-                         * We want to remove the password from the response
+                         * We want to remove the password from the response, if it exists.
                          */
                         if (settings?.password) {
                             // @ts-ignore
@@ -80,9 +80,9 @@ export const createSettingsGraphQL = () => {
                             input: args.data
                         });
                         /**
-                         * We want to remove the password from the response
+                         * We want to remove the password from the response, if it exists.
                          */
-                        if (settings) {
+                        if (settings?.password) {
                             // @ts-ignore
                             delete settings.password;
                         }

--- a/packages/app-mailer/src/views/settings/graphql.ts
+++ b/packages/app-mailer/src/views/settings/graphql.ts
@@ -53,7 +53,7 @@ export interface SaveSettingsMutationResponse {
     };
 }
 export const SAVE_SETTINGS_MUTATION = gql`
-    mutation SaveTransportSettings($data: TransportSettingsInput!) {
+    mutation SaveTransportSettings($data: MailerTransportSettingsInput!) {
         mailer {
             settings: saveSettings(data: $data) {
                 data ${SETTINGS_FIELDS}


### PR DESCRIPTION
## Changes
Change transport settings GraphQL input name to be as rest of inputs and types.

## How Has This Been Tested?
Jest.