### PR TITLE
Extend GraphQL API Scaffold - Ensure `createdBy` GraphQL Field Is Included 

### DIFF
--- a/packages/cli-plugin-scaffold-graphql-service/src/getContextMeta.ts
+++ b/packages/cli-plugin-scaffold-graphql-service/src/getContextMeta.ts
@@ -42,7 +42,7 @@ export default function (typesTsPath: string): ContextMeta {
         const i18NContextImportDeclaration = source.getFirstDescendant(node => {
             return (
                 Node.isImportDeclaration(node) &&
-                node.getModuleSpecifier().getText() === `"@webiny/api-i18n/types"` &&
+                node.getModuleSpecifier().getText().includes("@webiny/api-i18n/types") &&
                 Boolean(
                     (node.getImportClause() as ImportClause)
                         .getNamedImports()
@@ -73,7 +73,7 @@ export default function (typesTsPath: string): ContextMeta {
         const securityContextImportDeclaration = source.getFirstDescendant(node => {
             return (
                 Node.isImportDeclaration(node) &&
-                node.getModuleSpecifier().getText() === `"@webiny/api-security/types"` &&
+                node.getModuleSpecifier().getText().includes("@webiny/api-security/types") &&
                 Boolean(
                     (node.getImportClause() as ImportClause)
                         .getNamedImports()


### PR DESCRIPTION
## Changes
This PR addresses an **Extend GraphQL API** scaffold issue. 

Because of bad string check in the scaffold's code, in some cases, users would end up with a bad `typeDefs.ts` file: the file would not include the necessary `createdBy` GraphQL field.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.