### PR TITLE
fix(api-headless-cms-ddb-es): ddb storage plugin names

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/date.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/date.ts
@@ -39,7 +39,7 @@ const convertValueToStorage = (field: PartialCmsModelField, value: any): any => 
 };
 
 export const createDateStorageTransformPlugin = () => {
-    return new StorageTransformPlugin({
+    const plugin = new StorageTransformPlugin({
         fieldType: "datetime",
         fromStorage: async ({ value, field }) => {
             const { type } = field.settings || {};
@@ -73,4 +73,7 @@ export const createDateStorageTransformPlugin = () => {
             });
         }
     });
+    plugin.name = `headless-cms.dynamodb.storageTransform.date`;
+
+    return plugin;
 };

--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/longText.ts
@@ -24,7 +24,7 @@ export interface StorageValue {
 }
 
 export const createLongTextStorageTransformPlugin = () => {
-    return new StorageTransformPlugin<string | string[], StorageValue>({
+    const plugin = new StorageTransformPlugin<string | string[], StorageValue>({
         fieldType: "long-text",
         fromStorage: async ({ field, value: storageValue }) => {
             const typeOf = typeof storageValue;
@@ -98,4 +98,7 @@ export const createLongTextStorageTransformPlugin = () => {
             return result;
         }
     });
+    plugin.name = plugin.name = `headless-cms.dynamodb.storageTransform.long-text`;
+
+    return plugin;
 };

--- a/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/richText.ts
+++ b/packages/api-headless-cms-ddb-es/src/dynamoDb/storage/richText.ts
@@ -34,7 +34,7 @@ const transformArray = (value: any) => {
 };
 
 export const createRichTextStorageTransformPlugin = () => {
-    return new StorageTransformPlugin({
+    const plugin = new StorageTransformPlugin({
         fieldType: "rich-text",
         fromStorage: async ({ field, value: storageValue }) => {
             if (!storageValue) {
@@ -104,4 +104,7 @@ export const createRichTextStorageTransformPlugin = () => {
             };
         }
     });
+    plugin.name = `headless-cms.dynamodb.storageTransform.rich-text`;
+
+    return plugin;
 };


### PR DESCRIPTION
## Changes
Name plugins which are registered for the StorageOperations.
This helps with debugging.

## How Has This Been Tested?
Jest and manually.