### PR TITLE
fix(api-headless-cms): no error response on exception

### DIFF
--- a/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
@@ -1,4 +1,4 @@
-import { Response } from "@webiny/handler-graphql";
+import { ErrorResponse, Response } from "@webiny/handler-graphql";
 import { CmsEntry, CmsContext, CmsModel, CmsEntryListWhere } from "~/types";
 import { NotAuthorizedResponse } from "@webiny/api-security";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins/GraphQLSchemaPlugin";
@@ -70,7 +70,9 @@ const getContentEntriesMethods = {
     published: "getPublishedEntriesByIds",
     exact: "getEntriesByIds"
 };
-const getContentEntries = async (params: GetContentEntriesParams): Promise<Response> => {
+const getContentEntries = async (
+    params: GetContentEntriesParams
+): Promise<Response | ErrorResponse> => {
     const { args, context, type } = params;
 
     const method = getFetchMethod(type, context);
@@ -102,30 +104,34 @@ const getContentEntries = async (params: GetContentEntriesParams): Promise<Respo
         return new Response([]);
     }
 
-    const results = await Promise.all(getters);
+    try {
+        const results = await Promise.all(getters);
 
-    const entries = results
-        .reduce((collection, items) => {
-            return collection.concat(
-                items.map(item => {
-                    const model = modelsMap[item.modelId];
+        const entries = results
+            .reduce((collection, items) => {
+                return collection.concat(
+                    items.map(item => {
+                        const model = modelsMap[item.modelId];
 
-                    return {
-                        id: item.id,
-                        entryId: item.entryId,
-                        model: {
-                            modelId: model.modelId,
-                            name: model.name
-                        },
-                        status: item.status,
-                        title: getEntryTitle(model, item)
-                    };
-                })
-            );
-        }, [] as CmsEntryRecord[])
-        .filter(Boolean);
+                        return {
+                            id: item.id,
+                            entryId: item.entryId,
+                            model: {
+                                modelId: model.modelId,
+                                name: model.name
+                            },
+                            status: item.status,
+                            title: getEntryTitle(model, item)
+                        };
+                    })
+                );
+            }, [] as CmsEntryRecord[])
+            .filter(Boolean);
 
-    return new Response(entries);
+        return new Response(entries);
+    } catch (ex) {
+        return new ErrorResponse(ex);
+    }
 };
 
 /**
@@ -320,15 +326,19 @@ export const createContentEntriesSchema = ({
                             });
                         });
 
-                    const entries = await Promise.all(getters).then(results =>
-                        results.reduce((result, item) => result.concat(item), [])
-                    );
+                    try {
+                        const entries = await Promise.all(getters).then(results =>
+                            results.reduce((result, item) => result.concat(item), [])
+                        );
 
-                    return new Response(
-                        entries
-                            .sort((a, b) => Date.parse(b.savedOn) - Date.parse(a.savedOn))
-                            .slice(0, limit)
-                    );
+                        return new Response(
+                            entries
+                                .sort((a, b) => Date.parse(b.savedOn) - Date.parse(a.savedOn))
+                                .slice(0, limit)
+                        );
+                    } catch (ex) {
+                        return new ErrorResponse(ex);
+                    }
                 },
                 async getContentEntry(_, args: any, context) {
                     return getContentEntry({


### PR DESCRIPTION
## Changes
When exception happens in the searchContentEntries query, there is no error response as we did not catch and output the error.

## How Has This Been Tested?
Jest and manually.