### PR TITLE
fix(api-headless-cms-ddb-es): compress latest entry data on publish

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -1039,13 +1039,13 @@ export const createEntriesStorageOperations = (
                     index,
                     PK: createPartitionKey(latestEsEntryDataDecompressed),
                     SK: createLatestSortKey(),
-                    data: {
+                    data: await getESLatestEntryData(plugins, {
                         ...latestEsEntryDataDecompressed,
                         status: CONTENT_ENTRY_STATUS.PUBLISHED,
                         locked: true,
                         savedOn: entry.savedOn,
                         publishedOn: entry.publishedOn
-                    }
+                    })
                 })
             );
         }
@@ -1059,13 +1059,13 @@ export const createEntriesStorageOperations = (
         /**
          * Update the published revision entry in ES.
          */
-        const esLatestData = await getESPublishedEntryData(plugins, preparedEntryData);
+        const esPublishedData = await getESPublishedEntryData(plugins, preparedEntryData);
 
         esItems.push(
             esEntity.putBatch({
                 ...publishedKeys,
                 index,
-                data: esLatestData
+                data: esPublishedData
             })
         );
 


### PR DESCRIPTION
## Changes
When publishing content entry, the latest data is not compressed when being sent into the DynamoDB Elasticsearch table.
This possibly created a problem when having extremely large entry (400+kb)

## How Has This Been Tested?
Jest and manually.