### PR TITLE
feat(api-headless-cms): description field

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/definitions/model.ts
+++ b/packages/api-headless-cms-ddb-es/src/definitions/model.ts
@@ -78,6 +78,9 @@ export const createModelEntity = (params: CreateModelEntityParams): Entity<any> 
             titleFieldId: {
                 type: "string"
             },
+            descriptionFieldId: {
+                type: "string"
+            },
             tenant: {
                 type: "string",
                 required: true

--- a/packages/api-headless-cms-ddb/src/definitions/model.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/model.ts
@@ -78,6 +78,9 @@ export const createModelEntity = (params: Params): Entity<any> => {
             titleFieldId: {
                 type: "string"
             },
+            descriptionFieldId: {
+                type: "string"
+            },
             tenant: {
                 type: "string",
                 required: true

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -965,4 +965,112 @@ describe("content model test", () => {
         });
         expect(response.data.getContentModel.error).toEqual(null);
     });
+
+    it("should assign description field", async () => {
+        const { createContentModelMutation, getContentModelQuery, updateContentModelMutation } =
+            useGraphQLHandler(manageHandlerOpts);
+        const field = {
+            id: "testId",
+            fieldId: "testFieldId",
+            type: "long-text",
+            label: "Test Field"
+        };
+
+        const [createResponseWithInitialLongText] = await createContentModelMutation({
+            data: {
+                name: "Test Content model",
+                modelId: "test-content-model",
+                group: contentModelGroup.id,
+                fields: [field],
+                layout: [["testId"]]
+            }
+        });
+
+        expect(createResponseWithInitialLongText).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        modelId: "testContentModel",
+                        fields: [field],
+                        descriptionFieldId: "testFieldId"
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [responseAfterCreate] = await getContentModelQuery({
+            modelId: "testContentModel"
+        });
+        expect(responseAfterCreate).toMatchObject({
+            data: {
+                getContentModel: {
+                    data: {
+                        modelId: "testContentModel",
+                        fields: [field],
+                        descriptionFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [createResponseWithNoFields] = await createContentModelMutation({
+            data: {
+                name: "Test Content model",
+                modelId: "test-content-model-2",
+                group: contentModelGroup.id,
+                fields: [],
+                layout: []
+            }
+        });
+        expect(createResponseWithNoFields).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [],
+                        descriptionFieldId: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [updateResponseWithFields] = await updateContentModelMutation({
+            modelId: "testContentModel2",
+            data: {
+                fields: [field],
+                layout: [[field.id]]
+            }
+        });
+        expect(updateResponseWithFields).toMatchObject({
+            data: {
+                updateContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [field],
+                        descriptionFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [responseAfterUpdate] = await getContentModelQuery({
+            modelId: "testContentModel2"
+        });
+        expect(responseAfterUpdate).toMatchObject({
+            data: {
+                getContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [field],
+                        descriptionFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+    });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -134,6 +134,7 @@ describe("content model test", () => {
                         name: "Test Content model",
                         description: "",
                         titleFieldId: "id",
+                        descriptionFieldId: null,
                         modelId: "testContentModel",
                         createdBy: helpers.identity,
                         createdOn: expect.stringMatching(/^20/),
@@ -507,6 +508,7 @@ describe("content model test", () => {
                         createdOn: expect.stringMatching(/^20/),
                         description: null,
                         titleFieldId: textField.fieldId,
+                        descriptionFieldId: null,
                         fields: [
                             {
                                 ...textField,

--- a/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
@@ -33,9 +33,15 @@ const contentModelPlugin = new CmsModelPlugin({
             fieldId: "price",
             type: "number",
             label: "Price"
+        },
+        {
+            id: "descr",
+            fieldId: "descr",
+            label: "Description",
+            type: "long-text"
         }
     ],
-    layout: [["name"], ["sku", "price"]],
+    layout: [["name"], ["sku", "price"], ["descr"]],
     titleFieldId: "name",
     description: ""
 });
@@ -250,11 +256,100 @@ describe("content model plugins", () => {
             plugins: [contentModelPlugin]
         });
 
-        await getContentModelQuery({ modelId: "product" }).then(([response]) =>
-            expect(response).toEqual({
-                data: {
-                    getContentModel: {
-                        data: {
+        const [getContentModelResponse] = await getContentModelQuery({ modelId: "product" });
+        expect(getContentModelResponse).toEqual({
+            data: {
+                getContentModel: {
+                    data: {
+                        createdBy: null,
+                        createdOn: null,
+                        description: "",
+                        fields: [
+                            {
+                                storageId: "text@name",
+                                fieldId: "name",
+                                helpText: null,
+                                id: "name",
+                                label: "Product Name",
+                                listValidation: null,
+                                multipleValues: null,
+                                placeholderText: null,
+                                predefinedValues: null,
+                                renderer: null,
+                                settings: null,
+                                type: "text",
+                                validation: null
+                            },
+                            {
+                                storageId: "text@sku",
+                                fieldId: "sku",
+                                helpText: null,
+                                id: "sku",
+                                label: "SKU",
+                                listValidation: null,
+                                multipleValues: null,
+                                placeholderText: null,
+                                predefinedValues: null,
+                                renderer: null,
+                                settings: null,
+                                type: "text",
+                                validation: null
+                            },
+                            {
+                                storageId: "number@price",
+                                fieldId: "price",
+                                helpText: null,
+                                id: "price",
+                                label: "Price",
+                                listValidation: null,
+                                multipleValues: null,
+                                placeholderText: null,
+                                predefinedValues: null,
+                                renderer: null,
+                                settings: null,
+                                type: "number",
+                                validation: null
+                            },
+                            {
+                                storageId: "long-text@descr",
+                                fieldId: "descr",
+                                helpText: null,
+                                id: "descr",
+                                label: "Description",
+                                listValidation: null,
+                                multipleValues: null,
+                                placeholderText: null,
+                                predefinedValues: null,
+                                renderer: null,
+                                settings: null,
+                                type: "long-text",
+                                validation: null
+                            }
+                        ],
+                        group: {
+                            id: "ecommerce",
+                            name: "E-Commerce"
+                        },
+                        layout: [["name"], ["sku", "price"], ["descr"]],
+                        modelId: "product",
+                        name: "Product",
+                        plugin: true,
+                        savedOn: null,
+                        titleFieldId: "name",
+                        descriptionFieldId: "descr"
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listContentModelsResponse] = await listContentModelsQuery();
+
+        expect(listContentModelsResponse).toEqual({
+            data: {
+                listContentModels: {
+                    data: [
+                        {
                             createdBy: null,
                             createdOn: null,
                             description: "",
@@ -303,98 +398,40 @@ describe("content model plugins", () => {
                                     settings: null,
                                     type: "number",
                                     validation: null
+                                },
+                                {
+                                    storageId: "long-text@descr",
+                                    fieldId: "descr",
+                                    helpText: null,
+                                    id: "descr",
+                                    label: "Description",
+                                    listValidation: null,
+                                    multipleValues: null,
+                                    placeholderText: null,
+                                    predefinedValues: null,
+                                    renderer: null,
+                                    settings: null,
+                                    type: "long-text",
+                                    validation: null
                                 }
                             ],
                             group: {
                                 id: "ecommerce",
                                 name: "E-Commerce"
                             },
-                            layout: [["name"], ["sku", "price"]],
+                            layout: [["name"], ["sku", "price"], ["descr"]],
                             modelId: "product",
                             name: "Product",
                             plugin: true,
                             savedOn: null,
-                            titleFieldId: "name"
-                        },
-                        error: null
-                    }
+                            titleFieldId: "name",
+                            descriptionFieldId: "descr"
+                        }
+                    ],
+                    error: null
                 }
-            })
-        );
-
-        await listContentModelsQuery().then(([response]) =>
-            expect(response).toEqual({
-                data: {
-                    listContentModels: {
-                        data: [
-                            {
-                                createdBy: null,
-                                createdOn: null,
-                                description: "",
-                                fields: [
-                                    {
-                                        storageId: "text@name",
-                                        fieldId: "name",
-                                        helpText: null,
-                                        id: "name",
-                                        label: "Product Name",
-                                        listValidation: null,
-                                        multipleValues: null,
-                                        placeholderText: null,
-                                        predefinedValues: null,
-                                        renderer: null,
-                                        settings: null,
-                                        type: "text",
-                                        validation: null
-                                    },
-                                    {
-                                        storageId: "text@sku",
-                                        fieldId: "sku",
-                                        helpText: null,
-                                        id: "sku",
-                                        label: "SKU",
-                                        listValidation: null,
-                                        multipleValues: null,
-                                        placeholderText: null,
-                                        predefinedValues: null,
-                                        renderer: null,
-                                        settings: null,
-                                        type: "text",
-                                        validation: null
-                                    },
-                                    {
-                                        storageId: "number@price",
-                                        fieldId: "price",
-                                        helpText: null,
-                                        id: "price",
-                                        label: "Price",
-                                        listValidation: null,
-                                        multipleValues: null,
-                                        placeholderText: null,
-                                        predefinedValues: null,
-                                        renderer: null,
-                                        settings: null,
-                                        type: "number",
-                                        validation: null
-                                    }
-                                ],
-                                group: {
-                                    id: "ecommerce",
-                                    name: "E-Commerce"
-                                },
-                                layout: [["name"], ["sku", "price"]],
-                                modelId: "product",
-                                name: "Product",
-                                plugin: true,
-                                savedOn: null,
-                                titleFieldId: "name"
-                            }
-                        ],
-                        error: null
-                    }
-                }
-            })
-        );
+            }
+        });
     });
 
     test("must be able to perform basic CRUD operations with content models registered via plugin", async () => {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -25,6 +25,7 @@ export default /* GraphQL */ `
         ${revisionsComment}
         revisions: [Category]
         title: String
+        description: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -1,3 +1,5 @@
+import { metaDataComment, revisionsComment } from "./snippets";
+
 export default /* GraphQL */ `
     """
     Page
@@ -21,15 +23,11 @@ export default /* GraphQL */ `
         locked: Boolean
         publishedOn: DateTime
         status: String
-        """
-        CAUTION: this field is resolved by making an extra query to DB.
-        RECOMMENDATION: Use it only with "get" queries (avoid in "list")
-        """
+        ${revisionsComment}
         revisions: [Page]
         title: String
-        """
-        Custom meta data stored in the root of the entry object.
-        """
+        description: String
+        ${metaDataComment}
         data: JSON
     }
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -35,6 +35,7 @@ export default /* GraphQL */ `
         ${revisionsComment}
         revisions: [Product]
         title: String
+        description: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -27,6 +27,7 @@ export default /* GraphQL */ `
         ${revisionsComment}
         revisions: [Review]
         title: String
+        description: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
@@ -9,6 +9,7 @@ const DATA_FIELD = /* GraphQL*/ `
         }
         layout
         titleFieldId
+        descriptionFieldId
         fields {
             id
             label

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -574,6 +574,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
             const model: CmsModel = {
                 ...original,
                 ...data,
+                description: data.description || "",
                 group,
                 tenant: original.tenant || getTenant().id,
                 locale: original.locale || getLocale().code,

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -349,9 +349,9 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
             const identity = getIdentity();
             const model: CmsModel = {
                 ...data,
-                description: data.description || "",
                 modelId: data.modelId || "",
                 titleFieldId: "id",
+                description: data.description || "",
                 locale: getLocale().code,
                 tenant: getTenant().id,
                 group: {
@@ -574,7 +574,6 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
             const model: CmsModel = {
                 ...original,
                 ...data,
-                description: data.description || "",
                 group,
                 tenant: original.tenant || getTenant().id,
                 locale: original.locale || getLocale().code,

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -348,7 +348,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
 
             const identity = getIdentity();
             const model: CmsModel = {
-                name: data.name,
+                ...data,
                 description: data.description || "",
                 modelId: data.modelId || "",
                 titleFieldId: "id",
@@ -365,10 +365,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 },
                 createdOn: new Date().toISOString(),
                 savedOn: new Date().toISOString(),
-                fields: data.fields,
                 lockedFields: [],
-                layout: data.layout || [],
-                tags: [...(data.tags || [])],
                 webinyVersion: context.WEBINY_VERSION
             };
 

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -19,6 +19,7 @@ const fieldSystemFields: string[] = [
 const str = zod.string().trim();
 const shortString = str.max(255);
 const optionalShortString = shortString.optional();
+const optionalNullishShortString = optionalShortString.nullish();
 
 const fieldSchema = zod.object({
     id: shortString,
@@ -101,7 +102,7 @@ export const createModelCreateValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        description: optionalShortString,
+        description: optionalNullishShortString,
         group: shortString,
         fields: zod.array(fieldSchema).default([]),
         layout: zod.array(zod.array(shortString)).default([]),
@@ -115,7 +116,7 @@ export const createModelCreateFromValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        description: optionalShortString,
+        description: optionalNullishShortString,
         group: shortString,
         locale: optionalShortString
     });
@@ -124,7 +125,7 @@ export const createModelCreateFromValidation = () => {
 export const createModelUpdateValidation = () => {
     return zod.object({
         name: optionalShortString,
-        description: optionalShortString,
+        description: optionalNullishShortString,
         group: optionalShortString,
         fields: zod.array(fieldSchema),
         layout: zod.array(zod.array(shortString)),

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -106,7 +106,8 @@ export const createModelCreateValidation = () => {
         fields: zod.array(fieldSchema).default([]),
         layout: zod.array(zod.array(shortString)).default([]),
         tags: zod.array(shortString).optional(),
-        titleFieldId: optionalShortString
+        titleFieldId: optionalShortString,
+        descriptionFieldId: optionalShortString
     });
 };
 

--- a/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
@@ -4,6 +4,7 @@ import { CmsEntry, CmsContext, CmsModel, CmsEntryListWhere } from "~/types";
 import { NotAuthorizedResponse } from "@webiny/api-security";
 import { getEntryTitle } from "~/utils/getEntryTitle";
 import { CmsGraphQLSchemaPlugin } from "~/plugins";
+import { getEntryDescription } from "~/utils/getEntryDescription";
 
 interface EntriesByModel {
     [key: string]: string[];
@@ -118,7 +119,8 @@ const getContentEntries = async (params: GetContentEntriesParams): Promise<Respo
                             name: model.name
                         },
                         status: item.status,
-                        title: getEntryTitle(model, item)
+                        title: getEntryTitle(model, item),
+                        description: getEntryDescription(model, item)
                     };
                 })
             );
@@ -182,7 +184,8 @@ const getContentEntry = async (
             name: model.name
         },
         status: entry.status,
-        title: getEntryTitle(model, entry)
+        title: getEntryTitle(model, entry),
+        description: getEntryDescription(model, entry)
     });
 };
 
@@ -274,7 +277,8 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
                         return {
                             id: entry.id,
                             entryId: entry.entryId,
-                            title: getEntryTitle(model, entry)
+                            title: getEntryTitle(model, entry),
+                            description: getEntryDescription(model, entry)
                         };
                     } catch (ex) {
                         return null;
@@ -309,6 +313,7 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
                                     },
                                     status: entry.status,
                                     title: getEntryTitle(model, entry),
+                                    description: getEntryDescription(model, entry),
                                     // We need `savedOn` to sort entries from latest to oldest
                                     savedOn: entry.savedOn
                                 };

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -149,6 +149,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 layout: [[ID!]!]
                 fields: [CmsContentModelFieldInput!]
                 titleFieldId: String
+                descriptionFieldId: String
                 tags: [String!]
             }
 
@@ -167,6 +168,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 layout: [[ID!]!]!
                 fields: [CmsContentModelFieldInput!]!
                 titleFieldId: String
+                descriptionFieldId: String
                 tags: [String!]
             }
 
@@ -250,6 +252,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 lockedFields: [JSON]
                 layout: [[String!]!]!
                 titleFieldId: String
+                descriptionFieldId: String
                 tags: [String!]!
                 # Returns true if the content model is registered via a plugin.
                 plugin: Boolean!

--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -15,6 +15,7 @@ import { createFieldResolversFactory } from "./createFieldResolvers";
 import { createManageTypeName, createTypeName } from "~/utils/createTypeName";
 import { pluralizedTypeName } from "~/utils/pluralizedTypeName";
 import { getEntryTitle } from "~/utils/getEntryTitle";
+import { getEntryDescription } from "~/utils/getEntryDescription";
 
 interface CreateManageResolversParams {
     models: CmsModel[];
@@ -80,6 +81,9 @@ export const createManageResolvers: CreateManageResolvers = ({
         [`${mTypeName}Meta`]: {
             title(entry: CmsEntry) {
                 return getEntryTitle(model, entry);
+            },
+            description: (entry: CmsEntry) => {
+                return getEntryDescription(model, entry);
             },
             status(entry: CmsEntry) {
                 return entry.status;

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -59,6 +59,7 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
             """
             revisions: [${mTypeName}]
             title: String
+            description: String
             """
             Custom meta data stored in the root of the entry object.
             """

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1226,7 +1226,7 @@ export interface CmsModelCreateInput {
     /**
      * Description of the content model.
      */
-    description?: string;
+    description?: string | null;
     /**
      * Group where to put the content model in.
      */
@@ -1255,6 +1255,10 @@ export interface CmsModelCreateInput {
      * It is picked as first available text field. Or user can select own field.
      */
     titleFieldId?: string;
+    /**
+     *
+     */
+    descriptionFieldId?: string | null;
 }
 
 /**
@@ -1353,7 +1357,7 @@ export interface CmsModelUpdateInput {
     /**
      * A new description of the content model.
      */
-    description?: string;
+    description?: string | null;
     /**
      * A list of content model fields to define the entry values.
      */
@@ -1374,6 +1378,10 @@ export interface CmsModelUpdateInput {
      * It is picked as first available text field. Or user can select own field.
      */
     titleFieldId?: string;
+    /**
+     *
+     */
+    descriptionFieldId?: string | null;
 }
 
 /**

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -443,7 +443,7 @@ export interface CmsModel {
     /**
      * Description for the content model.
      */
-    description: string;
+    description: string | null;
     /**
      * Date created
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -485,6 +485,11 @@ export interface CmsModel {
      */
     titleFieldId: string;
     /**
+     * The field which is displayed as the description one.
+     * Only way this is null or undefined is that there are no long-text fields to be set as description.
+     */
+    descriptionFieldId?: string | null;
+    /**
      * The version of Webiny which this record was stored with.
      */
     webinyVersion: string;

--- a/packages/api-headless-cms/src/utils/getEntryDescription.ts
+++ b/packages/api-headless-cms/src/utils/getEntryDescription.ts
@@ -1,0 +1,13 @@
+import { CmsEntry, CmsModel } from "~/types";
+
+export function getEntryDescription(model: CmsModel, entry: CmsEntry): string {
+    if (!model.descriptionFieldId) {
+        return "";
+    }
+    const field = model.fields.find(f => f.fieldId === model.descriptionFieldId);
+    if (!field) {
+        return "";
+    }
+    const descriptionFieldId = field.fieldId;
+    return entry.values[descriptionFieldId] || "";
+}


### PR DESCRIPTION
## Changes
This PR adds description field for the entries. Works same as titleField, with a difference that description field must be of long-text type.

## How Has This Been Tested?
Jest.