### PR TITLE
feat(app-headless-cms): singular and plural model api name

### DIFF
--- a/cypress/integration/admin/headlessCms/contentModel/contentModels.spec.js
+++ b/cypress/integration/admin/headlessCms/contentModel/contentModels.spec.js
@@ -1,4 +1,6 @@
 import uniqid from "uniqid";
+import lodashUpperFirst from "lodash/upperFirst";
+import lodashCamelCase from "lodash/camelCase";
 
 context("Headless CMS - Content Models CRUD", () => {
     beforeEach(() => cy.login());
@@ -23,6 +25,18 @@ context("Headless CMS - Content Models CRUD", () => {
                 .wait(500)
                 .type(`Book - ${uniqueId}`)
                 .wait(500);
+            // add api singular and plural names
+            cy.findByTestId("cms.newcontentmodeldialog.singularApiName")
+                .focus()
+                .wait(500)
+                .type(lodashUpperFirst(lodashCamelCase(`Book${uniqueId}`)))
+                .wait(500);
+            cy.findByTestId("cms.newcontentmodeldialog.pluralApiName")
+                .focus()
+                .wait(500)
+                .type(lodashUpperFirst(lodashCamelCase(`Books${uniqueId}`)))
+                .wait(500);
+
             cy.findByTestId("cms.newcontentmodeldialog.description").type(newModelDescription);
             cy.findByRole("button", { name: "+ Create Model" }).click();
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.withId.test.ts
@@ -422,7 +422,7 @@ describe("Content entry with user defined ID", () => {
                                 id
                             },
                             message:
-                                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9, - and it cannot start or end with a -."
+                                "The provided ID is not valid. It must be a string which can be A-Z, a-z, 0-9, - and it cannot start or end with a -."
                         }
                     }
                 }

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -64,6 +64,8 @@ import { checkOwnership, validateOwnership } from "~/utils/ownership";
 import { entryFromStorageTransform, entryToStorageTransform } from "~/utils/entryStorage";
 import { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 import { getSearchableFields } from "./contentEntry/searchableFields";
+import { removeUndefinedValues } from "~/utils/removeUndefinedValues";
+import { removeNullValues } from "~/utils/removeNullValues";
 
 export const STATUS_DRAFT = "draft";
 export const STATUS_PUBLISHED = "published";
@@ -114,11 +116,8 @@ const getDefaultValue = (field: CmsModelField): (DefaultValue | DefaultValue[]) 
 /**
  * Cleans and adds default values to create input data.
  */
-const mapAndCleanCreateInputData = (
-    model: CmsModel,
-    input: CreateCmsEntryInput
-): CreateCmsEntryInput => {
-    return model.fields.reduce((acc, field) => {
+const mapAndCleanCreateInputData = (model: CmsModel, input: CreateCmsEntryInput) => {
+    return model.fields.reduce<CreateCmsEntryInput>((acc, field) => {
         /**
          * This should never happen, but let's make it sure.
          * The fix would be for the user to add the fieldId on the field definition.
@@ -134,16 +133,13 @@ const mapAndCleanCreateInputData = (
          */
         acc[field.fieldId] = value === undefined ? getDefaultValue(field) : value;
         return acc;
-    }, {} as CreateCmsEntryInput);
+    }, {});
 };
 /**
  * Cleans the update input entry data.
  */
-const mapAndCleanUpdatedInputData = (
-    model: CmsModel,
-    input: UpdateCmsEntryInput
-): UpdateCmsEntryInput => {
-    return model.fields.reduce((acc, field) => {
+const mapAndCleanUpdatedInputData = (model: CmsModel, input: UpdateCmsEntryInput) => {
+    return model.fields.reduce<UpdateCmsEntryInput>((acc, field) => {
         /**
          * This should never happen, but let's make it sure.
          * The fix would be for the user to add the fieldId on the field definition.
@@ -162,7 +158,7 @@ const mapAndCleanUpdatedInputData = (
         }
         acc[field.fieldId] = value;
         return acc;
-    }, {} as CreateCmsEntryInput);
+    }, {});
 };
 /**
  * This method takes original entry meta and new input.
@@ -170,15 +166,7 @@ const mapAndCleanUpdatedInputData = (
  */
 const createEntryMeta = (input?: Record<string, any>, original?: Record<string, any>) => {
     const meta = lodashMerge(original || {}, input || {});
-
-    for (const key in meta) {
-        if (meta[key] !== undefined || meta[key] !== null) {
-            continue;
-        }
-        delete meta[key];
-    }
-
-    return meta;
+    return removeUndefinedValues(removeNullValues(meta));
 };
 
 interface DeleteEntryParams {
@@ -186,27 +174,12 @@ interface DeleteEntryParams {
     entry: CmsEntry;
 }
 
-interface EntryIdResult {
-    /**
-     * A generated id that will connect all the entry records.
-     */
-    entryId: string;
-    /**
-     * Version of the entry.
-     */
-    version: number;
-    /**
-     * Combination of entryId and version.
-     */
-    id: string;
-}
-
-const createEntryId = (input: CreateCmsEntryInput): EntryIdResult => {
+const createEntryId = (input: CreateCmsEntryInput) => {
     let entryId = mdbid();
     if (input.id) {
         if (input.id.match(/^([a-zA-Z0-9])([a-zA-Z0-9\-]+)([a-zA-Z0-9])$/) === null) {
             throw new WebinyError(
-                "The provided ID is not valid. It must be a string which can A-Z, a-z, 0-9, - and it cannot start or end with a -.",
+                "The provided ID is not valid. It must be a string which can be A-Z, a-z, 0-9, - and it cannot start or end with a -.",
                 "INVALID_ID",
                 {
                     id: input.id
@@ -226,7 +199,7 @@ const createEntryId = (input: CreateCmsEntryInput): EntryIdResult => {
     };
 };
 
-const increaseEntryIdVersion = (id: string): EntryIdResult => {
+const increaseEntryIdVersion = (id: string) => {
     const { id: entryId, version } = parseIdentifier(id);
     if (!version) {
         throw new WebinyError(
@@ -253,7 +226,7 @@ const transformEntryStatus = (status: CmsEntryStatus | string): CmsEntryStatus =
     return allowedEntryStatus.includes(status) ? (status as CmsEntryStatus) : "draft";
 };
 
-export interface CreateContentEntryCrudParams {
+interface CreateContentEntryCrudParams {
     storageOperations: HeadlessCmsStorageOperations;
     context: CmsContext;
     getIdentity: () => SecurityIdentity;
@@ -262,7 +235,6 @@ export interface CreateContentEntryCrudParams {
 
 export const createContentEntryCrud = (params: CreateContentEntryCrudParams): CmsEntryContext => {
     const { storageOperations, context, getIdentity, getTenant } = params;
-
     const { plugins } = context;
 
     /**
@@ -341,7 +313,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     const onEntryAfterDelete = createTopic<OnEntryAfterDeleteTopicParams>("cms.onEntryAfterDelete");
     const onEntryDeleteError = createTopic<OnEntryDeleteErrorTopicParams>("cms.onEntryDeleteError");
 
-    // delete revision
+    /**
+     * Delete revision
+     */
     const onEntryRevisionBeforeDelete = createTopic<OnEntryRevisionBeforeDeleteTopicParams>(
         "cms.onEntryRevisionBeforeDelete"
     );
@@ -352,10 +326,14 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         "cms.onEntryRevisionDeleteError"
     );
 
-    // get
+    /**
+     * Get entry
+     */
     const onEntryBeforeGet = createTopic<OnEntryBeforeGetTopicParams>("cms.onEntryBeforeGet");
 
-    // list
+    /**
+     * List entries
+     */
     const onEntryBeforeList = createTopic<EntryBeforeListTopicParams>("cms.onEntryBeforeList");
 
     /**

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -1,4 +1,6 @@
 import zod from "zod";
+import upperFirst from "lodash/upperFirst";
+import camelCase from "lodash/camelCase";
 
 const fieldSystemFields: string[] = [
     "id",
@@ -97,12 +99,33 @@ const fieldSchema = zod.object({
     settings: zod.object({}).passthrough().optional().default({})
 });
 
+const refinementValidation = (value: string): boolean => {
+    return value === upperFirst(camelCase(value));
+};
+const refinementSingularValidationMessage = (value?: string) => {
+    return {
+        message: `The Singular API Name value "${
+            value || "undefined"
+        }" is not valid. It must in Upper First + Camel Cased form. For example: "ArticleCategory" or "CarMake".`
+    };
+};
+const refinementPluralValidationMessage = (value?: string) => {
+    return {
+        message: `The Plural API Name value "${
+            value || "undefined"
+        }" is not valid. It must in Upper First + Camel Cased form. For example: "ArticleCategories" or "CarMakes".`
+    };
+};
+
 export const createModelCreateValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        singularApiName: shortString,
-        pluralApiName: shortString,
+        singularApiName: shortString.refine(
+            refinementValidation,
+            refinementSingularValidationMessage
+        ),
+        pluralApiName: shortString.refine(refinementValidation, refinementPluralValidationMessage),
         description: optionalShortString.nullish(),
         group: shortString,
         fields: zod.array(fieldSchema).default([]),
@@ -116,8 +139,11 @@ export const createModelCreateFromValidation = () => {
     return zod.object({
         name: shortString,
         modelId: optionalShortString,
-        singularApiName: shortString,
-        pluralApiName: shortString,
+        singularApiName: shortString.refine(
+            refinementValidation,
+            refinementSingularValidationMessage
+        ),
+        pluralApiName: shortString.refine(refinementValidation, refinementPluralValidationMessage),
         description: optionalShortString.nullish(),
         group: shortString,
         locale: optionalShortString
@@ -127,8 +153,18 @@ export const createModelCreateFromValidation = () => {
 export const createModelUpdateValidation = () => {
     return zod.object({
         name: optionalShortString,
-        singularApiName: optionalShortString,
-        pluralApiName: optionalShortString,
+        singularApiName: optionalShortString.refine(value => {
+            if (!value) {
+                return true;
+            }
+            return refinementValidation(value);
+        }, refinementSingularValidationMessage),
+        pluralApiName: optionalShortString.refine(value => {
+            if (!value) {
+                return true;
+            }
+            return refinementValidation(value);
+        }, refinementPluralValidationMessage),
         description: optionalShortString.nullish(),
         group: optionalShortString,
         fields: zod.array(fieldSchema),

--- a/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
+++ b/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
@@ -47,7 +47,16 @@ export const generateSchemaPlugins = async (
     });
 
     models
-        .filter(model => model.fields.length > 0)
+        .filter(model => {
+            /**
+             * TODO @bruno Remove before 5.35.0
+             * Temporary check for the development.
+             */
+            if (!model.singularApiName || !model.pluralApiName) {
+                return false;
+            }
+            return model.fields.length > 0;
+        })
         .forEach(model => {
             switch (type) {
                 case "manage":

--- a/packages/api-headless-cms/src/utils/removeNullValues.ts
+++ b/packages/api-headless-cms/src/utils/removeNullValues.ts
@@ -1,0 +1,11 @@
+export const removeNullValues = <T extends Record<string, any>>(target: T): T => {
+    const result = {} as T;
+    for (const key in target) {
+        if (target[key] === null) {
+            continue;
+        }
+
+        result[key] = target[key];
+    }
+    return result as T;
+};

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
@@ -61,6 +61,7 @@ const menuStyles = css({
 
 const FieldExtra = styled.div`
     padding: 10px 0 10px;
+
     :empty {
         display: none;
     }
@@ -83,6 +84,7 @@ export interface FieldProps {
     onEdit: (field: CmsModelField) => void;
     parent?: CmsModelField;
 }
+
 const Field: React.FC<FieldProps> = props => {
     const { field, onEdit, parent } = props;
     const { showSnackbar } = useSnackbar();
@@ -151,8 +153,8 @@ const Field: React.FC<FieldProps> = props => {
                 <Info>
                     <Typography use={"subtitle1"}>{field.label}</Typography>
                     <Typography use={"caption"}>
-                        {fieldPlugin.field.label} {field.multipleValues && <></>}
-                        <LowerCase>({info})</LowerCase>
+                        {fieldPlugin.field.label}
+                        {info && <LowerCase> ({info})</LowerCase>}
                     </Typography>
                 </Info>
                 <Actions>

--- a/packages/app-headless-cms/src/admin/graphql/contentModels.ts
+++ b/packages/app-headless-cms/src/admin/graphql/contentModels.ts
@@ -48,6 +48,8 @@ export const MODEL_FIELDS = `
     }
     description
     modelId
+    singularApiName
+    pluralApiName
     savedOn
     titleFieldId
     lockedFields

--- a/packages/app-headless-cms/src/admin/hooks/index.ts
+++ b/packages/app-headless-cms/src/admin/hooks/index.ts
@@ -9,3 +9,4 @@ export { useModel } from "../components/ModelProvider";
 export { useModelEditor } from "../components/ContentModelEditor";
 export { useModelField } from "../components/ModelFieldProvider";
 export { useModelFieldEditor } from "../components/FieldEditor";
+export * from "./useContentModels";

--- a/packages/app-headless-cms/src/admin/hooks/useContentModels.ts
+++ b/packages/app-headless-cms/src/admin/hooks/useContentModels.ts
@@ -1,0 +1,30 @@
+import * as GQL from "~/admin/viewsGraphql";
+import { useQuery } from "~/admin/hooks/index";
+import { ListCmsModelsQueryResponse } from "~/admin/viewsGraphql";
+import { useMemo } from "react";
+import { CmsModel } from "~/types";
+
+export const useContentModels = () => {
+    const {
+        data,
+        loading,
+        error: apolloError
+    } = useQuery<ListCmsModelsQueryResponse>(GQL.LIST_CONTENT_MODELS);
+
+    const models = useMemo<CmsModel[]>(() => {
+        return data?.listContentModels?.data || [];
+    }, [data]);
+
+    const error = useMemo(() => {
+        if (!!apolloError) {
+            return apolloError.message;
+        }
+        return data?.listContentModels?.error?.message || null;
+    }, [apolloError]);
+
+    return {
+        models,
+        loading,
+        error
+    };
+};

--- a/packages/app-headless-cms/src/admin/plugins/editor/formSettings/components/GeneralSettings.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/formSettings/components/GeneralSettings.tsx
@@ -10,7 +10,7 @@ interface GeneralSettingsProps {
     Bind: BindComponent;
 }
 
-const GeneralSettings = ({ Bind }: GeneralSettingsProps) => {
+const GeneralSettings: React.VFC<GeneralSettingsProps> = ({ Bind }) => {
     return (
         <React.Fragment>
             <Grid>
@@ -22,6 +22,16 @@ const GeneralSettings = ({ Bind }: GeneralSettingsProps) => {
                 <Cell span={12}>
                     <Bind name={"modelId"}>
                         <Input disabled={true} label={"Content model ID"} />
+                    </Bind>
+                </Cell>
+                <Cell span={12}>
+                    <Bind name={"singularApiName"}>
+                        <Input disabled={true} label={"Singular API Name"} />
+                    </Bind>
+                </Cell>
+                <Cell span={12}>
+                    <Bind name={"pluralApiName"}>
+                        <Input disabled={true} label={"Plural API Name"} />
                     </Bind>
                 </Cell>
                 <Cell span={12}>

--- a/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
-import get from "lodash/get";
+import * as UID from "@webiny/ui/Dialog";
 import { useRouter } from "@webiny/react-router";
 import { Form } from "@webiny/form";
 import { Input } from "@webiny/ui/Input";
@@ -7,13 +7,12 @@ import { Select } from "@webiny/ui/Select";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { validation } from "@webiny/validation";
-import { useMutation, useQueryLocale } from "../../hooks";
+import { useApolloClient, useMutation, useQueryLocale } from "../../hooks";
 import { i18n } from "@webiny/app/i18n";
 import { ButtonDefault } from "@webiny/ui/Button";
-import * as UID from "@webiny/ui/Dialog";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { addModelToGroupCache, addModelToListCache } from "./cache";
-import { CmsEditorContentModel, CmsModel } from "~/types";
+import { CmsModel } from "~/types";
 import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 import {
     CREATE_CONTENT_MODEL_FROM,
@@ -22,29 +21,20 @@ import {
     CreateCmsModelFromMutationVariables,
     ListMenuCmsGroupsQueryResponse
 } from "../../viewsGraphql";
-import { CmsGroup } from "~/admin/views/contentModelGroups/graphql";
 import { CmsGroupOption } from "~/admin/views/contentModels/types";
 import { Dialog } from "~/admin/components/Dialog";
+import { createNameValidator } from "~/admin/views/contentModels/helpers/nameValidator";
+import { createApiNameValidator } from "~/admin/views/contentModels/helpers/apiNameValidator";
 
 const t = i18n.ns("app-headless-cms/admin/views/content-models/clone-content-model-dialog");
 
-export interface Props {
-    open: boolean;
+interface Props {
     onClose: UID.DialogOnClose;
-    contentModel: CmsEditorContentModel;
+    contentModel: CmsModel;
     closeModal: () => void;
 }
 
-/**
- * This list is to disallow creating models that might interfere with GraphQL schema creation.
- * Add more if required.
- */
-const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Input", "Sorter"];
-
-const getSelectedGroup = (
-    groups: CmsGroupOption[] | null,
-    model: CmsEditorContentModel
-): string | null => {
+const getSelectedGroup = (groups: CmsGroupOption[] | null, model: CmsModel): string | null => {
     if (!groups || groups.length === 0 || !model) {
         return "";
     }
@@ -57,15 +47,17 @@ const getSelectedGroup = (
     return defaultSelected ? defaultSelected.value : null;
 };
 
-const CloneContentModelDialog: React.FC<Props> = ({ open, onClose, contentModel, closeModal }) => {
+export const CloneContentModelDialog: React.FC<Props> = ({ onClose, contentModel, closeModal }) => {
     const [loading, setLoading] = useState<boolean>(false);
     const { showSnackbar } = useSnackbar();
     const { history } = useRouter();
     const { getLocales, getCurrentLocale, setCurrentLocale } = useI18N();
+    const client = useApolloClient();
 
     const currentLocale = getCurrentLocale("content");
     const [locale, setLocale] = useState<string>(currentLocale || "");
     const [groups, setGroups] = useState<CmsGroupOption[] | null>(null);
+    const [models, setModels] = useState<CmsModel[]>([]);
 
     const [createContentModelFrom] = useMutation<
         CreateCmsModelFromMutationResponse,
@@ -105,159 +97,169 @@ const CloneContentModelDialog: React.FC<Props> = ({ open, onClose, contentModel,
     const locales = getLocales().map(({ code }) => {
         return {
             value: code,
-            label: code === currentLocale ? "Current locale" : code
+            label: code === currentLocale ? `Current locale (${code})` : code
         };
     });
 
-    const { data, loading: groupsLoading } = useQueryLocale<ListMenuCmsGroupsQueryResponse>(
+    const listMenuGroupsQuery = useQueryLocale<ListMenuCmsGroupsQueryResponse>(
         LIST_MENU_CONTENT_GROUPS_MODELS,
-        locale,
-        {
-            skip: !open || !!groups
-        }
+        locale
     );
 
     useEffect(() => {
-        if (!data || groupsLoading) {
+        if (!listMenuGroupsQuery.data || listMenuGroupsQuery.loading) {
             return;
         }
-        const contentModelGroups: CmsGroupOption[] = get(
-            data,
-            "listContentModelGroups.data",
-            []
-        ).map((item: CmsGroup): CmsGroupOption => {
-            return {
+        const options: CmsGroupOption[] = [];
+        const models: CmsModel[] = [];
+        const items = listMenuGroupsQuery.data.listContentModelGroups.data || [];
+        for (const item of items) {
+            options.push({
                 value: item.id,
                 label: item.name
-            };
-        });
-        setGroups(contentModelGroups);
-    }, [data, groupsLoading]);
+            });
+            models.push(...item.contentModels);
+        }
+        setGroups(options);
+        setModels(models);
+    }, [listMenuGroupsQuery.data, listMenuGroupsQuery.loading]);
 
     const selectedGroup = getSelectedGroup(groups, contentModel);
 
-    const nameValidator = useCallback((name: string) => {
-        const target = (name || "").trim();
-        if (!target.charAt(0).match(/[a-zA-Z]/)) {
-            throw new Error("Value is not valid - must not start with a number.");
-        }
-        if (target.toLowerCase() === "id") {
-            throw new Error('Value is not valid - "id" is an auto-generated field.');
-        }
-        for (const ending of disallowedModelIdEndingList) {
-            const re = new RegExp(`${ending}$`, "i");
-            const matched = target.match(re);
-            if (matched === null) {
-                continue;
-            }
-            throw new Error(`Model name that ends with "${ending}" is not allowed.`);
-        }
-        return true;
-    }, []);
+    const nameValidator = useCallback(createNameValidator({ models }), [client, models]);
+
+    const apiNameValidator = useCallback(createApiNameValidator({ client, models }), [
+        client,
+        models
+    ]);
 
     return (
-        <Dialog open={open} onClose={onClose} data-testid="cms-clone-content-model-modal">
-            {(!groups || groupsLoading) && (
+        <Dialog open={true} onClose={onClose} data-testid="cms-clone-content-model-modal">
+            {!groups && (
                 <CircularProgress label={"Please wait while we load required information."} />
             )}
-            {open && (
-                <Form
-                    data={{
-                        group: selectedGroup,
-                        locale,
-                        name: contentModel.name
-                    }}
-                    onSubmit={data => {
-                        setLoading(true);
-                        createContentModelFrom({
-                            variables: {
-                                modelId: contentModel.modelId,
-                                /**
-                                 * We know that data is CmsModel
-                                 */
-                                data: data as unknown as CmsModel
-                            }
-                        });
-                    }}
-                >
-                    {({ Bind, submit }) => (
-                        <>
-                            {loading && <CircularProgress />}
-                            <UID.DialogTitle>{t`Clone Content Model`}</UID.DialogTitle>
-                            <UID.DialogContent>
-                                <Grid>
-                                    <Cell span={12}>
-                                        <Bind
-                                            name={"name"}
-                                            validators={[
-                                                validation.create("required,maxLength:100"),
-                                                nameValidator
-                                            ]}
-                                        >
-                                            <Input
-                                                label={t`Name`}
-                                                description={t`The name of the content model`}
-                                            />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind
-                                            name={"locale"}
-                                            validators={validation.create("required")}
-                                            afterChange={(value?: string) => {
-                                                if (!value) {
-                                                    return;
-                                                }
-                                                setLocale(value);
-                                                setGroups(null);
-                                            }}
-                                        >
-                                            <Select
-                                                description={t`Choose a locale into which you wish to clone the model`}
-                                                label={t`Content model locale`}
-                                                options={locales}
-                                            />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind
-                                            name={"group"}
-                                            validators={validation.create("required")}
-                                        >
-                                            <Select
-                                                description={t`Choose a content model group`}
-                                                label={t`Content model group`}
-                                                options={groups || []}
-                                            />
-                                        </Bind>
-                                    </Cell>
-                                    <Cell span={12}>
-                                        <Bind name="description">
-                                            <Input
-                                                rows={4}
-                                                maxLength={200}
-                                                characterCount
-                                                label={t`Description`}
-                                            />
-                                        </Bind>
-                                    </Cell>
-                                </Grid>
-                            </UID.DialogContent>
-                            <UID.DialogActions>
-                                <ButtonDefault
-                                    onClick={ev => {
-                                        submit(ev);
-                                    }}
-                                >
-                                    + {t`Clone`}
-                                </ButtonDefault>
-                            </UID.DialogActions>
-                        </>
-                    )}
-                </Form>
-            )}
+
+            <Form
+                data={{
+                    group: selectedGroup,
+                    locale,
+                    name: contentModel.name
+                }}
+                onSubmit={data => {
+                    setLoading(true);
+                    createContentModelFrom({
+                        variables: {
+                            modelId: contentModel.modelId,
+                            /**
+                             * We know that data is CmsModel
+                             */
+                            data: data as unknown as CmsModel
+                        }
+                    });
+                }}
+            >
+                {({ Bind, submit }) => (
+                    <>
+                        {loading && <CircularProgress />}
+                        <UID.DialogTitle>{t`Clone Content Model`}</UID.DialogTitle>
+                        <UID.DialogContent>
+                            <Grid>
+                                <Cell span={12}>
+                                    <Bind
+                                        name={"name"}
+                                        validators={[
+                                            validation.create("required,maxLength:100"),
+                                            nameValidator
+                                        ]}
+                                    >
+                                        <Input
+                                            label={t`Name`}
+                                            description={t`The name of the content model`}
+                                        />
+                                    </Bind>
+                                </Cell>
+                                <Cell span={12}>
+                                    <Bind
+                                        name={"locale"}
+                                        validators={validation.create("required")}
+                                        afterChange={(value?: string) => {
+                                            if (!value) {
+                                                return;
+                                            }
+                                            setLocale(value);
+                                            setGroups(null);
+                                        }}
+                                    >
+                                        <Select
+                                            description={t`Choose a locale into which you wish to clone the model`}
+                                            label={t`Content model locale`}
+                                            options={locales}
+                                        />
+                                    </Bind>
+                                </Cell>
+                                <Cell span={12}>
+                                    <Bind
+                                        name={"singularApiName"}
+                                        validators={[
+                                            validation.create("required,maxLength:100"),
+                                            apiNameValidator
+                                        ]}
+                                    >
+                                        <Input
+                                            label={t`Singular API Name`}
+                                            description={t`The API name of the content model. For example: AuthorCategory.`}
+                                            data-testid="cms.newcontentmodeldialog.singularApiName"
+                                        />
+                                    </Bind>
+                                </Cell>
+                                <Cell span={12}>
+                                    <Bind
+                                        name={"pluralApiName"}
+                                        validators={[
+                                            validation.create("required,maxLength:100"),
+                                            apiNameValidator
+                                        ]}
+                                    >
+                                        <Input
+                                            label={t`Plural API Name`}
+                                            description={t`The plural API name of the content model. For example: AuthorCategories.`}
+                                            data-testid="cms.newcontentmodeldialog.pluralApiName"
+                                        />
+                                    </Bind>
+                                </Cell>
+                                <Cell span={12}>
+                                    <Bind name={"group"} validators={validation.create("required")}>
+                                        <Select
+                                            description={t`Choose a content model group`}
+                                            label={t`Content model group`}
+                                            options={groups || []}
+                                        />
+                                    </Bind>
+                                </Cell>
+                                <Cell span={12}>
+                                    <Bind name="description">
+                                        <Input
+                                            rows={4}
+                                            maxLength={200}
+                                            characterCount
+                                            label={t`Description`}
+                                        />
+                                    </Bind>
+                                </Cell>
+                            </Grid>
+                        </UID.DialogContent>
+                        <UID.DialogActions>
+                            <ButtonDefault
+                                onClick={ev => {
+                                    submit(ev);
+                                }}
+                            >
+                                + {t`Clone`}
+                            </ButtonDefault>
+                        </UID.DialogActions>
+                    </>
+                )}
+            </Form>
         </Dialog>
     );
 };
-
-export default CloneContentModelDialog;

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import CloneContentModelDialog from "./CloneContentModelDialog";
+import { CloneContentModelDialog } from "./CloneContentModelDialog";
 import NewContentModelDialog from "./NewContentModelDialog";
 import ContentModelsDataList from "./ContentModelsDataList";
 import { css } from "emotion";
@@ -73,7 +73,6 @@ const ContentModels: React.FC = () => {
             <NewContentModelDialog open={newContentModelDialogOpened} onClose={onClose} />
             {cloneContentModel && (
                 <CloneContentModelDialog
-                    open={!!cloneContentModel}
                     contentModel={cloneContentModel}
                     onClose={onCloneClose}
                     closeModal={closeModal}

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -5,12 +5,11 @@ import React, { useCallback, useMemo, useState } from "react";
 // @ts-ignore
 import TimeAgo from "timeago-react";
 import { css } from "emotion";
-import get from "lodash/get";
 import { useRouter } from "@webiny/react-router";
 import { DeleteIcon, EditIcon } from "@webiny/ui/List/DataList/icons";
 import { ReactComponent as ViewListIcon } from "../../icons/view_list.svg";
 import { ReactComponent as CloneIcon } from "../../icons/clone.svg";
-import { useApolloClient, useQuery } from "../../hooks";
+import { useApolloClient, useContentModels } from "../../hooks";
 import { useSnackbar } from "@webiny/app-admin/hooks/useSnackbar";
 import * as UIL from "@webiny/ui/List";
 import { ButtonIcon, ButtonSecondary, IconButton } from "@webiny/ui/Button";
@@ -29,8 +28,7 @@ import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/fil
 import { CmsEditorContentModel, CmsModel } from "~/types";
 import {
     DeleteCmsModelMutationResponse,
-    DeleteCmsModelMutationVariables,
-    ListCmsModelsQueryResponse
+    DeleteCmsModelMutationVariables
 } from "../../viewsGraphql";
 import usePermission from "~/admin/hooks/usePermission";
 
@@ -40,6 +38,7 @@ interface Sorter {
     label: string;
     sorters: string;
 }
+
 const SORTERS: Sorter[] = [
     {
         label: t`Newest to oldest`,
@@ -73,6 +72,7 @@ interface ContentModelsDataListProps {
     onCreate: () => void;
     onClone: (contentModel: CmsEditorContentModel) => void;
 }
+
 const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
     canCreate,
     onCreate,
@@ -86,7 +86,7 @@ const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
     const { showConfirmation } = useConfirmationDialog({
         dataTestId: "cms-delete-content-model-dialog"
     });
-    const { data, loading } = useQuery<ListCmsModelsQueryResponse>(GQL.LIST_CONTENT_MODELS);
+    const { models, loading } = useContentModels();
     const { canDelete, canEdit } = usePermission();
 
     const filterData = useCallback(
@@ -106,8 +106,6 @@ const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
         },
         [sort]
     );
-
-    const models: CmsModel[] = loading ? [] : get(data, "listContentModels.data", []);
 
     const deleteRecord = async (item: CmsModel): Promise<void> => {
         showConfirmation(async () => {

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -1,6 +1,4 @@
-import React, { useCallback } from "react";
-import gql from "graphql-tag";
-import get from "lodash/get";
+import React, { useCallback, useMemo } from "react";
 import { useRouter } from "@webiny/react-router";
 import { Form } from "@webiny/form";
 import { Input } from "@webiny/ui/Input";
@@ -20,39 +18,17 @@ import {
     CreateCmsModelMutationVariables,
     ListMenuCmsGroupsQueryResponse
 } from "../../viewsGraphql";
-import { CmsGroup } from "~/types";
+import { CmsModel } from "~/types";
 import { CmsGroupOption } from "./types";
-import lodashUpperFirst from "lodash/upperFirst";
-import lodashCamelCase from "lodash/camelCase";
 import { Dialog } from "~/admin/components/Dialog";
+import { createApiNameValidator } from "~/admin/views/contentModels/helpers/apiNameValidator";
+import { createNameValidator } from "~/admin/views/contentModels/helpers/nameValidator";
 
 const t = i18n.ns("app-headless-cms/admin/views/content-models/new-content-model-dialog");
-
-/**
- * This list is to disallow creating models that might interfere with GraphQL schema creation.
- * Add more if required.
- */
-const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Input", "Sorter"];
 
 export interface NewContentModelDialogProps {
     open: boolean;
     onClose: UID.DialogOnClose;
-}
-
-const SCHEMA_TYPES = gql`
-    query ListSchemaTypes {
-        __schema {
-            types {
-                name
-            }
-        }
-    }
-`;
-
-interface SchemaTypes {
-    __schema: {
-        types: { name: string }[];
-    };
 }
 
 interface CmsModelData {
@@ -99,53 +75,34 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
         }
     );
 
-    const contentModelGroups = get(listMenuGroupsQuery, "data.listContentModelGroups.data", []).map(
-        (item: CmsGroup): CmsGroupOption => {
+    const groups = useMemo(() => {
+        return listMenuGroupsQuery.data?.listContentModelGroups?.data || [];
+    }, [listMenuGroupsQuery.data]);
+
+    const contentModelGroups = useMemo(() => {
+        return groups.map((item): CmsGroupOption => {
             return {
                 value: item.id,
                 label: item.name
             };
-        }
-    );
+        });
+    }, [groups]);
 
-    const nameValidator = useCallback(
-        async (name: string): Promise<boolean> => {
-            const target = (name || "").trim();
-            if (!target.charAt(0).match(/[a-zA-Z]/)) {
-                throw new Error("Model name can't start with a number.");
-            }
+    const models = useMemo(() => {
+        return groups.reduce<CmsModel[]>((collection, group) => {
+            collection.push(...group.contentModels);
+            return collection;
+        }, []);
+    }, [groups]);
 
-            for (const ending of disallowedModelIdEndingList) {
-                const re = new RegExp(`${ending}$`, "i");
-                const matched = target.match(re);
-                if (matched === null) {
-                    continue;
-                }
-                throw new Error(`Model must not end with "${ending}".`);
-            }
+    const nameValidator = useCallback(createNameValidator({ models }), [models]);
 
-            // Validate GraphQL Schema type
-            const { data } = await client.query<SchemaTypes>({
-                query: SCHEMA_TYPES,
-                fetchPolicy: "network-only"
-            });
+    const apiNameValidator = useCallback(createApiNameValidator({ client, models }), [
+        client,
+        models
+    ]);
 
-            const types = data.__schema.types.map(t => t.name);
-
-            const modelId = lodashUpperFirst(lodashCamelCase(name));
-
-            if (types.includes(modelId)) {
-                throw new Error(
-                    `"${name}" type already exists in the GraphQL schema. Please pick a different name.`
-                );
-            }
-
-            return true;
-        },
-        [client]
-    );
-
-    const group = contentModelGroups?.length > 0 ? contentModelGroups[0].value : null;
+    const group = contentModelGroups.length > 0 ? contentModelGroups[0].value : null;
 
     const onSubmit = async (data: CmsModelData) => {
         setLoading(true);
@@ -182,8 +139,38 @@ const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onC
                                         >
                                             <Input
                                                 label={t`Name`}
-                                                description={t`The name of the content model. Use the singular form, e.g. Person, not Persons.`}
+                                                description={t`The name of the content model. Use the singular form, e.g. Author Category, not Author Categories.`}
                                                 data-testid="cms.newcontentmodeldialog.name"
+                                            />
+                                        </Bind>
+                                    </Cell>
+                                    <Cell span={12}>
+                                        <Bind
+                                            name={"singularApiName"}
+                                            validators={[
+                                                validation.create("required,maxLength:100"),
+                                                apiNameValidator
+                                            ]}
+                                        >
+                                            <Input
+                                                label={t`Singular API Name`}
+                                                description={t`The API name of the content model. For example: AuthorCategory.`}
+                                                data-testid="cms.newcontentmodeldialog.singularApiName"
+                                            />
+                                        </Bind>
+                                    </Cell>
+                                    <Cell span={12}>
+                                        <Bind
+                                            name={"pluralApiName"}
+                                            validators={[
+                                                validation.create("required,maxLength:100"),
+                                                apiNameValidator
+                                            ]}
+                                        >
+                                            <Input
+                                                label={t`Plural API Name`}
+                                                description={t`The plural API name of the content model. For example: AuthorCategories.`}
+                                                data-testid="cms.newcontentmodeldialog.pluralApiName"
                                             />
                                         </Bind>
                                     </Cell>

--- a/packages/app-headless-cms/src/admin/views/contentModels/helpers/apiNameValidator.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/helpers/apiNameValidator.ts
@@ -1,0 +1,88 @@
+import lodashUpperFirst from "lodash/upperFirst";
+import lodashCamelCase from "lodash/camelCase";
+import gql from "graphql-tag";
+import ApolloClient from "apollo-client";
+import { CmsModel } from "~/types";
+
+/**
+ * This list is to disallow creating models that might interfere with GraphQL schema creation.
+ * Add more if required.
+ */
+const disallowedModelIdEndingList: string[] = ["Response", "List", "Meta", "Input", "Sorter"];
+
+const SCHEMA_TYPES = gql`
+    query ListSchemaTypes {
+        __schema {
+            types {
+                name
+            }
+        }
+    }
+`;
+
+interface SchemaTypes {
+    __schema: {
+        types: { name: string }[];
+    };
+}
+
+interface Params {
+    models: CmsModel[];
+    client: ApolloClient<any>;
+}
+
+export const createApiNameValidator = (params: Params) => {
+    const { models, client } = params;
+    return async (name: string): Promise<boolean> => {
+        const value = (name || "").trim();
+        if (!value) {
+            throw new Error("The name is required.");
+        } else if (!value.charAt(0).match(/[a-zA-Z]/)) {
+            throw new Error("The name can't start with a number.");
+        }
+
+        const transformed = lodashUpperFirst(lodashCamelCase(value));
+        if (transformed !== value) {
+            throw new Error(
+                `The name "${value}" must be in form of Upper First + Camel Cased word. For example: "ArticleCategory", "ArticleAuthor" or "BlogCategories".`
+            );
+        }
+        /**
+         * We need to check for models that might interfere with GraphQL schema creation.
+         *
+         * First, there are some reserved words that we need to check for.
+         */
+        for (const ending of disallowedModelIdEndingList) {
+            const re = new RegExp(`${ending}$`, "i");
+            const matched = value.match(re);
+            if (matched === null) {
+                continue;
+            }
+            throw new Error(`The name must not end with "${ending}".`);
+        }
+        /**
+         * Then we check the GraphQL schema for types that might interfere with the model creation.
+         */
+        if (models.some(m => m.singularApiName === value)) {
+            throw new Error(`"${name}" API name already exists. Please pick a different value.`);
+        } else if (models.some(m => m.pluralApiName === value)) {
+            throw new Error(`"${name}" API name already exists. Please pick a different value.`);
+        }
+
+        // Validate GraphQL Schema type
+        const { data } = await client.query<SchemaTypes>({
+            query: SCHEMA_TYPES,
+            fetchPolicy: "network-only"
+        });
+
+        const types = data.__schema.types.map(t => t.name);
+
+        if (types.includes(transformed)) {
+            throw new Error(
+                `"${name}" type already exists in the GraphQL schema. Please pick a different name.`
+            );
+        }
+
+        return true;
+    };
+};

--- a/packages/app-headless-cms/src/admin/views/contentModels/helpers/nameValidator.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/helpers/nameValidator.ts
@@ -1,0 +1,33 @@
+import lodashCamelCase from "lodash/camelCase";
+import { CmsModel } from "~/types";
+
+interface Params {
+    models: CmsModel[];
+}
+
+export const createNameValidator = (params: Params) => {
+    const { models } = params;
+    return async (name: string): Promise<boolean> => {
+        const target = (name || "").trim();
+        if (!target) {
+            throw new Error("The name is required.");
+        } else if (!target.charAt(0).match(/[a-zA-Z]/)) {
+            throw new Error("The name can't start with a number.");
+        } else if (models.length === 0) {
+            return true;
+        }
+
+        const modelId = lodashCamelCase(target);
+        const alreadyExists = models.some(model => {
+            if (model.name.toLowerCase() === target.toLowerCase()) {
+                return true;
+            }
+            return model.modelId.toLowerCase() === modelId.toLowerCase();
+        });
+        if (alreadyExists) {
+            throw new Error(`This name is already taken.`);
+        }
+
+        return true;
+    };
+};

--- a/packages/app-headless-cms/src/admin/viewsGraphql.ts
+++ b/packages/app-headless-cms/src/admin/viewsGraphql.ts
@@ -10,6 +10,8 @@ const ERROR_FIELDS = `
 const BASE_CONTENT_MODEL_FIELDS = `
     description
     modelId
+    singularApiName
+    pluralApiName
     name
     savedOn
     plugin
@@ -50,6 +52,8 @@ export const LIST_MENU_CONTENT_GROUPS_MODELS = gql`
                 contentModels {
                     name
                     modelId
+                    singularApiName
+                    pluralApiName
                     plugin
                     createdBy {
                         id

--- a/packages/app-headless-cms/src/types/model.ts
+++ b/packages/app-headless-cms/src/types/model.ts
@@ -73,6 +73,8 @@ export interface CmsModel {
     lockedFields: CmsModelField[];
     name: string;
     modelId: string;
+    singularApiName: string;
+    pluralApiName: string;
     titleFieldId: string;
     settings: {
         [key: string]: any;


### PR DESCRIPTION
e## Changes

This PR adds the Model Singular and Plural API Name to the `Create New Model` and `Clone Existing Model` forms.
Validation in those forms has been updated as well to use same methods for the validation.

## How Has This Been Tested?
Manually and cypress.

## Images
### New Model Dialog
![Screenshot 2023-03-16 at 14 21 50](https://user-images.githubusercontent.com/10399339/225630225-17af34b9-360a-4075-9cd6-4daf9b3692e3.png)
### Clone Model Dialog
![Screenshot 2023-03-16 at 14 22 08](https://user-images.githubusercontent.com/10399339/225630279-2f833f5e-05f1-47e4-af84-60998aed525c.png)
### Model Settings
![Screenshot 2023-03-16 at 14 22 57](https://user-images.githubusercontent.com/10399339/225630409-07d52c9c-9d03-4e5a-8174-f13890b64d4c.png)