### PR TITLE
fix: rename ACO models Ids

### DIFF
--- a/packages/api-aco/src/folder/folder.model.ts
+++ b/packages/api-aco/src/folder/folder.model.ts
@@ -83,7 +83,7 @@ const parentIdField = () =>
         parent: "folder"
     });
 
-export const FOLDER_MODEL_ID = "acoFolderModelDefinition";
+export const FOLDER_MODEL_ID = "acoFolder";
 
 export const createFolderModelDefinition = (): FolderModelDefinition => {
     return {

--- a/packages/api-aco/src/record/record.model.ts
+++ b/packages/api-aco/src/record/record.model.ts
@@ -63,7 +63,7 @@ const dataField = () =>
         parent: "searchRecord"
     });
 
-export const SEARCH_RECORD_MODEL_ID = "acoSearchRecordModelDefinition";
+export const SEARCH_RECORD_MODEL_ID = "acoSearchRecord";
 
 export const createSearchModelDefinition = (): SearchRecordModelDefinition => {
     return {


### PR DESCRIPTION
## Changes
With this PR we change the model ids for ACO entities (`folders` / `searchRecord`).

## How Has This Been Tested?
Jest
