### PR TITLE
Ensure `packages/*` Is Included In The List of Workspaces

### DIFF
--- a/packages/cwp-template-aws/template/ddb-es/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-es/dependencies.json
@@ -55,7 +55,8 @@
       "apps/website",
       "apps/theme",
       "apps/api/graphql",
-      "apps/api/headlessCMS"
+      "apps/api/headlessCMS",
+      "packages/*"
     ]
   },
   "scripts": {

--- a/packages/cwp-template-aws/template/ddb/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb/dependencies.json
@@ -55,7 +55,8 @@
       "apps/website",
       "apps/theme",
       "apps/api/graphql",
-      "apps/api/headlessCMS"
+      "apps/api/headlessCMS",
+      "packages/*"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## Changes
With every new project, the `packages/*` workspace will be included in the initial list of yarn workspaces. That way users don't have to add this entry themselves, making the DX a bit smoother.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.