### PR TITLE
fix(cypress): missing plural and singular model api name

### DIFF
--- a/cypress/integration/admin/headlessCms/contentModel/contentModels.spec.js
+++ b/cypress/integration/admin/headlessCms/contentModel/contentModels.spec.js
@@ -187,6 +187,17 @@ context("Headless CMS - Content Models CRUD", () => {
                 .wait(500)
                 .type(`Book - ${uniqueId}`)
                 .wait(500);
+            // add api singular and plural names
+            cy.findByTestId("cms.newcontentmodeldialog.singularApiName")
+                .focus()
+                .wait(500)
+                .type(lodashUpperFirst(lodashCamelCase(`Book${uniqueId}`)))
+                .wait(500);
+            cy.findByTestId("cms.newcontentmodeldialog.pluralApiName")
+                .focus()
+                .wait(500)
+                .type(lodashUpperFirst(lodashCamelCase(`Books${uniqueId}`)))
+                .wait(500);
             cy.findByTestId("cms.newcontentmodeldialog.description").type(newModelDescription);
             /**
              * checkbox is checked by default, but lets set it to true just in case someone changes that

--- a/cypress/integration/admin/headlessCms/contentModel/searchSortModels.spec.js
+++ b/cypress/integration/admin/headlessCms/contentModel/searchSortModels.spec.js
@@ -1,4 +1,6 @@
 import uniqid from "uniqid";
+import upperFirst from "lodash/upperFirst";
+import camelCase from "lodash/camelCase";
 
 context("Headless CMS - Search and Sort Content Models", () => {
     const totalModels = 2;
@@ -18,6 +20,8 @@ context("Headless CMS - Search and Sort Content Models", () => {
                 data: {
                     name: `${newModel} 1`,
                     modelId: `${newModel}-1`,
+                    singularApiName: upperFirst(camelCase(`${newModel}-1`)),
+                    pluralApiName: upperFirst(camelCase(`${newModel}-1S`)),
                     group: contentModelGroup.id
                 }
             }).then(data => {
@@ -27,6 +31,8 @@ context("Headless CMS - Search and Sort Content Models", () => {
                     data: {
                         name: `${newModel} 2`,
                         modelId: `${newModel}-2`,
+                        singularApiName: upperFirst(camelCase(`${newModel}-2`)),
+                        pluralApiName: upperFirst(camelCase(`${newModel}-2S`)),
                         group: contentModelGroup.id
                     }
                 }).then(data => {


### PR DESCRIPTION
## Changes
PR fixes the missing signgular and plural model api names after the new reference field and single/plural PR merges.

## How Has This Been Tested?
Manually and cypress.