### PR TITLE
fix: default block category icon state fix

### DIFF
--- a/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesForm.tsx
+++ b/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesForm.tsx
@@ -148,7 +148,10 @@ const CategoriesForm: React.FC<CategoriesFormProps> = ({ canCreate }) => {
     );
 
     const data = useMemo((): PbBlockCategory => {
-        return getQuery.data?.pageBuilder?.getBlockCategory.data || ({} as PbBlockCategory);
+        return (
+            getQuery.data?.pageBuilder?.getBlockCategory.data ||
+            ({ icon: "fas/star" } as PbBlockCategory)
+        );
     }, [loadedBlockCategory.slug]);
 
     const { identity, getPermission } = useSecurity();

--- a/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesForm.tsx
+++ b/packages/app-page-builder/src/admin/views/BlockCategories/BlockCategoriesForm.tsx
@@ -148,10 +148,7 @@ const CategoriesForm: React.FC<CategoriesFormProps> = ({ canCreate }) => {
     );
 
     const data = useMemo((): PbBlockCategory => {
-        return (
-            getQuery.data?.pageBuilder?.getBlockCategory.data ||
-            ({ icon: "fas/star" } as PbBlockCategory)
-        );
+        return getQuery.data?.pageBuilder?.getBlockCategory.data || ({} as PbBlockCategory);
     }, [loadedBlockCategory.slug]);
 
     const { identity, getPermission } = useSecurity();
@@ -230,7 +227,11 @@ const CategoriesForm: React.FC<CategoriesFormProps> = ({ canCreate }) => {
                                 </Bind>
                             </Cell>
                             <Cell span={12}>
-                                <Bind name="icon" validators={validation.create("required")}>
+                                <Bind
+                                    name="icon"
+                                    validators={validation.create("required")}
+                                    defaultValue={"fas/star"}
+                                >
                                     <IconPicker
                                         label={t`Category icon`}
                                         description={t`Icon that will be displayed in the page builder.`}


### PR DESCRIPTION
## Changes
Fix issue "Bug: Default icon pre-defined, but value still required"
(added initial value matches default picker image)

## How Has This Been Tested?
Manual

## Documentation
None