### PR TITLE
feat: use custom:id attribute as identity id

### DIFF
--- a/packages/api-admin-users-cognito/src/syncWithCognito.ts
+++ b/packages/api-admin-users-cognito/src/syncWithCognito.ts
@@ -104,21 +104,15 @@ export const syncWithCognito = ({
                     {
                         Name: "email",
                         Value: username
+                    },
+                    {
+                        Name: "custom:id",
+                        Value: user.id
                     }
                 ]
             };
 
-            const response = await cognito.adminCreateUser(params).promise();
-
-            const { User } = response;
-            /**
-             * TODO @ts-refactor @pavel are we doing anything in case there is no User variable?
-             * Same goes for the sub attribute.
-             */
-            // @ts-ignore
-            const subAttr = User.Attributes.find(attr => attr.Name === "sub");
-            // @ts-ignore
-            user.id = subAttr ? subAttr.Value : null;
+            await cognito.adminCreateUser(params).promise();
 
             const verify = {
                 UserPoolId: userPoolId,

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -25,7 +25,7 @@ export const getIdentity: GetIdentity = ({ identityType, token }) => {
     const displayName = [given_name, family_name].filter(Boolean).join(" ").trim() || null;
 
     return {
-        id: token["custom:id"] || token["sub"],
+        id: token["custom:id"] || token["sub"] || null,
         type: identityType,
         displayName,
         email: preferred_username || email,

--- a/packages/api-authentication-cognito/src/index.ts
+++ b/packages/api-authentication-cognito/src/index.ts
@@ -18,7 +18,6 @@ export const getIdentity: GetIdentity = ({ identityType, token }) => {
     const {
         given_name = null,
         family_name = null,
-        sub: id = null,
         email = null,
         preferred_username = null
     } = token;
@@ -26,7 +25,7 @@ export const getIdentity: GetIdentity = ({ identityType, token }) => {
     const displayName = [given_name, family_name].filter(Boolean).join(" ").trim() || null;
 
     return {
-        id,
+        id: token["custom:id"] || token["sub"],
         type: identityType,
         displayName,
         email: preferred_username || email,

--- a/packages/api-security-cognito/src/index.ts
+++ b/packages/api-security-cognito/src/index.ts
@@ -26,6 +26,7 @@ export interface CognitoTokenData extends TokenData {
     given_name: string;
     family_name: string;
     email: string;
+    "custom:id": string;
     [key: string]: any;
 }
 
@@ -60,7 +61,7 @@ export const createCognito = <
             }
 
             return {
-                id: tokenObj.sub,
+                id: tokenObj["custom:id"] || tokenObj.sub,
                 type: config.identityType,
                 displayName: `${tokenObj.given_name} ${tokenObj.family_name}`,
                 email: tokenObj.email,

--- a/packages/pulumi-aws/src/apps/core/CoreCognito.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreCognito.ts
@@ -75,6 +75,17 @@ export const CoreCognito = createAppModule({
                             maxLength: "2048",
                             minLength: "0"
                         }
+                    },
+                    {
+                        attributeDataType: "String",
+                        name: "id",
+                        required: false,
+                        developerOnlyAttribute: false,
+                        mutable: true,
+                        stringAttributeConstraints: {
+                            maxLength: "36",
+                            minLength: "0"
+                        }
                     }
                 ]
             },


### PR DESCRIPTION
## Changes
This PR adds a custom attribute to Cognito User Pool, called `custom:id`, which holds a Webiny-generated ID for the identity. This is necessary to support export/import of users from Cognito User Pool. The problem is that , when importing users into a Cognito User Pool, the `sub` (AWS-generated ID) changes. This means that we cannot rely on the value of the `sub` attribute. Storing our own ID into a custom attribute solves the issue, because we can now always reference this ID after importing users into a new user pool, and this ID will also stay consistent with a copy of Webiny DynamoDB table. 

This change is backwards compatible, so all existing identities will work with the `sub` attribute, but all new identities will be handled via this new `custom:id` attribute.

> Custom implementations of Cognito security can use whatever they want; this change is primarily for our out-of-the-box solution. If people do custom identities, this doesn't apply.
 
> `custom:` prefix is enforced by AWS for all non-standard attributes, so even though in Pulumi you specify simply `id`, when working with AWS SDK, you must include the `custom` prefix, and the prefix is also included in the idToken by AWS.

![image](https://user-images.githubusercontent.com/3920893/224282054-7bb0ee19-10f4-4e27-af5e-319178ce23f0.png)

![image](https://user-images.githubusercontent.com/3920893/224283497-1d73c8eb-5ab4-4579-970a-1eca387cf029.png)

![image](https://user-images.githubusercontent.com/3920893/224284095-630a95a7-1994-43ad-9f06-8c801dc772c2.png)

![image](https://user-images.githubusercontent.com/3920893/224284127-8dacb196-9741-439b-9d1c-9bbbe65982b8.png)

## How Has This Been Tested?
Manually.
