### PR TITLE
feat: add page category to page template settings

### DIFF
--- a/packages/api-page-builder-import-export/src/export/utils.ts
+++ b/packages/api-page-builder-import-export/src/export/utils.ts
@@ -108,7 +108,10 @@ export async function exportBlock(
 }
 
 export interface ExportedTemplateData {
-    template: Pick<PageTemplate, "title" | "slug" | "tags" | "description" | "content" | "layout">;
+    template: Pick<
+        PageTemplate,
+        "title" | "slug" | "tags" | "description" | "content" | "layout" | "pageCategory"
+    >;
     files: File[];
 }
 
@@ -135,7 +138,8 @@ export async function exportTemplate(
             tags: template.tags,
             description: template.description,
             content: template.content,
-            layout: template.layout
+            layout: template.layout,
+            pageCategory: template.pageCategory
         },
         files: imageFilesData
     };

--- a/packages/api-page-builder-import-export/src/import/process/templatesHandler.ts
+++ b/packages/api-page-builder-import-export/src/import/process/templatesHandler.ts
@@ -77,6 +77,7 @@ export const templatesHandler = async (
             slug: template.slug,
             tags: template.tags,
             layout: template.layout,
+            pageCategory: template.pageCategory,
             description: template.description,
             content: template.content
         });

--- a/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
@@ -36,6 +36,7 @@ const createSchema = zod.object({
     tags: zod.string().array(),
     description: zod.string().max(100),
     layout: zod.string().max(100).optional(),
+    pageCategory: zod.string().max(100),
     content: zod.any()
 });
 
@@ -45,6 +46,7 @@ const updateSchema = zod.object({
     tags: zod.string().array().optional(),
     description: zod.string().max(100).optional(),
     layout: zod.string().max(100).optional(),
+    pageCategory: zod.string().max(100).optional(),
     content: zod.any()
 });
 
@@ -360,12 +362,12 @@ export const createPageTemplatesCrud = (
 
             return await context.pageBuilder.resolvePageBlocks({ ...content, elements: blocks });
         },
