### PR TITLE
fix(api-apw): content review status when non mandatory steps

### DIFF
--- a/packages/api-apw/src/plugins/hooks/initializeContentReviewSteps.ts
+++ b/packages/api-apw/src/plugins/hooks/initializeContentReviewSteps.ts
@@ -1,5 +1,10 @@
 import lodashSet from "lodash/set";
-import { ApwContentReviewStepStatus, ApwContext } from "~/types";
+import {
+    ApwContentReviewStatus,
+    ApwContentReviewStepStatus,
+    ApwContext,
+    ApwWorkflowStepTypes
+} from "~/types";
 import { getContentReviewStepInitialStatus } from "~/plugins/utils";
 import { NotFoundError } from "@webiny/handler-graphql";
 import { getContentApwSettingsPlugin } from "~/utils/contentApwSettingsPlugin";
@@ -57,9 +62,15 @@ export const initializeContentReviewSteps = ({ apw, plugins }: ApwContext) => {
             };
         });
         /**
-         * TODO Figure our what does this actually do?
-         * There is no steps property on CreateApwContentReviewParams
+         * If there are only steps which are not mandatory ones, put review status to ApwContentReviewStatus.READY_TO_BE_PUBLISHED.
          */
+        const isNonMandatory = updatedSteps.every(step => {
+            return step.type === ApwWorkflowStepTypes.NON_MANDATORY;
+        });
+        if (isNonMandatory) {
+            input.reviewStatus = ApwContentReviewStatus.READY_TO_BE_PUBLISHED;
+        }
+
         input = lodashSet(input, "steps", updatedSteps);
     });
 };


### PR DESCRIPTION
## Changes
Fix for issue where content is not publishable immediately on creation when having only non mandatory steps.

## How Has This Been Tested?
Manually.
