### PR TITLE
Ensure `textAlign` Modifier Handles Both String and Object Values (Backwards Compatibility)

### DIFF
--- a/packages/app-page-builder-elements/src/modifiers/styles/textAlign.ts
+++ b/packages/app-page-builder-elements/src/modifiers/styles/textAlign.ts
@@ -6,7 +6,16 @@ const textAlign: ElementStylesModifier = ({ element }) => {
         return null;
     }
 
-    return { textAlign };
+    // Backwards compatibility.
+    // Older versions of Page Builder assigned both string and
+    // object values to the `horizontalAlign` property.
+    // Let's check which one is it and return styles accordingly.
+    if (typeof textAlign === "string") {
+        return { textAlign };
+    }
+
+    // If not string, then it's a `{ [breakpoint] : value }` object.
+    return textAlign;
 };
 
 export const createTextAlign = () => textAlign;


### PR DESCRIPTION
## Changes

Older versions of Page Builder assigned both string and object values to the `horizontalAlign` settings property. This is no longer relevant with the new rendering engine, but, because this affects users that are migrating from the legacy engine, this needs to be handled.

## How Has This Been Tested?
Manually.

## Documentation
None.