### PR TITLE
fix(api-headless-cms): generate ref union types recursively

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/extendingGqlSchemaError.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/extendingGqlSchemaError.test.ts
@@ -1,0 +1,31 @@
+import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
+import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins";
+
+const graphqlSchemaPlugin = new GraphQLSchemaPlugin({
+    typeDefs: /* GraphQL */ `
+        type BrokenType {
+            # types without fields are invalid
+        }
+    `
+});
+
+describe("invalid schema error formatting", () => {
+    test("print invalid part of the schema", async () => {
+        const { invoke } = useGraphQLHandler({
+            path: "manage/en-US",
+            plugins: [graphqlSchemaPlugin]
+        });
+
+        const [{ error }] = await invoke({
+            body: { query: `{ irrelevant }` }
+        });
+
+        expect(error).toEqual({
+            message: 'Syntax Error: Expected Name, found "}".',
+            code: "INVALID_GRAPHQL_SCHEMA",
+            data: {
+                invalidSegment: expect.stringContaining("type BrokenType")
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModelsRef.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModelsRef.test.ts
@@ -1,0 +1,336 @@
+import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
+import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
+
+const pageModelPlugin = new CmsModelPlugin({
+    fields: [
+        {
+            fieldId: "title",
+            helpText: null,
+            id: "jf7h0jsc",
+            label: "Title",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "contentBlocks",
+            helpText: null,
+            id: "0kbfq0j6",
+            label: "Content Blocks",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "object"
+            },
+            settings: {
+                fields: [
+                    {
+                        fieldId: "blocks",
+                        id: "lxza895k",
+                        label: "Blocks",
+                        renderer: {
+                            name: "ref-input"
+                        },
+                        settings: {
+                            models: [
+                                {
+                                    modelId: "faqGroupBanner"
+                                },
+                                {
+                                    modelId: "faq"
+                                }
+                            ]
+                        },
+                        type: "ref",
+                        validation: []
+                    }
+                ],
+                layout: [["lxza895k"]]
+            },
+            type: "object",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [["jf7h0jsc"], ["0kbfq0j6"]],
+    locale: "en-US",
+    lockedFields: [],
+    modelId: "page",
+    name: "Page",
+    description: "",
+    tenant: "root",
+    titleFieldId: "title"
+});
+
+const faqModelPlugin = new CmsModelPlugin({
+    locale: "en-US",
+    description: "",
+    fields: [
+        {
+            fieldId: "question",
+            helpText: null,
+            id: "c8pphxf2",
+            label: "Question",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "answer",
+            helpText: null,
+            id: "477qeutg",
+            label: "Answer",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "rich-text-input"
+            },
+            settings: {},
+            type: "rich-text",
+            validation: []
+        },
+        {
+            fieldId: "image",
+            helpText: null,
+            id: "7jubpw3w",
+            label: "Image",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "file-input"
+            },
+            settings: {
+                imagesOnly: true
+            },
+            type: "file",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [["c8pphxf2"], ["477qeutg"], ["7jubpw3w"]],
+    lockedFields: [],
+    modelId: "faq",
+    name: "FAQ",
+    titleFieldId: "id"
+});
+
+const faqGroupBannerModelPlugin = new CmsModelPlugin({
+    description: "",
+    fields: [
+        {
+            fieldId: "eyebrowText",
+            helpText: null,
+            id: "iqe2aw2g",
+            label: "Eyebrow Text",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "heading",
+            helpText: null,
+            id: "25kvqahf",
+            label: "Heading",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "subHeading",
+            helpText: null,
+            id: "an0tmg81",
+            label: "Sub Heading",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "alternateBackgroundColor",
+            helpText: null,
+            id: "g4ei6uhp",
+            label: "Alternate Background Color",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "boolean-input"
+            },
+            settings: {
+                defaultValue: null
+            },
+            type: "boolean",
+            validation: []
+        },
+        {
+            fieldId: "isFaqItemCollapsable",
+            helpText: null,
+            id: "g98nz2mr",
+            label: "Is FAQ Item Collapsable",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "boolean-input"
+            },
+            settings: {
+                defaultValue: null
+            },
+            type: "boolean",
+            validation: []
+        },
+        {
+            fieldId: "customId",
+            helpText: null,
+            id: "t03jq8ke",
+            label: "Custom ID",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "faqGroup",
+            helpText: null,
+            id: "5f0dbgvi",
+            label: "FAQ Group",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "ref-input"
+            },
+            settings: {
+                models: [
+                    {
+                        modelId: "faq"
+                    }
+                ]
+            },
+            type: "ref",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [
+        ["iqe2aw2g"],
+        ["25kvqahf"],
+        ["an0tmg81"],
+        ["5f0dbgvi"],
+        ["g4ei6uhp"],
+        ["g98nz2mr"],
+        ["t03jq8ke"]
+    ],
+    locale: "en-US",
+    lockedFields: [],
+    modelId: "faqGroupBanner",
+    name: "FAQ Group Banner",
+    tenant: "root",
+    titleFieldId: "id"
+});
+
+describe("content model plugins - nested `ref` field union types", () => {
+    const { introspect } = useGraphQLHandler({
+        plugins: [pageModelPlugin, faqModelPlugin, faqGroupBannerModelPlugin],
+        path: "read/en-US"
+    });
+
+    test("must generate valid schema for nested `ref` field union", async () => {
+        const [, response] = await introspect();
+        expect(response.statusCode).toBe(200);
+    });
+});

--- a/packages/api-headless-cms/package.json
+++ b/packages/api-headless-cms/package.json
@@ -37,6 +37,7 @@
     "@webiny/pubsub": "^5.33.2",
     "@webiny/utils": "^5.33.2",
     "@webiny/validation": "^5.33.2",
+    "code-frame": "^5.0.0",
     "commodo-fields-object": "^1.0.6",
     "dataloader": "^2.0.0",
     "dot-prop": "^6.0.1",

--- a/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
@@ -117,12 +117,9 @@ const checkEndpointAccess = async (context: CmsContext): Promise<void> => {
 const formatErrorPayload = (error: Error) => {
     if (error instanceof WebinyError) {
         return {
-            data: null,
-            error: {
-                message: error.message,
-                code: error.code,
-                data: error.data
-            }
+            message: error.message,
+            code: error.code,
+            data: error.data
         };
     }
 

--- a/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
@@ -114,6 +114,25 @@ const checkEndpointAccess = async (context: CmsContext): Promise<void> => {
     }
 };
 
+const formatErrorPayload = (error: Error) => {
+    if (error instanceof WebinyError) {
+        return {
+            data: null,
+            error: {
+                message: error.message,
+                code: error.code,
+                data: error.data
+            }
+        };
+    }
+
+    return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack
+    };
+};
+
 export interface GraphQLHandlerFactoryParams {
     debug?: boolean;
 }
@@ -144,18 +163,7 @@ const cmsRoutes = new RoutePlugin<CmsContext>(({ onPost, onOptions, context }) =
             const result = await processRequestBody(body, schema, context);
             return reply.code(200).send(result);
         } catch (ex) {
-            if (ex instanceof WebinyError) {
-                return reply.code(500).send({
-                    data: null,
-                    error: {
-                        message: ex.message,
-                        code: ex.code,
-                        data: ex.data
-                    }
-                });
-            }
-
-            return reply.code(500).send();
+            return reply.code(500).send(formatErrorPayload(ex));
         }
     });
 

--- a/packages/api-headless-cms/src/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/graphqlFields/ref.ts
@@ -15,14 +15,8 @@ interface RefFieldValue {
     modelId: string;
 }
 
-interface UnionField {
-    model: CmsModel;
-    field: CmsModelField;
-    typeName: string;
-}
-
 const createUnionTypeName = (model: CmsModel, field: CmsModelField) => {
-    return `${createReadTypeName(model.modelId)}${createReadTypeName(field.fieldId)}`;
+    return `${createReadTypeName(model.modelId)}_${createReadTypeName(field.fieldId)}`;
 };
 
 interface CreateListFilterParams {
@@ -85,7 +79,17 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                         ? createUnionTypeName(model, field)
                         : createReadTypeName(models[0].modelId);
 
-                return field.fieldId + `: ${field.multipleValues ? `[${gqlType}]` : gqlType}`;
+                const typeDefs =
+                    models.length > 1
+                        ? `union ${gqlType} = ${getFieldModels(field)
+                              .map(({ modelId }) => createReadTypeName(modelId))
+                              .join(" | ")}`
+                        : "";
+
+                return {
+                    fields: field.fieldId + `: ${field.multipleValues ? `[${gqlType}]` : gqlType}`,
+                    typeDefs
+                };
             },
             /**
              * TS is complaining about mixed types for createResolver.
@@ -182,40 +186,9 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                     };
                 };
             },
-            createSchema({ models }) {
-                const unionFields: UnionField[] = [];
-                for (const model of models) {
-                    // Generate a dedicated union type for every `ref` field which has more than 1 content model assigned.
-                    model.fields
-                        .filter(
-                            field =>
-                                field.type === "ref" && (field.settings?.models || []).length > 1
-                        )
-                        .forEach(field =>
-                            unionFields.push({
-                                model,
-                                field,
-                                typeName: createUnionTypeName(model, field)
-                            })
-                        );
-                }
-                const unionFieldsTypeDef = unionFields
-                    .map(
-                        ({ field, typeName }) =>
-                            `union ${typeName} = ${getFieldModels(field)
-                                .map(({ modelId }) => createReadTypeName(modelId))
-                                .join(" | ")}`
-                    )
-                    .join("\n");
-
-                const filteringTypeDef = `
-                ${createFilteringTypeDef()}
-                
-                ${unionFieldsTypeDef}
-            `;
-
+            createSchema() {
                 return {
-                    typeDefs: filteringTypeDef,
+                    typeDefs: createFilteringTypeDef(),
                     resolvers: {}
                 };
             },

--- a/packages/handler-graphql/src/createGraphQLHandler.ts
+++ b/packages/handler-graphql/src/createGraphQLHandler.ts
@@ -20,12 +20,9 @@ const createRequestBody = (body: any): any => {
 const formatErrorPayload = (error: Error) => {
     if (error instanceof WebinyError) {
         return {
-            data: null,
-            error: {
-                message: error.message,
-                code: error.code,
-                data: error.data
-            }
+            message: error.message,
+            code: error.code,
+            data: error.data
         };
     }
 

--- a/packages/handler-graphql/src/createGraphQLHandler.ts
+++ b/packages/handler-graphql/src/createGraphQLHandler.ts
@@ -1,11 +1,12 @@
 import { boolean } from "boolean";
-import { HandlerGraphQLOptions } from "./types";
-import { createGraphQLSchema } from "./createGraphQLSchema";
-import { PluginCollection } from "@webiny/plugins/types";
-import debugPlugins from "./debugPlugins";
-import processRequestBody from "./processRequestBody";
 import { GraphQLSchema } from "graphql";
 import { RoutePlugin } from "@webiny/handler";
+import WebinyError from "@webiny/error";
+import { PluginCollection } from "@webiny/plugins/types";
+import { HandlerGraphQLOptions } from "./types";
+import { createGraphQLSchema } from "./createGraphQLSchema";
+import debugPlugins from "./debugPlugins";
+import processRequestBody from "./processRequestBody";
 
 const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
 
@@ -14,6 +15,25 @@ const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
  */
 const createRequestBody = (body: any): any => {
     return typeof body === "string" ? JSON.parse(body) : body;
+};
+
+const formatErrorPayload = (error: Error) => {
+    if (error instanceof WebinyError) {
+        return {
+            data: null,
+            error: {
+                message: error.message,
+                code: error.code,
+                data: error.data
+            }
+        };
+    }
+
+    return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack
+    };
 };
 
 export default (options: HandlerGraphQLOptions = {}): PluginCollection => {
@@ -34,7 +54,11 @@ export default (options: HandlerGraphQLOptions = {}): PluginCollection => {
         });
         onPost(path, async (request, reply) => {
             if (!schema) {
-                schema = createGraphQLSchema(context);
+                try {
+                    schema = createGraphQLSchema(context);
+                } catch (ex) {
+                    return reply.code(500).send(formatErrorPayload(ex));
+                }
             }
             const body = createRequestBody(request.body);
             const result = await processRequestBody(body, schema, context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11045,6 +11045,7 @@ __metadata:
     "@webiny/utils": ^5.33.2
     "@webiny/validation": ^5.33.2
     apollo-graphql: ^0.9.5
+    code-frame: ^5.0.0
     commodo-fields-object: ^1.0.6
     dataloader: ^2.0.0
     dot-prop: ^6.0.1
@@ -18129,6 +18130,15 @@ __metadata:
   version: 10.1.1
   resolution: "code-block-writer@npm:10.1.1"
   checksum: e048037acbcbda19fca62a3a63e4a64226ea6b5dc0fad7632d34a88c1165b29a357e5e19f0497811e9911472e824ab85f68176f40e439da87e051908956eb47c
+  languageName: node
+  linkType: hard
+
+"code-frame@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "code-frame@npm:5.0.0"
+  dependencies:
+    left-pad: ^1.1.3
+  checksum: cf47b3f1aa7b052cf0117a6ae8be3da700afb803e96c89c468006e2bf6735f3b752391a50242623f08ebd05ba21e866561164507239f9822f780c60d8a3be11d
   languageName: node
   linkType: hard
 
@@ -28060,6 +28070,13 @@ __metadata:
   dependencies:
     readable-stream: ^2.0.5
   checksum: 822c54c6b87701a6491c70d4fabc4cafcf0f87d6b656af168ee7bb3c45de9128a801cb612e6eeeefc64d298a7524a698dd49b13b0121ae50c2ae305f0dcc5310
+  languageName: node
+  linkType: hard
+
+"left-pad@npm:^1.1.3":
+  version: 1.3.0
+  resolution: "left-pad@npm:1.3.0"
+  checksum: 13fa96e17b70a54836490de22d4bab706e2ed508338bbabecfac72ecce445a74139c5b009a8112252cab8fc4ab7ac4ebd870e5b35bd236b443b12be96f8745ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR solves an issue of generating `ref` field union types (when `ref` field accepts multiple content models) when nested within an `object` field. Essentially, the logic for union type generation was moved from the global `createSchema`, to a `createTypeField` function, because this one is being executed recursively by parent fields, so we will end up having all our union types generated for any depth.

I've also added schema error handling with the output of the invalid part of schema, so it's easier to locate syntax errors in the `headless-cms` Lambda function.

## How Has This Been Tested?
Jest tests.