### PR TITLE
fix: make sure query selection is only applied once per plugin instance

### DIFF
--- a/packages/app-admin/src/base/plugins/AddGraphQLQuerySelection.tsx
+++ b/packages/app-admin/src/base/plugins/AddGraphQLQuerySelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { plugins } from "@webiny/plugins";
 import { nanoid } from "nanoid";
 import { AddQuerySelectionPlugin } from "@webiny/app/plugins/AddQuerySelectionPlugin";
@@ -11,10 +11,11 @@ interface Props {
 }
 
 export const AddGraphQLQuerySelection: React.FC<Props> = props => {
+    const [name] = useState(`AddGraphQLQuerySelection:${props.operationName}:${nanoid()}`);
+
     useEffect(() => {
         const plugin = new AddQuerySelectionPlugin(props);
 
-        const name = nanoid();
         plugin.name = name;
         plugins.register(plugin);
 


### PR DESCRIPTION
## Changes
This PR fixes an issue where `AddQuerySelectionPlugin` would process the same document multiple times, and each time add the same selection. The trick here is that the document passed to the plugin is actually a reference to the original DocumentNode, so it is enough to only process it once. To keep track of all plugins applied to the document, I added our own property `__webiny__` onto the DocumentNode, and each plugin adds it's cache key into the Set. It is then easy to check whether this particular document was processed by the current plugin instance.

## How Has This Been Tested?
Manually.

## Documentation
Not needed, it's an internal bug fix.