### PR TITLE
fix(api-headless-cms-ddb): missing hasOwnProperty on where object

### DIFF
--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/createExpressions.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/createExpressions.ts
@@ -85,10 +85,6 @@ export const createExpressions = (params: Params): Expression => {
         };
 
         for (const key in where) {
-            if (where.hasOwnProperty && where.hasOwnProperty(key) === false) {
-                continue;
-            }
-
             const value = (where as any)[key];
             if (value === undefined) {
                 continue;

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/createExpressions.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/createExpressions.ts
@@ -85,7 +85,7 @@ export const createExpressions = (params: Params): Expression => {
         };
 
         for (const key in where) {
-            if (where.hasOwnProperty(key) === false) {
+            if (where.hasOwnProperty && where.hasOwnProperty(key) === false) {
                 continue;
             }
 


### PR DESCRIPTION
## Changes
This PR fixes missing hasOwnProperty on where object when having nested AND/OR operators.

## How Has This Been Tested?
Jest and manually.