### PR TITLE
fix(api-headless-cms): handle non-graphql exception on generate schema

### DIFF
--- a/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
@@ -75,6 +75,11 @@ const getSchema = async (params: GetSchemaParams): Promise<GraphQLSchema> => {
             });
             return schema;
         } catch (err) {
+            if (!Array.isArray(err.locations)) {
+                throw new WebinyError({
+                    ...err
+                });
+            }
             const [location] = err.locations;
 
             throw new WebinyError({


### PR DESCRIPTION
## Changes
This PR adds handling of non-graphql exception - when exception.locations does not exist.
This can happen if some schema plugin is trying to extend non-existing type or input.

## How Has This Been Tested?
Jest and manually.