### PR TITLE
fix(serverless-cms-aws): increase body limit to 1gb

### DIFF
--- a/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
+++ b/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
@@ -9,5 +9,8 @@ export const handler = createHandler({
         }),
         createGzipCompression(),
         createEventHandler()
-    ]
+    ],
+    options: {
+        bodyLimit: 1048576000
+    }
 });


### PR DESCRIPTION
## Changes
Increase body limit on DDB -> ES handler to 1GB.

## How Has This Been Tested?
Jest and manually.