### PR TITLE
Image Page Element - Further Optimize`srcset` Attribute

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -49,9 +49,33 @@ export const ImageRendererComponent: React.FC<ImageRendererComponentProps> = ({
         const { title } = element.data.image;
         const { src } = value || element.data?.image?.file;
 
-        const srcSet = SUPPORTED_IMAGE_RESIZE_WIDTHS.map(item => {
-            return `${src}?width=${item} ${item}w`;
-        }).join(", ");
+        let supportedImageResizeWidths: number[] = [];
+
+        // If an image width in pixels was set, let's filter
+        // out non-optimal image resize widths that are wider.
+        // We only use supported widths that are lower than the
+        // provided one, and the one above it.
+        const imageWidth = element.data.image.width;
+        if (imageWidth && imageWidth.endsWith("px")) {
+            const imageWidthInt = parseInt(imageWidth);
+            for (let i = 0; i < SUPPORTED_IMAGE_RESIZE_WIDTHS.length; i++) {
+                const resizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
+                if (imageWidthInt > resizeWidth) {
+                    supportedImageResizeWidths.push(resizeWidth);
+                } else {
+                    supportedImageResizeWidths.push(resizeWidth);
+                    break;
+                }
+            }
+        } else {
+            supportedImageResizeWidths = SUPPORTED_IMAGE_RESIZE_WIDTHS;
+        }
+
+        const srcSet = supportedImageResizeWidths
+            .map(item => {
+                return `${src}?width=${item} ${item}w`;
+            })
+            .join(", ");
 
         content = <PbImg alt={title} title={title} src={src} srcSet={srcSet} onClick={onClick} />;
     } else {

--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -49,29 +49,30 @@ export const ImageRendererComponent: React.FC<ImageRendererComponentProps> = ({
         const { title } = element.data.image;
         const { src } = value || element.data?.image?.file;
 
-        let supportedImageResizeWidths: number[] = [];
+        // If a fixed image width in pixels was set, let's filter out unneeded
+        // image resize widths. For example, if 155px was set as the fixed image
+        // width, then we want the `srcset` attribute to only contain 100w and 300w.
+        let srcSetWidths: number[] = [];
 
-        // If an image width in pixels was set, let's filter
-        // out non-optimal image resize widths that are wider.
-        // We only use supported widths that are lower than the
-        // provided one, and the one above it.
         const imageWidth = element.data.image.width;
         if (imageWidth && imageWidth.endsWith("px")) {
             const imageWidthInt = parseInt(imageWidth);
             for (let i = 0; i < SUPPORTED_IMAGE_RESIZE_WIDTHS.length; i++) {
                 const resizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
                 if (imageWidthInt > resizeWidth) {
-                    supportedImageResizeWidths.push(resizeWidth);
+                    srcSetWidths.push(resizeWidth);
                 } else {
-                    supportedImageResizeWidths.push(resizeWidth);
+                    srcSetWidths.push(resizeWidth);
                     break;
                 }
             }
         } else {
-            supportedImageResizeWidths = SUPPORTED_IMAGE_RESIZE_WIDTHS;
+            // If a fixed image width was not provided, we
+            // rely on all the supported image resize widths.
+            srcSetWidths = SUPPORTED_IMAGE_RESIZE_WIDTHS;
         }
 
-        const srcSet = supportedImageResizeWidths
+        const srcSet = srcSetWidths
             .map(item => {
                 return `${src}?width=${item} ${item}w`;
             })

--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -58,11 +58,11 @@ export const ImageRendererComponent: React.FC<ImageRendererComponentProps> = ({
         if (imageWidth && imageWidth.endsWith("px")) {
             const imageWidthInt = parseInt(imageWidth);
             for (let i = 0; i < SUPPORTED_IMAGE_RESIZE_WIDTHS.length; i++) {
-                const resizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
-                if (imageWidthInt > resizeWidth) {
-                    srcSetWidths.push(resizeWidth);
+                const supportedResizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
+                if (imageWidthInt > supportedResizeWidth) {
+                    srcSetWidths.push(supportedResizeWidth);
                 } else {
-                    srcSetWidths.push(resizeWidth);
+                    srcSetWidths.push(supportedResizeWidth);
                     break;
                 }
             }


### PR DESCRIPTION
## Changes
With this PR, Image page element will use a reduced set of image widhts if a custom image width was provided via the editor.

For example, if the image with was set to 265px, then only `100w` and `300w` sizes will be used.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.