### PR TITLE
Fix description input in the clone model dialog

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
@@ -233,16 +233,12 @@ const CloneContentModelDialog: React.FC<Props> = ({ open, onClose, contentModel,
                                     </Cell>
                                     <Cell span={12}>
                                         <Bind name="description">
-                                            {props => (
-                                                <Input
-                                                    {...props}
-                                                    rows={4}
-                                                    maxLength={200}
-                                                    characterCount
-                                                    label={t`Description`}
-                                                    value={contentModel.description}
-                                                />
-                                            )}
+                                            <Input
+                                                rows={4}
+                                                maxLength={200}
+                                                characterCount
+                                                label={t`Description`}
+                                            />
                                         </Bind>
                                     </Cell>
                                 </Grid>


### PR DESCRIPTION
## Changes
This PR fixes an issue with input value of the `description` field, which was locked from changes, so you could never update the description of the model.

## How Has This Been Tested?
Manually.

## Documentation
Not necessary.