### PR TITLE
fix(api-headless-cms-ddb-es): plugin loading on storage ops init

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/richText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/richText.ts
@@ -48,21 +48,10 @@ export const createRichTextStorageTransformPlugin = () => {
              * This is to circumvent a bug introduced with 5.8.0 storage operations.
              * Do not remove.
              */
-            if (storageValue.hasOwnProperty("compression") === false) {
+            if (!storageValue["compression"]) {
                 return storageValue;
             }
             const { compression, value } = storageValue;
-            if (!compression) {
-                throw new WebinyError(
-                    `Missing compression in "fromStorage" function in field "${
-                        field.storageId
-                    }": ${JSON.stringify(storageValue)}.`,
-                    "MISSING_COMPRESSION",
-                    {
-                        value: storageValue
-                    }
-                );
-            }
             if (compression !== "jsonpack") {
                 throw new WebinyError(
                     `This plugin cannot transform something not packed with "jsonpack".`,
@@ -71,6 +60,12 @@ export const createRichTextStorageTransformPlugin = () => {
                         compression
                     }
                 );
+            }
+            /**
+             * No point in going further if no value.
+             */
+            if (!value) {
+                return null;
             }
             try {
                 return jsonpack.unpack(value);
@@ -88,7 +83,7 @@ export const createRichTextStorageTransformPlugin = () => {
              * There is a possibility that we are trying to compress already compressed value.
              * Introduced a bug with 5.8.0 storage operations, so just return the value to correct it.
              */
-            if (value && value.hasOwnProperty("compression") === true) {
+            if (!!value?.compression) {
                 return value as any;
             }
             value = transformArray(value);

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/indexing/defaultFieldIndexing.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/indexing/defaultFieldIndexing.ts
@@ -18,7 +18,15 @@ export default (): CmsModelFieldToElasticsearchPlugin => ({
     },
     fromIndex({ field, getFieldTypePlugin, value, rawValue }) {
         const { isSearchable } = getFieldTypePlugin(field.type);
-
-        return isSearchable === true ? value : rawValue;
+        /**
+         * We will return the rawValue in case if not searchable and value in case of not searchable field.
+         * This is to make sure that changed isSearchable parameter does not make the data to be null / undefined.
+         *
+         * Users can change isSearchable parameter at any time on the GraphQL field - and that could create a problem for them.
+         */
+        if (isSearchable) {
+            return value === undefined ? rawValue : value;
+        }
+        return rawValue === undefined ? value : rawValue;
     }
 });

--- a/packages/api-headless-cms-ddb-es/src/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/index.ts
@@ -23,13 +23,17 @@ import {
 } from "@webiny/api-elasticsearch";
 import { elasticsearchIndexPlugins } from "./elasticsearch/indices";
 import { deleteElasticsearchIndex } from "./elasticsearch/deleteElasticsearchIndex";
-import { CmsModelFieldToGraphQLPlugin } from "@webiny/api-headless-cms/types";
 import {
     CmsEntryElasticsearchBodyModifierPlugin,
+    CmsEntryElasticsearchFullTextSearchPlugin,
+    CmsEntryElasticsearchIndexPlugin,
+    CmsEntryElasticsearchQueryBuilderValueSearchPlugin,
     CmsEntryElasticsearchQueryModifierPlugin,
-    CmsEntryElasticsearchSortModifierPlugin
+    CmsEntryElasticsearchSortModifierPlugin,
+    CmsEntryElasticsearchFieldPlugin
 } from "~/plugins";
 import { createFilterPlugins } from "~/operations/entry/elasticsearch/filtering/plugins";
+import { CmsEntryFilterPlugin } from "~/plugins/CmsEntryFilterPlugin";
 
 export * from "./plugins";
 
@@ -134,44 +138,25 @@ export const createStorageOperations: StorageOperationsFactory = params => {
              */
             context.plugins.register([dynamoDbPlugins()]);
             /**
-             * Collect all required plugins from parent context.
+             * We need to fetch all the plugin types in the list from the main container.
+             * This way we do not need to register plugins in the storage plugins contains.
              */
-            const fieldPlugins = context.plugins.byType<CmsModelFieldToGraphQLPlugin>(
-                "cms-model-field-to-graphql"
-            );
-            plugins.register(fieldPlugins);
-            /**
-             * We need to get all the operator plugins from the main plugin container.
-             */
-            const elasticsearchOperatorPlugins =
-                context.plugins.byType<ElasticsearchQueryBuilderOperatorPlugin>(
-                    ElasticsearchQueryBuilderOperatorPlugin.type
-                );
-            plugins.register(elasticsearchOperatorPlugins);
-            /**
-             * We need to get all the query modifier plugins
-             */
-            const queryModifierPlugins =
-                context.plugins.byType<CmsEntryElasticsearchQueryModifierPlugin>(
-                    CmsEntryElasticsearchQueryModifierPlugin.type
-                );
-            plugins.register(queryModifierPlugins);
-            /**
-             * We need to get all the sort modifier plugins
-             */
-            const sortModifierPlugins =
-                context.plugins.byType<CmsEntryElasticsearchSortModifierPlugin>(
-                    CmsEntryElasticsearchSortModifierPlugin.type
-                );
-            plugins.register(sortModifierPlugins);
-            /**
-             * We need to get all the body modifier plugins
-             */
-            const bodyModifierPlugins =
-                context.plugins.byType<CmsEntryElasticsearchBodyModifierPlugin>(
-                    CmsEntryElasticsearchBodyModifierPlugin.type
-                );
-            plugins.register(bodyModifierPlugins);
+            const types: string[] = [
+                "cms-model-field-to-graphql",
+                CmsEntryFilterPlugin.type,
+                ElasticsearchQueryBuilderOperatorPlugin.type,
+                CmsEntryElasticsearchBodyModifierPlugin.type,
+                CmsEntryElasticsearchFullTextSearchPlugin.type,
+                CmsEntryElasticsearchIndexPlugin.type,
+                CmsEntryElasticsearchQueryBuilderValueSearchPlugin.type,
+                CmsEntryElasticsearchQueryModifierPlugin.type,
+                CmsEntryElasticsearchSortModifierPlugin.type,
+                CmsEntryElasticsearchFieldPlugin.type
+            ];
+            for (const type of types) {
+                const contextPlugins = context.plugins.byType(type);
+                plugins.register(contextPlugins);
+            }
         },
         init: async context => {
             /**

--- a/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryBuilderValueSearchPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/plugins/CmsEntryElasticsearchQueryBuilderValueSearchPlugin.ts
@@ -53,3 +53,9 @@ export class CmsEntryElasticsearchQueryBuilderValueSearchPlugin extends Plugin {
         return null;
     }
 }
+
+export const createCmsEntryElasticsearchQueryBuilderValueSearchPlugin = (
+    params: CmsEntryElasticsearchQueryBuilderValueSearchPluginParams
+) => {
+    return new CmsEntryElasticsearchQueryBuilderValueSearchPlugin(params);
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -42,8 +42,10 @@ const ids = {
     field211: "variant",
     field212: "variantName",
     field213: "variantPrice",
+    field2110: "variantImage",
     field214: "variantOptions",
     field215: "variantOptionsName",
+    field2111: "variantOptionsImage",
     field216: "variantOptionsPrice",
     field217: "variantCategory",
     field218: "variantOptionsCategory",
@@ -517,6 +519,19 @@ const models: CmsModel[] = [
                             }
                         },
                         {
+                            id: ids.field2110,
+                            fieldId: "images",
+                            storageId: `file@${ids.field2110}`,
+                            multipleValues: true,
+                            placeholderText: null,
+                            helpText: "",
+                            label: "Image",
+                            type: "file",
+                            renderer: {
+                                name: "file"
+                            }
+                        },
+                        {
                             id: ids.field217,
                             multipleValues: false,
                             helpText: "",
@@ -595,6 +610,19 @@ const models: CmsModel[] = [
                                         },
                                         renderer: {
                                             name: "renderer"
+                                        }
+                                    },
+                                    {
+                                        id: ids.field2111,
+                                        fieldId: "image",
+                                        storageId: `file@${ids.field2111}`,
+                                        multipleValues: false,
+                                        placeholderText: null,
+                                        helpText: "",
+                                        label: "Image",
+                                        type: "file",
+                                        renderer: {
+                                            name: "file"
                                         }
                                     },
                                     {

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -1113,11 +1113,11 @@ describe("MANAGE - Resolvers", () => {
 
         const { vegetables } = await createCategories();
 
-        const { createProduct } = useProductManageHandler({
+        const { createProduct, listProducts } = useProductManageHandler({
             ...manageOpts
         });
 
-        const [potatoResponse] = await createProduct({
+        const [createPotatoResponse] = await createProduct({
             data: {
                 title: "Potato",
                 price: 99.9,
@@ -1139,6 +1139,7 @@ describe("MANAGE - Resolvers", () => {
                 variant: {
                     name: "Variant 1",
                     price: 100,
+                    images: ["testImage.jpg", "testImage2.jpg"],
                     category: {
                         modelId: "category",
                         id: vegetables.id
@@ -1147,6 +1148,7 @@ describe("MANAGE - Resolvers", () => {
                         {
                             name: "Option 1",
                             price: 10,
+                            image: "testImageOption1.jpg",
                             category: {
                                 modelId: "category",
                                 id: vegetables.id
@@ -1157,11 +1159,12 @@ describe("MANAGE - Resolvers", () => {
                                     id: vegetables.id
                                 }
                             ],
-                            longText: [null]
+                            longText: []
                         },
                         {
                             name: "Option 2",
                             price: 20,
+                            image: "testImageOption2.jpg",
                             category: {
                                 modelId: "category",
                                 id: vegetables.id
@@ -1179,9 +1182,9 @@ describe("MANAGE - Resolvers", () => {
             }
         });
 
-        expect(potatoResponse.errors).toBeUndefined();
+        expect(createPotatoResponse.errors).toBeUndefined();
 
-        expect(potatoResponse).toEqual({
+        expect(createPotatoResponse).toEqual({
             data: {
                 createProduct: {
                     data: {
@@ -1212,6 +1215,7 @@ describe("MANAGE - Resolvers", () => {
                         variant: {
                             name: "Variant 1",
                             price: 100,
+                            images: ["testImage.jpg", "testImage2.jpg"],
                             category: {
                                 modelId: "category",
                                 id: vegetables.id,
@@ -1221,6 +1225,7 @@ describe("MANAGE - Resolvers", () => {
                                 {
                                     name: "Option 1",
                                     price: 10,
+                                    image: "testImageOption1.jpg",
                                     category: {
                                         modelId: "category",
                                         id: vegetables.id,
@@ -1233,11 +1238,12 @@ describe("MANAGE - Resolvers", () => {
                                             entryId: vegetables.entryId
                                         }
                                     ],
-                                    longText: [null]
+                                    longText: []
                                 },
                                 {
                                     name: "Option 2",
                                     price: 20,
+                                    image: "testImageOption2.jpg",
                                     category: {
                                         modelId: "category",
                                         id: vegetables.id,
@@ -1254,6 +1260,28 @@ describe("MANAGE - Resolvers", () => {
                                 }
                             ]
                         }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const potato = createPotatoResponse.data.createProduct.data;
+
+        const [listResponse] = await listProducts();
+
+        expect(listResponse).toEqual({
+            data: {
+                listProducts: {
+                    data: [
+                        {
+                            ...potato
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -42,6 +42,7 @@ export default /* GraphQL */ `
     type Product_Variant_Options {
     name: String
     price: Number
+    image: String
     category: RefField
     categories: [RefField!]
     longText: [String]
@@ -78,6 +79,7 @@ export default /* GraphQL */ `
     type Product_Variant {
     name: String
     price: Number
+    images: [String]
     category: RefField
     options: [Product_Variant_Options!]
     }
@@ -122,6 +124,7 @@ export default /* GraphQL */ `
     input Product_Variant_OptionsInput {
         name: String
         price: Number
+        image: String
         category: RefFieldInput!
         categories: [RefFieldInput]
         longText: [String]
@@ -130,6 +133,7 @@ export default /* GraphQL */ `
     input Product_VariantInput {
         name: String
         price: Number
+        images: [String]
         category: RefFieldInput!
         options: [Product_Variant_OptionsInput!]
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -27,6 +27,7 @@ export default /* GraphQL */ `
     type Product_Variant_Options {
         name: String
         price: Number
+        image: String
         category(populate: Boolean = true): Category
         categories(populate: Boolean = true): [Category!]
         longText: [String]
@@ -63,6 +64,7 @@ export default /* GraphQL */ `
     type Product_Variant {
         name: String
         price: Number
+        images: [String]
         category(populate: Boolean = true): Category
         options: [Product_Variant_Options!]
     }

--- a/packages/api-headless-cms/__tests__/contentAPI/storageTransform.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/storageTransform.test.ts
@@ -73,12 +73,14 @@ describe("storage transform for complex entries", () => {
                 name: "variant #1",
                 category,
                 price: 101,
+                images: ["test-product.png"],
                 options: [
                     {
                         name: "subvariant #1",
                         category,
                         categories: [category],
                         price: 1234567890,
+                        image: "test-product.png",
                         longText: ["Long text in the subvariant #1"]
                     }
                 ]

--- a/packages/api-headless-cms/__tests__/testHelpers/useProductManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useProductManageHandler.ts
@@ -40,6 +40,7 @@ const productFields = `
     variant {
         name
         price
+        images
         category {
             modelId
             entryId
@@ -48,6 +49,7 @@ const productFields = `
         options {
             name
             price
+            image
             category {
                 modelId
                 entryId

--- a/packages/api-headless-cms/__tests__/types.ts
+++ b/packages/api-headless-cms/__tests__/types.ts
@@ -43,6 +43,7 @@ export interface ProductCategoryRef {
 export interface ProductVariantOption {
     name: string;
     price: number;
+    image: string;
     category: ProductCategoryRef;
     categories: ProductCategoryRef[];
     longText: string[];
@@ -50,6 +51,7 @@ export interface ProductVariantOption {
 export interface ProductVariant {
     name: string;
     price: number;
+    images: string[];
     category: ProductCategoryRef;
     options?: ProductVariantOption[];
 }


### PR DESCRIPTION
## Changes
The Headless CMS storage operations initialization did not collect all the necessary plugins from the main plugin container, received from the context.
I added an array of plugin types to be collected when the storage operation init method is ran.

## How Has This Been Tested?
Jest and manually