### PR TITLE
fix(api-headless-cms): full text search

### DIFF
--- a/packages/api-elasticsearch/__tests__/normalize.ts
+++ b/packages/api-elasticsearch/__tests__/normalize.ts
@@ -2,14 +2,14 @@ import { normalizeValue } from "~/normalize";
 
 describe(`GraphQL "contains" operator - query normalization`, () => {
     test("must properly escape ES reserved characters", async () => {
-        expect(normalizeValue("Sembach Germany")).toBe("*Sembach Germany*");
-        expect(normalizeValue("Sembach\\Germany")).toBe("*Sembach Germany*");
+        expect(normalizeValue("Sembach Germany")).toBe("Sembach Germany");
+        expect(normalizeValue("Sembach\\Germany")).toBe("Sembach Germany");
         expect(normalizeValue("AE0003 - VFW Post 12139 Donnersberg, Sembach-Germany")).toBe(
-            "*AE0003   VFW Post 12139 Donnersberg, Sembach Germany*"
+            "AE0003   VFW Post 12139 Donnersberg, Sembach Germany"
         );
 
         expect(normalizeValue('+ 1 - = && || > < ! ( A ) { } [ ] ^ " ~ * ? : \\ 2 /')).toBe(
-            "*  1                 A                         2  *"
+            "  1                 A                         2"
         );
     });
 });

--- a/packages/api-elasticsearch/__tests__/search/japanese.test.ts
+++ b/packages/api-elasticsearch/__tests__/search/japanese.test.ts
@@ -27,7 +27,7 @@ describe("Japanese search", () => {
                     index: indexName
                 });
             }
