### PR TITLE
Upgrade File Manager files and settings data

### DIFF
--- a/packages/api-file-manager-ddb-es/src/definitions/filesEntity.ts
+++ b/packages/api-file-manager-ddb-es/src/definitions/filesEntity.ts
@@ -1,15 +1,13 @@
 import { Entity, Table } from "dynamodb-toolbox";
-import { getExtraAttributes } from "@webiny/db-dynamodb/utils/attributes";
-import { FileManagerContext } from "~/types";
+import { FileManagerContext } from "@webiny/api-file-manager/types";
 
 export interface FilesEntityParams {
     context: FileManagerContext;
     table: Table;
 }
 export default (params: FilesEntityParams): Entity<any> => {
-    const { context, table } = params;
-    const entityName = "Files";
-    const attributes = getExtraAttributes(context, entityName);
+    const { table } = params;
+    const entityName = "FM.File";
     return new Entity({
         name: entityName,
         table,
@@ -20,46 +18,18 @@ export default (params: FilesEntityParams): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },
-            id: {
-                type: "string"
-            },
-            key: {
-                type: "string"
-            },
-            size: {
-                type: "number"
-            },
-            type: {
-                type: "string"
-            },
-            name: {
-                type: "string"
-            },
-            meta: {
+            data: {
                 type: "map"
-            },
-            tags: {
-                type: "list"
-            },
-            createdOn: {
-                type: "string"
-            },
-            createdBy: {
-                type: "map"
-            },
-            tenant: {
-                type: "string"
-            },
-            locale: {
-                type: "string"
-            },
-            webinyVersion: {
-                type: "string"
-            },
-            ...attributes
+            }
         }
     });
 };

--- a/packages/api-file-manager-ddb-es/src/definitions/settingsEntity.ts
+++ b/packages/api-file-manager-ddb-es/src/definitions/settingsEntity.ts
@@ -1,15 +1,13 @@
 import { Entity, Table } from "dynamodb-toolbox";
-import { getExtraAttributes } from "@webiny/db-dynamodb/utils/attributes";
-import { FileManagerContext } from "~/types";
+import { FileManagerContext } from "@webiny/api-file-manager/types";
 
-export interface SettingsEntityElasticsearch {
+export interface SettingsEntityParams {
     context: FileManagerContext;
     table: Table;
 }
-export default (params: SettingsEntityElasticsearch): Entity<any> => {
-    const { context, table } = params;
-    const entityName = "Settings";
-    const attributes = getExtraAttributes(context, entityName);
+export default (params: SettingsEntityParams): Entity<any> => {
+    const { table } = params;
+    const entityName = "FM.Settings";
     return new Entity({
         name: entityName,
         table,
@@ -20,22 +18,18 @@ export default (params: SettingsEntityElasticsearch): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },
-            key: {
-                type: "string"
-            },
-            uploadMinFileSize: {
-                type: "number"
-            },
-            uploadMaxFileSize: {
-                type: "number"
-            },
-            srcPrefix: {
-                type: "string"
-            },
-            ...attributes
+            data: {
+                type: "map"
+            }
         }
     });
 };

