### PR TITLE
feat(app-headless-cms): ui feature to support model default fields

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.defaultFields.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.defaultFields.test.ts
@@ -1,0 +1,158 @@
+import { CmsGroup } from "~/types";
+import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
+
+const name = "Model with default fields";
+const modelId = "modelWithDefaultFields";
+
+describe("content model default fields", () => {
+    const { createContentModelGroupMutation, createContentModelMutation, getContentModelQuery } =
+        useGraphQLHandler({
+            path: "manage/en-US"
+        });
+
+    let contentModelGroup: CmsGroup;
+
+    beforeEach(async () => {
+        const [createCMG] = await createContentModelGroupMutation({
+            data: {
+                name: "Group",
+                slug: "group",
+                icon: "ico/ico",
+                description: "description"
+            }
+        });
+        contentModelGroup = createCMG.data.createContentModelGroup.data;
+    });
+
+    it("should not create a content model with default fields - with undefined", async () => {
+        const [response] = await createContentModelMutation({
+            data: {
+                name,
+                modelId,
+                group: contentModelGroup.id
+            }
+        });
+
+        expect(response).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        name,
+                        modelId,
+                        fields: []
+                    },
+                    error: null
+                }
+            }
+        });
+        expect(response.data.createContentModel.data.fields).toHaveLength(0);
+        expect(response.data.createContentModel.data.layout).toHaveLength(0);
+    });
+
+    it("should not create a content model with default fields - with false", async () => {
+        const [response] = await createContentModelMutation({
+            data: {
+                name,
+                modelId,
+                group: contentModelGroup.id,
+                defaultFields: false
+            }
+        });
+
+        expect(response).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        name,
+                        modelId,
+                        fields: []
+                    },
+                    error: null
+                }
+            }
+        });
+        expect(response.data.createContentModel.data.fields).toHaveLength(0);
+        expect(response.data.createContentModel.data.layout).toHaveLength(0);
+    });
+
+    it("should create a content model with default fields", async () => {
+        const [createResponse] = await createContentModelMutation({
+            data: {
+                name,
+                modelId,
+                group: contentModelGroup.id,
+                defaultFields: true
+            }
+        });
+
+        expect(createResponse).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        name,
+                        modelId,
+                        fields: [
+                            {
+                                fieldId: "title",
+                                type: "text",
+                                label: "Title"
+                            },
+                            {
+                                fieldId: "description",
+                                type: "long-text",
+                                label: "Description"
+                            },
+                            {
+                                fieldId: "image",
+                                type: "file",
+                                label: "Image",
+                                settings: {
+                                    imagesOnly: true
+                                }
+                            }
+                        ]
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [response] = await getContentModelQuery({
+            modelId
+        });
+
+        expect(response).toMatchObject({
+            data: {
+                getContentModel: {
+                    data: {
+                        name,
+                        modelId,
+                        fields: [
+                            {
+                                fieldId: "title",
+                                type: "text",
+                                label: "Title"
+                            },
+                            {
+                                fieldId: "description",
+                                type: "long-text",
+                                label: "Description"
+                            },
+                            {
+                                fieldId: "image",
+                                type: "file",
+                                label: "Image",
+                                settings: {
+                                    imagesOnly: true
+                                }
+                            }
+                        ]
+                    },
+                    error: null
+                }
+            }
+        });
+        expect(response.data.getContentModel.data.fields).toHaveLength(3);
+        expect(response.data.getContentModel.data.layout).toHaveLength(2);
+    });
+});

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -48,6 +48,7 @@ import {
     createModelUpdateValidation
 } from "~/crud/contentModel/validation";
 import { createZodError } from "@webiny/utils";
+import { assignModelDefaultFields } from "~/crud/contentModel/defaultFields";
 
 /**
  * Given a model, return an array of tags ensuring the `type` tag is set.
@@ -336,8 +337,14 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
             if (!result.success) {
                 throw createZodError(result.error);
             }
+            /**
+             * We need to extract the defaultFields because it is not for the CmsModel object.
+             */
+            const { defaultFields, ...data } = result.data;
 
