### PR TITLE
fix(api-headless-cms): allow custom entry id

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
@@ -5,6 +5,19 @@
 import { setupContentModelGroup, setupContentModels } from "~tests/testHelpers/setup";
 import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler";
 import { useCategoryReadHandler } from "~tests/testHelpers/useCategoryReadHandler";
+interface Category {
+    id: string;
+    title: string;
+    slug: string;
+}
+const createCategory = (input?: Partial<Category>): Category => {
+    return {
+        id: "61b48412-d616-4f36-babd-4c6a67d7bd03",
+        title: "Category with defined ID",
+        slug: "category-with-defined-id",
+        ...input
+    };
+};
 
 describe("Content entry with user defined ID", () => {
     const handler = useCategoryManageHandler({
@@ -20,11 +33,7 @@ describe("Content entry with user defined ID", () => {
     });
 
     it("should create, update, publish, unpublish and delete an entry with the given user defined ID", async () => {
-        const category = {
-            id: "61b48412-d616-4f36-babd-4c6a67d7bd03",
-            title: "Category with defined ID",
-            slug: "category-with-defined-id"
-        };
+        const category = createCategory();
 
         /**
          * Create entry and check that it really is created.
@@ -342,4 +351,78 @@ describe("Content entry with user defined ID", () => {
             }
         });
     });
+
+    const malformedIds: [string][] = [
+        ["-malformed-id"],
+        ["malformed-id-"],
+        ["-malformed-id-"],
+        ["malformed-id-č"],
+        ["malformed-id-ć"],
+        ["malformed-id-š"],
+        ["malformed-id-đ"],
+        ["malformed-id-ž"],
+        ["malformed-id-Č"],
+        ["malformed-id-Ć"],
+        ["malformed-id-Š"],
+        ["malformed-id-Đ"],
+        ["malformed-id-Ž"],
+        ["malformed-id-!"],
+        ["malformed-id-@"],
+        ["malformed-id-#"],
+        ["malformed-id-$"],
+        ["malformed-id-%"],
+        ["malformed-id-^"],
+        ["malformed-id-&"],
+        ["malformed-id-*"],
+        ["malformed-id-("],
+        ["malformed-id-)"],
+        ["malformed-id-+"],
+        ["malformed-id-="],
+        ["malformed-id-{"],
+        ["malformed-id-}"],
+        ["malformed-id-["],
+        ["malformed-id-]"],
+        ["malformed-id-:"],
+        ["malformed-id-;"],
+        ["malformed-id-<"],
+        ["malformed-id->"],
+        ["malformed-id-,"],
+        ["malformed-id-."],
+        ["malformed-id-?"],
+        ["malformed-id-|"],
+        ["malformed-id-`"],
+        ["malformed-id-~"],
+        ["malformed-id- "],
+        ["malfo rmed id"]
+    ];
+
+    it.each(malformedIds)(
+        "should not allow to create an entry with malformed ID - %s",
+        async id => {
+            const category = createCategory({
+                id
+            });
+
+            const [response] = await handler.createCategory({
+                data: {
+                    ...category
+                }
+            });
+            expect(response).toEqual({
+                data: {
+                    createCategory: {
+                        data: null,
+                        error: {
+                            code: "INVALID_ID",
+                            data: {
+                                id
+                            },
+                            message:
+                                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9, - and it cannot start or end with a -."
+                        }
+                    }
+                }
+            });
+        }
+    );
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
@@ -5,6 +5,7 @@
 import { setupContentModelGroup, setupContentModels } from "~tests/testHelpers/setup";
 import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler";
 import { useCategoryReadHandler } from "~tests/testHelpers/useCategoryReadHandler";
+import { useProductManageHandler } from "~tests/testHelpers/useProductManageHandler";
 interface Category {
     id: string;
     title: string;
@@ -20,16 +21,19 @@ const createCategory = (input?: Partial<Category>): Category => {
 };
 
 describe("Content entry with user defined ID", () => {
-    const handler = useCategoryManageHandler({
+    const categoryManageHandler = useCategoryManageHandler({
         path: "manage/en-US"
     });
-    const readHandler = useCategoryReadHandler({
+    const productManageHandler = useProductManageHandler({
+        path: "manage/en-US"
+    });
+    const categoryReadHandler = useCategoryReadHandler({
         path: "read/en-US"
     });
 
     beforeEach(async () => {
-        const group = await setupContentModelGroup(handler);
-        await setupContentModels(handler, group, ["category"]);
+        const group = await setupContentModelGroup(categoryManageHandler);
+        await setupContentModels(categoryManageHandler, group, ["category", "product"]);
     });
 
     it("should create, update, publish, unpublish and delete an entry with the given user defined ID", async () => {
@@ -38,7 +42,7 @@ describe("Content entry with user defined ID", () => {
         /**
          * Create entry and check that it really is created.
          */
-        const [createResponse] = await handler.createCategory({
+        const [createResponse] = await categoryManageHandler.createCategory({
             data: category
         });
 
@@ -56,9 +60,9 @@ describe("Content entry with user defined ID", () => {
             }
         });
 
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return handler.listCategories().then(([data]) => data);
+                return categoryManageHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 const entry = data.listCategories.data[0];
@@ -69,7 +73,7 @@ describe("Content entry with user defined ID", () => {
             }
         );
 
-        const [getAfterCreateResponse] = await handler.getCategory({
+        const [getAfterCreateResponse] = await categoryManageHandler.getCategory({
             revision: id
         });
         expect(getAfterCreateResponse).toMatchObject({
@@ -93,7 +97,7 @@ describe("Content entry with user defined ID", () => {
          * Update entry and check that it really is updated.
          */
         const updatedTitle = "Updated category with defined ID";
-        const [updateResponse] = await handler.updateCategory({
+        const [updateResponse] = await categoryManageHandler.updateCategory({
             revision: id,
             data: {
                 title: updatedTitle,
@@ -118,9 +122,9 @@ describe("Content entry with user defined ID", () => {
             }
         });
 
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return handler.listCategories().then(([data]) => data);
+                return categoryManageHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 const entry = data.listCategories.data[0];
@@ -134,7 +138,7 @@ describe("Content entry with user defined ID", () => {
             }
         );
 
-        const [getAfterUpdateResponse] = await handler.getCategory({
+        const [getAfterUpdateResponse] = await categoryManageHandler.getCategory({
             revision: id
         });
         expect(getAfterUpdateResponse).toMatchObject({
@@ -158,7 +162,7 @@ describe("Content entry with user defined ID", () => {
         /**
          * Publish entry and check that it really is published.
          */
-        const [publishResponse] = await handler.publishCategory({
+        const [publishResponse] = await categoryManageHandler.publishCategory({
             revision: id
         });
         expect(publishResponse).toMatchObject({
@@ -179,9 +183,9 @@ describe("Content entry with user defined ID", () => {
             }
         });
 
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return handler.listCategories().then(([data]) => data);
+                return categoryManageHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 const entry = data.listCategories.data[0];
@@ -196,9 +200,9 @@ describe("Content entry with user defined ID", () => {
                 name: "list categories after published"
             }
         );
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return readHandler.listCategories().then(([data]) => data);
+                return categoryReadHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 const entry = data.listCategories.data[0];
@@ -212,7 +216,7 @@ describe("Content entry with user defined ID", () => {
             }
         );
 
-        const [getAfterPublishResponse] = await handler.getCategory({
+        const [getAfterPublishResponse] = await categoryManageHandler.getCategory({
             revision: id
         });
         expect(getAfterPublishResponse).toMatchObject({
@@ -235,7 +239,7 @@ describe("Content entry with user defined ID", () => {
         /**
          * After publishing, we should not be able to update the entry.
          */
-        const [updateAfterPublishResponse] = await handler.updateCategory({
+        const [updateAfterPublishResponse] = await categoryManageHandler.updateCategory({
             revision: id,
             data: {
                 title: "This should not work",
@@ -258,7 +262,7 @@ describe("Content entry with user defined ID", () => {
         /**
          * Unpublish the entry and check that it really is unpublished.
          */
-        const [unpublishResponse] = await handler.unpublishCategory({
+        const [unpublishResponse] = await categoryManageHandler.unpublishCategory({
             revision: id
         });
         expect(unpublishResponse).toMatchObject({
@@ -279,9 +283,9 @@ describe("Content entry with user defined ID", () => {
             }
         });
 
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return handler.listCategories().then(([data]) => data);
+                return categoryManageHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 const entry = data.listCategories.data[0];
@@ -296,9 +300,9 @@ describe("Content entry with user defined ID", () => {
                 name: "list categories after unpublished"
             }
         );
-        await handler.until(
+        await categoryManageHandler.until(
             () => {
-                return readHandler.listCategories().then(([data]) => data);
+                return categoryReadHandler.listCategories().then(([data]) => data);
             },
             ({ data }) => {
                 return data.listCategories.data.length === 0;
@@ -308,7 +312,7 @@ describe("Content entry with user defined ID", () => {
             }
         );
 
-        const [getAfterUnpublishResponse] = await handler.getCategory({
+        const [getAfterUnpublishResponse] = await categoryManageHandler.getCategory({
             revision: id
         });
         expect(getAfterUnpublishResponse).toMatchObject({
@@ -331,7 +335,7 @@ describe("Content entry with user defined ID", () => {
         /**
          * After unpublishing, we should not be able to update the entry.
          */
-        const [updateAfterUnpublishResponse] = await handler.updateCategory({
+        const [updateAfterUnpublishResponse] = await categoryManageHandler.updateCategory({
             revision: id,
             data: {
                 title: "This should not work",
@@ -403,7 +407,7 @@ describe("Content entry with user defined ID", () => {
                 id
             });
 
-            const [response] = await handler.createCategory({
+            const [response] = await categoryManageHandler.createCategory({
                 data: {
                     ...category
                 }
@@ -425,4 +429,87 @@ describe("Content entry with user defined ID", () => {
             });
         }
     );
+
+    it("should allow an entry with custom ID to be referenced in a new entry", async () => {
+        const category = createCategory();
+        await categoryManageHandler.createCategory({
+            data: {
+                ...category
+            }
+        });
+        const id = `${category.id}#0001`;
+        await categoryManageHandler.until(
+            () => {
+                return categoryManageHandler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                return entry.id === id;
+            },
+            {
+                name: "list categories after create"
+            }
+        );
+        const productCategory = {
+            id,
+            modelId: "category"
+        };
+        const product = {
+            title: "Server",
+            price: 37591,
+            inStock: false,
+            availableOn: "2021-01-01",
+            color: "red",
+            availableSizes: ["l", "m", "s"],
+            image: "server.jpg",
+            category: productCategory,
+            variant: {
+                category: productCategory,
+                options: [
+                    {
+                        category: productCategory,
+                        categories: [productCategory]
+                    }
+                ]
+            }
+        };
+        const [createProductResponse] = await productManageHandler.createProduct({
+            data: product
+        });
+        expect(createProductResponse).toMatchObject({
+            data: {
+                createProduct: {
+                    data: {
+                        ...product,
+                        category: {
+                            ...product.category,
+                            entryId: category.id
+                        },
+                        variant: {
+                            category: {
+                                ...product.category,
+                                entryId: category.id
+                            },
+                            options: [
+                                {
+                                    category: {
+                                        ...product.category,
+                                        entryId: category.id
+                                    },
+                                    categories: [
+                                        {
+                                            ...product.category,
+                                            entryId: category.id
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        id: expect.stringMatching(/^([a-zA-Z0-9]+)#0001$/)
+                    },
+                    error: null
+                }
+            }
+        });
+    });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
@@ -1,0 +1,345 @@
+/**
+ * This test determines that a user can send a custom ID when creating a content entry.
+ * The rest of functionality and limitations remain the same.
+ */
+import { setupContentModelGroup, setupContentModels } from "~tests/testHelpers/setup";
+import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler";
+import { useCategoryReadHandler } from "~tests/testHelpers/useCategoryReadHandler";
+
+describe("Content entry with user defined ID", () => {
+    const handler = useCategoryManageHandler({
+        path: "manage/en-US"
+    });
+    const readHandler = useCategoryReadHandler({
+        path: "read/en-US"
+    });
+
+    beforeEach(async () => {
+        const group = await setupContentModelGroup(handler);
+        await setupContentModels(handler, group, ["category"]);
+    });
+
+    it("should create, update, publish, unpublish and delete an entry with the given user defined ID", async () => {
+        const category = {
+            id: "61b48412-d616-4f36-babd-4c6a67d7bd03",
+            title: "Category with defined ID",
+            slug: "category-with-defined-id"
+        };
+
+        /**
+         * Create entry and check that it really is created.
+         */
+        const [createResponse] = await handler.createCategory({
+            data: category
+        });
+
+        const id = `${category.id}#0001`;
+        expect(createResponse).toMatchObject({
+            data: {
+                createCategory: {
+                    data: {
+                        ...category,
+                        entryId: category.id,
+                        id
+                    },
+                    error: null
+                }
+            }
+        });
+
+        await handler.until(
+            () => {
+                return handler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                return entry.id === id;
+            },
+            {
+                name: "list categories after create"
+            }
+        );
+
+        const [getAfterCreateResponse] = await handler.getCategory({
+            revision: id
+        });
+        expect(getAfterCreateResponse).toMatchObject({
+            data: {
+                getCategory: {
+                    data: {
+                        ...category,
+                        entryId: category.id,
+                        id,
+                        meta: {
+                            version: 1,
+                            status: "draft"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        /**
+         * Update entry and check that it really is updated.
+         */
+        const updatedTitle = "Updated category with defined ID";
+        const [updateResponse] = await handler.updateCategory({
+            revision: id,
+            data: {
+                title: updatedTitle,
+                slug: category.slug
+            }
+        });
+        expect(updateResponse).toMatchObject({
+            data: {
+                updateCategory: {
+                    data: {
+                        ...category,
+                        entryId: category.id,
+                        id,
+                        title: updatedTitle,
+                        meta: {
+                            version: 1,
+                            status: "draft"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        await handler.until(
+            () => {
+                return handler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                if (entry.title !== updatedTitle) {
+                    return false;
+                }
+                return entry.id === id;
+            },
+            {
+                name: "list categories after update"
+            }
+        );
+
+        const [getAfterUpdateResponse] = await handler.getCategory({
+            revision: id
+        });
+        expect(getAfterUpdateResponse).toMatchObject({
+            data: {
+                getCategory: {
+                    data: {
+                        ...category,
+                        title: updatedTitle,
+                        entryId: category.id,
+                        id,
+                        meta: {
+                            version: 1,
+                            status: "draft"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        /**
+         * Publish entry and check that it really is published.
+         */
+        const [publishResponse] = await handler.publishCategory({
+            revision: id
+        });
+        expect(publishResponse).toMatchObject({
+            data: {
+                publishCategory: {
+                    data: {
+                        ...category,
+                        title: updatedTitle,
+                        id,
+                        entryId: category.id,
+                        meta: {
+                            version: 1,
+                            status: "published"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        await handler.until(
+            () => {
+                return handler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                if (entry.title !== updatedTitle) {
+                    return false;
+                } else if (entry.meta.status !== "published") {
+                    return false;
+                }
+                return entry.id === id;
+            },
+            {
+                name: "list categories after published"
+            }
+        );
+        await handler.until(
+            () => {
+                return readHandler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                if (entry.title !== updatedTitle) {
+                    return false;
+                }
+                return entry.id === id;
+            },
+            {
+                name: "[READ] list categories after published"
+            }
+        );
+
+        const [getAfterPublishResponse] = await handler.getCategory({
+            revision: id
+        });
+        expect(getAfterPublishResponse).toMatchObject({
+            data: {
+                getCategory: {
+                    data: {
+                        ...category,
+                        title: updatedTitle,
+                        entryId: category.id,
+                        id,
+                        meta: {
+                            version: 1,
+                            status: "published"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+        /**
+         * After publishing, we should not be able to update the entry.
+         */
+        const [updateAfterPublishResponse] = await handler.updateCategory({
+            revision: id,
+            data: {
+                title: "This should not work",
+                slug: "this-should-not-work"
+            }
+        });
+        expect(updateAfterPublishResponse).toEqual({
+            data: {
+                updateCategory: {
+                    data: null,
+                    error: {
+                        code: "CONTENT_ENTRY_UPDATE_ERROR",
+                        message: "Cannot update entry because it's locked.",
+                        data: null
+                    }
+                }
+            }
+        });
+
+        /**
+         * Unpublish the entry and check that it really is unpublished.
+         */
+        const [unpublishResponse] = await handler.unpublishCategory({
+            revision: id
+        });
+        expect(unpublishResponse).toMatchObject({
+            data: {
+                unpublishCategory: {
+                    data: {
+                        ...category,
+                        title: updatedTitle,
+                        id,
+                        entryId: category.id,
+                        meta: {
+                            version: 1,
+                            status: "unpublished"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        await handler.until(
+            () => {
+                return handler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                const entry = data.listCategories.data[0];
+                if (entry.title !== updatedTitle) {
+                    return false;
+                } else if (entry.meta.status !== "unpublished") {
+                    return false;
+                }
+                return entry.id === id;
+            },
+            {
+                name: "list categories after unpublished"
+            }
+        );
+        await handler.until(
+            () => {
+                return readHandler.listCategories().then(([data]) => data);
+            },
+            ({ data }) => {
+                return data.listCategories.data.length === 0;
+            },
+            {
+                name: "[READ] list categories after unpublished"
+            }
+        );
+
+        const [getAfterUnpublishResponse] = await handler.getCategory({
+            revision: id
+        });
+        expect(getAfterUnpublishResponse).toMatchObject({
+            data: {
+                getCategory: {
+                    data: {
+                        ...category,
+                        title: updatedTitle,
+                        entryId: category.id,
+                        id,
+                        meta: {
+                            version: 1,
+                            status: "unpublished"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+        /**
+         * After unpublishing, we should not be able to update the entry.
+         */
+        const [updateAfterUnpublishResponse] = await handler.updateCategory({
+            revision: id,
+            data: {
+                title: "This should not work",
+                slug: "this-should-not-work"
+            }
+        });
+        expect(updateAfterUnpublishResponse).toEqual({
+            data: {
+                updateCategory: {
+                    data: null,
+                    error: {
+                        code: "CONTENT_ENTRY_UPDATE_ERROR",
+                        message: "Cannot update entry because it's locked.",
+                        data: null
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -30,6 +30,7 @@ export default /* GraphQL */ `
     }
 
     input CategoryInput {
+        id: ID
         title: String!
         slug: String!
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -203,6 +203,7 @@ export default /* GraphQL */ `
     }
 
     input PageInput {
+        id: ID
         content: [Page_ContentInput]
         header: Page_HeaderInput
         objective: Page_ObjectiveInput

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -140,6 +140,7 @@ export default /* GraphQL */ `
 
 
     input ProductInput {
+        id: ID
         title: String!
         category: RefFieldInput!
         price: Number!

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -32,6 +32,7 @@ export default /* GraphQL */ `
     }
 
     input ReviewInput {
+        id: ID
         text: String!
         product: RefFieldInput
         rating: Number

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -203,7 +203,7 @@ const createEntryId = (input: CreateCmsEntryInput): EntryIdResult => {
     if (input.id) {
         if (input.id.match(/^([a-zA-Z0-9])([a-zA-Z0-9\-]+)([a-zA-Z0-9])$/) === null) {
             throw new WebinyError(
-                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9 and -. It cannot start or end with a -.",
+                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9, - and it cannot start or end with a -.",
                 "INVALID_ID",
                 {
                     id: input.id

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -198,10 +198,23 @@ interface EntryIdResult {
     id: string;
 }
 
-const createEntryId = (version: number): EntryIdResult => {
-    const entryId = mdbid();
+const createEntryId = (input: CreateCmsEntryInput): EntryIdResult => {
+    let entryId = mdbid();
+    if (input.id) {
+        if (input.id.match(/^([a-zA-Z0-9])([a-zA-Z0-9\-]+)([a-zA-Z0-9])$/) === null) {
+            throw new WebinyError(
+                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9 and -. It cannot start or end with a -.",
+                "INVALID_ID",
+                {
+                    id: input.id
+                }
+            );
+        }
+        entryId = input.id;
+    }
+    const version = 1;
     return {
-        entryId,
+        entryId: entryId,
         version,
         id: createIdentifier({
             id: entryId,
@@ -730,8 +743,11 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 displayName: identity.displayName,
                 type: identity.type
             };
-
-            const { id, entryId, version } = createEntryId(1);
+            /**
+             * There is a possibility that user sends an ID in the input, so we will use that one.
+             * There is no check if the ID is unique or not, that is up to the user.
+             */
+            const { id, entryId, version } = createEntryId(inputData);
 
             const entry: CmsEntry = {
                 webinyVersion: context.WEBINY_VERSION,

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -84,6 +84,7 @@ export const createManageSDL: CreateManageSDL = ({
         ${
             inputFields &&
             `input ${mTypeName}Input {
+                id: ID
             ${inputFields.map(f => f.fields).join("\n")}
         }`
         }

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2040,6 +2040,7 @@ export interface EntryBeforeListTopicParams {
  * @category CmsEntry
  */
 export interface CreateCmsEntryInput {
+    id?: string;
     [key: string]: any;
 }
 


### PR DESCRIPTION
## Changes
This PR adds the possibility for user to define custom entry ID when creating a new entry.
Entry ID must be in form of `a-zA-Z0-9` and dash (`-`). Dash (-) cannot be first or last character in the ID.

It is up to user to make sure that they are giving unique IDs.

## How Has This Been Tested?
Jest and manually.