### PR TITLE
Introduce Limits To Number of Tenants (WCP)

### DIFF
--- a/packages/api-tenancy/__tests__/install.test.ts
+++ b/packages/api-tenancy/__tests__/install.test.ts
@@ -9,7 +9,13 @@ describe(`Test "Tenancy" install`, () => {
     beforeEach(async () => {
         tenancy = await createTenancy({
             tenant: null,
-            storageOperations
+            storageOperations,
+            incrementWcpTenants: async () => {
+                return Promise.resolve()
+            },
+            decrementWcpTenants: async () => {
+                return Promise.resolve()
+            }
         });
     });
 

--- a/packages/api-tenancy/__tests__/install.test.ts
+++ b/packages/api-tenancy/__tests__/install.test.ts
@@ -11,10 +11,10 @@ describe(`Test "Tenancy" install`, () => {
             tenant: null,
             storageOperations,
             incrementWcpTenants: async () => {
-                return Promise.resolve()
+                return Promise.resolve();
             },
             decrementWcpTenants: async () => {
-                return Promise.resolve()
+                return Promise.resolve();
             }
         });
     });

--- a/packages/api-tenancy/__tests__/tenants.test.ts
+++ b/packages/api-tenancy/__tests__/tenants.test.ts
@@ -6,10 +6,22 @@ describe(`Test "Tenancy" tenants`, () => {
     const { storageOperations } = __getStorageOperations();
     let tenancy: Tenancy;
 
+    let wcpTenantsCount: number;
+
+    beforeEach(async () => {
+        wcpTenantsCount = 0;
+    });
+
     beforeAll(async () => {
         tenancy = await createTenancy({
             tenant: null,
-            storageOperations
+            storageOperations,
+            incrementWcpTenants: async () => {
+                wcpTenantsCount++;
+            },
+            decrementWcpTenants: async () => {
+                wcpTenantsCount--;
+            }
         });
     });
 
@@ -35,6 +47,9 @@ describe(`Test "Tenancy" tenants`, () => {
         // Install root tenant
         await tenancy.install();
 
+        // After the installation, we should have one tenant recorded.
+        expect(wcpTenantsCount).toBe(1);
+
         // Create first subtenant
         await tenancy.createTenant(tenant1Data);
         const tenants = await tenancy.listTenants({ parent: "root" });
@@ -48,6 +63,9 @@ describe(`Test "Tenancy" tenants`, () => {
             savedOn: expect.any(String)
         });
 
+        // New tenant added, meaning total tenants count should be 2.
+        expect(wcpTenantsCount).toBe(2);
+
         // Create second subtenant
         await tenancy.createTenant(tenant2Data);
         const tenant2 = await tenancy.getTenantById("2");
@@ -59,6 +77,9 @@ describe(`Test "Tenancy" tenants`, () => {
             createdOn: expect.any(String),
             savedOn: expect.any(String)
         });
+
+        // Final tenants count should be 3.
+        expect(wcpTenantsCount).toBe(3);
 
         await tenancy.updateTenant("2", { name: "Tenant #2.1", description: "Subtenant" });
         await expect(tenancy.getTenantById("2")).resolves.toEqual({
@@ -77,6 +98,9 @@ describe(`Test "Tenancy" tenants`, () => {
         // Delete tenants
         await tenancy.deleteTenant("1");
         await tenancy.deleteTenant("2");
+
+        // With 2 tenants just deleted, the tenants count should fall back to 1.
+        expect(wcpTenantsCount).toBe(1);
 
         await expect(tenancy.listTenants({ parent: "root" })).resolves.toEqual([]);
         await expect(tenancy.getTenantById("1")).resolves.toEqual(undefined);

--- a/packages/api-tenancy/src/createTenancy.ts
+++ b/packages/api-tenancy/src/createTenancy.ts
@@ -6,6 +6,8 @@ export interface TenancyConfig {
     tenant: string | null;
     storageOperations: TenancyStorageOperations;
     multiTenancy?: boolean;
+    incrementWcpTenants: () => Promise<void>;
+    decrementWcpTenants: () => Promise<void>;
 }
 
 const withToString = (tenant: Tenant) => {
@@ -20,7 +22,9 @@ const withToString = (tenant: Tenant) => {
 export async function createTenancy({
     tenant,
     storageOperations,
-    multiTenancy = false
+    multiTenancy = false,
+    incrementWcpTenants,
+    decrementWcpTenants
 }: TenancyConfig): Promise<Tenancy> {
     let currentTenant: Tenant | null = null;
 
@@ -37,8 +41,8 @@ export async function createTenancy({
         setCurrentTenant(tenant: Tenant) {
             currentTenant = withToString(tenant);
         },
-        ...createSystemMethods(storageOperations),
-        ...createTenantsMethods(storageOperations)
+        ...createSystemMethods({ storageOperations }),
+        ...createTenantsMethods({ storageOperations, incrementWcpTenants, decrementWcpTenants })
     };
 
     if (tenant) {

--- a/packages/api-tenancy/src/createTenancy/createSystemMethods.ts
+++ b/packages/api-tenancy/src/createTenancy/createSystemMethods.ts
@@ -1,7 +1,11 @@
 import WebinyError from "@webiny/error";
 import { Tenancy, TenancyStorageOperations } from "~/types";
 
-export function createSystemMethods(storageOperations: TenancyStorageOperations) {
+interface CreateSystemMethodsParams {
+    storageOperations: TenancyStorageOperations;
+}
+
+export function createSystemMethods({ storageOperations }: CreateSystemMethodsParams) {
     return {
         async getVersion(this: Tenancy): Promise<string | null> {
             const system = await storageOperations.getSystemData();

--- a/packages/api-tenancy/src/createTenancy/createTenantsMethods.ts
+++ b/packages/api-tenancy/src/createTenancy/createTenantsMethods.ts
@@ -45,7 +45,17 @@ function createTenantLoaders(storageOperations: TenancyStorageOperations) {
     };
 }
 
-export function createTenantsMethods(storageOperations: TenancyStorageOperations) {
+export interface CreateTenantsMethodsParams {
+    storageOperations: TenancyStorageOperations;
+    incrementWcpTenants: () => Promise<void>;
+    decrementWcpTenants: () => Promise<void>;
+}
+
+export function createTenantsMethods({
+    storageOperations,
+    incrementWcpTenants,
+    decrementWcpTenants
+}: CreateTenantsMethodsParams) {
     const loaders = createTenantLoaders(storageOperations);
 
     return {
@@ -96,7 +106,14 @@ export function createTenantsMethods(storageOperations: TenancyStorageOperations
 
             await this.onTenantBeforeCreate.publish({ tenant });
 
-            await storageOperations.createTenant(tenant);
+            await incrementWcpTenants();
+
+            try {
+                await storageOperations.createTenant(tenant);
+            } catch (e) {
+                await decrementWcpTenants();
+                throw e;
+            }
 
             await this.onTenantAfterCreate.publish({ tenant });
 
@@ -134,6 +151,8 @@ export function createTenantsMethods(storageOperations: TenancyStorageOperations
             await this.onTenantBeforeDelete.publish({ tenant });
 
             await storageOperations.deleteTenant(id);
+
+            await decrementWcpTenants();
 
             await this.onTenantAfterDelete.publish({ tenant });
 

--- a/packages/api-tenancy/src/index.ts
+++ b/packages/api-tenancy/src/index.ts
@@ -49,7 +49,9 @@ export const createTenancyContext = ({ storageOperations }: TenancyPluginsParams
         context.tenancy = await createTenancy({
             tenant: tenantId,
             multiTenancy,
-            storageOperations
+            storageOperations,
+            incrementWcpTenants: context.wcp.incrementTenants,
+            decrementWcpTenants: context.wcp.decrementTenants
         });
 
         // Even though we don't have a full GraphQL schema when using the `context` plugins,

--- a/packages/api-tenancy/src/index.ts
+++ b/packages/api-tenancy/src/index.ts
@@ -50,8 +50,20 @@ export const createTenancyContext = ({ storageOperations }: TenancyPluginsParams
             tenant: tenantId,
             multiTenancy,
             storageOperations,
-            incrementWcpTenants: context.wcp.incrementTenants,
-            decrementWcpTenants: context.wcp.decrementTenants
+            incrementWcpTenants: async () => {
+                if (!context.wcp) {
+                    return;
+                }
+
+                await context.wcp.incrementTenants();
+            },
+            decrementWcpTenants: async () => {
+                if (!context.wcp) {
+                    return;
+                }
+
+                await context.wcp.decrementTenants();
+            }
         });
 
         // Even though we don't have a full GraphQL schema when using the `context` plugins,

--- a/packages/api-wcp/__tests__/context.test.ts
+++ b/packages/api-wcp/__tests__/context.test.ts
@@ -21,7 +21,9 @@ describe("context", () => {
             canUseFeature: expect.any(Function),
             ensureCanUseFeature: expect.any(Function),
             incrementSeats: expect.any(Function),
-            decrementSeats: expect.any(Function)
+            decrementSeats: expect.any(Function),
+            incrementTenants: expect.any(Function),
+            decrementTenants: expect.any(Function)
         });
     });
 });

--- a/packages/api-wcp/src/types.ts
+++ b/packages/api-wcp/src/types.ts
@@ -13,6 +13,8 @@ export interface WcpContextObject {
     ensureCanUseFeature: (featureId: keyof typeof WCP_FEATURE_LABEL) => void;
     incrementSeats: () => Promise<void>;
     decrementSeats: () => Promise<void>;
+    incrementTenants: () => Promise<void>;
+    decrementTenants: () => Promise<void>;
 }
 
 export interface CachedWcpProjectLicense {


### PR DESCRIPTION
## Changes
This PR introduces the limit to the number of tenants that can be created within a Webiny project. This can be later controlled via WCP.

## How Has This Been Tested?
Manually. Jest.

## Documentation
N/A
