### PR TITLE
fix(api-headless-cms): alow overriding existing storage transform plugins

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/dynamoDb/storage/longText.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/dynamoDb/storage/longText.test.ts
@@ -144,4 +144,42 @@ describe("long text storage plugin", () => {
             data: expect.any(Object)
         });
     });
+
+    it("should not compress already compressed value", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: string[] = [
+            "some text which is going to get compressed",
+            "some text which is going to get compressed 2",
+            "some text which is going to get compressed 3"
+        ];
+
+        const compressResult = await plugin.toStorage({
+            ...defaultArgs,
+            value
+        });
+
+        expect(compressResult).toEqual({
+            compression: "gzip",
+            value: expect.any(String),
+            isArray: true
+        });
+
+        const compressAgainResult = await plugin.toStorage({
+            ...defaultArgs,
+            value
+        });
+
+        expect(compressAgainResult).toEqual({
+            compression: "gzip",
+            value: expect.any(String),
+            isArray: true
+        });
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value: compressAgainResult
+        });
+        expect(decompressResult).toEqual(value);
+    });
 });

--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
@@ -77,6 +77,12 @@ export const createLongTextStorageTransformPlugin = () => {
             }
         },
         toStorage: async ({ value: initialValue }) => {
+            /**
+             * There is a possibility that we are trying to compress already compressed value.
+             */
+            if (initialValue && initialValue.hasOwnProperty("compression") === true) {
+                return initialValue as any;
+            }
             const isArray = Array.isArray(initialValue);
             const value = isArray ? JSON.stringify(initialValue) : initialValue;
             const compressedValue = await gzip(value);

--- a/packages/api-headless-cms-ddb/__tests__/plugins/dynamoDb/storage/longText.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/plugins/dynamoDb/storage/longText.test.ts
@@ -144,4 +144,42 @@ describe("long text storage plugin", () => {
             data: expect.any(Object)
         });
     });
+
+    it("should not compress already compressed value", async () => {
+        const plugin = createLongTextStorageTransformPlugin();
+
+        const value: string[] = [
+            "some text which is going to get compressed",
+            "some text which is going to get compressed 2",
+            "some text which is going to get compressed 3"
+        ];
+
+        const compressResult = await plugin.toStorage({
+            ...defaultArgs,
+            value
+        });
+
+        expect(compressResult).toEqual({
+            compression: "gzip",
+            value: expect.any(String),
+            isArray: true
+        });
+
+        const compressAgainResult = await plugin.toStorage({
+            ...defaultArgs,
+            value
+        });
+
+        expect(compressAgainResult).toEqual({
+            compression: "gzip",
+            value: expect.any(String),
+            isArray: true
+        });
+
+        const decompressResult = await plugin.fromStorage({
+            ...defaultArgs,
+            value: compressAgainResult
+        });
+        expect(decompressResult).toEqual(value);
+    });
 });

--- a/packages/api-headless-cms-ddb/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb/src/dynamoDb/storage/longText.ts
@@ -77,6 +77,12 @@ export const createLongTextStorageTransformPlugin = () => {
             }
         },
         toStorage: async ({ value: initialValue }) => {
+            /**
+             * There is a possibility that we are trying to compress already compressed value.
+             */
+            if (initialValue && initialValue.hasOwnProperty("compression") === true) {
+                return initialValue as any;
+            }
             const isArray = Array.isArray(initialValue);
             const value = isArray ? JSON.stringify(initialValue) : initialValue;
             const compressedValue = await gzip(value);

--- a/packages/api-headless-cms/src/utils/entryStorage.ts
+++ b/packages/api-headless-cms/src/utils/entryStorage.ts
@@ -15,19 +15,19 @@ const getStoragePluginFactory: GetStoragePluginFactory = context => {
         // we reverse plugins because we want to get latest added only
         .reverse()
         .reduce((collection, plugin) => {
-            // check if it's a default plugin
-            if (plugin.fieldType === "*" && !defaultStoragePlugin) {
+            /**
+             * Check if it's a default plugin and set it - always override the previous one.
+             */
+            if (plugin.fieldType === "*") {
                 defaultStoragePlugin = plugin;
                 return collection;
             }
 
             /**
-             * either existing plugin added or plugin fieldType does not exist in current model
-             * this is to iterate a bit less later
+             * We will just set the plugin for given type.
+             * The last one will override existing one - so users can override our default ones.
              */
-            if (!collection[plugin.fieldType]) {
-                collection[plugin.fieldType] = plugin;
-            }
+            collection[plugin.fieldType] = plugin;
 
             return collection;
         }, {} as Record<string, StorageTransformPlugin>);


### PR DESCRIPTION
## Changes
Allow overriding existing StorageTransform plugins.
DDB: Long - Text storage transform - check for existing value transformation
DDB/ES: Long - Text storage transform - check for existing value transformation

## How Has This Been Tested?
Jest.