-            const data = result.data;
+            if (defaultFields) {
+                assignModelDefaultFields(data);
+            }
 
             context.security.disableAuthorization();
             const group = await context.cms.getGroup(data.group);

--- a/packages/api-headless-cms/src/crud/contentModel/defaultFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/defaultFields.ts
@@ -1,0 +1,60 @@
+import { CmsModelCreateInput, CmsModelFieldInput } from "~/types";
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
+
+const createDefaultFields = (): CmsModelFieldInput[] => {
+    return [
+        {
+            id: generateAlphaNumericLowerCaseId(8),
+            fieldId: "title",
+            type: "text",
+            label: "Title",
+            validation: [
+                {
+                    name: "required",
+                    message: "Title is a required field."
+                }
+            ],
+            listValidation: [],
+            renderer: {
+                name: "text-input"
+            }
+        },
+        {
+            id: generateAlphaNumericLowerCaseId(8),
+            fieldId: "description",
+            type: "long-text",
+            label: "Description",
+            validation: [],
+            listValidation: [],
+            renderer: {
+                name: "long-text-text-area"
+            }
+        },
+        {
+            id: generateAlphaNumericLowerCaseId(8),
+            fieldId: "image",
+            type: "file",
+            label: "Image",
+            validation: [],
+            listValidation: [],
+            renderer: {
+                name: "file-input"
+            },
+            settings: {
+                imagesOnly: true
+            }
+        }
+    ];
+};
+
+/**
+ * We only assign default fields if there are no fields in the model already.
+ */
+export const assignModelDefaultFields = (model: CmsModelCreateInput): void => {
+    if (model.fields && model.fields.length !== 0) {
+        return;
+    }
+
+    model.fields = createDefaultFields();
+    model.layout = [[model.fields[0].id], [model.fields[1].id, model.fields[2].id]];
+};

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -109,7 +109,8 @@ export const createModelCreateValidation = () => {
         tags: zod.array(shortString).optional(),
         titleFieldId: optionalShortString,
         descriptionFieldId: optionalShortString.nullish(),
-        imageFieldId: optionalShortString.nullish()
+        imageFieldId: optionalShortString.nullish(),
+        defaultFields: zod.boolean().nullish()
     });
 };
 

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -152,6 +152,7 @@ export const createModelsSchema = (context: CmsContext): CmsGraphQLSchemaPlugin 
                 descriptionFieldId: String
                 imageFieldId: String
                 tags: [String!]
+                defaultFields: Boolean
             }
 
             input CmsContentModelCreateFromInput {

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -25,6 +25,7 @@ import { CmsGroupOption } from "./types";
 import lodashUpperFirst from "lodash/upperFirst";
 import lodashCamelCase from "lodash/camelCase";
 import { Dialog } from "~/admin/components/Dialog";
+import { Checkbox } from "@webiny/ui/Checkbox";
 
 const t = i18n.ns("app-headless-cms/admin/views/content-models/new-content-model-dialog");
 
@@ -212,6 +213,15 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
                                                     data-testid="cms.newcontentmodeldialog.description"
                                                 />
                                             )}
+                                        </Bind>
+                                    </Cell>
+                                    <Cell span={12}>
+                                        <Bind name={"defaultFields"} defaultValue={true}>
+                                            <Checkbox
+                                                description={t`Create model with default title (text), description (long text) and image (file) fields`}
+                                                label={t`Create model with default fields`}
+                                                data-testid="cms.newcontentmodeldialog.defaultfields"
+                                            />
                                         </Bind>
                                     </Cell>
                                 </Grid>


### PR DESCRIPTION
## Changes
A UI part of the create new cms model with default fields.

## How Has This Been Tested?
Jest and manually.
