### PR TITLE
Enable Defining Environment Variables via `webiny.project.ts`

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,32 +1,11 @@
 #!/usr/bin/env node
-const path = require("path");
 const yargs = require("yargs");
-const { log, getProject } = require("./utils");
-const { boolean } = require("boolean");
 
 // Disable help processing until after plugins are imported.
 yargs.help(false);
 
-// Immediately load .env.{PASSED_ENVIRONMENT} and .env files.
-// This way we ensure all of the environment variables are not loaded too late.
-const project = getProject();
-let paths = [path.join(project.root, ".env")];
-
-if (yargs.argv.env) {
-    paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
-}
-
-for (let i = 0; i < paths.length; i++) {
-    const path = paths[i];
-    const { error } = require("dotenv").config({ path });
-    if (boolean(yargs.argv.debug)) {
-        if (error) {
-            log.debug(`No environment file found on ${log.debug.hl(path)}.`);
-        } else {
-            log.success(`Successfully loaded environment variables from ${log.success.hl(path)}.`);
-        }
-    }
-}
+// Loads environment variables from multiple sources.
+require("./utils/loadEnvVariables");
 
 const { blue, red } = require("chalk");
 const context = require("./context");

--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -1,0 +1,38 @@
+const path = require("path");
+const yargs = require("yargs");
+const { log, getProject } = require("./utils");
+const { boolean } = require("boolean");
+
+// Load environment variables from following sources:
+// - `webiny.project.ts` file
+// - `.env` file
+// - `.env.{PASSED_ENVIRONMENT}` file
+
+const project = getProject();
+
+// `webiny.project.ts` file.
+// Environment variables defined via the `env` property.
+if (project.config.env) {
+    Object.assign(process.env, project.config.env);
+}
+
+// `.env.{PASSED_ENVIRONMENT}` and `.env` files.
+let paths = [path.join(project.root, ".env")];
+
+if (yargs.argv.env) {
+    paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
+}
+
+// Let's load environment variables
+for (let i = 0; i < paths.length; i++) {
+    const path = paths[i];
+    const { error } = require("dotenv").config({ path });
+    if (boolean(yargs.argv.debug)) {
+        if (error) {
+            log.debug(`No environment file found on ${log.debug.hl(path)}.`);
+        } else {
+            log.success(`Successfully loaded environment variables from ${log.success.hl(path)}.`);
+        }
+    }
+}
+

--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -35,4 +35,3 @@ for (let i = 0; i < paths.length; i++) {
         }
     }
 }
-


### PR DESCRIPTION
## Changes
In some cases, users might want to define environment variables "more statically", in a config file that's pushed to git and doesn't contain secrets or other sensitive info. For example, feature flags or similar values that set up the default app behaviour.

This is now possible via the `webiny.project.ts` file, via exported config's `env` property:

![image](https://user-images.githubusercontent.com/5121148/209426976-1852ef09-a14d-4e28-a824-0cd815aa19f4.png)


## How Has This Been Tested?
Manually.

## Documentation
Will update https://www.webiny.com/docs/core-development-concepts/basics/environment-variables.