### PR TITLE
Custom Domains - Wrap Domain Assignment Into a Handler

### DIFF
--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -215,16 +215,19 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 dynamoDbElasticsearchTable: core.elasticsearchDynamodbTableName
             });
 
-            addDomainsUrlsOutputs({
-                app,
-                cloudfrontDistribution: cloudfront,
-                map: {
-                    distributionDomain: "cloudfrontApiDomain",
-                    distributionUrl: "cloudfrontApiUrl",
-                    usedDomain: "apiDomain",
-                    usedUrl: "apiUrl"
-                }
-            });
+            app.addHandler(() => {
+                addDomainsUrlsOutputs({
+                    app,
+                    cloudfrontDistribution: cloudfront,
+                    map: {
+                        distributionDomain: "cloudfrontApiDomain",
+                        distributionUrl: "cloudfrontApiUrl",
+                        usedDomain: "apiDomain",
+                        usedUrl: "apiUrl"
+                    }
+                });
+            })
+
 
             tagResources({
                 WbyProjectName: String(process.env["WEBINY_PROJECT_NAME"]),

--- a/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
@@ -118,15 +118,17 @@ export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParam
 
             app.addOutput("appStorage", bucket.bucket.output.id);
 
-            addDomainsUrlsOutputs({
-                app,
-                cloudfrontDistribution: cloudfront,
-                map: {
-                    distributionDomain: "cloudfrontAppDomain",
-                    distributionUrl: "cloudfrontAppUrl",
-                    usedDomain: "appDomain",
-                    usedUrl: "appUrl"
-                }
+            app.addHandler(() => {
+                addDomainsUrlsOutputs({
+                    app,
+                    cloudfrontDistribution: cloudfront,
+                    map: {
+                        distributionDomain: "cloudfrontAppDomain",
+                        distributionUrl: "cloudfrontAppUrl",
+                        usedDomain: "appDomain",
+                        usedUrl: "appUrl"
+                    }
+                });
             });
 
             tagResources({

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -280,7 +280,7 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 // Page Builder and "previewing" pages. In other words, the "preview" property
                 // contains all resources related to serving page previews, unlike "delivery",
                 // which is used to serve published pages to actual website visitors.
-                // The "app" property was still left here just or backwards compatibility.
+                // The "app" property was still left here just for backwards compatibility.
                 preview: {
                     ...appBucket,
                     cloudfront: appCloudfront

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -275,6 +275,16 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
 
             return {
                 prerendering,
+                // "preview" and "app" are the same.
+                // We introduced "preview" just because it's the word we use when talking about
+                // Page Builder and "previewing" pages. In other words, the "preview" property
+                // contains all resources related to serving page previews, unlike "delivery",
+                // which is used to serve published pages to actual website visitors.
+                // The "app" property was still left here just or backwards compatibility.
+                preview: {
+                    ...appBucket,
+                    cloudfront: appCloudfront
+                },
                 app: {
                     ...appBucket,
                     cloudfront: appCloudfront

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -275,6 +275,7 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
 
             return {
                 prerendering,
+
                 // "preview" and "app" are the same.
                 // We introduced "preview" just because it's the word we use when talking about
                 // Page Builder and "previewing" pages. In other words, the "preview" property
@@ -289,6 +290,7 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     ...appBucket,
                     cloudfront: appCloudfront
                 },
+
                 delivery: {
                     ...deliveryBucket,
                     cloudfront: deliveryCloudfront

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -244,26 +244,28 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 deliveryStorage: deliveryBucket.bucket.output.id
             });
 
-            addDomainsUrlsOutputs({
-                app,
-                cloudfrontDistribution: appCloudfront,
-                map: {
-                    distributionDomain: "cloudfrontAppDomain",
-                    distributionUrl: "cloudfrontAppUrl",
-                    usedDomain: "appDomain",
-                    usedUrl: "appUrl"
-                }
-            });
+            app.addHandler(() => {
+                addDomainsUrlsOutputs({
+                    app,
+                    cloudfrontDistribution: appCloudfront,
+                    map: {
+                        distributionDomain: "cloudfrontAppDomain",
+                        distributionUrl: "cloudfrontAppUrl",
+                        usedDomain: "appDomain",
+                        usedUrl: "appUrl"
+                    }
+                });
 
-            addDomainsUrlsOutputs({
-                app,
-                cloudfrontDistribution: deliveryCloudfront,
-                map: {
-                    distributionDomain: "cloudfrontDeliveryDomain",
-                    distributionUrl: "cloudfrontDeliveryUrl",
-                    usedDomain: "deliveryDomain",
-                    usedUrl: "deliveryUrl"
-                }
+                addDomainsUrlsOutputs({
+                    app,
+                    cloudfrontDistribution: deliveryCloudfront,
+                    map: {
+                        distributionDomain: "cloudfrontDeliveryDomain",
+                        distributionUrl: "cloudfrontDeliveryUrl",
+                        usedDomain: "deliveryDomain",
+                        usedUrl: "deliveryUrl"
+                    }
+                });
             });
 
             tagResources({


### PR DESCRIPTION
## Changes
With this PR, we're further polishing the custom domains assignment. 

With it, assigning custom domains works both via the `domains` Pulumi app param, and via the `pulumi` callback. Previously, the latter would not work, because of the order of execution was incorrect, thus the domain/stack output assignment would happen too early.

### Additional Change

Prior to this PR, Website's Pulumi code would expose two Cloudfront distributions via the `app` and `delivery` properties. From now, the `app` can also be accessed via the `preview` property. More on this in the included code comment:

```
// "preview" and "app" are the same.
// We introduced "preview" just because it's the word we use when talking about
// Page Builder and "previewing" pages. In other words, the "preview" property
// contains all resources related to serving page previews, unlike "delivery",
// which is used to serve published pages to actual website visitors.
// The "app" property was still left here just or backwards compatibility.
```

## How Has This Been Tested?
Manually.

## Documentation
Changelog.