### PR TITLE
Ensure `accountRecoverySetting` Is Passed To Cognito User Pool

### DIFF
--- a/packages/pulumi-aws/src/apps/core/CoreCognito.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreCognito.ts
@@ -42,6 +42,9 @@ export const CoreCognito = createAppModule({
                 verificationMessageTemplate: {
                     defaultEmailOption: "CONFIRM_WITH_CODE"
                 },
+                accountRecoverySetting: {
+                    recoveryMechanisms: [{ name: "verified_email", priority: 1 }]
+                },
                 schemas: [
                     {
                         attributeDataType: "String",


### PR DESCRIPTION
## Changes
This PR tries to resolve the following: https://github.com/pulumi/pulumi-aws/issues/2412.

## How Has This Been Tested?
Manually, with existing 5.33.5 project and a 5.33.5 -> 5.33.6 upgraded one.

## Documentation
Will add a note in changelog.