### PR TITLE
Make New PB rendering work with Theme Manager

### DIFF
--- a/packages/app-page-builder-elements/src/contexts/PageElements.tsx
+++ b/packages/app-page-builder-elements/src/contexts/PageElements.tsx
@@ -76,7 +76,7 @@ export const PageElementsProvider: React.FC<PageElementsProviderProps> = ({
                 afterRenderer
             });
         },
-        [customElementStylesCallback, customAssignStylesCallback]
+        [theme, customElementStylesCallback, customAssignStylesCallback]
     );
 
     const getStyles = useCallback<GetStyles>(
@@ -92,7 +92,7 @@ export const PageElementsProvider: React.FC<PageElementsProviderProps> = ({
                 afterRenderer
             });
         },
-        [customStylesCallback, customAssignStylesCallback]
+        [theme, customStylesCallback, customAssignStylesCallback]
     );
 
     const getRenderers = useCallback<GetRenderers>(() => {

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder.tsx
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo, useRef } from "react";
+import React, { createContext, useMemo, useRef } from "react";
 import ApolloClient from "apollo-client";
 import { useApolloClient, MutationHookOptions } from "@apollo/react-hooks";
 import { usePageBuilder } from "~/hooks/usePageBuilder";
-import { PageBuilderContextValue } from "~/contexts/PageBuilder";
+import { PageBuilderContext } from "~/contexts/PageBuilder";
 import { AsyncProcessor, composeAsync } from "@webiny/utils";
 
-export const AdminPageBuilderContext = React.createContext<AdminPageBuilderContextValue>(
-    {} as AdminPageBuilderContextValue
+export const AdminPageBuilderContext = createContext<AdminPageBuilderContext | undefined>(
+    undefined
 );
 
 interface Page {
@@ -20,7 +20,7 @@ export interface PublishPageOptions {
 
 export type DeletePageOptions = PublishPageOptions;
 
-export interface AdminPageBuilderContextValue extends PageBuilderContextValue {
+export interface AdminPageBuilderContext extends PageBuilderContext {
     publishPage: (page: Page, options: PublishPageOptions) => Promise<OnPagePublish>;
     onPagePublish: (fn: OnPagePublishSubscriber) => () => void;
     deletePage: (page: Page, options: DeletePageOptions) => Promise<OnPageDelete>;
@@ -52,7 +52,7 @@ export const AdminPageBuilderContextProvider: React.FC = ({ children }) => {
     const onPagePublish = useRef<OnPagePublishSubscriber[]>([]);
     const onPageDelete = useRef<OnPageDeleteSubscriber[]>([]);
 
-    const context: AdminPageBuilderContextValue = useMemo(() => {
+    const context: AdminPageBuilderContext = useMemo(() => {
         return {
             ...pageBuilder,
             async publishPage(page, options) {

--- a/packages/app-page-builder/src/admin/hooks/useAdminPageBuilder.ts
+++ b/packages/app-page-builder/src/admin/hooks/useAdminPageBuilder.ts
@@ -1,9 +1,14 @@
 import { useContext } from "react";
-import {
-    AdminPageBuilderContext,
-    AdminPageBuilderContextValue
-} from "../contexts/AdminPageBuilder";
+import { AdminPageBuilderContext } from "../contexts/AdminPageBuilder";
 
-export function useAdminPageBuilder(): AdminPageBuilderContextValue {
-    return useContext(AdminPageBuilderContext);
+export function useAdminPageBuilder() {
+    const context = useContext(AdminPageBuilderContext);
+
+    if (!context) {
+        throw Error(
+            `AdminPageBuilder context was not found! Are you using the "useAdminPageBuilder()" hook in the right place?`
+        );
+    }
+
+    return context;
 }

--- a/packages/app-page-builder/src/hooks/usePageBuilder.ts
+++ b/packages/app-page-builder/src/hooks/usePageBuilder.ts
@@ -1,6 +1,14 @@
 import { useContext } from "react";
-import { PageBuilderContext, PageBuilderContextValue } from "../contexts/PageBuilder";
+import { PageBuilderContext } from "~/contexts/PageBuilder";
 
-export function usePageBuilder(): PageBuilderContextValue {
-    return useContext(PageBuilderContext);
+export function usePageBuilder() {
+    const context = useContext(PageBuilderContext);
+
+    if (!context) {
+        throw Error(
+            `PageBuilder context was not found! Are you using the "usePageBuilder()" hook in the right place?`
+        );
+    }
+
+    return context;
 }

--- a/packages/app-page-builder/src/hooks/useResponsiveClassName.ts
+++ b/packages/app-page-builder/src/hooks/useResponsiveClassName.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { plugins } from "@webiny/plugins";
 import kebabCase from "lodash/kebabCase";
 import { PbRenderResponsiveModePlugin } from "~/types";
-import { PageBuilderContext } from "~/contexts/PageBuilder";
+import { usePageBuilder } from "~/hooks/usePageBuilder";
 
 interface UseResponsiveClassName {
     pageElementRef: (node: HTMLElement | null) => void;
@@ -13,7 +13,7 @@ interface UseResponsiveClassName {
 const useResponsiveClassName = (): UseResponsiveClassName => {
     const {
         responsiveDisplayMode: { displayMode, setDisplayMode }
-    } = React.useContext(PageBuilderContext);
+    } = usePageBuilder();
     const ref = React.useRef<HTMLElement>();
 
     // Get "responsive-mode" plugins

--- a/packages/app-page-builder/src/render/plugins/elements/block/Block.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/block/Block.tsx
@@ -6,7 +6,7 @@ import { ElementRoot } from "~/render/components/ElementRoot";
 import { PbElement } from "~/types";
 import ElementAnimation from "~/render/components/ElementAnimation";
 import { Interpolation } from "@emotion/core";
-import { PageBuilderContext } from "~/contexts/PageBuilder";
+import { usePageBuilder } from "~/hooks/usePageBuilder";
 
 interface BlockProps {
     element: PbElement;
@@ -15,7 +15,7 @@ interface BlockProps {
 const Block: React.FC<BlockProps> = ({ element }) => {
     const {
         responsiveDisplayMode: { displayMode }
-    } = React.useContext(PageBuilderContext);
+    } = usePageBuilder();
 
     return (
         <>

--- a/packages/app-page-builder/src/render/plugins/elements/button/Button.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/button/Button.tsx
@@ -1,10 +1,10 @@
 import React, { CSSProperties, useCallback, useMemo } from "react";
 import kebabCase from "lodash/kebabCase";
 import { plugins } from "@webiny/plugins";
-import { ElementRoot } from "../../../components/ElementRoot";
+import { ElementRoot } from "~/render";
 import { PbButtonElementClickHandlerPlugin, PbElement, PbElementDataType } from "~/types";
 import { Link } from "@webiny/react-router";
-import { PageBuilderContext } from "~/contexts/PageBuilder";
+import { usePageBuilder } from "~/hooks/usePageBuilder";
 
 const formatUrl = (url: string): string => {
     // Check if external domain url (e.g. google.com, https://www.google.com)
@@ -31,7 +31,7 @@ interface ButtonProps {
 const Button: React.FC<ButtonProps> = ({ element }) => {
     const {
         responsiveDisplayMode: { displayMode }
-    } = React.useContext(PageBuilderContext);
+    } = usePageBuilder();
     const {
         type = "default",
         icon = {},

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -491,7 +491,7 @@ export interface PbEditorPageElementPluginToolbar {
     // Element group this element belongs to.
     group?: string;
     // A function to render an element preview in the toolbar.
-    preview?: (params?: { theme: PbTheme | Theme }) => ReactNode; // @deprecation-warning pb-legacy-rendering-engine
+    preview?: (params?: { theme: PbTheme | Theme | undefined }) => ReactNode; // @deprecation-warning pb-legacy-rendering-engine
 }
 
 export type PbEditorPageElementPluginSettings = string[] | Record<string, any>;

--- a/packages/app-theme-manager/src/components/ThemeLoader.tsx
+++ b/packages/app-theme-manager/src/components/ThemeLoader.tsx
@@ -2,6 +2,7 @@ import React, { FC, Fragment, useEffect, useState } from "react";
 import { plugins } from "@webiny/plugins";
 import { useCurrentTheme } from "~/hooks/useCurrentTheme";
 import { ThemeSource } from "~/types";
+import { usePageBuilder } from "@webiny/app-page-builder/hooks/usePageBuilder";
 
 export interface ThemeLoaderProps {
     themes: ThemeSource[];
@@ -13,10 +14,12 @@ interface LoadThemeProps {
 
 const LoadTheme: FC<LoadThemeProps> = ({ theme, children }) => {
     const [loaded, setLoaded] = useState(false);
+    const { loadThemeFromPlugins } = usePageBuilder();
 
     useEffect(() => {
         theme.load().then(pluginFactory => {
             plugins.register(pluginFactory());
+            loadThemeFromPlugins();
             setLoaded(true);
         });
     }, []);

--- a/packages/app-website/src/Website.tsx
+++ b/packages/app-website/src/Website.tsx
@@ -38,7 +38,7 @@ export const Website: React.FC<WebsiteProps> = ({
                 <App
                     debounceRender={debounceMs}
                     routes={[...routes, { path: "*", element: <Page /> }]}
-                    providers={[...providers, PageBuilderProviderHOC]}
+                    providers={[PageBuilderProviderHOC, ...providers]}
                 >
                     {children}
                 </App>


### PR DESCRIPTION
## Changes
This PR adds several tweaks to make the new PB rendering mechanism work with asynchronously loaded themes. This means that themes are lazy loaded, so we can't expect the `theme` plugin to always be there. This required several TS type changes, and allow Theme Manager to trigger theme detection after plugins are registered.

## How Has This Been Tested?
Manually, by adding 2 themes, switching between them, and checking the results on the prerendered website.