--- a/packages/api-file-manager-ddb-es/src/definitions/table.ts
+++ b/packages/api-file-manager-ddb-es/src/definitions/table.ts
@@ -8,9 +8,15 @@ export interface TableParams {
 export default (params: TableParams): Table => {
     const { context } = params;
     return new Table({
-        name: process.env.DB_TABLE || getTable(context),
+        name: process.env.DB_TABLE_FILE_MANGER || process.env.DB_TABLE || getTable(context),
         partitionKey: "PK",
         sortKey: "SK",
-        DocumentClient: getDocumentClient(context)
+        DocumentClient: getDocumentClient(context),
+        indexes: {
+            GSI1: {
+                partitionKey: "GSI1_PK",
+                sortKey: "GSI1_SK"
+            }
+        }
     });
 };

--- a/packages/api-file-manager-ddb-es/src/operations/settings/SettingsStorageOperations.ts
+++ b/packages/api-file-manager-ddb-es/src/operations/settings/SettingsStorageOperations.ts
@@ -9,7 +9,7 @@ import WebinyError from "@webiny/error";
 import defineTable from "~/definitions/table";
 import defineSettingsEntity from "~/definitions/settingsEntity";
 import { FileManagerContext } from "~/types";
-import { queryOne } from "@webiny/db-dynamodb/utils/query";
+import { get } from "@webiny/db-dynamodb/utils/get";
 
 interface SettingsStorageOperationsConstructorParams {
     context: FileManagerContext;
@@ -43,11 +43,11 @@ export class SettingsStorageOperations implements FileManagerSettingsStorageOper
 
     public async get(): Promise<FileManagerSettings | null> {
         try {
-            const settings = await queryOne<{ data: FileManagerSettings }>({
+            const settings = await get<{ data: FileManagerSettings }>({
                 entity: this._entity,
-                partitionKey: this.partitionKey,
-                options: {
-                    eq: SORT_KEY
+                keys: {
+                    PK: this.partitionKey,
+                    SK: SORT_KEY
                 }
             });
 

--- a/packages/api-file-manager-ddb-es/src/operations/settings/SettingsStorageOperations.ts
+++ b/packages/api-file-manager-ddb-es/src/operations/settings/SettingsStorageOperations.ts
@@ -9,12 +9,13 @@ import WebinyError from "@webiny/error";
 import defineTable from "~/definitions/table";
 import defineSettingsEntity from "~/definitions/settingsEntity";
 import { FileManagerContext } from "~/types";
+import { queryOne } from "@webiny/db-dynamodb/utils/query";
 
 interface SettingsStorageOperationsConstructorParams {
     context: FileManagerContext;
 }
 
-const SORT_KEY = "default";
+const SORT_KEY = "A";
 
 export class SettingsStorageOperations implements FileManagerSettingsStorageOperations {
     private readonly _context: FileManagerContext;
@@ -42,14 +43,15 @@ export class SettingsStorageOperations implements FileManagerSettingsStorageOper
 
     public async get(): Promise<FileManagerSettings | null> {
         try {
-            const settings = await this._entity.get({
-                PK: this.partitionKey,
-                SK: SORT_KEY
+            const settings = await queryOne<{ data: FileManagerSettings }>({
+                entity: this._entity,
+                partitionKey: this.partitionKey,
+                options: {
+                    eq: SORT_KEY
+                }
             });
-            if (!settings || !settings.Item) {
-                return null;
-            }
-            return settings.Item;
+
+            return settings ? settings.data : null;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not fetch the FileManager settings.",
@@ -73,7 +75,8 @@ export class SettingsStorageOperations implements FileManagerSettingsStorageOper
             await this._entity.put({
                 PK: this.partitionKey,
                 SK: SORT_KEY,
-                ...data
+                TYPE: "fm.settings",
+                data
             });
             return data;
         } catch (ex) {
@@ -94,7 +97,8 @@ export class SettingsStorageOperations implements FileManagerSettingsStorageOper
             await this._entity.update({
                 PK: this.partitionKey,
                 SK: SORT_KEY,
-                ...data
+                TYPE: "fm.settings",
+                data
             });
             return data;
         } catch (ex) {

--- a/packages/api-file-manager-ddb/src/definitions/filesEntity.ts
+++ b/packages/api-file-manager-ddb/src/definitions/filesEntity.ts
@@ -1,15 +1,13 @@
 import { Entity, Table } from "dynamodb-toolbox";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
-import { getExtraAttributes } from "@webiny/db-dynamodb/utils/attributes";
 
 export interface FilesEntityParams {
     context: FileManagerContext;
     table: Table;
 }
 export default (params: FilesEntityParams): Entity<any> => {
-    const { context, table } = params;
-    const entityName = "Files";
-    const attributes = getExtraAttributes(context, entityName);
+    const { table } = params;
+    const entityName = "FM.File";
     return new Entity({
         name: entityName,
         table,
@@ -20,46 +18,18 @@ export default (params: FilesEntityParams): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },
-            id: {
-                type: "string"
-            },
-            key: {
-                type: "string"
-            },
-            size: {
-                type: "number"
-            },
-            type: {
-                type: "string"
-            },
-            name: {
-                type: "string"
-            },
-            meta: {
+            data: {
                 type: "map"
-            },
-            tags: {
-                type: "list"
-            },
-            createdOn: {
-                type: "string"
-            },
-            createdBy: {
-                type: "map"
-            },
-            tenant: {
-                type: "string"
-            },
-            locale: {
-                type: "string"
-            },
-            webinyVersion: {
-                type: "string"
-            },
-            ...attributes
+            }
         }
     });
 };

--- a/packages/api-file-manager-ddb/src/definitions/settingsEntity.ts
+++ b/packages/api-file-manager-ddb/src/definitions/settingsEntity.ts
@@ -1,15 +1,13 @@
 import { Entity, Table } from "dynamodb-toolbox";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
-import { getExtraAttributes } from "@webiny/db-dynamodb/utils/attributes";
 
 export interface SettingsEntityParams {
     context: FileManagerContext;
     table: Table;
 }
 export default (params: SettingsEntityParams): Entity<any> => {
-    const { context, table } = params;
-    const entityName = "Settings";
-    const attributes = getExtraAttributes(context, entityName);
+    const { table } = params;
+    const entityName = "FM.Settings";
     return new Entity({
         name: entityName,
         table,
@@ -20,22 +18,18 @@ export default (params: SettingsEntityParams): Entity<any> => {
             SK: {
                 sortKey: true
             },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
             TYPE: {
                 type: "string"
             },
-            key: {
-                type: "string"
-            },
-            uploadMinFileSize: {
-                type: "number"
-            },
-            uploadMaxFileSize: {
-                type: "number"
-            },
-            srcPrefix: {
-                type: "string"
-            },
-            ...attributes
+            data: {
+                type: "map"
+            }
         }
     });
 };

--- a/packages/api-file-manager-ddb/src/definitions/table.ts
+++ b/packages/api-file-manager-ddb/src/definitions/table.ts
@@ -11,6 +11,12 @@ export default (params: TableParams): Table => {
         name: process.env.DB_TABLE_FILE_MANGER || process.env.DB_TABLE || getTable(context),
         partitionKey: "PK",
         sortKey: "SK",
-        DocumentClient: getDocumentClient(context)
+        DocumentClient: getDocumentClient(context),
+        indexes: {
+            GSI1: {
+                partitionKey: "GSI1_PK",
+                sortKey: "GSI1_SK"
+            }
+        }
     });
 };

--- a/packages/api-file-manager-ddb/src/operations/settings/SettingsStorageOperations.ts
+++ b/packages/api-file-manager-ddb/src/operations/settings/SettingsStorageOperations.ts
@@ -9,7 +9,7 @@ import { Entity } from "dynamodb-toolbox";
 import WebinyError from "@webiny/error";
 import defineTable from "~/definitions/table";
 import defineSettingsEntity from "~/definitions/settingsEntity";
-import { queryOne } from "@webiny/db-dynamodb/utils/query";
+import { get } from "@webiny/db-dynamodb/utils/get";
 
 interface SettingsStorageOperationsConstructorParams {
     context: FileManagerContext;
@@ -43,18 +43,15 @@ export class SettingsStorageOperations implements FileManagerSettingsStorageOper
 
     public async get(): Promise<FileManagerSettings | null> {
         try {
-            const settings = await queryOne<{ data: FileManagerSettings }>({
+            const settings = await get<{ data: FileManagerSettings }>({
                 entity: this._entity,
-                partitionKey: this.partitionKey,
-                options: {
-                    eq: "A"
+                keys: {
+                    PK: this.partitionKey,
+                    SK: "A"
                 }
             });
 
-            if (!settings) {
-                return null;
-            }
-            return settings.data;
+            return settings ? settings.data : null;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not fetch the FileManager settings.",

--- a/packages/api-file-manager-ddb/src/plugins/FileAttributePlugin.ts
+++ b/packages/api-file-manager-ddb/src/plugins/FileAttributePlugin.ts
@@ -7,7 +7,7 @@ export class FileAttributePlugin extends AttributePlugin {
     public constructor(params: Omit<AttributePluginParams, "entity">) {
         super({
             ...params,
-            entity: "Files"
+            entity: "FM.File"
         });
     }
 }

--- a/packages/api-file-manager-ddb/src/plugins/SettingsAttributePlugin.ts
+++ b/packages/api-file-manager-ddb/src/plugins/SettingsAttributePlugin.ts
@@ -7,7 +7,7 @@ export class SettingsAttributePlugin extends AttributePlugin {
     public constructor(params: Omit<AttributePluginParams, "entity">) {
         super({
             ...params,
-            entity: "Settings"
+            entity: "FM.Settings"
         });
     }
 }

--- a/packages/data-migration/__tests__/createDdbMigration.ts
+++ b/packages/data-migration/__tests__/createDdbMigration.ts
@@ -1,6 +1,6 @@
 import { Table } from "dynamodb-toolbox";
 import { makeInjectable, inject, Constructor } from "@webiny/ioc";
-import { DataMigration, Logger, PrimaryDynamoTableSymbol } from "~/index";
+import { DataMigration, DataMigrationContext, PrimaryDynamoTableSymbol } from "~/index";
 
 export const createDdbMigration = (
     id: string,
@@ -13,8 +13,8 @@ export const createDdbMigration = (
             this.table = table;
         }
 
-        execute(logger: Logger): Promise<void> {
-            logger.info(`Migrating stuff...`, { id });
+        execute(context: DataMigrationContext): Promise<void> {
+            context.logger.info(`Migrating stuff...`, { id });
             if (opts.error) {
                 throw Error(`Something went wrong in ${id}`);
             }

--- a/packages/data-migration/src/MigrationRunner.ts
+++ b/packages/data-migration/src/MigrationRunner.ts
@@ -8,7 +8,8 @@ import {
     ExecutedMigrationResponse,
     SkippedMigrationResponse,
     MigrationRepository,
-    DataMigration
+    DataMigration,
+    DataMigrationContext
 } from "~/types";
 
 export type IsMigrationApplicable = (migration: DataMigration) => boolean;
@@ -96,8 +97,9 @@ export class MigrationRunner {
 
         for (const migration of executableMigrations) {
             const logger = getChildLogger(this.logger, migration);
+            const context: DataMigrationContext = { projectVersion, logger };
 
-            const shouldExecute = await migration.shouldExecute(logger);
+            const shouldExecute = await migration.shouldExecute(context);
 
             if (!shouldExecute) {
                 this.logger.info(`Skipping migration %s.`, migration.getId());
@@ -131,7 +133,7 @@ export class MigrationRunner {
                     migration.getId(),
                     migration.getDescription()
                 );
-                await migration.execute(logger);
+                await migration.execute(context);
             } catch (err) {
                 result.success = false;
                 this.logger.error(err, err.message);

--- a/packages/data-migration/src/index.ts
+++ b/packages/data-migration/src/index.ts
@@ -3,3 +3,4 @@ export * from "./handlers/createDdbEsProjectMigration";
 export * from "./symbols";
 export * from "./types";
 export * from "./createTable";
+export * from "./createPinoLogger";

--- a/packages/data-migration/src/types.ts
+++ b/packages/data-migration/src/types.ts
@@ -15,13 +15,18 @@ export interface MigrationRepository {
     logMigration(migration: MigrationItem): Promise<void>;
 }
 
+export interface DataMigrationContext {
+    projectVersion: string;
+    logger: Logger;
+}
+
 export interface DataMigration {
     getId(): string;
     getDescription(): string;
     // This function should check of the migration needs to apply some changes to the system.
     // Returning `false` means "everything is ok, mark this migration as executed".
-    shouldExecute(logger: Logger): Promise<boolean>;
-    execute(logger: Logger): Promise<void>;
+    shouldExecute(context: DataMigrationContext): Promise<boolean>;
+    execute(context: DataMigrationContext): Promise<void>;
 }
 
 export interface MigrationResult {

--- a/packages/migrations/__tests__/migrations/5.35.0-001/001.data.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0-001/001.data.ts
@@ -53,32 +53,15 @@ export const testData = [
         _et: "I18NLocale",
         _md: "2023-01-25T09:38:22.041Z"
     },
-    ...Array.from({ length: 5000 }).map((_, index) => {
-        return {
-            PK: "T#root#L#en-US#FM#F",
-            SK: "63d0f8a1ce8f180008bb6054" + index,
-            createdBy: {
-                displayName: "Pavel Denisjuk",
-                id: "e6ea2871-ba36-4494-87ac-afb73d4e7eb2",
-                type: "admin"
-            },
-            createdOn: "2023-01-25T09:38:41.943Z",
-            id: "63d0f8a1ce8f180008bb6054" + index,
-            key: index + "welcome-to-webiny-page-8ldbh4sq4-hero-block-bg.svg",
-            locale: "en-US",
-            meta: {
-                private: true
-            },
-            name: "welcome-to-webiny-page-8ldbh4sq4-hero-block-bg.svg",
-            size: 1864,
-            tags: [],
-            tenant: "root",
-            TYPE: "fm.file",
-            type: "image/svg+xml",
-            webinyVersion: "0.0.0",
-            _ct: "2023-01-25T09:38:41.961Z",
-            _et: "Files",
-            _md: "2023-01-25T09:38:41.961Z"
-        };
-    })
+    // TODO: delete this record in 5.36.0
+    {
+        PK: "T#root#FM#SETTINGS",
+        SK: "default",
+        srcPrefix: "https://d30lvz3v210qz3.cloudfront.net/files/",
+        uploadMaxFileSize: 26214401,
+        uploadMinFileSize: 0,
+        _ct: "2023-01-25T09:38:22.381Z",
+        _et: "Settings",
+        _md: "2023-01-25T09:38:22.381Z"
+    }
 ];

--- a/packages/migrations/__tests__/migrations/5.35.0-001/001.test.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0-001/001.test.ts
@@ -8,11 +8,56 @@ import {
     logTestNameBeforeEachTest
 } from "~tests/utils";
 import { testData } from "./001.data";
+import {
+    createLegacySettingsEntity,
+    createSettingsEntity
+} from "~/migrations/5.35.0/001/createSettingsEntity";
 
 jest.retryTimes(0);
+jest.setTimeout(900000);
+
+const NUMBER_OF_FILES = 100;
 
 describe("5.35.0-001", () => {
     const table = getPrimaryDynamoDbTable();
+
+    const insertTestFiles = async (numberOfFiles = NUMBER_OF_FILES) => {
+        let batch = [];
+        for (let index = 0; index < numberOfFiles; index++) {
+            if (index % 25 === 0) {
+                await insertTestData(table, batch);
+                batch = [];
+            }
+
+            batch.push({
+                PK: "T#root#L#en-US#FM#F",
+                SK: "63d0f8a1ce8f180008bb6054" + index,
+                createdBy: {
+                    displayName: "Pavel Denisjuk",
+                    id: "e6ea2871-ba36-4494-87ac-afb73d4e7eb2",
+                    type: "admin"
+                },
+                createdOn: "2023-01-25T09:38:41.943Z",
+                id: "63d0f8a1ce8f180008bb6054" + index,
+                key: index + "welcome-to-webiny-page-8ldbh4sq4-hero-block-bg.svg",
+                locale: "en-US",
+                meta: {
+                    private: true
+                },
+                name: "welcome-to-webiny-page-8ldbh4sq4-hero-block-bg.svg",
+                size: 1864,
+                tags: [],
+                tenant: "root",
+                TYPE: "fm.file",
+                type: "image/svg+xml",
+                webinyVersion: "0.0.0",
+                _ct: "2023-01-25T09:38:41.961Z",
+                _et: "Files",
+                _md: "2023-01-25T09:38:41.961Z"
+            });
+        }
+        await insertTestData(table, batch);
+    };
 
     logTestNameBeforeEachTest();
 
@@ -29,8 +74,11 @@ describe("5.35.0-001", () => {
     });
 
     it("should execute migration", async () => {
+        process.stdout.write("Inserting test data...\n");
         await insertTestData(table, testData);
+        await insertTestFiles();
 
+        process.stdout.write("Running migration...\n");
         const handler = createDdbMigrationHandler({ table, migrations: [FileManager_5_35_0_001] });
         const { data, error } = await handler();
 
@@ -39,6 +87,8 @@ describe("5.35.0-001", () => {
         expect(data.executed.length).toBe(1);
         expect(data.skipped.length).toBe(0);
         expect(data.notApplicable.length).toBe(0);
+
+        // ASSERT FILE CHANGES
 
         // Let's make sure that the number of migrated records corresponds to the number of the original records.
         const allNewFiles = (
@@ -62,15 +112,39 @@ describe("5.35.0-001", () => {
             })
         ).sort((a, b) => (a.id > b.id ? 1 : -1));
 
-        expect(allNewFiles.length).toEqual(5000);
-        expect(allOldFiles.length).toEqual(5000);
+        expect(allNewFiles.length).toEqual(NUMBER_OF_FILES);
+        expect(allOldFiles.length).toEqual(NUMBER_OF_FILES);
 
         expect(allNewFiles[0].GSI1_PK.endsWith("#FM#FILES")).toBe(true);
         expect(allNewFiles[0].data.id).toEqual(allOldFiles[0].id);
+
+        // ASSERT FILE MANAGER SETTINGS CHANGES
+        const legacySettings = createLegacySettingsEntity(table);
+        const { Item: legacyRecord } = await legacySettings.get({
+            PK: `T#root#FM#SETTINGS`,
+            SK: "default"
+        });
+
+        expect(legacyRecord).toBeTruthy();
+        expect(legacyRecord.SK).toEqual("default");
+        expect(legacyRecord.uploadMaxFileSize).toEqual(26214401);
+        expect(legacyRecord.srcPrefix).toEqual("https://d30lvz3v210qz3.cloudfront.net/files/");
+
+        const newSettings = createSettingsEntity(table);
+        const { Item: newRecord } = await newSettings.get({
+            PK: `T#root#FM#SETTINGS`,
+            SK: "A"
+        });
+
+        expect(newRecord).toBeTruthy();
+        expect(newRecord.SK).toEqual("A");
+        expect(newRecord.data.uploadMaxFileSize).toEqual(26214401);
+        expect(newRecord.data.srcPrefix).toEqual("https://d30lvz3v210qz3.cloudfront.net/files/");
     });
 
     it("should not run migration if data is already in the expected shape", async () => {
         await insertTestData(table, testData);
+        await insertTestFiles(25);
         const handler = createDdbMigrationHandler({ table, migrations: [FileManager_5_35_0_001] });
 
         // Should run the migration

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -7,11 +7,13 @@
     "watch": "yarn webiny run watch"
   },
   "dependencies": {
+    "@types/lodash.chunk": "^4.2.7",
     "@types/lodash.pick": "^4.4.7",
     "@webiny/data-migration": "0.0.0",
     "@webiny/db-dynamodb": "0.0.0",
     "@webiny/ioc": "0.0.0",
     "dynamodb-toolbox": "^0.3.5",
+    "lodash.chunk": "^4.2.0",
     "lodash.pick": "^4.4.0"
   },
   "publishConfig": {
@@ -27,7 +29,8 @@
   "adio": {
     "ignore": {
       "dependencies": [
-        "@types/lodash.pick"
+        "@types/lodash.pick",
+        "@types/lodash.chunk"
       ]
     }
   }

--- a/packages/migrations/src/ddb-es.ts
+++ b/packages/migrations/src/ddb-es.ts
@@ -1,7 +1,5 @@
-// import { FileManager_5_35_0_001 } from "./migrations/5.35.0/001";
+import { FileManager_5_35_0_001 } from "./migrations/5.35.0/001";
 
 export const migrations = () => {
-    return [
-        /*FileManager_5_35_0_001*/
-    ];
+    return [FileManager_5_35_0_001];
 };

--- a/packages/migrations/src/ddb.ts
+++ b/packages/migrations/src/ddb.ts
@@ -1,9 +1,5 @@
-// import { FileManager_5_35_0_001 } from "./migrations/5.35.0/001";
-import { DataMigration } from "@webiny/data-migration";
-import { Constructor } from "@webiny/ioc";
+import { FileManager_5_35_0_001 } from "./migrations/5.35.0/001";
 
-export const migrations = (): Constructor<DataMigration>[] => {
-    return [
-        /*FileManager_5_35_0_001*/
-    ];
+export const migrations = () => {
+    return [FileManager_5_35_0_001];
 };

--- a/packages/migrations/src/migrations/5.35.0/001/FileDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/001/FileDataMigration.ts
@@ -1,0 +1,134 @@
+import { Table } from "dynamodb-toolbox";
+import { DataMigrationContext } from "@webiny/data-migration";
+import {
+    createStandardEntity,
+    queryOne,
+    queryAll,
+    queryAllWithCallback,
+    batchWriteAll
+} from "~/utils";
+import { createFileEntity, getFileData, createLegacyFileEntity } from "./createFileEntity";
+import { createLocaleEntity } from "./createLocaleEntity";
+import { createTenantEntity } from "./createTenantEntity";
+
+export class FileManager_5_35_0_001_FileData {
+    private readonly newFileEntity: ReturnType<typeof createFileEntity>;
+    private readonly legacyFileEntity: ReturnType<typeof createLegacyFileEntity>;
+    private readonly tenantEntity: ReturnType<typeof createTenantEntity>;
+    private readonly localeEntity: ReturnType<typeof createLocaleEntity>;
+
+    constructor(table: Table) {
+        this.newFileEntity = createStandardEntity(table, "File");
+        this.legacyFileEntity = createLegacyFileEntity(table);
+        this.tenantEntity = createTenantEntity(table);
+        this.localeEntity = createLocaleEntity(table);
+    }
+
+    getId() {
+        return "FileData";
+    }
+
+    getDescription() {
+        return "";
+    }
+
+    async shouldExecute({ logger }: DataMigrationContext): Promise<boolean> {
+        const defaultLocale = await queryOne<{ code: string }>({
+            entity: this.localeEntity,
+            partitionKey: `T#root#I18N#L#D`,
+            options: {
+                eq: "default"
+            }
+        });
+
+        if (!defaultLocale) {
+            logger.info(`Default locale not found; system is not yet installed.`);
+            // The system is not yet installed, skip migration.
+            return false;
+        }
+
+        // Check if there are file records using the old record structure
+        const PK = `T#root#L#${defaultLocale.code}#FM#F`;
+        const lastLegacyFile = await queryOne<{ id: string }>({
+            entity: this.legacyFileEntity,
+            partitionKey: PK,
+            options: { gt: " ", reverse: true }
+        });
+
+        if (!lastLegacyFile) {
+            logger.info(`No applicable files were found to migrate.`);
+            return false;
+        }
+
+        if (lastLegacyFile) {
+            // Check if there's a corresponding new file for the same file ID
+            const lastNewFile = await queryOne({
+                entity: this.newFileEntity,
+                partitionKey: `T#root#L#${defaultLocale.code}#FM#FILE#${lastLegacyFile.id}`,
+                options: {
+                    eq: "A"
+                }
+            });
+
+            if (lastNewFile) {
+                logger.info(`All files seem to be in order.`);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    async execute({ logger }: DataMigrationContext): Promise<void> {
+        const tenants = await queryAll<{ id: string }>({
+            entity: this.tenantEntity,
+            partitionKey: "TENANTS",
+            options: {
+                index: "GSI1",
+                gt: " "
+            }
+        });
+
+        for (const tenant of tenants) {
+            const locales = await queryAll<{ code: string }>({
+                entity: this.localeEntity,
+                partitionKey: `T#${tenant.id}#I18N#L`,
+                options: {
+                    gt: " "
+                }
+            });
+
+            for (const locale of locales) {
+                let batch = 0;
+                await queryAllWithCallback<{ id: string }>(
+                    {
+                        entity: this.legacyFileEntity,
+                        partitionKey: `T#${tenant.id}#L#${locale.code}#FM#F`,
+                        options: {
+                            gt: " "
+                        }
+                    },
+                    async files => {
+                        batch++;
+                        logger.info(`Processing batch #${batch} (${files.length} files).`);
+                        const items = files.map(file => {
+                            return this.newFileEntity.putBatch({
+                                PK: `T#${tenant.id}#L#${locale.code}#FM#FILE#${file.id}`,
+                                SK: "A",
+                                GSI1_PK: `T#${tenant.id}#L#${locale.code}#FM#FILES`,
+                                GSI1_SK: file.id,
+                                TYPE: "fm.file",
+                                data: {
+                                    ...getFileData(file),
+                                    webinyVersion: process.env.WEBINY_VERSION
+                                }
+                            });
+                        });
+
+                        await batchWriteAll({ table: this.newFileEntity.table, items });
+                    }
+                );
+            }
+        }
+    }
+}

--- a/packages/migrations/src/migrations/5.35.0/001/FileSettingsMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/001/FileSettingsMigration.ts
@@ -1,0 +1,100 @@
+import { Table } from "dynamodb-toolbox";
+import { DataMigrationContext } from "@webiny/data-migration";
+import { createStandardEntity, queryOne, queryAll } from "~/utils";
+import { createTenantEntity } from "./createTenantEntity";
+import {
+    createLegacySettingsEntity,
+    createSettingsEntity,
+    getSettingsData
+} from "./createSettingsEntity";
+
+export class FileManager_5_35_0_001_FileManagerSettings {
+    private readonly newSettingsEntity: ReturnType<typeof createSettingsEntity>;
+    private readonly legacySettingsEntity: ReturnType<typeof createLegacySettingsEntity>;
+    private readonly tenantEntity: ReturnType<typeof createTenantEntity>;
+
+    constructor(table: Table) {
+        this.newSettingsEntity = createStandardEntity(table, "FM.Settings");
+        this.legacySettingsEntity = createLegacySettingsEntity(table);
+        this.tenantEntity = createTenantEntity(table);
+    }
+
+    getId() {
+        return "FM Settings";
+    }
+
+    getDescription() {
+        return "";
+    }
+
+    async shouldExecute({ logger }: DataMigrationContext): Promise<boolean> {
+        const settings = await queryOne({
+            entity: this.legacySettingsEntity,
+            partitionKey: `T#root#FM#SETTINGS`,
+            options: {
+                eq: "default"
+            }
+        });
+
+        if (!settings) {
+            logger.info(`Settings not found; system is not yet installed.`);
+            // The system is not yet installed, skip migration.
+            return false;
+        }
+
+        const newSettings = await queryOne({
+            entity: this.newSettingsEntity,
+            partitionKey: `T#root#FM#SETTINGS`,
+            options: {
+                eq: "A"
+            }
+        });
+
+        if (newSettings) {
+            logger.info(`Settings record seems to be in order.`);
+            return false;
+        }
+
+        return true;
+    }
+
+    async execute({ logger }: DataMigrationContext): Promise<void> {
+        const tenants = await queryAll<{ id: string; name: string }>({
+            entity: this.tenantEntity,
+            partitionKey: "TENANTS",
+            options: {
+                index: "GSI1",
+                gt: " "
+            }
+        });
+
+        for (const tenant of tenants) {
+            const settings = await queryOne({
+                entity: this.legacySettingsEntity,
+                partitionKey: `T#${tenant.id}#FM#SETTINGS`,
+                options: {
+                    eq: "default"
+                }
+            });
+
+            if (!settings) {
+                // It's possible that a tenant exists, but it was not yet installed.
+                logger.info(
+                    `Tenant ${tenant.name} (${tenant.id}) is not installed. Skipping migration of settings.`
+                );
+                return;
+            }
+
+            logger.info(`Updating FM settings for tenant ${tenant.name} (${tenant.id}).`);
+            await this.newSettingsEntity.put({
+                PK: `T#${tenant.id}#FM#SETTINGS`,
+                SK: "A",
+                TYPE: "fm.settings",
+                data: {
+                    ...getSettingsData(settings),
+                    tenant: tenant.id
+                }
+            });
+        }
+    }
+}

--- a/packages/migrations/src/migrations/5.35.0/001/createFileEntity.ts
+++ b/packages/migrations/src/migrations/5.35.0/001/createFileEntity.ts
@@ -50,5 +50,5 @@ export const createLegacyFileEntity = (table: Table) => {
 };
 
 export const createFileEntity = (table: Table) => {
-    return createStandardEntity(table, "File");
+    return createStandardEntity(table, "FM.File");
 };

--- a/packages/migrations/src/migrations/5.35.0/001/createSettingsEntity.ts
+++ b/packages/migrations/src/migrations/5.35.0/001/createSettingsEntity.ts
@@ -1,0 +1,30 @@
+import { Table } from "dynamodb-toolbox";
+import pick from "lodash.pick";
+import { createLegacyEntity, createStandardEntity } from "~/utils";
+
+const attributes: Parameters<typeof createLegacyEntity>[2] = {
+    tenant: {
+        type: "string"
+    },
+    srcPrefix: {
+        type: "string"
+    },
+    uploadMaxFileSize: {
+        type: "number"
+    },
+    uploadMinFileSize: {
+        type: "number"
+    }
+};
+
+export const getSettingsData = (settings: any) => {
+    return pick(settings, Object.keys(attributes));
+};
+
+export const createLegacySettingsEntity = (table: Table) => {
+    return createLegacyEntity(table, "Settings", attributes);
+};
+
+export const createSettingsEntity = (table: Table) => {
+    return createStandardEntity(table, "FM.Settings");
+};

--- a/packages/migrations/src/migrations/5.35.0/001/index.ts
+++ b/packages/migrations/src/migrations/5.35.0/001/index.ts
@@ -1,28 +1,22 @@
 import { Table } from "dynamodb-toolbox";
-import { DataMigration, Logger, PrimaryDynamoTableSymbol } from "@webiny/data-migration";
-import { makeInjectable, inject } from "@webiny/ioc";
 import {
-    createStandardEntity,
-    queryOne,
-    queryAll,
-    queryAllWithCallback,
-    batchWriteAll
-} from "~/utils";
-import { createFileEntity, getFileData, createLegacyFileEntity } from "./createFileEntity";
-import { createLocaleEntity } from "./createLocaleEntity";
-import { createTenantEntity } from "./createTenantEntity";
+    DataMigration,
+    DataMigrationContext,
+    getChildLogger,
+    PrimaryDynamoTableSymbol
+} from "@webiny/data-migration";
+import { makeInjectable, inject } from "@webiny/ioc";
+import { FileManager_5_35_0_001_FileData } from "./FileDataMigration";
+import { FileManager_5_35_0_001_FileManagerSettings } from "./FileSettingsMigration";
 
 export class FileManager_5_35_0_001 implements DataMigration {
-    private readonly newFileEntity: ReturnType<typeof createFileEntity>;
-    private readonly legacyFileEntity: ReturnType<typeof createLegacyFileEntity>;
-    private readonly tenantEntity: ReturnType<typeof createTenantEntity>;
-    private readonly localeEntity: ReturnType<typeof createLocaleEntity>;
+    private migrations: DataMigration[];
 
     constructor(table: Table) {
-        this.newFileEntity = createStandardEntity(table, "File");
-        this.legacyFileEntity = createLegacyFileEntity(table);
-        this.tenantEntity = createTenantEntity(table);
-        this.localeEntity = createLocaleEntity(table);
+        this.migrations = [
+            new FileManager_5_35_0_001_FileData(table),
+            new FileManager_5_35_0_001_FileManagerSettings(table)
+        ];
     }
 
     getId(): string {
@@ -30,102 +24,26 @@ export class FileManager_5_35_0_001 implements DataMigration {
     }
 
     getDescription(): string {
-        return "Migrate partition key to use file ID as part of the PK";
+        return "Upgrade File Manager to use better PKs and `data` envelope.";
     }
 
-    async shouldExecute(logger: Logger): Promise<boolean> {
-        const defaultLocale = await queryOne<{ code: string }>({
-            entity: this.localeEntity,
-            partitionKey: `T#root#I18N#L#D`,
-            options: {
-                eq: "default"
-            }
-        });
-
-        if (!defaultLocale) {
-            logger.info(`Default locale not found; system is not yet installed.`);
-            // The system is not yet installed, skip migration.
-            return false;
-        }
-
-        // Check if there are file records using the old record structure
-        const PK = `T#root#L#${defaultLocale.code}#FM#F`;
-        const oldFile = await queryOne<{ id: string }>({
-            entity: this.legacyFileEntity,
-            partitionKey: PK,
-            options: { gt: " " }
-        });
-
-        if (!oldFile) {
-            logger.info(`No applicable files were found to migrate.`);
-            return false;
-        }
-
-        if (oldFile) {
-            // Check if there's a corresponding new file for the same file ID
-            const newFile = await queryOne({
-                entity: this.newFileEntity,
-                partitionKey: `T#root#L#${defaultLocale.code}#FM#FILE#${oldFile.id}`,
-                options: {
-                    eq: "A"
-                }
-            });
-
-            if (newFile) {
-                logger.info(`All files seem to be in order.`);
-                return false;
+    async shouldExecute(context: DataMigrationContext): Promise<boolean> {
+        for (const migration of this.migrations) {
+            const childLogger = getChildLogger(context.logger, migration);
+            const childContext = { ...context, logger: childLogger };
+            if (await migration.shouldExecute(childContext)) {
+                return true;
             }
         }
-
-        return true;
+        return false;
     }
 
-    async execute(logger: Logger): Promise<void> {
-        const tenants = await queryAll<{ id: string }>({
-            entity: this.tenantEntity,
-            partitionKey: "TENANTS",
-            options: {
-                index: "GSI1",
-                gt: " "
-            }
-        });
-
-        for (const tenant of tenants) {
-            const locales = await queryAll<{ code: string }>({
-                entity: this.localeEntity,
-                partitionKey: `T#${tenant.id}#I18N#L`,
-                options: {
-                    gt: " "
-                }
-            });
-
-            for (const locale of locales) {
-                let batch = 0;
-                await queryAllWithCallback<{ id: string }>(
-                    {
-                        entity: this.legacyFileEntity,
-                        partitionKey: `T#${tenant.id}#L#${locale.code}#FM#F`,
-                        options: {
-                            gt: " "
-                        }
-                    },
-                    async files => {
-                        batch++;
-                        logger.info(`Processing batch #${batch} (${files.length} files).`);
-                        const items = files.map(file => {
-                            return this.newFileEntity.putBatch({
-                                PK: `T#${tenant.id}#L#${locale.code}#FM#FILE#${file.id}`,
-                                SK: "A",
-                                GSI1_PK: `T#${tenant.id}#L#${locale.code}#FM#FILES`,
-                                GSI1_SK: file.id,
-                                TYPE: "fm.file",
-                                data: getFileData(file)
-                            });
-                        });
-
-                        await batchWriteAll({ table: this.newFileEntity.table, items });
-                    }
-                );
+    async execute(context: DataMigrationContext): Promise<void> {
+        for (const migration of this.migrations) {
+            const childLogger = getChildLogger(context.logger, migration);
+            const childContext = { ...context, logger: childLogger };
+            if (await migration.shouldExecute(childContext)) {
+                await migration.execute(childContext);
             }
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10415,6 +10415,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash.chunk@npm:^4.2.7":
+  version: 4.2.7
+  resolution: "@types/lodash.chunk@npm:4.2.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 09df5ca00d8866776038bf94658d30b4ea84bffe5f81c14c01568bcb6be692bf59f6ea093de2bb0afbb3f8e54ae96ebd97595f2838ab59b77865427ca77d391e
+  languageName: node
+  linkType: hard
+
 "@types/lodash.debounce@npm:^4.0.7":
   version: 4.0.7
   resolution: "@types/lodash.debounce@npm:4.0.7"
@@ -15229,6 +15238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/migrations@workspace:packages/migrations"
   dependencies:
+    "@types/lodash.chunk": ^4.2.7
     "@types/lodash.pick": ^4.4.7
     "@webiny/cli": 0.0.0
     "@webiny/data-migration": 0.0.0
@@ -15238,6 +15248,7 @@ __metadata:
     "@webiny/project-utils": 0.0.0
     dynamodb-toolbox: ^0.3.5
     jest-dynalite: ^3.2.0
+    lodash.chunk: ^4.2.0
     lodash.pick: ^4.4.0
   languageName: unknown
   linkType: soft
@@ -30658,6 +30669,13 @@ __metadata:
   version: 3.0.0
   resolution: "lodash._reinterpolate@npm:3.0.0"
   checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
+  languageName: node
+  linkType: hard
+
+"lodash.chunk@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.chunk@npm:4.2.0"
+  checksum: 6286c6d06814fbeda502164015c42ef53a9194e6ebaac52ec2b41e83344aefe7bc3d94fdfec525adcd2c66cefdf05dc333b6a1128e4de739797342315c17cbc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR upgrades File Manager Storage Operations to work with better partition keys and use the `data` envelope to hold actual business-related data: `{ PK, SK, GSI1_PK, GSI1_SK, TYPE, data }` - this is the standard envelope we'll be pushing across the system over time. This will allow us to add new entity attributes easily,  and allow users to extend the system with less code, and less understanding of the underlying storage layer.

## How Has This Been Tested?
Jest tests.

## Documentation
These are internals, so no documentation is necessary at this stage.
