### PR TITLE
fix: block title update fix

### DIFF
--- a/packages/app-page-builder/src/blockEditor/config/eventActions/EventActionPlugins.tsx
+++ b/packages/app-page-builder/src/blockEditor/config/eventActions/EventActionPlugins.tsx
@@ -18,9 +18,17 @@ const EventActionHandlers = () => {
 
         const offUpdateBlockAction = eventActionHandler.on(
             UpdateDocumentActionEvent,
-            async state => {
+            async (state, _, args) => {
                 setDirty(true);
-                return { state, actions: [] };
+                return {
+                    state: {
+                        block: {
+                            ...state.block,
+                            ...(args?.document || {})
+                        }
+                    },
+                    actions: []
+                };
             }
         );
 


### PR DESCRIPTION
## Changes
Closes "Bug: When you edit an existing block the block title changes to “new block”"

## How Has This Been Tested?
Manual

## Documentation
None