### PR TITLE
Introduce multi-threaded build to utilize all CPU cores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,4 @@
 **/.out/
 **/*.d.ts
 idea.js
-scripts
-packages/ui/src/RichTextEditor/editorjs/**
-packages-v6/pb-editor/**
-packages-v6/core/**/artifacts/**
+scripts/**/*.js

--- a/.github/workflows/devPush.yml
+++ b/.github/workflows/devPush.yml
@@ -7,7 +7,6 @@ on:
 env:
   NODE_OPTIONS: --max_old_space_size=4096
   AWS_REGION: eu-central-1
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 jobs:
   init:
@@ -64,7 +63,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -127,7 +126,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages (full)
-        run: node scripts/buildWithCache.js
+        run: yarn build
 
   jest-tests:
     name: ${{ matrix.package }} (${{ matrix.os }}, Node v${{ matrix.node }})
@@ -166,7 +165,7 @@ jobs:
           key: packages-cache-${{ needs.init.outputs.ts }}
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Run tests
         run: yarn test ${{ matrix.package }}
@@ -245,7 +244,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -354,8 +353,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        node: [ 14 ]
+        os: [ubuntu-latest]
+        node: [14]
         cypress-folder: ${{ fromJson(needs.e2e-wby-cms-ddb-init.outputs.cypress-folders) }}
     runs-on: ubuntu-latest
     environment: next
@@ -389,7 +388,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: dev
@@ -477,7 +476,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -586,8 +585,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        node: [ 14 ]
+        os: [ubuntu-latest]
+        node: [14]
         cypress-folder: ${{ fromJson(needs.e2e-wby-cms-ddb-es-init.outputs.cypress-folders) }}
     runs-on: ubuntu-latest
     environment: next
@@ -624,7 +623,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: dev

--- a/.github/workflows/experiments.yml
+++ b/.github/workflows/experiments.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   NODE_OPTIONS: --max_old_space_size=4096
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 jobs:
   init:
@@ -72,7 +71,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -147,7 +146,7 @@ jobs:
           key: packages-cache-${{ needs.init.outputs.ts }}
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Run tests
         run: yarn test ${{ matrix.package }}
@@ -171,7 +170,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages (full)
-        run: node scripts/buildWithCache.js
+        run: yarn build
 
   npm-release-experimental:
     needs: [init, code-analysis, jest-tests, code-analysis-typescript]

--- a/.github/workflows/nextPush.yml
+++ b/.github/workflows/nextPush.yml
@@ -7,7 +7,6 @@ on:
 env:
   NODE_OPTIONS: --max_old_space_size=4096
   AWS_REGION: eu-central-1
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 jobs:
   init:
@@ -64,7 +63,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -127,7 +126,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages (full)
-        run: node scripts/buildWithCache.js
+        run: yarn build
 
   jest-tests:
     name: ${{ matrix.package }} (${{ matrix.os }}, Node v${{ matrix.node }})
@@ -166,7 +165,7 @@ jobs:
           key: packages-cache-${{ needs.init.outputs.ts }}
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Run tests
         run: yarn test ${{ matrix.package }}
@@ -245,7 +244,7 @@ jobs:
 
       - name: Build packages
         working-directory: next
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -389,7 +388,7 @@ jobs:
 
       - name: Build packages
         working-directory: next
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: next
@@ -477,7 +476,7 @@ jobs:
 
       - name: Build packages
         working-directory: next
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -624,7 +623,7 @@ jobs:
 
       - name: Build packages
         working-directory: next
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: next

--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -4,7 +4,6 @@ on: [pull_request]
 
 env:
   NODE_OPTIONS: --max_old_space_size=4096
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 jobs:
   validate-commits:
@@ -66,7 +65,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -129,7 +128,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages (full)
-        run: node scripts/buildWithCache.js
+        run: yarn build
 
   jest-tests:
     needs: init
@@ -170,7 +169,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Run tests
         run: yarn test ${{ matrix.package }}
@@ -206,7 +205,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Start Verdaccio local server
         run: npx pm2 start verdaccio -- -c .verdaccio.yaml

