### PR TITLE
fix: listContentModels returns duplicated data

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/useCmsData.ts
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/useCmsData.ts
@@ -9,6 +9,7 @@ export interface CmsDataCmsGroup {
 }
 export interface CmsDataCmsModel {
     id: string;
+    modelId: string;
     label: string;
     group: CmsDataCmsGroup;
 }
@@ -30,6 +31,7 @@ const LIST_DATA = gql`
     query CmsLoadPermissionsData {
         listContentModels {
             data {
+                modelId
                 id: modelId
                 label: name
                 group {


### PR DESCRIPTION
## Changes
With this PR we fix `listContentModels` that returns duplicated data within `useCmsData` method. The issue can be related to field aliasing and Apollo query cache.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Jest + Cypress