### PR TITLE
Introduce Feature Flags

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,32 +1,11 @@
 #!/usr/bin/env node
-const path = require("path");
 const yargs = require("yargs");
-const { log, getProject } = require("./utils");
-const { boolean } = require("boolean");
 
 // Disable help processing until after plugins are imported.
 yargs.help(false);
 
-// Immediately load .env.{PASSED_ENVIRONMENT} and .env files.
-// This way we ensure all of the environment variables are not loaded too late.
-const project = getProject();
-let paths = [path.join(project.root, ".env")];
-
-if (yargs.argv.env) {
-    paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
-}
-
-for (let i = 0; i < paths.length; i++) {
-    const path = paths[i];
-    const { error } = require("dotenv").config({ path });
-    if (boolean(yargs.argv.debug)) {
-        if (error) {
-            log.debug(`No environment file found on ${log.debug.hl(path)}.`);
-        } else {
-            log.success(`Successfully loaded environment variables from ${log.success.hl(path)}.`);
-        }
-    }
-}
+// Loads environment variables from multiple sources.
+require("./utils/loadEnvVariables");
 
 const { blue, red } = require("chalk");
 const context = require("./context");

--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -36,3 +36,11 @@ for (let i = 0; i < paths.length; i++) {
     }
 }
 
+// Feature flags defined via the `featureFlags` property.
+// We set twice, to be available for both backend and frontend application code.
+// TODO: one day we might want to sync this up a bit.
+if (project.config.featureFlags) {
+    process.env.WEBINY_FEATURE_FLAGS = JSON.stringify(project.config.featureFlags);
+    process.env.REACT_APP_WEBINY_FEATURE_FLAGS = JSON.stringify(project.config.featureFlags);
+}
+

--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -1,0 +1,38 @@
+const path = require("path");
+const yargs = require("yargs");
+const { log, getProject } = require("./utils");
+const { boolean } = require("boolean");
+
+// Load environment variables from following sources:
+// - `webiny.project.ts` file
+// - `.env` file
+// - `.env.{PASSED_ENVIRONMENT}` file
+
+const project = getProject();
+
+// `webiny.project.ts` file.
+// Environment variables defined via the `env` property.
+if (project.config.env) {
+    Object.assign(process.env, project.config.env);
+}
+
+// `.env.{PASSED_ENVIRONMENT}` and `.env` files.
+let paths = [path.join(project.root, ".env")];
+
+if (yargs.argv.env) {
+    paths.push(path.join(project.root, `.env.${yargs.argv.env}`));
+}
+
+// Let's load environment variables
+for (let i = 0; i < paths.length; i++) {
+    const path = paths[i];
+    const { error } = require("dotenv").config({ path });
+    if (boolean(yargs.argv.debug)) {
+        if (error) {
+            log.debug(`No environment file found on ${log.debug.hl(path)}.`);
+        } else {
+            log.success(`Successfully loaded environment variables from ${log.success.hl(path)}.`);
+        }
+    }
+}
+

--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -35,4 +35,3 @@ for (let i = 0; i < paths.length; i++) {
         }
     }
 }
-

--- a/packages/feature-flags/.babelrc.js
+++ b/packages/feature-flags/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("@webiny/project-utils").createBabelConfigForNode({ path: __dirname });

--- a/packages/feature-flags/LICENSE
+++ b/packages/feature-flags/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -62,7 +62,7 @@ const someOtherFeatureMyCustomProperty = featureFlags.someFeature.myCustomProper
 
 > **NOTE**
 > 
-> Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) that enables the propagation of the `featureFlags` object into the actual application. As mentioned, the `featureFlags` object is propagated to both backend and frontend application code. 
+> Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) that enables the propagation of the `featureFlags` object into the actual applications. As mentioned, the `featureFlags` object can be accessed within both backend and frontend application code. 
 
 ## Examples
 

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -1,17 +1,96 @@
-# @webiny/feature-flags
+# `@webiny/feature-flags`
 [![](https://img.shields.io/npm/dw/@webiny/feature-flags.svg)](https://www.npmjs.com/package/@webiny/feature-flags)
 [![](https://img.shields.io/npm/v/@webiny/feature-flags.svg)](https://www.npmjs.com/package/@webiny/feature-flags)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-A React component that renders pages created with Webiny Page Builder.
+A small library that provides a simple way to define and read feature flags in a Webiny project.
 
-## Install
+## Table of Contents
+
+-   [Installation](#installation)
+-   [Overview](#overview)
+-   [Examples](#examples)
+-   [Reference](#reference)
+    -   [Functions](#functions)
+        -   [`getFeature-flagsAppUrl`](#getFeature-flagsAppUrl)
+        -   [`getFeature-flagsApiUrl`](#getFeature-flagsApiUrl)
+        -   [`getFeature-flagsGqlApiUrl`](#getFeature-flagsGqlApiUrl)
+
+## Installation
+
 ```
 npm install --save @webiny/feature-flags
 ```
 
 Or if you prefer yarn:
+
 ```
 yarn add @webiny/feature-flags
+```
+
+
+## Overview
+
+The `@webiny/feature-flags` exports a single `featureFlags` object which contains all of the feature flags initially set via the Webiny project's `webiny.project.ts` config file, via its `featureFlags` property.
+
+For example, given the following `webiny.project.ts` config file;
+
+```ts
+// webiny.project.ts
+export default {
+    name: "webiny-js",
+    cli: {
+        ...
+    },
+    featureFlags: {
+        myCustomFeatureFlag: false,
+        someFeature: { enabled: true, myCustomProperty: 123, thisIsJson: "yes"}
+    }
+};
+```
+
+Within both backend and frontend application code, the `featureFlags` object can be read like the following:
+
+```ts
+import { featureFlags } from "@webiny/feature-flags"; 
+
+const useMyCustomFeature = featureFlags.myCustomFeatureFlag;
+
+const someOtherFeatureMyCustomProperty = featureFlags.someFeature.myCustomProperty;
+```
+
+> NOTE
+> Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) is that enables the propagation of the values defined via the `featureFlags` parameter to the application both. As mentioned, the values are propagated to both backend and frontend application code. 
+
+## Examples
+
+No additional examples.
+
+## Reference
+
+### Objects
+
+#### `featureFlags`
+
+<details>
+<summary>Type Declaration</summary>
+<p>
+
+```ts
+declare let featureFlags: Record<string, any>;
+```
+
+</p>
+</details>  
+
+The `featureFlags` object contains all of the feature flags initially set via the Webiny project's `webiny.project.ts` config file, via its `featureFlags` property.
+
+
+```ts
+import { featureFlags } from "@webiny/feature-flags";
+
+const useMyCustomFeature = featureFlags.myCustomFeatureFlag;
+
+const someOtherFeatureMyCustomProperty = featureFlags.someFeature.myCustomProperty;
 ```

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -1,0 +1,17 @@
+# @webiny/feature-flags
+[![](https://img.shields.io/npm/dw/@webiny/feature-flags.svg)](https://www.npmjs.com/package/@webiny/feature-flags)
+[![](https://img.shields.io/npm/v/@webiny/feature-flags.svg)](https://www.npmjs.com/package/@webiny/feature-flags)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+A React component that renders pages created with Webiny Page Builder.
+
+## Install
+```
+npm install --save @webiny/feature-flags
+```
+
+Or if you prefer yarn:
+```
+yarn add @webiny/feature-flags
+```

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -13,7 +13,7 @@ A small library that provides a simple way to define and read feature flags in a
 -   [Examples](#examples)
 -   [Reference](#reference)
     -   [Objects](#objects)
-        -   [`featureflags`](#featureflags)
+        -   [`featureFlags`](#featureFlags)
 
 ## Installation
 

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -12,10 +12,8 @@ A small library that provides a simple way to define and read feature flags in a
 -   [Overview](#overview)
 -   [Examples](#examples)
 -   [Reference](#reference)
-    -   [Functions](#functions)
-        -   [`getFeature-flagsAppUrl`](#getFeature-flagsAppUrl)
-        -   [`getFeature-flagsApiUrl`](#getFeature-flagsApiUrl)
-        -   [`getFeature-flagsGqlApiUrl`](#getFeature-flagsGqlApiUrl)
+    -   [Objects](#objects)
+        -   [`featureflags`](#featureflags)
 
 ## Installation
 
@@ -43,6 +41,8 @@ export default {
     cli: {
         ...
     },
+    
+    // Feature flags are defined via a simple JavaScript object.
     featureFlags: {
         myCustomFeatureFlag: false,
         someFeature: { enabled: true, myCustomProperty: 123, thisIsJson: "yes"}
@@ -50,7 +50,7 @@ export default {
 };
 ```
 
-Within both backend and frontend application code, the `featureFlags` object can be read like the following:
+Within both backend and frontend application code, the `featureFlags` object can then be read like so:
 
 ```ts
 import { featureFlags } from "@webiny/feature-flags"; 
@@ -60,7 +60,8 @@ const useMyCustomFeature = featureFlags.myCustomFeatureFlag;
 const someOtherFeatureMyCustomProperty = featureFlags.someFeature.myCustomProperty;
 ```
 
-> NOTE
+> **NOTE**
+> 
 > Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) is that enables the propagation of the values defined via the `featureFlags` parameter to the application both. As mentioned, the values are propagated to both backend and frontend application code. 
 
 ## Examples

--- a/packages/feature-flags/README.md
+++ b/packages/feature-flags/README.md
@@ -62,7 +62,7 @@ const someOtherFeatureMyCustomProperty = featureFlags.someFeature.myCustomProper
 
 > **NOTE**
 > 
-> Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) is that enables the propagation of the values defined via the `featureFlags` parameter to the application both. As mentioned, the values are propagated to both backend and frontend application code. 
+> Behind the scenes, it's the [Webiny CLI](https://www.webiny.com/docs/core-development-concepts/basics/webiny-cli) that enables the propagation of the `featureFlags` object into the actual application. As mentioned, the `featureFlags` object is propagated to both backend and frontend application code. 
 
 ## Examples
 

--- a/packages/feature-flags/index.ts
+++ b/packages/feature-flags/index.ts
@@ -1,0 +1,1 @@
+export * from "./src";

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/webiny/webiny-js.git"
   },
+  "description": "A small library that provides a simple way to define and read feature flags in a Webiny project.",
   "contributors": [
     "Adrian Smijulj <adrian@webiny.com>"
   ],

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@webiny/feature-flags",
+  "version": "5.33.2",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "contributors": [
+    "Adrian Smijulj <adrian@webiny.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.19.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.19.3",
+    "@babel/core": "^7.19.3",
+    "@types/uniqid": "^5.3.2",
+    "@webiny/cli": "^5.33.2",
+    "@webiny/project-utils": "^5.33.2",
+    "rimraf": "^3.0.2",
+    "ttypescript": "^1.5.13",
+    "typescript": "4.7.4"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  }
+}

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -1,0 +1,12 @@
+let featureFlags: Record<string, any> = {};
+
+// In API applications.
+if (process.env.WEBINY_FEATURE_FLAGS) {
+    featureFlags = JSON.parse(process.env.WEBINY_FEATURE_FLAGS);
+
+    // In React applications.
+} else if (process.env.REACT_APP_WEBINY_FEATURE_FLAGS) {
+    featureFlags = JSON.parse(process.env.REACT_APP_WEBINY_FEATURE_FLAGS);
+}
+
+export { featureFlags };

--- a/packages/feature-flags/tsconfig.build.json
+++ b/packages/feature-flags/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": { "~/*": ["./src/*"] },
+    "baseUrl": "."
+  }
+}

--- a/packages/feature-flags/tsconfig.json
+++ b/packages/feature-flags/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__/**/*.ts"],
+  "references": [],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": { "~/*": ["./src/*"] },
+    "baseUrl": "."
+  }
+}

--- a/packages/feature-flags/webiny.config.js
+++ b/packages/feature-flags/webiny.config.js
@@ -1,0 +1,8 @@
+const { createWatchPackage, createBuildPackage } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: createBuildPackage({ cwd: __dirname }),
+        watch: createWatchPackage({ cwd: __dirname })
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13379,6 +13379,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/feature-flags@workspace:packages/feature-flags":
+  version: 0.0.0-use.local
+  resolution: "@webiny/feature-flags@workspace:packages/feature-flags"
+  dependencies:
+    "@babel/cli": ^7.19.3
+    "@babel/core": ^7.19.3
+    "@babel/runtime": ^7.19.0
+    "@types/uniqid": ^5.3.2
+    "@webiny/cli": ^5.33.2
+    "@webiny/project-utils": ^5.33.2
+    rimraf: ^3.0.2
+    ttypescript: ^1.5.13
+    typescript: 4.7.4
+  languageName: unknown
+  linkType: soft
+
 "@webiny/form@^5.33.2, @webiny/form@workspace:packages/form":
   version: 0.0.0-use.local
   resolution: "@webiny/form@workspace:packages/form"


### PR DESCRIPTION
## Changes
With this PR, users are now able to use their `webiny.project.ts` file to set feature flags. For example:

![image](https://user-images.githubusercontent.com/5121148/209427420-dd231bd2-78da-4331-9aee-faa16886fe8b.png)

Once defined, users can access these values in their application code easily via the new `@webiny/feature-flags` package like so:

![image](https://user-images.githubusercontent.com/5121148/209427532-37eda0e4-7fc0-449a-a9e7-a19b1c4417ea.png)

The above approach works both on the backend and frontend.

## How Has This Been Tested?
Manually.

## Documentation
README and changelog.