### PR TITLE
fix(api-i18n): variable keeps old tenant after switch between tenants

### DIFF
--- a/packages/api-i18n/src/graphql/crud/index.ts
+++ b/packages/api-i18n/src/graphql/crud/index.ts
@@ -35,15 +35,21 @@ export const createCrudContext = () => {
             SystemStorageOperationsProviderPlugin.type
         );
 
+        const getTenant = () => {
+            return context.tenancy.getCurrentTenant();
+        };
+
         context.i18n = {
             ...(context.i18n || ({} as any)),
             locales: createLocalesCrud({
                 context,
-                storageOperations: localeStorageOperations
+                storageOperations: localeStorageOperations,
+                getTenant
             }),
             system: createSystemCrud({
                 context,
-                storageOperations: systemStorageOperations
+                storageOperations: systemStorageOperations,
+                getTenant
             })
         };
     });

--- a/packages/api-i18n/src/graphql/crud/system.crud.ts
+++ b/packages/api-i18n/src/graphql/crud/system.crud.ts
@@ -9,16 +9,18 @@ import {
 import WebinyError from "@webiny/error";
 import { NotAuthorizedError } from "@webiny/api-security";
 import { createTopic } from "@webiny/pubsub";
+import { Tenant } from "@webiny/api-tenancy/types";
 
 interface CreateSystemCrudParams {
     context: I18NContext;
     storageOperations: I18NSystemStorageOperations;
+    getTenant: () => Tenant;
 }
 export const createSystemCrud = (params: CreateSystemCrudParams): SystemCRUD => {
-    const { context, storageOperations } = params;
+    const { context, storageOperations, getTenant } = params;
 
     const getTenantId = (): string => {
-        return context.tenancy.getCurrentTenant().id;
+        return getTenant().id;
     };
 
     const onSystemBeforeInstall = createTopic<OnSystemBeforeInstallTopicParams>(
@@ -50,7 +52,7 @@ export const createSystemCrud = (params: CreateSystemCrudParams): SystemCRUD => 
 
             const system: I18NSystem = {
                 ...(original || {}),
-                tenant: original && original.tenant ? original.tenant : getTenantId(),
+                tenant: original?.tenant || getTenantId(),
                 version
             };
             if (original) {


### PR DESCRIPTION
## Changes
A variable in the `createLocaleCrud` meethod keeps old tenant after switching the system to another tenant.
I added a function which will take the tenant from context every time when it is required - no more tenant caching.

## How Has This Been Tested?
Jest.