### PR TITLE
Improve admin app components

### DIFF
--- a/packages/app-admin-users-cognito/src/plugins/installation.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/installation.tsx
@@ -1,4 +1,5 @@
 import gql from "graphql-tag";
+import { css } from "emotion";
 import React, { useState, useCallback } from "react";
 import { useApolloClient } from "@apollo/react-hooks";
 import { Form } from "@webiny/form";
@@ -17,6 +18,12 @@ import {
 } from "@webiny/app-admin/components/SimpleForm";
 import { View } from "@webiny/app/components/View";
 import { AdminInstallationPlugin } from "@webiny/app-admin/types";
+
+const removeGridPadding = css`
+    > .mdc-layout-grid {
+        padding: 0;
+    }
+`;
 
 const IS_INSTALLED = gql`
     query IsAdminUsersInstalled {
@@ -39,9 +46,11 @@ const INSTALL = gql`
         }
     }
 `;
+
 export interface InstallProps {
     onInstalled: () => void;
 }
+
 const Install: React.FC<InstallProps> = ({ onInstalled }) => {
     const client = useApolloClient();
     const [loading, setLoading] = useState<boolean>(false);
@@ -148,7 +157,7 @@ const Install: React.FC<InstallProps> = ({ onInstalled }) => {
                             </Cell>
                         </Grid>
                     </SimpleFormContent>
-                    <SimpleFormFooter>
+                    <SimpleFormFooter className={removeGridPadding}>
                         <Grid>
                             <Cell span={8}>
                                 <p style={{ textAlign: "left" }}>

--- a/packages/app-admin/src/components/Permissions/Permissions.tsx
+++ b/packages/app-admin/src/components/Permissions/Permissions.tsx
@@ -3,18 +3,24 @@ import { AdminAppPermissionRendererPlugin } from "~/types";
 import { Accordion } from "@webiny/ui/Accordion";
 import { plugins } from "@webiny/plugins";
 import { BindComponentRenderProp } from "@webiny/form";
+import { PermissionRendererPlugin } from "~/plugins/PermissionRendererPlugin";
 
 interface PermissionsProps extends BindComponentRenderProp {
     id: string;
+    plugins?: PermissionRendererPlugin[];
 }
 
 interface PermissionPlugins {
-    systemPlugins: AdminAppPermissionRendererPlugin[];
-    permissionPlugins: AdminAppPermissionRendererPlugin[];
+    systemPlugins: (AdminAppPermissionRendererPlugin | PermissionRendererPlugin)[];
+    permissionPlugins: (AdminAppPermissionRendererPlugin | PermissionRendererPlugin)[];
 }
 
-export const Permissions: React.FC<PermissionsProps> = ({ id, value, onChange }) => {
+export const Permissions: React.FC<PermissionsProps> = ({ id, value, onChange, ...props }) => {
     const { systemPlugins, permissionPlugins } = useMemo<PermissionPlugins>(() => {
+        if (props.plugins) {
+            return { permissionPlugins: props.plugins, systemPlugins: [] };
+        }
+
         return plugins
             .byType<AdminAppPermissionRendererPlugin>("admin-app-permissions-renderer")
             .reduce(

--- a/packages/app-admin/src/components/SearchUI.tsx
+++ b/packages/app-admin/src/components/SearchUI.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "@emotion/styled";
 import InputField from "./SimpleUI/InputField";
 import { ReactComponent as SearchIcon } from "../assets/icons/search-24px.svg";
@@ -41,15 +41,31 @@ const SearchWrapper = styled("div")({
 export interface SearchProps {
     value: string;
     onChange: (value: string) => void;
+    onEnter?: () => any;
     inputPlaceholder?: string;
 }
-const Search: React.FC<SearchProps> = ({ value, onChange, inputPlaceholder = "Search..." }) => {
+const Search: React.FC<SearchProps> = ({
+    value,
+    onChange,
+    onEnter,
+    inputPlaceholder = "Search..."
+}) => {
+    const inputOnKeyDown = useCallback(
+        e => {
+            if (typeof onEnter === "function" && e.key === "Enter") {
+                onEnter();
+            }
+        },
+        [onEnter]
+    );
+
     return (
         <SearchWrapper data-testid={"default-data-list.search"}>
             <div className="search__icon">
                 <SearchIcon />
             </div>
             <InputField
+                onKeyDown={inputOnKeyDown}
                 className="search__input"
                 placeholder={inputPlaceholder}
                 value={value}

--- a/packages/app-admin/src/components/SimpleForm/SimpleForm.tsx
+++ b/packages/app-admin/src/components/SimpleForm/SimpleForm.tsx
@@ -33,14 +33,18 @@ const icon = css({
     color: "var(--mdc-theme-text-primary-on-background)"
 });
 
-const footer = css({
-    borderTop: "1px solid var(--mdc-theme-on-background)",
-    color: "var(--mdc-theme-text-primary-on-background)",
-    textAlign: "right",
-    "&.mdc-layout-grid": {
-        padding: 25 // "25px 50px"
+const footer = css`
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    border-top: 1px solid var(--mdc-theme-on-background);
+    padding: 24px;
+    box-sizing: border-box;
+    min-height: 52px;
+    button:last-of-type {
+        margin-left: 8px;
     }
