### PR TITLE
fix(api-apw): wrong arn in the cms plugin

### DIFF
--- a/packages/api-apw/src/scheduler/handlers/executeAction/plugins/HeadlessCMSGraphQL.ts
+++ b/packages/api-apw/src/scheduler/handlers/executeAction/plugins/HeadlessCMSGraphQL.ts
@@ -66,7 +66,7 @@ export class HeadlessCMSGraphQL extends ApplicationGraphQL {
     }
 
     public override getArn(settings: ApwSettings): string {
-        return settings.cmsGraphqlFunctionArn;
+        return settings.mainGraphqlFunctionArn;
     }
 
     public override getGraphQLBody(data: ApwScheduleActionData): ApplicationGraphQLBody | null {

--- a/packages/api-apw/src/scheduler/handlers/utils.ts
+++ b/packages/api-apw/src/scheduler/handlers/utils.ts
@@ -121,7 +121,6 @@ export const basePlugins = () => [
  */
 export interface ApwSettings {
     mainGraphqlFunctionArn: string;
-    cmsGraphqlFunctionArn: string;
     eventRuleName: string;
     eventTargetId: string;
 }
@@ -141,7 +140,6 @@ export const getApwSettings = async (): Promise<ApwSettings> => {
 
     return {
         mainGraphqlFunctionArn: Item ? Item["mainGraphqlFunctionArn"] : "mainGraphqlFunctionArn",
-        cmsGraphqlFunctionArn: Item ? Item["cmsGraphqlFunctionArn"] : "cmsGraphqlFunctionArn",
         eventRuleName: Item ? Item["eventRuleName"] : "eventRuleName",
         eventTargetId: Item ? Item["eventTargetId"] : "eventTargetId"
     };


### PR DESCRIPTION
## Changes
Replace the cms arn with the main graphql one.

## How Has This Been Tested?
Manually.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