-            console.log(`Creating index "${indexName}" @${new Date().getTime()}: ${indexName}`);
+            // console.log(`Creating index "${indexName}" @${new Date().getTime()}: ${indexName}`);
             const result = await client.indices.create({
                 index: indexName,
                 body: japaneseIndexConfiguration
@@ -75,13 +75,13 @@ describe("Japanese search", () => {
     };
 
     const refreshIndex = async () => {
-        console.log(`Refreshing index ${indexName} @${new Date().getTime()}`);
+        // console.log(`Refreshing index ${indexName} @${new Date().getTime()}`);
         return await client.indices.refresh({
             index: indexName
         });
     };
     const fetchAllData = async () => {
-        console.log(`Fetching all data from index ${indexName} @${new Date().getTime()}`);
+        // console.log(`Fetching all data from index ${indexName} @${new Date().getTime()}`);
         return await clientSearch({
             index: indexName,
             body: {
@@ -122,7 +122,7 @@ describe("Japanese search", () => {
     };
 
     const clientSearch = async (request: RequestParams.Search) => {
-        console.log(`Searching index "${indexName}" @${new Date().getTime()}`);
+        // console.log(`Searching index "${indexName}" @${new Date().getTime()}`);
         try {
             return await client.search(request);
         } catch (ex) {

--- a/packages/api-elasticsearch/src/normalize.ts
+++ b/packages/api-elasticsearch/src/normalize.ts
@@ -41,5 +41,5 @@ export const normalizeValue = (value: string) => {
         result = result.replace(new RegExp(character, "g"), `\\${character}`);
     }
 
-    return result ? `*${result}*` : "";
+    return result || "";
 };

--- a/packages/api-elasticsearch/src/plugins/operator/contains.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/contains.ts
@@ -18,7 +18,7 @@ export class ElasticsearchQueryBuilderOperatorContainsPlugin extends Elasticsear
             query_string: {
                 allow_leading_wildcard: true,
                 fields: [basePath],
-                query: normalizeValue(value),
+                query: `*${normalizeValue(value)}*`,
                 default_operator: "and"
             }
         });

--- a/packages/api-elasticsearch/src/plugins/operator/japanese/contains.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/japanese/contains.ts
@@ -25,14 +25,14 @@ export class ElasticsearchQueryBuilderJapaneseOperatorContainsPlugin extends Ela
         const value = normalizeValue(initialValue);
         query.must.push({
             multi_match: {
-                query: value,
+                query: `*${value}*`,
                 type: "phrase",
                 fields: [`${basePath}.ngram`]
             }
         });
         query.should.push({
             multi_match: {
-                query: value,
+                query: `*${value}*`,
                 type: "phrase",
                 fields: [`${basePath}`]
             }

--- a/packages/api-elasticsearch/src/plugins/operator/notContains.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/notContains.ts
@@ -18,7 +18,7 @@ export class ElasticsearchQueryBuilderOperatorNotContainsPlugin extends Elastics
             query_string: {
                 allow_leading_wildcard: true,
                 fields: [basePath],
-                query: normalizeValue(value),
+                query: `*${normalizeValue(value)}*`,
                 default_operator: "and"
             }
         });

--- a/packages/api-file-manager-ddb-es/src/operations/files/body.ts
+++ b/packages/api-file-manager-ddb-es/src/operations/files/body.ts
@@ -1,5 +1,5 @@
 import { FileManagerFilesStorageOperationsListParamsWhere } from "@webiny/api-file-manager/types";
-import { decodeCursor } from "@webiny/api-elasticsearch";
+import { decodeCursor, normalizeValue } from "@webiny/api-elasticsearch";
 import {
     ElasticsearchBoolQueryConfig,
     SearchBody as ElasticTsSearchBody
@@ -8,7 +8,6 @@ import {
     createLimit,
     createSort,
     applyWhere,
-    normalizeValue,
     getElasticsearchOperatorPluginsByLocale
 } from "@webiny/api-elasticsearch";
 import { FileElasticsearchFieldPlugin } from "~/plugins/FileElasticsearchFieldPlugin";
@@ -72,7 +71,7 @@ const createElasticsearchQuery = (
      * It produces something like "AND (name contains search value OR tags contains 'search words')"
      */
     if (where.search) {
-        const search = normalizeValue(where.search).replace(/^\*/, "").replace(/\*$/, "");
+        const search = normalizeValue(where.search);
 
         query.must.push({
             bool: {

--- a/packages/api-headless-cms-ddb-es/__tests__/filtering/contains.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/filtering/contains.test.ts
@@ -33,7 +33,7 @@ describe("contains filter", () => {
                     query_string: {
                         allow_leading_wildcard: true,
                         fields: ["values.title"],
-                        query: normalizeValue(title),
+                        query: `*${normalizeValue(title)}*`,
                         default_operator: "and"
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/__tests__/filtering/not_contains.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/filtering/not_contains.test.ts
@@ -36,7 +36,7 @@ describe("not_contains filter", () => {
                     query_string: {
                         allow_leading_wildcard: true,
                         fields: ["values.title"],
-                        query: normalizeValue(title),
+                        query: `*${normalizeValue(title)}*`,
                         default_operator: "and"
                     }
                 }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/body.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/body.ts
@@ -71,6 +71,8 @@ export const createElasticsearchBody = ({ plugins, model, params }: Params): Sea
      * Apply the full text search, if term is set.
      */
     applyFullTextSearch({
+        model,
+        plugins,
         query,
         term,
         fields: fullTextSearchFields

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
@@ -7,6 +7,9 @@ import {
     createCmsEntryElasticsearchFullTextSearchPlugin
 } from "~/plugins";
 
+/**
+ * Our default plugin is working with the AND operator for the multiple words query string.
+ */
 const defaultPlugin = createCmsEntryElasticsearchFullTextSearchPlugin({
     apply: params => {
         const { query, term, fields, createFieldPath } = params;
@@ -29,6 +32,9 @@ interface GetPluginParams {
 }
 const getPlugin = (params: GetPluginParams): CmsEntryElasticsearchFullTextSearchPlugin => {
     const { container, model } = params;
+    /**
+     * We need to reverse the plugins, so we can take the last one first - possibility to override existing plugins.
+     */
     const plugins = container
         .byType<CmsEntryElasticsearchFullTextSearchPlugin>(
             CmsEntryElasticsearchFullTextSearchPlugin.type
@@ -40,9 +46,19 @@ const getPlugin = (params: GetPluginParams): CmsEntryElasticsearchFullTextSearch
      */
     let plugin: CmsEntryElasticsearchFullTextSearchPlugin | null = null;
     for (const pl of plugins) {
-        if (pl.models.includes(model.modelId)) {
+        const models = pl.models || [];
+        /**
+         * We take the first available plugin for the given model.
+         */
+        if (models.includes(model.modelId)) {
             return pl;
-        } else if (!plugin) {
+        }
+        /**
+         * Then we set the first possible plugin, which has no models defined, as the default one.
+         * It is important not to set the plugin which has models defined as they are specifically for the targeted model.
+         */
+        //
+        else if (!plugin && models.length === 0) {
             plugin = pl;
         }
     }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
@@ -12,13 +12,13 @@ import {
  */
 const defaultPlugin = createCmsEntryElasticsearchFullTextSearchPlugin({
     apply: params => {
-        const { query, term, fields, createFieldPath } = params;
+        const { query, term, fields, createFieldPath, prepareTerm } = params;
 
         query.must.push({
             query_string: {
                 allow_leading_wildcard: true,
                 fields: fields.map(createFieldPath),
-                query: normalizeValue(term),
+                query: `*${prepareTerm(term)}*`,
                 default_operator: "and"
             }
         });
@@ -89,6 +89,7 @@ export const applyFullTextSearch = (params: Params): void => {
         createFieldPath: field => `values.${field.storageId}`,
         fields,
         query,
-        term
+        term,
+        prepareTerm: normalizeValue
     });
 };

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearch.ts
@@ -1,28 +1,78 @@
 import { ElasticsearchBoolQueryConfig } from "@webiny/api-elasticsearch/types";
 import { normalizeValue } from "@webiny/api-elasticsearch";
-import { CmsModelField } from "@webiny/api-headless-cms/types";
+import { CmsModel, CmsModelField } from "@webiny/api-headless-cms/types";
+import { PluginsContainer } from "@webiny/plugins";
+import {
+    CmsEntryElasticsearchFullTextSearchPlugin,
+    createCmsEntryElasticsearchFullTextSearchPlugin
+} from "~/plugins";
+
+const defaultPlugin = createCmsEntryElasticsearchFullTextSearchPlugin({
+    apply: params => {
+        const { query, term, fields, createFieldPath } = params;
+
+        query.must.push({
+            query_string: {
+                allow_leading_wildcard: true,
+                fields: fields.map(createFieldPath),
+                query: normalizeValue(term),
+                default_operator: "and"
+            }
+        });
+    }
+});
+defaultPlugin.name = "headless-cms.elasticsearch.entry.fullTextSearch.default";
+
+interface GetPluginParams {
+    container: PluginsContainer;
+    model: CmsModel;
+}
+const getPlugin = (params: GetPluginParams): CmsEntryElasticsearchFullTextSearchPlugin => {
+    const { container, model } = params;
+    const plugins = container
+        .byType<CmsEntryElasticsearchFullTextSearchPlugin>(
+            CmsEntryElasticsearchFullTextSearchPlugin.type
+        )
+        .reverse();
+    /**
+     * We need to find the most specific plugin for the given model.
+     * Also, we need to use the first possible plugin if the specific one is not found.
+     */
+    let plugin: CmsEntryElasticsearchFullTextSearchPlugin | null = null;
+    for (const pl of plugins) {
+        if (pl.models.includes(model.modelId)) {
+            return pl;
+        } else if (!plugin) {
+            plugin = pl;
+        }
+    }
+
+    return plugin || defaultPlugin;
+};
 
 interface Params {
+    plugins: PluginsContainer;
+    model: CmsModel;
     query: ElasticsearchBoolQueryConfig;
     term?: string;
     fields: CmsModelField[];
 }
 export const applyFullTextSearch = (params: Params): void => {
-    const { query, term, fields } = params;
+    const { plugins, query, term, fields, model } = params;
     if (!term || term.length === 0 || fields.length === 0) {
         return;
     }
 
-    const fieldPaths = fields.map(field => {
-        return `values.${field.storageId}`;
+    const plugin = getPlugin({
+        container: plugins,
+        model
     });
 
-    query.must.push({
-        query_string: {
-            allow_leading_wildcard: true,
-            fields: fieldPaths,
-            query: normalizeValue(term),
-            default_operator: "or"
-        }
+    plugin.apply({
+        model,
+        createFieldPath: field => `values.${field.storageId}`,
+        fields,
+        query,
+        term
     });
 };

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearchFields.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fullTextSearchFields.ts
@@ -1,16 +1,4 @@
-/* eslint-disable */
 import { CmsModel, CmsModelField } from "@webiny/api-headless-cms/types";
-
-const extractFields = (fields: CmsModelField[]): string[] => {
-    return fields.reduce<string[]>((collection, field) => {
-        if (field.settings?.fields) {
-            collection.push(...extractFields(field.settings.fields));
-        } else if (field) {
-        }
-
-        return collection;
-    }, []);
-};
 
 interface Params {
     model: CmsModel;
@@ -19,21 +7,15 @@ interface Params {
 }
 export const createFullTextSearchFields = (params: Params): CmsModelField[] => {
     const { term, model, fields } = params;
-    if (!fields || fields.length === 0 || !term || term.length === 0) {
+    if (!fields || fields.length === 0 || !term || term.trim().length === 0) {
         return [];
     }
-    const fullTextSearchFields: CmsModelField[] = [];
-    /**
-     * No point in going through fields if there is no search performed - no search term.
-     */
-    if (!!term) {
-        for (const fieldId of fields) {
-            const field = model.fields.find(f => f.fieldId === fieldId);
-            if (!field) {
-                continue;
-            }
-            fullTextSearchFields.push(field);
+    return fields.reduce<CmsModelField[]>((collection, fieldId) => {
+        const field = model.fields.find(f => f.fieldId === fieldId);
+        if (!field) {
+            return collection;
         }
-    }
-    return fullTextSearchFields;
+        collection.push(field);
+        return collection;
+    }, []);
 };

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
@@ -1,0 +1,40 @@
+import { Plugin } from "@webiny/plugins";
+import { ElasticsearchBoolQueryConfig } from "@webiny/api-elasticsearch/types";
+import { CmsModel, CmsModelField } from "@webiny/api-headless-cms/types";
+
+export interface CmsEntryElasticsearchFullTextSearchPluginCbParams {
+    model: CmsModel;
+    query: ElasticsearchBoolQueryConfig;
+    term: string;
+    fields: CmsModelField[];
+    createFieldPath: (field: CmsModelField) => string;
+}
+export interface CmsEntryElasticsearchFullTextSearchPluginParams {
+    models?: string[];
+    apply: (params: CmsEntryElasticsearchFullTextSearchPluginCbParams) => void;
+}
+export class CmsEntryElasticsearchFullTextSearchPlugin extends Plugin {
+    public static override readonly type: string =
+        "headless-cms.elasticsearch.entry.fullTextSearch";
+
+    private readonly params: CmsEntryElasticsearchFullTextSearchPluginParams;
+
+    public get models() {
+        return this.params.models || [];
+    }
+
+    public constructor(params: CmsEntryElasticsearchFullTextSearchPluginParams) {
+        super();
+        this.params = params;
+    }
+
+    public apply(params: CmsEntryElasticsearchFullTextSearchPluginCbParams): void {
+        return this.params.apply(params);
+    }
+}
+
+export const createCmsEntryElasticsearchFullTextSearchPlugin = (
+    params: CmsEntryElasticsearchFullTextSearchPluginParams
+) => {
+    return new CmsEntryElasticsearchFullTextSearchPlugin(params);
+};

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
@@ -8,6 +8,7 @@ export interface CmsEntryElasticsearchFullTextSearchPluginCbParams {
     term: string;
     fields: CmsModelField[];
     createFieldPath: (field: CmsModelField) => string;
+    prepareTerm: (term: string) => string;
 }
 export interface CmsEntryElasticsearchFullTextSearchPluginParams {
     models?: string[];

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchFullTextSearchPlugin.ts
@@ -20,7 +20,7 @@ export class CmsEntryElasticsearchFullTextSearchPlugin extends Plugin {
     private readonly params: CmsEntryElasticsearchFullTextSearchPluginParams;
 
     public get models() {
-        return this.params.models || [];
+        return this.params.models;
     }
 
     public constructor(params: CmsEntryElasticsearchFullTextSearchPluginParams) {

--- a/packages/api-headless-cms-ddb-es/src/plugins/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/index.ts
@@ -4,3 +4,4 @@ export * from "./CmsEntryElasticsearchIndexPlugin";
 export * from "./CmsEntryElasticsearchQueryBuilderValueSearchPlugin";
 export * from "./CmsEntryElasticsearchQueryModifierPlugin";
 export * from "./CmsEntryElasticsearchSortModifierPlugin";
+export * from "./CmsEntryElasticsearchFullTextSearchPlugin";


### PR DESCRIPTION
## Changes
PR fixes a full-text search where the value being search for has a dash in it (-). Problem was with the Elasticsearch systems as dash is not allowed, so we stripped it and results were wrong.
PR also adds the `CmsEntryElasticsearchFullTextSearchPlugin` so users can override our default one - per model basis if they want to.

## How Has This Been Tested?
Jest.

## Example
```typescript
import { createCmsEntryElasticsearchFullTextSearchPlugin } from "@webiny/api-headless-cms-ddb-es";

const plugin = createCmsEntryElasticsearchFullTextSearchPlugin({
    models: ["car"],
    apply: ({ model, query, term, fields, createFieldPath }) => {
        query.must.push({
            query_string: {
                allow_leading_wildcard: true,
                fields: fields.map(createFieldPath),
                query: `*${term.replace(/-/g, " ")}*`,
                default_operator: "or"
            }
        });
    }
});
```