### PR TITLE
fix: fix GraphQL error after page duplicate

### DIFF
--- a/packages/app-page-builder/src/admin/graphql/pages.ts
+++ b/packages/app-page-builder/src/admin/graphql/pages.ts
@@ -86,17 +86,6 @@ export const DUPLICATE_PAGE = gql`
             duplicatePage(id: $id) {
                 data {
                     ${LIST_PAGES_DATA_FIELDS}
-                    settings {
-                        general {
-                            snippet
-                            tags
-                            layout
-                            image {
-                                id
-                                src
-                            }
-                        }
-                    }
                 }
                 ${error}
             }


### PR DESCRIPTION
## Changes
Fix issue "Use the “Duplicate page” button, then click “Edit” on the new page, GraphQL breaks. After browser reload everything is ok."

## How Has This Been Tested?
Manual

## Documentation
None
