### PR TITLE
Introducing App Aliases

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/watch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch.js
@@ -5,7 +5,7 @@ const path = require("path");
 const localtunnel = require("localtunnel");
 const express = require("express");
 const bodyParser = require("body-parser");
-const { getProjectApplication } = require("@webiny/cli/utils");
+const { getProjectApplication, getProject } = require("@webiny/cli/utils");
 const get = require("lodash/get");
 const merge = require("lodash/merge");
 const browserOutput = require("./watch/output/browserOutput");
@@ -40,6 +40,15 @@ module.exports = async (inputs, context) => {
 
     let projectApplication;
     if (inputs.folder) {
+        // Detect if an app alias was provided.
+        const project = getProject();
+        if (project.config.appAliases) {
+            const appAliases = project.config.appAliases;
+            if (appAliases[inputs.folder]) {
+                inputs.folder = appAliases[inputs.folder];
+            }
+        }
+
         // Get project application metadata. Will throw an error if invalid folder specified.
         projectApplication = getProjectApplication({
             cwd: path.join(process.cwd(), inputs.folder)

--- a/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { getProjectApplication } = require("@webiny/cli/utils");
+const { getProjectApplication, getProject } = require("@webiny/cli/utils");
 const createProjectApplicationWorkspace = require("./createProjectApplicationWorkspace");
 const login = require("./login");
 const loadEnvVariables = require("./loadEnvVariables");
@@ -22,6 +22,15 @@ const createPulumiCommand = ({
             }
 
             return plugin[name](inputs, context);
+        } else {
+            // Detect if an app alias was provided.
+            const project = getProject();
+            if (project.config.appAliases) {
+                const appAliases = project.config.appAliases;
+                if (appAliases[inputs.folder]) {
+                    inputs.folder = appAliases[inputs.folder];
+                }
+            }
         }
 
         if (!inputs.env) {

--- a/packages/cwp-template-aws/template/common/webiny.project.ts
+++ b/packages/cwp-template-aws/template/common/webiny.project.ts
@@ -23,5 +23,11 @@ export default {
             cliScaffoldAdminModule(),
             cliScaffoldCiCd()
         ]
+    },
+    appAliases: {
+        core: "apps/core",
+        api: "apps/api",
+        admin: "apps/admin",
+        website: "apps/website"
     }
 };

--- a/webiny.project.ts
+++ b/webiny.project.ts
@@ -41,5 +41,11 @@ export default {
                 return [];
             }
         }
+    },
+    appAliases: {
+        core: "apps/core",
+        api: "apps/api",
+        admin: "apps/admin",
+        website: "apps/website"
     }
 };


### PR DESCRIPTION
## Changes
With this PR, we're introducing app aliases. In other words, upon running CLI commands, instead of users having to type `apps/api` all the time, now they can just type `api`. 

```yarn webiny deploy api --env dev```

This is possible via the newly introduced `appAliases` param that's now available in the `webiny.project.ts` config file:

![image](https://user-images.githubusercontent.com/5121148/209426473-023aaa30-d824-4ee5-ab0b-e3903c1570ad.png)

This change will not only make it easier for users to type the commands, but will also easen the communication.

All new projects will receive this configuration out of the box. Existing projects will receive these once they upgrade.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.