### PR TITLE
fix(api-headless-cms): generate nested ref field union types

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModelsRef.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModelsRef.test.ts
@@ -1,0 +1,336 @@
+import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
+import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
+
+const pageModelPlugin = new CmsModelPlugin({
+    fields: [
+        {
+            fieldId: "title",
+            helpText: null,
+            id: "jf7h0jsc",
+            label: "Title",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "contentBlocks",
+            helpText: null,
+            id: "0kbfq0j6",
+            label: "Content Blocks",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "object"
+            },
+            settings: {
+                fields: [
+                    {
+                        fieldId: "blocks",
+                        id: "lxza895k",
+                        label: "Blocks",
+                        renderer: {
+                            name: "ref-input"
+                        },
+                        settings: {
+                            models: [
+                                {
+                                    modelId: "faqGroupBanner"
+                                },
+                                {
+                                    modelId: "faq"
+                                }
+                            ]
+                        },
+                        type: "ref",
+                        validation: []
+                    }
+                ],
+                layout: [["lxza895k"]]
+            },
+            type: "object",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [["jf7h0jsc"], ["0kbfq0j6"]],
+    locale: "en-US",
+    lockedFields: [],
+    modelId: "page",
+    name: "Page",
+    description: "",
+    tenant: "root",
+    titleFieldId: "title"
+});
+
+const faqModelPlugin = new CmsModelPlugin({
+    locale: "en-US",
+    description: "",
+    fields: [
+        {
+            fieldId: "question",
+            helpText: null,
+            id: "c8pphxf2",
+            label: "Question",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "answer",
+            helpText: null,
+            id: "477qeutg",
+            label: "Answer",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "rich-text-input"
+            },
+            settings: {},
+            type: "rich-text",
+            validation: []
+        },
+        {
+            fieldId: "image",
+            helpText: null,
+            id: "7jubpw3w",
+            label: "Image",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "file-input"
+            },
+            settings: {
+                imagesOnly: true
+            },
+            type: "file",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [["c8pphxf2"], ["477qeutg"], ["7jubpw3w"]],
+    lockedFields: [],
+    modelId: "faq",
+    name: "FAQ",
+    titleFieldId: "id"
+});
+
+const faqGroupBannerModelPlugin = new CmsModelPlugin({
+    description: "",
+    fields: [
+        {
+            fieldId: "eyebrowText",
+            helpText: null,
+            id: "iqe2aw2g",
+            label: "Eyebrow Text",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "heading",
+            helpText: null,
+            id: "25kvqahf",
+            label: "Heading",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "subHeading",
+            helpText: null,
+            id: "an0tmg81",
+            label: "Sub Heading",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "alternateBackgroundColor",
+            helpText: null,
+            id: "g4ei6uhp",
+            label: "Alternate Background Color",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "boolean-input"
+            },
+            settings: {
+                defaultValue: null
+            },
+            type: "boolean",
+            validation: []
+        },
+        {
+            fieldId: "isFaqItemCollapsable",
+            helpText: null,
+            id: "g98nz2mr",
+            label: "Is FAQ Item Collapsable",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "boolean-input"
+            },
+            settings: {
+                defaultValue: null
+            },
+            type: "boolean",
+            validation: []
+        },
+        {
+            fieldId: "customId",
+            helpText: null,
+            id: "t03jq8ke",
+            label: "Custom ID",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "text-input"
+            },
+            settings: {},
+            type: "text",
+            validation: []
+        },
+        {
+            fieldId: "faqGroup",
+            helpText: null,
+            id: "5f0dbgvi",
+            label: "FAQ Group",
+            listValidation: [],
+            multipleValues: false,
+            placeholderText: null,
+            predefinedValues: {
+                enabled: false,
+                values: []
+            },
+            renderer: {
+                name: "ref-input"
+            },
+            settings: {
+                models: [
+                    {
+                        modelId: "faq"
+                    }
+                ]
+            },
+            type: "ref",
+            validation: []
+        }
+    ],
+    group: {
+        id: "62f39c13ebe1d800091bf33c",
+        name: "Ungrouped"
+    },
+    layout: [
+        ["iqe2aw2g"],
+        ["25kvqahf"],
+        ["an0tmg81"],
+        ["5f0dbgvi"],
+        ["g4ei6uhp"],
+        ["g98nz2mr"],
+        ["t03jq8ke"]
+    ],
+    locale: "en-US",
+    lockedFields: [],
+    modelId: "faqGroupBanner",
+    name: "FAQ Group Banner",
+    tenant: "root",
+    titleFieldId: "id"
+});
+
+describe("content model plugins - nested `ref` field union types", () => {
+    const { introspect } = useGraphQLHandler({
+        plugins: [pageModelPlugin, faqModelPlugin, faqGroupBannerModelPlugin],
+        path: "read/en-US"
+    });
+
+    test("must generate valid schema for nested `ref` field union", async () => {
+        const [, response] = await introspect();
+        expect(response.statusCode).toBe(200);
+    });
+});

