### PR TITLE
fix: empty folder render and loading flickering

### DIFF
--- a/packages/app-folders/src/components/Dialogs/DialogCreate.tsx
+++ b/packages/app-folders/src/components/Dialogs/DialogCreate.tsx
@@ -61,9 +61,7 @@ export const FolderDialogCreate: React.FC<Props> = ({ type, onClose, open, paren
                 >
                     {({ Bind, submit }) => (
                         <>
-                            {loading.CREATE_FOLDER && (
-                                <CircularProgress label={t`Creating folder...`} />
-                            )}
+                            {loading.CREATE && <CircularProgress label={t`Creating folder...`} />}
                             <DialogTitle>{t`Create a new folder`}</DialogTitle>
                             <DialogContent>
                                 <Grid>

--- a/packages/app-folders/src/components/Dialogs/DialogDelete.tsx
+++ b/packages/app-folders/src/components/Dialogs/DialogDelete.tsx
@@ -59,7 +59,7 @@ export const FolderDialogDelete = ({ folder, open, onClose }: Props) => {
 
     return (
         <DialogContainer open={dialogOpen} onClose={onClose}>
-            {loading.DELETE_FOLDER && <CircularProgress label={t`Deleting folder...`} />}
+            {loading.DELETE && <CircularProgress label={t`Deleting folder...`} />}
             <DialogTitle>{t`Delete folder`}</DialogTitle>
             <DialogContent>
                 {t`You are about to delete the entire folder "{name}" and all the entries inside! Are you sure you want to continue?`(

--- a/packages/app-folders/src/components/Dialogs/DialogUpdate.tsx
+++ b/packages/app-folders/src/components/Dialogs/DialogUpdate.tsx
@@ -76,7 +76,7 @@ export const FolderDialogUpdate: React.FC<Props> = ({ folder, onClose, open }) =
                     >
                         {({ Bind, submit }) => (
                             <>
-                                {loading.UPDATE_FOLDER && (
+                                {loading.UPDATE && (
                                     <CircularProgress label={t`Updating folder...`} />
                                 )}
                                 <DialogTitle>{t`Update folder`}</DialogTitle>

--- a/packages/app-folders/src/contexts/folders.tsx
+++ b/packages/app-folders/src/contexts/folders.tsx
@@ -43,9 +43,11 @@ interface Props {
     children: ReactNode;
 }
 
-const defaultLoading = {
+const defaultLoading: Record<LoadingActions, boolean> = {
     INIT: true,
     LIST: false,
+    LIST_MORE: false,
+    GET: false,
     CREATE: false,
     UPDATE: false,
     DELETE: false

--- a/packages/app-folders/src/contexts/folders.tsx
+++ b/packages/app-folders/src/contexts/folders.tsx
@@ -44,7 +44,7 @@ interface Props {
 }
 
 const defaultLoading = {
-    IDLE: true,
+    INIT: true,
     LIST: false,
     CREATE: false,
     UPDATE: false,
@@ -64,20 +64,14 @@ export const FoldersProvider = ({ children }: Props) => {
                 throw new Error("Folder `type` is mandatory");
             }
 
-            setLoading(prev => {
-                return {
-                    ...prev,
-                    LIST: true
-                };
-            });
-
-            const { data: response } = await client.query<
-                ListFoldersResponse,
-                ListFoldersQueryVariables
-            >({
-                query: LIST_FOLDERS,
-                variables: { type }
-            });
+            const { data: response } = await apolloFetchingHandler(
+                loadingHandler("LIST", setLoading),
+                () =>
+                    client.query<ListFoldersResponse, ListFoldersQueryVariables>({
+                        query: LIST_FOLDERS,
+                        variables: { type }
+                    })
+            );
 
             const { data, error } = response.folders.listFolders;
 
@@ -92,8 +86,7 @@ export const FoldersProvider = ({ children }: Props) => {
 
             setLoading(prev => ({
                 ...prev,
-                LIST: false,
-                IDLE: false
+                INIT: false
             }));
 
             return data;
@@ -105,7 +98,7 @@ export const FoldersProvider = ({ children }: Props) => {
             }
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("GET", setLoading),
+                loadingHandler("GET", setLoading),
                 () =>
                     client.query<GetFolderResponse, GetFolderQueryVariables>({
                         query: GET_FOLDER,
@@ -126,7 +119,7 @@ export const FoldersProvider = ({ children }: Props) => {
             const { type } = folder;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("CREATE", setLoading),
+                loadingHandler("CREATE", setLoading),
                 () =>
                     client.mutate<CreateFolderResponse, CreateFolderVariables>({
                         mutation: CREATE_FOLDER,
@@ -153,7 +146,7 @@ export const FoldersProvider = ({ children }: Props) => {
             const { id, type, name, slug, parentId } = folder;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("UPDATE", setLoading),
+                loadingHandler("UPDATE", setLoading),
                 () =>
                     client.mutate<UpdateFolderResponse, UpdateFolderVariables>({
                         mutation: UPDATE_FOLDER,
@@ -197,7 +190,7 @@ export const FoldersProvider = ({ children }: Props) => {
             const { id, type } = folder;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("DELETE", setLoading),
+                loadingHandler("DELETE", setLoading),
                 () =>
                     client.mutate<DeleteFolderResponse, DeleteFolderVariables>({
                         mutation: DELETE_FOLDER,

--- a/packages/app-folders/src/contexts/links.tsx
+++ b/packages/app-folders/src/contexts/links.tsx
@@ -41,7 +41,7 @@ interface Props {
 }
 
 const defaultLoading = {
-    IDLE: true,
+    INIT: true,
     LIST: false,
     LIST_MORE: false,
     CREATE: false,
@@ -66,20 +66,14 @@ export const LinksProvider = ({ children }: Props) => {
 
             const action = after ? "LIST_MORE" : "LIST";
 
-            setLoading(prev => {
-                return {
-                    ...prev,
-                    [action]: true
-                };
-            });
-
-            const { data: response } = await client.query<
-                ListLinksResponse,
-                ListLinksQueryVariables
-            >({
-                query: LIST_LINKS,
-                variables: { folderId, limit, after }
-            });
+            const { data: response } = await apolloFetchingHandler(
+                loadingHandler(action, setLoading),
+                () =>
+                    client.query<ListLinksResponse, ListLinksQueryVariables>({
+                        query: LIST_LINKS,
+                        variables: { folderId, limit, after }
+                    })
+            );
 
             const { data, meta: responseMeta, error } = response.folders.listLinks;
 
@@ -97,8 +91,7 @@ export const LinksProvider = ({ children }: Props) => {
             setLoading(prev => {
                 return {
                     ...prev,
-                    [action]: false,
-                    IDLE: false
+                    INIT: false
                 };
             });
 
@@ -111,7 +104,7 @@ export const LinksProvider = ({ children }: Props) => {
             }
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("GET", setLoading),
+                loadingHandler("GET", setLoading),
                 () =>
                     client.query<GetLinkResponse, GetLinkQueryVariables>({
                         query: GET_LINK,
@@ -132,7 +125,7 @@ export const LinksProvider = ({ children }: Props) => {
             const { folderId } = link;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("CREATE", setLoading),
+                loadingHandler("CREATE", setLoading),
                 () =>
                     client.mutate<CreateLinkResponse, CreateLinkVariables>({
                         mutation: CREATE_LINK,
@@ -167,7 +160,7 @@ export const LinksProvider = ({ children }: Props) => {
             const { id, folderId } = link;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("UPDATE", setLoading),
+                loadingHandler("UPDATE", setLoading),
                 () =>
                     client.mutate<UpdateLinkResponse, UpdateLinkVariables>({
                         mutation: UPDATE_LINK,
@@ -198,7 +191,7 @@ export const LinksProvider = ({ children }: Props) => {
             const { id, folderId } = link;
 
             const { data: response } = await apolloFetchingHandler(
-                () => loadingHandler("DELETE", setLoading),
+                loadingHandler("DELETE", setLoading),
                 () =>
                     client.mutate<DeleteLinkResponse, DeleteLinkVariables>({
                         mutation: DELETE_LINK,

--- a/packages/app-folders/src/contexts/links.tsx
+++ b/packages/app-folders/src/contexts/links.tsx
@@ -40,10 +40,11 @@ interface Props {
     children: ReactNode;
 }
 
-const defaultLoading = {
+const defaultLoading: Record<LoadingActions, boolean> = {
     INIT: true,
     LIST: false,
     LIST_MORE: false,
+    GET: false,
     CREATE: false,
     UPDATE: false,
     DELETE: false

--- a/packages/app-folders/src/handlers.tsx
+++ b/packages/app-folders/src/handlers.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from "react";
 import { ApolloQueryResult } from "apollo-client/core/types";
 import { FetchResult } from "apollo-link";
-import { Loading } from "~/types";
+import { Loading, LoadingActions } from "~/types";
 
 /**
  * A simple wrapper for Apollo fetching operations that handles the `loading` state as side effect.
@@ -27,9 +27,9 @@ export const apolloFetchingHandler = async (
  * @param action: the `action` that has been performed.
  * @param setState: the logic to update the loading state.
  */
-export const loadingHandler = <T extends string>(
-    action: T,
-    setState: Dispatch<SetStateAction<Loading<T>>>
+export const loadingHandler = (
+    action: LoadingActions,
+    setState: Dispatch<SetStateAction<Loading<LoadingActions>>>
 ) => {
     return (flag: boolean) => {
         setState(state => {

--- a/packages/app-folders/src/handlers.tsx
+++ b/packages/app-folders/src/handlers.tsx
@@ -10,13 +10,13 @@ import { Loading } from "~/types";
  * @param apolloQuery: Apollo Query or Mutation
  */
 export const apolloFetchingHandler = async (
-    loadingHandler: () => void,
+    loadingHandler: (flag: boolean) => void,
     apolloQuery: () => Promise<ApolloQueryResult<any> | FetchResult<any>>
 ) => {
-    loadingHandler();
+    loadingHandler(true);
 
     const response = await apolloQuery();
-    loadingHandler();
+    loadingHandler(false);
 
     return response;
 };
@@ -30,11 +30,13 @@ export const apolloFetchingHandler = async (
 export const loadingHandler = <T extends string>(
     action: T,
     setState: Dispatch<SetStateAction<Loading<T>>>
-): void => {
-    setState(state => {
-        return {
-            ...state,
-            [action]: !state[action]
-        };
-    });
+) => {
+    return (flag: boolean) => {
+        setState(state => {
+            return {
+                ...state,
+                [action]: flag
+            };
+        });
+    };
 };

--- a/packages/app-folders/src/handlers.tsx
+++ b/packages/app-folders/src/handlers.tsx
@@ -16,7 +16,6 @@ export const apolloFetchingHandler = async (
     loadingHandler();
 
     const response = await apolloQuery();
-
     loadingHandler();
 
     return response;
@@ -25,25 +24,17 @@ export const apolloFetchingHandler = async (
 /**
  * A simple function to handle `loading` state.
  *
- * @param context: string that define where the context the operation works.
  * @param action: the `action` that has been performed.
  * @param setState: the logic to update the loading state.
  */
 export const loadingHandler = <T extends string>(
-    context: string,
     action: T,
     setState: Dispatch<SetStateAction<Loading<T>>>
 ): void => {
     setState(state => {
-        const currentContext = state[context] || {};
-        const currentAction = currentContext[action] || false;
-
         return {
             ...state,
-            [context]: {
-                ...currentContext,
-                [action]: !currentAction
-            }
+            [action]: !state[action]
         };
     });
 };

--- a/packages/app-folders/src/hooks/useFolders.ts
+++ b/packages/app-folders/src/hooks/useFolders.ts
@@ -32,10 +32,10 @@ export const useFolders = (type: string) => {
              * You'll never need to call `listFolders` from any component. As soon as you call `useFolders()`, you'll initiate
              * fetching of `folders`, which is managed by the FoldersContext.
              */
-            loading: loading[type] || {},
+            loading,
             folders: folders[type],
             getFolder(id: string) {
-                return getFolder(id, type);
+                return getFolder(id);
             },
             createFolder(folder: Omit<FolderItem, "id">) {
                 return createFolder(folder);

--- a/packages/app-folders/src/hooks/useLinks.ts
+++ b/packages/app-folders/src/hooks/useLinks.ts
@@ -27,7 +27,7 @@ export const useLinks = (folderId: string) => {
              * As soon as you call `useLinks()`, you'll initiate fetching of `links`, which is managed by the `LinksContext`.
              * Since this method lists links with pagination, you might need to call it multiple times passing the `after` param.
              */
-            loading: loading[folderId] || {},
+            loading,
             meta: meta[folderId] || {},
             links: links.filter(link => link.folderId === folderId),
             listLinks(after: string, limit?: number) {

--- a/packages/app-folders/src/types.ts
+++ b/packages/app-folders/src/types.ts
@@ -17,22 +17,9 @@ export interface LinkItem {
     folderId: string;
 }
 
-export type Loading<T extends string> = Record<string, { [P in T]?: boolean }>;
+export type Loading<T extends string> = { [P in T]?: boolean };
 
-export type FoldersActions =
-    | "LIST_FOLDERS"
-    | "GET_FOLDER"
-    | "CREATE_FOLDER"
-    | "UPDATE_FOLDER"
-    | "DELETE_FOLDER";
-
-export type LinksActions =
-    | "LIST_LINKS"
-    | "LIST_MORE_LINKS"
-    | "GET_LINK"
-    | "CREATE_LINK"
-    | "UPDATE_LINK"
-    | "DELETE_LINK";
+export type LoadingActions = "IDLE" | "LIST" | "LIST_MORE" | "GET" | "CREATE" | "UPDATE" | "DELETE";
 
 export interface Error {
     code: string;

--- a/packages/app-folders/src/types.ts
+++ b/packages/app-folders/src/types.ts
@@ -19,7 +19,7 @@ export interface LinkItem {
 
 export type Loading<T extends string> = { [P in T]?: boolean };
 
-export type LoadingActions = "IDLE" | "LIST" | "LIST_MORE" | "GET" | "CREATE" | "UPDATE" | "DELETE";
+export type LoadingActions = "INIT" | "LIST" | "LIST_MORE" | "GET" | "CREATE" | "UPDATE" | "DELETE";
 
 export interface Error {
     code: string;

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -21,7 +21,7 @@ import { FOLDER_ID_DEFAULT, FOLDER_TYPE } from "~/admin/constants/folders";
 
 import { Container, Wrapper } from "./styled";
 
-import { FolderItem } from "@webiny/app-folders/types";
+import { FolderItem, LinksActions, Loading } from "@webiny/app-folders/types";
 
 interface Props {
     folderId?: string;
@@ -55,7 +55,11 @@ export const Main = ({ folderId }: Props) => {
         deleteLink
     } = useLinks(folderId || FOLDER_ID_DEFAULT);
 
-    const { pages, loading: pagesLoading } = useGetPages(links, folderId);
+    const { pages = undefined, loading: pagesLoading } = useGetPages(
+        links,
+        linksLoading as Loading<LinksActions>,
+        folderId
+    );
 
     const [subFolders, setSubFolders] = useState<FolderItem[]>([]);
 

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -115,7 +115,6 @@ export const Main = ({ folderId }: Props) => {
 
     return (
         <>
-            {JSON.stringify(pagesLoading)}
             <Container>
                 <Header
                     canCreate={canCreate}

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -100,9 +100,9 @@ export const Main = ({ folderId }: Props) => {
 
     const isLoading = useMemo(() => {
         return (
-            pagesLoading.IDLE ||
-            linksLoading.IDLE ||
-            foldersLoading.IDLE ||
+            pagesLoading.INIT ||
+            linksLoading.INIT ||
+            foldersLoading.INIT ||
             pagesLoading.LIST ||
             linksLoading.LIST ||
             foldersLoading.LIST
@@ -115,6 +115,7 @@ export const Main = ({ folderId }: Props) => {
 
     return (
         <>
+            {JSON.stringify(pagesLoading)}
             <Container>
                 <Header
                     canCreate={canCreate}

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -55,7 +55,7 @@ export const Main = ({ folderId }: Props) => {
         deleteLink
     } = useLinks(folderId || FOLDER_ID_DEFAULT);
 
-    const { pages = undefined, loading: pagesLoading } = useGetPages(
+    const { pages, loading: pagesLoading } = useGetPages(
         links,
         linksLoading as Loading<LinksActions>,
         folderId

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/useGetPages.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/useGetPages.ts
@@ -10,7 +10,7 @@ import { i18n } from "@webiny/app/i18n";
 
 const t = i18n.ns("app-headless-cms/app-page-builder/pages-table/get-pages");
 
-const defaultLoading = {
+const defaultLoading: Record<LoadingActions, boolean> = {
     INIT: true,
     LIST: false,
     LIST_MORE: false

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -931,4 +931,4 @@ export interface PageBuilderSecurityPermission extends SecurityPermission {
 
 export type Loading<T extends string> = { [P in T]?: boolean };
 
-export type LoadingActions = "IDLE" | "LIST" | "LIST_MORE";
+export type LoadingActions = "INIT" | "LIST" | "LIST_MORE";

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -929,6 +929,6 @@ export interface PageBuilderSecurityPermission extends SecurityPermission {
     pw?: string | boolean;
 }
 
-export type Loading<T extends string> = Record<string, { [P in T]?: boolean }>;
+export type Loading<T extends string> = { [P in T]?: boolean };
 
-export type PagesLinksActions = "LIST_PAGES_BY_LINKS" | "LIST_MORE_PAGES_BY_LINKS";
+export type LoadingActions = "IDLE" | "LIST" | "LIST_MORE";


### PR DESCRIPTION
## Changes
With this PR we are fixing issues related to loading and empty state within the folders and pages list:

- fix: flickering page list showing the empty state while loading data
- fix: empty links list was not triggering the page details fetch.
- refactor: simplify `loading` by removing the bound with the current `folderId` or folder `type`
- refactor: shorten the loading enum, eg `LIST_FOLDERS` / `LIST_LINKS` -> `LIST`
- refactor: improve loading check within the list
- refactor: better handling of pages details fetch
