### PR TITLE
Use `arm64` Arch Pulumi CLI When Possible

### DIFF
--- a/packages/pulumi-sdk/src/downloadBinaries.ts
+++ b/packages/pulumi-sdk/src/downloadBinaries.ts
@@ -51,9 +51,13 @@ export default async (
     return true;
 };
 
+const SUPPORTED_ARCHITECTURES = ["x64", "arm64"];
+
 async function setupDarwin(downloadFolder: string) {
     const version = getPulumiVersion();
-    const filename = `pulumi-v${version}-darwin-x64.tar.gz`;
+    const arch = SUPPORTED_ARCHITECTURES.includes(process.arch) ? process.arch : "x64";
+
+    const filename = `pulumi-v${version}-darwin-${arch}.tar.gz`;
     const downloadUrl = "https://get.pulumi.com/releases/sdk/" + filename;
 
     await download(downloadUrl, downloadFolder);


### PR DESCRIPTION
## Changes
This PR ensures that `arm64` version of Pulumi CLI is downloaded for the user, if that's the CPU architecture they're using.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.