### PR TITLE
Webiny CLI - Introduce Ability to Specify a List of Apps Upon Running Different Commands

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
@@ -23,6 +23,23 @@ const createPulumiCommand = ({
 
             return plugin[name](inputs, context);
         } else {
+            // Before proceeding, let's detect if multiple project applications were passed.
+            const folders = inputs.folder.split(",");
+            if (folders.length > 1) {
+                for (let i = 0; i < folders.length; i++) {
+                    const folder = folders[i];
+                    await createPulumiCommand({ name, command, createProjectApplicationWorkspace })(
+                        {
+                            ...inputs,
+                            folder
+                        },
+                        context
+                    );
+                }
+
+                return;
+            }
+
             // Detect if an app alias was provided.
             const project = getProject();
             if (project.config.appAliases) {

--- a/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
@@ -24,7 +24,7 @@ const createPulumiCommand = ({
             return plugin[name](inputs, context);
         } else {
             // Before proceeding, let's detect if multiple project applications were passed.
-            const folders = inputs.folder.split(",");
+            const folders = inputs.folder.split(",").map(current => current.trim());
             if (folders.length > 1) {
                 for (let i = 0; i < folders.length; i++) {
                     const folder = folders[i];


### PR DESCRIPTION
## Changes
This PR introduces the ability to specify multiple apps upon running different Webiny CLI commands. An example:

https://user-images.githubusercontent.com/5121148/214272524-c5495fee-f27b-44e2-8435-f4efa0d4e0d2.mov

## How Has This Been Tested?
Manually.


## Documentation
Changelog.