### PR TITLE
fix(app-headless-cms): disable dynamic zone in object field

### DIFF
--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -88,7 +88,7 @@ const fieldSchema = zod.object({
         .array(
             zod.object({
                 name: shortString,
-                message: shortString,
+                message: optionalShortString.default("Value is required."),
                 settings: zod
                     .object({})
                     .passthrough()
@@ -106,7 +106,7 @@ const fieldSchema = zod.object({
         .array(
             zod.object({
                 name: shortString,
-                message: shortString,
+                message: optionalShortString.default("Value is required."),
                 settings: zod
                     .object({})
                     .passthrough()

--- a/packages/api-headless-cms/src/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/graphqlFields/object.ts
@@ -1,3 +1,4 @@
+import WebinyError from "@webiny/error";
 import upperFirst from "lodash/upperFirst";
 import {
     CmsFieldTypePlugins,
@@ -96,8 +97,25 @@ export const createObjectField = (): CmsModelFieldToGraphQLPlugin => {
         validateChildFields: params => {
             const { field, originalField, validate } = params;
 
+            const fields = field.settings?.fields || [];
+            /**
+             * At the moment we do not allow dynamic zone fields inside the object field.
+             */
+            const hasDynamicZone = fields.some(f => f.type === "dynamicZone");
+            if (hasDynamicZone) {
+                throw new WebinyError(
+                    "Dynamic zones cannot be used inside of an object field.",
+                    "DYNAMIC_ZONE_INSIDE_OBJECT",
+                    {
+                        id: field.id,
+                        fieldId: field.fieldId,
+                        fieldLabel: field.label
+                    }
+                );
+            }
+
             validate({
-                fields: field.settings?.fields || [],
+                fields,
                 originalFields: originalField?.settings?.fields || []
             });
         },

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/AddTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/AddTemplate.tsx
@@ -15,6 +15,7 @@ const AddIconContainer = styled.div`
 const AddButtonContainer = styled.div`
     text-align: center;
     margin-top: 20px;
+
     :first-of-type {
         margin-top: 0;
     }
@@ -25,6 +26,7 @@ const Info = styled.div`
     justify-content: center;
     align-items: center;
     margin-top: 5px;
+
     > svg {
         width: 20px;
         margin-right: 5px;
@@ -64,7 +66,7 @@ interface AddTemplateProps {
     onTemplate: UseAddTemplateParams["onTemplate"];
 }
 
-export const AddTemplateButton = (props: AddTemplateProps) => {
+export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
     const { showGallery, onTemplate, browseTemplates, onGalleryClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });
@@ -88,7 +90,7 @@ export const AddTemplateButton = (props: AddTemplateProps) => {
     );
 };
 
-export const AddTemplateIcon = (props: AddTemplateProps) => {
+export const AddTemplateIcon: React.VFC<AddTemplateProps> = props => {
     const { showGallery, onTemplate, browseTemplates, onGalleryClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/MultiValueDynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/MultiValueDynamicZone.tsx
@@ -42,7 +42,7 @@ interface TemplateValueFormProps {
     onClone: () => void;
 }
 
-const TemplateValueForm = ({
+const TemplateValueForm: React.VFC<TemplateValueFormProps> = ({
     value,
     contentModel,
     Bind,
@@ -52,7 +52,7 @@ const TemplateValueForm = ({
     onMoveDown,
     onDelete,
     onClone
-}: TemplateValueFormProps) => {
+}) => {
     const { field } = useModelField();
     const templates = field.settings?.templates || [];
 
@@ -104,11 +104,11 @@ interface MultiValueDynamicZoneProps {
     getBind: GetBind;
 }
 
-export const MultiValueDynamicZone = ({
+export const MultiValueDynamicZone: React.VFC<MultiValueDynamicZoneProps> = ({
     bind,
     getBind,
     contentModel
-}: MultiValueDynamicZoneProps) => {
+}) => {
     const onTemplate = (template: CmsDynamicZoneTemplate) => {
         bind.appendValue({ _templateId: template.id });
     };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/SingleValueDynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/SingleValueDynamicZone.tsx
@@ -21,12 +21,12 @@ interface SingleValueDynamicZoneProps {
     getBind: GetBind;
 }
 
-export const SingleValueDynamicZone = ({
+export const SingleValueDynamicZone: React.VFC<SingleValueDynamicZoneProps> = ({
     field,
     bind,
     contentModel,
     getBind
-}: SingleValueDynamicZoneProps) => {
+}) => {
     const onTemplate = (template: CmsDynamicZoneTemplate) => {
         bind.onChange({ _templateId: template.id });
     };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateCard.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateCard.tsx
@@ -52,7 +52,7 @@ interface TemplateCardProps {
     onTemplate: (template: CmsDynamicZoneTemplate) => void;
 }
 
-export const TemplateCard = ({ template, onTemplate }: TemplateCardProps) => {
+export const TemplateCard: React.VFC<TemplateCardProps> = ({ template, onTemplate }) => {
     return (
         <CardContainer>
             <CardIcon>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
@@ -20,7 +20,7 @@ interface TemplateGalleryProps {
     onClose: () => void;
 }
 
-export const TemplateGallery = ({ onTemplate, onClose }: TemplateGalleryProps) => {
+export const TemplateGallery: React.VFC<TemplateGalleryProps> = ({ onTemplate, onClose }) => {
     const { field } = useModelField();
     const templates = field.settings?.templates || [];
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateIcon.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateIcon.tsx
@@ -5,7 +5,7 @@ interface TemplateIconProps {
     icon: string;
 }
 
-export const TemplateIcon = ({ icon }: TemplateIconProps) => {
+export const TemplateIcon: React.VFC<TemplateIconProps> = ({ icon }) => {
     const faIcon = icon ? (icon.split("/") as FontAwesomeIconProps["icon"]) : undefined;
 
     return faIcon ? <FontAwesomeIcon icon={faIcon} /> : null;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
@@ -12,7 +12,11 @@ const noBottomPadding = css`
     }
 `;
 
-const DynamicZoneContent = ({ field, getBind, contentModel }: CmsEditorFieldRendererProps) => {
+const DynamicZoneContent: React.VFC<CmsEditorFieldRendererProps> = ({
+    field,
+    getBind,
+    contentModel
+}) => {
     const isMultipleValues = field.multipleValues === true;
     const Bind = getBind();
 

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/AddTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/AddTemplate.tsx
@@ -19,6 +19,7 @@ const AddTemplateButtonContainer = styled(Elevation)`
 const AddTemplateIconContainer = styled.div`
     text-align: center;
     height: 36px;
+
     > button {
         margin-left: -24px;
         position: absolute;
@@ -30,6 +31,7 @@ const Info = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
+
     > svg {
         width: 20px;
         margin-right: 5px;
@@ -67,7 +69,7 @@ function useAddTemplate(params: UseAddTemplateParams) {
     };
 }
 
-export const AddTemplateButton = (props: AddTemplateProps) => {
+export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
     const { addTemplate, onTemplate, showTemplateDialog, onDialogClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });
@@ -88,7 +90,7 @@ export const AddTemplateButton = (props: AddTemplateProps) => {
     );
 };
 
-export const AddTemplateIcon = (props: AddTemplateProps) => {
+export const AddTemplateIcon: React.VFC<AddTemplateProps> = props => {
     const { addTemplate, onTemplate, showTemplateDialog, onDialogClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
@@ -22,7 +22,7 @@ function updateOrCreateTemplate(
     return [...templates, template];
 }
 
-export const DynamicZone = () => {
+export const DynamicZone: React.VFC = () => {
     const { field } = useModelField();
     const { updateField } = useModelFieldEditor();
     const newTemplateId = useRef<string | undefined>(undefined);

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
@@ -31,13 +31,13 @@ interface UpdateFieldsAndLayout {
 
 const TEMPLATES_PATH = "settings.templates";
 
-export const DynamicZoneTemplate = ({
+export const DynamicZoneTemplate: React.VFC<DynamicZoneTemplateProps> = ({
     index,
     field,
     template,
     onChange,
     open
-}: DynamicZoneTemplateProps) => {
+}) => {
     const { showConfirmation } = useConfirmationDialog({
         title: "Delete content template",
         message: "Are you sure you want to delete this content template?",

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
@@ -32,7 +32,7 @@ interface TemplateDialogProps {
     onTemplate: (template: CmsDynamicZoneTemplate) => void;
 }
 
-export const TemplateDialog = (props: TemplateDialogProps) => {
+export const TemplateDialog: React.VFC<TemplateDialogProps> = props => {
     const [showWarning, setWarning] = useState(false);
     const newTemplate = !Boolean(props.template);
     const dialogTitle = newTemplate ? "Add Template" : "Edit Template";

--- a/packages/app-headless-cms/src/admin/plugins/fields/object.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/object.tsx
@@ -18,6 +18,9 @@ const plugin: CmsModelFieldTypePlugin = {
         allowMultipleValues: true,
         allowPredefinedValues: false,
         multipleValuesLabel: t`Use as a repeatable object`,
+        canAccept(_, draggable): boolean {
+            return draggable.fieldType !== "dynamicZone";
+        },
         createField() {
             return {
                 type: this.type,


### PR DESCRIPTION
## Changes
This PR disables adding Dynamic Zone field into the Object field.

At the moment, due to our structure of the fields in the models we cannot support this.

## How Has This Been Tested?
Manually.

## Documentation
Note to users that they cannot add DZ into the object field.