--- a/packages/api-headless-cms/src/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/graphqlFields/ref.ts
@@ -15,14 +15,8 @@ interface RefFieldValue {
     modelId: string;
 }
 
-interface UnionField {
-    model: CmsModel;
-    field: CmsModelField;
-    typeName: string;
-}
-
 const createUnionTypeName = (model: CmsModel, field: CmsModelField) => {
-    return `${createReadTypeName(model.modelId)}${createReadTypeName(field.fieldId)}`;
+    return `${createReadTypeName(model.modelId)}_${createReadTypeName(field.fieldId)}`;
 };
 
 interface CreateListFilterParams {
@@ -85,7 +79,17 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                         ? createUnionTypeName(model, field)
                         : createReadTypeName(models[0].modelId);
 
-                return field.fieldId + `: ${field.multipleValues ? `[${gqlType}]` : gqlType}`;
+                const typeDefs =
+                    models.length > 1
+                        ? `union ${gqlType} = ${getFieldModels(field)
+                              .map(({ modelId }) => createReadTypeName(modelId))
+                              .join(" | ")}`
+                        : "";
+
+                return {
+                    fields: field.fieldId + `: ${field.multipleValues ? `[${gqlType}]` : gqlType}`,
+                    typeDefs
+                };
             },
             /**
              * TS is complaining about mixed types for createResolver.
@@ -182,40 +186,9 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                     };
                 };
             },
-            createSchema({ models }) {
-                const unionFields: UnionField[] = [];
-                for (const model of models) {
-                    // Generate a dedicated union type for every `ref` field which has more than 1 content model assigned.
-                    model.fields
-                        .filter(
-                            field =>
-                                field.type === "ref" && (field.settings?.models || []).length > 1
-                        )
-                        .forEach(field =>
-                            unionFields.push({
-                                model,
-                                field,
-                                typeName: createUnionTypeName(model, field)
-                            })
-                        );
-                }
-                const unionFieldsTypeDef = unionFields
-                    .map(
-                        ({ field, typeName }) =>
-                            `union ${typeName} = ${getFieldModels(field)
-                                .map(({ modelId }) => createReadTypeName(modelId))
-                                .join(" | ")}`
-                    )
-                    .join("\n");
-
-                const filteringTypeDef = `
-                ${createFilteringTypeDef()}
-                
-                ${unionFieldsTypeDef}
-            `;
-
+            createSchema() {
                 return {
-                    typeDefs: filteringTypeDef,
+                    typeDefs: createFilteringTypeDef(),
                     resolvers: {}
                 };
             },


### PR DESCRIPTION
## Changes
This PR fixes an issue with GraphQL union type generation for `ref` fields, configured to accept multiple models, within a nested object field.

The code actually got simpler than the original implementation, by moving the logic of type generation from `createSchema` to `createFieldType` plugin function, which by itself makes it work recursively.

## How Has This Been Tested?
Jest.
