### PR TITLE
fix: fix duplicate images when importing pages/blocks/templates

### DIFF
--- a/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
@@ -29,9 +29,12 @@ export const uploadAssets = async (params: UploadAssetsParams) => {
     }
 
     // Check if files with such keys already exist
-    const [existingFiles] = await context.fileManager.files.listFiles();
+    const fileIds = files.map(file => file.id);
+    const [existingImages] = await context.fileManager.files.listFiles({
+        where: { id_in: fileIds }
+    });
     const filteredFiles = files.filter(
-        file => !existingFiles.some(existingFile => existingFile.key === file.key)
+        file => !existingImages.some(existingImage => existingImage.key === file.key)
     );
 
     // A map of temporary file keys (created during ZIP upload) to permanent file keys.

--- a/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
@@ -28,13 +28,19 @@ export const uploadAssets = async (params: UploadAssetsParams) => {
         return oldIdToNewFileMap;
     }
 
+    // Check if files with such keys already exist
+    const [existingFiles] = await context.fileManager.files.listFiles();
+    const filteredFiles = files.filter(
+        file => !existingFiles.some(existingFile => existingFile.key === file.key)
+    );
+
     // A map of temporary file keys (created during ZIP upload) to permanent file keys.
     const uploadFileMap: UploadFileMap = new Map();
 
     // Array of file inputs, to insert into the DB.
     const createFilesInput: FileInput[] = [];
 
-    for (const oldFile of files) {
+    for (const oldFile of filteredFiles) {
         const id = mdbid();
         // We replace the old file ID with a new one.
         const newKey = `${id}/${oldFile.key.replace(`${oldFile.id}/`, "")}`;


### PR DESCRIPTION
## Changes
Resolve issue "When importing pages, blocks and templates see we don’t duplicate images"

## How Has This Been Tested?
Manual

## Documentation
None
