### PR TITLE
fix: delete link on page deletetion

### DIFF
--- a/packages/app-page-builder/src/admin/components/Table/Preview.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Preview.tsx
@@ -18,7 +18,7 @@ export const Preview = ({ open, onClose, canCreate, onCreatePage }: PreviewProps
     return (
         <Content modal={true} open={open} dir="rtl" onClose={onClose}>
             <DrawerContent dir="ltr">
-                <PageDetails canCreate={canCreate} onCreatePage={onCreatePage} />
+                <PageDetails canCreate={canCreate} onCreatePage={onCreatePage} onDelete={onClose} />
             </DrawerContent>
         </Content>
     );

--- a/packages/app-page-builder/src/admin/components/Table/Row/Page/PageActionDelete.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Row/Page/PageActionDelete.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
 
-import { LinkItem } from "@webiny/app-folders/types";
 import { i18n } from "@webiny/app/i18n";
 import { MenuItem } from "@webiny/ui/Menu";
 
@@ -13,17 +12,15 @@ const t = i18n.ns("app-headless-cms/app-page-builder/pages-table/actions/page/de
 
 interface Props {
     page: PbPageDataLink;
-    onDeletePageSuccess: (linkItem: LinkItem) => void;
 }
-export const PageActionDelete = ({ page, onDeletePageSuccess }: Props): ReactElement => {
+export const PageActionDelete = ({ page }: Props): ReactElement => {
     const { canDelete } = usePermission();
-
-    const { deletePageMutation } = useDeletePage({ page, onDeletePageSuccess });
+    const { openDialogDeletePage } = useDeletePage({ page });
 
     if (!canDelete(page)) {
         console.log("Does not have permission to delete page.");
         return <></>;
     }
 
-    return <MenuItem onClick={deletePageMutation}>{t`Delete`}</MenuItem>;
+    return <MenuItem onClick={openDialogDeletePage}>{t`Delete`}</MenuItem>;
 };

--- a/packages/app-page-builder/src/admin/components/Table/Table.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useMemo, useState } from "react";
 
 import { ReactComponent as More } from "@material-design-icons/svg/filled/more_vert.svg";
 import { FolderDialogUpdate } from "@webiny/app-folders";
-import { FolderItem, LinkItem } from "@webiny/app-folders/types";
+import { FolderItem } from "@webiny/app-folders/types";
 import { Columns, DataTable } from "@webiny/ui/DataTable";
 import { Menu } from "@webiny/ui/Menu";
 
@@ -31,7 +31,6 @@ interface Props {
     pages: PbPageDataLink[];
     folders: FolderItem[];
     loading?: boolean;
-    onDeletePage: (link: LinkItem) => void;
     openPreviewDrawer: () => void;
 }
 
@@ -47,13 +46,7 @@ interface Entry {
     original: PbPageDataLink | FolderItem;
 }
 
-export const Table = ({
-    folders,
-    pages,
-    loading,
-    onDeletePage,
-    openPreviewDrawer
-}: Props): ReactElement => {
+export const Table = ({ folders, pages, loading, openPreviewDrawer }: Props): ReactElement => {
     const [data, setData] = useState<Entry[]>([]);
     const [selectedFolder, setSelectedFolder] = useState<FolderItem>();
     const [updateDialogOpen, setUpdateDialogOpen] = useState<boolean>(false);
@@ -144,10 +137,7 @@ export const Table = ({
                             <PageActionEdit page={original as PbPageDataLink} />
                             <PageActionPreview page={original as PbPageDataLink} />
                             <PageActionPublish page={original as PbPageDataLink} />
-                            <PageActionDelete
-                                page={original as PbPageDataLink}
-                                onDeletePageSuccess={onDeletePage}
-                            />
+                            <PageActionDelete page={original as PbPageDataLink} />
                         </Menu>
                     );
                 } else {

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/header/deletePage/DeletePage.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/header/deletePage/DeletePage.tsx
@@ -1,94 +1,19 @@
-import React, { useCallback } from "react";
-import { useRouter } from "@webiny/react-router";
-import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
-import { useConfirmationDialog } from "@webiny/app-admin/hooks/useConfirmationDialog";
-import { useDialog } from "@webiny/app-admin/hooks/useDialog";
+import React from "react";
 import { IconButton } from "@webiny/ui/Button";
 import { Tooltip } from "@webiny/ui/Tooltip";
 import { ReactComponent as DeleteIcon } from "~/admin/assets/delete.svg";
-import { i18n } from "@webiny/app/i18n";
 import usePermission from "~/hooks/usePermission";
-import * as GQLCache from "~/admin/views/Pages/cache";
-import { useAdminPageBuilder } from "~/admin/hooks/useAdminPageBuilder";
 import { PbPageData } from "~/types";
-
-const t = i18n.ns("app-headless-cms/app-page-builder/page-details/header/delete-page");
+import { useDeletePage } from "~/admin/views/Pages/hooks/useDeletePage";
 
 interface DeletePageProps {
     page: PbPageData;
+    onDelete?: () => void;
 }
 const DeletePage: React.FC<DeletePageProps> = props => {
-    const { page } = props;
-    const { showSnackbar } = useSnackbar();
-    const { history } = useRouter();
-    const { showDialog } = useDialog();
+    const { page, onDelete } = props;
     const { canDelete } = usePermission();
-    const { deletePage, client } = useAdminPageBuilder();
-
-    const { showConfirmation } = useConfirmationDialog({
-        title: t`Delete page`,
-        message: (
-            <p>
-                {t`You are about to delete the entire page and all of its revisions!`}
-                <br />
-                {t`Are you sure you want to permanently delete the page {title}?`({
-                    title: <strong>{page.title}</strong>
-                })}
-            </p>
-        ),
-        dataTestId: "pb-page-details-header-delete-dialog"
-    });
-
-    const confirmDelete = useCallback(
-        () =>
-            showConfirmation(async () => {
-                const [uniquePageId] = page.id.split("#");
-                const id = `${uniquePageId}#0001`;
-                /**
-                 * Delete page using pageBuilder deletePage hook.
-                 */
-                const response = await deletePage(
-                    { id },
-                    {
-                        client: client,
-                        mutationOptions: {
-                            update(_, { data }) {
-                                if (data.pageBuilder.deletePage.error) {
-                                    return;
-                                }
-                                // Also, delete the page from "LIST_PAGES_ cache
-                                GQLCache.removePageFromListCache(client.cache, page);
-                            }
-                        }
-                    }
-                );
-
-                if (!response) {
-                    return;
-                }
-                const { error } = response;
-                if (error) {
-                    showDialog(error.message, { title: t`Could not delete page.` });
-                    return;
-                }
-
-                showSnackbar(
-                    <span>
-                        {t`The page {title} was deleted successfully.`({
-                            title: (
-                                <strong>
-                                    {page.title.slice(0, 20)}
-                                    ...
-                                </strong>
-                            )
-                        })}
-                    </span>
-                );
-
-                history.push("/page-builder/pages");
-            }),
-        [page.id]
-    );
+    const { openDialogDeletePage } = useDeletePage({ page, onDelete });
 
     if (!canDelete(page)) {
         return null;
@@ -98,7 +23,7 @@ const DeletePage: React.FC<DeletePageProps> = props => {
         <Tooltip content={"Delete Page"} placement={"top"}>
             <IconButton
                 icon={<DeleteIcon />}
-                onClick={confirmDelete}
+                onClick={openDialogDeletePage}
                 data-testid={"pb-page-details-header-delete-button"}
             />
         </Tooltip>

--- a/packages/app-page-builder/src/admin/views/Pages/PageDetails.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PageDetails.tsx
@@ -56,8 +56,9 @@ const EmptyPageDetails: React.FC<EmptyPageDetailsProps> = ({ onCreatePage, canCr
 interface PageDetailsProps {
     onCreatePage: (event?: React.SyntheticEvent) => void;
     canCreate: boolean;
+    onDelete: () => void;
 }
-const PageDetails: React.FC<PageDetailsProps> = ({ onCreatePage, canCreate }) => {
+const PageDetails: React.FC<PageDetailsProps> = ({ onCreatePage, canCreate, onDelete }) => {
     const { history, location } = useRouter();
     const { showSnackbar } = useSnackbar();
 
@@ -89,7 +90,8 @@ const PageDetails: React.FC<PageDetailsProps> = ({ onCreatePage, canCreate }) =>
                     <test-id data-testid="pb-page-details">
                         {renderPlugins("pb-page-details", {
                             page,
-                            getPageQuery
+                            getPageQuery,
+                            onDelete
                         })}
                     </test-id>
                 </DetailsContainer>

--- a/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
@@ -8,6 +8,7 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import useImportPage from "./hooks/useImportPage";
 import useCreatePage from "./hooks/useCreatePage";
 import { PageBuilderSecurityPermission } from "~/types";
+import { useRouter } from "@webiny/react-router";
 
 enum LoadingLabel {
     CREATING_PAGE = "Creating page...",
@@ -20,6 +21,7 @@ enum Operation {
 }
 
 const Pages: React.FC = () => {
+    const { history } = useRouter();
     const [operation, setOperation] = useState<string>(Operation.CREATE);
     const [loadingLabel, setLoadingLabel] = useState<string | null>(null);
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
@@ -80,7 +82,11 @@ const Pages: React.FC = () => {
                     />
                 </LeftPanel>
                 <RightPanel>
-                    <PageDetails canCreate={canCreate} onCreatePage={handleOnCreatePage} />
+                    <PageDetails
+                        canCreate={canCreate}
+                        onCreatePage={handleOnCreatePage}
+                        onDelete={() => history.push("/page-builder/pages")}
+                    />
                 </RightPanel>
             </SplitView>
         </>

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from "react";
 import debounce from "lodash/debounce";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import { FolderDialogCreate, useFolders, useLinks } from "@webiny/app-folders";
+import { useRouter } from "@webiny/react-router";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { Scrollbar } from "@webiny/ui/Scrollbar";
 
@@ -46,13 +47,14 @@ const getCurrentFolderList = (
 };
 
 export const Main = ({ folderId }: Props) => {
+    const { history, location } = useRouter();
+
     const { folders = [], loading: foldersLoading } = useFolders(FOLDER_TYPE);
     const {
         links,
         loading: linksLoading,
         meta,
-        listLinks,
-        deleteLink
+        listLinks
     } = useLinks(folderId || FOLDER_ID_DEFAULT);
 
     const { pages, loading: pagesLoading } = useGetPages(links, folderId);
@@ -70,7 +72,10 @@ export const Main = ({ folderId }: Props) => {
 
     const [showPreviewDrawer, setPreviewDrawer] = useState(false);
     const openPreviewDrawer = useCallback(() => setPreviewDrawer(true), []);
-    const closePreviewDrawer = useCallback(() => setPreviewDrawer(false), []);
+    const closePreviewDrawer = useCallback(() => {
+        removeUrlParam("id");
+        setPreviewDrawer(false);
+    }, []);
 
     const canCreate = useCanCreatePage();
 
@@ -97,6 +102,12 @@ export const Main = ({ folderId }: Props) => {
         }, 200),
         [meta]
     );
+
+    const removeUrlParam = (param: string) => {
+        const params = new URLSearchParams(location.search);
+        params.delete(param);
+        history.push(`${location.pathname}?${params.toString()}`);
+    };
 
     return (
         <>
@@ -137,7 +148,6 @@ export const Main = ({ folderId }: Props) => {
                                         linksLoading.LIST_LINKS ||
                                         foldersLoading.LIST_FOLDERS
                                     }
-                                    onDeletePage={deleteLink}
                                     openPreviewDrawer={openPreviewDrawer}
                                 />
                             </Scrollbar>


### PR DESCRIPTION
## Changes
With this PR: 
- refactor: `useDeletePage` handle the page deletion process for both `Table` and `Preview` component. It exports `openDialogDeletePage` method, used to open the confirmation dialog that handles the process.
- refactor: we subscribe to  `onPageDelete` to delete the bound link and the page in the state.
- feat: when the user closes the `Preview` drawer, we remove the `id` param from the URL.

Closes [WEB-1941](https://webiny.atlassian.net/browse/WEB-1941)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Cypress

