### PR TITLE
feat(handler): update and lock fastify to 4.11.0

### DIFF
--- a/packages/handler-aws/package.json
+++ b/packages/handler-aws/package.json
@@ -13,12 +13,12 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.19.0",
-    "@fastify/aws-lambda": "^3.1.1",
+    "@fastify/aws-lambda": "3.1.3",
     "@webiny/handler": "^5.33.2",
     "@webiny/handler-client": "^5.33.2",
     "@webiny/plugins": "^5.33.2",
     "aws-lambda": "^1.0.7",
-    "fastify": "^4.7.0"
+    "fastify": "4.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -13,14 +13,14 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.19.0",
-    "@fastify/compress": "^6.2.0",
-    "@fastify/cookie": "^8.3.0",
+    "@fastify/compress": "6.2.0",
+    "@fastify/cookie": "8.3.0",
     "@webiny/api": "^5.33.2",
     "@webiny/error": "^5.33.2",
     "@webiny/handler-client": "^5.33.2",
     "@webiny/plugins": "^5.33.2",
     "@webiny/utils": "^5.33.2",
-    "fastify": "4.9.2"
+    "fastify": "4.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4102,14 +4102,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/aws-lambda@npm:^3.1.1":
+"@fastify/aws-lambda@npm:3.1.3":
   version: 3.1.3
   resolution: "@fastify/aws-lambda@npm:3.1.3"
   checksum: cd41d7ec0e4e28d6771219b29a7541489dfcda7a39edb4299b89f041ddb7e5cb2a731bc5e88516abf46ff54be2e6ee2bfc8524865c6b206200a5ff8076520fd9
   languageName: node
   linkType: hard
 
-"@fastify/compress@npm:^6.2.0":
+"@fastify/compress@npm:6.2.0":
   version: 6.2.0
   resolution: "@fastify/compress@npm:6.2.0"
   dependencies:
@@ -4125,7 +4125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/cookie@npm:^8.3.0":
+"@fastify/cookie@npm:8.3.0":
   version: 8.3.0
   resolution: "@fastify/cookie@npm:8.3.0"
   dependencies:
@@ -13451,14 +13451,14 @@ __metadata:
     "@babel/preset-env": ^7.19.4
     "@babel/preset-typescript": ^7.18.6
     "@babel/runtime": ^7.19.0
-    "@fastify/aws-lambda": ^3.1.1
+    "@fastify/aws-lambda": 3.1.3
     "@webiny/cli": ^5.33.2
     "@webiny/handler": ^5.33.2
     "@webiny/handler-client": ^5.33.2
     "@webiny/plugins": ^5.33.2
     "@webiny/project-utils": ^5.33.2
     aws-lambda: ^1.0.7
-    fastify: ^4.7.0
+    fastify: 4.11.0
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.7.4
@@ -13560,8 +13560,8 @@ __metadata:
     "@babel/preset-env": ^7.19.4
     "@babel/preset-typescript": ^7.18.6
     "@babel/runtime": ^7.19.0
-    "@fastify/compress": ^6.2.0
-    "@fastify/cookie": ^8.3.0
+    "@fastify/compress": 6.2.0
+    "@fastify/cookie": 8.3.0
     "@webiny/api": ^5.33.2
     "@webiny/cli": ^5.33.2
     "@webiny/error": ^5.33.2
@@ -13570,7 +13570,7 @@ __metadata:
     "@webiny/project-utils": ^5.33.2
     "@webiny/utils": ^5.33.2
     babel-plugin-lodash: ^3.3.4
-    fastify: 4.9.2
+    fastify: 4.11.0
     merge: ^1.2.1
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
@@ -18684,7 +18684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4":
+"content-type@npm:^1.0.4, content-type@npm:~1.0.4":
   version: 1.0.4
   resolution: "content-type@npm:1.0.4"
   checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
@@ -22704,15 +22704,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify@npm:4.9.2, fastify@npm:^4.7.0":
-  version: 4.9.2
-  resolution: "fastify@npm:4.9.2"
+"fastify@npm:4.11.0":
+  version: 4.11.0
+  resolution: "fastify@npm:4.11.0"
   dependencies:
     "@fastify/ajv-compiler": ^3.3.1
     "@fastify/error": ^3.0.0
     "@fastify/fast-json-stringify-compiler": ^4.1.0
     abstract-logging: ^2.0.1
     avvio: ^8.2.0
+    content-type: ^1.0.4
     find-my-way: ^7.3.0
     light-my-request: ^5.6.1
     pino: ^8.5.0
@@ -22721,8 +22722,8 @@ __metadata:
     rfdc: ^1.3.0
     secure-json-parse: ^2.5.0
     semver: ^7.3.7
-    tiny-lru: ^9.0.2
-  checksum: 78d931a569b8ef30ceade1c3f6c820ad36eebb4caf1551e4c3f181fd4750309c4912e3db85fbeeb1cabf087454d7cc1568f2614e17aef44f69461268968c87a3
+    tiny-lru: ^10.0.0
+  checksum: 814803b1015ae47cce4d7877a16788abee3ba6bba23e7e1b08a6cc62b43828aa6c38624de835c5b422da902fa93b316d1222d191b8373bebd8acbd68c8843584
   languageName: node
   linkType: hard
 
@@ -38568,10 +38569,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-lru@npm:^9.0.2":
-  version: 9.0.3
-  resolution: "tiny-lru@npm:9.0.3"
-  checksum: 8ded11a875d622a2d4c3ee2d33331ddfaa80f86b5b280bad17810ecbfd94d774c1726948f91031527bb03e2fd38c4385bd4db27fd5614b3c59fe3fa7d3359451
+"tiny-lru@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "tiny-lru@npm:10.0.1"
+  checksum: 58b5f17a357625335aa3b90ee8c9b3e9abede5c1f46066c73deb129574a205efb112807d6d473909e73f1d874ea99bf14eb5c88223d540eb32ebb5e1ff146689
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
Update Fastify to version 4.11.0 and lock it. Fastify cookie and compress are updated and locked as well.

## How Has This Been Tested?
Jest and manually.
