### PR TITLE
fix(api-elasticsearch): base index numbers mapping

### DIFF
--- a/packages/api-elasticsearch/src/indexConfiguration/common.ts
+++ b/packages/api-elasticsearch/src/indexConfiguration/common.ts
@@ -15,7 +15,13 @@ const getDefaultMappings = (): ElasticsearchIndexRequestBodyMappingsDynamicTempl
                 match: "number@*",
                 mapping: {
                     type: "scaled_float",
-                    scaling_factor: 10000
+                    scaling_factor: 10000,
+                    fields: {
+                        keyword: {
+                            type: "keyword",
+                            ignore_above: 256
+                        }
+                    }
                 }
             }
         },
@@ -35,6 +41,7 @@ interface Modifier {
         mappings: ElasticsearchIndexRequestBodyMappingsDynamicTemplate[]
     ): ElasticsearchIndexRequestBodyMappingsDynamicTemplate[];
 }
+
 /**
  * @internal
  */


### PR DESCRIPTION
## Changes
Add `.keyword` mapping to all number fields. Helps with custom search (distinct values).

## How Has This Been Tested?
Jest and manually.