### PR TITLE
fix(app-page-builder-elements): exclude page only if Page context exists

### DIFF
--- a/packages/app-page-builder-elements/src/hooks/usePage.ts
+++ b/packages/app-page-builder-elements/src/hooks/usePage.ts
@@ -11,3 +11,7 @@ export function usePage() {
 
     return context;
 }
+
+export function useOptionalPage() {
+    return useContext(PageContext);
+}

--- a/packages/app-page-builder-elements/src/renderers/pagesList/index.tsx
+++ b/packages/app-page-builder-elements/src/renderers/pagesList/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "~/renderers/pagesList/types";
 import { createRenderer } from "~/createRenderer";
 import { useRenderer } from "~/hooks/useRenderer";
-import { usePage } from "~/hooks/usePage";
+import { useOptionalPage } from "~/hooks/usePage";
 
 export interface PagesListComponent {
     id: string;
@@ -32,7 +32,8 @@ export const createPagesList = (params: CreatePagesListParams) => {
 
     const RendererComponent = createRenderer(() => {
         const { getElement } = useRenderer();
-        const { page } = usePage();
+        const pageContext = useOptionalPage();
+        const exclude = pageContext ? [pageContext.page.path] : [];
 
         const element = getElement();
 
@@ -54,7 +55,7 @@ export const createPagesList = (params: CreatePagesListParams) => {
             },
             limit: parseInt(vars.resultsPerPage),
             after: null,
-            exclude: [page.path]
+            exclude
         };
 
         const variablesHash = JSON.stringify(variables);


### PR DESCRIPTION
## Changes
This PR resolves a bug which is caused by the use of the `usePage()` hook in the `pages-list` renderer. `PageContext` is not always present; page template editor, and block editor, do not work with pages, but they still can use the `pages-list` element. This caused the "not-so-happy" execution path, which runs into a `usePage()` hook, which throws an error if the context is missing. 

The solution was to introduce a `useOptionalPage()` hook, which does not throw an error, and allows the developer to decide what to do, if the context is not present.

## How Has This Been Tested?
Manually.