### PR TITLE
fix(api-headles-cms): model graphql validation

### DIFF
--- a/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
@@ -394,14 +394,6 @@ export const validateModelFields = async (params: ValidateModelFieldsParams): Pr
          */
         if (!existingField) {
             continue;
-            // throw new WebinyError(
-            //     `Cannot remove the field "${lockedField.fieldId}" because it's already in use in created content.`,
-            //     "ENTRY_FIELD_USED",
-            //     {
-            //         lockedField,
-            //         fields
-            //     }
-            // );
         }
 
         if (lockedField.multipleValues !== existingField.multipleValues) {

--- a/packages/api-headless-cms/src/graphql/schema/baseContentSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseContentSchema.ts
@@ -22,7 +22,7 @@ export const createBaseContentSchema = ({ context }: Params): GraphQLSchemaPlugi
         .byType<GraphQLScalarPlugin>("graphql-scalar")
         .map(item => item.scalar);
 
-    return new GraphQLSchemaPlugin({
+    const plugin = new GraphQLSchemaPlugin({
         typeDefs: /* GraphQL */ `
             ${scalars.map(scalar => `scalar ${scalar.name}`).join(" ")}
             scalar JSON
@@ -77,4 +77,7 @@ export const createBaseContentSchema = ({ context }: Params): GraphQLSchemaPlugi
             }
         }
     });
+    plugin.name = `headless-cms.graphql.schema.base`;
+
+    return plugin;
 };

--- a/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
@@ -205,7 +205,7 @@ export const createContentEntriesSchema = ({
         });
     }
 
-    return new GraphQLSchemaPlugin<CmsContext>({
+    const plugin = new GraphQLSchemaPlugin<CmsContext>({
         typeDefs: /* GraphQL */ `
             type CmsModelMeta {
                 modelId: String
@@ -385,4 +385,7 @@ export const createContentEntriesSchema = ({
             }
         }
     });
+    plugin.name = `headless-cms.graphql.schema.${context.cms.type}.contentEntries`;
+
+    return plugin;
 };

--- a/packages/api-headless-cms/src/graphql/schema/contentModelGroups.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModelGroups.ts
@@ -134,7 +134,7 @@ export const createGroupsSchema = ({ context }: Params): GraphQLSchemaPlugin<Cms
         };
     }
 
-    return new GraphQLSchemaPlugin<CmsContext>({
+    const plugin = new GraphQLSchemaPlugin<CmsContext>({
         typeDefs: /* GraphQL */ `
             type CmsContentModelGroup {
                 id: ID!
@@ -155,4 +155,7 @@ export const createGroupsSchema = ({ context }: Params): GraphQLSchemaPlugin<Cms
         `,
         resolvers
     });
+    plugin.name = `headless-cms.graphql.schema.${context.cms.type}.groups`;
+
+    return plugin;
 };

--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -212,7 +212,7 @@ export const createModelsSchema = ({ context }: Params): GraphQLSchemaPlugin<Cms
         `;
     }
 
-    return new GraphQLSchemaPlugin<CmsContext>({
+    const plugin = new GraphQLSchemaPlugin<CmsContext>({
         typeDefs: /* GraphQL */ `
             type CmsFieldValidation {
                 name: String!
@@ -292,4 +292,7 @@ export const createModelsSchema = ({ context }: Params): GraphQLSchemaPlugin<Cms
         `,
         resolvers
     });
+
+    plugin.name = `headless-cms.graphql.schema.${context.cms.type}.models`;
+    return plugin;
 };


### PR DESCRIPTION
## Changes
Error when validating the updated model and the existing GraphQL schema is cached. This created a bug because cached schema means there are no generated `GraphQLSchemaPlugins` for all existing models.

## How Has This Been Tested?
Jest and manually.