### PR TITLE
feat(serverless-cms-aws): increase body limit to 1gb

### DIFF
--- a/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
+++ b/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
@@ -11,9 +11,6 @@ export const handler = createHandler({
         createEventHandler()
     ],
     options: {
-        /**
-         * 1GB - really hope this is going to be enough.
-         */
         bodyLimit: 1048576000
     }
 });

--- a/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
+++ b/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
@@ -9,5 +9,11 @@ export const handler = createHandler({
         }),
         createGzipCompression(),
         createEventHandler()
-    ]
+    ],
+    options: {
+        /**
+         * 1GB - really hope this is going to be enough.
+         */
+        bodyLimit: 1048576000
+    }
 });


### PR DESCRIPTION
## Changes
Increase DynamoDB to Elasticsearch Fastify handler limit to 1GB to be able to take a lot of data and transfer to the Elasticsearch.

## How Has This Been Tested?
Manually.