### PR TITLE
feat: get lexical content text

### DIFF
--- a/packages/lexical-editor/package.json
+++ b/packages/lexical-editor/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@lexical/code": "0.8.1",
     "@lexical/hashtag": "0.8.1",
+    "@lexical/headless": "0.8.1",
     "@lexical/link": "0.8.1",
     "@lexical/list": "0.8.1",
     "@lexical/mark": "0.8.1",

--- a/packages/lexical-editor/src/index.tsx
+++ b/packages/lexical-editor/src/index.tsx
@@ -41,5 +41,6 @@ export { AddRichTextEditorNodeType } from "~/components/AddRichTextEditorNodeTyp
 // utils
 export { generateInitialLexicalValue } from "~/utils/generateInitialLexicalValue";
 export { isValidLexicalData } from "~/utils/isValidLexicalData";
+export { getLexicalContentText } from "~/utils/getLexicalContentText";
 // types
 export * as types from "./types";

--- a/packages/lexical-editor/src/utils/getLexicalContentText.ts
+++ b/packages/lexical-editor/src/utils/getLexicalContentText.ts
@@ -1,8 +1,6 @@
 import { LexicalValue } from "~/types";
 import { $getRoot } from "lexical";
 import { createHeadlessEditor } from "@lexical/headless";
-import { WebinyNodes } from "~/nodes/webinyNodes";
-import { theme } from "~/themes/webinyLexicalTheme";
 import { isValidLexicalData } from "~/utils/isValidLexicalData";
 
 /**
@@ -19,16 +17,7 @@ export const getLexicalContentText = (value: LexicalValue | null): string | null
         return value;
     }
 
-    const config = {
-        namespace: "webiny",
-        nodes: [...WebinyNodes],
-        onError: (error: Error) => {
-            throw error;
-        },
-        theme: theme
-    };
-
-    const editor = createHeadlessEditor(config);
+    const editor = createHeadlessEditor();
     const newEditorState = editor.parseEditorState(value);
 
     return newEditorState.read(() => $getRoot().getTextContent());

--- a/packages/lexical-editor/src/utils/getLexicalContentText.ts
+++ b/packages/lexical-editor/src/utils/getLexicalContentText.ts
@@ -1,0 +1,35 @@
+import { LexicalValue } from "~/types";
+import { $getRoot } from "lexical";
+import { createHeadlessEditor } from "@lexical/headless";
+import { WebinyNodes } from "~/nodes/webinyNodes";
+import { theme } from "~/themes/webinyLexicalTheme";
+import { isValidLexicalData } from "~/utils/isValidLexicalData";
+
+/**
+ * Extract plain text with spaces and new lines from lexical JSON data structure.
+ * Note: This method use the lexical headless library so can be used for back-end processing.
+ * @param value
+ */
+export const getLexicalContentText = (value: LexicalValue | null): string | null => {
+    if (!value) {
+        return value;
+    }
+
+    if (!isValidLexicalData(value)) {
+        return value;
+    }
+
+    const config = {
+        namespace: "webiny",
+        nodes: [...WebinyNodes],
+        onError: (error: Error) => {
+            throw error;
+        },
+        theme: theme
+    };
+
+    const editor = createHeadlessEditor(config);
+    const newEditorState = editor.parseEditorState(value);
+
+    return newEditorState.read(() => $getRoot().getTextContent());
+};

--- a/packages/lexical-editor/tsconfig.json
+++ b/packages/lexical-editor/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "__tests__/**/*.ts"],
+  "include": ["src", "__tests__"],
   "references": [{ "path": "../react-composition" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6540,6 +6540,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lexical/headless@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@lexical/headless@npm:0.8.1"
+  peerDependencies:
+    lexical: 0.8.1
+  checksum: f9b65d6c0bed4c9dc2d0fea74c2a920b47e59f8a504037dde9f781913f01be2b5119646fac444249eafe61459b0120ef2e4e32b3d12bec068a1116d118724daf
+  languageName: node
+  linkType: hard
+
 "@lexical/history@npm:0.8.1":
   version: 0.8.1
   resolution: "@lexical/history@npm:0.8.1"
@@ -14999,6 +15008,7 @@ __metadata:
   dependencies:
     "@lexical/code": 0.8.1
     "@lexical/hashtag": 0.8.1
+    "@lexical/headless": 0.8.1
     "@lexical/link": 0.8.1
     "@lexical/list": 0.8.1
     "@lexical/mark": 0.8.1


### PR DESCRIPTION
New utility method that extracts and returns the plain text from a lexical JSON structure.

## Changes
- New method `getLexicalContentText` in the `utils` folder.
- export the method in the `index.ts`


## How Has This Been Tested?
Manually.
![Screenshot 2023-03-09 at 15 50 57](https://user-images.githubusercontent.com/82515066/224062447-b67481fe-3bf7-4b59-83a9-6e3c5f5e5d29.png)
