### PR TITLE
feat: 5.34.0 upgrade script for PageBuilder

### DIFF
--- a/packages/api-page-builder/__tests__/folders.ts
+++ b/packages/api-page-builder/__tests__/folders.ts
@@ -1,0 +1,45 @@
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
+import { ContextPlugin } from "@webiny/api";
+import { FoldersContext, Link } from "@webiny/api-folders/types";
+import { createFoldersContext, createFoldersGraphQL } from "@webiny/api-folders";
+import { createStorageOperations } from "@webiny/api-folders-so-ddb";
+
+// IMPORTANT: This must be removed from here in favor of a dynamic SO setup.
+const documentClient = new DocumentClient({
+    convertEmptyValues: true,
+    endpoint: process.env.MOCK_DYNAMODB_ENDPOINT || "http://localhost:8001",
+    sslEnabled: false,
+    region: "local",
+    accessKeyId: "test",
+    secretAccessKey: "test"
+});
+
+export const createFolders = () => {
+    return [
+        createFoldersContext({
+            storageOperations: createStorageOperations({
+                documentClient,
+                table: process.env.DB_TABLE
+            })
+        }),
+        createFoldersGraphQL(),
+        new ContextPlugin<FoldersContext>(async context => {
+            context.folders.createLink = async ({ id, folderId }): Promise<Link> => {
+                return {
+                    id: id || "id",
+                    linkId: "linkId",
+                    folderId: folderId || "folderId",
+                    createdOn: new Date().toISOString(),
+                    createdBy: {
+                        id: "1",
+                        displayName: "Admin Webiny",
+                        type: "type"
+                    },
+                    tenant: "root",
+                    locale: "en-US",
+                    webinyVersion: process.env.WEBINY_VERSION || "5.34.0"
+                };
+            };
+        })
+    ];
+};

--- a/packages/api-page-builder/__tests__/folders.ts
+++ b/packages/api-page-builder/__tests__/folders.ts
@@ -1,6 +1,4 @@
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
-import { ContextPlugin } from "@webiny/api";
-import { FoldersContext, Link } from "@webiny/api-folders/types";
 import { createFoldersContext, createFoldersGraphQL } from "@webiny/api-folders";
 import { createStorageOperations } from "@webiny/api-folders-so-ddb";
 
@@ -22,24 +20,6 @@ export const createFolders = () => {
                 table: process.env.DB_TABLE
             })
         }),
-        createFoldersGraphQL(),
-        new ContextPlugin<FoldersContext>(async context => {
-            context.folders.createLink = async ({ id, folderId }): Promise<Link> => {
-                return {
-                    id: id || "id",
-                    linkId: "linkId",
-                    folderId: folderId || "folderId",
-                    createdOn: new Date().toISOString(),
-                    createdBy: {
-                        id: "1",
-                        displayName: "Admin Webiny",
-                        type: "type"
-                    },
-                    tenant: "root",
-                    locale: "en-US",
-                    webinyVersion: process.env.WEBINY_VERSION || "5.34.0"
-                };
-            };
-        })
+        createFoldersGraphQL()
     ];
 };

--- a/packages/api-page-builder/__tests__/graphql/useGqlHandler.ts
+++ b/packages/api-page-builder/__tests__/graphql/useGqlHandler.ts
@@ -73,6 +73,7 @@ import fs from "fs";
 import { until } from "@webiny/project-utils/testing/helpers/until";
 import { createTenancyAndSecurity } from "../tenancySecurity";
 import { getStorageOperations } from "../storageOperations";
+import { createFolders } from "../folders";
 
 interface Params {
     permissions?: any;
@@ -104,6 +105,7 @@ export default ({ permissions, identity, plugins, storageOperationPlugins }: Par
                 storageOperations: ops.storageOperations
             }),
             prerenderingHookPlugins(),
