### PR TITLE
fix(api-file-manager): use Long scalar type in GraphQL schema

### DIFF
--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -38,6 +38,28 @@ describe("Files CRUD test", () => {
     const { createFile, updateFile, createFiles, getFile, listFiles, listTags, until } =
         useGqlHandler();
 
+    test("should create a file with a large file size", async () => {
+        const largeFileData = {
+            key: "/files/large-file.png",
+            name: "filenameD.png",
+            size: Number.MAX_SAFE_INTEGER,
+            type: "image/png",
+            tags: []
+        };
+
+        const [create] = await createFile({ data: largeFileData });
+        expect(create).toEqual({
+            data: {
+                fileManager: {
+                    createFile: {
+                        data: { ...largeFileData, id: expect.any(String) },
+                        error: null
+                    }
+                }
+            }
+        });
+    });
+
     test("should create, read, update and delete files", async () => {
         const [create] = await createFile({ data: fileAData });
         expect(create).toEqual({

--- a/packages/api-file-manager/src/plugins/graphql.ts
+++ b/packages/api-file-manager/src/plugins/graphql.ts
@@ -32,7 +32,7 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
             input FileInput {
                 key: String
                 name: String
-                size: Int
+                size: Long
                 type: String
                 tags: [String]
                 meta: JSON
@@ -41,7 +41,7 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
             type UploadFileResponseDataFile {
                 name: String
                 type: String
-                size: Int
+                size: Long
                 key: String
             }
 
@@ -84,7 +84,7 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
                 id: ID
                 key: String
                 name: String
-                size: Int
+                size: Long
                 type: String
                 src: String
                 tags: [String]

--- a/packages/handler-graphql/src/builtInTypes/LongScalar.ts
+++ b/packages/handler-graphql/src/builtInTypes/LongScalar.ts
@@ -1,2 +1,54 @@
-import { LongResolver } from "graphql-scalars";
-export const LongScalar = LongResolver;
+import { GraphQLScalarType } from "graphql";
+import { Kind } from "graphql/language";
+import WebinyError from "@webiny/error";
+
+const parseValue = (value: any) => {
+    if (String(value).includes(".")) {
+        throw new WebinyError("Value sent must be an integer.", "INVALID_VALUE", {
+            value
+        });
+    }
+    if (typeof value === "number") {
+        return value;
+    }
+
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    if (isNaN(value) === true) {
+        throw new WebinyError("Value sent must be an integer.", "INVALID_VALUE", {
+            value
+        });
+    }
+
+    return parseInt(value);
+};
+
+export const LongScalar = new GraphQLScalarType({
+    name: "Long",
+    description: "A custom input type to be used for large integers (Long).",
+    serialize: (value: any) => {
+        try {
+            return parseValue(value);
+        } catch (ex) {
+            console.log({
+                message: "Value sent must be an integer.",
+                code: "INVALID_VALUE",
+                data: {
+                    value
+                }
+            });
+            return null;
+        }
+    },
+    parseValue,
+    parseLiteral: ast => {
+        const value = (ast as any).value;
+        if (ast.kind === Kind.INT) {
+            return parseInt(value);
+        }
+
+        throw new Error(`Expected type Long, found {${value}}`);
+    }
+});


### PR DESCRIPTION
## Changes
This PR fixes an issue with File Manager API, where we used an `Int` for file size in the GraphQL schema. This was a problem with large files, several GB large. This is now switched to Long.

Long in itself was an issue because the library we use for common GraphQL scalar types serializes Long to a string, which is wrong. I had to implement a custom scalar type for `Long` to fix the serialization issue.

## How Has This Been Tested?
Jest tests.
