### PR TITLE
Page Builder / Page Elements - Pass Renderers Via a Getter Function

### DIFF
--- a/apps/admin/src/plugins/pageBuilder.ts
+++ b/apps/admin/src/plugins/pageBuilder.ts
@@ -7,15 +7,25 @@ import pageBuilderConfig from "@webiny/app-page-builder/editor/plugins/pageBuild
 /* Welcome screen widget for Page Builder */
 import welcomeScreenWidget from "@webiny/app-page-builder/admin/plugins/welcomeScreenWidget";
 
-import editorPlugins from "./pageBuilder/editorPlugins";
-import renderPlugins from "./pageBuilder/renderPlugins";
-
 export default [
     pageBuilderConfig({
         maxEventActionsNesting: 10
     }),
     pageBuilderPlugins(),
     welcomeScreenWidget,
-    editorPlugins,
-    renderPlugins
+    /**
+     * This plugin is responsible for lazy-loading plugin presets for page builder editor and list views.
+     * Since Editor is quite heavy, we don't want to include it in the main app bundle.
+     * The tricky part here is that we want developers to be able to customize which plugins are being loaded, so
+     * we need this plugin to allow plugin customization while still using code splitting.
+     */
+    {
+        type: "pb-plugins-loader",
+        async loadEditorPlugins() {
+            return (await import("./pageBuilder/editorPlugins")).default;
+        },
+        async loadRenderPlugins() {
+            return (await import("./pageBuilder/renderPlugins")).default;
+        }
+    }
 ];

--- a/packages/app-page-builder-elements/src/components/Element.tsx
+++ b/packages/app-page-builder-elements/src/components/Element.tsx
@@ -9,7 +9,9 @@ export interface Props {
 }
 
 export const Element: React.FC<Props> = props => {
-    const { renderers } = usePageElements();
+    const { getRenderers } = usePageElements();
+
+    const renderers = getRenderers();
 
     const { element } = props;
     if (!element) {

--- a/packages/app-page-builder-elements/src/contexts/PageElements.tsx
+++ b/packages/app-page-builder-elements/src/contexts/PageElements.tsx
@@ -10,7 +10,8 @@ import {
     AssignStylesCallback,
     SetElementStylesCallback,
     SetStylesCallback,
-    SetAssignStylesCallback
+    SetAssignStylesCallback,
+    GetRenderers
 } from "~/types";
 import {
     setUsingPageElements,
@@ -94,6 +95,10 @@ export const PageElementsProvider: React.FC<PageElementsProviderProps> = ({
         [customStylesCallback, customAssignStylesCallback]
     );
 
+    const getRenderers = useCallback<GetRenderers>(() => {
+        return typeof renderers === "function" ? renderers() : renderers;
+    }, []);
+
     // Provides a way to check whether the `PageElementsProvider` React component was mounted or not,
     // in a non-React context. In React contexts, it's strongly recommended the value of `usePageElements`
     // React hook is checked instead (a `null` value means the provider React component wasn't mounted).
@@ -103,6 +108,7 @@ export const PageElementsProvider: React.FC<PageElementsProviderProps> = ({
         theme,
         renderers,
         modifiers,
+        getRenderers,
         getElementAttributes,
         getElementStyles,
         getStyles,

--- a/packages/app-page-builder-elements/src/types.ts
+++ b/packages/app-page-builder-elements/src/types.ts
@@ -23,7 +23,7 @@ export interface Element<TElementData = Record<string, any>> {
 
 export interface PageElementsProviderProps {
     theme: Theme;
-    renderers: Record<string, Renderer>;
+    renderers: Record<string, Renderer> | (() => Record<string, Renderer>);
     modifiers: {
         styles: Record<string, ElementStylesModifier>;
         attributes: Record<string, ElementAttributesModifier>;
@@ -34,6 +34,7 @@ export interface PageElementsProviderProps {
 
 export type AttributesObject = React.ComponentProps<any>;
 
+export type GetRenderers = () => Record<string, Renderer>;
 export type GetElementAttributes = (element: Element) => AttributesObject;
 export type GetElementStyles = (element: Element) => CSSObject;
 export type GetStyles = (styles: StylesObject | ((theme: Theme) => StylesObject)) => CSSObject;
@@ -78,6 +79,7 @@ export type SetElementStylesCallback = (callback: ElementStylesCallback) => void
 export type SetStylesCallback = (callback: StylesCallback) => void;
 
 export interface PageElementsContextValue extends PageElementsProviderProps {
+    getRenderers: GetRenderers;
     getElementAttributes: GetElementAttributes;
     getElementStyles: GetElementStyles;
     getStyles: GetStyles;

--- a/packages/app-page-builder/src/contexts/PageBuilder/PageElementsProvider.tsx
+++ b/packages/app-page-builder/src/contexts/PageBuilder/PageElementsProvider.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { PageElementsProvider as PbPageElementsProvider } from "@webiny/app-page-builder-elements/contexts/PageElements";
 
 // Attributes modifiers.
@@ -31,40 +31,45 @@ import { PbRenderElementPlugin } from "~/types";
 export const PageElementsProvider: React.FC = ({ children }) => {
     const pageBuilder = usePageBuilder();
 
-    const renderers = plugins
-        .byType<PbRenderElementPlugin>("pb-render-page-element")
-        .reduce((current, item) => {
-            return { ...current, [item.elementType]: item.render };
-        }, {});
+    const getRenderers = useCallback(() => {
+        return plugins
+            .byType<PbRenderElementPlugin>("pb-render-page-element")
+            .reduce((current, item) => {
+                return { ...current, [item.elementType]: item.render };
+            }, {});
+    }, []);
 
-    const modifiers = {
-        attributes: {
-            id: createId(),
-            className: createClassName(),
-            animation: createAnimation({ initializeAos })
-        },
-        styles: {
-            background: createBackground(),
-            border: createBorder(),
-            gridFlexWrap: createGridFlexWrap(),
-            height: createHeight(),
-            horizontalAlign: createHorizontalAlign(),
-            margin: createMargin(),
-            text: createText(),
-            textAlign: createTextAlign(),
-            padding: createPadding(),
-            shadow: createShadow(),
-            verticalAlign: createVerticalAlign(),
-            visibility: createVisibility(),
-            width: createWidth()
-        }
-    };
+    const modifiers = useMemo(
+        () => ({
+            attributes: {
+                id: createId(),
+                className: createClassName(),
+                animation: createAnimation({ initializeAos })
+            },
+            styles: {
+                background: createBackground(),
+                border: createBorder(),
+                gridFlexWrap: createGridFlexWrap(),
+                height: createHeight(),
+                horizontalAlign: createHorizontalAlign(),
+                margin: createMargin(),
+                text: createText(),
+                textAlign: createTextAlign(),
+                padding: createPadding(),
+                shadow: createShadow(),
+                verticalAlign: createVerticalAlign(),
+                visibility: createVisibility(),
+                width: createWidth()
+            }
+        }),
+        []
+    );
 
     return (
         <PbPageElementsProvider
             // We can assign `Theme` here because we know at this point we're using the new elements rendering engine.
             theme={pageBuilder.theme as Theme}
-            renderers={renderers}
+            renderers={getRenderers}
             modifiers={modifiers}
         >
             {children}


### PR DESCRIPTION
## Changes
This PR introduces the ability to pass renderers via a getter function. 

This ability enabled us to fix an issue that occurred in the Admin app - when previewing pages or opening a page in the editor, depending on the loading times, the page would sometimes not get rendered. This new addition fixes the issue.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.