### PR TITLE
feat: add folder pubsub events and delete links on folder deletion

### DIFF
--- a/apps/api/graphql/src/index.ts
+++ b/apps/api/graphql/src/index.ts
@@ -29,7 +29,11 @@ import tenantManager from "@webiny/api-tenant-manager";
 import { createApwPageBuilderContext, createApwGraphQL } from "@webiny/api-apw";
 import { createStorageOperations as createApwSaStorageOperations } from "@webiny/api-apw-scheduler-so-ddb";
 
-import { createFoldersGraphQL, createFoldersContext } from "@webiny/api-folders";
+import {
+    createFoldersGraphQL,
+    createFoldersContext,
+    createFoldersSubscriptions
+} from "@webiny/api-folders";
 import { createStorageOperations as createFoldersStorageOperations } from "@webiny/api-folders-so-ddb";
 
 // Imports plugins created via scaffolding utilities.
@@ -94,6 +98,7 @@ export const handler = createHandler({
             })
         }),
         createFoldersGraphQL(),
+        createFoldersSubscriptions(),
         scaffoldsPlugins()
     ],
     http: { debug }

--- a/apps/api/graphql/tsconfig.json
+++ b/apps/api/graphql/tsconfig.json
@@ -21,6 +21,12 @@
       "path": "../../../packages/api-file-manager-s3/tsconfig.build.json"
     },
     {
+      "path": "../../../packages/api-folders/tsconfig.build.json"
+    },
+    {
+      "path": "../../../packages/api-folders-so-ddb/tsconfig.build.json"
+    },
+    {
       "path": "../../../packages/api-form-builder/tsconfig.build.json"
     },
     {
@@ -118,6 +124,10 @@
       "@webiny/api-file-manager-ddb": ["../../../packages/api-file-manager-ddb/src"],
       "@webiny/api-file-manager-s3/*": ["../../../packages/api-file-manager-s3/src/*"],
       "@webiny/api-file-manager-s3": ["../../../packages/api-file-manager-s3/src"],
+      "@webiny/api-folders/*": ["../../../packages/api-folders/src/*"],
+      "@webiny/api-folders": ["../../../packages/api-folders/src"],
+      "@webiny/api-folders-so-ddb/*": ["../../../packages/api-folders-so-ddb/src/*"],
+      "@webiny/api-folders-so-ddb": ["../../../packages/api-folders-so-ddb/src"],
       "@webiny/api-form-builder/*": ["../../../packages/api-form-builder/src/*"],
       "@webiny/api-form-builder": ["../../../packages/api-form-builder/src"],
       "@webiny/api-form-builder-so-ddb/*": ["../../../packages/api-form-builder-so-ddb/src/*"],

--- a/packages/api-folders-so-ddb/src/index.ts
+++ b/packages/api-folders-so-ddb/src/index.ts
@@ -39,7 +39,7 @@ export const createStorageOperations = (params: StorageParams): StorageOperation
     };
 
     return {
-        ...createLinksStorageOperations(entities.links),
+        ...createLinksStorageOperations(entities.links, table),
         ...createFoldersStorageOperations(entities.folders, table)
     };
 };

--- a/packages/api-folders-so-ddb/src/operations/folders.ts
+++ b/packages/api-folders-so-ddb/src/operations/folders.ts
@@ -96,22 +96,9 @@ export const createFoldersStorageOperations = (
             }
         },
 
