### PR TITLE
fix(app-headless-cms): dynamic zone template cancel

### DIFF
--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/ValidatorsList.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/ValidatorsList.tsx
@@ -139,7 +139,7 @@ const ValidatorItem = ({ validator, value, onChange }: ValidatorItemProps) => {
 
     const description = [<span key={"msg"}>This message will be displayed to the user.</span>];
     const variables = validator.getVariables();
-    console.log(variables);
+
     if (variables.length) {
         description.push(<span key={"vars"}>&nbsp;Available variables:&nbsp;</span>);
         for (let i = 0; i < variables.length; i++) {

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
@@ -74,7 +74,14 @@ export const TemplateDialog = (props: TemplateDialogProps) => {
 
     const nameOnBlur = (form: FormAPI<CmsDynamicZoneTemplate>) => () => {
         if (!form.data.gqlTypeName) {
-            form.setValue("gqlTypeName", getGraphQLTypeName(form.data.name));
+            /**
+             * There is a possibility that name is undefined, so let's check for it.
+             */
+            const name = form.data.name;
+            if (!name) {
+                return;
+            }
+            form.setValue("gqlTypeName", getGraphQLTypeName(name));
         }
     };
 


### PR DESCRIPTION
## Changes
Do a check if `form.data.name` is actually populated when running `getGraphQLTypeName` method.
Remove unnecessary console.log from ValidatorsList.tsx

## How Has This Been Tested?
Manually
