### PR TITLE
Introduce Application Name-based Environment Variables Naming

### DIFF
--- a/packages/project-utils/bundling/app/config/env.js
+++ b/packages/project-utils/bundling/app/config/env.js
@@ -28,9 +28,19 @@ process.env.NODE_PATH = (process.env.NODE_PATH || "")
 // injected into the application via DefinePlugin in Webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
-function getClientEnvironment(publicUrl) {
+function getClientEnvironment({ publicUrl, projectApplication }) {
     const raw = Object.keys(process.env)
-        .filter(key => REACT_APP.test(key))
+        .filter(key => {
+            if (REACT_APP.test(key)) {
+                return true;
+            }
+
+            if (projectApplication) {
+                return new RegExp(`^WEBINY_${projectApplication.id.toUpperCase()}_`).test(key);
+            }
+
+            return false;
+        })
         .reduce(
             (env, key) => {
                 env[key] = process.env[key];
@@ -57,6 +67,8 @@ function getClientEnvironment(publicUrl) {
         stringified[`process.env.${key}`] = JSON.stringify(raw[key]);
     }
 
+    console.log(JSON.stringify(raw, null, 2));
+    process.exit();
     return { raw, stringified };
 }
 

--- a/packages/project-utils/bundling/app/config/env.js
+++ b/packages/project-utils/bundling/app/config/env.js
@@ -67,8 +67,6 @@ function getClientEnvironment({ publicUrl, projectApplication }) {
         stringified[`process.env.${key}`] = JSON.stringify(raw[key]);
     }
 
-    console.log(JSON.stringify(raw, null, 2));
-    process.exit();
     return { raw, stringified };
 }
 

--- a/packages/project-utils/bundling/app/config/webpack.config.js
+++ b/packages/project-utils/bundling/app/config/webpack.config.js
@@ -18,6 +18,7 @@ const ModuleNotFoundPlugin = require("react-dev-utils/ModuleNotFoundPlugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const WebpackBar = require("webpackbar");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+const { getProjectApplication } = require("@webiny/cli/utils");
 
 const materialNodeModules = require.resolve("@material/base/package.json").split("@material")[0];
 const sassIncludePaths = [
@@ -55,6 +56,8 @@ const sassLoader = {
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (webpackEnv, { paths, options }) {
+    const projectApplication = getProjectApplication({ cwd: options.cwd });
+
     const isEnvDevelopment = webpackEnv === "development";
     const isEnvProduction = webpackEnv === "production";
 
@@ -89,7 +92,7 @@ module.exports = function (webpackEnv, { paths, options }) {
     // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
     const publicUrl = isEnvProduction ? publicPath.slice(0, -1) : isEnvDevelopment && "";
     // Get environment variables to inject into our app.
-    const env = getClientEnvironment(publicUrl);
+    const env = getClientEnvironment({ publicUrl, projectApplication });
 
     return {
         mode: isEnvProduction ? "production" : isEnvDevelopment && "development",

--- a/packages/pulumi-aws/src/utils/lambdaEnvVariables.ts
+++ b/packages/pulumi-aws/src/utils/lambdaEnvVariables.ts
@@ -7,7 +7,7 @@ const variablesRegistry: EnvVariables = {};
 
 export let sealEnvVariables: () => void;
 
-const magicPrefixes = ["WEBINY_", "WCP_", "OKTA_", "AUTH0_"];
+const magicPrefixes = ["WEBINY_", "WEBINY_API_", "WCP_", "OKTA_", "AUTH0_"];
 
 const variablesPromise = new Promise<EnvVariables>(resolve => {
     sealEnvVariables = () => {


### PR DESCRIPTION
## Changes
With this PR, we're simplifying the way environment variables are defined by users.

At the moment, to assign an env var to the API app (to all of its AWS Lambda functions), users use `WEBINY_` prefix, e.g. `WEBINY_STRIPE_KEY`.

When it comes to Admin and Website apps, users use `REACT_APP_` prefix, for example `REACT_APP_STRIPE_KEY`. As we can see, the prefix we use here is different than what we had with the API app. Furthermore, any environment variable we define ends up being assigned to both Admin and Website apps when built. So, the user can't really pick the app to which the env var belongs.

So, we're introducing the following environment variable prefixes:

```
WEBINY_API_
WEBINY_ADMIN_
WEBINY_WEBSITE_
```

With this approach, the way we're assigning environment variables is unified across all apps. The prefix always starts with `WEBINY_`, and then only the name of the app is appended. Plus, this way it's clear to which app the environment variable belongs to. 

Finally, the user has the ability to assign an env var only to the Website app, not Admin too.

#### Backwards Compatibility
This new feature is backwards compatible. All previously defined environment variables in users' projects will still work as usual.

## How Has This Been Tested?
Manually.

## Documentation
Changelog. Will update environment variables article.