### PR TITLE
fix(api-headless-cms): initialize model data param

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/deepNestedObject/mutation.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/deepNestedObject/mutation.ts
@@ -280,8 +280,8 @@ export const createCarsMutation = () => {
 
 export const createInitializeModelMutation = () => {
     return `
-        mutation InitializeModelMutation($modelId: ID!) {
-            initializeModel(modelId: $modelId) {
+        mutation InitializeModelMutation($modelId: ID!, $data: JSON) {
+            initializeModel(modelId: $modelId, data: $data) {
                 data
                 error {
                     message

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -576,7 +576,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
 
             managers.delete(model.modelId);
         },
-        async initializeModel(modelId) {
+        async initializeModel(modelId, data) {
             /**
              * We require that users have write permissions to initialize models.
              * Maybe introduce another permission for it?
@@ -585,7 +585,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
 
             const model = await getModel(modelId);
 
-            await onModelInitialize.publish({ model });
+            await onModelInitialize.publish({ model, data });
 
             return true;
         },

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -78,10 +78,10 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
                 }
             },
             initializeModel: async (_, args, context) => {
-                const { modelId } = args;
+                const { modelId, data } = args;
 
                 try {
-                    const result = await context.cms.initializeModel(modelId);
+                    const result = await context.cms.initializeModel(modelId, data || {});
                     return new Response(result);
                 } catch (e) {
                     return new ErrorResponse(e);
@@ -175,7 +175,8 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
 
                 deleteContentModel(modelId: ID!): CmsDeleteResponse
 
-                initializeModel(modelId: ID!): InitializeModelResponse!
+                # users can send anything into the data variable
+                initializeModel(modelId: ID!, data: JSON): InitializeModelResponse!
             }
         `;
     }

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1428,6 +1428,7 @@ export interface AfterModelDeleteTopicParams {
 
 export interface OnModelInitializeParams {
     model: CmsModel;
+    data: Record<string, any>;
 }
 
 export interface CmsModelUpdateDirectParams {
@@ -1477,7 +1478,7 @@ export interface CmsModelContext {
      *
      * Primary idea behind this is creating the index, for the code models, in the ES.
      */
-    initializeModel: (modelId: string) => Promise<boolean>;
+    initializeModel: (modelId: string, data: Record<string, any>) => Promise<boolean>;
     /**
      * Get a instance of CmsModelManager for given content modelId.
      *


### PR DESCRIPTION
## Changes
Add data to the `initializeModel` GraphQL mutation so users can send any kind of data in it.

## How Has This Been Tested?
Jest and manually.