### PR TITLE
Webiny CLI - Improved Error Reporting When There's No Internal Workspace Folder

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/build.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/build.js
@@ -1,0 +1,30 @@
+const buildPackages = require("./deploy/buildPackages");
+const { createPulumiCommand, runHook } = require("../utils");
+
+module.exports = (params, context) => {
+    const command = createPulumiCommand({
+        name: "build",
+        createProjectApplicationWorkspace: true,
+        command: async ({ inputs, context, projectApplication }) => {
+            const { env } = inputs;
+
+            const hookArgs = { context, env, inputs, projectApplication };
+
+            await runHook({
+                hook: "hook-before-build",
+                args: hookArgs,
+                context
+            });
+
+            await buildPackages({ projectApplication, inputs, context });
+
+            await runHook({
+                hook: "hook-after-build",
+                args: hookArgs,
+                context
+            });
+        }
+    });
+
+    return command(params, context);
+};

--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -1,5 +1,6 @@
 const destroy = require("./destroy");
 const deploy = require("./deploy");
+const build = require("./build");
 const watch = require("./watch");
 const output = require("./output");
 
@@ -9,6 +10,7 @@ module.exports = [
         name: "cli-command-deployment",
         create({ yargs, context }) {
             yargs.example("$0 deploy api --env=dev");
+            yargs.example("$0 build api --env=dev");
             yargs.example("$0 destroy api --env=dev");
             yargs.example("$0 output api --env=dev");
             yargs.example("$0 pulumi api --env dev -- config set foo bar --secret");
@@ -59,6 +61,41 @@ module.exports = [
                 },
                 async argv => {
                     await deploy(argv, context);
+                    process.exit(0);
+                }
+            );
+
+            yargs.command(
+                "build [folder]",
+                `Builds application code for given project application`,
+                yargs => {
+                    yargs.example("$0 build api --env=dev");
+                    yargs.example("$0 build --env=dev");
+                    yargs.positional("folder", {
+                        describe: `Project application folder`,
+                        type: "string"
+                    });
+                    yargs.option("env", {
+                        describe: `Environment`,
+                        type: "string"
+                    });
+                    // yargs.option("variant", {
+                    //     describe: `Variant (only for staged rollouts)`,
+                    //     type: "string"
+                    // });
+                    yargs.option("debug", {
+                        default: false,
+                        describe: `Turn on debug logs`,
+                        type: "boolean"
+                    });
+                    yargs.option("logs", {
+                        default: undefined,
+                        describe: `Enable base compilation-related logs`,
+                        type: "boolean"
+                    });
+                },
+                async argv => {
+                    await build(argv, context);
                     process.exit(0);
                 }
             );

--- a/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
@@ -15,7 +15,7 @@ module.exports = async ({ projectApplication, pulumi, install }) => {
         if (!fs.existsSync(cwd)) {
             const message = [
                 "The command cannot be run because the project application hasn't been built. ",
-                "To build the application, run ",
+                "To build it, run ",
                 red(`yarn webiny build ${projectApplication.paths.relative} --env {environment}`),
                 "."
             ].join("");

--- a/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/getPulumi.js
@@ -14,15 +14,11 @@ module.exports = async ({ projectApplication, pulumi, install }) => {
         cwd = projectApplication.paths.workspace;
         if (!fs.existsSync(cwd)) {
             const message = [
-                "The command cannot be run because the internal",
-                red(projectApplication.paths.workspace),
-                "workspace folder does not exist.",
-                "This usually happens when a project application wasn't built or deployed.",
-                "To fix this, either fully deploy the project application by running the",
-                red(`yarn webiny deploy ${projectApplication.paths.relative} --env {environment}`),
-                "command, or build it by running",
-                red(`yarn webiny build ${projectApplication.paths.relative} --env {environment}.`)
-            ].join(" ");
+                "The command cannot be run because the project application hasn't been built. ",
+                "To build the application, run ",
+                red(`yarn webiny build ${projectApplication.paths.relative} --env {environment}`),
+                "."
+            ].join("");
             throw new Error(message);
         }
     }


### PR DESCRIPTION
## Changes
Some of the Webiny CLI commands require the project application to be previously built. For example, the `webiny output` and `webiny pulumi` commands.

Prior to this PR, if the application wasn't built upon running one of the two, users would get presented with a really bad error report:

![image](https://user-images.githubusercontent.com/5121148/222436217-abc19231-acd3-4cd7-b696-4280a0b6595e.png)

With this PR, we're improving the error report. In the same scenario, the user will now see the following:
![image](https://user-images.githubusercontent.com/5121148/222436439-af01847f-a360-4550-a1ac-4957356de363.png)

Maybe in the future we'll find a way so that user's don't have to deal with this at all, but for now, this is the first step.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.