### PR TITLE
feat(plugins): add support for plugin decorators

### DIFF
--- a/packages/api/__tests__/Context.test.ts
+++ b/packages/api/__tests__/Context.test.ts
@@ -1,5 +1,6 @@
 import { Context } from "~/index";
 import { Context as ContextInterface } from "~/types";
+import { PluginsContainer } from "@webiny/plugins";
 
 interface DummyContextInterface extends ContextInterface {
     cms: any;
@@ -14,18 +15,7 @@ describe("Context", () => {
         });
 
         expect(context).toBeInstanceOf(Context);
-        expect(context).toEqual({
-            plugins: {
-                _byTypeCache: {},
-                plugins: {}
-            },
-            WEBINY_VERSION: "test",
-            waiters: []
-        });
-        expect(context.plugins).toEqual({
-            _byTypeCache: {},
-            plugins: {}
-        });
+        expect(context.plugins).toBeInstanceOf(PluginsContainer);
         expect(context.WEBINY_VERSION).toEqual("test");
     });
 

--- a/packages/plugins/src/PluginsContainer.ts
+++ b/packages/plugins/src/PluginsContainer.ts
@@ -95,7 +95,7 @@ export class PluginsContainer {
                 `There is a requirement for plugin of type "${type}" to be only one registered.`
             );
         }
-        return this.decorate(list[0]) as T;
+        return list[0] as T;
     }
 
     public all<T extends Plugin>(): T[] {

--- a/packages/plugins/src/PluginsContainer.ts
+++ b/packages/plugins/src/PluginsContainer.ts
@@ -129,6 +129,10 @@ export class PluginsContainer {
     }
 
     private decorate(plugin: Plugin) {
+        if (!plugin) {
+            return undefined;
+        }
+
         const Decorator = this.pluginDecorators[plugin.type];
         if (!Decorator) {
             return plugin;


### PR DESCRIPTION
## Changes
This PR adds support for registering plugin decorators. This is useful for our old POJO plugins (and we have many of those),  as very often in our code we do conditional checks if certain optional plugin properties are set, and if so, execute those functions. This adds a lot of overhead in various views where same plugin types are being used.

Using decorators we can now register decorators (classes), which decorate (wrap) the original plugin, and that way we can implement default behavior on those optional plugin functions. 

## Why not just switch the original plugins with classes? 
Because there are many plugins in the user land, which would break the app if we just assumed that everybody is now using classes. This way we can add a decorator and achieve the same result without breaking anything, and remove the redundant conditionals from our main logic.

@brunozoric @adrians5j please have a look at the tests and post your thoughts.

## How Has This Been Tested?
Jest tests.