-        async createPageFromTemplate({ id, slug, category, path, meta }) {
+        async createPageFromTemplate({ id, slug, path, meta }) {
             const template = await this.getPageTemplate({ where: { id, slug } });
             if (!template) {
                 throw new NotFoundError(`Page template "${id || slug}" was not found!`);
             }
-            const page = await context.pageBuilder.createPage(category, meta);
+            const page = await context.pageBuilder.createPage(template.pageCategory, meta);
             this.copyTemplateDataToPage(template, page);
 
             await context.pageBuilder.updatePage(page.id, {

--- a/packages/api-page-builder/src/graphql/graphql/pageTemplates.gql.ts
+++ b/packages/api-page-builder/src/graphql/graphql/pageTemplates.gql.ts
@@ -24,6 +24,7 @@ export const createPageTemplateGraphQL = new GraphQLSchemaPlugin<PbContext>({
             savedOn: DateTime!
             createdBy: PbCreatedBy!
             layout: String
+            pageCategory: String
         }
 
         input PbCreatePageTemplateInput {
@@ -32,6 +33,7 @@ export const createPageTemplateGraphQL = new GraphQLSchemaPlugin<PbContext>({
             slug: String!
             tags: [String!]
             layout: String
+            pageCategory: String
             content: JSON
         }
 
@@ -40,6 +42,7 @@ export const createPageTemplateGraphQL = new GraphQLSchemaPlugin<PbContext>({
             slug: String
             description: String
             layout: String
+            pageCategory: String
             content: JSON
             tags: [String!]
         }
@@ -62,7 +65,7 @@ export const createPageTemplateGraphQL = new GraphQLSchemaPlugin<PbContext>({
 
         extend type PbMutation {
             createPageTemplate(data: PbCreatePageTemplateInput!): PbPageTemplateResponse
-            createPageFromTemplate(templateId: ID, category: String, meta: JSON): PbPageResponse
+            createPageFromTemplate(templateId: ID, meta: JSON): PbPageResponse
             updatePageTemplate(id: ID!, data: PbUpdatePageTemplateInput!): PbPageTemplateResponse
             deletePageTemplate(id: ID!): PbPageTemplateResponse
         }
@@ -101,11 +104,10 @@ export const createPageTemplateGraphQL = new GraphQLSchemaPlugin<PbContext>({
                     return context.pageBuilder.createPageTemplate(args.data);
                 });
             },
-            createPageFromTemplate: async (_, { templateId, category, meta }: any, context) => {
+            createPageFromTemplate: async (_, { templateId, meta }: any, context) => {
                 return resolve(() => {
                     return context.pageBuilder.createPageFromTemplate({
                         id: templateId,
-                        category,
                         meta
                     });
                 });

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -863,7 +863,6 @@ export interface OnPageTemplateAfterDeleteTopicParams {
 interface CreatePageFromTemplateParams {
     id?: string;
     slug?: string;
-    category: string;
     path?: string;
     meta?: Record<string, any>;
 }

--- a/packages/api-page-builder/src/types.ts
+++ b/packages/api-page-builder/src/types.ts
@@ -892,6 +892,7 @@ export interface PageTemplate {
     tags: string[];
     description: string;
     layout?: string;
+    pageCategory: string;
     content?: any;
     createdOn: string;
     savedOn: string;
@@ -902,7 +903,7 @@ export interface PageTemplate {
 
 export type PageTemplateInput = Pick<
     PageTemplate,
-    "title" | "description" | "content" | "slug" | "tags" | "layout"
+    "title" | "description" | "content" | "slug" | "tags" | "layout" | "pageCategory"
 > & { id?: string };
 
 /**

--- a/packages/app-page-builder/src/admin/graphql/pages.ts
+++ b/packages/app-page-builder/src/admin/graphql/pages.ts
@@ -68,9 +68,9 @@ export const CREATE_PAGE = gql`
 `;
 
 export const CREATE_PAGE_FROM_TEMPLATE = gql`
-    mutation PbCreatePageFromTemplate($templateId: ID, $category: String, $meta: JSON) {
+    mutation PbCreatePageFromTemplate($templateId: ID, $meta: JSON) {
         pageBuilder {
-            createPage: createPageFromTemplate(templateId: $templateId, category: $category, meta: $meta) {
+            createPage: createPageFromTemplate(templateId: $templateId, meta: $meta) {
                 data {
                     ${LIST_PAGES_DATA_FIELDS}
                 }

--- a/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplates.tsx
+++ b/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplates.tsx
@@ -82,7 +82,8 @@ const PageTemplates: React.FC = () => {
                     slug: "new-template",
                     description: "Blank template",
                     tags: [],
-                    layout: "static" // Hardcoded until better UI is in place
+                    layout: "static", // Hardcoded until better UI is in place
+                    pageCategory: "static"
                 }
             },
             refetchQueries: [{ query: LIST_PAGE_TEMPLATES }]

--- a/packages/app-page-builder/src/admin/views/PageTemplates/graphql.ts
+++ b/packages/app-page-builder/src/admin/views/PageTemplates/graphql.ts
@@ -8,6 +8,7 @@ const PAGE_TEMPLATE_BASE_FIELDS = `
     tags
     description
     layout
+    pageCategory
     createdOn
     savedOn
     createdBy {
@@ -131,6 +132,7 @@ export interface UpdatePageTemplateMutationVariables {
         slug?: string;
         tags?: string[];
         layout?: string;
+        pageCategory?: string;
         content?: string;
     };
 }

--- a/packages/app-page-builder/src/templateEditor/config/editorBar/TemplateSettings/TemplateSettingsModal.tsx
+++ b/packages/app-page-builder/src/templateEditor/config/editorBar/TemplateSettings/TemplateSettingsModal.tsx
@@ -2,12 +2,15 @@ import React, { useCallback } from "react";
 import slugify from "slugify";
 import { css } from "emotion";
 import { useRecoilState } from "recoil";
+import get from "lodash/get";
 import pick from "lodash/pick";
+import { useQuery } from "@apollo/react-hooks";
 import { Form, FormAPI } from "@webiny/form";
 import { plugins } from "@webiny/plugins";
 import { ButtonPrimary } from "@webiny/ui/Button";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { Select } from "@webiny/ui/Select";
+import { CircularProgress } from "@webiny/ui/Progress";
 import { SimpleFormContent } from "@webiny/app-admin/components/SimpleForm";
 import { validation } from "@webiny/validation";
 import { Dialog, DialogCancel, DialogTitle, DialogActions, DialogContent } from "@webiny/ui/Dialog";
@@ -18,8 +21,9 @@ import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { UpdateDocumentActionEvent } from "~/editor/recoil/actions";
 import { PageTemplate } from "~/templateEditor/state";
 import { Input } from "@webiny/ui/Input";
-import { PbPageLayoutPlugin } from "~/types";
+import { PbCategory, PbPageLayoutPlugin } from "~/types";
 import { Tags } from "@webiny/ui/Tags";
+import { LIST_CATEGORIES } from "~/admin/views/Categories/graphql";
 
 const narrowDialog = css`
     & .mdc-dialog__surface {
@@ -40,6 +44,13 @@ const TemplateSettingsModal: React.FC = () => {
         const layoutPlugins = plugins.byType<PbPageLayoutPlugin>("pb-page-layout");
         return (layoutPlugins || []).map(pl => pl.layout);
     }, []);
+
+    const pageCategoriesQuery = useQuery(LIST_CATEGORIES);
+    const pageCategories: PbCategory[] = get(
+        pageCategoriesQuery,
+        "data.pageBuilder.listCategories.data",
+        []
+    );
 
     const updateTemplate = (data: Partial<PageTemplate>) => {
         handler.trigger(
@@ -72,7 +83,16 @@ const TemplateSettingsModal: React.FC = () => {
         onClose();
     }, []);
 
-    const settings = pick(template, ["title", "description", "slug", "layout", "tags"]);
+    const settings = pick(template, [
+        "title",
+        "description",
+        "slug",
+        "layout",
+        "tags",
+        "pageCategory"
+    ]);
+
+    const loading = [pageCategoriesQuery].some(item => item.loading);
 
     return (
         <Dialog open={true} onClose={onClose} className={narrowDialog}>
@@ -82,48 +102,70 @@ const TemplateSettingsModal: React.FC = () => {
                         <DialogTitle>Template Settings</DialogTitle>
                         <DialogContent>
                             <SimpleFormContent>
-                                <Grid>
-                                    <Cell span={6}>
-                                        <Bind
-                                            name="title"
-                                            validators={[validation.create("required")]}
-                                        >
-                                            <Input label="Title" onBlur={generateSlug(form)} />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={6}>
-                                        <Bind
-                                            name="slug"
-                                            validators={[validation.create("required")]}
-                                        >
-                                            <Input label="Slug" />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind name="description">
-                                            <Input label="Description" />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind
-                                            name="layout"
-                                            defaultValue={layouts.length ? layouts[0].name : ""}
-                                        >
-                                            <Select label="Layout">
-                                                {layouts.map(({ name, title }) => (
-                                                    <option key={name} value={name}>
-                                                        {title}
-                                                    </option>
-                                                ))}
-                                            </Select>
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind name="tags">
-                                            <Tags label="Tags" />
-                                        </Bind>
-                                    </Cell>
-                                </Grid>
+                                {loading ? (
+                                    <CircularProgress />
+                                ) : (
+                                    <Grid>
+                                        <Cell span={6}>
+                                            <Bind
+                                                name="title"
+                                                validators={[validation.create("required")]}
+                                            >
+                                                <Input label="Title" onBlur={generateSlug(form)} />
+                                            </Bind>
+                                        </Cell>
+                                        <Cell span={6}>
+                                            <Bind
+                                                name="slug"
+                                                validators={[validation.create("required")]}
+                                            >
+                                                <Input label="Slug" />
+                                            </Bind>
+                                        </Cell>
+                                        <Cell span={12}>
+                                            <Bind name="description">
+                                                <Input label="Description" />
+                                            </Bind>
+                                        </Cell>
+                                        <Cell span={12}>
+                                            <Bind
+                                                name="pageCategory"
+                                                defaultValue={
+                                                    pageCategories.length
+                                                        ? pageCategories[0].slug
+                                                        : ""
+                                                }
+                                            >
+                                                <Select label="Page Category">
+                                                    {pageCategories.map(({ slug, name }) => (
+                                                        <option key={slug} value={slug}>
+                                                            {name}
+                                                        </option>
+                                                    ))}
+                                                </Select>
+                                            </Bind>
+                                        </Cell>
+                                        <Cell span={12}>
+                                            <Bind
+                                                name="layout"
+                                                defaultValue={layouts.length ? layouts[0].name : ""}
+                                            >
+                                                <Select label="Layout">
+                                                    {layouts.map(({ name, title }) => (
+                                                        <option key={name} value={name}>
+                                                            {title}
+                                                        </option>
+                                                    ))}
+                                                </Select>
+                                            </Bind>
+                                        </Cell>
+                                        <Cell span={12}>
+                                            <Bind name="tags">
+                                                <Tags label="Tags" />
+                                            </Bind>
+                                        </Cell>
+                                    </Grid>
+                                )}
                             </SimpleFormContent>
                         </DialogContent>
                         <DialogActions>

--- a/packages/app-page-builder/src/templateEditor/config/eventActions/saveTemplate/saveTemplateAction.ts
+++ b/packages/app-page-builder/src/templateEditor/config/eventActions/saveTemplate/saveTemplateAction.ts
@@ -93,6 +93,7 @@ export const saveTemplateAction: TemplateEventActionCallable<SaveTemplateActionA
         tags: state.template.tags || [],
         description: state.template?.description || "",
         layout: state.template?.layout || "",
+        pageCategory: state.template?.pageCategory || "",
         content: syncTemplateVariables({ ...content, elements })
     };
 

--- a/packages/app-page-builder/src/templateEditor/graphql.ts
+++ b/packages/app-page-builder/src/templateEditor/graphql.ts
@@ -16,6 +16,7 @@ const DATA_FIELD = `
         slug
         tags
         layout
+        pageCategory
         description
         content
         createdOn

--- a/packages/app-page-builder/src/templateEditor/state/templateAtom.ts
+++ b/packages/app-page-builder/src/templateEditor/state/templateAtom.ts
@@ -12,6 +12,7 @@ export interface PageTemplate {
     tags?: string[];
     description?: string;
     layout?: string;
+    pageCategory?: string;
     savedOn?: string;
     createdBy: {
         id: string | null;


### PR DESCRIPTION
## Changes
Implements issue "Add page category to page template settings".

FYI: Page Category can be selected only for Page Templates (see Settings inside Template Editor) for now.
For Pages WIP (will be a select in Settings inside Page Editor).

## How Has This Been Tested?
Manual

## Documentation
None