### PR TITLE
fix(api-headless-cms): default limit for list entries

### DIFF
--- a/packages/api-apw/__tests__/graphql/commentOnChangeRequest.test.ts
+++ b/packages/api-apw/__tests__/graphql/commentOnChangeRequest.test.ts
@@ -266,7 +266,10 @@ describe("Comment on a change request test", () => {
         /**
          * List all comments.
          */
-        let [listCommentsResponse] = await listCommentsQuery({ sort: ["createdOn_DESC"] });
+        let [listCommentsResponse] = await listCommentsQuery({
+            sort: ["createdOn_DESC"],
+            limit: 10
+        });
         expect(listCommentsResponse).toEqual({
             data: {
                 apw: {

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -587,7 +587,8 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 plugins
             });
 
-            const { where: initialWhere } = params;
+            const { where: initialWhere, limit: initialLimit } = params;
+            const limit = initialLimit && initialLimit > 0 ? initialLimit : 50;
             /**
              * We always assign tenant and locale because we do not allow one model to have content through multiple tenants.
              */
@@ -639,6 +640,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 const { hasMoreItems, totalCount, cursor, items } =
                     await storageOperations.entries.list(model, {
                         ...params,
+                        limit,
                         where,
                         fields
                     });

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2471,7 +2471,7 @@ export interface CmsEntryStorageOperationsListParams {
     sort?: CmsEntryListSort;
     search?: string;
     fields?: string[];
-    limit?: number;
+    limit: number;
     after?: string | null;
 }
 


### PR DESCRIPTION
## Changes
Add the default limit (50) to the list entries crud operation.

Storage Operations have their own defaults as well.

## How Has This Been Tested?
Jest.