### PR TITLE
Introduce `pulumiResourceNamePrefix ` Parameter

### DIFF
--- a/apps/admin/webiny.application.ts
+++ b/apps/admin/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createAdminApp } from "@webiny/serverless-cms-aws";
 
-export default createAdminApp();
+export default createAdminApp({
+    prefixPulumiResources: "wby-"
+});

--- a/apps/admin/webiny.application.ts
+++ b/apps/admin/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createAdminApp } from "@webiny/serverless-cms-aws";
 
 export default createAdminApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/apps/api/webiny.application.ts
+++ b/apps/api/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createApiApp } from "@webiny/serverless-cms-aws";
 
-export default createApiApp();
+export default createApiApp({
+    prefixPulumiResources: "wby-"
+});

--- a/apps/api/webiny.application.ts
+++ b/apps/api/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createApiApp } from "@webiny/serverless-cms-aws";
 
 export default createApiApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/apps/core/webiny.application.ts
+++ b/apps/core/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createCoreApp } from "@webiny/serverless-cms-aws";
 
 export default createCoreApp({
-    elasticSearch: false
+    prefixPulumiResources: "wby-"
 });

--- a/apps/core/webiny.application.ts
+++ b/apps/core/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createCoreApp } from "@webiny/serverless-cms-aws";
 
 export default createCoreApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/apps/website/webiny.application.ts
+++ b/apps/website/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createWebsiteApp } from "@webiny/serverless-cms-aws";
 
-export default createWebsiteApp();
+export default createWebsiteApp({
+    prefixPulumiResources: "wby-"
+});

--- a/apps/website/webiny.application.ts
+++ b/apps/website/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createWebsiteApp } from "@webiny/serverless-cms-aws";
 
 export default createWebsiteApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/common/apps/admin/webiny.application.ts
+++ b/packages/cwp-template-aws/template/common/apps/admin/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createAdminApp } from "@webiny/serverless-cms-aws";
 
-export default createAdminApp();
+export default createAdminApp({
+    prefixPulumiResources: "wby-"
+});

--- a/packages/cwp-template-aws/template/common/apps/admin/webiny.application.ts
+++ b/packages/cwp-template-aws/template/common/apps/admin/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createAdminApp } from "@webiny/serverless-cms-aws";
 
 export default createAdminApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/common/apps/website/webiny.application.ts
+++ b/packages/cwp-template-aws/template/common/apps/website/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createWebsiteApp } from "@webiny/serverless-cms-aws";
 
-export default createWebsiteApp();
+export default createWebsiteApp({
+    prefixPulumiResources: "wby-"
+});

--- a/packages/cwp-template-aws/template/common/apps/website/webiny.application.ts
+++ b/packages/cwp-template-aws/template/common/apps/website/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createWebsiteApp } from "@webiny/serverless-cms-aws";
 
 export default createWebsiteApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb-es/apps/api/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/api/webiny.application.ts
