### PR TITLE
Support for legacy content in PB block editor form

### DIFF
--- a/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/RichVariableInputPlugin.tsx
+++ b/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/RichVariableInputPlugin.tsx
@@ -2,9 +2,15 @@ import React from "react";
 import { createComponentPlugin } from "@webiny/react-composition";
 import RichVariableInput from "@webiny/app-page-builder/editor/plugins/elementSettings/variable/RichVariableInput";
 import { LexicalVariableInputPlugin } from "~/plugins/elementSettings/variables/LexicalVariableInputPlugin";
+import { useVariable } from "@webiny/app-page-builder/hooks/useVariable";
+import { isValidLexicalData } from "@webiny/lexical-editor";
 
-export const RichVariableInputPlugin = createComponentPlugin(RichVariableInput, () => {
+export const RichVariableInputPlugin = createComponentPlugin(RichVariableInput, Original => {
     return function RichVariableInputPlugin({ variableId }) {
+        const { value } = useVariable(variableId);
+        if (!isValidLexicalData(value)) {
+            return <Original variableId={variableId} />;
+        }
         return <LexicalVariableInputPlugin tag={"p"} variableId={variableId} />;
     };
 });

--- a/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/TextVariableInputPlugin.tsx
+++ b/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/TextVariableInputPlugin.tsx
@@ -2,9 +2,15 @@ import React from "react";
 import { createComponentPlugin } from "@webiny/react-composition";
 import TextVariableInput from "@webiny/app-page-builder/editor/plugins/elementSettings/variable/TextVariableInput";
 import { LexicalVariableInputPlugin } from "~/plugins/elementSettings/variables/LexicalVariableInputPlugin";
+import { isValidLexicalData } from "@webiny/lexical-editor";
+import { useVariable } from "@webiny/app-page-builder/hooks/useVariable";
 
-export const TextVariableInputPlugin = createComponentPlugin(TextVariableInput, () => {
+export const TextVariableInputPlugin = createComponentPlugin(TextVariableInput, Original => {
     return function TextVariableInputPlugin({ variableId }): JSX.Element {
+        const { value } = useVariable(variableId);
+        if (!isValidLexicalData(value)) {
+            return <Original variableId={variableId} />;
+        }
         return <LexicalVariableInputPlugin tag={"h1"} variableId={variableId} />;
     };
 });


### PR DESCRIPTION
With this PR we add support for legacy content in the PB block editor form.

## Changes
Added lexical data check in `RichVariableInputPlugin` and `TextVariableInputPlugin` components.

## How Has This Been Tested?
Manually.

### Tested for lexical content 
https://user-images.githubusercontent.com/82515066/221837550-9737602e-bba9-4044-9861-267ba061aed7.mov


### Tested for legacy content
https://user-images.githubusercontent.com/82515066/221837724-858c7378-0eb2-45cb-b5fe-30ce5cf23f80.mov