--- a/.github/workflows/pullRequestsCommandCypress.yml
+++ b/.github/workflows/pullRequestsCommandCypress.yml
@@ -3,7 +3,6 @@ on: issue_comment
 env:
   NODE_OPTIONS: --max_old_space_size=4096
   AWS_REGION: eu-central-1
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 name: Pull Requests Command - Cypress
 
@@ -111,7 +110,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -270,7 +269,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: dev
@@ -374,7 +373,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         id: packages-cache
@@ -536,7 +535,7 @@ jobs:
 
       - name: Build packages
         working-directory: dev
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - name: Set up Cypress config
         working-directory: dev

--- a/.github/workflows/rebuildCache.yml
+++ b/.github/workflows/rebuildCache.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js
+        run: yarn build
 
   cache-dependencies-packages-next:
     name: Cache dependencies and packages ("next" folder)
@@ -80,4 +80,4 @@ jobs:
 
       - name: Build packages
         working-directory: next
-        run: node scripts/buildWithCache.js
+        run: yarn build

--- a/.github/workflows/stablePush.yml
+++ b/.github/workflows/stablePush.yml
@@ -7,7 +7,6 @@ on:
 env:
   NODE_OPTIONS: --max_old_space_size=4096
   AWS_REGION: eu-central-1
-  BUILD_OVERRIDES: '{"tsConfig":{"compilerOptions":{"skipLibCheck":true}}}'
 
 jobs:
   init:
@@ -59,7 +58,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build packages
-        run: node scripts/buildWithCache.js --build-overrides='${{ env.BUILD_OVERRIDES }}'
+        run: yarn build:quick
 
       - uses: actions/cache@v3
         with:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "apps/api/migration",
       "apps/api/pageBuilder/updateSettings",
       "apps/api/pageBuilder/import/*",
-      "apps/api/pageBuilder/export/*"
+      "apps/api/pageBuilder/export/*",
+      "scripts/buildPackages"
     ]
   },
   "author": "Webiny Ltd.",
@@ -121,8 +122,8 @@
     "check-ts-configs": "node scripts/checkTsConfigs.js",
     "eslint": "eslint \"**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "eslint:fix": "yarn eslint --fix",
-    "build": "node scripts/buildWithCache.js",
-    "build:quick": "node scripts/buildWithCache.js --build-overrides='{\"tsConfig\":{\"compilerOptions\":{\"skipLibCheck\":true}}}'",
+    "build": "node scripts/buildPackages",
+    "build:quick": "node scripts/buildPackages --build-overrides='{\"tsConfig\":{\"compilerOptions\":{\"skipLibCheck\":true}}}'",
     "build:apps": "yarn webiny ws run build --scope='@webiny/app*'",
     "build:api": "yarn webiny ws run build --scope='@webiny/api*' --scope='@webiny/handler*'",
     "watch:apps": "yarn webiny ws run watch --scope='@webiny/app*'",

--- a/packages/api-page-builder-aco/package.json
+++ b/packages/api-page-builder-aco/package.json
@@ -36,6 +36,7 @@
     "@webiny/api-security-so-ddb": "0.0.0",
     "@webiny/api-tenancy": "0.0.0",
     "@webiny/api-tenancy-so-ddb": "0.0.0",
+    "@webiny/cli": "0.0.0",
     "@webiny/handler-aws": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/plugins": "0.0.0",

