### PR TITLE
fix(api-headless-cms): model description validation

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -959,4 +959,94 @@ describe("content model test", () => {
         });
         expect(response.data.getContentModel.error).toEqual(null);
     });
+
+    it("should allow to update a model with description set to null", async () => {
+        const { createContentModelMutation, updateContentModelMutation } =
+            useGraphQLHandler(manageHandlerOpts);
+
+        const model = {
+            name: `Test Content model instance`,
+            modelId: `testContentModel`
+        };
+        const [createResponse] = await createContentModelMutation({
+            data: {
+                ...model,
+                group: contentModelGroup.id
+            }
+        });
+        expect(createResponse).toMatchObject({
+            data: {
+                createContentModel: {
+                    data: {
+                        ...model,
+                        description: ""
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [updateNoDescriptionResponse] = await updateContentModelMutation({
+            modelId: model.modelId,
+            data: {
+                name: "Updated",
+                fields: [],
+                layout: []
+            }
+        });
+        expect(updateNoDescriptionResponse).toMatchObject({
+            data: {
+                updateContentModel: {
+                    data: {
+                        name: "Updated",
+                        modelId: model.modelId,
+                        description: null
+                    },
+                    error: null
+                }
+            }
+        });
+        const [updateNullDescriptionResponse] = await updateContentModelMutation({
+            modelId: model.modelId,
+            data: {
+                name: "Updated",
+                fields: [],
+                layout: [],
+                description: null
+            }
+        });
+        expect(updateNullDescriptionResponse).toMatchObject({
+            data: {
+                updateContentModel: {
+                    data: {
+                        name: "Updated",
+                        modelId: model.modelId,
+                        description: null
+                    },
+                    error: null
+                }
+            }
+        });
+        const [updateEmptyDescriptionResponse] = await updateContentModelMutation({
+            modelId: model.modelId,
+            data: {
+                name: "Updated",
+                fields: [],
+                layout: [],
+                description: ""
+            }
+        });
+        expect(updateEmptyDescriptionResponse).toMatchObject({
+            data: {
+                updateContentModel: {
+                    data: {
+                        name: "Updated",
+                        modelId: model.modelId,
+                        description: null
+                    },
+                    error: null
+                }
+            }
+        });
+    });
 });

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -568,6 +568,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 ...original,
                 ...data,
                 group,
+                description: data.description || original.description,
                 tenant: original.tenant || getTenant().id,
                 locale: original.locale || getLocale().code,
                 webinyVersion: context.WEBINY_VERSION,

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -101,7 +101,7 @@ export const createModelCreateValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        description: optionalShortString,
+        description: optionalShortString.nullish(),
         group: shortString,
         fields: zod.array(fieldSchema).default([]),
         layout: zod.array(zod.array(shortString)).default([]),
@@ -114,7 +114,7 @@ export const createModelCreateFromValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        description: optionalShortString,
+        description: optionalShortString.nullish(),
         group: shortString,
         locale: optionalShortString
     });
@@ -123,7 +123,7 @@ export const createModelCreateFromValidation = () => {
 export const createModelUpdateValidation = () => {
     return zod.object({
         name: optionalShortString,
-        description: optionalShortString,
+        description: optionalShortString.nullish(),
         group: optionalShortString,
         fields: zod.array(fieldSchema),
         layout: zod.array(zod.array(shortString)),

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1221,7 +1221,7 @@ export interface CmsModelCreateInput {
     /**
      * Description of the content model.
      */
-    description?: string;
+    description?: string | null;
     /**
      * Group where to put the content model in.
      */
@@ -1348,7 +1348,7 @@ export interface CmsModelUpdateInput {
     /**
      * A new description of the content model.
      */
-    description?: string;
+    description?: string | null;
     /**
      * A list of content model fields to define the entry values.
      */


### PR DESCRIPTION
## Changes
This is a fix for faulty model description validation.
We allow nullish values to be sent in the description in create, createFrom and update model GraphQL mutations and the validation must allow that as well.

## How Has This Been Tested?
Jest and manually.