### PR TITLE
Ability To Define Multiple Production Environments Via `webiny.application.ts`

### DIFF
--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -17,6 +17,13 @@ export interface CreateAdminPulumiAppParams {
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
     pulumiResourceNamePrefix?: PulumiAppParam<string>;
+
+    /**
+     * Treats provided environments as production environments, which
+     * are deployed in production deployment mode.
+     * https://www.webiny.com/docs/architecture/deployment-modes/production
+     */
+    productionEnvironments: PulumiAppParam<string[]>;
 }
 
 export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParams) => {

--- a/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/admin/createAdminPulumiApp.ts
@@ -23,7 +23,7 @@ export interface CreateAdminPulumiAppParams {
      * are deployed in production deployment mode.
      * https://www.webiny.com/docs/architecture/deployment-modes/production
      */
-    productionEnvironments: PulumiAppParam<string[]>;
+    productionEnvironments?: PulumiAppParam<string[]>;
 }
 
 export const createAdminPulumiApp = (projectAppParams: CreateAdminPulumiAppParams) => {

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -36,6 +36,13 @@ export interface CreateApiPulumiAppParams {
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
     pulumiResourceNamePrefix?: PulumiAppParam<string>;
+
+    /**
+     * Treats provided environments as production environments, which
+     * are deployed in production deployment mode.
+     * https://www.webiny.com/docs/architecture/deployment-modes/production
+     */
+    productionEnvironments: PulumiAppParam<string[]>;
 }
 
 export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = {}) => {

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -42,7 +42,7 @@ export interface CreateApiPulumiAppParams {
      * are deployed in production deployment mode.
      * https://www.webiny.com/docs/architecture/deployment-modes/production
      */
-    productionEnvironments: PulumiAppParam<string[]>;
+    productionEnvironments?: PulumiAppParam<string[]>;
 }
 
 export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = {}) => {

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -63,7 +63,8 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 });
             }
 
-            const prod = app.params.run.env === "prod";
+            const productionEnvironments = app.params.create.productionEnvironments || ["prod"];
+            const isProduction = productionEnvironments.includes(app.params.run.env);
 
             // Enables logs forwarding.
             // https://www.webiny.com/docs/how-to-guides/use-watch-command#enabling-logs-forwarding
@@ -73,7 +74,7 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
             const core = app.addModule(CoreOutput);
 
             // Register VPC config module to be available to other modules.