--- a/packages/project-utils/packages/buildPackage.js
+++ b/packages/project-utils/packages/buildPackage.js
@@ -15,6 +15,12 @@ module.exports = async options => {
     rimraf.sync(join(cwd, "*.tsbuildinfo"));
 
     options.logs !== false && console.log("Building...");
+
+    // Make sure `overrides` is an object.
+    if (options.overrides && typeof options.overrides === "string") {
+        options.overrides = JSON.parse(options.overrides);
+    }
+
     await Promise.all([tsCompile(options), babelCompile(options)]);
 
     options.logs !== false && console.log("Copying meta files...");

--- a/scripts/buildPackages/package.json
+++ b/scripts/buildPackages/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "@webiny-scripts/build-packages",
+  "version": "0.0.0",
+  "sideEffects": false,
+  "bin": "./src/index.js",
+  "main": "./src/index.js",
+  "dependencies": {
+    "chalk": "^4.1.0",
+    "execa": "^5.1.1",
+    "folder-hash": "^4.0.4",
+    "fs-extra": "^7.0.1",
+    "listr2": "^5.0.8",
+    "load-json-file": "^6.2.0",
+    "write-json-file": "^4.3.0",
+    "yargs": "^17.3.1"
+  },
+  "devDependencies": {
+    "@types/folder-hash": "^4.0.2",
+    "@types/yargs": "^17.0.8",
+    "ts-node": "^10.5.0"
+  }
+}

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -1,0 +1,102 @@
+import { green } from "chalk";
+import yargs from "yargs";
+import writeJson from "write-json-file";
+import { Listr, ListrTask } from "listr2";
+import { getBatches } from "./getBatches";
+import { META_FILE_PATH } from "./constants";
+import { getPackageSourceHash } from "./getPackageSourceHash";
+import { getBuildMeta } from "./getBuildMeta";
+import { buildPackageInNewProcess } from "./buildSinglePackage";
+import { MetaJSON, Package } from "./types";
+
+interface BuildOptions {
+    debug?: boolean;
+    cache?: boolean;
+    buildOverrides?: string;
+}
+
+interface BuildContext {
+    [key: string]: boolean;
+}
+
+export const buildPackages = async () => {
+    const options = yargs.argv as BuildOptions;
+
+    const { batches, packagesNoCache, allPackages } = await getBatches({
+        cache: options.cache ?? true
+    });
+
+    if (!packagesNoCache.length) {
+        console.log("There are no packages that need to be built.");
+        return;
+    }
+
+    if (packagesNoCache.length > 10) {
+        console.log(`\nRunning build for ${green(packagesNoCache.length)} packages.`);
+    } else {
+        console.log("\nRunning build for the following packages:");
+        for (let i = 0; i < packagesNoCache.length; i++) {
+            const item = packagesNoCache[i];
+            console.log(`‣ ${green(item.packageJson.name)}`);
+        }
+    }
+
+    console.log(
+        `\nThe build process will be performed in ${green(batches.length)} ${
+            batches.length > 1 ? "batches" : "batch"
+        }.\n`
+    );
+    const metaJson = getBuildMeta();
+
+    const tasks = new Listr<BuildContext>(
+        batches.map<ListrTask>((packageNames, index) => {
+            const id = `${index + 1}`.padStart(2, "0");
+            const title = `[${id}/${batches.length}] Batch #${id} (${packageNames.length} packages)`;
+
+            return {
+                title,
+                task: (ctx, task): Listr => {
+                    const packages = allPackages.filter(pkg => packageNames.includes(pkg.name));
+
+                    const batchTasks = task.newListr([], {
+                        concurrent: true,
+                        exitOnError: true
+                    });
+
+                    packages.forEach(pkg => {
+                        batchTasks.add(createPackageTask(pkg, options, metaJson));
+                    });
+
+                    return batchTasks;
+                }
+            };
+        }),
+        { concurrent: false, rendererOptions: { showTimer: true, collapse: true } }
+    );
+
+    const start = Date.now();
+    const ctx = {};
+    await tasks.run(ctx);
+    const duration = (Date.now() - start) / 1000;
+
+    console.log(`\nBuild finished in ${green(duration)} seconds.`);
+};
+
+const createPackageTask = (pkg: Package, options: BuildOptions, metaJson: MetaJSON) => {
+    return {
+        title: `${pkg.name}`,
+        task: async () => {
+            try {
+                await buildPackageInNewProcess(pkg, options.buildOverrides);
+
+                // Store package hash
+                const sourceHash = await getPackageSourceHash(pkg);
+                metaJson.packages[pkg.packageJson.name] = { sourceHash };
+
+                await writeJson(META_FILE_PATH, metaJson);
+            } catch (err) {
+                throw new Error(`[${pkg.packageJson.name}] ${err.message}`);
+            }
+        }
+    };
+};

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -59,7 +59,7 @@ export const buildPackages = async () => {
                     const packages = allPackages.filter(pkg => packageNames.includes(pkg.name));
 
                     const batchTasks = task.newListr([], {
-                        concurrent: true,
+                        concurrent: !process.env.CI,
                         exitOnError: true
                     });
 

--- a/scripts/buildPackages/src/buildSinglePackage.ts
+++ b/scripts/buildPackages/src/buildSinglePackage.ts
@@ -16,3 +16,21 @@ export const buildPackageInNewProcess = async (pkg: Package, buildOverrides = "{
     const buildFolder = getBuildOutputFolder(pkg);
     fs.copySync(buildFolder, cacheFolderPath);
 };
+
+export const buildPackageInSameProcess = async (pkg: Package, buildOverrides = "{}") => {
+    const configPath = path.join(pkg.packageFolder, "webiny.config").replace(/\\/g, "/");
+
+    const config = require(configPath);
+    await config.commands.build({
+        // We don't want debug nor regular logs logged within the build command.
+        logs: false,
+        debug: false,
+        overrides: buildOverrides
+    });
+
+    // Copy and paste built code into the cache folder.
+    const cacheFolderPath = path.join(CACHE_FOLDER_PATH, pkg.packageJson.name);
+
+    const buildFolder = getBuildOutputFolder(pkg);
+    fs.copySync(buildFolder, cacheFolderPath);
+};

--- a/scripts/buildPackages/src/buildSinglePackage.ts
+++ b/scripts/buildPackages/src/buildSinglePackage.ts
@@ -1,0 +1,18 @@
+import path from "path";
+import fs from "fs-extra";
+import execa from "execa";
+import { Package } from "./types";
+import { getBuildOutputFolder } from "./getBuildOutputFolder";
+import { CACHE_FOLDER_PATH } from "./constants";
+
+export const buildPackageInNewProcess = async (pkg: Package, buildOverrides = "{}") => {
+    // Run build script using execa
+    await execa("yarn", ["build", "--overrides", buildOverrides], {
+        cwd: pkg.packageFolder
+    });
+
+    const cacheFolderPath = path.join(CACHE_FOLDER_PATH, pkg.packageJson.name);
+
+    const buildFolder = getBuildOutputFolder(pkg);
+    fs.copySync(buildFolder, cacheFolderPath);
+};

--- a/scripts/buildPackages/src/constants.ts
+++ b/scripts/buildPackages/src/constants.ts
@@ -1,0 +1,4 @@
+import path from "path";
+
+export const CACHE_FOLDER_PATH = ".webiny/cached-packages";
+export const META_FILE_PATH = path.join(CACHE_FOLDER_PATH, "meta.json");

--- a/scripts/buildPackages/src/getBatches.ts
+++ b/scripts/buildPackages/src/getBatches.ts
@@ -1,0 +1,135 @@
+import fs from "fs-extra";
+import execa from "execa";
+import path from "path";
+import { green } from "chalk";
+import { getPackages } from "../../utils/getPackages";
+import { Package } from "./types";
+import { CACHE_FOLDER_PATH } from "./constants";
+import { getBuildOutputFolder } from "./getBuildOutputFolder";
+import { getPackageSourceHash } from "./getPackageSourceHash";
+import { getBuildMeta } from "./getBuildMeta";
+import { getPackageCacheFolderPath } from "./getPackageCacheFolderPath";
+
+interface GetBatchesOptions {
+    cache?: boolean;
+}
+
+export async function getBatches(options: GetBatchesOptions = {}) {
+    const metaJson = getBuildMeta();
+
+    const packagesNoCache: Package[] = [];
+    const packagesUseCache: Package[] = [];
+
+    const workspacesPackages = (
+        getPackages({
+            includes: ["/packages/", "/packages-v6/"]
+        }) as Package[]
+    )
+        .filter(item => item.isTs)
+        .filter(pkg => {
+            // Check if packages has a build script
+            return pkg.packageJson.scripts && "build" in pkg.packageJson.scripts;
+        });
+
+    console.log(`There is a total of ${green(workspacesPackages.length)} packages.`);
+    const useCache = options.cache ?? false;
+
+    // 1. Determine for which packages we can use the cached built code, and for which we need to execute build.
+    if (!useCache) {
+        workspacesPackages.forEach(pkg => packagesNoCache.push(pkg));
+    } else {
+        for (const workspacePackage of workspacesPackages) {
+            const cacheFolderPath = getPackageCacheFolderPath(workspacePackage);
+            if (!fs.existsSync(cacheFolderPath)) {
+                packagesNoCache.push(workspacePackage);
+                continue;
+            }
+
+            const sourceHash = await getPackageSourceHash(workspacePackage);
+
+            const packageMeta = metaJson.packages[workspacePackage.packageJson.name] || {};
+
+            if (packageMeta.sourceHash === sourceHash) {
+                packagesUseCache.push(workspacePackage);
+            } else {
+                packagesNoCache.push(workspacePackage);
+            }
+        }
+    }
+
+    // 2. Let's use cached built code where possible.
+    if (packagesUseCache.length) {
+        if (packagesUseCache.length > 10) {
+            console.log(`Using cache for ${green(packagesUseCache.length)} packages.`);
+            console.log(
+                `To build all packages regardless of cache, use the ${green("--no-cache")} flag.`
+            );
+        } else {
+            console.log("Using cache for following packages:");
+            for (let i = 0; i < packagesUseCache.length; i++) {
+                const item = packagesUseCache[i];
+                console.log(green(item.packageJson.name));
+            }
+        }
+
+        for (let i = 0; i < packagesUseCache.length; i++) {
+            const workspacePackage = packagesUseCache[i];
+            const cacheFolderPath = path.join(CACHE_FOLDER_PATH, workspacePackage.packageJson.name);
+            fs.copySync(cacheFolderPath, getBuildOutputFolder(workspacePackage));
+        }
+    } else {
+        if (useCache) {
+            console.log("Cache is empty, all packages need to be built.");
+        } else {
+            console.log("Skipping cache.");
+        }
+    }
+
+    // 3. Where needed, let's build and update the cache.
+    if (packagesNoCache.length === 0) {
+        return { batches: [], packagesNoCache, allPackages: workspacesPackages };
+    }
+
+    // Building all packages - we're respecting the dependency graph.
+    // Note: lists only packages in "packages" folder (check `lerna.json` config).
+    const rawPackagesList: Record<string, string[]> = await execa("lerna", [
+        "list",
+        "--toposort",
+        "--graph",
+        "--all"
+    ]).then(({ stdout }) => JSON.parse(stdout));
+
+    const packagesList: Record<string, string[]> = {};
+
+    for (const packageName in rawPackagesList) {
+        // If in cache, skip.
+        if (packagesUseCache.find(item => item.name === packageName)) {
+            continue;
+        }
+
+        // If not a TS package, skip.
+        if (!workspacesPackages.find(item => item.name === packageName)) {
+            continue;
+        }
+
+        packagesList[packageName] = rawPackagesList[packageName];
+    }
+
+    const batches: string[][] = [[]];
+    for (const packageName in packagesList) {
+        const dependencies = packagesList[packageName];
+        const latestBatch = batches[batches.length - 1];
+        const canEnterCurrentBatch = !dependencies.find(name => latestBatch.includes(name));
+        if (canEnterCurrentBatch) {
+            latestBatch.push(packageName);
+        } else {
+            batches.push([packageName]);
+        }
+    }
+
+    return {
+        batches,
+        packagesNoCache,
+        allPackages: workspacesPackages
+    };
+}

--- a/scripts/buildPackages/src/getBuildMeta.ts
+++ b/scripts/buildPackages/src/getBuildMeta.ts
@@ -1,0 +1,14 @@
+import loadJson from "load-json-file";
+import { MetaJSON } from "./types";
+import { META_FILE_PATH } from "./constants";
+
+export function getBuildMeta() {
+    let metaJson: MetaJSON = { packages: {} };
+    try {
+        metaJson = loadJson.sync(META_FILE_PATH);
+    } catch {
+        // An error means there's no meta file, so we start a fresh build.
+    }
+
+    return metaJson;
+}

--- a/scripts/buildPackages/src/getBuildOutputFolder.ts
+++ b/scripts/buildPackages/src/getBuildOutputFolder.ts
@@ -1,0 +1,20 @@
+import path from "path";
+import { PackageJSON } from "./types";
+
+export function getBuildOutputFolder({
+    packageJson,
+    packageFolder
+}: {
+    packageJson: PackageJSON;
+    packageFolder: string;
+}) {
+    const webinyConfig = packageJson.webiny;
+    // `dist` is the default output folder for v5 packages.
+    let buildFolder = "dist";
+    if (webinyConfig) {
+        // Until the need arises, let's just use the default `lib` folder.
+        buildFolder = "lib";
+    }
+
+    return path.join(packageFolder, buildFolder);
+}

--- a/scripts/buildPackages/src/getHardwareInfo.ts
+++ b/scripts/buildPackages/src/getHardwareInfo.ts
@@ -1,0 +1,14 @@
+import os from "os";
+
+export const getHardwareInfo = () => {
+    const cpus = os.cpus();
+    const totalMemory = os.totalmem();
+    const freeMemory = os.freemem();
+
+    return {
+        cpuCount: cpus.length,
+        cpuName: cpus[0].model,
+        totalMemory,
+        freeMemory
+    };
+};

--- a/scripts/buildPackages/src/getPackageCacheFolderPath.ts
+++ b/scripts/buildPackages/src/getPackageCacheFolderPath.ts
@@ -1,0 +1,7 @@
+import path from "path";
+import { Package } from "./types";
+import { CACHE_FOLDER_PATH } from "./constants";
+
+export function getPackageCacheFolderPath(workspacePackage: Package) {
+    return path.join(CACHE_FOLDER_PATH, workspacePackage.packageJson.name);
+}

--- a/scripts/buildPackages/src/getPackageSourceHash.ts
+++ b/scripts/buildPackages/src/getPackageSourceHash.ts
@@ -1,0 +1,11 @@
+import { hashElement } from "folder-hash";
+import { Package } from "./types";
+
+export async function getPackageSourceHash(workspacePackage: Package) {
+    const { hash } = await hashElement(workspacePackage.packageFolder, {
+        folders: { exclude: ["dist", "lib"] },
+        files: { exclude: ["tsconfig.build.tsbuildinfo"] }
+    });
+
+    return hash;
+}

--- a/scripts/buildPackages/src/index.js
+++ b/scripts/buildPackages/src/index.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+process.env.NODE_PATH = process.cwd();
+const tsNode = require("ts-node");
+
+tsNode.register({
+    dir: process.cwd()
+});
+
+const { buildPackages } = require("./buildPackages");
+
+(async () => {
+    await buildPackages();
+    process.exit();
+})();

--- a/scripts/buildPackages/src/types.ts
+++ b/scripts/buildPackages/src/types.ts
@@ -1,0 +1,27 @@
+export interface Package {
+    isTs: boolean;
+    hasTests: boolean;
+    name: string;
+    folderName: string;
+    packageFolder: string;
+    packageFolderRelativePath: string;
+    packageJsonPath: string;
+    tsConfigJsonPath: string;
+    tsConfigBuildJsonPath: string;
+    packageJson: Record<string, any>;
+    tsConfigJson: Record<string, any>;
+    tsConfigBuildJson: Record<string, any>;
+}
+
+export interface MetaJSON {
+    packages: {
+        [packageName: string]: {
+            sourceHash: string;
+        };
+    };
+}
+
+export interface PackageJSON {
+    webiny?: any;
+    [key: string]: any;
+}

--- a/scripts/buildPackages/tsconfig.json
+++ b/scripts/buildPackages/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./buildMultiCore.ts"],
+  "compilerOptions": {
+    "rootDirs": ["."],
+    "baseUrl": "."
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4444,6 +4444,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
 "@csstools/normalize.css@npm:*":
   version: 12.0.0
   resolution: "@csstools/normalize.css@npm:12.0.0"
@@ -5578,7 +5587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:3.1.0":
+"@jridgewell/resolve-uri@npm:3.1.0, @jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
   checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
@@ -5606,6 +5615,16 @@ __metadata:
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -9993,6 +10012,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node10@npm:1.0.9"
+  checksum: a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@tsconfig/node16@npm:1.0.3"
+  checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
+  languageName: node
+  linkType: hard
+
 "@types/accept-language-parser@npm:^1.5.3":
   version: 1.5.3
   resolution: "@types/accept-language-parser@npm:1.5.3"
@@ -10153,6 +10200,13 @@ __metadata:
   version: 1.6.2
   resolution: "@types/extract-zip@npm:1.6.2"
   checksum: 5f33ebe9d22d31537b943ef4bb6d51829d5f8e8ed7c884813b2c698a228ecab0dd0e6175561e4d5c22d04a57c78c7cf0d0bea71209a4aeb122907aa8e4855d09
+  languageName: node
+  linkType: hard
+
+"@types/folder-hash@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@types/folder-hash@npm:4.0.2"
+  checksum: 5ce73a1ea59300469d14df4ca82e4b5605883d945fb344a12aebd1acce3f1936f63cd153c22f99e06c190992159c42421681a9a95e6cfd1858cd69b76db90f18
   languageName: node
   linkType: hard
 
@@ -11537,6 +11591,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webiny-scripts/build-packages@workspace:scripts/buildPackages":
+  version: 0.0.0-use.local
+  resolution: "@webiny-scripts/build-packages@workspace:scripts/buildPackages"
+  dependencies:
+    "@types/folder-hash": ^4.0.2
+    "@types/yargs": ^17.0.8
+    chalk: ^4.1.0
+    execa: ^5.1.1
+    folder-hash: ^4.0.4
+    fs-extra: ^7.0.1
+    listr2: ^5.0.8
+    load-json-file: ^6.2.0
+    ts-node: ^10.5.0
+    write-json-file: ^4.3.0
+    yargs: ^17.3.1
+  bin:
+    build-packages: ./src/index.js
+  languageName: unknown
+  linkType: soft
+
 "@webiny/api-aco@0.0.0, @webiny/api-aco@workspace:packages/api-aco":
   version: 0.0.0-use.local
   resolution: "@webiny/api-aco@workspace:packages/api-aco"
@@ -12355,6 +12429,7 @@ __metadata:
     "@webiny/api-security-so-ddb": 0.0.0
     "@webiny/api-tenancy": 0.0.0
     "@webiny/api-tenancy-so-ddb": 0.0.0
+    "@webiny/cli": 0.0.0
     "@webiny/error": 0.0.0
     "@webiny/handler": 0.0.0
     "@webiny/handler-aws": 0.0.0
@@ -15953,6 +16028,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^5.2.1":
   version: 5.7.4
   resolution: "acorn@npm:5.7.4"
@@ -15980,7 +16062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0":
+"acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
@@ -16979,6 +17061,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^2.0.6
   checksum: 70d251719c969b2745bfe5ddf3ebaefa846a636e90a6d5212573676af5d6670e15457761d4725731e19cbebdce42c4ab0cbedf23ab047f2a08274985aa10a3c7
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -19858,7 +19947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.10, colorette@npm:^2.0.16, colorette@npm:^2.0.7":
+"colorette@npm:^2.0.10, colorette@npm:^2.0.16, colorette@npm:^2.0.19, colorette@npm:^2.0.7":
   version: 2.0.19
   resolution: "colorette@npm:2.0.19"
   checksum: 888cf5493f781e5fcf54ce4d49e9d7d698f96ea2b2ef67906834bb319a392c667f9ec69f4a10e268d2946d13a9503d2d19b3abaaaf174e3451bfe91fb9d82427
@@ -20713,6 +20802,13 @@ __metadata:
     prop-types: ^15.0.0
     react: ^0.14.0 || ^15.0.0 || ^16.0.0
   checksum: e59b7a65671e59f5b11e06f67faadf0733ab6c33247d5631331aeb05450d180b8ae44d73817b9c02f1527654ba490ea3d3dd7320f8d6debb36776f10b0ae6a47
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
   languageName: node
   linkType: hard
 
@@ -22091,7 +22187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^4.0.2":
+"diff@npm:^4.0.1, diff@npm:^4.0.2":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
@@ -23888,7 +23984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:5.1.1, execa@npm:^5.0.0, execa@npm:^5.1.0":
+"execa@npm:5.1.1, execa@npm:^5.0.0, execa@npm:^5.1.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -24999,7 +25095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"folder-hash@npm:^4.0.0":
+"folder-hash@npm:^4.0.0, folder-hash@npm:^4.0.4":
   version: 4.0.4
   resolution: "folder-hash@npm:4.0.4"
   dependencies:
@@ -30220,6 +30316,27 @@ __metadata:
     enquirer:
       optional: true
   checksum: fdb8b2d6bdf5df9371ebd5082bee46c6d0ca3d1e5f2b11fbb5a127839855d5f3da9d4968fce94f0a5ec67cac2459766abbb1faeef621065ebb1829b11ef9476d
+  languageName: node
+  linkType: hard
+
+"listr2@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "listr2@npm:5.0.8"
+  dependencies:
+    cli-truncate: ^2.1.0
+    colorette: ^2.0.19
+    log-update: ^4.0.0
+    p-map: ^4.0.0
+    rfdc: ^1.3.0
+    rxjs: ^7.8.0
+    through: ^2.3.8
+    wrap-ansi: ^7.0.0
+  peerDependencies:
+    enquirer: ">= 2.3.0 < 3"
+  peerDependenciesMeta:
+    enquirer:
+      optional: true
+  checksum: 8be9f5632627c4df0dc33f452c98d415a49e5f1614650d3cab1b103c33e95f2a7a0e9f3e1e5de00d51bf0b4179acd8ff11b25be77dbe097cf3773c05e728d46c
   languageName: node
   linkType: hard
 
@@ -38038,7 +38155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1":
+"rxjs@npm:^7.5.1, rxjs@npm:^7.8.0":
   version: 7.8.0
   resolution: "rxjs@npm:7.8.0"
   dependencies:
@@ -40846,6 +40963,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.5.0":
+  version: 10.9.1
+  resolution: "ts-node@npm:10.9.1"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
 "ts-node@npm:^7.0.1":
   version: 7.0.1
   resolution: "ts-node@npm:7.0.1"
@@ -41732,6 +41887,13 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -42965,6 +43127,13 @@ __metadata:
     buffer-crc32: ~0.2.3
     fd-slicer: ~1.1.0
   checksum: 7f21fe0bbad6e2cb130044a5d1d0d5a0e5bf3d8d4f8c4e6ee12163ce798fee3de7388d22a7a0907f563ac5f9d40f8699a223d3d5c1718da90b0156da6904022b
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR introduces a new build process for repo packages in non-CI environments, which runs build scripts within each batch in parallel, using `execa`, which in turn utilizes all the available CPUs. With this, build time is cut down by 50% on a Macbook with 10 CPU cores. Speed improvements will vary depending on hardware, but for local development, this will be a huge improvement. CI environments are built same as before, so no changes there.

Other improvements:
- the output in the terminal was improved by switching to [Listr2](https://listr2.kilic.dev/)
- `buildPackages` is now a proper workspace, written in TS, and executed with `ts-node`
- Github workflow files are updated to use scripts from the root package.json, instead of calling them via `node` (easier to maintain in the future)
- `project-utils` had a bug which prevented TS config overrides to be applied via a CLI argument

![image](https://user-images.githubusercontent.com/3920893/226135396-ee9d2d4b-a3ed-4c61-897d-f668bfbe0b30.png)

![image](https://user-images.githubusercontent.com/3920893/226135405-2fa3efa7-78bf-4c48-a96a-51b9f2e9b594.png)


https://user-images.githubusercontent.com/3920893/226135450-6b5cfa24-712d-412c-9997-2b973c5f7509.mp4


## How Has This Been Tested?
Manually.