-        async listFolders({ where: { tenant, locale, type, parentId }, sort }): Promise<Folder[]> {
+        async listFolders({ where: { tenant, locale, type }, sort }): Promise<Folder[]> {
             try {
-                let items;
-
-                if (parentId) {
-                    items = await queryAll<DataContainer<Folder>>({
-                        entity,
-                        partitionKey: createFolderGsiPartitionKey({ tenant, locale, type }),
-                        options: {
-                            index: "GSI1",
-                            beginsWith: `${parentId}#`
-                        }
-                    });
-                }
-
-                items = await queryAll<DataContainer<Folder>>({
+                const items = await queryAll<DataContainer<Folder>>({
                     entity,
                     partitionKey: createFolderGsiPartitionKey({ tenant, locale, type }),
                     options: {

--- a/packages/api-folders-so-ddb/src/operations/folders.ts
+++ b/packages/api-folders-so-ddb/src/operations/folders.ts
@@ -96,9 +96,22 @@ export const createFoldersStorageOperations = (
             }
         },
 
-        async listFolders({ where: { tenant, locale, type }, sort }): Promise<Folder[]> {
+        async listFolders({ where: { tenant, locale, type, parentId }, sort }): Promise<Folder[]> {
             try {
-                const items = await queryAll<DataContainer<Folder>>({
+                let items;
+
+                if (parentId) {
+                    items = await queryAll<DataContainer<Folder>>({
+                        entity,
+                        partitionKey: createFolderGsiPartitionKey({ tenant, locale, type }),
+                        options: {
+                            index: "GSI1",
+                            beginsWith: `${parentId}#`
+                        }
+                    });
+                }
+
+                items = await queryAll<DataContainer<Folder>>({
                     entity,
                     partitionKey: createFolderGsiPartitionKey({ tenant, locale, type }),
                     options: {

--- a/packages/api-folders-so-ddb/src/operations/links.ts
+++ b/packages/api-folders-so-ddb/src/operations/links.ts
@@ -5,7 +5,11 @@ import { decodeCursor, encodeCursor } from "@webiny/db-dynamodb/utils/cursor";
 import { batchWriteAll } from "@webiny/db-dynamodb/utils/batchWrite";
 import WebinyError from "@webiny/error";
 
-import { Link, LinksStorageOperations, StorageOperationListLinksResponse } from "@webiny/api-folders/types";
+import {
+    Link,
+    LinksStorageOperations,
+    StorageOperationListLinksResponse
+} from "@webiny/api-folders/types";
 import { Entity, Table } from "dynamodb-toolbox";
 
 import { DataContainer } from "~/types";

--- a/packages/api-folders/package.json
+++ b/packages/api-folders/package.json
@@ -47,6 +47,7 @@
     "@webiny/error": "^5.33.2",
     "@webiny/handler": "^5.33.2",
     "@webiny/handler-graphql": "^5.33.2",
+    "@webiny/pubsub": "^5.33.2",
     "joi": "^17.6.0",
     "mdbid": "^1.0.0"
   }

--- a/packages/api-folders/src/context/links.ts
+++ b/packages/api-folders/src/context/links.ts
@@ -226,6 +226,23 @@ export const createLinksContext = async ({
                     }
                 );
             }
+        },
+
+        async deleteLinks(folderIds: string[]): Promise<void> {
+            const tenant = getTenantId();
+            const locale = getLocaleCode();
+
+            try {
+                return await storageOperations.deleteLinks({ tenant, locale, folderIds });
+            } catch (error) {
+                throw new WebinyError(
+                    error.message || "Could not batch delete links.",
+                    error.code || "DELETE_LINKS_ERROR",
+                    {
+                        folderIds
+                    }
+                );
+            }
         }
     };
 };

--- a/packages/api-folders/src/index.ts
+++ b/packages/api-folders/src/index.ts
@@ -2,6 +2,7 @@ import { ContextPlugin } from "@webiny/api";
 import WebinyError from "@webiny/error";
 
 import { createContext } from "./context";
+import { subscriptions } from "./subscriptions";
 import { graphqlPlugins } from "./graphql";
 
 import { SecurityIdentity } from "@webiny/api-security/types";
@@ -43,3 +44,5 @@ export const createFoldersContext = ({ storageOperations }: FoldersConfig) => {
 };
 
 export const createFoldersGraphQL = () => graphqlPlugins;
+
+export const createFoldersSubscriptions = () => subscriptions();

--- a/packages/api-folders/src/subscriptions/afterFolderDelete.ts
+++ b/packages/api-folders/src/subscriptions/afterFolderDelete.ts
@@ -1,0 +1,22 @@
+import { ContextPlugin } from "@webiny/api";
+import { FoldersContext } from "~/types";
+
+export const afterFolderDelete = () => {
+    return new ContextPlugin<FoldersContext>(async ({ folders }) => {
+        /**
+         * After a folder has been deleted, delete all related links.
+         */
+        folders.onFolderAfterDelete.subscribe(async ({ folder }) => {
+            const { id, type } = folder;
+
+            // Fetching all child folders by `type` and `id`
+            const children = await folders.listFolders({
+                where: { type, parentId: id }
+            });
+
+            const ids = [id, ...children.map(child => child.id)];
+
+            await folders.deleteLinks(ids);
+        });
+    });
+};

--- a/packages/api-folders/src/subscriptions/index.ts
+++ b/packages/api-folders/src/subscriptions/index.ts
@@ -1,0 +1,7 @@
+import { ContextPlugin } from "@webiny/api";
+import { afterFolderDelete } from "./afterFolderDelete";
+import { FoldersContext } from "~/types";
+
+export const subscriptions = (): ContextPlugin<FoldersContext>[] => {
+    return [afterFolderDelete()];
+};

--- a/packages/api-folders/src/types.ts
+++ b/packages/api-folders/src/types.ts
@@ -150,6 +150,32 @@ export type StorageOperationsCreateLinkParams = CreateLinkParams;
 export type StorageOperationsUpdateLinkParams = UpdateLinkParams;
 export type StorageOperationsDeleteLinkParams = DeleteLinkParams;
 
+export interface OnLinkBeforeCreateTopicParams {
+    link: Link;
+}
+
+export interface OnLinkAfterCreateTopicParams {
+    link: Link;
+}
+
+export interface OnLinkBeforeUpdateTopicParams {
+    link: Link;
+    original: Link;
+}
+
+export interface OnLinkAfterUpdateTopicParams {
+    link: Link;
+    original: Link;
+}
+
+export interface OnLinkBeforeDeleteTopicParams {
+    link: Link;
+}
+
+export interface OnLinkAfterDeleteTopicParams {
+    link: Link;
+}
+
 export interface FoldersContext extends BaseContext, I18NContext, TenancyContext, SecurityContext {
     folders: Folders;
 }
@@ -176,6 +202,12 @@ export interface ILinks {
     createLink(input: LinkInput): Promise<Link>;
     updateLink(id: string, input: Partial<Link>): Promise<Link>;
     deleteLink(id: string): Promise<void>;
+    onLinkBeforeCreate: Topic<OnLinkBeforeCreateTopicParams>;
+    onLinkAfterCreate: Topic<OnLinkAfterCreateTopicParams>;
+    onLinkBeforeUpdate: Topic<OnLinkBeforeUpdateTopicParams>;
+    onLinkAfterUpdate: Topic<OnLinkAfterUpdateTopicParams>;
+    onLinkBeforeDelete: Topic<OnLinkBeforeDeleteTopicParams>;
+    onLinkAfterDelete: Topic<OnLinkAfterDeleteTopicParams>;
 }
 
 export interface FoldersConfig {

--- a/packages/api-folders/src/types.ts
+++ b/packages/api-folders/src/types.ts
@@ -31,6 +31,7 @@ export interface GetFolderParams {
 
 export interface ListFoldersWhere {
     type: string;
+    parentId?: string;
 }
 
 export interface ListFoldersParams {
@@ -131,6 +132,12 @@ export interface DeleteLinkParams {
     link: Link;
 }
 
+export interface DeleteLinksParams {
+    tenant: string;
+    locale: string;
+    folderIds: string[];
+}
+
 export interface StorageOperationsGetLinkParams {
     id?: string;
     folderId?: string;
@@ -149,6 +156,7 @@ export interface StorageOperationsListLinksParams extends ListLinksParams {
 export type StorageOperationsCreateLinkParams = CreateLinkParams;
 export type StorageOperationsUpdateLinkParams = UpdateLinkParams;
 export type StorageOperationsDeleteLinkParams = DeleteLinkParams;
+export type StorageOperationsDeleteLinksParams = DeleteLinksParams;
 
 export interface OnLinkBeforeCreateTopicParams {
     link: Link;
@@ -202,6 +210,7 @@ export interface ILinks {
     createLink(input: LinkInput): Promise<Link>;
     updateLink(id: string, input: Partial<Link>): Promise<Link>;
     deleteLink(id: string): Promise<void>;
+    deleteLinks(folderIds: string[]): Promise<void>;
     onLinkBeforeCreate: Topic<OnLinkBeforeCreateTopicParams>;
     onLinkAfterCreate: Topic<OnLinkAfterCreateTopicParams>;
     onLinkBeforeUpdate: Topic<OnLinkBeforeUpdateTopicParams>;
@@ -233,4 +242,5 @@ export interface LinksStorageOperations {
     createLink(params: StorageOperationsCreateLinkParams): Promise<Link>;
     updateLink(params: StorageOperationsUpdateLinkParams): Promise<Link>;
     deleteLink(params: StorageOperationsDeleteLinkParams): Promise<void>;
+    deleteLinks(params: StorageOperationsDeleteLinksParams): Promise<void>;
 }

--- a/packages/api-folders/src/types.ts
+++ b/packages/api-folders/src/types.ts
@@ -2,6 +2,7 @@ import { TenancyContext } from "@webiny/api-tenancy/types";
 import { Context as BaseContext } from "@webiny/handler/types";
 import { I18NContext } from "@webiny/api-i18n/types";
 import { SecurityContext, SecurityIdentity } from "@webiny/api-security/types";
+import { Topic } from "@webiny/pubsub/types";
 
 export interface CreatedBy {
     id: string;
@@ -70,6 +71,32 @@ export type StorageOperationsCreateFolderParams = CreateFolderParams;
 export type StorageOperationsUpdateFolderParams = UpdateFolderParams;
 export type StorageOperationsDeleteFolderParams = DeleteFolderParams;
 
+export interface OnFolderBeforeCreateTopicParams {
+    folder: Folder;
+}
+
+export interface OnFolderAfterCreateTopicParams {
+    folder: Folder;
+}
+
+export interface OnFolderBeforeUpdateTopicParams {
+    folder: Folder;
+    original: Folder;
+}
+
+export interface OnFolderAfterUpdateTopicParams {
+    folder: Folder;
+    original: Folder;
+}
+
+export interface OnFolderBeforeDeleteTopicParams {
+    folder: Folder;
+}
+
+export interface OnFolderAfterDeleteTopicParams {
+    folder: Folder;
+}
+
 export interface Link {
     id: string;
     linkId: string;
@@ -135,6 +162,12 @@ export interface IFolders {
     createFolder(input: FolderInput): Promise<Folder>;
     updateFolder(id: string, input: Partial<Folder>): Promise<Folder>;
     deleteFolder(id: string): Promise<void>;
+    onFolderBeforeCreate: Topic<OnFolderBeforeCreateTopicParams>;
+    onFolderAfterCreate: Topic<OnFolderAfterCreateTopicParams>;
+    onFolderBeforeUpdate: Topic<OnFolderBeforeUpdateTopicParams>;
+    onFolderAfterUpdate: Topic<OnFolderAfterUpdateTopicParams>;
+    onFolderBeforeDelete: Topic<OnFolderBeforeDeleteTopicParams>;
+    onFolderAfterDelete: Topic<OnFolderAfterDeleteTopicParams>;
 }
 
 export interface ILinks {

--- a/packages/api-folders/src/types.ts
+++ b/packages/api-folders/src/types.ts
@@ -37,7 +37,6 @@ export interface GetFolderParams {
 
 export interface ListFoldersWhere {
     type: string;
-    parentId?: string;
 }
 
 export interface ListFoldersParams {

--- a/packages/api-folders/src/types.ts
+++ b/packages/api-folders/src/types.ts
@@ -195,6 +195,14 @@ export interface OnLinkAfterDeleteTopicParams {
     link: Link;
 }
 
+export interface OnLinkBeforeDeleteBatchTopicParams {
+    folderIds: string[];
+}
+
+export interface OnLinkAfterDeleteBatchTopicParams {
+    folderIds: string[];
+}
+
 export interface FoldersContext extends BaseContext, I18NContext, TenancyContext, SecurityContext {
     folders: Folders;
 }
@@ -228,6 +236,8 @@ export interface ILinks {
     onLinkAfterUpdate: Topic<OnLinkAfterUpdateTopicParams>;
     onLinkBeforeDelete: Topic<OnLinkBeforeDeleteTopicParams>;
     onLinkAfterDelete: Topic<OnLinkAfterDeleteTopicParams>;
+    onLinkBeforeDeleteBatch: Topic<OnLinkBeforeDeleteBatchTopicParams>;
+    onLinkAfterDeleteBatch: Topic<OnLinkAfterDeleteBatchTopicParams>;
 }
 
 export interface FoldersConfig {

--- a/packages/api-folders/tsconfig.build.json
+++ b/packages/api-folders/tsconfig.build.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "../plugins/tsconfig.build.json"
+    },
+    {
+      "path": "../pubsub/tsconfig.build.json"
     }
   ],
   "compilerOptions": {

--- a/packages/api-folders/tsconfig.json
+++ b/packages/api-folders/tsconfig.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "../plugins"
+    },
+    {
+      "path": "../pubsub"
     }
   ],
   "compilerOptions": {
@@ -73,7 +76,9 @@
       "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],
       "@webiny/handler-graphql": ["../handler-graphql/src"],
       "@webiny/plugins/*": ["../plugins/src/*"],
-      "@webiny/plugins": ["../plugins/src"]
+      "@webiny/plugins": ["../plugins/src"],
+      "@webiny/pubsub/*": ["../pubsub/src/*"],
+      "@webiny/pubsub": ["../pubsub/src"]
     },
     "baseUrl": "."
   }

--- a/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/index.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/index.ts
@@ -24,7 +24,11 @@ import { createFormBuilder } from "@webiny/api-form-builder";
 import { createFormBuilderStorageOperations } from "@webiny/api-form-builder-so-ddb";
 import { createHeadlessCmsContext, createHeadlessCmsGraphQL } from "@webiny/api-headless-cms";
 import { createStorageOperations as createHeadlessCmsStorageOperations } from "@webiny/api-headless-cms-ddb";
-import { createFoldersContext, createFoldersGraphQL } from "@webiny/api-folders";
+import {
+    createFoldersContext,
+    createFoldersGraphQL,
+    createFoldersSubscriptions
+} from "@webiny/api-folders";
 import { createStorageOperations as createFoldersStorageOperations } from "@webiny/api-folders-so-ddb";
 import securityPlugins from "./security";
 import tenantManager from "@webiny/api-tenant-manager";
@@ -92,6 +96,7 @@ export const handler = createHandler({
             })
         }),
         createFoldersGraphQL(),
+        createFoldersSubscriptions(),
         createApwGraphQL(),
         createApwPageBuilderContext({
             storageOperations: createApwSaStorageOperations({ documentClient })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10822,6 +10822,7 @@ __metadata:
     "@webiny/handler-graphql": ^5.33.2
     "@webiny/plugins": ^5.33.2
     "@webiny/project-utils": ^5.33.2
+    "@webiny/pubsub": ^5.33.2
     joi: ^17.6.0
     mdbid: ^1.0.0
     rimraf: ^3.0.2


### PR DESCRIPTION
## Changes
With this PR:
- add `pubsub` events to folders and links
- add `deleteLinks` operation to delete all links bound to a folder id list
- on folder deletion, delete all links bound to that folder and its folders
 
Closes [WEB-1921](https://webiny.atlassian.net/browse/WEB-1921)