-            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? prod;
+            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? isProduction;
             app.addModule(VpcConfig, { enabled: vpcEnabled });
 
             const pageBuilder = app.addModule(ApiPageBuilder, {

--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -39,7 +39,10 @@ export const ElasticSearch = createAppModule({
     config(app, params: ElasticSearchParams) {
         const domainName = "webiny-js";
         const accountId = getAwsAccountId(app);
-        const prod = app.params.run.env === "prod";
+
+        const productionEnvironments = app.params.create.productionEnvironments || ["prod"];
+        const isProduction = productionEnvironments.includes(app.params.run.env);
+
         const vpc = app.getModule(CoreVpc, { optional: true });
 
         // This needs to be implemented in order to be able to use a shared ElasticSearch cluster.
@@ -62,7 +65,7 @@ export const ElasticSearch = createAppModule({
                 name: domainName,
                 config: {
                     elasticsearchVersion: "7.10",
-                    clusterConfig: prod ? getProdClusterConfig() : getDevClusterConfig(),
+                    clusterConfig: isProduction ? getProdClusterConfig() : getDevClusterConfig(),
                     vpcOptions: vpc
                         ? {
                               subnetIds: vpc.subnets.private.map(s => s.output.id),

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -43,6 +43,13 @@ export interface CreateCorePulumiAppParams {
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
     pulumiResourceNamePrefix?: PulumiAppParam<string>;
+
+    /**
+     * Treats provided environments as production environments, which
+     * are deployed in production deployment mode.
+     * https://www.webiny.com/docs/architecture/deployment-modes/production
+     */
+    productionEnvironments: PulumiAppParam<string[]>;
 }
 
 export interface CoreAppLegacyConfig {
@@ -74,15 +81,17 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
                 });
             }
 
-            const prod = app.params.run.env === "prod";
-            const protect = app.getParam(projectAppParams.protect) ?? prod;
+            const productionEnvironments = app.params.create.productionEnvironments || ["prod"];
+            const isProduction = productionEnvironments.includes(app.params.run.env);
+
+            const protect = app.getParam(projectAppParams.protect) ?? isProduction;
             const legacyConfig = app.getParam(projectAppParams.legacy) || {};
 
             // Setup DynamoDB table
             const dynamoDbTable = app.addModule(CoreDynamo, { protect });
 
             // Setup VPC
-            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? prod;
+            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? isProduction;
             const vpc = vpcEnabled ? app.addModule(CoreVpc) : null;
 
             // Setup Cognito

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -49,7 +49,7 @@ export interface CreateCorePulumiAppParams {
      * are deployed in production deployment mode.
      * https://www.webiny.com/docs/architecture/deployment-modes/production
      */
-    productionEnvironments: PulumiAppParam<string[]>;
+    productionEnvironments?: PulumiAppParam<string[]>;
 }
 
 export interface CoreAppLegacyConfig {

--- a/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
@@ -33,6 +33,13 @@ export interface CreateReactPulumiAppParams {
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
     pulumiResourceNamePrefix?: PulumiAppParam<string>;
+
+    /**
+     * Treats provided environments as production environments, which
+     * are deployed in production deployment mode.
+     * https://www.webiny.com/docs/architecture/deployment-modes/production
+     */
+    productionEnvironments?: PulumiAppParam<string[]>;
 }
 
 export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParams) => {

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -44,7 +44,7 @@ export interface CreateWebsitePulumiAppParams {
      * are deployed in production deployment mode.
      * https://www.webiny.com/docs/architecture/deployment-modes/production
      */
-    productionEnvironments: PulumiAppParam<string[]>;
+    productionEnvironments?: PulumiAppParam<string[]>;
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -65,13 +65,14 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 });
             }
 
-            const prod = app.params.run.env === "prod";
+            const productionEnvironments = app.params.create.productionEnvironments || ["prod"];
+            const isProduction = productionEnvironments.includes(app.params.run.env);
 
             // Register core output as a module available for all other modules
             const core = app.addModule(CoreOutput);
 
             // Register VPC config module to be available to other modules.
-            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? prod;
+            const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? isProduction;
             app.addModule(VpcConfig, { enabled: vpcEnabled });
 
             const appBucket = createPrivateAppBucket(app, "app");

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -38,6 +38,13 @@ export interface CreateWebsitePulumiAppParams {
      * Prefixes names of all Pulumi cloud infrastructure resource with given prefix.
      */
     pulumiResourceNamePrefix?: PulumiAppParam<string>;
+
+    /**
+     * Treats provided environments as production environments, which
+     * are deployed in production deployment mode.
+     * https://www.webiny.com/docs/architecture/deployment-modes/production
+     */
+    productionEnvironments: PulumiAppParam<string[]>;
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {


### PR DESCRIPTION
## Changes
With this PR, users are able to define multiple "production" environments.

In other words, at the moment, only when passing "prod" as the environment name,  the [production deployment mode](https://www.webiny.com/docs/architecture/deployment-modes/production) will be used. But, if a user wanted to use the same mode for, say, "staging", that would not be easily possible.

That's why we're introducing the `productionEnvironments` parameter for all applications / respective factory functions, located in `webiny.application.ts` files. For example:

```ts
// apps/core/webiny.application.ts
import { createCoreApp } from "@webiny/serverless-cms-aws";

export default createCoreApp({
    pulumiResourceNamePrefix: "wby-",

    // Treats provided environments as production environments, which
    // are deployed in production deployment mode.
    productionEnvironments: ["prod", "staging"]
});

```

## How Has This Been Tested?
Manually.

## Documentation
Changelog.