### PR TITLE
feat: improve folders and search records listing 

### DIFF
--- a/packages/app-aco/src/contexts/records.tsx
+++ b/packages/app-aco/src/contexts/records.tsx
@@ -78,7 +78,7 @@ export const SearchRecordsProvider = ({ children }: Props) => {
         loading,
         meta,
         async listRecords(params) {
-            const { type, folderId, after, limit, sort: sorting } = params;
+            const { type, folderId, after, limit = 5, sort: sorting } = params;
 
             /**
              * Both folderId and type are optional to init `useRecords` but required to list records:

--- a/packages/app-aco/src/contexts/records.tsx
+++ b/packages/app-aco/src/contexts/records.tsx
@@ -30,7 +30,7 @@ import {
     UpdateSearchRecordVariables,
     ListDbSort
 } from "~/types";
-import { handleDbSorting, handleTableSorting } from "~/sorting";
+import { sortTableItems, validateOrGetDefaultDbSort } from "~/sorting";
 
 interface SearchRecordsContext {
     records: SearchRecordItem[];
@@ -78,7 +78,7 @@ export const SearchRecordsProvider = ({ children }: Props) => {
         loading,
         meta,
         async listRecords(params) {
-            const { type, folderId, after, limit, sort: initialSorting } = params;
+            const { type, folderId, after, limit, sort: sorting } = params;
 
             /**
              * Both folderId and type are optional to init `useRecords` but required to list records:
@@ -102,12 +102,12 @@ export const SearchRecordsProvider = ({ children }: Props) => {
             }
 
             // Remove records in case of sorting change and not a paginated request.
-            if (initialSorting && !after) {
+            if (sorting && !after) {
                 setRecords([]);
             }
 
             const action = after ? "LIST_MORE" : "LIST";
-            const sort = handleDbSorting(initialSorting);
+            const sort = validateOrGetDefaultDbSort(sorting);
 
             const { data: response } = await apolloFetchingHandler(
                 loadingHandler(action, setLoading),
@@ -126,7 +126,7 @@ export const SearchRecordsProvider = ({ children }: Props) => {
             }
 
             // Adjusting sorting while merging records with data received from the server.
-            setRecords(records => handleTableSorting(unionBy(data, records, "id"), sort));
+            setRecords(records => sortTableItems(unionBy(data, records, "id"), sort));
 
             setMeta(meta => ({
                 ...meta,

--- a/packages/app-aco/src/hooks/index.ts
+++ b/packages/app-aco/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from "./useListAco";
 export * from "./useFolders";
 export * from "./useRecords";

--- a/packages/app-aco/src/hooks/index.ts
+++ b/packages/app-aco/src/hooks/index.ts
@@ -1,3 +1,3 @@
-export * from "./useListAco";
+export * from "./useAcoList";
 export * from "./useFolders";
 export * from "./useRecords";

--- a/packages/app-aco/src/hooks/useAcoList.ts
+++ b/packages/app-aco/src/hooks/useAcoList.ts
@@ -4,7 +4,7 @@ import useDeepCompareEffect from "use-deep-compare-effect";
 
 import { FoldersContext } from "~/contexts/folders";
 import { SearchRecordsContext } from "~/contexts/records";
-import { handleDbSorting, handleTableSorting } from "~/sorting";
+import { sortTableItems, validateOrGetDefaultDbSort } from "~/sorting";
 
 import { FolderItem, ListDbSort, SearchRecordItem } from "~/types";
 
@@ -65,7 +65,7 @@ export const useAcoList = (type: string, originalFolderId?: string) => {
      */
     useDeepCompareEffect(() => {
         const subFolders = getCurrentFolderList(originalFolders[type], originalFolderId);
-        setFolders(handleTableSorting(subFolders, sort));
+        setFolders(sortTableItems(subFolders, sort));
 
         const currentFolder = originalFolders[type]?.find(folder => folder.id === originalFolderId);
         setListTitle(currentFolder?.title || undefined);
@@ -85,7 +85,7 @@ export const useAcoList = (type: string, originalFolderId?: string) => {
      * - we sort the current `folders` list according to `sort` value;
      */
     useEffect(() => {
-        setFolders(folders => handleTableSorting(folders, sort));
+        setFolders(folders => sortTableItems(folders, sort));
     }, [sort]);
 
     return useMemo(
@@ -103,7 +103,7 @@ export const useAcoList = (type: string, originalFolderId?: string) => {
             listItems(params: { after?: string; limit?: number; sort?: ListDbSort }) {
                 // We store `sort` param to local state to handle `folders` and future `records` sorting.
                 if (params.sort && Object.values(params.sort).length > 0) {
-                    setSort(handleDbSorting(params.sort));
+                    setSort(validateOrGetDefaultDbSort(params.sort));
                 }
 
                 return listRecords({ ...params, type, folderId });

--- a/packages/app-aco/src/hooks/useListAco.ts
+++ b/packages/app-aco/src/hooks/useListAco.ts
@@ -1,0 +1,130 @@
+import { useContext, useEffect, useMemo, useState } from "react";
+import orderBy from "lodash/orderBy";
+import unionBy from "lodash/unionBy";
+import useDeepCompareEffect from "use-deep-compare-effect";
+
+import { FoldersContext } from "~/contexts/folders";
+import { SearchRecordsContext } from "~/contexts/records";
+import { FolderItem, ListSort, SearchRecordItem } from "~/types";
+
+interface TableSort {
+    fields: string[];
+    orders: Array<"asc" | "desc">;
+}
+
+export const useListAco = (type: string, originalFolderId?: string) => {
+    const folderContext = useContext(FoldersContext);
+    const searchContext = useContext(SearchRecordsContext);
+
+    if (!folderContext || !searchContext) {
+        throw new Error("useListAco must be used within a ACOProvider");
+    }
+
+    const [folders, setFolders] = useState<FolderItem[]>([]);
+    const [records, setRecords] = useState<SearchRecordItem[]>([]);
+    const [listTitle, setListTitle] = useState<string | undefined>();
+    const [dbSort, setDbSort] = useState<ListSort>(Object.create(null));
+    const [tableSort, setTableSort] = useState<TableSort>(
+        Object.create({ fields: [], orders: [] })
+    );
+
+    const { folders: originalFolders, loading: foldersLoading, listFolders } = folderContext;
+    const { records: originalRecords, loading: recordsLoading, listRecords, meta } = searchContext;
+
+    const folderId = originalFolderId || "ROOT";
+
+    const getCurrentFolderList = (
+        folders: FolderItem[],
+        currentFolderId?: string
+    ): FolderItem[] | [] => {
+        if (!folders) {
+            return [];
+        }
+        if (currentFolderId) {
+            return folders.filter(folder => folder.parentId === currentFolderId);
+        } else {
+            return folders.filter(folder => !folder.parentId);
+        }
+    };
+
+    const handleSorting = (sort: ListSort) => {
+        const sorting =
+            sort && Object.keys(sort).length > 0
+                ? sort
+                : ({ savedOn: "DESC" } as unknown as ListSort);
+
+        console.log("handleSorting", sorting);
+        setDbSort(sorting);
+
+        const fields = [] as TableSort["fields"];
+        const orders = [] as TableSort["orders"];
+        for (const [field, order] of Object.entries(sorting)) {
+            fields.push(field);
+            orders.push(order.toLowerCase() as "asc" | "desc");
+        }
+
+        setTableSort({ fields, orders });
+    };
+
+    // Initial List both records and folders
+    useEffect(() => {
+        if (!originalFolders[type]) {
+            listFolders(type);
+        }
+        if (type && folderId) {
+            listRecords({ type, folderId, sort: dbSort });
+        }
+    }, [type, folderId]);
+
+    // Sync folders
+    useDeepCompareEffect(() => {
+        const subFolders = getCurrentFolderList(originalFolders[type], originalFolderId);
+        setFolders(subFolders);
+
+        const currentFolder = originalFolders[type]?.find(folder => folder.id === originalFolderId);
+        setListTitle(currentFolder?.title || undefined);
+    }, [{ ...originalFolders[type] }, folderId]);
+
+    // Sorting
+    useEffect(() => {
+        setFolders(folders => orderBy(folders, tableSort.fields, tableSort.orders));
+    }, [tableSort]);
+
+    // Sync records
+    useDeepCompareEffect(() => {
+        const subRecords = originalRecords.filter(record => record.location.folderId === folderId);
+        setRecords(subRecords);
+    }, [{ ...originalRecords }, folderId]);
+
+    return useMemo(
+        () => ({
+            folders,
+            records,
+            listTitle,
+            isListLoading:
+                recordsLoading.INIT ||
+                foldersLoading.INIT ||
+                recordsLoading.LIST ||
+                foldersLoading.LIST,
+            isListLoadingMore: recordsLoading.LIST_MORE,
+            meta: meta[folderId!] || {},
+            async listItems(params: { after?: string; limit?: number; sort?: ListSort }) {
+                // Store `sort` param for further list records
+                if (params.sort) {
+                    console.log("qui");
+                    handleSorting(params.sort);
+                }
+
+                const data = await listRecords({ ...params, type, folderId, sort: dbSort });
+
+                console.log("dbSort", dbSort);
+                console.log("tableSort", tableSort);
+
+                setRecords(records =>
+                    orderBy(unionBy(data, records, "id"), tableSort.fields, tableSort.orders)
+                );
+            }
+        }),
+        [folders, records, foldersLoading, recordsLoading, meta]
+    );
+};

--- a/packages/app-aco/src/hooks/useRecords.ts
+++ b/packages/app-aco/src/hooks/useRecords.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo } from "react";
 import { SearchRecordsContext } from "~/contexts/records";
-import { ListSort, SearchRecordItem } from "~/types";
+import { ListDbSort, SearchRecordItem } from "~/types";
 
 export const useRecords = (type?: string, folderId?: string) => {
     const context = useContext(SearchRecordsContext);
@@ -40,7 +40,7 @@ export const useRecords = (type?: string, folderId?: string) => {
             loading,
             meta: meta[folderId!] || {},
             records: records.filter(record => record.location.folderId === folderId),
-            listRecords(params: { after?: string; limit?: number; sort?: ListSort }) {
+            listRecords(params: { after?: string; limit?: number; sort?: ListDbSort }) {
                 return listRecords({ type, folderId, ...params });
             },
             getRecord(id: string) {

--- a/packages/app-aco/src/index.ts
+++ b/packages/app-aco/src/index.ts
@@ -5,4 +5,4 @@ export {
     FolderDialogDelete
 } from "./components";
 export { ACOProvider } from "./contexts";
-export { useListAco, useFolders, useRecords } from "./hooks";
+export { useAcoList, useFolders, useRecords } from "./hooks";

--- a/packages/app-aco/src/index.ts
+++ b/packages/app-aco/src/index.ts
@@ -5,4 +5,4 @@ export {
     FolderDialogDelete
 } from "./components";
 export { ACOProvider } from "./contexts";
-export { useFolders, useRecords } from "./hooks";
+export { useListAco, useFolders, useRecords } from "./hooks";

--- a/packages/app-aco/src/sorting.tsx
+++ b/packages/app-aco/src/sorting.tsx
@@ -1,0 +1,24 @@
+import orderBy from "lodash/orderBy";
+
+import { ListDbSort, ListTableSort, ListTableSortDirection } from "~/types";
+
+export const handleDbSorting = (initial?: ListDbSort): ListDbSort => {
+    if (!initial || Object.keys(initial).length === 0) {
+        return { savedOn: "DESC" } as unknown as ListDbSort;
+    }
+
+    return initial;
+};
+
+export const handleTableSorting = (records: any[], sort?: ListDbSort): any[] => {
+    const dbSorting = handleDbSorting(sort);
+    const fields = [] as ListTableSort["fields"];
+    const orders = [] as ListTableSort["orders"];
+
+    for (const [field, order] of Object.entries(dbSorting)) {
+        fields.push(field);
+        orders.push(order.toLowerCase() as ListTableSortDirection);
+    }
+
+    return orderBy(records, fields, orders);
+};

--- a/packages/app-aco/src/sorting.tsx
+++ b/packages/app-aco/src/sorting.tsx
@@ -2,7 +2,7 @@ import orderBy from "lodash/orderBy";
 
 import { ListDbSort, ListTableSort, ListTableSortDirection } from "~/types";
 
-export const handleDbSorting = (initial?: ListDbSort): ListDbSort => {
+export const validateOrGetDefaultDbSort = (initial?: ListDbSort): ListDbSort => {
     if (!initial || Object.keys(initial).length === 0) {
         return { savedOn: "DESC" } as unknown as ListDbSort;
     }
@@ -10,8 +10,8 @@ export const handleDbSorting = (initial?: ListDbSort): ListDbSort => {
     return initial;
 };
 
-export const handleTableSorting = (records: any[], sort?: ListDbSort): any[] => {
-    const dbSorting = handleDbSorting(sort);
+export const sortTableItems = (records: any[], sort?: ListDbSort): any[] => {
+    const dbSorting = validateOrGetDefaultDbSort(sort);
     const fields = [] as ListTableSort["fields"];
     const orders = [] as ListTableSort["orders"];
 

--- a/packages/app-aco/src/types.ts
+++ b/packages/app-aco/src/types.ts
@@ -41,12 +41,22 @@ export interface Error {
 
 export type Meta<T> = Record<string, { [P in keyof T]: T[P] }>;
 
-export enum ListSortDirection {
+export enum ListDbSortDirection {
     ASC = "ASC",
     DESC = "DESC"
 }
 
-export type ListSort = Record<string, ListSortDirection>;
+export enum ListTableSortDirection {
+    asc = "asc",
+    desc = "desc"
+}
+
+export type ListDbSort = Record<string, ListDbSortDirection>;
+
+export interface ListTableSort {
+    fields: string[];
+    orders: ListTableSortDirection[];
+}
 
 export interface ListMeta {
     cursor: string | null;
@@ -135,7 +145,7 @@ export interface ListSearchRecordsQueryVariables {
     location: Location;
     limit?: number;
     after?: string | null;
-    sort?: ListSort;
+    sort?: ListDbSort;
 }
 
 export interface GetSearchRecordResponse {

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import debounce from "lodash/debounce";
 import { i18n } from "@webiny/app/i18n";
-import { FolderDialogCreate, useListAco } from "@webiny/app-aco";
+import { FolderDialogCreate, useAcoList } from "@webiny/app-aco";
 import { useHistory, useLocation } from "@webiny/react-router";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { Scrollbar } from "@webiny/ui/Scrollbar";
@@ -24,7 +24,7 @@ import { FOLDER_TYPE } from "~/admin/constants/folders";
 
 import { MainContainer, Wrapper } from "./styled";
 
-import { ListMeta, ListSort, SearchRecordItem } from "@webiny/app-aco/types";
+import { ListMeta, ListDbSort, SearchRecordItem } from "@webiny/app-aco/types";
 import { PbPageDataItem } from "~/types";
 import { Sorting } from "@webiny/ui/DataTable";
 
@@ -47,7 +47,7 @@ export const Main = ({ folderId, defaultFolderName }: Props) => {
         isListLoading,
         isListLoadingMore,
         listItems
-    } = useListAco(FOLDER_TYPE, folderId);
+    } = useAcoList(FOLDER_TYPE, folderId);
 
     const [isCreateLoading, setIsCreateLoading] = useState<boolean>(false);
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
@@ -73,7 +73,7 @@ export const Main = ({ folderId, defaultFolderName }: Props) => {
 
     const [selected, setSelected] = useState<string[]>([]);
     const [tableSorting, setTableSorting] = useState<Sorting>([]);
-    const [sort, setSort] = useState<ListSort>();
+    const [sort, setSort] = useState<ListDbSort>();
 
     useEffect(() => {
         setTableHeight(tableRef?.current?.clientHeight || 0);


### PR DESCRIPTION
## Changes

With this PR we expose `useAcoList()` hooks that exposes:
- `folders` and `records` state, coming from the respective state;
- `listItems` method, to fetch more or sorted `records`; 
- `meta` (coming from `records` state);
- `listTitle`, the current folder name;
- `loading` states.

Using `useAcoList()` allows us to sort both `records` and `folders`:
- `records` sorting is done server-side;
- `folders` sorting is done client-side, since the folder list tree has been already fetched from the server.

Closes [https://webiny.atlassian.net/browse/WEB-2279](WEB-2279)

## How Has This Been Tested?
Jest + Cypress

## Documentation
Inline