+            ...createFolders(),
             prerenderingServicePlugins({
                 handlers: {
                     render: "render",

--- a/packages/api-page-builder/package.json
+++ b/packages/api-page-builder/package.json
@@ -59,6 +59,7 @@
     "@types/node-fetch": "^2.6.1",
     "@types/rimraf": "^3.0.2",
     "@webiny/api-file-manager-ddb": "^5.33.2",
+    "@webiny/api-folders-so-ddb": "^5.33.2",
     "@webiny/api-i18n-ddb": "^5.33.2",
     "@webiny/api-security-so-ddb": "^5.33.2",
     "@webiny/api-tenancy-so-ddb": "^5.33.2",

--- a/packages/api-page-builder/package.json
+++ b/packages/api-page-builder/package.json
@@ -18,6 +18,7 @@
     "@commodo/fields": "beta",
     "@webiny/api": "^5.33.2",
     "@webiny/api-file-manager": "^5.33.2",
+    "@webiny/api-folders": "^5.33.2",
     "@webiny/api-i18n": "^5.33.2",
     "@webiny/api-prerendering-service": "^5.33.2",
     "@webiny/api-security": "^5.33.2",

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -209,7 +209,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
                 // Create folder link for initialPages
                 await Promise.all(
                     initialPagesData.map(page =>
-                        context.folders.createLink({ id: page.id, folderId: "ROOT" })
+                        context.folders.createLink({ id: page.pid, folderId: "ROOT" })
                     )
                 );
             }

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -205,13 +205,6 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
                         notFound: notFoundPage.pid
                     }
                 });
-
-                // Create folder link for initialPages
-                await Promise.all(
-                    initialPagesData.map(page =>
-                        context.folders.createLink({ id: page.pid, folderId: "ROOT" })
-                    )
-                );
             }
 
             // 6. Mark the Page Builder app as installed.

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -233,7 +233,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
             await plugin.apply(context);
 
             //Store new app version
-            //await this.setSystemVersion(version);
+            await this.setSystemVersion(version);
 
             return true;
         }

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -188,6 +188,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
                     // We can safely cast.
                     initialPagesData.map(() => this.createPage((staticCategory as Category).slug))
                 );
+
                 const updatedPages = await Promise.all(
                     initialPagesData.map((data, index) => {
                         return this.updatePage(initialPages[index].id, data);
@@ -204,6 +205,13 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
                         notFound: notFoundPage.pid
                     }
                 });
+
+                // Create folder link for initialPages
+                await Promise.all(
+                    initialPagesData.map(page =>
+                        context.folders.createLink({ id: page.id, folderId: "ROOT" })
+                    )
+                );
             }
 
             // 6. Mark the Page Builder app as installed.
@@ -232,7 +240,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
 
             await plugin.apply(context);
 
-            //Store new app version
+            // Store new app version
             await this.setSystemVersion(version);
 
             return true;

--- a/packages/api-page-builder/src/graphql/crud/system.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/system.crud.ts
@@ -232,8 +232,8 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCrud => 
 
             await plugin.apply(context);
 
-            // Store new app version
-            await this.setSystemVersion(version);
+            //Store new app version
+            //await this.setSystemVersion(version);
 
             return true;
         }

--- a/packages/api-page-builder/src/graphql/index.ts
+++ b/packages/api-page-builder/src/graphql/index.ts
@@ -2,6 +2,7 @@ import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/types";
 import { createCrud, CreateCrudParams } from "./crud";
 import graphql from "./graphql";
 import upgrades from "./upgrades";
+import { subscriptions } from "~/graphql/subscriptions";
 import { createElementProcessors } from "~/graphql/elementProcessors";
 
 export const createPageBuilderGraphQL = (): GraphQLSchemaPlugin[] => {
@@ -10,5 +11,5 @@ export const createPageBuilderGraphQL = (): GraphQLSchemaPlugin[] => {
 
 export type ContextParams = CreateCrudParams;
 export const createPageBuilderContext = (params: ContextParams) => {
-    return [createCrud(params), upgrades(), createElementProcessors()];
+    return [createCrud(params), upgrades(), subscriptions(), createElementProcessors()];
 };

--- a/packages/api-page-builder/src/graphql/subscriptions/afterSystemInstall.ts
+++ b/packages/api-page-builder/src/graphql/subscriptions/afterSystemInstall.ts
@@ -1,0 +1,35 @@
+import { ContextPlugin } from "@webiny/api";
+import WebinyError from "@webiny/error";
+import { PbContext } from "~/types";
+
+export const afterSystemInstall = () => {
+    return new ContextPlugin<PbContext>(async context => {
+        try {
+            context.pageBuilder.onSystemAfterInstall.subscribe(async () => {
+                const [data] = await context.pageBuilder.listLatestPages({ limit: 100 });
+                const pageIds = data.map(page => page.pid);
+
+                await Promise.all(
+                    pageIds.map(async id => {
+                        try {
+                            await context.folders.createLink({ id, folderId: "ROOT" });
+                        } catch (e) {
+                            /**
+                             * In case the link already exists for the current page, just return and continue the process.
+                             */
+                            if (e.code === "LINK_EXISTS") {
+                                return;
+                            }
+                            throw e;
+                        }
+                    })
+                );
+            });
+        } catch (error) {
+            throw WebinyError.from(error, {
+                message: "Error while creating page links to ROOT folder.",
+                code: "AFTER_PAGE_BUILDER_SYSTEM_INSTALL"
+            });
+        }
+    });
+};

--- a/packages/api-page-builder/src/graphql/subscriptions/afterSystemInstall.ts
+++ b/packages/api-page-builder/src/graphql/subscriptions/afterSystemInstall.ts
@@ -4,8 +4,8 @@ import { PbContext } from "~/types";
 
 export const afterSystemInstall = () => {
     return new ContextPlugin<PbContext>(async context => {
-        try {
-            context.pageBuilder.onSystemAfterInstall.subscribe(async () => {
+        context.pageBuilder.onSystemAfterInstall.subscribe(async () => {
+            try {
                 const [data] = await context.pageBuilder.listLatestPages({ limit: 100 });
                 const pageIds = data.map(page => page.pid);
 
@@ -24,12 +24,12 @@ export const afterSystemInstall = () => {
                         }
                     })
                 );
-            });
-        } catch (error) {
-            throw WebinyError.from(error, {
-                message: "Error while creating page links to ROOT folder.",
-                code: "AFTER_PAGE_BUILDER_SYSTEM_INSTALL"
-            });
-        }
+            } catch (error) {
+                throw WebinyError.from(error, {
+                    message: "Error while creating page links to ROOT folder.",
+                    code: "AFTER_PAGE_BUILDER_SYSTEM_INSTALL"
+                });
+            }
+        });
     });
 };

