### PR TITLE
feat(api-headless-cms): dynamic zone converter

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -86,7 +86,7 @@ interface ConvertStorageEntryParams {
     entry: CmsStorageEntry;
     model: StorageOperationsCmsModel;
 }
-const convertToStorageEntry = (params: ConvertStorageEntryParams): CmsStorageEntry => {
+const convertEntryKeysToStorage = (params: ConvertStorageEntryParams): CmsStorageEntry => {
     const { model, entry } = params;
 
     const values = model.convertValueKeyToStorage({
@@ -99,7 +99,7 @@ const convertToStorageEntry = (params: ConvertStorageEntryParams): CmsStorageEnt
     };
 };
 
-const convertFromStorageEntry = (params: ConvertStorageEntryParams): CmsStorageEntry => {
+const convertEntryKeysFromStorage = (params: ConvertStorageEntryParams): CmsStorageEntry => {
     const { model, entry } = params;
 
     const values = model.convertValueKeyFromStorage({
@@ -140,11 +140,11 @@ export const createEntriesStorageOperations = (
         const isPublished = initialEntry.status === "published";
         const locked = isPublished ? true : initialEntry.locked;
 
-        const entry = convertToStorageEntry({
+        const entry = convertEntryKeysToStorage({
             model,
             entry: initialEntry
         });
-        const storageEntry = convertToStorageEntry({
+        const storageEntry = convertEntryKeysToStorage({
             model,
             entry: initialStorageEntry
         });
@@ -279,11 +279,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry: initialEntry, storageEntry: initialStorageEntry } = params;
 
-        const entry = convertToStorageEntry({
+        const entry = convertEntryKeysToStorage({
             model,
             entry: initialEntry
         });
-        const storageEntry = convertToStorageEntry({
+        const storageEntry = convertEntryKeysToStorage({
             model,
             entry: initialStorageEntry
         });
@@ -380,11 +380,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry: initialEntry, storageEntry: initialStorageEntry } = params;
 
-        const entry = convertToStorageEntry({
+        const entry = convertEntryKeysToStorage({
             model,
             entry: initialEntry
         });
-        const storageEntry = convertToStorageEntry({
+        const storageEntry = convertEntryKeysToStorage({
             model,
             entry: initialStorageEntry
         });
@@ -851,7 +851,7 @@ export const createEntriesStorageOperations = (
             model,
             entries: hits.map(item => item._source)
         }).map(item => {
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 model,
                 entry: item
             });
@@ -894,11 +894,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry: initialEntry, storageEntry: initialStorageEntry } = params;
 
-        const entry = convertToStorageEntry({
+        const entry = convertEntryKeysToStorage({
             model,
             entry: initialEntry
         });
-        const storageEntry = convertToStorageEntry({
+        const storageEntry = convertEntryKeysToStorage({
             model,
             entry: initialStorageEntry
         });
@@ -1122,11 +1122,11 @@ export const createEntriesStorageOperations = (
     ) => {
         const { entry: initialEntry, storageEntry: initialStorageEntry } = params;
 
-        const entry = convertToStorageEntry({
+        const entry = convertEntryKeysToStorage({
             model,
             entry: initialEntry
         });
-        const storageEntry = convertToStorageEntry({
+        const storageEntry = convertEntryKeysToStorage({
             model,
             entry: initialStorageEntry
         });
@@ -1244,7 +1244,7 @@ export const createEntriesStorageOperations = (
         if (!entry) {
             return null;
         }
-        return convertFromStorageEntry({
+        return convertEntryKeysFromStorage({
             model,
             entry
         });
@@ -1260,7 +1260,7 @@ export const createEntriesStorageOperations = (
         if (!entry) {
             return null;
         }
-        return convertFromStorageEntry({
+        return convertEntryKeysFromStorage({
             model,
             entry
         });
@@ -1277,7 +1277,7 @@ export const createEntriesStorageOperations = (
         if (!entry) {
             return null;
         }
-        return convertFromStorageEntry({
+        return convertEntryKeysFromStorage({
             model,
             entry
         });
@@ -1293,7 +1293,7 @@ export const createEntriesStorageOperations = (
         });
 
         return entries.map(entry => {
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 model,
                 entry
             });
@@ -1309,7 +1309,7 @@ export const createEntriesStorageOperations = (
             ids: params.ids
         });
         return entries.map(entry => {
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 model,
                 entry
             });
@@ -1325,7 +1325,7 @@ export const createEntriesStorageOperations = (
             ids: params.ids
         });
         return entries.map(entry => {
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 model,
                 entry
             });
@@ -1342,7 +1342,7 @@ export const createEntriesStorageOperations = (
         });
 
         return entries.map(entry => {
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 model,
                 entry
             });
@@ -1389,7 +1389,7 @@ export const createEntriesStorageOperations = (
             if (!entry) {
                 return null;
             }
-            return convertFromStorageEntry({
+            return convertEntryKeysFromStorage({
                 entry,
                 model
             });

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModelToSDL.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModelToSDL.manage.test.ts
@@ -42,7 +42,7 @@ describe("MANAGE - ContentModel to SDL", () => {
     });
 
     test("Dynamic Zone SDL", async () => {
-        const sdl = createManageSDL({ model: pageModel, fieldTypePlugins });
+        const sdl = createManageSDL({ model: pageModel as any, fieldTypePlugins });
         const prettyGql = prettier.format(sdl.trim(), { parser: "graphql" });
         const prettySnapshot = prettier.format(pageManage.trim(), { parser: "graphql" });
         expect(prettyGql).toBe(prettySnapshot);

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModelToSDL.read.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModelToSDL.read.test.ts
@@ -65,7 +65,7 @@ describe("READ - ContentModel to SDL", () => {
     });
 
     test("Dynamic Zone SDL", async () => {
-        const sdl = createReadSDL({ model: pageModel, fieldTypePlugins });
+        const sdl = createReadSDL({ model: pageModel as any, fieldTypePlugins });
         const prettyGql = prettier.format(sdl.trim(), { parser: "graphql" });
         const prettySnapshot = prettier.format(pageSDL.trim(), { parser: "graphql" });
         expect(prettyGql).toBe(prettySnapshot);

--- a/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
@@ -48,7 +48,22 @@ const contentEntryQueryData = {
                     nestedObjectNestedTitle: "Objective nested title #2"
                 }
             ],
-            objectTitle: "Objective title #1"
+            objectTitle: "Objective title #1",
+            objectBody: [
+                {
+                    tag: "h1",
+                    content: "Rich Text"
+                },
+                {
+                    tag: "div",
+                    children: [
+                        {
+                            tag: "p",
+                            content: "Testing the rich text storage"
+                        }
+                    ]
+                }
+            ]
         },
         __typename: "Page_Objective_Objecting"
     }
@@ -91,6 +106,21 @@ const contentEntryMutationData = {
         Objecting: {
             nestedObject: {
                 objectTitle: "Objective title #1",
+                objectBody: [
+                    {
+                        tag: "h1",
+                        content: "Rich Text"
+                    },
+                    {
+                        tag: "div",
+                        children: [
+                            {
+                                tag: "p",
+                                content: "Testing the rich text storage"
+                            }
+                        ]
+                    }
+                ],
                 objectNestedObject: [
                     {
                         nestedObjectNestedTitle: "Objective nested title #1"

--- a/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
@@ -17,12 +17,40 @@ const contentEntryQueryData = {
         {
             title: "Hero Title #2",
             __typename: "Page_Content_Hero"
+        },
+        {
+            __typename: "Page_Content_Objecting",
+            nestedObject: {
+                objectNestedObject: [
+                    {
+                        nestedObjectNestedTitle: "Objective nested title #1"
+                    },
+                    {
+                        nestedObjectNestedTitle: "Objective nested title #2"
+                    }
+                ],
+                objectTitle: "Objective title #1"
+            }
         }
     ],
     header: {
         title: "Header #1",
         image: "https://d3bwcib4j08r73.cloudfront.net/files/webiny-serverless-cms.png",
         __typename: "Page_Header_ImageHeader"
+    },
+    objective: {
+        nestedObject: {
+            objectNestedObject: [
+                {
+                    nestedObjectNestedTitle: "Objective nested title #1"
+                },
+                {
+                    nestedObjectNestedTitle: "Objective nested title #2"
+                }
+            ],
+            objectTitle: "Objective title #1"
+        },
+        __typename: "Page_Objective_Objecting"
     }
 };
 
@@ -36,12 +64,42 @@ const contentEntryMutationData = {
         },
         {
             Hero: { title: "Hero Title #2" }
+        },
+        {
+            Objecting: {
+                nestedObject: {
+                    objectTitle: "Objective title #1",
+                    objectNestedObject: [
+                        {
+                            nestedObjectNestedTitle: "Objective nested title #1"
+                        },
+                        {
+                            nestedObjectNestedTitle: "Objective nested title #2"
+                        }
+                    ]
+                }
+            }
         }
     ],
     header: {
         ImageHeader: {
             title: "Header #1",
             image: "https://d3bwcib4j08r73.cloudfront.net/files/webiny-serverless-cms.png"
+        }
+    },
+    objective: {
+        Objecting: {
+            nestedObject: {
+                objectTitle: "Objective title #1",
+                objectNestedObject: [
+                    {
+                        nestedObjectNestedTitle: "Objective nested title #1"
+                    },
+                    {
+                        nestedObjectNestedTitle: "Objective nested title #2"
+                    }
+                ]
+            }
         }
     }
 };
@@ -66,7 +124,8 @@ describe("dynamicZone field", () => {
                     data: {
                         id: expect.any(String),
                         content: contentEntryQueryData.content,
-                        header: contentEntryQueryData.header
+                        header: contentEntryQueryData.header,
+                        objective: contentEntryQueryData.objective
                     },
                     error: null
                 }
@@ -86,7 +145,8 @@ describe("dynamicZone field", () => {
                     data: {
                         id: page.id,
                         content: contentEntryQueryData.content,
-                        header: contentEntryQueryData.header
+                        header: contentEntryQueryData.header,
+                        objective: contentEntryQueryData.objective
                     },
                     error: null
                 }
@@ -121,7 +181,8 @@ describe("dynamicZone field", () => {
                     data: {
                         id: page.id,
                         content: contentEntryQueryData.content,
-                        header: contentEntryQueryData.header
+                        header: contentEntryQueryData.header,
+                        objective: contentEntryQueryData.objective
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
@@ -112,7 +112,7 @@ describe("dynamicZone field", () => {
     const preview = usePageReadHandler(previewOpts);
 
     test("should create a page with dynamic zone fields", async () => {
-        await setupGroupAndModels({ manager: manage, models: [pageModel] });
+        await setupGroupAndModels({ manager: manage, models: [pageModel as any] });
 
         const [createPageResponse] = await manage.createPage({
             data: contentEntryMutationData

--- a/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
@@ -164,6 +164,36 @@ describe("dynamicZone field", () => {
 
         const page = createPageResponse.data.createPage.data;
 
+        await manage.until(
+            () => manage.listPages().then(([data]) => data),
+            ({ data }: any) => {
+                return data.listPages.data.length === 1;
+            }
+        );
+
+        const [manageList] = await manage.listPages();
+
+        expect(manageList).toEqual({
+            data: {
+                listPages: {
+                    data: [
+                        {
+                            id: page.id,
+                            content: contentEntryQueryData.content,
+                            header: contentEntryQueryData.header,
+                            objective: contentEntryQueryData.objective
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
         // Test `manage` get
         const [manageGet] = await manage.getPage({
             revision: page.id

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
@@ -279,6 +279,12 @@ export const pageModel: CmsModel = {
                                             label: "Object title"
                                         },
                                         {
+                                            id: "ijg4ufdsundsj",
+                                            fieldId: "objectBody",
+                                            type: "rich-text",
+                                            label: "Object body"
+                                        },
+                                        {
                                             id: "xj0waxngrejno",
                                             fieldId: "objectNestedObject",
                                             type: "object",

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
@@ -1,5 +1,10 @@
 const { version: webinyVersion } = require("@webiny/cli/package.json");
-import { CmsModel } from "~/types";
+import { CmsModel as BaseCmsModel, CmsModelField as BaseCmsModelField } from "~/types";
+
+type CmsModelField = Omit<BaseCmsModelField, "storageId">;
+interface CmsModel extends Omit<BaseCmsModel, "fields"> {
+    fields: CmsModelField[];
+}
 
 export const pageModel: CmsModel = {
     tenant: "root",
@@ -21,7 +26,6 @@ export const pageModel: CmsModel = {
         {
             id: "peeeyhtc",
             fieldId: "content",
-            storageId: "dynamic-zone@peeeyhtc", // storage ID does not have any effect
             type: "dynamicZone",
             label: "Content",
             tags: [],
@@ -126,7 +130,6 @@ export const pageModel: CmsModel = {
                             {
                                 id: "ttyh493ugfd",
                                 fieldId: "nestedObject",
-                                storageId: "someMockStorageIdWhichIsNotUsed",
                                 label: "Nested Object",
                                 type: "object",
                                 settings: {
@@ -134,14 +137,12 @@ export const pageModel: CmsModel = {
                                         {
                                             id: "rt3uhvds",
                                             fieldId: "objectTitle",
-                                            storageId: "objectTitleStorageId",
                                             type: "text",
                                             label: "Object title"
                                         },
                                         {
                                             id: "r329gdfhsaufdsa",
                                             fieldId: "objectNestedObject",
-                                            storageId: "objectNestedObjectStorageId",
                                             type: "object",
                                             label: "Object nested object",
                                             multipleValues: true,
@@ -150,8 +151,6 @@ export const pageModel: CmsModel = {
                                                     {
                                                         id: "g9huerprgds",
                                                         fieldId: "nestedObjectNestedTitle",
-                                                        storageId:
-                                                            "nestedObjectNestedTitleStorageId",
                                                         type: "text",
                                                         label: "Nested object nested title"
                                                     }
@@ -172,7 +171,6 @@ export const pageModel: CmsModel = {
         {
             id: "kcq9kt40",
             fieldId: "header",
-            storageId: "dynamic-zone@kcq9kt40",
             type: "dynamicZone",
             label: "Header",
             tags: [],
@@ -255,7 +253,6 @@ export const pageModel: CmsModel = {
         {
             id: "t4pfesadsa",
             fieldId: "objective",
-            storageId: "dynamicZone@objectiveStorageId",
             type: "dynamicZone",
             label: "Objective",
             settings: {
@@ -271,7 +268,6 @@ export const pageModel: CmsModel = {
                             {
                                 id: "ngutrblkf",
                                 fieldId: "nestedObject",
-                                storageId: "someMockStorageIdWhichIsNotUsed",
                                 label: "Nested Object",
                                 type: "object",
                                 settings: {
@@ -279,14 +275,12 @@ export const pageModel: CmsModel = {
                                         {
                                             id: "gpbebgjbefs",
                                             fieldId: "objectTitle",
-                                            storageId: "objectTitleStorageId",
                                             type: "text",
                                             label: "Object title"
                                         },
                                         {
                                             id: "xj0waxngrejno",
                                             fieldId: "objectNestedObject",
-                                            storageId: "objectNestedObjectStorageId",
                                             type: "object",
                                             label: "Object nested object",
                                             multipleValues: true,
@@ -295,8 +289,6 @@ export const pageModel: CmsModel = {
                                                     {
                                                         id: "hpgtierghpiue",
                                                         fieldId: "nestedObjectNestedTitle",
-                                                        storageId:
-                                                            "nestedObjectNestedTitleStorageId",
                                                         type: "text",
                                                         label: "Nested object nested title"
                                                     }

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
@@ -15,13 +15,13 @@ export const pageModel: CmsModel = {
     savedOn: "2022-12-19T19:10:02.731Z",
     titleFieldId: "id",
     lockedFields: [],
-    layout: [["kcq9kt40"], ["peeeyhtc"]],
+    layout: [["kcq9kt40"], ["peeeyhtc"], ["t4pfesadsa"]],
     tags: ["type:model"],
     fields: [
         {
             id: "peeeyhtc",
             fieldId: "content",
-            storageId: "dynamic-zone@peeeyhtc",
+            storageId: "dynamic-zone@peeeyhtc", // storage ID does not have any effect
             type: "dynamicZone",
             label: "Content",
             tags: [],
@@ -114,6 +114,57 @@ export const pageModel: CmsModel = {
                                 }
                             }
                         ]
+                    },
+                    {
+                        layout: [["ttyh493ugfd"]],
+                        name: "Objecting",
+                        gqlTypeName: "Objecting",
+                        icon: "fas/file-text",
+                        description: "Objecting test.",
+                        id: "9ht43gurhegkbdfsaafyads",
+                        fields: [
+                            {
+                                id: "ttyh493ugfd",
+                                fieldId: "nestedObject",
+                                storageId: "someMockStorageIdWhichIsNotUsed",
+                                label: "Nested Object",
+                                type: "object",
+                                settings: {
+                                    fields: [
+                                        {
+                                            id: "rt3uhvds",
+                                            fieldId: "objectTitle",
+                                            storageId: "objectTitleStorageId",
+                                            type: "text",
+                                            label: "Object title"
+                                        },
+                                        {
+                                            id: "r329gdfhsaufdsa",
+                                            fieldId: "objectNestedObject",
+                                            storageId: "objectNestedObjectStorageId",
+                                            type: "object",
+                                            label: "Object nested object",
+                                            multipleValues: true,
+                                            settings: {
+                                                fields: [
+                                                    {
+                                                        id: "g9huerprgds",
+                                                        fieldId: "nestedObjectNestedTitle",
+                                                        storageId:
+                                                            "nestedObjectNestedTitleStorageId",
+                                                        type: "text",
+                                                        label: "Nested object nested title"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                renderer: {
+                                    name: "dynamicZone"
+                                }
+                            }
+                        ]
                     }
                 ]
             }
@@ -195,6 +246,68 @@ export const pageModel: CmsModel = {
                                 type: "file",
                                 validation: [],
                                 fieldId: "image"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            id: "t4pfesadsa",
+            fieldId: "objective",
+            storageId: "dynamicZone@objectiveStorageId",
+            type: "dynamicZone",
+            label: "Objective",
+            settings: {
+                templates: [
+                    {
+                        layout: [["ngutrblkf"]],
+                        name: "Objecting",
+                        gqlTypeName: "Objecting",
+                        icon: "fas/file-text",
+                        description: "Objecting test.",
+                        id: "t804h3gufashguasffds",
+                        fields: [
+                            {
+                                id: "ngutrblkf",
+                                fieldId: "nestedObject",
+                                storageId: "someMockStorageIdWhichIsNotUsed",
+                                label: "Nested Object",
+                                type: "object",
+                                settings: {
+                                    fields: [
+                                        {
+                                            id: "gpbebgjbefs",
+                                            fieldId: "objectTitle",
+                                            storageId: "objectTitleStorageId",
+                                            type: "text",
+                                            label: "Object title"
+                                        },
+                                        {
+                                            id: "xj0waxngrejno",
+                                            fieldId: "objectNestedObject",
+                                            storageId: "objectNestedObjectStorageId",
+                                            type: "object",
+                                            label: "Object nested object",
+                                            multipleValues: true,
+                                            settings: {
+                                                fields: [
+                                                    {
+                                                        id: "hpgtierghpiue",
+                                                        fieldId: "nestedObjectNestedTitle",
+                                                        storageId:
+                                                            "nestedObjectNestedTitleStorageId",
+                                                        type: "text",
+                                                        label: "Nested object nested title"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                renderer: {
+                                    name: "dynamicZone"
+                                }
                             }
                         ]
                     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -121,6 +121,7 @@ export default /* GraphQL */ `
 
     type Page_Objective_Objecting_NestedObject {
         objectTitle: String
+        objectBody: JSON
         objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObject!]
     }
     input Page_Objective_Objecting_NestedObjectWhereInput {
@@ -189,6 +190,7 @@ export default /* GraphQL */ `
 
     input Page_Objective_Objecting_NestedObjectInput {
         objectTitle: String
+        objectBody: JSON
         objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObjectInput!]
     }
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -12,6 +12,7 @@ export default /* GraphQL */ `
         meta: PageMeta
         content: [Page_Content!]
         header: Page_Header
+        objective: Page_Objective
     }
 
     type PageMeta {
@@ -32,7 +33,7 @@ export default /* GraphQL */ `
         data: JSON
     }
 
-    union Page_Content = Page_Content_Hero | Page_Content_SimpleText
+    union Page_Content = Page_Content_Hero | Page_Content_SimpleText | Page_Content_Objecting
 
     type Page_Content_Hero {
         title: String
@@ -42,11 +43,46 @@ export default /* GraphQL */ `
         text: String
     }
 
+    type Page_Content_Objecting_NestedObject_ObjectNestedObject {
+        nestedObjectNestedTitle: String
+    }
+    input Page_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput {
+        nestedObjectNestedTitle: String
+        nestedObjectNestedTitle_not: String
+        nestedObjectNestedTitle_in: [String]
+        nestedObjectNestedTitle_not_in: [String]
+        nestedObjectNestedTitle_contains: String
+        nestedObjectNestedTitle_not_contains: String
+    }
+
+    type Page_Content_Objecting_NestedObject {
+        objectTitle: String
+        objectNestedObject: [Page_Content_Objecting_NestedObject_ObjectNestedObject!]
+    }
+    input Page_Content_Objecting_NestedObjectWhereInput {
+        objectTitle: String
+        objectTitle_not: String
+        objectTitle_in: [String]
+        objectTitle_not_in: [String]
+        objectTitle_contains: String
+        objectTitle_not_contains: String
+
+        objectNestedObject: Page_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    type Page_Content_Objecting {
+        nestedObject: Page_Content_Objecting_NestedObject
+    }
+
     extend type Page_Content_Hero {
         _templateId: ID!
     }
 
     extend type Page_Content_SimpleText {
+        _templateId: ID!
+    }
+
+    extend type Page_Content_Objecting {
         _templateId: ID!
     }
 
@@ -69,6 +105,43 @@ export default /* GraphQL */ `
         _templateId: ID!
     }
 
+    union Page_Objective = Page_Objective_Objecting
+
+    type Page_Objective_Objecting_NestedObject_ObjectNestedObject {
+        nestedObjectNestedTitle: String
+    }
+    input Page_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput {
+        nestedObjectNestedTitle: String
+        nestedObjectNestedTitle_not: String
+        nestedObjectNestedTitle_in: [String]
+        nestedObjectNestedTitle_not_in: [String]
+        nestedObjectNestedTitle_contains: String
+        nestedObjectNestedTitle_not_contains: String
+    }
+
+    type Page_Objective_Objecting_NestedObject {
+        objectTitle: String
+        objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObject!]
+    }
+    input Page_Objective_Objecting_NestedObjectWhereInput {
+        objectTitle: String
+        objectTitle_not: String
+        objectTitle_in: [String]
+        objectTitle_not_in: [String]
+        objectTitle_contains: String
+        objectTitle_not_contains: String
+
+        objectNestedObject: Page_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    type Page_Objective_Objecting {
+        nestedObject: Page_Objective_Objecting_NestedObject
+    }
+
+    extend type Page_Objective_Objecting {
+        _templateId: ID!
+    }
+
     input Page_Content_HeroInput {
         title: String!
     }
@@ -77,9 +150,23 @@ export default /* GraphQL */ `
         text: String
     }
 
+    input Page_Content_Objecting_NestedObject_ObjectNestedObjectInput {
+        nestedObjectNestedTitle: String
+    }
+
+    input Page_Content_Objecting_NestedObjectInput {
+        objectTitle: String
+        objectNestedObject: [Page_Content_Objecting_NestedObject_ObjectNestedObjectInput!]
+    }
+
+    input Page_Content_ObjectingInput {
+        nestedObject: Page_Content_Objecting_NestedObjectInput
+    }
+
     input Page_ContentInput {
         Hero: Page_Content_HeroInput
         SimpleText: Page_Content_SimpleTextInput
+        Objecting: Page_Content_ObjectingInput
     }
 
     input Page_Header_TextHeaderInput {
@@ -96,9 +183,27 @@ export default /* GraphQL */ `
         ImageHeader: Page_Header_ImageHeaderInput
     }
 
+    input Page_Objective_Objecting_NestedObject_ObjectNestedObjectInput {
+        nestedObjectNestedTitle: String
+    }
+
+    input Page_Objective_Objecting_NestedObjectInput {
+        objectTitle: String
+        objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObjectInput!]
+    }
+
+    input Page_Objective_ObjectingInput {
+        nestedObject: Page_Objective_Objecting_NestedObjectInput
+    }
+
+    input Page_ObjectiveInput {
+        Objecting: Page_Objective_ObjectingInput
+    }
+
     input PageInput {
         content: [Page_ContentInput]
         header: Page_HeaderInput
+        objective: Page_ObjectiveInput
     }
 
     input PageGetWhereInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -82,6 +82,7 @@ export default `
     
     type Page_Objective_Objecting_NestedObject {
         objectTitle: String
+        objectBody: JSON
         objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObject!]
     }
     input Page_Objective_Objecting_NestedObjectWhereInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -11,9 +11,10 @@ export default `
         ownedBy: CmsOwnedBy!
         content: [Page_Content!]
         header: Page_Header
+        objective: Page_Objective
     }
 
-    union Page_Content = Page_Content_Hero | Page_Content_SimpleText
+    union Page_Content = Page_Content_Hero | Page_Content_SimpleText | Page_Content_Objecting
 
     type Page_Content_Hero {
         title: String
@@ -21,6 +22,37 @@ export default `
 
     type Page_Content_SimpleText {
         text: String
+    }
+    
+    type Page_Content_Objecting_NestedObject_ObjectNestedObject {
+        nestedObjectNestedTitle: String
+    }
+    input Page_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput {
+        nestedObjectNestedTitle: String
+        nestedObjectNestedTitle_not: String
+        nestedObjectNestedTitle_in: [String]
+        nestedObjectNestedTitle_not_in: [String]
+        nestedObjectNestedTitle_contains: String
+        nestedObjectNestedTitle_not_contains: String
+    }
+    
+    type Page_Content_Objecting_NestedObject {
+        objectTitle: String
+        objectNestedObject: [Page_Content_Objecting_NestedObject_ObjectNestedObject!]
+    }
+    input Page_Content_Objecting_NestedObjectWhereInput {
+        objectTitle: String
+        objectTitle_not: String
+        objectTitle_in: [String]
+        objectTitle_not_in: [String]
+        objectTitle_contains: String
+        objectTitle_not_contains: String
+    
+        objectNestedObject: Page_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+    
+    type Page_Content_Objecting {
+        nestedObject: Page_Content_Objecting_NestedObject
     }
 
     union Page_Header = Page_Header_TextHeader | Page_Header_ImageHeader
@@ -33,7 +65,40 @@ export default `
         title: String
         image: String
     }
-
+    
+    union Page_Objective = Page_Objective_Objecting
+    
+    type Page_Objective_Objecting_NestedObject_ObjectNestedObject {
+        nestedObjectNestedTitle: String
+    }
+    input Page_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput {
+        nestedObjectNestedTitle: String
+        nestedObjectNestedTitle_not: String
+        nestedObjectNestedTitle_in: [String]
+        nestedObjectNestedTitle_not_in: [String]
+        nestedObjectNestedTitle_contains: String
+        nestedObjectNestedTitle_not_contains: String
+    }
+    
+    type Page_Objective_Objecting_NestedObject {
+        objectTitle: String
+        objectNestedObject: [Page_Objective_Objecting_NestedObject_ObjectNestedObject!]
+    }
+    input Page_Objective_Objecting_NestedObjectWhereInput {
+        objectTitle: String
+        objectTitle_not: String
+        objectTitle_in: [String]
+        objectTitle_not_in: [String]
+        objectTitle_contains: String
+        objectTitle_not_contains: String
+    
+        objectNestedObject: Page_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+    
+    type Page_Objective_Objecting {
+        nestedObject: Page_Objective_Objecting_NestedObject
+    }
+    
     input PageGetWhereInput {
         id: ID
         entryId: String

--- a/packages/api-headless-cms/__tests__/converters/fieldIdStorageConverter.test.ts
+++ b/packages/api-headless-cms/__tests__/converters/fieldIdStorageConverter.test.ts
@@ -28,33 +28,7 @@ describe("field id storage converter", () => {
         expect(entry).toMatchObject({
             id: "someEntryId#0001",
             values: {
-                name: "John Doe",
-                dynamicZoneArray: [
-                    {
-                        dzText: "Dynamic zone array title",
-                        dzObjectArray: [
-                            {
-                                titleInDzObjectArray: "Dynamic zone object array title"
-                            }
-                        ],
-                        dzObject: {
-                            titleInDzObject: "Dynamic zone object title"
-                        },
-                        _templateId: "dzTemplateArray1"
-                    }
-                ],
-                dynamicZoneObject: {
-                    dzText: "Dynamic zone object title",
-                    dzObjectArray: [
-                        {
-                            titleInDzObjectArray: "Dynamic zone object array title"
-                        }
-                    ],
-                    dzObject: {
-                        titleInDzObject: "Dynamic zone object title"
-                    },
-                    _templateId: "dzTemplateObject1"
-                }
+                name: "John Doe"
             }
         });
 

--- a/packages/api-headless-cms/__tests__/converters/fieldIdStorageConverter.test.ts
+++ b/packages/api-headless-cms/__tests__/converters/fieldIdStorageConverter.test.ts
@@ -28,7 +28,33 @@ describe("field id storage converter", () => {
         expect(entry).toMatchObject({
             id: "someEntryId#0001",
             values: {
-                name: "John Doe"
+                name: "John Doe",
+                dynamicZoneArray: [
+                    {
+                        dzText: "Dynamic zone array title",
+                        dzObjectArray: [
+                            {
+                                titleInDzObjectArray: "Dynamic zone object array title"
+                            }
+                        ],
+                        dzObject: {
+                            titleInDzObject: "Dynamic zone object title"
+                        },
+                        _templateId: "dzTemplateArray1"
+                    }
+                ],
+                dynamicZoneObject: {
+                    dzText: "Dynamic zone object title",
+                    dzObjectArray: [
+                        {
+                            titleInDzObjectArray: "Dynamic zone object array title"
+                        }
+                    ],
+                    dzObject: {
+                        titleInDzObject: "Dynamic zone object title"
+                    },
+                    _templateId: "dzTemplateObject1"
+                }
             }
         });
 

--- a/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
+++ b/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
@@ -714,22 +714,7 @@ const createRawValues = () => {
         ],
         dynamicZoneArray: [
             {
-                DzTextObjectArray: {
-                    dzText: "Dynamic zone array title",
-                    dzObjectArray: [
-                        {
-                            titleInDzObjectArray: "Dynamic zone object array title"
-                        }
-                    ],
-                    dzObject: {
-                        titleInDzObject: "Dynamic zone object title"
-                    }
-                }
-            }
-        ],
-        dynamicZoneObject: {
-            DzTextObject: {
-                dzText: "Dynamic zone object title",
+                dzText: "Dynamic zone array title",
                 dzObjectArray: [
                     {
                         titleInDzObjectArray: "Dynamic zone object array title"
@@ -737,8 +722,21 @@ const createRawValues = () => {
                 ],
                 dzObject: {
                     titleInDzObject: "Dynamic zone object title"
-                }
+                },
+                _templateId: "dzTemplateArray1"
             }
+        ],
+        dynamicZoneObject: {
+            dzText: "Dynamic zone object title",
+            dzObjectArray: [
+                {
+                    titleInDzObjectArray: "Dynamic zone object array title"
+                }
+            ],
+            dzObject: {
+                titleInDzObject: "Dynamic zone object title"
+            },
+            _templateId: "dzTemplateObject1"
         }
     };
 };

--- a/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
+++ b/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
@@ -1,9 +1,11 @@
-import { CmsEntry, CmsModel, CmsModelField } from "~/types";
+import { CmsEntry, CmsModel, CmsModelDynamicZoneField, CmsModelField } from "~/types";
 import lodashCamelCase from "lodash/camelCase";
 
-const createModelField = (
-    base: Partial<CmsModelField> & Pick<CmsModelField, "fieldId" | "type">
-): CmsModelField => {
+type BaseCmsModelField =
+    | (Partial<CmsModelDynamicZoneField> & Pick<CmsModelDynamicZoneField, "fieldId" | "type">)
+    | (Partial<CmsModelField> & Pick<CmsModelField, "fieldId" | "type">);
+
+const createModelField = (base: BaseCmsModelField): CmsModelField => {
     const { fieldId, type } = base;
     const id = base.id || `${fieldId}Id`;
     return {
@@ -471,6 +473,108 @@ const createModelFields = (): CmsModelField[] => {
                     })
                 ]
             }
+        }),
+        createModelField({
+            type: "dynamicZone",
+            fieldId: "dynamicZoneArray",
+            multipleValues: true,
+            settings: {
+                templates: [
+                    {
+                        layout: [["dzText", "dzObject", "dzObjectArray"]],
+                        name: "DZ Text",
+                        gqlTypeName: "DzText",
+                        icon: "fas/flag",
+                        description: "",
+                        id: "dzTemplateArray1",
+                        fields: [
+                            createModelField({
+                                fieldId: "dzText",
+                                type: "text"
+                            }),
+                            createModelField({
+                                type: "object",
+                                multipleValues: true,
+                                fieldId: "dzObjectArray",
+                                settings: {
+                                    fields: [
+                                        createModelField({
+                                            type: "text",
+                                            multipleValues: false,
+                                            fieldId: "titleInDzObjectArray"
+                                        })
+                                    ]
+                                }
+                            }),
+                            createModelField({
+                                type: "object",
+                                multipleValues: false,
+                                fieldId: "dzObject",
+                                settings: {
+                                    fields: [
+                                        createModelField({
+                                            type: "text",
+                                            multipleValues: false,
+                                            fieldId: "titleInDzObject"
+                                        })
+                                    ]
+                                }
+                            })
+                        ]
+                    }
+                ]
+            }
+        }),
+        createModelField({
+            type: "dynamicZone",
+            fieldId: "dynamicZoneObject",
+            multipleValues: false,
+            settings: {
+                templates: [
+                    {
+                        layout: [["dzText", "dzObject", "dzObjectArray"]],
+                        name: "DZ Text",
+                        gqlTypeName: "DzText",
+                        icon: "fas/flag",
+                        description: "",
+                        id: "dzTemplateObject1",
+                        fields: [
+                            createModelField({
+                                fieldId: "dzText",
+                                type: "text"
+                            }),
+                            createModelField({
+                                type: "object",
+                                multipleValues: true,
+                                fieldId: "dzObjectArray",
+                                settings: {
+                                    fields: [
+                                        createModelField({
+                                            type: "text",
+                                            multipleValues: false,
+                                            fieldId: "titleInDzObjectArray"
+                                        })
+                                    ]
+                                }
+                            }),
+                            createModelField({
+                                type: "object",
+                                multipleValues: false,
+                                fieldId: "dzObject",
+                                settings: {
+                                    fields: [
+                                        createModelField({
+                                            type: "text",
+                                            multipleValues: false,
+                                            fieldId: "titleInDzObject"
+                                        })
+                                    ]
+                                }
+                            })
+                        ]
+                    }
+                ]
+            }
         })
     ];
 };
@@ -607,7 +711,33 @@ const createRawValues = () => {
                     titleInRepeatableObjectsObject: "Title In My Object List Child Object #2"
                 }
             }
-        ]
+        ],
+        dynamicZoneArray: [
+            {
+                dzText: "Dynamic zone array title",
+                dzObjectArray: [
+                    {
+                        titleInDzObjectArray: "Dynamic zone object array title"
+                    }
+                ],
+                dzObject: {
+                    titleInDzObject: "Dynamic zone object title"
+                },
+                _templateId: "dzTemplateArray1"
+            }
+        ],
+        dynamicZoneObject: {
+            dzText: "Dynamic zone object title",
+            dzObjectArray: [
+                {
+                    titleInDzObjectArray: "Dynamic zone object array title"
+                }
+            ],
+            dzObject: {
+                titleInDzObject: "Dynamic zone object title"
+            },
+            _templateId: "dzTemplateObject1"
+        }
     };
 };
 
@@ -727,7 +857,33 @@ const createStoredValues = () => {
                         "Title In My Object List Child Object #2"
                 }
             }
-        ]
+        ],
+        "dynamicZone@dynamicZoneArrayId": [
+            {
+                "text@dzTextId": "Dynamic zone array title",
+                "object@dzObjectArrayId": [
+                    {
+                        "text@titleInDzObjectArrayId": "Dynamic zone object array title"
+                    }
+                ],
+                "object@dzObjectId": {
+                    "text@titleInDzObjectId": "Dynamic zone object title"
+                },
+                _templateId: "dzTemplateArray1"
+            }
+        ],
+        "dynamicZone@dynamicZoneObjectId": {
+            "text@dzTextId": "Dynamic zone object title",
+            "object@dzObjectArrayId": [
+                {
+                    "text@titleInDzObjectArrayId": "Dynamic zone object array title"
+                }
+            ],
+            "object@dzObjectId": {
+                "text@titleInDzObjectId": "Dynamic zone object title"
+            },
+            _templateId: "dzTemplateObject1"
+        }
     };
 };
 

--- a/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
+++ b/packages/api-headless-cms/__tests__/converters/mocks/fieldIdStorageConverter.ts
@@ -483,7 +483,7 @@ const createModelFields = (): CmsModelField[] => {
                     {
                         layout: [["dzText", "dzObject", "dzObjectArray"]],
                         name: "DZ Text",
-                        gqlTypeName: "DzText",
+                        gqlTypeName: "DzTextObjectArray",
                         icon: "fas/flag",
                         description: "",
                         id: "dzTemplateArray1",
@@ -534,7 +534,7 @@ const createModelFields = (): CmsModelField[] => {
                     {
                         layout: [["dzText", "dzObject", "dzObjectArray"]],
                         name: "DZ Text",
-                        gqlTypeName: "DzText",
+                        gqlTypeName: "DzTextObject",
                         icon: "fas/flag",
                         description: "",
                         id: "dzTemplateObject1",
@@ -714,7 +714,22 @@ const createRawValues = () => {
         ],
         dynamicZoneArray: [
             {
-                dzText: "Dynamic zone array title",
+                DzTextObjectArray: {
+                    dzText: "Dynamic zone array title",
+                    dzObjectArray: [
+                        {
+                            titleInDzObjectArray: "Dynamic zone object array title"
+                        }
+                    ],
+                    dzObject: {
+                        titleInDzObject: "Dynamic zone object title"
+                    }
+                }
+            }
+        ],
+        dynamicZoneObject: {
+            DzTextObject: {
+                dzText: "Dynamic zone object title",
                 dzObjectArray: [
                     {
                         titleInDzObjectArray: "Dynamic zone object array title"
@@ -722,21 +737,8 @@ const createRawValues = () => {
                 ],
                 dzObject: {
                     titleInDzObject: "Dynamic zone object title"
-                },
-                _templateId: "dzTemplateArray1"
-            }
-        ],
-        dynamicZoneObject: {
-            dzText: "Dynamic zone object title",
-            dzObjectArray: [
-                {
-                    titleInDzObjectArray: "Dynamic zone object array title"
                 }
-            ],
-            dzObject: {
-                titleInDzObject: "Dynamic zone object title"
-            },
-            _templateId: "dzTemplateObject1"
+            }
         }
     };
 };

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
@@ -37,6 +37,7 @@ const pageFields = `
         ...on Page_Objective_Objecting {
             nestedObject {
                 objectTitle
+                objectBody
                 objectNestedObject {
                     nestedObjectNestedTitle
                 }

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
@@ -12,6 +12,15 @@ const pageFields = `
             text
             __typename
         }
+        ...on Page_Content_Objecting {
+            nestedObject {
+                objectTitle
+                objectNestedObject {
+                    nestedObjectNestedTitle
+                }
+            }
+            __typename
+        }
     }
     header {
         ...on Page_Header_TextHeader {
@@ -21,6 +30,17 @@ const pageFields = `
         ...on Page_Header_ImageHeader {
             title
             image
+            __typename
+        }
+    }
+    objective {
+        ...on Page_Objective_Objecting {
+            nestedObject {
+                objectTitle
+                objectNestedObject {
+                    nestedObjectNestedTitle
+                }
+            }
             __typename
         }
     }

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageReadHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageReadHandler.ts
@@ -11,6 +11,15 @@ const pageFields = `
             text
             __typename
         }
+        ...on Page_Content_Objecting {
+            nestedObject {
+                objectTitle
+                objectNestedObject {
+                    nestedObjectNestedTitle
+                }
+            }
+            __typename
+        }
     }
     header {
         ...on Page_Header_TextHeader {
@@ -20,6 +29,17 @@ const pageFields = `
         ...on Page_Header_ImageHeader {
             title
             image
+            __typename
+        }
+    }
+    objective {
+        ...on Page_Objective_Objecting {
+            nestedObject {
+                objectTitle
+                objectNestedObject {
+                    nestedObjectNestedTitle
+                }
+            }
             __typename
         }
     }

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageReadHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageReadHandler.ts
@@ -36,6 +36,7 @@ const pageFields = `
         ...on Page_Objective_Objecting {
             nestedObject {
                 objectTitle
+                objectBody
                 objectNestedObject {
                     nestedObjectNestedTitle
                 }

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -1,0 +1,197 @@
+import WebinyError from "@webiny/error";
+import {
+    CmsModelFieldConverterPlugin,
+    ConvertParams
+} from "~/plugins/CmsModelFieldConverterPlugin";
+import { CmsDynamicZoneTemplate, CmsEntryValues, CmsModelDynamicZoneField } from "~/types";
+import { ConverterCollection } from "~/utils/converters/ConverterCollection";
+
+interface DynamicZoneValue {
+    _templateId: string;
+    [key: string]: any;
+}
+
+interface ProcessToStorage {
+    templates: CmsDynamicZoneTemplate[];
+    value: DynamicZoneValue | null;
+    converterCollection: ConverterCollection;
+}
+
+export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConverterPlugin {
+    public override name = "cms.field.converter.dynamicZone";
+
+    public override getFieldType(): string {
+        return "dynamicZone";
+    }
+
+    private getTemplates(field: CmsModelDynamicZoneField): CmsDynamicZoneTemplate[] {
+        return field.settings?.templates || [];
+    }
+
+    public override convertToStorage(
+        params: ConvertParams<CmsModelDynamicZoneField>
+    ): CmsEntryValues {
+        const { field, value, converterCollection } = params;
+
+        const templates = this.getTemplates(field);
+
+        if (templates.length === 0) {
+            return {};
+        }
+
+        if (field.multipleValues) {
+            if (!Array.isArray(value)) {
+                throw new WebinyError(
+                    `Dynamic zone field "${field.fieldId}" is expecting an array value.`,
+                    "DYNAMIC_ZONE_EXPECTING_ARRAY_VALUE",
+                    {
+                        field,
+                        value
+                    }
+                );
+            }
+            return {
+                [field.storageId]: value.map(item => {
+                    return this.processToStorage({
+                        templates,
+                        converterCollection,
+                        value: item
+                    });
+                })
+            };
+        }
+        if (Array.isArray(value)) {
+            throw new WebinyError(
+                `Dynamic zone field "${field.fieldId}" is expecting a non-array value.`,
+                "DYNAMIC_ZONE_EXPECTING_NON_ARRAY_VALUE",
+                {
+                    field,
+                    value
+                }
+            );
+        }
+
+        const processedValue = this.processToStorage({
+            templates,
+            converterCollection,
+            value
+        });
+        return {
+            [field.storageId]: processedValue
+        };
+    }
+
+    private processToStorage(params: ProcessToStorage) {
+        const { templates, value, converterCollection } = params;
+        if (value === null || value === undefined) {
+            return undefined;
+        }
+
+        const { _templateId } = value;
+
+        const template = templates.find(t => t.id === _templateId);
+        if (!template) {
+            throw new WebinyError("Unknown template.", "UNKNOWN_TEMPLATE", {
+                templateId: _templateId
+            });
+        }
+
+        return template.fields.reduce<Record<string, any>>(
+            (values, field) => {
+                const converter = converterCollection.getConverter(field.type);
+                const converted = converter.convertToStorage({
+                    field,
+                    value: value[field.fieldId]
+                });
+                Object.assign(values, converted);
+                return values;
+            },
+            {
+                _templateId
+            }
+        );
+    }
+
+    public override convertFromStorage(
+        params: ConvertParams<CmsModelDynamicZoneField>
+    ): CmsEntryValues {
+        const { field, value, converterCollection } = params;
+
+        const templates = this.getTemplates(field);
+
+        if (templates.length === 0) {
+            return {};
+        }
+
+        if (field.multipleValues) {
+            if (!Array.isArray(value)) {
+                throw new WebinyError(
+                    `Dynamic zone field "${field.fieldId}" is expecting an array value.`,
+                    "DYNAMIC_ZONE_EXPECTING_ARRAY_VALUE",
+                    {
+                        field,
+                        value
+                    }
+                );
+            }
+            return {
+                [field.fieldId]: value.map(item => {
+                    return this.processFromStorage({
+                        templates,
+                        converterCollection,
+                        value: item
+                    });
+                })
+            };
+        }
+        if (Array.isArray(value)) {
+            throw new WebinyError(
+                `Dynamic zone field "${field.fieldId}" is expecting a non-array value.`,
+                "DYNAMIC_ZONE_EXPECTING_NON_ARRAY_VALUE",
+                {
+                    field,
+                    value
+                }
+            );
+        }
+
+        const processedValue = this.processFromStorage({
+            templates,
+            converterCollection,
+            value
+        });
+        return {
+            [field.fieldId]: processedValue
+        };
+    }
+
+    private processFromStorage(params: ProcessToStorage) {
+        const { templates, value, converterCollection } = params;
+        if (value === null || value === undefined) {
+            return undefined;
+        }
+
+        const { _templateId } = value;
+
+        const template = templates.find(t => t.id === _templateId);
+        if (!template) {
+            throw new WebinyError("Unknown template.", "UNKNOWN_TEMPLATE", {
+                templateId: _templateId
+            });
+        }
+        return template.fields.reduce<Record<string, any>>(
+            (values, field) => {
+                const converter = converterCollection.getConverter(field.type);
+                const converted = converter.convertFromStorage({
+                    field,
+                    value: value[field.storageId]
+                });
+                Object.assign(values, converted);
+                return values;
+            },
+            {
+                _templateId
+            }
+        );
+    }
+}

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -221,19 +221,18 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
                 }
             );
         }
-        return template.fields.reduce<Record<string, any>>(
-            (values, field) => {
-                const converter = converterCollection.getConverter(field.type);
-                const converted = converter.convertFromStorage({
-                    field,
-                    value: value[field.storageId]
-                });
-                Object.assign(values, converted);
-                return values;
-            },
-            {
-                _templateId
-            }
-        );
+
+        const processedValues = template.fields.reduce<Record<string, any>>((values, field) => {
+            const converter = converterCollection.getConverter(field.type);
+            const converted = converter.convertFromStorage({
+                field,
+                value: value[field.storageId]
+            });
+            Object.assign(values, converted);
+            return values;
+        }, {});
+        return {
+            [template.gqlTypeName]: processedValues
+        };
     }
 }

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -222,17 +222,19 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
             );
         }
 
-        const processedValues = template.fields.reduce<Record<string, any>>((values, field) => {
-            const converter = converterCollection.getConverter(field.type);
-            const converted = converter.convertFromStorage({
-                field,
-                value: value[field.storageId]
-            });
-            Object.assign(values, converted);
-            return values;
-        }, {});
-        return {
-            [template.gqlTypeName]: processedValues
-        };
+        return template.fields.reduce<Record<string, any>>(
+            (values, field) => {
+                const converter = converterCollection.getConverter(field.type);
+                const converted = converter.convertFromStorage({
+                    field,
+                    value: value[field.storageId]
+                });
+                Object.assign(values, converted);
+                return values;
+            },
+            {
+                _templateId: template.id
+            }
+        );
     }
 }

--- a/packages/api-headless-cms/src/fieldConverters/index.ts
+++ b/packages/api-headless-cms/src/fieldConverters/index.ts
@@ -1,6 +1,11 @@
 import { CmsModelObjectFieldConverterPlugin } from "~/fieldConverters/CmsModelObjectFieldConverterPlugin";
 import { CmsModelDefaultFieldConverterPlugin } from "~/fieldConverters/CmsModelDefaultFieldConverterPlugin";
+import { CmsModelDynamicZoneFieldConverterPlugin } from "~/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin";
 
 export const createFieldConverters = () => {
-    return [new CmsModelObjectFieldConverterPlugin(), new CmsModelDefaultFieldConverterPlugin()];
+    return [
+        new CmsModelObjectFieldConverterPlugin(),
+        new CmsModelDynamicZoneFieldConverterPlugin(),
+        new CmsModelDefaultFieldConverterPlugin()
+    ];
 };

--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
@@ -103,7 +103,7 @@ export const createDynamicZoneField =
             type: "cms-model-field-to-graphql",
             fieldType: "dynamicZone",
             isSortable: false,
-            isSearchable: true,
+            isSearchable: false,
             validateChildFields: params => {
                 const { validate, originalField, field } = params;
 

--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
@@ -103,7 +103,7 @@ export const createDynamicZoneField =
             type: "cms-model-field-to-graphql",
             fieldType: "dynamicZone",
             isSortable: false,
-            isSearchable: false,
+            isSearchable: true,
             validateChildFields: params => {
                 const { validate, originalField, field } = params;
 

--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
@@ -104,6 +104,26 @@ export const createDynamicZoneField =
             fieldType: "dynamicZone",
             isSortable: false,
             isSearchable: false,
+            validateChildFields: params => {
+                const { validate, originalField, field } = params;
+
+                const getOriginalTemplateFields = (templateId: string) => {
+                    if (!originalField?.settings?.templates) {
+                        return [];
+                    }
+                    const template = originalField.settings.templates.find(
+                        t => t.id === templateId
+                    );
+                    return template?.fields || [];
+                };
+
+                for (const template of field.settings.templates) {
+                    validate({
+                        fields: template.fields,
+                        originalFields: getOriginalTemplateFields(template.id)
+                    });
+                }
+            },
             read: {
                 createTypeField({ model, field, fieldTypePlugins }) {
                     const templates = getFieldTemplates(field);
@@ -194,7 +214,7 @@ export const createDynamicZoneField =
                             ([key, value]) => `
                             ${key}: ${value}
                         `
-                        )} 
+                        )}
                     }`);
 
                     return {

--- a/packages/api-headless-cms/src/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/graphqlFields/object.ts
@@ -93,6 +93,14 @@ export const createObjectField = (): CmsModelFieldToGraphQLPlugin => {
         fieldType: "object",
         isSortable: false,
         isSearchable: false,
+        validateChildFields: params => {
+            const { field, originalField, validate } = params;
+
+            validate({
+                fields: field.settings?.fields || [],
+                originalFields: originalField?.settings?.fields || []
+            });
+        },
         read: {
             createTypeField({ field, model, fieldTypePlugins }) {
                 const result = createTypeFromFields({

--- a/packages/api-headless-cms/src/plugins/CmsModelFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelFieldConverterPlugin.ts
@@ -2,8 +2,8 @@ import { Plugin } from "@webiny/plugins";
 import { CmsEntryValues, CmsModelFieldWithParent } from "~/types";
 import { ConverterCollection } from "~/utils/converters/ConverterCollection";
 
-export interface ConvertParams {
-    field: CmsModelFieldWithParent;
+export interface ConvertParams<F = CmsModelFieldWithParent> {
+    field: F;
     value: any;
     converterCollection: ConverterCollection;
 }

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -524,6 +524,27 @@ export interface CmsModelFieldToGraphQLCreateResolver<TField = CmsModelField> {
         | false;
 }
 
+export interface CmsModelFieldToGraphQLPluginValidateChildFieldsValidateParams<
+    TField extends CmsModelField = CmsModelField
+> {
+    fields: TField[];
+    originalFields: TField[];
+}
+export interface CmsModelFieldToGraphQLPluginValidateChildFieldsValidate {
+    (params: CmsModelFieldToGraphQLPluginValidateChildFieldsValidateParams): void;
+}
+export interface CmsModelFieldToGraphQLPluginValidateChildFieldsParams<
+    TField extends CmsModelField = CmsModelField
+> {
+    field: TField;
+    originalField?: TField;
+    validate: CmsModelFieldToGraphQLPluginValidateChildFieldsValidate;
+}
+export interface CmsModelFieldToGraphQLPluginValidateChildFields<
+    TField extends CmsModelField = CmsModelField
+> {
+    (params: CmsModelFieldToGraphQLPluginValidateChildFieldsParams<TField>): void;
+}
 /**
  * @category Plugin
  * @category ModelField
@@ -772,6 +793,11 @@ export interface CmsModelFieldToGraphQLPlugin<TField extends CmsModelField = Cms
          */
         createResolver?: CmsModelFieldToGraphQLCreateResolver<TField>;
     };
+    /**
+     *
+     * @param field
+     */
+    validateChildFields?: CmsModelFieldToGraphQLPluginValidateChildFields<TField>;
 }
 
 /**

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -163,6 +163,7 @@ export interface CmsModelField {
         | "ref"
         | "rich-text"
         | "text"
+        | "dynamicZone"
         | string;
     /**
      * A unique storage ID for storing actual values.
@@ -263,6 +264,9 @@ export interface CmsModelDynamicZoneField extends CmsModelField {
  */
 export interface CmsModelFieldWithParent extends CmsModelField {
     parent?: CmsModelFieldWithParent | null;
+}
+export interface CmsModelDynamicZoneFieldWithParent extends CmsModelDynamicZoneField {
+    parent?: CmsModelDynamicZoneFieldWithParent | null;
 }
 
 /**


### PR DESCRIPTION
## Changes
This PR adds the missing DynamicZone field converter for the `fieldId` to `storageId`.
Converter is important because we store the data with the `storageId`, not the `fieldId` - so users can change the GraphQL field identification without loosing the data.

## How Has This Been Tested?
Jest.