@@ -1,5 +1,6 @@
 import { createApiApp } from "@webiny/serverless-cms-aws";
 
 export default createApiApp({
-    elasticSearch: true
+    elasticSearch: true,
+    prefixPulumiResources: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb-es/apps/api/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/api/webiny.application.ts
@@ -2,5 +2,5 @@ import { createApiApp } from "@webiny/serverless-cms-aws";
 
 export default createApiApp({
     elasticSearch: true,
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb-es/apps/core/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/core/webiny.application.ts
@@ -1,5 +1,6 @@
 import { createCoreApp } from "@webiny/serverless-cms-aws";
 
 export default createCoreApp({
-    elasticSearch: true
+    elasticSearch: true,
+    prefixPulumiResources: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb-es/apps/core/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/core/webiny.application.ts
@@ -2,5 +2,5 @@ import { createCoreApp } from "@webiny/serverless-cms-aws";
 
 export default createCoreApp({
     elasticSearch: true,
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb/apps/api/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/api/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createApiApp } from "@webiny/serverless-cms-aws";
 
-export default createApiApp();
+export default createApiApp({
+    prefixPulumiResources: "wby-"
+});

--- a/packages/cwp-template-aws/template/ddb/apps/api/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/api/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createApiApp } from "@webiny/serverless-cms-aws";
 
 export default createApiApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/cwp-template-aws/template/ddb/apps/core/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/core/webiny.application.ts
@@ -1,3 +1,5 @@
 import { createCoreApp } from "@webiny/serverless-cms-aws";
 
-export default createCoreApp();
+export default createCoreApp({
+    prefixPulumiResources: "wby-"
+});

--- a/packages/cwp-template-aws/template/ddb/apps/core/webiny.application.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/core/webiny.application.ts
@@ -1,5 +1,5 @@
 import { createCoreApp } from "@webiny/serverless-cms-aws";
 
 export default createCoreApp({
-    prefixPulumiResources: "wby-"
+    pulumiResourceNamePrefix: "wby-"
 });

--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -16,7 +16,7 @@ export interface CreateAdminPulumiAppParams {
     /**
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
-    prefixPulumiResources?: PulumiAppParam<string>;
+    pulumiResourceNamePrefix?: PulumiAppParam<string>;
 }
 
 export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParams) => {

--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -1,4 +1,4 @@
-import {PulumiAppParam, PulumiAppParamCallback} from "@webiny/pulumi";
+import { PulumiAppParam, PulumiAppParamCallback } from "@webiny/pulumi";
 import { createReactPulumiApp, CustomDomainParams } from "~/apps";
 
 export type AdminPulumiApp = ReturnType<typeof createReactPulumiApp>;

--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -1,4 +1,4 @@
-import { PulumiAppParamCallback } from "@webiny/pulumi";
+import {PulumiAppParam, PulumiAppParamCallback} from "@webiny/pulumi";
 import { createReactPulumiApp, CustomDomainParams } from "~/apps";
 
 export type AdminPulumiApp = ReturnType<typeof createReactPulumiApp>;
@@ -12,6 +12,11 @@ export interface CreateAdminPulumiAppParams {
      * or add additional ones into the mix.
      */
     pulumi?: (app: AdminPulumiApp) => void | Promise<void>;
+
+    /**
+     * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
+     */
+    prefixPulumiResources?: PulumiAppParam<string>;
 }
 
 export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParams) => {

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -31,6 +31,11 @@ export interface CreateApiPulumiAppParams {
      * or add additional ones into the mix.
      */
     pulumi?: (app: ApiPulumiApp) => void | Promise<void>;
+
+    /**
+     * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
+     */
+    prefixPulumiResources?: PulumiAppParam<string>;
 }
 
 export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = {}) => {
@@ -39,6 +44,15 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
         path: "apps/api",
         config: projectAppParams,
         program: async app => {
+            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
+            if (prefixPulumiResources) {
+                app.onResource(resource => {
+                    if (!resource.name.startsWith(prefixPulumiResources)) {
+                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    }
+                });
+            }
+
             // Overrides must be applied via a handler, registered at the very start of the program.
             // By doing this, we're ensuring user's adjustments are not applied too late.
             if (projectAppParams.pulumi) {

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -35,7 +35,7 @@ export interface CreateApiPulumiAppParams {
     /**
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
-    prefixPulumiResources?: PulumiAppParam<string>;
+    pulumiResourceNamePrefix?: PulumiAppParam<string>;
 }
 
 export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = {}) => {
@@ -44,11 +44,13 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
         path: "apps/api",
         config: projectAppParams,
         program: async app => {
-            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
-            if (prefixPulumiResources) {
+            const pulumiResourceNamePrefix = app.getParam(
+                projectAppParams.pulumiResourceNamePrefix
+            );
+            if (pulumiResourceNamePrefix) {
                 app.onResource(resource => {
-                    if (!resource.name.startsWith(prefixPulumiResources)) {
-                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    if (!resource.name.startsWith(pulumiResourceNamePrefix)) {
+                        resource.name = `${pulumiResourceNamePrefix}${resource.name}`;
                     }
                 });
             }

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -42,7 +42,7 @@ export interface CreateCorePulumiAppParams {
     /**
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
-    prefixPulumiResources?: PulumiAppParam<string>;
+    pulumiResourceNamePrefix?: PulumiAppParam<string>;
 }
 
 export interface CoreAppLegacyConfig {
@@ -55,11 +55,13 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         path: "apps/core",
         config: projectAppParams,
         program: async app => {
-            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
-            if (prefixPulumiResources) {
+            const pulumiResourceNamePrefix = app.getParam(
+                projectAppParams.pulumiResourceNamePrefix
+            );
+            if (pulumiResourceNamePrefix) {
                 app.onResource(resource => {
-                    if (!resource.name.startsWith(prefixPulumiResources)) {
-                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    if (!resource.name.startsWith(pulumiResourceNamePrefix)) {
+                        resource.name = `${pulumiResourceNamePrefix}${resource.name}`;
                     }
                 });
             }

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -38,6 +38,11 @@ export interface CreateCorePulumiAppParams {
      * or add additional ones into the mix.
      */
     pulumi?: (app: CorePulumiApp) => void | Promise<void>;
+
+    /**
+     * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
+     */
+    prefixPulumiResources?: PulumiAppParam<string>;
 }
 
 export interface CoreAppLegacyConfig {
@@ -50,6 +55,15 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         path: "apps/core",
         config: projectAppParams,
         program: async app => {
+            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
+            if (prefixPulumiResources) {
+                app.onResource(resource => {
+                    if (!resource.name.startsWith(prefixPulumiResources)) {
+                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    }
+                });
+            }
+
             // Overrides must be applied via a handler, registered at the very start of the program.
             // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {

--- a/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
@@ -1,6 +1,6 @@
 import * as aws from "@pulumi/aws";
 
-import { createPulumiApp, PulumiAppParamCallback } from "@webiny/pulumi";
+import { createPulumiApp, PulumiAppParam, PulumiAppParamCallback } from "@webiny/pulumi";
 import { tagResources } from "~/utils";
 import { createPrivateAppBucket } from "../createAppBucket";
 import { applyCustomDomain, CustomDomainParams } from "../customDomain";
@@ -26,6 +26,11 @@ export interface CreateReactPulumiAppParams {
      * or add additional ones into the mix.
      */
     pulumi?: (app: ReactPulumiApp) => void | Promise<void>;
+
+    /**
+     * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
+     */
+    prefixPulumiResources?: PulumiAppParam<string>;
 }
 
 export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParams) => {
@@ -34,6 +39,15 @@ export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParam
         path: projectAppParams.folder,
         config: projectAppParams,
         program: async app => {
+            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
+            if (prefixPulumiResources) {
+                app.onResource(resource => {
+                    if (!resource.name.startsWith(prefixPulumiResources)) {
+                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    }
+                });
+            }
+
             const { name } = projectAppParams;
 
             // Overrides must be applied via a handler, registered at the very start of the program.

--- a/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
@@ -30,7 +30,7 @@ export interface CreateReactPulumiAppParams {
     /**
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
-    prefixPulumiResources?: PulumiAppParam<string>;
+    pulumiResourceNamePrefix?: PulumiAppParam<string>;
 }
 
 export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParams) => {
@@ -39,11 +39,13 @@ export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParam
         path: projectAppParams.folder,
         config: projectAppParams,
         program: async app => {
-            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
-            if (prefixPulumiResources) {
+            const pulumiResourceNamePrefix = app.getParam(
+                projectAppParams.pulumiResourceNamePrefix
+            );
+            if (pulumiResourceNamePrefix) {
                 app.onResource(resource => {
-                    if (!resource.name.startsWith(prefixPulumiResources)) {
-                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    if (!resource.name.startsWith(pulumiResourceNamePrefix)) {
+                        resource.name = `${pulumiResourceNamePrefix}${resource.name}`;
                     }
                 });
             }

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -37,7 +37,7 @@ export interface CreateWebsitePulumiAppParams {
     /**
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
-    prefixPulumiResources?: PulumiAppParam<string>;
+    pulumiResourceNamePrefix?: PulumiAppParam<string>;
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {
@@ -46,11 +46,13 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
         path: "apps/website",
         config: projectAppParams,
         program: async app => {
-            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
-            if (prefixPulumiResources) {
+            const pulumiResourceNamePrefix = app.getParam(
+                projectAppParams.pulumiResourceNamePrefix
+            );
+            if (pulumiResourceNamePrefix) {
                 app.onResource(resource => {
-                    if (!resource.name.startsWith(prefixPulumiResources)) {
-                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    if (!resource.name.startsWith(pulumiResourceNamePrefix)) {
+                        resource.name = `${pulumiResourceNamePrefix}${resource.name}`;
                     }
                 });
             }

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -33,6 +33,11 @@ export interface CreateWebsitePulumiAppParams {
      * or add additional ones into the mix.
      */
     pulumi?: (app: WebsitePulumiApp) => void | Promise<void>;
+
+    /**
+     * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
+     */
+    prefixPulumiResources?: PulumiAppParam<string>;
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {
@@ -41,6 +46,15 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
         path: "apps/website",
         config: projectAppParams,
         program: async app => {
+            const prefixPulumiResources = app.getParam(projectAppParams.prefixPulumiResources);
+            if (prefixPulumiResources) {
+                app.onResource(resource => {
+                    if (!resource.name.startsWith(prefixPulumiResources)) {
+                        resource.name = `${prefixPulumiResources}${resource.name}`;
+                    }
+                });
+            }
+
             // Overrides must be applied via a handler, registered at the very start of the program.
             // By doing this, we're ensuring user's adjustments are not applied to late.
             if (projectAppParams.pulumi) {


### PR DESCRIPTION
## Changes
In order to prefix all cloud infrastructure (Pulumi) resource names, users had to use the following piece of code in their `webiny.application.ts` files:

```ts
import { createWebsiteApp } from "@webiny/serverless-cms-aws";

export default createWebsiteApp({
    pulumi: app => {
        app.onResource(resource => {
            if (!resource.name.startsWith("wby-")) {
                resource.name = `wby-${resource.name}`;
            }
        });
    }
});
```

This PR makes this a bit nicer, by introducing the `pulumiResourceNamePrefix ` parameter. With it, prefixing all resources now looks like the following:

```ts
import { createWebsiteApp } from "@webiny/serverless-cms-aws";

export default createWebsiteApp({
    pulumiResourceNamePrefix: "wby-"
});
```

Why is this important? It's because of the #2856 and the fact that the new CWP CloudFormation template now expects the `wby-` prefix in deployed resource names. Which means, all new Webiny projects will now be deployed with the `wby-` prefix applied OOTB, via the generated `webiny.application.ts` files (we've updated the `@webiny/cwp-template-aws` package).

## How Has This Been Tested?
Manually.

## Documentation
Updated package README and will add this to the changelog.