--- a/packages/api-page-builder/src/graphql/subscriptions/index.ts
+++ b/packages/api-page-builder/src/graphql/subscriptions/index.ts
@@ -1,0 +1,7 @@
+import { ContextPlugin } from "@webiny/api";
+import { afterSystemInstall } from "./afterSystemInstall";
+import { PbContext } from "~/types";
+
+export const subscriptions = (): ContextPlugin<PbContext>[] => {
+    return [afterSystemInstall()];
+};

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -21,6 +21,7 @@ import {
 } from "~/types";
 import { PrerenderingServiceClientContext } from "@webiny/api-prerendering-service/client/types";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
+import { FoldersContext } from "@webiny/api-folders/types";
 
 // CRUD types.
 export interface ListPagesParams {
@@ -818,7 +819,8 @@ export interface PbContext
         SecurityContext,
         TenancyContext,
         FileManagerContext,
-        PrerenderingServiceClientContext {
+        PrerenderingServiceClientContext,
+        FoldersContext {
     pageBuilder: PageBuilderContextObject;
 }
 

--- a/packages/api-page-builder/src/graphql/upgrades/index.ts
+++ b/packages/api-page-builder/src/graphql/upgrades/index.ts
@@ -1,2 +1,3 @@
-// @ts-ignore
-export default () => [];
+import { createUpgrade as upgrade5340 } from "./v5.34.0";
+
+export default () => [upgrade5340()];

--- a/packages/api-page-builder/src/graphql/upgrades/v5.34.0/index.ts
+++ b/packages/api-page-builder/src/graphql/upgrades/v5.34.0/index.ts
@@ -1,0 +1,201 @@
+import { UpgradePlugin } from "@webiny/api-upgrade";
+import WebinyError from "@webiny/error";
+import { PageBuilderContextObject, PbContext } from "~/graphql/types";
+import { Tenant } from "@webiny/api-tenancy/types";
+import { I18NContextObject } from "@webiny/api-i18n/types";
+import { IFolders } from "@webiny/api-folders/types";
+
+interface CreatePageLinksParams {
+    tenant: Tenant;
+    pageBuilder: PageBuilderContextObject;
+    folders: IFolders;
+    i18n: I18NContextObject;
+}
+
+const createPageLinks = async (params: CreatePageLinksParams): Promise<void> => {
+    const { tenant, pageBuilder, i18n } = params;
+    /**
+     * Find all locales for the current tenant, so we can find all pages for each locale.
+     */
+    const [locales] = await i18n.locales.storageOperations.list({
+        where: {
+            tenant: tenant.id
+        },
+        limit: 100
+    });
+    if (locales.length === 0) {
+        console.log(`There are no locales under the tenant "${tenant.id}".`);
+        return;
+    }
+    for (const locale of locales) {
+        i18n.setContentLocale(locale);
+
+        const [pages] = await pageBuilder.listLatestPages({ limit: 100 });
+
+        const pageIds = pages.map(page => page.pid);
+
+        console.log(pageIds);
+    }
+    /**
+     * We need all the models that are not plugin models.
+     */
+
+    //
+    //
+    // const models = await cms.storageOperations.models.list({
+    //     where: {
+    //         tenant: tenant.id,
+    //         locale: locale.code
+    //     }
+    // });
+    // if (models.length === 0) {
+    //     console.log(
+    //         `No models in tenant "${tenant.id}" and locale "${locale.code}" combination.`
+    //     );
+    //     continue;
+    // }
+    //
+    // /**
+    //  * Then we need to go into each of the model fields and add the storageId, which is the same as the fieldId
+    //  */
+    // const updatedModels = models
+    //     .filter(model => {
+    //         /**
+    //          * If model has at least one field with no storageId, continue with the update.
+    //          */
+    //         const toUpdate = shouldUpdate(model.fields);
+    //
+    //         /**
+    //          * If not updating the model, lets log it - just in case...
+    //          */
+    //         if (!toUpdate) {
+    //             console.log(
+    //                 `Skipping update of model "${model.modelId} - ${tenant.id} - ${locale.code}".`
+    //             );
+    //             return false;
+    //         }
+    //         return true;
+    //     })
+    //     .map(model => {
+    //         return {
+    //             ...model,
+    //             fields: assignStorageId(model.fields)
+    //         };
+    //     });
+    // /**
+    //  * And update all the models
+    //  */
+    // for (const model of updatedModels) {
+    //     try {
+    //         await cms.storageOperations.models.update({
+    //             model
+    //         });
+    //     } catch (ex) {
+    //         throw new WebinyError(
+    //             `Could not update CMS model ${model.modelId}`,
+    //             "MODEL_UPGRADE_ERROR",
+    //             {
+    //                 model
+    //             }
+    //         );
+    //     }
+    // }
+};
+
+export const createUpgrade = (): UpgradePlugin<PbContext> => {
+    return {
+        type: "api-upgrade",
+        version: "5.34.0",
+        app: "page-builder",
+        apply: async context => {
+            const { security, tenancy, i18n, pageBuilder, folders } = context;
+
+            /**
+             * We need to be able to access all data.
+             */
+            security.disableAuthorization();
+
+            const initialTenant = tenancy.getCurrentTenant();
+
+            try {
+                const tenants = await tenancy.listTenants();
+                for (const tenant of tenants) {
+                    tenancy.setCurrentTenant(tenant);
+                    await createPageLinks({
+                        tenant,
+                        i18n,
+                        pageBuilder,
+                        folders
+                    });
+                }
+            } catch (e) {
+                console.log(
+                    `Upgrade error: ${JSON.stringify({
+                        message: e.message,
+                        code: e.code,
+                        data: e.data
+                    })}`
+                );
+                throw new WebinyError(
+                    `Could not finish the 5.34.0 upgrade. Please contact Webiny team on Slack and share the error.`,
+                    "UPGRADE_ERROR",
+                    {
+                        message: e.message,
+                        code: e.code,
+                        data: e.data
+                    }
+                );
+            } finally {
+                /**
+                 * Always enable the security after all the code runs.
+                 */
+                security.enableAuthorization();
+                tenancy.setCurrentTenant(initialTenant);
+            }
+        }
+        //     const { security, tenancy, cms, i18n } = context;
+        //
+        //     /**
+        //      * We need to be able to access all data.
+        //      */
+        //     security.disableAuthorization();
+        //
+        //     const initialTenant = tenancy.getCurrentTenant();
+        //
+        //     const tenants = await tenancy.listTenants();
+        //     try {
+        //         for (const tenant of tenants) {
+        //             tenancy.setCurrentTenant(tenant);
+        //             await upgradeTenantModels({
+        //                 tenant,
+        //                 cms,
+        //                 i18n
+        //             });
+        //         }
+        //     } catch (ex) {
+        //         console.log(
+        //             `Upgrade error: ${JSON.stringify({
+        //                 message: ex.message,
+        //                 code: ex.code,
+        //                 data: ex.data
+        //             })}`
+        //         );
+        //         throw new WebinyError(
+        //             `Could not finish the 5.33.0 upgrade. Please contact Webiny team on Slack and share the error.`,
+        //             "UPGRADE_ERROR",
+        //             {
+        //                 message: ex.message,
+        //                 code: ex.code,
+        //                 data: ex.data
+        //             }
+        //         );
+        //     } finally {
+        //         /**
+        //          * Always enable the security after all the code runs.
+        //          */
+        //         security.enableAuthorization();
+        //         tenancy.setCurrentTenant(initialTenant);
+        //     }
+        // }
+    };
+};

--- a/packages/api-page-builder/tsconfig.build.json
+++ b/packages/api-page-builder/tsconfig.build.json
@@ -4,6 +4,7 @@
   "references": [
     { "path": "../api-file-manager/tsconfig.build.json" },
     { "path": "../api-folders/tsconfig.build.json" },
+    { "path": "../api-folders-so-ddb/tsconfig.build.json" },
     { "path": "../api-i18n/tsconfig.build.json" },
     { "path": "../api-prerendering-service/tsconfig.build.json" },
     { "path": "../api-security/tsconfig.build.json" },

--- a/packages/api-page-builder/tsconfig.build.json
+++ b/packages/api-page-builder/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "references": [
     { "path": "../api-file-manager/tsconfig.build.json" },
+    { "path": "../api-folders/tsconfig.build.json" },
     { "path": "../api-i18n/tsconfig.build.json" },
     { "path": "../api-prerendering-service/tsconfig.build.json" },
     { "path": "../api-security/tsconfig.build.json" },

--- a/packages/api-page-builder/tsconfig.json
+++ b/packages/api-page-builder/tsconfig.json
@@ -4,6 +4,7 @@
   "references": [
     { "path": "../api-file-manager" },
     { "path": "../api-folders" },
+    { "path": "../api-folders-so-ddb" },
     { "path": "../api-i18n" },
     { "path": "../api-prerendering-service" },
     { "path": "../api-security" },
@@ -36,6 +37,8 @@
       "@webiny/api-file-manager": ["../api-file-manager/src"],
       "@webiny/api-folders/*": ["../api-folders/src/*"],
       "@webiny/api-folders": ["../api-folders/src"],
+      "@webiny/api-folders-so-ddb/*": ["../api-folders-so-ddb/src/*"],
+      "@webiny/api-folders-so-ddb": ["../api-folders-so-ddb/src"],
       "@webiny/api-i18n/*": ["../api-i18n/src/*"],
       "@webiny/api-i18n": ["../api-i18n/src"],
       "@webiny/api-prerendering-service/*": ["../api-prerendering-service/src/*"],

--- a/packages/api-page-builder/tsconfig.json
+++ b/packages/api-page-builder/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "__tests__/**/*.ts"],
   "references": [
     { "path": "../api-file-manager" },
+    { "path": "../api-folders" },
     { "path": "../api-i18n" },
     { "path": "../api-prerendering-service" },
     { "path": "../api-security" },
@@ -33,6 +34,8 @@
       "~/*": ["./src/*"],
       "@webiny/api-file-manager/*": ["../api-file-manager/src/*"],
       "@webiny/api-file-manager": ["../api-file-manager/src"],
+      "@webiny/api-folders/*": ["../api-folders/src/*"],
+      "@webiny/api-folders": ["../api-folders/src"],
       "@webiny/api-i18n/*": ["../api-i18n/src/*"],
       "@webiny/api-i18n": ["../api-i18n/src"],
       "@webiny/api-prerendering-service/*": ["../api-prerendering-service/src/*"],

--- a/packages/app-page-builder/src/admin/plugins/installation.tsx
+++ b/packages/app-page-builder/src/admin/plugins/installation.tsx
@@ -148,6 +148,12 @@ const adminInstallationPlugin: AdminInstallationPlugin = {
             getComponent() {
                 return lazy(() => import("./upgrades/v5.15.0"));
             }
+        },
+        {
+            version: "5.34.0",
+            getComponent() {
+                return lazy(() => import("./upgrades/v5.34.0"));
+            }
         }
     ]
 };

--- a/packages/app-page-builder/src/admin/plugins/upgrades/v5.34.0.tsx
+++ b/packages/app-page-builder/src/admin/plugins/upgrades/v5.34.0.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useCallback, useState } from "react";
 import gql from "graphql-tag";
 import { i18n } from "@webiny/app/i18n";
@@ -87,7 +86,13 @@ const Upgrade: React.FC<UpgradeProps> = ({ onInstalled }) => {
                 </Grid>
             </SimpleFormContent>
             <SimpleFormFooter>
-                <ButtonPrimary onClick={startUpgrade}>Upgrade</ButtonPrimary>
+                <ButtonPrimary
+                    onClick={() => {
+                        startUpgrade();
+                    }}
+                >
+                    Upgrade
+                </ButtonPrimary>
             </SimpleFormFooter>
         </SimpleForm>
     );

--- a/packages/app-page-builder/src/admin/plugins/upgrades/v5.34.0.tsx
+++ b/packages/app-page-builder/src/admin/plugins/upgrades/v5.34.0.tsx
@@ -1,0 +1,96 @@
+// @ts-nocheck
+import React, { useCallback, useState } from "react";
+import gql from "graphql-tag";
+import { i18n } from "@webiny/app/i18n";
+import {
+    SimpleForm,
+    SimpleFormContent,
+    SimpleFormFooter,
+    SimpleFormHeader
+} from "@webiny/app-admin/components/SimpleForm";
+import { useApolloClient } from "@apollo/react-hooks";
+import { Alert } from "@webiny/ui/Alert";
+import { CircularProgress } from "@webiny/ui/Progress";
+import { Cell, Grid } from "@webiny/ui/Grid";
+import { ButtonPrimary } from "@webiny/ui/Button";
+import { Typography } from "@webiny/ui/Typography";
+
+const t = i18n.ns("app-headless-cms/admin/installation");
+
+const UPGRADE = gql`
+    mutation UpgradePageBuilder($version: String!) {
+        pageBuilder {
+            upgrade(version: $version) {
+                data
+                error {
+                    code
+                    message
+                    data
+                }
+            }
+        }
+    }
+`;
+interface UpgradeProps {
+    onInstalled: () => void;
+}
+const Upgrade: React.FC<UpgradeProps> = ({ onInstalled }) => {
+    const client = useApolloClient();
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(false);
+
+    const startUpgrade = useCallback(async () => {
+        setLoading(true);
+        await client
+            .mutate({
+                mutation: UPGRADE,
+                variables: {
+                    version: "5.34.0"
+                }
+            })
+            .then(({ data }) => {
+                setLoading(false);
+                const { error } = data.pageBuilder.upgrade;
+                if (error) {
+                    setError(error.message);
+                    return;
+                }
+
+                onInstalled();
+            });
+    }, []);
+
+    const label = error ? (
+        <Alert title={t`Something went wrong`} type={"danger"}>
+            {error}
+        </Alert>
+    ) : (
+        t`Upgrading Page Builder...`
+    );
+
+    return (
+        <SimpleForm>
+            {loading && <CircularProgress label={label} />}
+            <SimpleFormHeader title={"Upgrade Page Builder"} />
+            <SimpleFormContent>
+                <Grid>
+                    <Cell span={12}>
+                        <Typography use={"body1"} tag={"div"}>
+                            This upgrade will do the following:
+                            <ul>
+                                <li>
+                                    link existing pages to <strong>ROOT</strong> folder
+                                </li>
+                            </ul>
+                        </Typography>
+                    </Cell>
+                </Grid>
+            </SimpleFormContent>
+            <SimpleFormFooter>
+                <ButtonPrimary onClick={startUpgrade}>Upgrade</ButtonPrimary>
+            </SimpleFormFooter>
+        </SimpleForm>
+    );
+};
+
+export default Upgrade;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11367,6 +11367,7 @@ __metadata:
     "@webiny/api": ^5.33.2
     "@webiny/api-file-manager": ^5.33.2
     "@webiny/api-file-manager-ddb": ^5.33.2
+    "@webiny/api-folders": ^5.33.2
     "@webiny/api-i18n": ^5.33.2
     "@webiny/api-i18n-ddb": ^5.33.2
     "@webiny/api-prerendering-service": ^5.33.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -11368,6 +11368,7 @@ __metadata:
     "@webiny/api-file-manager": ^5.33.2
     "@webiny/api-file-manager-ddb": ^5.33.2
     "@webiny/api-folders": ^5.33.2
+    "@webiny/api-folders-so-ddb": ^5.33.2
     "@webiny/api-i18n": ^5.33.2
     "@webiny/api-i18n-ddb": ^5.33.2
     "@webiny/api-prerendering-service": ^5.33.2


### PR DESCRIPTION
## Changes
With this PR:
- PageBuilder: add `5.34.0` upgrade page.
- PageBuilder: add `5.34.0` upgrade script -> fetch existing pages and create a folder `link` to ROOT. The script works for all tenants and locales.
- PageBuilder: add `link` to ROOT folder for initialPages during Page Builder install.

Closes [WEB-1952](https://webiny.atlassian.net/browse/WEB-1952)