-});
+`;
 
 interface SimpleFormProps {
     children: React.ReactNode;
@@ -87,11 +91,7 @@ interface SimpleFormFooterProps {
     className?: string;
 }
 export const SimpleFormFooter: React.FC<SimpleFormFooterProps> = props => {
-    return (
-        <Grid className={classNames(footer, props.className)}>
-            <Cell span={12}>{props.children}</Cell>
-        </Grid>
-    );
+    return <div className={classNames(footer, props.className)}>{props.children}</div>;
 };
 
 export const SimpleFormContent: React.FC = props => {

--- a/packages/app-admin/src/components/SimpleUI/InputField.tsx
+++ b/packages/app-admin/src/components/SimpleUI/InputField.tsx
@@ -65,6 +65,7 @@ const getValue = (params: GetValueParams): string => {
 interface InputBoxProps {
     value?: string | number;
     onChange?: (value: any) => void;
+    onKeyDown?: (e: React.SyntheticEvent<HTMLInputElement>) => any;
     defaultValue?: string | number;
     type?: "string" | "number";
     [key: string]: any;
@@ -73,6 +74,7 @@ const InputField: React.FC<InputBoxProps> = ({
     className,
     value,
     onChange,
+    onKeyDown,
     label,
     description,
     validation = { isValid: true },
@@ -93,6 +95,7 @@ const InputField: React.FC<InputBoxProps> = ({
                     type: props.type || "string",
                     defaultValue
                 })}
+                onKeyDown={onKeyDown}
                 onChange={ev => {
                     if (!onChange) {
                         return;

--- a/packages/app-admin/src/styles/theme.scss
+++ b/packages/app-admin/src/styles/theme.scss
@@ -42,5 +42,35 @@ a {
   text-decoration: none;
 }
 
-@import "@webiny/ui/styles.scss";
+// Default heading styles
+h1 {
+  font-size: 3rem;
+  line-height: 1;
+}
 
+h2 {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
+h3 {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+h4 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+h5 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+h6 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+@import "@webiny/ui/styles.scss";


### PR DESCRIPTION
## Changes
This PR introduces the following improvements:
- `Permissions` component can now accept an array of plugins to render. The default behavior is preserved, and works as before.
- `SearchUI` component now accepts an `onEnter` prop
- `SimpleFormFooter` component styles are fixed to reflect the global button alignment (all buttons aligned to the right)
- Admin Users installer form footer styles are adjusted to work nicely with the previous change ⬆️ 
- `@webiny/app-admin` theme now has default `h1-h6` styles defined (they got lost with the 5.34.0 release, due to theme refactors)

## How Has This Been Tested?
Manually.