### PR TITLE
fix(api-headless-cms): nested file graphql

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.images.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.images.test.ts
@@ -1,0 +1,32 @@
+import { useGraphQLHandler } from "~tests/testHelpers/useGraphQLHandler";
+import { CmsGroupPlugin } from "~/plugins";
+import { createContentModelGroup } from "~tests/contentAPI/mocks/contentModelGroup";
+import { createImageModel } from "~tests/contentAPI/mocks/models/images";
+
+describe("Content Model Nested Object Images", () => {
+    const group = createContentModelGroup();
+    const handler = useGraphQLHandler({
+        path: "manage/en-US",
+        plugins: [new CmsGroupPlugin(group)]
+    });
+
+    it("should properly create a content model with nested object images", async () => {
+        const model = createImageModel(group);
+        const [result] = await handler.createContentModelMutation({
+            data: {
+                ...model
+            }
+        });
+
+        expect(result).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        modelId: "imagesModel"
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModelGroup.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModelGroup.ts
@@ -1,9 +1,11 @@
-import { CmsGroup } from "~/types";
+import { CmsGroup } from "~tests/types";
 
-export default {
-    id: "5e7c96c46adcbe0007268295",
-    name: "A sample content model group",
-    slug: "a-sample-content-model-group",
-    description: "This is a simple content model group example.",
-    icon: "fas/star"
-} as CmsGroup;
+export const createContentModelGroup = (): CmsGroup => {
+    return {
+        id: "5e7c96c46adcbe0007268295",
+        name: "A sample content model group",
+        slug: "a-sample-content-model-group",
+        description: "This is a simple content model group example.",
+        icon: "fas/star"
+    };
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.noValidation.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.noValidation.ts
@@ -1,4 +1,4 @@
-import contentModelGroup from "./contentModelGroup";
+import { createContentModelGroup } from "./contentModelGroup";
 import { CmsModel } from "~/types";
 import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
 
@@ -8,6 +8,8 @@ const ids = {
     field11: generateAlphaNumericLowerCaseId(8),
     field12: generateAlphaNumericLowerCaseId(8)
 };
+
+const contentModelGroup = createContentModelGroup();
 
 const models: CmsModel[] = [
     {

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -1,7 +1,9 @@
-import contentModelGroup from "./contentModelGroup";
+import { createContentModelGroup } from "./contentModelGroup";
 import { CmsModel } from "~/types";
 
 const { version: webinyVersion } = require("@webiny/cli/package.json");
+
+const contentModelGroup = createContentModelGroup();
 
 export interface Fruit {
     id?: string;

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/models/images.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/models/images.ts
@@ -1,0 +1,48 @@
+import { CmsGroup, CmsModel } from "~tests/types";
+
+export const createImageModel = (group: Pick<CmsGroup, "id" | "name">): CmsModel => {
+    const model: CmsModel = {
+        name: "Images Model",
+        modelId: "imagesModel",
+        fields: [
+            {
+                id: "name",
+                fieldId: "name",
+                type: "text",
+                label: "Name",
+                storageId: ""
+            },
+            {
+                id: "images",
+                fieldId: "images",
+                type: "object",
+                label: "Images",
+                storageId: "",
+                multipleValues: true,
+                settings: {
+                    fields: [
+                        {
+                            id: "imagesImage",
+                            fieldId: "image",
+                            type: "file",
+                            storageId: "",
+                            label: "Image"
+                        }
+                    ],
+                    layout: [["zrwlqm4x"]]
+                }
+            }
+        ],
+        layout: [],
+        titleFieldId: "name",
+        group: {
+            id: group.id,
+            name: group.name
+        },
+        description: "Images Model Description"
+    };
+
+    model.layout = model.fields.map(field => [field.id]);
+
+    return model;
+};

--- a/packages/api-headless-cms/__tests__/types.ts
+++ b/packages/api-headless-cms/__tests__/types.ts
@@ -1,4 +1,4 @@
-import { CmsModel as BaseCmsModel } from "~/types";
+import { CmsGroup as BaseCmsGroup, CmsModel as BaseCmsModel } from "~/types";
 import { useCategoryManageHandler } from "./testHelpers/useCategoryManageHandler";
 import { useProductManageHandler } from "./testHelpers/useProductManageHandler";
 
@@ -13,6 +13,7 @@ export type CmsModel = Omit<
     | "savedOn"
     | "isPrivate"
 >;
+export type CmsGroup = Omit<BaseCmsGroup, "tenant" | "locale" | "webinyVersion">;
 /**
  * Managers / Readers
  */

--- a/packages/api-headless-cms/src/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/graphqlFields/object.ts
@@ -51,7 +51,7 @@ const createChildTypeDefs = (params: AttachTypeDefinitionsParams): string => {
         .filter(Boolean)
         .join("\n");
     return `input ${typeName}WhereInput {
-        ${filters}
+        ${filters || "_empty: String"}
     }`;
 };
 


### PR DESCRIPTION
## Changes
PR fixes an issue where GraphQL schema is broken if there is a single image field in the object field.
The issue started to happen after the introduction of the nested field filtering.

The fix is actually to add an `_empty` field into the nested where condition. In future, we might add some kind of filtering on the file field.

## How Has This Been Tested?
Jest and manually.