### PR TITLE
fix(api-headless-cms): move modelId field to original gql type

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.read.ts
@@ -5,16 +5,13 @@ export default /* GraphQL */ `
     type Category {
         id: ID!
         entryId: String!
+        modelId: String!
         createdOn: DateTime!
         savedOn: DateTime!
         createdBy: CmsCreatedBy!
         ownedBy: CmsOwnedBy!
         title: String
         slug: String
-    }
-
-    extend type Category {
-        modelId: String!
     }
 
     input CategoryGetWhereInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -5,6 +5,7 @@ export default `
     type Page {
         id: ID!
         entryId: String!
+        modelId: String!
         createdOn: DateTime!
         savedOn: DateTime!
         createdBy: CmsCreatedBy!
@@ -12,10 +13,6 @@ export default `
         content: [Page_Content!]
         header: Page_Header
         objective: Page_Objective
-    }
-    
-    extend type Page {
-        modelId: String!
     }
 
     union Page_Content = Page_Content_Hero | Page_Content_SimpleText | Page_Content_Objecting

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -5,6 +5,7 @@ export default /* GraphQL */ `
     type Product {
         id: ID!
         entryId: String!
+        modelId: String!
         createdOn: DateTime!
         savedOn: DateTime!
         createdBy: CmsCreatedBy!
@@ -21,10 +22,6 @@ export default /* GraphQL */ `
         richText: JSON
         variant: Product_Variant
         fieldsObject: Product_FieldsObject
-    }
-
-    extend type Product {
-        modelId: String!
     }
 
     type Product_Variant_Options {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.read.ts
@@ -5,6 +5,7 @@ export default /* GraphQL */ `
     type Review {
         id: ID!
         entryId: String!
+        modelId: String!
         createdOn: DateTime!
         savedOn: DateTime!
         createdBy: CmsCreatedBy!
@@ -13,10 +14,6 @@ export default /* GraphQL */ `
         product(populate: Boolean = true): Product
         rating: Number
         author(populate: Boolean = true): Author
-    }
-
-    extend type Review {
-        modelId: String!
     }
 
     input ReviewGetWhereInput {

--- a/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
@@ -58,19 +58,12 @@ export const createReadSDL: CreateReadSDL = ({
         type ${rTypeName} {
             id: ID!
             entryId: String!
+            ${hasModelIdField ? "" : "modelId: String!"}
             createdOn: DateTime!
             savedOn: DateTime!
             createdBy: CmsCreatedBy!
             ownedBy: CmsOwnedBy!
             ${fieldsRender.map(f => f.fields).join("\n")}
-        }
-        
-        ${
-            hasModelIdField
-                ? ""
-                : `extend type ${rTypeName} {
-                modelId: String!
-            }`
         }
         
         ${fieldsRender


### PR DESCRIPTION
## Changes
Move the modelId GraphQL field from the extending type to the original one. There is no point in having the extend type as the schema breaks anyway if there are two fields with same name.

## How Has This Been Tested?
Jest.