### PR TITLE
`5.34.3` Page Builder Fixes

### DIFF
--- a/packages/app-page-builder-elements/src/modifiers/attributes/animation/initializeAos.ts
+++ b/packages/app-page-builder-elements/src/modifiers/attributes/animation/initializeAos.ts
@@ -1,9 +1,3 @@
-declare global {
-    interface Window {
-        aosInitialized: boolean;
-    }
-}
-
 let pbDocumentCheck: Promise<void>;
 
 export const initializeAos = async () => {
@@ -11,13 +5,6 @@ export const initializeAos = async () => {
     // these dependencies only when the attributes modifier is actually used.
     // Additionally, we only want to do this in the browser, hence the window check.
     if (typeof window === "undefined") {
-        return;
-    }
-
-    // By assigning this flag into the `window` object, we get to ensure
-    // that AOS is not initialized multiple times by multiple `createAnimation`
-    // calls. This is something that's possible in the Admin application.
-    if (window.aosInitialized) {
         return;
     }
 
@@ -38,6 +25,5 @@ export const initializeAos = async () => {
     await import("aos/dist/aos.css");
     const aos = await import("aos");
 
-    window.aosInitialized = true;
     aos.init();
 };

--- a/packages/app-page-builder-elements/src/modifiers/styles/border.ts
+++ b/packages/app-page-builder-elements/src/modifiers/styles/border.ts
@@ -12,9 +12,15 @@ const border: ElementStylesModifier = ({ element, theme }) => {
         }
 
         const values = border[breakpointName];
+
+        let borderColor = values.color;
+        if (theme.styles.colors?.[borderColor]) {
+            borderColor = theme.styles.colors?.[borderColor];
+        }
+
         const styles = {
             borderStyle: values.style,
-            borderColor: values.color
+            borderColor
         };
 
         const { width } = values;

--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -22,6 +22,8 @@ export interface ImageElementData {
 
 export interface ImageRendererComponentProps extends Props, CreateImageParams {}
 
+const SUPPORTED_IMAGE_RESIZE_WIDTHS = [100, 300, 500, 750, 1000, 1500, 2500];
+
 export const ImageRendererComponent: React.FC<ImageRendererComponentProps> = ({
     onClick,
     renderEmpty,
@@ -46,7 +48,12 @@ export const ImageRendererComponent: React.FC<ImageRendererComponentProps> = ({
 
         const { title } = element.data.image;
         const { src } = value || element.data?.image?.file;
-        content = <PbImg alt={title} title={title} src={src} onClick={onClick} />;
+
+        const srcSet = SUPPORTED_IMAGE_RESIZE_WIDTHS.map(item => {
+            return `${src}?width=${item} ${item}w`;
+        }).join(", ");
+
+        content = <PbImg alt={title} title={title} srcSet={srcSet} onClick={onClick} />;
     } else {
         content = renderEmpty || null;
     }

--- a/packages/app-page-builder-elements/src/renderers/paragraph.tsx
+++ b/packages/app-page-builder-elements/src/renderers/paragraph.tsx
@@ -13,6 +13,10 @@ export const createParagraph = () => {
 
         // If the text already contains `p` tags (happens when c/p-ing text into the editor),
         // we don't want to wrap it with another pair of `p` tag.
+        // Additional note: alternatively, instead of adding the `p-wrap` wrapper tag, we tried
+        // removing the wrapper `p` tags from the received text. But that wasn't enough. There
+        // were cases where the received text was not just one `p` tag, but an array of `p` tags.
+        // In that case, we still need a separate wrapper element. So, we're leaving this solution.
         if (__html.startsWith("<p")) {
             // @ts-ignore We don't need type-checking here.
             return <p-wrap dangerouslySetInnerHTML={{ __html }} />;

--- a/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
+++ b/packages/app-page-builder/src/admin/utils/createElementPlugin.tsx
@@ -40,7 +40,7 @@ export default (el: PbEditorElement): void => {
                         src={el.preview.src}
                         // @ts-ignore
                         alt={el.name}
-                        style={{ width: 227, height: "auto", backgroundColor: "#fff" }}
+                        style={{ width: "100%", height: "auto", backgroundColor: "#fff" }}
                     />
                 );
             }

--- a/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/getPreviewImage.ts
+++ b/packages/app-page-builder/src/blockEditor/config/eventActions/saveBlock/getPreviewImage.ts
@@ -40,7 +40,7 @@ function takePageScreenshot(element: PbElement) {
     }
 
     return domToImage.toPng(node, {
-        width: 1000,
+        width: 2000,
         filter: (element: Element) => {
             return element.tagName !== "PB-ELEMENT-CONTROLS-OVERLAY";
         }

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
@@ -22,6 +22,10 @@ import { createVerticalAlign } from "@webiny/app-page-builder-elements/modifiers
 import { createVisibility } from "@webiny/app-page-builder-elements/modifiers/styles/visibility";
 import { createWidth } from "@webiny/app-page-builder-elements/modifiers/styles/width";
 
+// Additional editor styles modifiers.
+import { createAnimationZIndexFix } from "./EditorPageElementsProvider/modifiers/styles/animationZIndexFix";
+
+// Other.
 import { usePageBuilder } from "~/hooks/usePageBuilder";
 import { Theme } from "@webiny/app-theme/types";
 import { plugins } from "@webiny/plugins";
@@ -45,6 +49,7 @@ export const EditorPageElementsProvider: React.FC = ({ children }) => {
             animation: createAnimation({ initializeAos })
         },
         styles: {
+            animationZIndexFix: createAnimationZIndexFix(),
             background: createBackground(),
             border: createBorder(),
             gridFlexWrap: createGridFlexWrap(),

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControls.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControls.tsx
@@ -62,7 +62,7 @@ export const ElementControls = () => {
                 type={element.type}
                 isVisible={() => true}
             >
-                {({ drop }) => <ElementControlsOverlay innerRef={drop} />}
+                {({ drop }) => <ElementControlsOverlay dropRef={drop} />}
             </Droppable>
         );
     }

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/modifiers/styles/animationZIndexFix.ts
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/modifiers/styles/animationZIndexFix.ts
@@ -1,0 +1,20 @@
+import { ElementAttributesModifier } from "@webiny/app-page-builder-elements/types";
+
+/**
+ * This styles modifier adds additional `z-index: 1` CSS rule to all elements
+ * that have animation enabled for them. Without this, users would not be able
+ * to properly interact with those elements. Not being able to edit the text
+ * of a child paragraph text element, not being able to drop an element below
+ * an existing one, are just some of the symptoms that users would experience.
+ */
+export const createAnimationZIndexFix = () => {
+    const animation: ElementAttributesModifier = ({ element }) => {
+        const animation = element.data.settings?.animation;
+        if (animation) {
+            return { zIndex: 1 };
+        }
+        return null;
+    };
+
+    return animation;
+};

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
@@ -30,7 +30,9 @@ const narrowDialog = css({
 });
 
 const PreviewBox = styled("div")({
-    width: 500,
+    width: "100%",
+    padding: "25px",
+    boxSizing: "border-box",
     minHeight: 250,
     border: "1px solid var(--mdc-theme-on-background)",
     backgroundColor: "#fff", // this must always be white

--- a/packages/app-page-builder/src/pageEditor/config/editorBar/Title/Title.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/editorBar/Title/Title.tsx
@@ -31,6 +31,7 @@ interface PageInfo {
     pageCategory?: string;
     pageCategoryUrl?: string;
 }
+
 const extractPageInfo = (page: PageAtomType): PageInfo => {
     const { title, version, locked, category } = page;
     return {
@@ -75,7 +76,7 @@ const Title: React.FC = () => {
     }, [title]);
 
     const onKeyDown = useCallback(
-        (e: SyntheticEvent) => {
+        (e: SyntheticEvent<HTMLInputElement>) => {
             // @ts-ignore
             switch (e.key) {
                 case "Escape":
@@ -84,7 +85,8 @@ const Title: React.FC = () => {
                     setTitle(pageTitle);
                     break;
                 case "Enter":
-                    if (title === "") {
+                    let title = e.currentTarget.value;
+                    if (!title) {
                         title = "Untitled";
                         setTitle(title);
                     }
@@ -92,7 +94,7 @@ const Title: React.FC = () => {
                     e.preventDefault();
                     setEdit(false);
 
-                    updatePage({ title });
+                    updatePage({ title: title });
                     break;
                 default:
                     return;


### PR DESCRIPTION
## Changes
This PR addresses several PB-related issues.

#### 1. Theme Colors Work on Borders
When setting border color, if the selected color was a theme color, users would always see black border. This now works correctly.

#### 2. Interactivity Issues On Animated Elements 
In the editor, when an element had an animation set, it would loose usual interactivity. Users would not be able to type any text in text-based elements, nor were they able to drop elements above/below the animated element. Both interactions now work correctly.

#### 3. Animations Not Being Triggered Upon Opening the PB Editor
If a user first opened, for example, the pages list view, and then navigated to the editor, the animation on the animated elements would not be triggered and users would just see a blank canvas. The [AOS](https://michalsnik.github.io/aos/)-related caching logic was adjusted, so now the animation will be triggered in the editor correctly.

#### 4. Improved Preview Image Generation Of Saved Blocks and Elements

Prior to this PR, images of saved blocks and elements would visually not look good. With this PR, we've adjusted the width of the image that the [dom-to-image](https://github.com/tsayen/dom-to-image) takes library, and now it's looking better.

But there are still two glitches to solve:
1) text contains weird `%0A` strings sometimes
2) although width of taken image is good, height is still something that needs to be improved (element sometimes gets cut off on the bottom edge of the image)

![image](https://user-images.githubusercontent.com/5121148/217475243-b28fec81-1377-4889-b4d7-23b03d110f09.png)


#### 5. Image Element Now Renders the Image Using `srcset`

Images are now rendered responsively, using `srcset` attribute, instead of just `src`.

#### 6. Page Title Correctly Saved When Pressing the Enter Key

Prior to this PR, if a user pressed Enter key once they typed a new page title, the new title would not get saved. This now works correctly.

#### 7. Elements Can Now Be Moved Up and Down On The Canvas (Drag and Drop)

Dragging existing elements on the canvas can now be done.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.