### PR TITLE
feat(api-headless-cms): add image field to model

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/definitions/model.ts
+++ b/packages/api-headless-cms-ddb-es/src/definitions/model.ts
@@ -81,6 +81,9 @@ export const createModelEntity = (params: CreateModelEntityParams): Entity<any> 
             descriptionFieldId: {
                 type: "string"
             },
+            imageFieldId: {
+                type: "string"
+            },
             tenant: {
                 type: "string",
                 required: true

--- a/packages/api-headless-cms-ddb/src/definitions/model.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/model.ts
@@ -81,6 +81,9 @@ export const createModelEntity = (params: Params): Entity<any> => {
             descriptionFieldId: {
                 type: "string"
             },
+            imageFieldId: {
+                type: "string"
+            },
             tenant: {
                 type: "string",
                 required: true

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -135,6 +135,7 @@ describe("content model test", () => {
                         description: "",
                         titleFieldId: "id",
                         descriptionFieldId: null,
+                        imageFieldId: null,
                         modelId: "testContentModel",
                         createdBy: helpers.identity,
                         createdOn: expect.stringMatching(/^20/),
@@ -509,6 +510,7 @@ describe("content model test", () => {
                         description: null,
                         titleFieldId: textField.fieldId,
                         descriptionFieldId: null,
+                        imageFieldId: null,
                         fields: [
                             {
                                 ...textField,
@@ -1069,6 +1071,117 @@ describe("content model test", () => {
                         modelId: "testContentModel2",
                         fields: [field],
                         descriptionFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should assign image field", async () => {
+        const { createContentModelMutation, getContentModelQuery, updateContentModelMutation } =
+            useGraphQLHandler(manageHandlerOpts);
+        const field = {
+            id: "testId",
+            fieldId: "testFieldId",
+            type: "file",
+            label: "Test Field",
+            settings: {
+                imagesOnly: true
+            }
+        };
+
+        const [createResponseWithInitialFile] = await createContentModelMutation({
+            data: {
+                name: "Test Content model",
+                modelId: "test-content-model",
+                group: contentModelGroup.id,
+                fields: [field],
+                layout: [["testId"]]
+            }
+        });
+
+        expect(createResponseWithInitialFile).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        modelId: "testContentModel",
+                        fields: [field],
+                        imageFieldId: "testFieldId"
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [responseAfterCreate] = await getContentModelQuery({
+            modelId: "testContentModel"
+        });
+        expect(responseAfterCreate).toMatchObject({
+            data: {
+                getContentModel: {
+                    data: {
+                        modelId: "testContentModel",
+                        fields: [field],
+                        imageFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [createResponseWithNoFields] = await createContentModelMutation({
+            data: {
+                name: "Test Content model",
+                modelId: "test-content-model-2",
+                group: contentModelGroup.id,
+                fields: [],
+                layout: []
+            }
+        });
+        expect(createResponseWithNoFields).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [],
+                        imageFieldId: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [updateResponseWithFields] = await updateContentModelMutation({
+            modelId: "testContentModel2",
+            data: {
+                fields: [field],
+                layout: [[field.id]]
+            }
+        });
+        expect(updateResponseWithFields).toMatchObject({
+            data: {
+                updateContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [field],
+                        imageFieldId: field.fieldId
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [responseAfterUpdate] = await getContentModelQuery({
+            modelId: "testContentModel2"
+        });
+        expect(responseAfterUpdate).toMatchObject({
+            data: {
+                getContentModel: {
+                    data: {
+                        modelId: "testContentModel2",
+                        fields: [field],
+                        imageFieldId: field.fieldId
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
@@ -336,7 +336,8 @@ describe("content model plugins", () => {
                         plugin: true,
                         savedOn: null,
                         titleFieldId: "name",
-                        descriptionFieldId: "descr"
+                        descriptionFieldId: "descr",
+                        imageFieldId: null
                     },
                     error: null
                 }
@@ -425,7 +426,8 @@ describe("content model plugins", () => {
                             plugin: true,
                             savedOn: null,
                             titleFieldId: "name",
-                            descriptionFieldId: "descr"
+                            descriptionFieldId: "descr",
+                            imageFieldId: null
                         }
                     ],
                     error: null

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -23,9 +23,10 @@ export default /* GraphQL */ `
         publishedOn: DateTime
         status: String
         ${revisionsComment}
-        revisions: [Category]
+        revisions: [Category!]
         title: String
         description: String
+        image: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -24,9 +24,10 @@ export default /* GraphQL */ `
         publishedOn: DateTime
         status: String
         ${revisionsComment}
-        revisions: [Page]
+        revisions: [Page!]
         title: String
         description: String
+        image: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -33,9 +33,10 @@ export default /* GraphQL */ `
         publishedOn: DateTime
         status: String
         ${revisionsComment}
-        revisions: [Product]
+        revisions: [Product!]
         title: String
         description: String
+        image: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -25,9 +25,10 @@ export default /* GraphQL */ `
         publishedOn: DateTime
         status: String
         ${revisionsComment}
-        revisions: [Review]
+        revisions: [Review!]
         title: String
         description: String
+        image: String
         ${metaDataComment}
         data: JSON
     }

--- a/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
@@ -10,6 +10,7 @@ const DATA_FIELD = /* GraphQL*/ `
         layout
         titleFieldId
         descriptionFieldId
+        imageFieldId
         fields {
             id
             label

--- a/packages/api-headless-cms/src/crud/contentModel/fields/descriptionField.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/fields/descriptionField.ts
@@ -1,0 +1,50 @@
+import { CmsModelField } from "~/types";
+import { getBaseFieldType } from "~/utils/getBaseFieldType";
+import WebinyError from "@webiny/error";
+
+export const getContentModelDescriptionFieldId = (
+    fields: CmsModelField[],
+    descriptionFieldId?: string | null
+): string | null | undefined => {
+    /**
+     * If there are no fields defined, we will just set as null.
+     */
+    if (fields.length === 0) {
+        return null;
+    }
+    /**
+     * If description field is not defined, let us find possible one.
+     */
+    if (!descriptionFieldId) {
+        const descriptionField = fields.find(field => {
+            return getBaseFieldType(field) === "long-text" && !field.multipleValues;
+        });
+        return descriptionField?.fieldId;
+    }
+    const target = fields.find(
+        field => field.fieldId === descriptionFieldId && getBaseFieldType(field) === "long-text"
+    );
+    if (!target) {
+        throw new WebinyError(
+            `Field selected for the description field does not exist in the model.`,
+            "VALIDATION_ERROR",
+            {
+                fieldId: descriptionFieldId,
+                fields
+            }
+        );
+    }
+    if (target.multipleValues) {
+        throw new WebinyError(
+            `Fields that accept multiple values cannot be used as the entry description.`,
+            "ENTRY_TITLE_FIELD_TYPE",
+            {
+                storageId: target.storageId,
+                fieldId: target.fieldId,
+                type: target.type
+            }
+        );
+    }
+
+    return target.fieldId;
+};

--- a/packages/api-headless-cms/src/crud/contentModel/fields/imageField.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/fields/imageField.ts
@@ -1,0 +1,57 @@
+import { CmsModelField } from "~/types";
+import { getBaseFieldType } from "~/utils/getBaseFieldType";
+import WebinyError from "@webiny/error";
+
+export const getContentModelImageFieldId = (
+    fields: CmsModelField[],
+    imageFieldId?: string | null
+): string | null | undefined => {
+    /**
+     * If there are no fields defined, we will just set as null.
+     */
+    if (fields.length === 0) {
+        return null;
+    }
+    /**
+     * If image field is not defined, let us find possible one.
+     */
+    if (!imageFieldId) {
+        const imageField = fields.find(field => {
+            return (
+                getBaseFieldType(field) === "file" &&
+                !field.multipleValues &&
+                field.settings?.imagesOnly
+            );
+        });
+        return imageField?.fieldId;
+    }
+    const target = fields.find(
+        field =>
+            field.fieldId === imageFieldId &&
+            getBaseFieldType(field) === "file" &&
+            field.settings?.imagesOnly
+    );
+    if (!target) {
+        throw new WebinyError(
+            `Field selected for the image field does not exist in the model.`,
+            "VALIDATION_ERROR",
+            {
+                fieldId: imageFieldId,
+                fields
+            }
+        );
+    }
+    if (target.multipleValues) {
+        throw new WebinyError(
+            `Fields that accept multiple values cannot be used as the entry image.`,
+            "ENTRY_TITLE_FIELD_TYPE",
+            {
+                storageId: target.storageId,
+                fieldId: target.fieldId,
+                type: target.type
+            }
+        );
+    }
+
+    return target.fieldId;
+};

--- a/packages/api-headless-cms/src/crud/contentModel/fields/titleField.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/fields/titleField.ts
@@ -1,0 +1,74 @@
+import { CmsModelField } from "~/types";
+import { getBaseFieldType } from "~/utils/getBaseFieldType";
+import WebinyError from "@webiny/error";
+
+const defaultTitleFieldId = "id";
+
+const allowedTitleFieldTypes = ["text", "number"];
+
+export const getContentModelTitleFieldId = (
+    fields: CmsModelField[],
+    titleFieldId?: string
+): string => {
+    /**
+     * If there are no fields defined, we will return the default field
+     */
+    if (fields.length === 0) {
+        return defaultTitleFieldId;
+    }
+    /**
+     * if there is no title field defined either in input data or existing content model data
+     * we will take first text field that has no multiple values enabled
+     * or if initial titleFieldId is the default one also try to find first available text field
+     */
+    if (!titleFieldId || titleFieldId === defaultTitleFieldId) {
+        const titleField = fields.find(field => {
+            return getBaseFieldType(field) === "text" && !field.multipleValues;
+        });
+        return titleField?.fieldId || defaultTitleFieldId;
+    }
+    /**
+     * check existing titleFieldId for existence in the model
+     * for correct type
+     * and that it is not multiple values field
+     */
+    const target = fields.find(f => f.fieldId === titleFieldId);
+    if (!target) {
+        throw new WebinyError(
+            `Field selected for the title field does not exist in the model.`,
+            "VALIDATION_ERROR",
+            {
+                fieldId: titleFieldId,
+                fields
+            }
+        );
+    }
+
+    if (allowedTitleFieldTypes.includes(target.type) === false) {
+        throw new WebinyError(
+            `Only ${allowedTitleFieldTypes.join(
+                ", "
+            )} and id fields can be used as an entry title.`,
+            "ENTRY_TITLE_FIELD_TYPE",
+            {
+                storageId: target.storageId,
+                fieldId: target.fieldId,
+                type: target.type
+            }
+        );
+    }
+
+    if (target.multipleValues) {
+        throw new WebinyError(
+            `Fields that accept multiple values cannot be used as the entry title.`,
+            "ENTRY_TITLE_FIELD_TYPE",
+            {
+                storageId: target.storageId,
+                fieldId: target.fieldId,
+                type: target.type
+            }
+        );
+    }
+
+    return target.fieldId;
+};

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -108,7 +108,8 @@ export const createModelCreateValidation = () => {
         layout: zod.array(zod.array(shortString)).default([]),
         tags: zod.array(shortString).optional(),
         titleFieldId: optionalShortString,
-        descriptionFieldId: optionalShortString
+        descriptionFieldId: optionalShortString,
+        imageFieldId: optionalShortString
     });
 };
 
@@ -130,6 +131,8 @@ export const createModelUpdateValidation = () => {
         fields: zod.array(fieldSchema),
         layout: zod.array(zod.array(shortString)),
         titleFieldId: optionalShortString,
+        descriptionFieldId: optionalShortString,
+        imageFieldId: optionalShortString,
         tags: zod.array(shortString).optional()
     });
 };

--- a/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
@@ -5,6 +5,7 @@ import { NotAuthorizedResponse } from "@webiny/api-security";
 import { getEntryTitle } from "~/utils/getEntryTitle";
 import { CmsGraphQLSchemaPlugin } from "~/plugins";
 import { getEntryDescription } from "~/utils/getEntryDescription";
+import { getEntryImage } from "~/utils/getEntryImage";
 
 interface EntriesByModel {
     [key: string]: string[];
@@ -120,7 +121,8 @@ const getContentEntries = async (params: GetContentEntriesParams): Promise<Respo
                         },
                         status: item.status,
                         title: getEntryTitle(model, item),
-                        description: getEntryDescription(model, item)
+                        description: getEntryDescription(model, item),
+                        image: getEntryImage(model, item)
                     };
                 })
             );
@@ -185,7 +187,8 @@ const getContentEntry = async (
         },
         status: entry.status,
         title: getEntryTitle(model, entry),
-        description: getEntryDescription(model, entry)
+        description: getEntryDescription(model, entry),
+        image: getEntryImage(model, entry)
     });
 };
 
@@ -200,27 +203,31 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
     return new CmsGraphQLSchemaPlugin({
         typeDefs: /* GraphQL */ `
             type CmsModelMeta {
-                modelId: String
-                name: String
+                modelId: String!
+                name: String!
             }
 
             type CmsPublishedContentEntry {
                 id: ID!
                 entryId: String!
                 title: String
+                description: String
+                image: String
             }
 
             type CmsContentEntry {
                 id: ID!
                 entryId: String!
-                model: CmsModelMeta
+                model: CmsModelMeta!
                 status: String
                 title: String
+                description: String
+                image: String
                 published: CmsPublishedContentEntry
             }
 
             type CmsContentEntriesResponse {
-                data: [CmsContentEntry]
+                data: [CmsContentEntry!]
                 error: CmsError
             }
 
@@ -241,20 +248,20 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
                     query: String
                     fields: [String!]
                     limit: Int
-                ): CmsContentEntriesResponse
+                ): CmsContentEntriesResponse!
 
                 # Get content entry meta data
-                getContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse
+                getContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse!
 
-                getLatestContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse
-                getPublishedContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse
+                getLatestContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse!
+                getPublishedContentEntry(entry: CmsModelEntryInput!): CmsContentEntryResponse!
 
                 # Get content entries meta data
-                getContentEntries(entries: [CmsModelEntryInput!]!): CmsContentEntriesResponse
-                getLatestContentEntries(entries: [CmsModelEntryInput!]!): CmsContentEntriesResponse
+                getContentEntries(entries: [CmsModelEntryInput!]!): CmsContentEntriesResponse!
+                getLatestContentEntries(entries: [CmsModelEntryInput!]!): CmsContentEntriesResponse!
                 getPublishedContentEntries(
                     entries: [CmsModelEntryInput!]!
-                ): CmsContentEntriesResponse
+                ): CmsContentEntriesResponse!
             }
         `,
         resolvers: {
@@ -278,7 +285,8 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
                             id: entry.id,
                             entryId: entry.entryId,
                             title: getEntryTitle(model, entry),
-                            description: getEntryDescription(model, entry)
+                            description: getEntryDescription(model, entry),
+                            image: getEntryImage(model, entry)
                         };
                     } catch (ex) {
                         return null;
@@ -314,6 +322,7 @@ export const createContentEntriesSchema = (context: CmsContext): CmsGraphQLSchem
                                     status: entry.status,
                                     title: getEntryTitle(model, entry),
                                     description: getEntryDescription(model, entry),
+                                    image: getEntryImage(model, entry),
                                     // We need `savedOn` to sort entries from latest to oldest
                                     savedOn: entry.savedOn
                                 };

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -150,6 +150,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 fields: [CmsContentModelFieldInput!]
                 titleFieldId: String
                 descriptionFieldId: String
+                imageFieldId: String
                 tags: [String!]
             }
 
@@ -169,6 +170,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 fields: [CmsContentModelFieldInput!]!
                 titleFieldId: String
                 descriptionFieldId: String
+                imageFieldId: String
                 tags: [String!]
             }
 
@@ -253,6 +255,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 layout: [[String!]!]!
                 titleFieldId: String
                 descriptionFieldId: String
+                imageFieldId: String
                 tags: [String!]!
                 # Returns true if the content model is registered via a plugin.
                 plugin: Boolean!

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -57,9 +57,10 @@ export const createManageSDL: CreateManageSDL = ({ model, fieldTypePlugins }): s
             CAUTION: this field is resolved by making an extra query to DB.
             RECOMMENDATION: Use it only with "get" queries (avoid in "list")
             """
-            revisions: [${mTypeName}]
+            revisions: [${mTypeName}!]
             title: String
             description: String
+            image: String
             """
             Custom meta data stored in the root of the entry object.
             """

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -117,6 +117,10 @@ export interface CmsModelFieldSettings {
      */
     fields?: CmsModelField[];
     /**
+     * Is the file field images only one?
+     */
+    imagesOnly?: boolean;
+    /**
      * Object field has child fields - so it needs to have a layout.
      */
     layout?: string[][];
@@ -489,6 +493,11 @@ export interface CmsModel {
      * Only way this is null or undefined is that there are no long-text fields to be set as description.
      */
     descriptionFieldId?: string | null;
+    /**
+     * The field which is displayed as the image.
+     * Only way this is null or undefined is that there are no file fields, with images only set, to be set as image.
+     */
+    imageFieldId?: string | null;
     /**
      * The version of Webiny which this record was stored with.
      */

--- a/packages/api-headless-cms/src/utils/getEntryImage.ts
+++ b/packages/api-headless-cms/src/utils/getEntryImage.ts
@@ -1,0 +1,13 @@
+import { CmsEntry, CmsModel } from "~/types";
+
+export function getEntryImage(model: CmsModel, entry: CmsEntry): string | null {
+    if (!model.imageFieldId) {
+        return null;
+    }
+    const field = model.fields.find(f => f.fieldId === model.imageFieldId);
+    if (!field) {
+        return null;
+    }
+    const imageFieldId = field.fieldId;
+    return entry.values[imageFieldId] || null;
+}


### PR DESCRIPTION
## Changes
Image field, similar as the title field, for the CMS entry.
Adds definitions in to DDB and DDB+ES packages as well.

## How Has This Been Tested?
Jest.