### PR TITLE
Introduced `webiny build` Command

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/build.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/build.js
@@ -1,0 +1,30 @@
+const buildPackages = require("./deploy/buildPackages");
+const { createPulumiCommand, runHook } = require("../utils");
+
+module.exports = (params, context) => {
+    const command = createPulumiCommand({
+        name: "build",
+        createProjectApplicationWorkspace: true,
+        command: async ({ inputs, context, projectApplication }) => {
+            const { env } = inputs;
+
+            const hookArgs = { context, env, inputs, projectApplication };
+
+            await runHook({
+                hook: "hook-before-build",
+                args: hookArgs,
+                context
+            });
+
+            await buildPackages({ projectApplication, inputs, context });
+
+            await runHook({
+                hook: "hook-after-build",
+                args: hookArgs,
+                context
+            });
+        }
+    });
+
+    return command(params, context);
+};

--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -1,5 +1,6 @@
 const destroy = require("./destroy");
 const deploy = require("./deploy");
+const build = require("./build");
 const watch = require("./watch");
 const output = require("./output");
 
@@ -9,6 +10,7 @@ module.exports = [
         name: "cli-command-deployment",
         create({ yargs, context }) {
             yargs.example("$0 deploy api --env=dev");
+            yargs.example("$0 build api --env=dev");
             yargs.example("$0 destroy api --env=dev");
             yargs.example("$0 output api --env=dev");
             yargs.example("$0 pulumi api --env dev -- config set foo bar --secret");
@@ -59,6 +61,41 @@ module.exports = [
                 },
                 async argv => {
                     await deploy(argv, context);
+                    process.exit(0);
+                }
+            );
+
+            yargs.command(
+                "build [folder]",
+                `Builds application code for given project application`,
+                yargs => {
+                    yargs.example("$0 build api --env=dev");
+                    yargs.example("$0 build --env=dev");
+                    yargs.positional("folder", {
+                        describe: `Project application folder`,
+                        type: "string"
+                    });
+                    yargs.option("env", {
+                        describe: `Environment`,
+                        type: "string"
+                    });
+                    // yargs.option("variant", {
+                    //     describe: `Variant (only for staged rollouts)`,
+                    //     type: "string"
+                    // });
+                    yargs.option("debug", {
+                        default: false,
+                        describe: `Turn on debug logs`,
+                        type: "boolean"
+                    });
+                    yargs.option("logs", {
+                        default: undefined,
+                        describe: `Enable base compilation-related logs`,
+                        type: "boolean"
+                    });
+                },
+                async argv => {
+                    await build(argv, context);
                     process.exit(0);
                 }
             );


### PR DESCRIPTION
## Changes
This PR introduced the long awaited `webiny build` command. With this command, users will no longer have to run `yarn webiny deploy --env xyz --no-deploy` in order to achieve the same effect.

## How Has This Been Tested?
Manually.

## Documentation
Changelog / updated list of commands on the Webiny CLI page.