### PR TITLE
fix(api-headless-cms-ddb-es): compress latest data on publish

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -1050,13 +1050,13 @@ export const createEntriesStorageOperations = (
                     index,
                     PK: createPartitionKey(latestEsEntryDataDecompressed),
                     SK: createLatestSortKey(),
-                    data: {
+                    data: await getESLatestEntryData(plugins, {
                         ...latestEsEntryDataDecompressed,
                         status: CONTENT_ENTRY_STATUS.PUBLISHED,
                         locked: true,
                         savedOn: entry.savedOn,
                         publishedOn: entry.publishedOn
-                    }
+                    })
                 })
             );
         }
@@ -1070,13 +1070,13 @@ export const createEntriesStorageOperations = (
         /**
          * Update the published revision entry in ES.
          */
-        const esLatestData = await getESPublishedEntryData(plugins, preparedEntryData);
+        const esPublishedData = await getESPublishedEntryData(plugins, preparedEntryData);
 
         esItems.push(
             esEntity.putBatch({
                 ...publishedKeys,
                 index,
-                data: esLatestData
+                data: esPublishedData
             })
         );
 


### PR DESCRIPTION
## Changes
Compress latest data for Elasticsearch in the publish method.

## How Has This Been Tested?
Jest and manually.