### PR TITLE
fix(api-headless-cms): graphql group slug

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.clone.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.clone.test.ts
@@ -1,6 +1,7 @@
 import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
 import { CmsGroup, CmsModel, CmsModelField } from "~/types";
 import models from "./mocks/contentModels";
+import { toSlug } from "~/utils/toSlug";
 
 const setEmptyTextsAsNull = (fields: CmsModelField[]): CmsModelField[] => {
     return fields.map(field => {
@@ -20,7 +21,8 @@ const createExpectedModel = (original: CmsModel, group?: CmsGroup) => {
         ...original,
         group: {
             id: group ? group.id : original.group.id,
-            name: group ? group.name : original.group.name
+            name: group ? group.name : original.group.name,
+            slug: group ? group.slug : toSlug(original.group.name)
         },
         fields: setEmptyTextsAsNull(original.fields),
         createdOn: expect.stringMatching(/^20/),

--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -143,7 +143,8 @@ describe("content model test", () => {
                         plugin: false,
                         group: {
                             id: contentModelGroup.id,
-                            name: contentModelGroup.name
+                            name: contentModelGroup.name,
+                            slug: contentModelGroup.slug
                         }
                     },
                     error: null
@@ -519,7 +520,8 @@ describe("content model test", () => {
                         ],
                         group: {
                             id: contentModelGroup.id,
-                            name: "Group"
+                            name: "Group",
+                            slug: contentModelGroup.slug
                         },
                         modelId: contentModel.modelId,
                         layout: [[textField.id], [numberField.id]],

--- a/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/pluginsContentModels.test.ts
@@ -307,6 +307,7 @@ describe("content model plugins", () => {
                             ],
                             group: {
                                 id: "ecommerce",
+                                slug: "e-commerce",
                                 name: "E-Commerce"
                             },
                             layout: [["name"], ["sku", "price"]],
@@ -380,6 +381,7 @@ describe("content model plugins", () => {
                                 ],
                                 group: {
                                     id: "ecommerce",
+                                    slug: "e-commerce",
                                     name: "E-Commerce"
                                 },
                                 layout: [["name"], ["sku", "price"]],

--- a/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/graphql/contentModel.ts
@@ -6,6 +6,7 @@ const DATA_FIELD = /* GraphQL*/ `
         group {
             id
             name
+            slug
         }
         layout
         titleFieldId

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -3,6 +3,7 @@ import { CmsContext, CmsModel } from "~/types";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins/GraphQLSchemaPlugin";
 import { Resolvers } from "@webiny/handler-graphql/types";
 import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
+import { toSlug } from "~/utils/toSlug";
 
 export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<CmsContext> => {
     const resolvers: Resolvers<CmsContext> = {
@@ -38,6 +39,18 @@ export const createModelsSchema = (context: CmsContext): GraphQLSchemaPlugin<Cms
             }
         },
         CmsContentModel: {
+            group: async (model: CmsModel) => {
+                context.security.disableAuthorization();
+                const groups = await context.cms.listGroups();
+                context.security.enableAuthorization();
+
+                const group = groups.find(group => group.id === model.group.id);
+                return {
+                    ...model.group,
+                    slug: toSlug(model.group.name),
+                    ...(group || {})
+                };
+            },
             tags(model: CmsModel) {
                 // Make sure `tags` always contain a `type` tag, to differentiate between models.
                 const hasType = (model.tags || []).find(tag => tag.startsWith("type:"));

--- a/packages/handler/src/Context.ts
+++ b/packages/handler/src/Context.ts
@@ -13,6 +13,8 @@ export class Context extends BaseContext implements BaseContextType {
     public handlerClient: BaseContextType["handlerClient"];
     // @ts-ignore
     public request: BaseContextType["request"];
+    // @ts-ignore
+    public reply: BaseContextType["reply"];
 
     public constructor(params: ContextParams) {
         super(params);

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -303,8 +303,9 @@ export const createHandler = (params: CreateHandlerParams) => {
             .hijack();
     });
 
-    app.addHook("preParsing", async request => {
+    app.addHook("preParsing", async (request, reply) => {
         app.webiny.request = request;
+        app.webiny.reply = reply;
         const plugins = app.webiny.plugins.byType<ContextPlugin>(ContextPlugin.type);
         for (const plugin of plugins) {
             await plugin.apply(app.webiny);

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -46,6 +46,10 @@ export interface Context extends ClientContext {
      */
     request: FastifyRequest;
     /**
+     * Current reply. Must be set only once!
+     */
+    reply: FastifyReply;
+    /**
      * @internal
      */
     routes: ContextRoutes;


### PR DESCRIPTION
## Changes
There is a missing resolver for the group field when querying the CmsContentModel GraphQL type.
We also attached the Reply object to the default context.

## How Has This Been Tested?
Jest and manually.