### PR TITLE
feat(page-builder): add slug and tags fields

### DIFF
--- a/packages/api-page-builder-import-export/src/export/process/templatesHandler.ts
+++ b/packages/api-page-builder-import-export/src/export/process/templatesHandler.ts
@@ -52,7 +52,7 @@ export const templatesHandler = async (
         const { input } = subTask;
         const { templateId, exportTemplatesDataKey } = input;
 
-        const template = await pageBuilder.getPageTemplate(templateId);
+        const template = await pageBuilder.getPageTemplate({ where: { id: templateId } });
 
         if (!template) {
             log(`Unable to load template "${templateId}"`);

--- a/packages/api-page-builder-import-export/src/export/utils.ts
+++ b/packages/api-page-builder-import-export/src/export/utils.ts
@@ -108,7 +108,7 @@ export async function exportBlock(
 }
 
 export interface ExportedTemplateData {
-    template: Pick<PageTemplate, "title" | "description" | "content">;
+    template: Pick<PageTemplate, "title" | "slug" | "tags" | "description" | "content" | "layout">;
     files: File[];
 }
 
@@ -131,8 +131,11 @@ export async function exportTemplate(
     const templateData = {
         template: {
             title: template.title,
+            slug: template.slug,
+            tags: template.tags,
             description: template.description,
-            content: template.content
+            content: template.content,
+            layout: template.layout
         },
         files: imageFilesData
     };

--- a/packages/api-page-builder-import-export/src/import/process/templatesHandler.ts
+++ b/packages/api-page-builder-import-export/src/import/process/templatesHandler.ts
@@ -74,6 +74,9 @@ export const templatesHandler = async (
         // Create a template
         const pbTemplate = await context.pageBuilder.createPageTemplate({
             title: template.title,
+            slug: template.slug,
+            tags: template.tags,
+            layout: template.layout,
             description: template.description,
             content: template.content
         });

--- a/packages/api-page-builder-so-ddb-es/src/definitions/pageTemplateEntity.ts
+++ b/packages/api-page-builder-so-ddb-es/src/definitions/pageTemplateEntity.ts
@@ -19,6 +19,12 @@ export const createPageTemplateEntity = (params: Params): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/dataLoader.ts
@@ -2,7 +2,7 @@ import DataLoader from "dataloader";
 import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 import { PageTemplate } from "@webiny/api-page-builder/types";
 import { Entity } from "dynamodb-toolbox";
-import { createPartitionKey, createSortKey } from "./keys";
+import { createPrimaryPK } from "./keys";
 import { DataContainer } from "~/types";
 
 interface Params {
@@ -41,8 +41,8 @@ export class PageTemplateDataLoader {
                 async items => {
                     const batched = items.map(item => {
                         return this.entity.getBatch({
-                            PK: createPartitionKey(item),
-                            SK: createSortKey(item)
+                            PK: createPrimaryPK(item),
+                            SK: "A"
                         });
                     });
 

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
@@ -9,14 +9,14 @@ import {
     PageTemplateStorageOperationsUpdateParams
 } from "@webiny/api-page-builder/types";
 import { Entity } from "dynamodb-toolbox";
-import { queryAll, QueryAllParams } from "@webiny/db-dynamodb/utils/query";
+import { queryAll, QueryAllParams, queryOne } from "@webiny/db-dynamodb/utils/query";
 import { sortItems } from "@webiny/db-dynamodb/utils/sort";
 import { filterItems } from "@webiny/db-dynamodb/utils/filter";
 import { PageTemplateDataLoader } from "./dataLoader";
 import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { PageTemplateDynamoDbElasticFieldPlugin } from "~/plugins/definitions/PageTemplateDynamoDbElasticFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
-import { createPartitionKey, createSortKey } from "./keys";
+import { createGSI1PK, createPrimaryPK } from "./keys";
 import { DataContainer } from "~/types";
 
 const createType = (): string => {
@@ -39,7 +39,24 @@ export const createPageTemplateStorageOperations = ({
         const { where } = params;
 
         try {
-            return await dataLoader.getOne(where);
+            if (where.id) {
+                return await dataLoader.getOne({
+                    id: where.id,
+                    tenant: where.tenant,
+                    locale: where.locale
+                });
+            }
+
+            const result = await queryOne<{ data: PageTemplate }>({
+                entity,
+                partitionKey: createGSI1PK(where),
+                options: {
+                    index: "GSI1",
+                    eq: where.slug
+                }
+            });
+
+            return result?.data || null;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load page template by given parameters.",
@@ -57,8 +74,9 @@ export const createPageTemplateStorageOperations = ({
         const { tenant, locale, ...restWhere } = where;
         const queryAllParams: QueryAllParams = {
             entity,
-            partitionKey: createPartitionKey({ tenant, locale }),
+            partitionKey: createGSI1PK({ tenant, locale }),
             options: {
+                index: "GSI1",
                 gt: " "
             }
         };
@@ -107,11 +125,10 @@ export const createPageTemplateStorageOperations = ({
         const { pageTemplate } = params;
 
         const keys = {
-            PK: createPartitionKey({
-                tenant: pageTemplate.tenant,
-                locale: pageTemplate.locale
-            }),
-            SK: createSortKey(pageTemplate)
+            PK: createPrimaryPK(pageTemplate),
+            SK: "A",
+            GSI1_PK: createGSI1PK(pageTemplate),
+            GSI1_SK: pageTemplate.slug
         };
 
         try {
@@ -140,11 +157,10 @@ export const createPageTemplateStorageOperations = ({
     const update = async (params: PageTemplateStorageOperationsUpdateParams) => {
         const { original, pageTemplate } = params;
         const keys = {
-            PK: createPartitionKey({
-                tenant: original.tenant,
-                locale: original.locale
-            }),
-            SK: createSortKey(pageTemplate)
+            PK: createPrimaryPK(pageTemplate),
+            SK: "A",
+            GSI1_PK: createGSI1PK(pageTemplate),
+            GSI1_SK: pageTemplate.slug
         };
 
         try {
@@ -175,11 +191,8 @@ export const createPageTemplateStorageOperations = ({
     const deletePageTemplate = async (params: PageTemplateStorageOperationsDeleteParams) => {
         const { pageTemplate } = params;
         const keys = {
-            PK: createPartitionKey({
-                tenant: pageTemplate.tenant,
-                locale: pageTemplate.locale
-            }),
-            SK: createSortKey(pageTemplate)
+            PK: createPrimaryPK(pageTemplate),
+            SK: "A"
         };
 
         try {

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/keys.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/keys.ts
@@ -1,16 +1,12 @@
-export interface PartitionKeyParams {
-    tenant: string;
-    locale: string;
-}
-export const createPartitionKey = (params: PartitionKeyParams): string => {
-    const { tenant, locale } = params;
-    return `T#${tenant}#L#${locale}#PB#PT`;
+import { PageTemplate } from "@webiny/api-page-builder/types";
+
+export type PrimaryPKParams = Pick<PageTemplate, "id" | "tenant" | "locale">;
+export type GSI1Params = Pick<PageTemplate, "tenant" | "locale">;
+
+export const createPrimaryPK = ({ id, tenant, locale }: PrimaryPKParams): string => {
+    return `T#${tenant}#L#${locale}#PB#TEMPLATE#${id}`;
 };
 
-export interface SortKeyParams {
-    id: string;
-}
-export const createSortKey = (params: SortKeyParams): string => {
-    const { id } = params;
-    return id;
+export const createGSI1PK = ({ tenant, locale }: GSI1Params): string => {
+    return `T#${tenant}#L#${locale}#PB#TEMPLATES`;
 };

--- a/packages/api-page-builder-so-ddb/src/definitions/pageTemplateEntity.ts
+++ b/packages/api-page-builder-so-ddb/src/definitions/pageTemplateEntity.ts
@@ -19,6 +19,12 @@ export const createPageTemplateEntity = (params: Params): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },

--- a/packages/api-page-builder-so-ddb/src/operations/pageTemplate/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageTemplate/dataLoader.ts
@@ -2,7 +2,7 @@ import DataLoader from "dataloader";
 import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 import { PageTemplate } from "@webiny/api-page-builder/types";
 import { Entity } from "dynamodb-toolbox";
-import { createPartitionKey, createSortKey } from "./keys";
+import { createPrimaryPK } from "./keys";
 import { DataContainer } from "~/types";
 
 interface Params {
@@ -41,8 +41,8 @@ export class PageTemplateDataLoader {
                 async items => {
                     const batched = items.map(item => {
                         return this.entity.getBatch({
-                            PK: createPartitionKey(item),
-                            SK: createSortKey(item)
+                            PK: createPrimaryPK(item),
+                            SK: "A"
                         });
                     });
 

--- a/packages/api-page-builder-so-ddb/src/operations/pageTemplate/keys.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageTemplate/keys.ts
@@ -1,16 +1,12 @@
-export interface PartitionKeyParams {
-    tenant: string;
-    locale: string;
-}
-export const createPartitionKey = (params: PartitionKeyParams): string => {
-    const { tenant, locale } = params;
-    return `T#${tenant}#L#${locale}#PB#PT`;
+import { PageTemplate } from "@webiny/api-page-builder/types";
+
+export type PrimaryPKParams = Pick<PageTemplate, "id" | "tenant" | "locale">;
+export type GSI1Params = Pick<PageTemplate, "tenant" | "locale">;
+
+export const createPrimaryPK = ({ id, tenant, locale }: PrimaryPKParams): string => {
+    return `T#${tenant}#L#${locale}#PB#TEMPLATE#${id}`;
 };
 
-export interface SortKeyParams {
-    id: string;
-}
-export const createSortKey = (params: SortKeyParams): string => {
-    const { id } = params;
-    return id;
+export const createGSI1PK = ({ tenant, locale }: GSI1Params): string => {
+    return `T#${tenant}#L#${locale}#PB#TEMPLATES`;
 };

--- a/packages/api-page-builder/src/graphql/elementProcessors/useElementVariables.ts
+++ b/packages/api-page-builder/src/graphql/elementProcessors/useElementVariables.ts
@@ -4,10 +4,10 @@ export function useElementVariables(
     block: PbPageElement,
     element: PbPageElement
 ): PbBlockVariable[] {
-    if (element?.data?.variableId) {
-        return block?.data?.variables?.filter(
-            (variable: PbBlockVariable) => variable.id.split(".")[0] === element?.data?.variableId
-        );
+    if (element.data?.variableId) {
+        return block.data?.variables?.filter((variable: PbBlockVariable) => {
+            return variable.id.split(".")[0] === element.data?.variableId;
+        });
     }
 
     return [];

--- a/packages/api-page-builder/src/graphql/graphql/pages.gql.ts
+++ b/packages/api-page-builder/src/graphql/graphql/pages.gql.ts
@@ -5,13 +5,17 @@ import {
     NotFoundResponse
 } from "@webiny/handler-graphql/responses";
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/types";
-import { Page, PbContext, PageSecurityPermission } from "~/types";
+import { Page, PbContext, PageSecurityPermission, PageContentWithTemplate } from "~/types";
 import WebinyError from "@webiny/error";
 import resolve from "./utils/resolve";
 import { createPageSettingsGraphQL } from "./pages/pageSettings";
 import { fetchEmbed, findProvider } from "./pages/oEmbed";
 import lodashGet from "lodash/get";
 import checkBasePermissions from "~/graphql/crud/utils/checkBasePermissions";
+
+function hasTemplate(content: Page["content"]): content is PageContentWithTemplate {
+    return content?.data?.template;
+}
 
 const createBasePageGraphQL = (): GraphQLSchemaPlugin<PbContext> => {
     return {
@@ -279,9 +283,9 @@ const createBasePageGraphQL = (): GraphQLSchemaPlugin<PbContext> => {
                             return page.content;
                         }
 
-                        let blocks = {};
+                        let blocks;
 
-                        if (page.content.data.templateId) {
+                        if (hasTemplate(page.content)) {
                             blocks = await context.pageBuilder.resolvePageTemplate(page.content);
                         } else {
                             blocks = await context.pageBuilder.resolvePageBlocks(page.content);

--- a/packages/api-page-builder/src/graphql/index.ts
+++ b/packages/api-page-builder/src/graphql/index.ts
@@ -1,3 +1,5 @@
+export { useElementVariables } from "./elementProcessors/useElementVariables";
+
 import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/types";
 import { createCrud, CreateCrudParams } from "./crud";
 import graphql from "./graphql";

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -18,7 +18,8 @@ import {
     PageSettings,
     PageSpecialType,
     Settings,
-    System
+    System,
+    PageTemplateInput
 } from "~/types";
 import { PrerenderingServiceClientContext } from "@webiny/api-prerendering-service/client/types";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
@@ -854,16 +855,55 @@ export interface OnPageTemplateAfterDeleteTopicParams {
     pageTemplate: PageTemplate;
 }
 
+interface CreatePageFromTemplateParams {
+    id?: string;
+    slug?: string;
+    category: string;
+    path?: string;
+    meta?: Record<string, any>;
+}
+
+export interface PageBlockVariable {
+    id: string;
+    label: string;
+    type: string;
+    value: string;
+}
+
+export interface PageTemplateVariable {
+    blockId: string;
+    variables: PageBlockVariable[];
+}
+
+interface GetPageTemplateParams {
+    where: {
+        id?: string;
+        slug?: string;
+    };
+}
+
+export interface PageContentWithTemplate extends PbPageElement {
+    data: {
+        template: {
+            slug: string;
+            variables?: PageTemplateVariable[];
+        };
+    };
+}
+
 /**
  * @category PageTemplates
  */
 export interface PageTemplatesCrud {
-    getPageTemplate(id: string): Promise<PageTemplate | null>;
+    getPageTemplate(params: GetPageTemplateParams): Promise<PageTemplate | null>;
     listPageTemplates(params?: ListPageTemplatesParams): Promise<PageTemplate[]>;
-    createPageTemplate(data: Record<string, any>): Promise<PageTemplate>;
+    createPageTemplate(data: PageTemplateInput): Promise<PageTemplate>;
+    createPageFromTemplate(data: CreatePageFromTemplateParams): Promise<Page>;
+    // Copy relevant data from page template to page instance, by reference.
+    copyTemplateDataToPage(template: PageTemplate, page: Page): void;
     updatePageTemplate(id: string, data: Record<string, any>): Promise<PageTemplate>;
     deletePageTemplate(id: string): Promise<PageTemplate>;
-    resolvePageTemplate(content: Record<string, any> | null): Promise<any>;
+    resolvePageTemplate(content: PageContentWithTemplate): Promise<any>;
 
     /**
      * Lifecycle events

--- a/packages/api-page-builder/src/types.ts
+++ b/packages/api-page-builder/src/types.ts
@@ -66,10 +66,10 @@ export interface PageSettings {
         meta: Array<{ name: string; content: string }>;
     };
     general?: {
-        tags: string[];
-        snippet: string;
-        layout: string;
-        image: File;
+        tags?: string[];
+        snippet?: string;
+        layout?: string;
+        image?: File;
     };
     /**
      * Basically we can have anything in page settings.
@@ -89,7 +89,7 @@ export interface Page {
     content: Record<string, any> | null;
     publishedOn: string | null;
     version: number;
-    settings?: PageSettings;
+    settings: PageSettings;
     locked: boolean;
     status: PageStatus;
     createdOn: string;
@@ -895,7 +895,9 @@ export interface PageBlockStorageOperations {
 export interface PageTemplate {
     id: string;
     title: string;
-    description?: string;
+    slug: string;
+    tags: string[];
+    description: string;
     layout?: string;
     content?: any;
     createdOn: string;
@@ -905,7 +907,10 @@ export interface PageTemplate {
     locale: string;
 }
 
-export type PageTemplateInput = Pick<PageTemplate, "title" | "description" | "content">;
+export type PageTemplateInput = Pick<
+    PageTemplate,
+    "title" | "description" | "content" | "slug" | "tags" | "layout"
+> & { id?: string };
 
 /**
  * @category StorageOperations
@@ -913,7 +918,8 @@ export type PageTemplateInput = Pick<PageTemplate, "title" | "description" | "co
  */
 export interface PageTemplateStorageOperationsGetParams {
     where: {
-        id: string;
+        id?: string;
+        slug?: string;
         tenant: string;
         locale: string;
     };

--- a/packages/app-page-builder/src/admin/graphql/pages.ts
+++ b/packages/app-page-builder/src/admin/graphql/pages.ts
@@ -67,6 +67,19 @@ export const CREATE_PAGE = gql`
     }
 `;
 
+export const CREATE_PAGE_FROM_TEMPLATE = gql`
+    mutation PbCreatePageFromTemplate($templateId: ID, $category: String, $meta: JSON) {
+        pageBuilder {
+            createPage: createPageFromTemplate(templateId: $templateId, category: $category, meta: $meta) {
+                data {
+                    ${LIST_PAGES_DATA_FIELDS}
+                }
+                ${error}
+            }
+        }
+    }
+`;
+
 export const DUPLICATE_PAGE = gql`
     mutation PbDuplicatePage($id: ID!) {
         pageBuilder {

--- a/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplates.tsx
+++ b/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplates.tsx
@@ -78,7 +78,11 @@ const PageTemplates: React.FC = () => {
             mutation: CREATE_PAGE_TEMPLATE,
             variables: {
                 data: {
-                    title: "New template"
+                    title: "New template",
+                    slug: "new-template",
+                    description: "Blank template",
+                    tags: [],
+                    layout: "static" // Hardcoded until better UI is in place
                 }
             },
             refetchQueries: [{ query: LIST_PAGE_TEMPLATES }]

--- a/packages/app-page-builder/src/admin/views/PageTemplates/graphql.ts
+++ b/packages/app-page-builder/src/admin/views/PageTemplates/graphql.ts
@@ -4,9 +4,10 @@ import { PbPageTemplate, PbErrorResponse } from "~/types";
 const PAGE_TEMPLATE_BASE_FIELDS = `
     id
     title
+    slug
+    tags
     description
     layout
-    content
     createdOn
     savedOn
     createdBy {
@@ -26,15 +27,18 @@ export interface GetPageTemplateQueryResponse {
         error?: PbErrorResponse;
     };
 }
+
 export interface GetPageTemplateQueryVariables {
     id: string;
 }
+
 export const GET_PAGE_TEMPLATE = gql`
-    query GetPageTemplates($id: ID!) {
+    query GetPageTemplate($id: ID!) {
         pageBuilder {
             getPageTemplate(id: $id) {
                 data {
                     ${PAGE_TEMPLATE_BASE_FIELDS}
+                    content
                 }
                 error {
                     code
@@ -55,9 +59,11 @@ export interface ListPageTemplatesQueryResponse {
         error?: PbErrorResponse;
     };
 }
+
 export interface ListPageTemplatesQueryVariables {
     templateCategory: string;
 }
+
 export const LIST_PAGE_TEMPLATES = gql`
     query ListPageTemplates {
         pageBuilder {
@@ -122,6 +128,8 @@ export interface UpdatePageTemplateMutationVariables {
     data: {
         title?: string;
         description?: string;
+        slug?: string;
+        tags?: string[];
         layout?: string;
         content?: string;
     };
@@ -132,6 +140,7 @@ export const UPDATE_PAGE_TEMPLATE = gql`
             pageTemplate: updatePageTemplate(id: $id, data: $data) {
                 data {
                     ${PAGE_TEMPLATE_BASE_FIELDS}
+                    content
                 }
                 error {
                     code

--- a/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Pages.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState, useCallback } from "react";
-import { useMutation } from "@apollo/react-hooks";
-
+import { useApolloClient } from "@apollo/react-hooks";
 import { SplitView, LeftPanel, RightPanel } from "@webiny/app-admin/components/SplitView";
 import { useSecurity } from "@webiny/app-security";
 import { CircularProgress } from "@webiny/ui/Progress";
@@ -9,7 +8,7 @@ import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 
 import * as GQLCache from "~/admin/views/Pages/cache";
 import CategoriesDialog from "~/admin/views/Categories/CategoriesDialog";
-import { CREATE_PAGE, UPDATE_PAGE } from "~/admin/graphql/pages";
+import { CREATE_PAGE, CREATE_PAGE_FROM_TEMPLATE } from "~/admin/graphql/pages";
 import useImportPage from "./hooks/useImportPage";
 import PagesDataList from "./PagesDataList";
 import PageDetails from "./PageDetails";
@@ -21,8 +20,7 @@ const Pages: React.FC = () => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
     const [showTemplatesDialog, setTemplatesDialog] = useState(false);
-    const [create] = useMutation(CREATE_PAGE);
-    const [update] = useMutation(UPDATE_PAGE);
+    const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
 
     const openCategoriesDialog = useCallback(() => setCategoriesDialog(true), []);
@@ -39,8 +37,16 @@ const Pages: React.FC = () => {
     const onCreatePage = useCallback(async (template?: PbPageTemplate) => {
         setIsLoading(true);
         try {
-            const res = await create({
-                variables: { category: "static" }, // hardcoded for now
+            const MUTATION = template ? CREATE_PAGE_FROM_TEMPLATE : CREATE_PAGE;
+            const variables = {
+                // category is temporarily hardcoded
+                category: "static",
+                templateId: template?.id
+            };
+
+            const newPage = await client.mutate({
+                mutation: MUTATION,
+                variables,
                 update(cache, { data }) {
                     if (data.pageBuilder.createPage.error) {
                         return;
@@ -50,31 +56,7 @@ const Pages: React.FC = () => {
                 }
             });
 
-            if (template) {
-                await update({
-                    variables: {
-                        id: res.data.pageBuilder.createPage.data.id,
-                        data: {
-                            content: {
-                                ...template.content,
-                                data: {
-                                    ...template.content.data,
-                                    templateId: template.id
-                                },
-                                elements: []
-                            },
-                            settings: {
-                                general: {
-                                    ...res.data.pageBuilder.createPage.data.settings.general,
-                                    layout: template.layout
-                                }
-                            }
-                        }
-                    }
-                });
-            }
-
-            const { error, data } = res.data.pageBuilder.createPage;
+            const { error, data } = newPage.data.pageBuilder.createPage;
             if (error) {
                 showSnackbar(error.message);
             } else {

--- a/packages/app-page-builder/src/editor/plugins/toolbar/addElement/StyledComponents.ts
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/addElement/StyledComponents.ts
@@ -20,7 +20,10 @@ export const ElementPreviewCanvas = styled("div")({
     backgroundColor: "var(--mdc-theme-surface)",
     color: "var(--mdc-theme-on-surface)",
     padding: 15,
-    boxSizing: "border-box"
+    boxSizing: "border-box",
+    "> *": {
+        width: "100%"
+    }
 });
 
 export const Backdrop = styled("div")({

--- a/packages/app-page-builder/src/pageEditor/config/ToolbarActionsPlugin.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/ToolbarActionsPlugin.tsx
@@ -25,7 +25,7 @@ import {
 
 const unlinkTemplateDialog = css`
     & .mdc-dialog__surface {
-        width: 400px;
+        width: 500px;
     }
 
     & .webiny-ui-dialog__title {
@@ -45,12 +45,6 @@ const unlinkTemplateDialog = css`
             width: 18px;
             margin-right: 5px;
         }
-    }
-
-    & .button-wrapper {
-        display: flex;
-        justify-content: space-between;
-        width: 100%;
     }
 `;
 
@@ -85,10 +79,9 @@ export const ToolbarActionsPlugin = createComponentPlugin(ToolbarActions, Toolba
         }, []);
 
         const onUnlink = useCallback(() => {
-            // we need to drop templateId and templateVariables properties when unlinking,
-            // so they are separated from all other element data
+            // we need to drop the `template` property when unlinking.
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { templateId, templateVariables, ...newPageData } = rootElement.data;
+            const { template, ...newPageData } = rootElement.data;
 
             setIsTemplateMode(false);
             updateElement({ ...rootElement, data: newPageData }, { history: false });
@@ -121,12 +114,10 @@ export const ToolbarActionsPlugin = createComponentPlugin(ToolbarActions, Toolba
                         </div>
                     </DialogContent>
                     <DialogActions>
-                        <div className="button-wrapper">
-                            <DialogCancel onClick={onClose}>Cancel</DialogCancel>
-                            <ButtonPrimary disabled={!unlinkPermission} onClick={onUnlink}>
-                                {unlinkPermission ? "Unlink template" : "No permissions"}
-                            </ButtonPrimary>
-                        </div>
+                        <DialogCancel onClick={onClose}>Cancel</DialogCancel>
+                        <ButtonPrimary disabled={!unlinkPermission} onClick={onUnlink}>
+                            {unlinkPermission ? "Unlink template" : "No permissions"}
+                        </ButtonPrimary>
                     </DialogActions>
                 </Dialog>
             </>

--- a/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
+++ b/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
@@ -24,8 +24,8 @@ const triggerOnFinish = (args?: SaveRevisionActionArgsType): void => {
     }
     args.onFinish();
 };
-// TODO @ts-refactor not worth it
-let debouncedSave: any = null;
+
+let debouncedSave: ReturnType<typeof lodashDebounce> | null = null;
 
 const syncTemplateVariables = (content: PbElement) => {
     const templateVariables = [];
@@ -39,7 +39,9 @@ const syncTemplateVariables = (content: PbElement) => {
         }
     }
 
-    return { ...content, data: { ...content.data, templateVariables }, elements: [] };
+    const template = { ...content.data.template, variables: templateVariables };
+
+    return { ...content, data: { ...content.data, template }, elements: [] };
 };
 
 const removeTemplateBlockIds = (content: PbElement) => {
@@ -77,7 +79,7 @@ export const saveRevisionAction: PageEventActionCallable<SaveRevisionActionArgsT
 
     let updatedContent = (await state.getElementTree()) as PbElement;
 
-    if (updatedContent.data.templateId) {
+    if (updatedContent.data.template) {
         updatedContent = syncTemplateVariables(updatedContent);
     } else {
         updatedContent = removeTemplateBlockIds(updatedContent);

--- a/packages/app-page-builder/src/pageEditor/createStateInitializer.ts
+++ b/packages/app-page-builder/src/pageEditor/createStateInitializer.ts
@@ -23,7 +23,7 @@ export const createStateInitializer = (
 
             set(pageAtom, pageData);
             set(revisionsAtom, revisions);
-            set(templateModeAtom, !!page?.content?.data?.templateId);
+            set(templateModeAtom, !!page?.content?.data?.template);
         }
     });
 };

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/graphql.ts
@@ -7,7 +7,7 @@ export const LIST_PUBLISHED_PAGES = gql`
         $sort: [PbListPagesSort!]
         $after: String
         $exclude: [String]
-    ) {
+    ) @ps(cache: true) {
         pageBuilder {
             listPublishedPages(
                 where: $where

--- a/packages/app-page-builder/src/templateEditor/Editor.tsx
+++ b/packages/app-page-builder/src/templateEditor/Editor.tsx
@@ -29,7 +29,7 @@ import {
     PbPageTemplate
 } from "~/types";
 import createBlockCategoryPlugin from "~/admin/utils/createBlockCategoryPlugin";
-import { TemplateWithContent } from "~/templateEditor/state";
+import { PageTemplateWithContent } from "~/templateEditor/state";
 import { createStateInitializer } from "./createStateInitializer";
 import { TemplateEditorConfig } from "./config/TemplateEditorConfig";
 import elementVariableRendererPlugins from "~/blockEditor/plugins/elementVariables";
@@ -49,7 +49,7 @@ export const TemplateEditor: React.FC = () => {
     const client = useApolloClient();
     const { history, params } = useRouter();
     const { showSnackbar } = useSnackbar();
-    const [template, setTemplate] = useState<TemplateWithContent>();
+    const [template, setTemplate] = useState<PageTemplateWithContent>();
 
     const templateId = decodeURIComponent(params["id"]);
 
@@ -142,7 +142,7 @@ export const TemplateEditor: React.FC = () => {
             <LoadData>
                 <PbEditor
                     stateInitializerFactory={createStateInitializer(
-                        template as TemplateWithContent
+                        template as PageTemplateWithContent
                     )}
                 />
             </LoadData>

--- a/packages/app-page-builder/src/templateEditor/config/editorBar/TemplateSettings/TemplateSettingsModal.tsx
+++ b/packages/app-page-builder/src/templateEditor/config/editorBar/TemplateSettings/TemplateSettingsModal.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from "react";
-import styled from "@emotion/styled";
+import slugify from "slugify";
 import { css } from "emotion";
 import { useRecoilState } from "recoil";
-
-import { Form } from "@webiny/form";
+import pick from "lodash/pick";
+import { Form, FormAPI } from "@webiny/form";
 import { plugins } from "@webiny/plugins";
 import { ButtonPrimary } from "@webiny/ui/Button";
 import { Grid, Cell } from "@webiny/ui/Grid";
@@ -16,15 +16,10 @@ import { templateSettingsStateAtom } from "./state";
 import { useTemplate } from "~/templateEditor/hooks/useTemplate";
 import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { UpdateDocumentActionEvent } from "~/editor/recoil/actions";
-import { TemplateAtomType } from "~/templateEditor/state";
+import { PageTemplate } from "~/templateEditor/state";
 import { Input } from "@webiny/ui/Input";
 import { PbPageLayoutPlugin } from "~/types";
-
-const ButtonWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-`;
+import { Tags } from "@webiny/ui/Tags";
 
 const narrowDialog = css`
     & .mdc-dialog__surface {
@@ -46,7 +41,7 @@ const TemplateSettingsModal: React.FC = () => {
         return (layoutPlugins || []).map(pl => pl.layout);
     }, []);
 
-    const updateTemplate = (data: Partial<TemplateAtomType>) => {
+    const updateTemplate = (data: Partial<PageTemplate>) => {
         handler.trigger(
             new UpdateDocumentActionEvent({
                 history: false,
@@ -55,33 +50,53 @@ const TemplateSettingsModal: React.FC = () => {
         );
     };
 
+    const generateSlug = (form: FormAPI) => () => {
+        if (form.data.slug) {
+            return;
+        }
+
+        // We want to update slug only when the group is first being created.
+        form.setValue(
+            "slug",
+            slugify(form.data.title, {
+                replacement: "-",
+                lower: true,
+                remove: /[*#\?<>_\{\}\[\]+~.()'"!:;@]/g,
+                trim: false
+            })
+        );
+    };
+
     const onSubmit = useCallback(formData => {
-        updateTemplate({
-            title: formData.title,
-            description: formData.description,
-            layout: formData.layout
-        });
+        updateTemplate(formData);
         onClose();
     }, []);
 
+    const settings = pick(template, ["title", "description", "slug", "layout", "tags"]);
+
     return (
         <Dialog open={true} onClose={onClose} className={narrowDialog}>
-            <Form
-                data={{ title: template.title, description: template.description }}
-                onSubmit={onSubmit}
-            >
+            <Form data={settings} onSubmit={onSubmit}>
                 {({ form, Bind }) => (
                     <>
                         <DialogTitle>Template Settings</DialogTitle>
                         <DialogContent>
                             <SimpleFormContent>
                                 <Grid>
-                                    <Cell span={12}>
+                                    <Cell span={6}>
                                         <Bind
                                             name="title"
                                             validators={[validation.create("required")]}
                                         >
-                                            <Input label="Title" />
+                                            <Input label="Title" onBlur={generateSlug(form)} />
+                                        </Bind>
+                                    </Cell>
+                                    <Cell span={6}>
+                                        <Bind
+                                            name="slug"
+                                            validators={[validation.create("required")]}
+                                        >
+                                            <Input label="Slug" />
                                         </Bind>
                                     </Cell>
                                     <Cell span={12}>
@@ -103,20 +118,23 @@ const TemplateSettingsModal: React.FC = () => {
                                             </Select>
                                         </Bind>
                                     </Cell>
+                                    <Cell span={12}>
+                                        <Bind name="tags">
+                                            <Tags label="Tags" />
+                                        </Bind>
+                                    </Cell>
                                 </Grid>
                             </SimpleFormContent>
                         </DialogContent>
                         <DialogActions>
-                            <ButtonWrapper>
-                                <DialogCancel onClick={onClose}>Cancel</DialogCancel>
-                                <ButtonPrimary
-                                    onClick={ev => {
-                                        form.submit(ev);
-                                    }}
-                                >
-                                    Save
-                                </ButtonPrimary>
-                            </ButtonWrapper>
+                            <DialogCancel onClick={onClose}>Cancel</DialogCancel>
+                            <ButtonPrimary
+                                onClick={ev => {
+                                    form.submit(ev);
+                                }}
+                            >
+                                Save
+                            </ButtonPrimary>
                         </DialogActions>
                     </>
                 )}

--- a/packages/app-page-builder/src/templateEditor/config/editorBar/Title/Title.tsx
+++ b/packages/app-page-builder/src/templateEditor/config/editorBar/Title/Title.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "@webiny/ui/Tooltip";
 import { createComponentPlugin } from "@webiny/app-admin";
 import { TemplateTitle, templateTitleWrapper, TitleInputWrapper, TitleWrapper } from "./Styled";
 import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
-import { TemplateAtomType } from "~/templateEditor/state";
+import { PageTemplate } from "~/templateEditor/state";
 import { UpdateDocumentActionEvent } from "~/editor/recoil/actions";
 import { EditorBar } from "~/editor";
 import { useTemplate } from "~/templateEditor/hooks/useTemplate";
@@ -30,7 +30,7 @@ const Title: React.FC = () => {
         }
     }, [template.title]);
 
-    const updateTemplate = (data: Partial<TemplateAtomType>) => {
+    const updateTemplate = (data: Partial<PageTemplate>) => {
         handler.trigger(
             new UpdateDocumentActionEvent({
                 history: false,

--- a/packages/app-page-builder/src/templateEditor/config/eventActions/EventActionHandlerPlugin.tsx
+++ b/packages/app-page-builder/src/templateEditor/config/eventActions/EventActionHandlerPlugin.tsx
@@ -6,7 +6,7 @@ import {
     GetCallableState
 } from "~/editor/contexts/EventActionHandlerProvider";
 import { TemplateEditorEventActionCallableState } from "~/templateEditor/types";
-import { TemplateAtomType } from "~/templateEditor/state";
+import { PageTemplate } from "~/templateEditor/state";
 import { useTemplate } from "~/templateEditor/hooks/useTemplate";
 import { PbElement, PbEditorElement } from "~/types";
 
@@ -16,7 +16,7 @@ export const EventActionHandlerPlugin = createComponentPlugin(
     EventActionHandlerProvider as ComposableFC<ProviderProps>,
     Component => {
         return function PbEventActionHandlerProvider(props) {
-            const templateAtomValueRef = useRef<TemplateAtomType>();
+            const templateAtomValueRef = useRef<PageTemplate>();
             const [templateAtomValue, setTemplateAtomValue] = useTemplate();
 
             useEffect(() => {
@@ -77,7 +77,7 @@ export const EventActionHandlerPlugin = createComponentPlugin(
                 const callableState = next(state);
 
                 return {
-                    template: templateAtomValueRef.current as TemplateAtomType,
+                    template: templateAtomValueRef.current as PageTemplate,
                     ...callableState
                 };
             };

--- a/packages/app-page-builder/src/templateEditor/config/eventActions/saveTemplate/saveTemplateAction.ts
+++ b/packages/app-page-builder/src/templateEditor/config/eventActions/saveTemplate/saveTemplateAction.ts
@@ -2,7 +2,7 @@ import lodashDebounce from "lodash/debounce";
 import { plugins } from "@webiny/plugins";
 import { SaveTemplateActionArgsType } from "./types";
 import { TemplateEventActionCallable } from "~/templateEditor/types";
-import { TemplateWithContent } from "~/templateEditor/state";
+import { PageTemplateWithContent } from "~/templateEditor/state";
 import { UPDATE_PAGE_TEMPLATE } from "~/admin/views/PageTemplates/graphql";
 import { PbElement, PbBlockVariable, PbBlockEditorCreateVariablePlugin } from "~/types";
 
@@ -52,19 +52,17 @@ const syncTemplateBlockVariables = (block: PbElement) => {
 };
 
 const syncTemplateVariables = (content: PbElement) => {
-    const templateVariables = [];
+    const variables = [];
 
     for (const block of content.elements) {
-        templateVariables.push({
+        variables.push({
             blockId: block.data.templateBlockId,
             variables: block.data.variables
         });
     }
 
-    return { ...content, data: { ...content.data, templateVariables } };
+    return { ...content, data: { ...content.data, template: { variables } } };
 };
-
-type TemplateType = Pick<TemplateWithContent, "title" | "description" | "content" | "layout">;
 
 const triggerOnFinish = (args?: SaveTemplateActionArgsType): void => {
     if (!args || !args.onFinish || typeof args.onFinish !== "function") {
@@ -89,8 +87,10 @@ export const saveTemplateAction: TemplateEventActionCallable<SaveTemplateActionA
         return element;
     });
 
-    const data: TemplateType = {
+    const data: Omit<PageTemplateWithContent, "id" | "createdBy"> = {
         title: state.template.title,
+        slug: state.template.slug,
+        tags: state.template.tags || [],
         description: state.template?.description || "",
         layout: state.template?.layout || "",
         content: syncTemplateVariables({ ...content, elements })

--- a/packages/app-page-builder/src/templateEditor/createStateInitializer.ts
+++ b/packages/app-page-builder/src/templateEditor/createStateInitializer.ts
@@ -1,9 +1,9 @@
 import omit from "lodash/omit";
-import { templateAtom, TemplateAtomType, TemplateWithContent } from "~/templateEditor/state";
+import { templateAtom, PageTemplate, PageTemplateWithContent } from "~/templateEditor/state";
 import { EditorStateInitializerFactory } from "~/editor/Editor";
 
 export const createStateInitializer = (
-    template: TemplateWithContent
+    template: PageTemplateWithContent
 ): EditorStateInitializerFactory => {
     return () => ({
         content: template.content,
@@ -11,7 +11,7 @@ export const createStateInitializer = (
             /**
              * We always unset the content because we are not using it via the template atom.
              */
-            const templateData: TemplateAtomType = omit(template, ["content"]);
+            const templateData: PageTemplate = omit(template, ["content"]);
 
             set(templateAtom, templateData);
         }

--- a/packages/app-page-builder/src/templateEditor/graphql.ts
+++ b/packages/app-page-builder/src/templateEditor/graphql.ts
@@ -13,6 +13,9 @@ const DATA_FIELD = `
     {
         id
         title
+        slug
+        tags
+        layout
         description
         content
         createdOn

--- a/packages/app-page-builder/src/templateEditor/state/templateAtom.ts
+++ b/packages/app-page-builder/src/templateEditor/state/templateAtom.ts
@@ -1,13 +1,15 @@
 import { atom } from "recoil";
 import { PbEditorElement } from "~/types";
 
-export interface TemplateWithContent extends TemplateAtomType {
+export interface PageTemplateWithContent extends PageTemplate {
     content: PbEditorElement;
 }
 
-export interface TemplateAtomType {
+export interface PageTemplate {
     id: string;
     title?: string;
+    slug?: string;
+    tags?: string[];
     description?: string;
     layout?: string;
     savedOn?: string;
@@ -16,7 +18,7 @@ export interface TemplateAtomType {
     };
 }
 
-export const templateAtom = atom<TemplateAtomType>({
+export const templateAtom = atom<PageTemplate>({
     key: "templateAtom",
     default: {
         id: "",

--- a/packages/app-page-builder/src/templateEditor/types.ts
+++ b/packages/app-page-builder/src/templateEditor/types.ts
@@ -1,8 +1,8 @@
 import { EventActionCallable } from "~/types";
-import { TemplateAtomType } from "~/templateEditor/state";
+import { PageTemplate } from "~/templateEditor/state";
 
 export interface TemplateEditorEventActionCallableState {
-    template: TemplateAtomType;
+    template: PageTemplate;
 }
 
 export type TemplateEventActionCallable<TArgs> = EventActionCallable<

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,37 +162,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/ie11-detection@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/ie11-detection@npm:2.0.2"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: 713293deea8eefd3ab43dc05e62228571d27754e7293f8ec2fd8a0c693fbbfc55213e6599387776e3cdbc951965dc62e24e92b9c4a853e4a50d00ae6a9f6b2bd
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/ie11-detection@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
   dependencies:
     tslib: ^1.11.1
   checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-browser@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/ie11-detection": ^2.0.0
-    "@aws-crypto/sha256-js": ^2.0.0
-    "@aws-crypto/supports-web-crypto": ^2.0.0
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
   languageName: node
   linkType: hard
 
@@ -238,17 +213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/sha256-js@npm:3.0.0"
@@ -271,32 +235,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/sha256-js@npm:2.0.2"
-  dependencies:
-    "@aws-crypto/util": ^2.0.2
-    "@aws-sdk/types": ^3.110.0
-    tslib: ^1.11.1
-  checksum: 9125ec65a2b05fce908ac2289ba97b995a299f2d717684804211df8e8bcffd8cd9b8861582240655b88f2255c46fcee34026f75c057ffb22f44b6a76cd43f65a
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/supports-web-crypto@npm:^1.0.0":
   version: 1.0.0
   resolution: "@aws-crypto/supports-web-crypto@npm:1.0.0"
   dependencies:
     tslib: ^1.11.1
   checksum: 2d5878e3d5e2b7c94b51e33ceaa2e0d350dcc31067f557a4e598f80681dc4d1c5437e69db45f0b76f4e0a1cee2dbe4ccb1b25ea33ec70fef26b03db70106ab4a
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/supports-web-crypto@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.2"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: 03d04d29292dc1b76db9bc6becd05f52fa79adee0ec084f971b0767f7e73250dd0422bea57636015f8c27f38aefcd1d9c58800a4749cf35339296c8d670f3ccb
   languageName: node
   linkType: hard
 
@@ -317,17 +261,6 @@ __metadata:
     "@aws-sdk/util-utf8-browser": ^3.0.0
     tslib: ^1.11.1
   checksum: 54d72ce4945b52f3fcbcb62574a55bc038cc3ff165742f340cabca1bdc979faf69c97709cf56daf434e4ad69e33582a04a64da33b4e4e13b25c6ff67f8abe5ae
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@aws-crypto/util@npm:2.0.2"
-  dependencies:
-    "@aws-sdk/types": ^3.110.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 13cb33a39005b09c062398d361043c2224bc8ba42b1432bad52e15bc4bf9ffad4facdddc394b3cc71b3fb8d86a7ec325fd1afa107b5fde0dab84a7e32d311d7f
   languageName: node
   linkType: hard
 
@@ -352,16 +285,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/abort-controller@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 56dcab3bcbf018cd5790169b8af64a0e28fe4e252b20e3ee384711b37f7b163160830b144a11c23ccfdc9960c1e75895239b1e294fb331839c7adcdf7ae9721d
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/abort-controller@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/abort-controller@npm:3.6.1"
@@ -369,47 +292,6 @@ __metadata:
     "@aws-sdk/types": 3.6.1
     tslib: ^1.8.0
   checksum: ac7d85675c7cf6979d17e2a09b15d28aa3806fa64ddb50e475e2d41a0fbf287ab20fac70c61c65bfc896fb9d904ad50a76e311bc7a35a9abca721f9bf4baa431
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cloudwatch-events@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/client-cloudwatch-events@npm:3.54.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.54.1
-    "@aws-sdk/config-resolver": 3.54.1
-    "@aws-sdk/credential-provider-node": 3.54.1
-    "@aws-sdk/fetch-http-handler": 3.54.1
-    "@aws-sdk/hash-node": 3.54.1
-    "@aws-sdk/invalid-dependency": 3.54.1
-    "@aws-sdk/middleware-content-length": 3.54.1
-    "@aws-sdk/middleware-host-header": 3.54.1
-    "@aws-sdk/middleware-logger": 3.54.1
-    "@aws-sdk/middleware-retry": 3.54.1
-    "@aws-sdk/middleware-serde": 3.54.1
-    "@aws-sdk/middleware-signing": 3.54.1
-    "@aws-sdk/middleware-stack": 3.54.1
-    "@aws-sdk/middleware-user-agent": 3.54.1
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/node-http-handler": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/smithy-client": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/url-parser": 3.54.1
-    "@aws-sdk/util-base64-browser": 3.52.0
-    "@aws-sdk/util-base64-node": 3.52.0
-    "@aws-sdk/util-body-length-browser": 3.54.0
-    "@aws-sdk/util-body-length-node": 3.54.0
-    "@aws-sdk/util-defaults-mode-browser": 3.54.1
-    "@aws-sdk/util-defaults-mode-node": 3.54.1
-    "@aws-sdk/util-user-agent-browser": 3.54.1
-    "@aws-sdk/util-user-agent-node": 3.54.1
-    "@aws-sdk/util-utf8-browser": 3.52.0
-    "@aws-sdk/util-utf8-node": 3.52.0
-    tslib: ^2.3.0
-  checksum: 0580e60887e9c34adfd74e694d1c50b27f6d472ce9190b549ac041024c9aa98bee93cc72b32a473b25fa63e05571b62d70ef57b0936cac80a1c01d5ed9547b55
   languageName: node
   linkType: hard
 
@@ -614,44 +496,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/client-sso@npm:3.54.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.54.1
-    "@aws-sdk/fetch-http-handler": 3.54.1
-    "@aws-sdk/hash-node": 3.54.1
-    "@aws-sdk/invalid-dependency": 3.54.1
-    "@aws-sdk/middleware-content-length": 3.54.1
-    "@aws-sdk/middleware-host-header": 3.54.1
-    "@aws-sdk/middleware-logger": 3.54.1
-    "@aws-sdk/middleware-retry": 3.54.1
-    "@aws-sdk/middleware-serde": 3.54.1
-    "@aws-sdk/middleware-stack": 3.54.1
-    "@aws-sdk/middleware-user-agent": 3.54.1
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/node-http-handler": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/smithy-client": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/url-parser": 3.54.1
-    "@aws-sdk/util-base64-browser": 3.52.0
-    "@aws-sdk/util-base64-node": 3.52.0
-    "@aws-sdk/util-body-length-browser": 3.54.0
-    "@aws-sdk/util-body-length-node": 3.54.0
-    "@aws-sdk/util-defaults-mode-browser": 3.54.1
-    "@aws-sdk/util-defaults-mode-node": 3.54.1
-    "@aws-sdk/util-user-agent-browser": 3.54.1
-    "@aws-sdk/util-user-agent-node": 3.54.1
-    "@aws-sdk/util-utf8-browser": 3.52.0
-    "@aws-sdk/util-utf8-node": 3.52.0
-    tslib: ^2.3.0
-  checksum: 6852688e007ad75ef73e7d6d6ced693312c8272b7e7d74680e2d7a5949af722f481365612941b3872604ab0c8bf3fc23e3477f098b30e04dee209d6b150c6441
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/client-sts@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/client-sts@npm:3.266.0"
@@ -696,49 +540,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/client-sts@npm:3.54.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.54.1
-    "@aws-sdk/credential-provider-node": 3.54.1
-    "@aws-sdk/fetch-http-handler": 3.54.1
-    "@aws-sdk/hash-node": 3.54.1
-    "@aws-sdk/invalid-dependency": 3.54.1
-    "@aws-sdk/middleware-content-length": 3.54.1
-    "@aws-sdk/middleware-host-header": 3.54.1
-    "@aws-sdk/middleware-logger": 3.54.1
-    "@aws-sdk/middleware-retry": 3.54.1
-    "@aws-sdk/middleware-sdk-sts": 3.54.1
-    "@aws-sdk/middleware-serde": 3.54.1
-    "@aws-sdk/middleware-signing": 3.54.1
-    "@aws-sdk/middleware-stack": 3.54.1
-    "@aws-sdk/middleware-user-agent": 3.54.1
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/node-http-handler": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/smithy-client": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/url-parser": 3.54.1
-    "@aws-sdk/util-base64-browser": 3.52.0
-    "@aws-sdk/util-base64-node": 3.52.0
-    "@aws-sdk/util-body-length-browser": 3.54.0
-    "@aws-sdk/util-body-length-node": 3.54.0
-    "@aws-sdk/util-defaults-mode-browser": 3.54.1
-    "@aws-sdk/util-defaults-mode-node": 3.54.1
-    "@aws-sdk/util-user-agent-browser": 3.54.1
-    "@aws-sdk/util-user-agent-node": 3.54.1
-    "@aws-sdk/util-utf8-browser": 3.52.0
-    "@aws-sdk/util-utf8-node": 3.52.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
-    tslib: ^2.3.0
-  checksum: 85f4a4261f8fa48d13ae93d8f36a792c8cb83c059ce2c78ed7fc2cd318cd0e27e9d2d7104a58e72dee9af4ecf00b112dacb909bf2cd93fbca490fd3f70a38ff6
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/config-resolver@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/config-resolver@npm:3.266.0"
@@ -749,18 +550,6 @@ __metadata:
     "@aws-sdk/util-middleware": 3.266.0
     tslib: ^2.3.1
   checksum: 7b726573ca7a24e8bab29fb02308f22b4c2492756417ef8ab5bf818576b25d0e19c2d8dc243542ddbac606d37d7d9aeaa17725fb95b4c78e68df4f4aab899dc3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/config-resolver@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/config-resolver@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/signature-v4": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/util-config-provider": 3.52.0
-    tslib: ^2.3.0
-  checksum: 23cfc4d50a1f1736e13d271e31746c6871b0d99dfd0072aa17f4ae5a51e831488b79f34f0120e263d1043600d8a41899f6efb15917d2b2fffc6c6b4fa65bcd34
   languageName: node
   linkType: hard
 
@@ -798,17 +587,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-env@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 418a48be64581806b72190f967e15d413e2a80e657863b6d3412ab35a74392145fec7c313e03b047fa4bf9e3fccbba487a6aff84eb4bd9f65d97ae5f6b58b2f1
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/credential-provider-env@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/credential-provider-env@npm:3.6.1"
@@ -830,19 +608,6 @@ __metadata:
     "@aws-sdk/url-parser": 3.266.0
     tslib: ^2.3.1
   checksum: eb155398aecdf3a48ff6e84867d488b492822113c05e43f86e3cea2cb1dd01f5fa605325ff2810712b5b6a98ee5c21589ee7412a154deceea89a31e6601c2e36
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/url-parser": 3.54.1
-    tslib: ^2.3.0
-  checksum: c899245283bc3bfc229544d074a750f6a6d83b57557e4e7ea6002938dadd11e62888bb75f74294497f1ad8d133224d4cbd0be24ae169d0f9789f9d904e3bbab2
   languageName: node
   linkType: hard
 
@@ -871,22 +636,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 0ee2652b47b2ae8621d38dd1d6afff3b8771591682777b85f7e1d7ac7b3c8f600e23ee4d27bec83b7ec2159abe9203604993acbabb27c29d8b539264de8ecde9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.54.1
-    "@aws-sdk/credential-provider-imds": 3.54.1
-    "@aws-sdk/credential-provider-sso": 3.54.1
-    "@aws-sdk/credential-provider-web-identity": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/shared-ini-file-loader": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 4c8190862538499c6e42af72ac09dc508bf99f1bd20f16c49449ec11715fed8cf727da2bd2efa003ab184de62ef439fa16549cc4eb06b197ae085df43ef59900
   languageName: node
   linkType: hard
 
@@ -920,24 +669,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-node@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.54.1
-    "@aws-sdk/credential-provider-imds": 3.54.1
-    "@aws-sdk/credential-provider-ini": 3.54.1
-    "@aws-sdk/credential-provider-process": 3.54.1
-    "@aws-sdk/credential-provider-sso": 3.54.1
-    "@aws-sdk/credential-provider-web-identity": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/shared-ini-file-loader": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: d3c566ba0afc7fdc5213fe9f0f060f40011a3d74a4169705bad053bfed44fe84b14be83b877ef3c3b6a04f2e7a6117a202f17f060fce3c429c9a160c39d2eb61
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/credential-provider-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/credential-provider-node@npm:3.6.1"
@@ -963,18 +694,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 742c75d7b019364ec17d787094e4b3a4acde4ce3d0136c75c7e002a19f9c73ea80f844dc4b1ee2305048d2d08795715dd02e7c6afb42b9679ce2802bd1e708cf
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-process@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/shared-ini-file-loader": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 2b200d4a71d2e5c12dad4a60183ea2e464f5ec688f5602fd4e0d1118b535fa8bf3872a3d7203a4d0be72b9d7e02005df45bdce6a139f8fe849f1500152f41c16
   languageName: node
   linkType: hard
 
@@ -1005,19 +724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/client-sso": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/shared-ini-file-loader": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 241fa2fad0457642ee5dfd70c9ce0d9ba87bc39e507eb769fc2924d55491ec528fc3461518f689b1311fb115ebb0e88a31458235ea2ab2dd27bd3742e198158d
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/credential-provider-web-identity@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.266.0"
@@ -1026,17 +732,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: ff1ef92aa5d2d641132079787479e445aaf16b99231067b5a39c8bd7fb2a95c7ab5004b7199749508750e0ac8626d8ffc99454c44130800f266787a9d053e730
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 70a4e94abb5bffbbe5a9e14e0731e845202b83c201733099952507b793b1c11f9e814d76ac80b5777f8a9187adfcf1c2b6624c027f883439bbb5f29899efb0f4
   languageName: node
   linkType: hard
 
@@ -1050,19 +745,6 @@ __metadata:
     "@aws-sdk/util-base64": 3.208.0
     tslib: ^2.3.1
   checksum: cf4ce1ed565890101e4bef15a380c185887e04d16ba34c60dde53fcd98d70f7c8102045a4ab0ca11cb6dfb841425dd9765737e2c11181fa3664e21cab44933bc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/querystring-builder": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/util-base64-browser": 3.52.0
-    tslib: ^2.3.0
-  checksum: 331e68fbdb723b01434b31b30f1d6fa2768e6846044b7d7337e1ada1f1548bc373c9e3b139a45a1ae48860c7f10d81219fc53e33ec8ee95422cba89ad0e0b7aa
   languageName: node
   linkType: hard
 
@@ -1091,17 +773,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/hash-node@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/util-buffer-from": 3.52.0
-    tslib: ^2.3.0
-  checksum: 260c8804f20d00167f576919e24a5515c83454f91c1cc3b64f347f278d49c408bf520dd3f046df6fb98a16ddb94823ae5cb55f8d29efdd12be85ae50ebcaf657
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/hash-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/hash-node@npm:3.6.1"
@@ -1120,16 +791,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b898eaf0bd8c87a9a32032dedd714d5892dc252aefd0ae65598842745db6c176a55f66e819c7686b101da9a78901b4e3275ebecaf464d849a03db50361e59399
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/invalid-dependency@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 0e9f0de855d98e96245e7ce8f5b3c624897787c20f2c2f137e7580380eabf26d2efb7cda0eeef6529bbbcc18bbfb2c3815b9dc017ce15a4afd4efefb58484b69
   languageName: node
   linkType: hard
 
@@ -1152,15 +813,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/is-array-buffer@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 4cf515f9017741e7f6c4f307a240fa1f29b7f7d5f018220b777200aba16fa4e592afeee4a2ed10eb7de372bcc6fc3d8c34eaf1f1d4f29b314943b5ae154bcbf4
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/is-array-buffer@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/is-array-buffer@npm:3.6.1"
@@ -1178,17 +830,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b8881f3fd2964304380aae1e737e2f80ec0f0bf7ab20ebe081817cd5bbedde60d0aefd95c7112f0d36b3eeb46d6b8b15e091bc0aab66dd77a19a9dd0cfb29c8c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-content-length@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 76c38a06f1d4a26dc830ffdc93c947445d11af83d5018bb723f2874f040d7c68d84141ea01ee1597e1bf4a0de58bed65c248dae8cf40b6ff9b2a067b9f177e11
   languageName: node
   linkType: hard
 
@@ -1230,17 +871,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-host-header@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: f297b05ca2a34e2d1182bb20828d64c03360b3a7e773d510d2bc29cabbb550cc70ae23db71d19c04974f76f1d763084105513720b86978dbdba04ff9108e4c43
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-host-header@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-host-header@npm:3.6.1"
@@ -1259,16 +889,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b5e9ead43cef932157675b7cfbfdf78699ad4f59ce6cd3e5879f1cdf3cbd6b87530261b262c45a54d7aedf602ea821adc0a70b377de2b4c13caf439741f387d0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-logger@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 42ca99baa2c5b9cf6bb942fb806c56dca1abecd48cb3a44dcb1ecee3f189f944d58def71ee73a3c2eb79b131a4ae717f03ef364b25153bad311be472da3eff0b
   languageName: node
   linkType: hard
 
@@ -1308,19 +928,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-retry@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/service-error-classification": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-    uuid: ^8.3.2
-  checksum: 4b54d9b1c0ed3f2938fa231bb67894ebd6570e6a8a79109d5f89badbbb4e369a86da1adf349e1b8cc82007f15c93a56f6fd7ab33110fcd14e261f78c52645e56
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-retry@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-retry@npm:3.6.1"
@@ -1349,20 +956,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/middleware-signing": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/signature-v4": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 1ebbf13d056a099f3cb3875698ef0ed989beb8cce6ca0c586609351c3ecbe10479cd1aaf2a969b33305203d0c37b774fb86203f585c2319c4228277d666d36bd
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-serde@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/middleware-serde@npm:3.266.0"
@@ -1370,16 +963,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 2cf05d20361e38983ad4e2d2de775b8e56532e7ca7a2632b1a450a4d635a8ec5a92245c9c8abc09d34cc6556501338cd5d4155370c9ba02ea55cc5d105153117
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-serde@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: b2e97276c6dc192a6151ffdaa30c727a316c75024a0a067e5b22c0ebc587f3a2aac6c49d80d1046bd1d13a80908f39a6f4018db97f392a3e48628f39fda49075
   languageName: node
   linkType: hard
 
@@ -1407,19 +990,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-signing@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/signature-v4": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: cd513fccf8c338f1325d1e8c1022bc1ad6a73e998135333bb8d1a47ffb5b0c95f85dd3cdf89371cac889476bf18d4e0ac16dd4ab128db07e3c686e40d6b058be
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-signing@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-signing@npm:3.6.1"
@@ -1438,15 +1008,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: f386f220abea8a80756c19562912b555a6223f8e96fc97aebce851e920c05055cae77778272a88638fdd93ceab2680f9ab47c556e9480a3a538a33c8abcc4e66
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-stack@npm:3.54.1"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 29539417d47465ee676d4f10ea488d9689ead44a5c0609986dea650ebd02afbe46e1e19715749a5ce7f3ebe1dae1b00b6ff2fc22fbc17b1dcce52b73b74d66df
   languageName: node
   linkType: hard
 
@@ -1470,17 +1031,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 407b4361271c941e55e941e4e2d4ee327333b6b0602a95a3c329e4f04d17e773b397625a4bdfd171a7bdb0b57db07782fd7365714e77581ba3d2758aed316340
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-user-agent@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-user-agent@npm:3.6.1"
@@ -1501,18 +1051,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 370e76590ec70471c90cb0b2f2cf44f189a2c5515de0ff1952b8c54f8a17f2fc9899f38ff7016bf02310bad4b5aa695920426792d83e900df8fc637ff617bae2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/node-config-provider@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/shared-ini-file-loader": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 4aeee3b0c6f224229f4cbe31cd74ee61d31431906aa25633518af3f7238a8d18fc056020112d5e5b114951f503716d58822e59476ff77a4088db24f1ea674a4a
   languageName: node
   linkType: hard
 
@@ -1541,19 +1079,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/node-http-handler@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.54.1
-    "@aws-sdk/protocol-http": 3.54.1
-    "@aws-sdk/querystring-builder": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 2383d82cc4b1e5750c7abc7e0b7f3e06780b3f7be37dcf2e4f8631ce5aad0ef5cb4a1f85ffd0455b86a0fa3dd0b36e885d11b1e292ebc116a503a39a67001b01
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/node-http-handler@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/node-http-handler@npm:3.6.1"
@@ -1577,16 +1102,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/property-provider@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 98b4f88c06fa819233fff961722c91e0f394073b11966c009704270cb6c670598f5166a696b848c64b017d2d0a9cdf5957e20ab733c3d913eee17ce6b6a75dcd
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/property-provider@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/property-provider@npm:3.6.1"
@@ -1604,16 +1119,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 538bf9f57c67b6677262c14ee3768585436e2421c73d241bff53ebc86a22680320f77f7916c3e02fb9c95844f83b787a749529fbd2cf44ada2f1d3edfeda7a17
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/protocol-http@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 6d6cf10661819bd2d26ca1b262f3606b53b3f9c5bc5de36de1d2be56b492bbcdffd65d84e842bfbbb437d6f7faa4d7b876b261f015896cf5d93991a14bc45704
   languageName: node
   linkType: hard
 
@@ -1638,17 +1143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-builder@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/querystring-builder@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/util-uri-escape": 3.52.0
-    tslib: ^2.3.0
-  checksum: 4f6c0e47be2aa3d601eb4e4ab10fe4ecf8d29ce8f9bb9503e8287584748f5f6262fe735b995fee59e5589dd4186cfae718053a7202c703dc846c43db66899fde
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/querystring-builder@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/querystring-builder@npm:3.6.1"
@@ -1670,16 +1164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/querystring-parser@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 38cc41099977af8ef22fa76070a4ccdf463485756ebc4818bf5c55cb479243394865dbc57c991c9929b342b31f52e663aab341ac56ef7b00b82ef3e537c210aa
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/querystring-parser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/querystring-parser@npm:3.6.1"
@@ -1697,13 +1181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/service-error-classification@npm:3.54.1"
-  checksum: 36b94fe116b11a55dd3582c144b88c5ffa92b3f687b9fc33ca01d978991ceb6a5183809c6309c85fca23516430505defa10a978c743ed9de39cda36a2e853e14
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/service-error-classification@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/service-error-classification@npm:3.6.1"
@@ -1718,15 +1195,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: ac294f5b9f8ec55938f233e626e8c5adf7fa7e331d744a0c2c1267b669e7f6d3abeb22f59b4e3456ce32bdecee0b3a53983730de718750eec1fb4e589fdb1535
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.54.1"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 7aa46b54e76828428f3f776dfdda3b4c766607a9ebb9898a87e0daf67679619aa775f806c2cf87a029a77d09e46df270c37ac4cbca09261241dd783e55038d28
   languageName: node
   linkType: hard
 
@@ -1754,19 +1222,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/signature-v4@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.52.0
-    "@aws-sdk/types": 3.54.1
-    "@aws-sdk/util-hex-encoding": 3.52.0
-    "@aws-sdk/util-uri-escape": 3.52.0
-    tslib: ^2.3.0
-  checksum: 78ab39dd141df4639ed435db15c13df358653bf0163deb8661046530519009030081b400a03432f06bae1af831b90832f45743fecaf0cce230d7b35fc9eda8af
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/signature-v4@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/signature-v4@npm:3.6.1"
@@ -1788,17 +1243,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 6a5a8a180642d9d3ecef53f315cd6f6cd6f9bd765765c546d53e3372125fa8b6083265669e8aa0981be7a8c8889bfad8d00bda6d01d2a1d5a0a9227739912b0a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/smithy-client@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/smithy-client@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 68fdba1a7bc0d4e5ea2e9f3a10d3d78ce4f5a7d06aac96555438bbaeb7b19bd44ad2593563ff70df2a78bb3535e8bdff1bac8909753c2ac6baee2ff7650c6d13
   languageName: node
   linkType: hard
 
@@ -1835,13 +1279,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/types@npm:3.54.1"
-  checksum: e46699b8a595906d5f0c8aec68ac66d63343eaf3f31e6b9610735525e14ff4d7954998e99761eb3c8da9c9157a5437d0ad0f39b33e53af45f86f8fd00adc859c
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/types@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/types@npm:3.6.1"
@@ -1853,15 +1290,6 @@ __metadata:
   version: 1.0.0-rc.10
   resolution: "@aws-sdk/types@npm:1.0.0-rc.10"
   checksum: 46e5ce8937a3abac4dfbff91a8aee980631ec847373b32635f2e1541849ae724ee736ab5a3d8a259352099b7851a71d72c63231b2fcb85b7742bcd1ae59c299b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:^3.110.0":
-  version: 3.272.0
-  resolution: "@aws-sdk/types@npm:3.272.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: c4e4f09dd2672eab4fc15b08006c730c1d07d4b54ae35e03167d99f6110751e36b5332165e03c71c28724037f623f8da87a45a018eb631a1ce86d406f9d08da6
   languageName: node
   linkType: hard
 
@@ -1888,17 +1316,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/url-parser@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: 48e47b7c117bb4246370eb3562bf221b79a778cb74cba3e312081c2937c6812437876e4348d36b7412798335403d0e484a28121efd416c9c27278875d25c6b27
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/url-parser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/url-parser@npm:3.6.1"
@@ -1910,31 +1327,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-browser@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: faf11fd975c1758c9a289b22c4f0230591633c9fa7b45d824d346231f1408a0b9cbf32c1017970449ba8267bb0155fa4d4d9178d77875b19c3d37251f4b7083d
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-base64-browser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-base64-browser@npm:3.6.1"
   dependencies:
     tslib: ^1.8.0
   checksum: 1957aa9a8e639eccdce727feaa098794085775afbfc4950fba68567a8cf114543a3136babb035b1c9c52986d958076f4029b06969cb2deebf7b716486a26e9a2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-node@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.52.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.52.0
-    tslib: ^2.3.0
-  checksum: 7d02a6f611eef9cd4e491533508f07a2db147a49d801c9e5483bae335ea0c74c0197e72000207b784b7063632c1b0d52052055147056aa396df16ed5413422b5
   languageName: node
   linkType: hard
 
@@ -1967,15 +1365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.54.0":
-  version: 3.54.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.54.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 0fd251c5ff950a9e507c9eaa94785902fd4b76cc2b6d6867fa226e318e02dda3a51636c4ee103cf9599d033b4dbef149b0c680bf39e7ad3256089769b7d455f6
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-body-length-browser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-body-length-browser@npm:3.6.1"
@@ -1991,15 +1380,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: 986b42b358656dec4e75c231213331c4f01785f9ab17c8b87b6e268b6880818a96117f1785cef9786e6c0f7e2c1332c80e8388a43bfd83e8c7224ad059a72733
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-node@npm:3.54.0":
-  version: 3.54.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.54.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 527b3904acc0e7577af90202ddb08bcc02a2510493aa9c518244d6b7173178dffc210152eef53cfaf6f98bebf9ee1d80007f193e6b371d1da4d3457b33916da6
   languageName: node
   linkType: hard
 
@@ -2022,16 +1402,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.52.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.52.0
-    tslib: ^2.3.0
-  checksum: adac69278c07e171546550c6e44b2b1fdcfa0a728b46a04d175f9e336b9525f843179606cbdeacd4817facdac21028ecdbc8a166ab22f656283b8d94cc1c117a
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-buffer-from@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-buffer-from@npm:3.6.1"
@@ -2051,15 +1421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-config-provider@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 3b21896b62243a59ed88ff69148a26ed8ddb8a424b4be2aabc9402610c4fcc4ba08809e643d0ae079486769601942aaa1f3bbd0c13013461b63a9870bd12e92f
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-defaults-mode-browser@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.266.0"
@@ -2069,18 +1430,6 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.3.1
   checksum: d12ee57fef9303aedd7347c91fac93ba6ff34c98979c1f7a557a14a4b20a9cb2e7e3b318072f67053080c21b70b72fb6a0e7c60fd54464803bf31af597ce6c97
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-defaults-mode-browser@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    bowser: ^2.11.0
-    tslib: ^2.3.0
-  checksum: 6a0f249cf2473361bfb44a283eab4937c05a9285d2b460a8e4e5e53f4eff88822497c59ddc5c467879f45be020e770dd06335b8ea26dc96279ff074206a7cb5c
   languageName: node
   linkType: hard
 
@@ -2095,20 +1444,6 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 35e5029f7a210f85516a1ffa1d0826e360dd4a85cfb90740229b2a3ce367da434c50a0d5fdb56079a803d29edd9230e28a2d1493270cb23de63610f2c65c25bd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-defaults-mode-node@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/config-resolver": 3.54.1
-    "@aws-sdk/credential-provider-imds": 3.54.1
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/property-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: a04be3d3a5df8448d190c1acfefa7d6bcad67f900460fa8c4a9e98bb55f62c83cfab6f4cec520ec29c211b15b8bfeddebbea14871e7249528296ae4976c54edf
   languageName: node
   linkType: hard
 
@@ -2128,15 +1463,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: a27f3365dfb1e6ece79ea34fd6e2c4540eb0084536d7300ff0ff42a7334ddf07f21958c6cfd0bbeb71361ee408e16deae2c82b7c7378b048b8e81a52c75f190a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 682219e1add4b5698edeb11932573743b008d0685cd14d0b3d152f5a5f214cddaa67d99b00c50cf0963a06a396949176b4bea01820c3a2bd0273b2a9a2a5a946
   languageName: node
   linkType: hard
 
@@ -2186,15 +1512,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-uri-escape@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 8935fd47135cd18c950d3dc6f9679a31f5fd94caf2fcac595dc2fc94db773ede45e08a5427a19a0fc97e4f6e784a2c4847e625b30b6d057b593e335643960536
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-uri-escape@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-uri-escape@npm:3.6.1"
@@ -2212,17 +1529,6 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.3.1
   checksum: ec845b66a6e6d072e803d3ab604e8245b744d92594f6cc3adb4120ecca06335c9f2ce77de6442189ec3f29c4b5f19f2c210888d20e435a49dab326568c997006
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/types": 3.54.1
-    bowser: ^2.11.0
-    tslib: ^2.3.0
-  checksum: 56409fd98813b6073390b53785060822323f94acbd9bd1edbabbab47c7522c0f68ace8a0782923f2196eff22b6651f11955488e2ae7da903fd2fd98360b5f2e3
   languageName: node
   linkType: hard
 
@@ -2253,17 +1559,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.54.1":
-  version: 3.54.1
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.54.1"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.54.1
-    "@aws-sdk/types": 3.54.1
-    tslib: ^2.3.0
-  checksum: b0de34d201cf63a4512086aea73fbdc1f6422f948693d7a09dac7feff10d0314bddada7830d744da63348b0979d12bf5057b456d72e64eedf66eb41ffa20a8d0
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-user-agent-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-user-agent-node@npm:3.6.1"
@@ -2272,15 +1567,6 @@ __metadata:
     "@aws-sdk/types": 3.6.1
     tslib: ^1.8.0
   checksum: 7fe2fefd2eccac9177e5571d589e13496395fb7ba2ac6e70f1c8d36fdc9e0083f851b77b3f2daf7175be8af9cbcca3c616b34eee6cc47f3cb341517e9def2ecc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.52.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 3a46ba47a2a70cd7ff5b3dbf89447f9033b78d208f35cd68901cbf37c4931bb2c11dff9529d068808632ad5cdc1885a5cc06ba8c456c6702bdfbcaf81bbc3a53
   languageName: node
   linkType: hard
 
@@ -2308,16 +1594,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-node@npm:3.52.0":
-  version: 3.52.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.52.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.52.0
-    tslib: ^2.3.0
-  checksum: 67cb7c9aa74be544d473c880d33118242c35c08b184793f1849ac7f7cec9c8f2b3bbef79a9d4f9c20abb899f13a6103bd7b34cfc1eec00fdd2f9f3bcc9fc856e
   languageName: node
   linkType: hard
 
@@ -11146,7 +10422,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/api-apw@workspace:packages/api-apw"
   dependencies:
-    "@aws-sdk/client-cloudwatch-events": 3.54.1
+    "@aws-sdk/client-cloudwatch-events": ^3.54.1
     "@babel/cli": ^7.19.3
     "@babel/core": ^7.19.3
     "@babel/preset-env": ^7.19.4
@@ -22335,17 +21611,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:2.2.0, entities@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "entities@npm:2.2.0"
-  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
-  languageName: node
-  linkType: hard
-
 "entities@npm:^1.1.1":
   version: 1.1.2
   resolution: "entities@npm:1.1.2"
   checksum: d537b02799bdd4784ffd714d000597ed168727bddf4885da887c5a491d735739029a00794f1998abbf35f3f6aeda32ef5c15010dca1817d401903a501b6d3e05
+  languageName: node
+  linkType: hard
+
+"entities@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
   languageName: node
   linkType: hard
 
@@ -23755,15 +23031,6 @@ __metadata:
   version: 2.2.0
   resolution: "fast-uri@npm:2.2.0"
   checksum: edac64d50628f21d562cdc19ea86f5af00902dbb09d2f96fff5974e5317157825e9aa163af9defd11a0818aac6ea2e9958597bed98dd041200a08a976809d08b
-  languageName: node
-  linkType: hard
-
-"fast-xml-parser@npm:3.19.0":
-  version: 3.19.0
-  resolution: "fast-xml-parser@npm:3.19.0"
-  bin:
-    xml2js: cli.js
-  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,12 +162,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/ie11-detection@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/ie11-detection@npm:2.0.2"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 713293deea8eefd3ab43dc05e62228571d27754e7293f8ec2fd8a0c693fbbfc55213e6599387776e3cdbc951965dc62e24e92b9c4a853e4a50d00ae6a9f6b2bd
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/ie11-detection@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
   dependencies:
     tslib: ^1.11.1
   checksum: 299b2ddd46eddac1f2d54d91386ceb37af81aef8a800669281c73d634ed17fd855dcfb8b3157f2879344b93a2666a6d602550eb84b71e4d7868100ad6da8f803
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/sha256-js": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
   languageName: node
   linkType: hard
 
@@ -213,6 +238,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/sha256-js@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/sha256-js@npm:3.0.0"
@@ -235,12 +271,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/sha256-js@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/sha256-js@npm:2.0.2"
+  dependencies:
+    "@aws-crypto/util": ^2.0.2
+    "@aws-sdk/types": ^3.110.0
+    tslib: ^1.11.1
+  checksum: 9125ec65a2b05fce908ac2289ba97b995a299f2d717684804211df8e8bcffd8cd9b8861582240655b88f2255c46fcee34026f75c057ffb22f44b6a76cd43f65a
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/supports-web-crypto@npm:^1.0.0":
   version: 1.0.0
   resolution: "@aws-crypto/supports-web-crypto@npm:1.0.0"
   dependencies:
     tslib: ^1.11.1
   checksum: 2d5878e3d5e2b7c94b51e33ceaa2e0d350dcc31067f557a4e598f80681dc4d1c5437e69db45f0b76f4e0a1cee2dbe4ccb1b25ea33ec70fef26b03db70106ab4a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.2"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 03d04d29292dc1b76db9bc6becd05f52fa79adee0ec084f971b0767f7e73250dd0422bea57636015f8c27f38aefcd1d9c58800a4749cf35339296c8d670f3ccb
   languageName: node
   linkType: hard
 
@@ -261,6 +317,17 @@ __metadata:
     "@aws-sdk/util-utf8-browser": ^3.0.0
     tslib: ^1.11.1
   checksum: 54d72ce4945b52f3fcbcb62574a55bc038cc3ff165742f340cabca1bdc979faf69c97709cf56daf434e4ad69e33582a04a64da33b4e4e13b25c6ff67f8abe5ae
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@aws-crypto/util@npm:2.0.2"
+  dependencies:
+    "@aws-sdk/types": ^3.110.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 13cb33a39005b09c062398d361043c2224bc8ba42b1432bad52e15bc4bf9ffad4facdddc394b3cc71b3fb8d86a7ec325fd1afa107b5fde0dab84a7e32d311d7f
   languageName: node
   linkType: hard
 
@@ -285,6 +352,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/abort-controller@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/abort-controller@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 56dcab3bcbf018cd5790169b8af64a0e28fe4e252b20e3ee384711b37f7b163160830b144a11c23ccfdc9960c1e75895239b1e294fb331839c7adcdf7ae9721d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/abort-controller@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/abort-controller@npm:3.6.1"
@@ -292,6 +369,47 @@ __metadata:
     "@aws-sdk/types": 3.6.1
     tslib: ^1.8.0
   checksum: ac7d85675c7cf6979d17e2a09b15d28aa3806fa64ddb50e475e2d41a0fbf287ab20fac70c61c65bfc896fb9d904ad50a76e311bc7a35a9abca721f9bf4baa431
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-cloudwatch-events@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/client-cloudwatch-events@npm:3.54.1"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/client-sts": 3.54.1
+    "@aws-sdk/config-resolver": 3.54.1
+    "@aws-sdk/credential-provider-node": 3.54.1
+    "@aws-sdk/fetch-http-handler": 3.54.1
+    "@aws-sdk/hash-node": 3.54.1
+    "@aws-sdk/invalid-dependency": 3.54.1
+    "@aws-sdk/middleware-content-length": 3.54.1
+    "@aws-sdk/middleware-host-header": 3.54.1
+    "@aws-sdk/middleware-logger": 3.54.1
+    "@aws-sdk/middleware-retry": 3.54.1
+    "@aws-sdk/middleware-serde": 3.54.1
+    "@aws-sdk/middleware-signing": 3.54.1
+    "@aws-sdk/middleware-stack": 3.54.1
+    "@aws-sdk/middleware-user-agent": 3.54.1
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/node-http-handler": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/smithy-client": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/url-parser": 3.54.1
+    "@aws-sdk/util-base64-browser": 3.52.0
+    "@aws-sdk/util-base64-node": 3.52.0
+    "@aws-sdk/util-body-length-browser": 3.54.0
+    "@aws-sdk/util-body-length-node": 3.54.0
+    "@aws-sdk/util-defaults-mode-browser": 3.54.1
+    "@aws-sdk/util-defaults-mode-node": 3.54.1
+    "@aws-sdk/util-user-agent-browser": 3.54.1
+    "@aws-sdk/util-user-agent-node": 3.54.1
+    "@aws-sdk/util-utf8-browser": 3.52.0
+    "@aws-sdk/util-utf8-node": 3.52.0
+    tslib: ^2.3.0
+  checksum: 0580e60887e9c34adfd74e694d1c50b27f6d472ce9190b549ac041024c9aa98bee93cc72b32a473b25fa63e05571b62d70ef57b0936cac80a1c01d5ed9547b55
   languageName: node
   linkType: hard
 
@@ -496,6 +614,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/client-sso@npm:3.54.1"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.54.1
+    "@aws-sdk/fetch-http-handler": 3.54.1
+    "@aws-sdk/hash-node": 3.54.1
+    "@aws-sdk/invalid-dependency": 3.54.1
+    "@aws-sdk/middleware-content-length": 3.54.1
+    "@aws-sdk/middleware-host-header": 3.54.1
+    "@aws-sdk/middleware-logger": 3.54.1
+    "@aws-sdk/middleware-retry": 3.54.1
+    "@aws-sdk/middleware-serde": 3.54.1
+    "@aws-sdk/middleware-stack": 3.54.1
+    "@aws-sdk/middleware-user-agent": 3.54.1
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/node-http-handler": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/smithy-client": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/url-parser": 3.54.1
+    "@aws-sdk/util-base64-browser": 3.52.0
+    "@aws-sdk/util-base64-node": 3.52.0
+    "@aws-sdk/util-body-length-browser": 3.54.0
+    "@aws-sdk/util-body-length-node": 3.54.0
+    "@aws-sdk/util-defaults-mode-browser": 3.54.1
+    "@aws-sdk/util-defaults-mode-node": 3.54.1
+    "@aws-sdk/util-user-agent-browser": 3.54.1
+    "@aws-sdk/util-user-agent-node": 3.54.1
+    "@aws-sdk/util-utf8-browser": 3.52.0
+    "@aws-sdk/util-utf8-node": 3.52.0
+    tslib: ^2.3.0
+  checksum: 6852688e007ad75ef73e7d6d6ced693312c8272b7e7d74680e2d7a5949af722f481365612941b3872604ab0c8bf3fc23e3477f098b30e04dee209d6b150c6441
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sts@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/client-sts@npm:3.266.0"
@@ -540,6 +696,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sts@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/client-sts@npm:3.54.1"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.54.1
+    "@aws-sdk/credential-provider-node": 3.54.1
+    "@aws-sdk/fetch-http-handler": 3.54.1
+    "@aws-sdk/hash-node": 3.54.1
+    "@aws-sdk/invalid-dependency": 3.54.1
+    "@aws-sdk/middleware-content-length": 3.54.1
+    "@aws-sdk/middleware-host-header": 3.54.1
+    "@aws-sdk/middleware-logger": 3.54.1
+    "@aws-sdk/middleware-retry": 3.54.1
+    "@aws-sdk/middleware-sdk-sts": 3.54.1
+    "@aws-sdk/middleware-serde": 3.54.1
+    "@aws-sdk/middleware-signing": 3.54.1
+    "@aws-sdk/middleware-stack": 3.54.1
+    "@aws-sdk/middleware-user-agent": 3.54.1
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/node-http-handler": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/smithy-client": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/url-parser": 3.54.1
+    "@aws-sdk/util-base64-browser": 3.52.0
+    "@aws-sdk/util-base64-node": 3.52.0
+    "@aws-sdk/util-body-length-browser": 3.54.0
+    "@aws-sdk/util-body-length-node": 3.54.0
+    "@aws-sdk/util-defaults-mode-browser": 3.54.1
+    "@aws-sdk/util-defaults-mode-node": 3.54.1
+    "@aws-sdk/util-user-agent-browser": 3.54.1
+    "@aws-sdk/util-user-agent-node": 3.54.1
+    "@aws-sdk/util-utf8-browser": 3.52.0
+    "@aws-sdk/util-utf8-node": 3.52.0
+    entities: 2.2.0
+    fast-xml-parser: 3.19.0
+    tslib: ^2.3.0
+  checksum: 85f4a4261f8fa48d13ae93d8f36a792c8cb83c059ce2c78ed7fc2cd318cd0e27e9d2d7104a58e72dee9af4ecf00b112dacb909bf2cd93fbca490fd3f70a38ff6
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/config-resolver@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/config-resolver@npm:3.266.0"
@@ -550,6 +749,18 @@ __metadata:
     "@aws-sdk/util-middleware": 3.266.0
     tslib: ^2.3.1
   checksum: 7b726573ca7a24e8bab29fb02308f22b4c2492756417ef8ab5bf818576b25d0e19c2d8dc243542ddbac606d37d7d9aeaa17725fb95b4c78e68df4f4aab899dc3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/config-resolver@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/config-resolver@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/signature-v4": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/util-config-provider": 3.52.0
+    tslib: ^2.3.0
+  checksum: 23cfc4d50a1f1736e13d271e31746c6871b0d99dfd0072aa17f4ae5a51e831488b79f34f0120e263d1043600d8a41899f6efb15917d2b2fffc6c6b4fa65bcd34
   languageName: node
   linkType: hard
 
@@ -587,6 +798,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-env@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-env@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 418a48be64581806b72190f967e15d413e2a80e657863b6d3412ab35a74392145fec7c313e03b047fa4bf9e3fccbba487a6aff84eb4bd9f65d97ae5f6b58b2f1
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-env@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/credential-provider-env@npm:3.6.1"
@@ -608,6 +830,19 @@ __metadata:
     "@aws-sdk/url-parser": 3.266.0
     tslib: ^2.3.1
   checksum: eb155398aecdf3a48ff6e84867d488b492822113c05e43f86e3cea2cb1dd01f5fa605325ff2810712b5b6a98ee5c21589ee7412a154deceea89a31e6601c2e36
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-imds@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/url-parser": 3.54.1
+    tslib: ^2.3.0
+  checksum: c899245283bc3bfc229544d074a750f6a6d83b57557e4e7ea6002938dadd11e62888bb75f74294497f1ad8d133224d4cbd0be24ae169d0f9789f9d904e3bbab2
   languageName: node
   linkType: hard
 
@@ -636,6 +871,22 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 0ee2652b47b2ae8621d38dd1d6afff3b8771591682777b85f7e1d7ac7b3c8f600e23ee4d27bec83b7ec2159abe9203604993acbabb27c29d8b539264de8ecde9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.54.1
+    "@aws-sdk/credential-provider-imds": 3.54.1
+    "@aws-sdk/credential-provider-sso": 3.54.1
+    "@aws-sdk/credential-provider-web-identity": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/shared-ini-file-loader": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 4c8190862538499c6e42af72ac09dc508bf99f1bd20f16c49449ec11715fed8cf727da2bd2efa003ab184de62ef439fa16549cc4eb06b197ae085df43ef59900
   languageName: node
   linkType: hard
 
@@ -669,6 +920,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-node@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.54.1
+    "@aws-sdk/credential-provider-imds": 3.54.1
+    "@aws-sdk/credential-provider-ini": 3.54.1
+    "@aws-sdk/credential-provider-process": 3.54.1
+    "@aws-sdk/credential-provider-sso": 3.54.1
+    "@aws-sdk/credential-provider-web-identity": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/shared-ini-file-loader": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: d3c566ba0afc7fdc5213fe9f0f060f40011a3d74a4169705bad053bfed44fe84b14be83b877ef3c3b6a04f2e7a6117a202f17f060fce3c429c9a160c39d2eb61
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/credential-provider-node@npm:3.6.1"
@@ -694,6 +963,18 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 742c75d7b019364ec17d787094e4b3a4acde4ce3d0136c75c7e002a19f9c73ea80f844dc4b1ee2305048d2d08795715dd02e7c6afb42b9679ce2802bd1e708cf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-process@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/shared-ini-file-loader": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 2b200d4a71d2e5c12dad4a60183ea2e464f5ec688f5602fd4e0d1118b535fa8bf3872a3d7203a4d0be72b9d7e02005df45bdce6a139f8fe849f1500152f41c16
   languageName: node
   linkType: hard
 
@@ -724,6 +1005,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/client-sso": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/shared-ini-file-loader": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 241fa2fad0457642ee5dfd70c9ce0d9ba87bc39e507eb769fc2924d55491ec528fc3461518f689b1311fb115ebb0e88a31458235ea2ab2dd27bd3742e198158d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.266.0"
@@ -732,6 +1026,17 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: ff1ef92aa5d2d641132079787479e445aaf16b99231067b5a39c8bd7fb2a95c7ab5004b7199749508750e0ac8626d8ffc99454c44130800f266787a9d053e730
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 70a4e94abb5bffbbe5a9e14e0731e845202b83c201733099952507b793b1c11f9e814d76ac80b5777f8a9187adfcf1c2b6624c027f883439bbb5f29899efb0f4
   languageName: node
   linkType: hard
 
@@ -745,6 +1050,19 @@ __metadata:
     "@aws-sdk/util-base64": 3.208.0
     tslib: ^2.3.1
   checksum: cf4ce1ed565890101e4bef15a380c185887e04d16ba34c60dde53fcd98d70f7c8102045a4ab0ca11cb6dfb841425dd9765737e2c11181fa3664e21cab44933bc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/fetch-http-handler@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/querystring-builder": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/util-base64-browser": 3.52.0
+    tslib: ^2.3.0
+  checksum: 331e68fbdb723b01434b31b30f1d6fa2768e6846044b7d7337e1ada1f1548bc373c9e3b139a45a1ae48860c7f10d81219fc53e33ec8ee95422cba89ad0e0b7aa
   languageName: node
   linkType: hard
 
@@ -773,6 +1091,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/hash-node@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/hash-node@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/util-buffer-from": 3.52.0
+    tslib: ^2.3.0
+  checksum: 260c8804f20d00167f576919e24a5515c83454f91c1cc3b64f347f278d49c408bf520dd3f046df6fb98a16ddb94823ae5cb55f8d29efdd12be85ae50ebcaf657
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/hash-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/hash-node@npm:3.6.1"
@@ -791,6 +1120,16 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b898eaf0bd8c87a9a32032dedd714d5892dc252aefd0ae65598842745db6c176a55f66e819c7686b101da9a78901b4e3275ebecaf464d849a03db50361e59399
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/invalid-dependency@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/invalid-dependency@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 0e9f0de855d98e96245e7ce8f5b3c624897787c20f2c2f137e7580380eabf26d2efb7cda0eeef6529bbbcc18bbfb2c3815b9dc017ce15a4afd4efefb58484b69
   languageName: node
   linkType: hard
 
@@ -813,6 +1152,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/is-array-buffer@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 4cf515f9017741e7f6c4f307a240fa1f29b7f7d5f018220b777200aba16fa4e592afeee4a2ed10eb7de372bcc6fc3d8c34eaf1f1d4f29b314943b5ae154bcbf4
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/is-array-buffer@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/is-array-buffer@npm:3.6.1"
@@ -830,6 +1178,17 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b8881f3fd2964304380aae1e737e2f80ec0f0bf7ab20ebe081817cd5bbedde60d0aefd95c7112f0d36b3eeb46d6b8b15e091bc0aab66dd77a19a9dd0cfb29c8c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-content-length@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-content-length@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 76c38a06f1d4a26dc830ffdc93c947445d11af83d5018bb723f2874f040d7c68d84141ea01ee1597e1bf4a0de58bed65c248dae8cf40b6ff9b2a067b9f177e11
   languageName: node
   linkType: hard
 
@@ -871,6 +1230,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-host-header@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-host-header@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: f297b05ca2a34e2d1182bb20828d64c03360b3a7e773d510d2bc29cabbb550cc70ae23db71d19c04974f76f1d763084105513720b86978dbdba04ff9108e4c43
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-host-header@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-host-header@npm:3.6.1"
@@ -889,6 +1259,16 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: b5e9ead43cef932157675b7cfbfdf78699ad4f59ce6cd3e5879f1cdf3cbd6b87530261b262c45a54d7aedf602ea821adc0a70b377de2b4c13caf439741f387d0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-logger@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 42ca99baa2c5b9cf6bb942fb806c56dca1abecd48cb3a44dcb1ecee3f189f944d58def71ee73a3c2eb79b131a4ae717f03ef364b25153bad311be472da3eff0b
   languageName: node
   linkType: hard
 
@@ -928,6 +1308,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-retry@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-retry@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/service-error-classification": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+    uuid: ^8.3.2
+  checksum: 4b54d9b1c0ed3f2938fa231bb67894ebd6570e6a8a79109d5f89badbbb4e369a86da1adf349e1b8cc82007f15c93a56f6fd7ab33110fcd14e261f78c52645e56
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-retry@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-retry@npm:3.6.1"
@@ -956,6 +1349,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-sdk-sts@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/signature-v4": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 1ebbf13d056a099f3cb3875698ef0ed989beb8cce6ca0c586609351c3ecbe10479cd1aaf2a969b33305203d0c37b774fb86203f585c2319c4228277d666d36bd
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-serde@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/middleware-serde@npm:3.266.0"
@@ -963,6 +1370,16 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 2cf05d20361e38983ad4e2d2de775b8e56532e7ca7a2632b1a450a4d635a8ec5a92245c9c8abc09d34cc6556501338cd5d4155370c9ba02ea55cc5d105153117
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-serde@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-serde@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: b2e97276c6dc192a6151ffdaa30c727a316c75024a0a067e5b22c0ebc587f3a2aac6c49d80d1046bd1d13a80908f39a6f4018db97f392a3e48628f39fda49075
   languageName: node
   linkType: hard
 
@@ -990,6 +1407,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-signing@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-signing@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/signature-v4": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: cd513fccf8c338f1325d1e8c1022bc1ad6a73e998135333bb8d1a47ffb5b0c95f85dd3cdf89371cac889476bf18d4e0ac16dd4ab128db07e3c686e40d6b058be
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-signing@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-signing@npm:3.6.1"
@@ -1008,6 +1438,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: f386f220abea8a80756c19562912b555a6223f8e96fc97aebce851e920c05055cae77778272a88638fdd93ceab2680f9ab47c556e9480a3a538a33c8abcc4e66
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-stack@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-stack@npm:3.54.1"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 29539417d47465ee676d4f10ea488d9689ead44a5c0609986dea650ebd02afbe46e1e19715749a5ce7f3ebe1dae1b00b6ff2fc22fbc17b1dcce52b73b74d66df
   languageName: node
   linkType: hard
 
@@ -1031,6 +1470,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 407b4361271c941e55e941e4e2d4ee327333b6b0602a95a3c329e4f04d17e773b397625a4bdfd171a7bdb0b57db07782fd7365714e77581ba3d2758aed316340
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-user-agent@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/middleware-user-agent@npm:3.6.1"
@@ -1051,6 +1501,18 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 370e76590ec70471c90cb0b2f2cf44f189a2c5515de0ff1952b8c54f8a17f2fc9899f38ff7016bf02310bad4b5aa695920426792d83e900df8fc637ff617bae2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-config-provider@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/node-config-provider@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/shared-ini-file-loader": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 4aeee3b0c6f224229f4cbe31cd74ee61d31431906aa25633518af3f7238a8d18fc056020112d5e5b114951f503716d58822e59476ff77a4088db24f1ea674a4a
   languageName: node
   linkType: hard
 
@@ -1079,6 +1541,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/node-http-handler@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/node-http-handler@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.54.1
+    "@aws-sdk/protocol-http": 3.54.1
+    "@aws-sdk/querystring-builder": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 2383d82cc4b1e5750c7abc7e0b7f3e06780b3f7be37dcf2e4f8631ce5aad0ef5cb4a1f85ffd0455b86a0fa3dd0b36e885d11b1e292ebc116a503a39a67001b01
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/node-http-handler@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/node-http-handler@npm:3.6.1"
@@ -1102,6 +1577,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/property-provider@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/property-provider@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 98b4f88c06fa819233fff961722c91e0f394073b11966c009704270cb6c670598f5166a696b848c64b017d2d0a9cdf5957e20ab733c3d913eee17ce6b6a75dcd
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/property-provider@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/property-provider@npm:3.6.1"
@@ -1119,6 +1604,16 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 538bf9f57c67b6677262c14ee3768585436e2421c73d241bff53ebc86a22680320f77f7916c3e02fb9c95844f83b787a749529fbd2cf44ada2f1d3edfeda7a17
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/protocol-http@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 6d6cf10661819bd2d26ca1b262f3606b53b3f9c5bc5de36de1d2be56b492bbcdffd65d84e842bfbbb437d6f7faa4d7b876b261f015896cf5d93991a14bc45704
   languageName: node
   linkType: hard
 
@@ -1143,6 +1638,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/querystring-builder@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/querystring-builder@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/util-uri-escape": 3.52.0
+    tslib: ^2.3.0
+  checksum: 4f6c0e47be2aa3d601eb4e4ab10fe4ecf8d29ce8f9bb9503e8287584748f5f6262fe735b995fee59e5589dd4186cfae718053a7202c703dc846c43db66899fde
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/querystring-builder@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/querystring-builder@npm:3.6.1"
@@ -1164,6 +1670,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/querystring-parser@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/querystring-parser@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 38cc41099977af8ef22fa76070a4ccdf463485756ebc4818bf5c55cb479243394865dbc57c991c9929b342b31f52e663aab341ac56ef7b00b82ef3e537c210aa
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/querystring-parser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/querystring-parser@npm:3.6.1"
@@ -1181,6 +1697,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/service-error-classification@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/service-error-classification@npm:3.54.1"
+  checksum: 36b94fe116b11a55dd3582c144b88c5ffa92b3f687b9fc33ca01d978991ceb6a5183809c6309c85fca23516430505defa10a978c743ed9de39cda36a2e853e14
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/service-error-classification@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/service-error-classification@npm:3.6.1"
@@ -1195,6 +1718,15 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: ac294f5b9f8ec55938f233e626e8c5adf7fa7e331d744a0c2c1267b669e7f6d3abeb22f59b4e3456ce32bdecee0b3a53983730de718750eec1fb4e589fdb1535
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.54.1"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 7aa46b54e76828428f3f776dfdda3b4c766607a9ebb9898a87e0daf67679619aa775f806c2cf87a029a77d09e46df270c37ac4cbca09261241dd783e55038d28
   languageName: node
   linkType: hard
 
@@ -1222,6 +1754,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/signature-v4@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/signature-v4@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.52.0
+    "@aws-sdk/types": 3.54.1
+    "@aws-sdk/util-hex-encoding": 3.52.0
+    "@aws-sdk/util-uri-escape": 3.52.0
+    tslib: ^2.3.0
+  checksum: 78ab39dd141df4639ed435db15c13df358653bf0163deb8661046530519009030081b400a03432f06bae1af831b90832f45743fecaf0cce230d7b35fc9eda8af
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/signature-v4@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/signature-v4@npm:3.6.1"
@@ -1243,6 +1788,17 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 6a5a8a180642d9d3ecef53f315cd6f6cd6f9bd765765c546d53e3372125fa8b6083265669e8aa0981be7a8c8889bfad8d00bda6d01d2a1d5a0a9227739912b0a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/smithy-client@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/smithy-client@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 68fdba1a7bc0d4e5ea2e9f3a10d3d78ce4f5a7d06aac96555438bbaeb7b19bd44ad2593563ff70df2a78bb3535e8bdff1bac8909753c2ac6baee2ff7650c6d13
   languageName: node
   linkType: hard
 
@@ -1279,6 +1835,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/types@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/types@npm:3.54.1"
+  checksum: e46699b8a595906d5f0c8aec68ac66d63343eaf3f31e6b9610735525e14ff4d7954998e99761eb3c8da9c9157a5437d0ad0f39b33e53af45f86f8fd00adc859c
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/types@npm:3.6.1"
@@ -1290,6 +1853,15 @@ __metadata:
   version: 1.0.0-rc.10
   resolution: "@aws-sdk/types@npm:1.0.0-rc.10"
   checksum: 46e5ce8937a3abac4dfbff91a8aee980631ec847373b32635f2e1541849ae724ee736ab5a3d8a259352099b7851a71d72c63231b2fcb85b7742bcd1ae59c299b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.110.0":
+  version: 3.272.0
+  resolution: "@aws-sdk/types@npm:3.272.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: c4e4f09dd2672eab4fc15b08006c730c1d07d4b54ae35e03167d99f6110751e36b5332165e03c71c28724037f623f8da87a45a018eb631a1ce86d406f9d08da6
   languageName: node
   linkType: hard
 
@@ -1316,6 +1888,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/url-parser@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/url-parser@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/querystring-parser": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: 48e47b7c117bb4246370eb3562bf221b79a778cb74cba3e312081c2937c6812437876e4348d36b7412798335403d0e484a28121efd416c9c27278875d25c6b27
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/url-parser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/url-parser@npm:3.6.1"
@@ -1327,12 +1910,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-base64-browser@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: faf11fd975c1758c9a289b22c4f0230591633c9fa7b45d824d346231f1408a0b9cbf32c1017970449ba8267bb0155fa4d4d9178d77875b19c3d37251f4b7083d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-base64-browser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-base64-browser@npm:3.6.1"
   dependencies:
     tslib: ^1.8.0
   checksum: 1957aa9a8e639eccdce727feaa098794085775afbfc4950fba68567a8cf114543a3136babb035b1c9c52986d958076f4029b06969cb2deebf7b716486a26e9a2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64-node@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-base64-node@npm:3.52.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.52.0
+    tslib: ^2.3.0
+  checksum: 7d02a6f611eef9cd4e491533508f07a2db147a49d801c9e5483bae335ea0c74c0197e72000207b784b7063632c1b0d52052055147056aa396df16ed5413422b5
   languageName: node
   linkType: hard
 
@@ -1365,6 +1967,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-body-length-browser@npm:3.54.0":
+  version: 3.54.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.54.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 0fd251c5ff950a9e507c9eaa94785902fd4b76cc2b6d6867fa226e318e02dda3a51636c4ee103cf9599d033b4dbef149b0c680bf39e7ad3256089769b7d455f6
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-body-length-browser@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-body-length-browser@npm:3.6.1"
@@ -1380,6 +1991,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: 986b42b358656dec4e75c231213331c4f01785f9ab17c8b87b6e268b6880818a96117f1785cef9786e6c0f7e2c1332c80e8388a43bfd83e8c7224ad059a72733
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-node@npm:3.54.0":
+  version: 3.54.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.54.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 527b3904acc0e7577af90202ddb08bcc02a2510493aa9c518244d6b7173178dffc210152eef53cfaf6f98bebf9ee1d80007f193e6b371d1da4d3457b33916da6
   languageName: node
   linkType: hard
 
@@ -1402,6 +2022,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-buffer-from@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.52.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.52.0
+    tslib: ^2.3.0
+  checksum: adac69278c07e171546550c6e44b2b1fdcfa0a728b46a04d175f9e336b9525f843179606cbdeacd4817facdac21028ecdbc8a166ab22f656283b8d94cc1c117a
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-buffer-from@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-buffer-from@npm:3.6.1"
@@ -1421,6 +2051,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-config-provider@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 3b21896b62243a59ed88ff69148a26ed8ddb8a424b4be2aabc9402610c4fcc4ba08809e643d0ae079486769601942aaa1f3bbd0c13013461b63a9870bd12e92f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-defaults-mode-browser@npm:3.266.0":
   version: 3.266.0
   resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.266.0"
@@ -1430,6 +2069,18 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.3.1
   checksum: d12ee57fef9303aedd7347c91fac93ba6ff34c98979c1f7a557a14a4b20a9cb2e7e3b318072f67053080c21b70b72fb6a0e7c60fd54464803bf31af597ce6c97
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-browser@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    bowser: ^2.11.0
+    tslib: ^2.3.0
+  checksum: 6a0f249cf2473361bfb44a283eab4937c05a9285d2b460a8e4e5e53f4eff88822497c59ddc5c467879f45be020e770dd06335b8ea26dc96279ff074206a7cb5c
   languageName: node
   linkType: hard
 
@@ -1444,6 +2095,20 @@ __metadata:
     "@aws-sdk/types": 3.266.0
     tslib: ^2.3.1
   checksum: 35e5029f7a210f85516a1ffa1d0826e360dd4a85cfb90740229b2a3ce367da434c50a0d5fdb56079a803d29edd9230e28a2d1493270cb23de63610f2c65c25bd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.54.1
+    "@aws-sdk/credential-provider-imds": 3.54.1
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/property-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: a04be3d3a5df8448d190c1acfefa7d6bcad67f900460fa8c4a9e98bb55f62c83cfab6f4cec520ec29c211b15b8bfeddebbea14871e7249528296ae4976c54edf
   languageName: node
   linkType: hard
 
@@ -1463,6 +2128,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: a27f3365dfb1e6ece79ea34fd6e2c4540eb0084536d7300ff0ff42a7334ddf07f21958c6cfd0bbeb71361ee408e16deae2c82b7c7378b048b8e81a52c75f190a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 682219e1add4b5698edeb11932573743b008d0685cd14d0b3d152f5a5f214cddaa67d99b00c50cf0963a06a396949176b4bea01820c3a2bd0273b2a9a2a5a946
   languageName: node
   linkType: hard
 
@@ -1512,6 +2186,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-uri-escape@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 8935fd47135cd18c950d3dc6f9679a31f5fd94caf2fcac595dc2fc94db773ede45e08a5427a19a0fc97e4f6e784a2c4847e625b30b6d057b593e335643960536
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-uri-escape@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-uri-escape@npm:3.6.1"
@@ -1529,6 +2212,17 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.3.1
   checksum: ec845b66a6e6d072e803d3ab604e8245b744d92594f6cc3adb4120ecca06335c9f2ce77de6442189ec3f29c4b5f19f2c210888d20e435a49dab326568c997006
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/types": 3.54.1
+    bowser: ^2.11.0
+    tslib: ^2.3.0
+  checksum: 56409fd98813b6073390b53785060822323f94acbd9bd1edbabbab47c7522c0f68ace8a0782923f2196eff22b6651f11955488e2ae7da903fd2fd98360b5f2e3
   languageName: node
   linkType: hard
 
@@ -1559,6 +2253,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-node@npm:3.54.1":
+  version: 3.54.1
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.54.1"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.54.1
+    "@aws-sdk/types": 3.54.1
+    tslib: ^2.3.0
+  checksum: b0de34d201cf63a4512086aea73fbdc1f6422f948693d7a09dac7feff10d0314bddada7830d744da63348b0979d12bf5057b456d72e64eedf66eb41ffa20a8d0
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-user-agent-node@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/util-user-agent-node@npm:3.6.1"
@@ -1567,6 +2272,15 @@ __metadata:
     "@aws-sdk/types": 3.6.1
     tslib: ^1.8.0
   checksum: 7fe2fefd2eccac9177e5571d589e13496395fb7ba2ac6e70f1c8d36fdc9e0083f851b77b3f2daf7175be8af9cbcca3c616b34eee6cc47f3cb341517e9def2ecc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.52.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 3a46ba47a2a70cd7ff5b3dbf89447f9033b78d208f35cd68901cbf37c4931bb2c11dff9529d068808632ad5cdc1885a5cc06ba8c456c6702bdfbcaf81bbc3a53
   languageName: node
   linkType: hard
 
@@ -1594,6 +2308,16 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-node@npm:3.52.0":
+  version: 3.52.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.52.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.52.0
+    tslib: ^2.3.0
+  checksum: 67cb7c9aa74be544d473c880d33118242c35c08b184793f1849ac7f7cec9c8f2b3bbef79a9d4f9c20abb899f13a6103bd7b34cfc1eec00fdd2f9f3bcc9fc856e
   languageName: node
   linkType: hard
 
@@ -10422,7 +11146,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/api-apw@workspace:packages/api-apw"
   dependencies:
-    "@aws-sdk/client-cloudwatch-events": ^3.54.1
+    "@aws-sdk/client-cloudwatch-events": 3.54.1
     "@babel/cli": ^7.19.3
     "@babel/core": ^7.19.3
     "@babel/preset-env": ^7.19.4
@@ -21611,17 +22335,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:2.2.0, entities@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
+  languageName: node
+  linkType: hard
+
 "entities@npm:^1.1.1":
   version: 1.1.2
   resolution: "entities@npm:1.1.2"
   checksum: d537b02799bdd4784ffd714d000597ed168727bddf4885da887c5a491d735739029a00794f1998abbf35f3f6aeda32ef5c15010dca1817d401903a501b6d3e05
-  languageName: node
-  linkType: hard
-
-"entities@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "entities@npm:2.2.0"
-  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
   languageName: node
   linkType: hard
 
@@ -23031,6 +23755,15 @@ __metadata:
   version: 2.2.0
   resolution: "fast-uri@npm:2.2.0"
   checksum: edac64d50628f21d562cdc19ea86f5af00902dbb09d2f96fff5974e5317157825e9aa163af9defd11a0818aac6ea2e9958597bed98dd041200a08a976809d08b
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:3.19.0":
+  version: 3.19.0
+  resolution: "fast-xml-parser@npm:3.19.0"
+  bin:
+    xml2js: cli.js
+  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR does the following:
- adds `slug` and `tags` fields to the Page Template entity; this was absolutely necessary for programmatic usage
- changes primary PK to use template ID: `T#${tenant}#L#${locale}#PB#TEMPLATE#${id}`
- adds GSI1 for template listing: `T#${tenant}#L#${locale}#PB#TEMPLATES`
- uses GSI1 to query for template by `slug` (note that query by slug doesn't use dataloader, as dataloader uses `batchGetItem`, which doesn't support queries by GSIs, only by primary index )
- moves `createPageFromTemplate` logic to the API; this makes it programmatically usable, and easy to maintain in one place
- makes `PbPageTemplate` GraphQL type fields `required`; this makes it easier to reason about the returned data, and write less checks for undefined values. It's easier to set [default values](https://github.com/webiny/webiny-js/compare/next...feat/pb-template-slug?expand=1#diff-50e8a965dbffbf6812806f9d59c4b6a32e0d685280f5d144a1c8c5f0ae25cdd4R81-R85), than constantly check for undefined values on the client
- improves TS types to have less `any`s and have better autocomplete on template variables and page content
- exports `useElementVariables` from the root of the package, so it is easily accessible to 3rd party developers
- removes `content` field from `ListPageTemplates` query in page templates data list; this makes API calls faster, and we don't use that data on the client side anyway.
- moves `templateId` and `templateVariables` to a dedicated `template` namespace within content element data: 
`{ template: { slug: "template-slug", variables: [] } }`, and uses template `slug` instead of exact id, as it makes programmatic usage a lot easier, and it takes less effort to copy templates between tenants, because we no longer need to worry about ID mismatches; we just get templates by slug.

## How Has This Been Tested?
Manually, via UI and programmatically.
