### PR TITLE
feat(tenancy): add tags to tenant entity

### DIFF
--- a/packages/api-tenancy-so-ddb/src/index.ts
+++ b/packages/api-tenancy-so-ddb/src/index.ts
@@ -20,6 +20,18 @@ interface TenantDomainRecord {
     webinyVersion: string;
 }
 
+const setTenantDefaults = (item: Tenant) => {
+    if (!item.tags) {
+        item.tags = [];
+    }
+
+    if (!item.description) {
+        item.description = "";
+    }
+
+    return item;
+};
+
 export const createStorageOperations: CreateTenancyStorageOperations = params => {
     const { table, documentClient } = params;
 
@@ -128,7 +140,7 @@ export const createStorageOperations: CreateTenancyStorageOperations = params =>
 
             const tenants = await batchReadAll<{ data: TTenant }>({ table: tableInstance, items });
 
-            return tenants.map(item => item.data);
+            return tenants.map(item => item.data).map(item => setTenantDefaults(item) as TTenant);
         },
 
         async listTenants<TTenant extends Tenant = Tenant>(
@@ -152,7 +164,7 @@ export const createStorageOperations: CreateTenancyStorageOperations = params =>
                 options
             });
 
-            return tenants.map(item => item.data);
+            return tenants.map(item => item.data).map(item => setTenantDefaults(item) as TTenant);
         },
 
         async createTenant<TTenant extends Tenant = Tenant>(data: TTenant): Promise<TTenant> {

--- a/packages/api-tenancy/__tests__/install.test.ts
+++ b/packages/api-tenancy/__tests__/install.test.ts
@@ -34,6 +34,7 @@ describe(`Test "Tenancy" install`, () => {
             id: "root",
             name: "Root",
             description: "The top-level Webiny tenant.",
+            tags: [],
             webinyVersion: process.env.WEBINY_VERSION,
             parent: null,
             createdOn: expect.any(String),

--- a/packages/api-tenancy/__tests__/tenants.test.ts
+++ b/packages/api-tenancy/__tests__/tenants.test.ts
@@ -17,6 +17,7 @@ describe(`Test "Tenancy" tenants`, () => {
         const tenant1Data = {
             id: "1",
             name: "Tenant #1",
+            tags: [],
             description: "The first sub-tenant",
             parent: "root"
         };
@@ -27,6 +28,7 @@ describe(`Test "Tenancy" tenants`, () => {
             description: "The second sub-tenant",
             parent: "root",
             status: "pending",
+            tags: ["blog"],
             settings: {
                 domains: [{ fqdn: "domain.com" }]
             }

--- a/packages/api-tenancy/src/createTenancy/createSystemMethods.ts
+++ b/packages/api-tenancy/src/createTenancy/createSystemMethods.ts
@@ -65,6 +65,7 @@ export function createSystemMethods(storageOperations: TenancyStorageOperations)
                 await this.createTenant({
                     id: "root",
                     name: "Root",
+                    tags: [],
                     description: "The top-level Webiny tenant.",
                     parent: ""
                 });

--- a/packages/api-tenancy/src/createTenancy/createTenantsMethods.ts
+++ b/packages/api-tenancy/src/createTenancy/createTenantsMethods.ts
@@ -86,7 +86,6 @@ export function createTenantsMethods(storageOperations: TenancyStorageOperations
                 settings: {
                     ...(data.settings || {}),
                     domains: (data.settings && data.settings.domains) || []
-                    // themes: (data.settings && data.settings.themes) || []
                 },
                 savedOn: new Date().toISOString(),
                 createdOn: new Date().toISOString(),
@@ -94,11 +93,11 @@ export function createTenantsMethods(storageOperations: TenancyStorageOperations
                 webinyVersion: process.env.WEBINY_VERSION
             };
 
-            await this.onTenantBeforeCreate.publish({ tenant });
+            await this.onTenantBeforeCreate.publish({ tenant, input: data });
 
             await storageOperations.createTenant(tenant);
 
-            await this.onTenantAfterCreate.publish({ tenant });
+            await this.onTenantAfterCreate.publish({ tenant, input: data });
 
             // Store data in cache
             loaders.getTenant.clear(tenant.id).prime(tenant.id, tenant);

--- a/packages/api-tenancy/src/graphql/types.gql.ts
+++ b/packages/api-tenancy/src/graphql/types.gql.ts
@@ -8,6 +8,7 @@ export default new GraphQLSchemaPlugin<TenancyContext>({
             name: String!
             description: String!
             parent: ID
+            tags: [String!]!
             settings: TenantSettings!
         }
 
@@ -18,12 +19,5 @@ export default new GraphQLSchemaPlugin<TenancyContext>({
         type TenantSettings {
             domains: [TenantDomain!]!
         }
-    `,
-    resolvers: {
-        Tenant: {
-            description(tenant) {
-                return tenant.description || "";
-            }
-        }
-    }
+    `
 });

--- a/packages/api-tenancy/src/types.ts
+++ b/packages/api-tenancy/src/types.ts
@@ -15,6 +15,7 @@ export interface Tenant {
     id: string;
     name: string;
     description: string;
+    tags: string[];
     status: string;
     settings: TenantSettings;
     parent: string | null;
@@ -56,6 +57,7 @@ export interface CreateTenantInput {
     id?: string;
     name: string;
     description: string;
+    tags: string[];
     status?: string;
     settings?: TenantSettings;
     parent: string;
@@ -83,10 +85,12 @@ export interface System {
 // Tenant lifecycle events
 export interface TenantBeforeCreateEvent {
     tenant: Tenant;
+    input: CreateTenantInput & Record<string, any>;
 }
 
 export interface TenantAfterCreateEvent {
     tenant: Tenant;
+    input: CreateTenantInput & Record<string, any>;
 }
 
 export interface TenantBeforeUpdateEvent {

--- a/packages/api-tenant-manager/__tests__/crud.test.ts
+++ b/packages/api-tenant-manager/__tests__/crud.test.ts
@@ -9,6 +9,7 @@ describe(`Test "Tenant Manager"`, () => {
         const tenant1Data = {
             name: "Tenant #1",
             description: "The first sub-tenant",
+            tags: [],
             settings: {
                 domains: [{ fqdn: "domain1.com" }]
             }
@@ -17,6 +18,7 @@ describe(`Test "Tenant Manager"`, () => {
         const tenant2Data = {
             name: "Tenant #2",
             description: "The second sub-tenant",
+            tags: ["child"],
             settings: {
                 domains: [{ fqdn: "domain2.com" }]
             }
@@ -29,6 +31,7 @@ describe(`Test "Tenant Manager"`, () => {
             id: expect.any(String),
             name: "Tenant #1",
             description: "The first sub-tenant",
+            tags: [],
             parent: "root",
             settings: {
                 domains: [{ fqdn: "domain1.com" }]
@@ -47,6 +50,7 @@ describe(`Test "Tenant Manager"`, () => {
             id: expect.any(String),
             name: "Tenant #2",
             description: "The second sub-tenant",
+            tags: ["child"],
             parent: "root",
             settings: {
                 domains: [{ fqdn: "domain2.com" }]
@@ -61,7 +65,12 @@ describe(`Test "Tenant Manager"`, () => {
         // Update
         const [response3] = await handler.updateTenant({
             id: tenant1.id,
-            data: { name: "Updated #1", description: "Updated desc", settings: tenant1.settings }
+            data: {
+                name: "Updated #1",
+                description: "Updated desc",
+                settings: tenant1.settings,
+                tags: ["child", "blog"]
+            }
         });
 
         const tenant1a = response3.data.tenancy.updateTenant.data;
@@ -69,6 +78,7 @@ describe(`Test "Tenant Manager"`, () => {
             id: expect.any(String),
             name: "Updated #1",
             description: "Updated desc",
+            tags: ["child", "blog"],
             parent: "root",
             settings: tenant1.settings
         });
@@ -99,6 +109,7 @@ describe(`Test "Tenant Manager"`, () => {
         const tenant1Data = {
             name: "Tenant #1",
             description: "The first sub-tenant",
+            tags: [],
             settings: {
                 domains: [{ fqdn: "domain1.com" }]
             }
@@ -136,6 +147,7 @@ describe(`Test "Tenant Manager"`, () => {
                 data: {
                     name: "Updated #1",
                     description: "Updated desc",
+                    tags: [],
                     settings: tenant1.settings
                 }
             });
@@ -147,7 +159,12 @@ describe(`Test "Tenant Manager"`, () => {
         // Update with a valid identity
         const [updateResponse] = await authHandler.updateTenant({
             id: tenant1.id,
-            data: { name: "Updated #1", description: "Updated desc", settings: tenant1.settings }
+            data: {
+                name: "Updated #1",
+                description: "Updated desc",
+                tags: [],
+                settings: tenant1.settings
+            }
         });
 
         const tenant1a = updateResponse.data.tenancy.updateTenant.data;
@@ -155,6 +172,7 @@ describe(`Test "Tenant Manager"`, () => {
             id: expect.any(String),
             name: "Updated #1",
             description: "Updated desc",
+            tags: [],
             parent: "root",
             settings: tenant1.settings
         });

--- a/packages/api-tenant-manager/__tests__/graphql/tenants.ts
+++ b/packages/api-tenant-manager/__tests__/graphql/tenants.ts
@@ -2,6 +2,7 @@ const fields = /* GraphQL */ `
     id
     name
     description
+    tags
     parent
     settings {
         domains {

--- a/packages/api-tenant-manager/src/graphql/tenants.ts
+++ b/packages/api-tenant-manager/src/graphql/tenants.ts
@@ -40,12 +40,14 @@ export default new GraphQLSchemaPlugin<Context>({
         input CreateTenantInput {
             name: String!
             description: String!
+            tags: [String!]!
             settings: TenantSettingsInput!
         }
 
         input UpdateTenantInput {
             name: String!
             description: String!
+            tags: [String!]!
             settings: TenantSettingsInput!
         }
 
@@ -100,11 +102,9 @@ export default new GraphQLSchemaPlugin<Context>({
                     await checkPermissions(context);
                     const tenant = context.tenancy.getCurrentTenant();
                     const newTenant = await context.tenancy.createTenant({
+                        ...args.data,
                         id: mdbid(),
-                        name: args.data.name,
-                        description: args.data.description,
-                        parent: tenant.id,
-                        settings: args.data.settings
+                        parent: tenant.id
                     });
 
                     return new Response(newTenant);

--- a/packages/app-tenant-manager/src/graphql/index.ts
+++ b/packages/app-tenant-manager/src/graphql/index.ts
@@ -6,6 +6,7 @@ const fields = /* GraphQL */ `
         id
         name
         description
+        tags
         parent
     }
 `;
@@ -34,6 +35,7 @@ interface CreateTenantInputSettings {
 interface CreateTenantInput {
     name: string;
     description: string;
+    tags: string[];
     settings: CreateTenantInputSettings;
 }
 export interface CreateTenantMutationResponse {

--- a/packages/app-tenant-manager/src/modules/tenants/TenantForm.tsx
+++ b/packages/app-tenant-manager/src/modules/tenants/TenantForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import styled from "@emotion/styled";
 import { i18n } from "@webiny/app/i18n";
 import { Form } from "@webiny/form";
+import { Tags } from "@webiny/ui/Tags";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { ButtonDefault, ButtonIcon, ButtonPrimary } from "@webiny/ui/Button";
 import { CircularProgress } from "@webiny/ui/Progress";
@@ -19,11 +19,6 @@ import { Input } from "@webiny/ui/Input";
 import { TenantFormFields } from "~/components/TenantFormFields";
 
 const t = i18n.ns("app-i18n/admin/locales/form");
-
-const ButtonWrapper = styled("div")({
-    display: "flex",
-    justifyContent: "space-between"
-});
 
 const TenantForm: React.FC = () => {
     const { loading, showEmptyView, createTenant, cancelEditing, tenant, onSubmit } =
@@ -44,7 +39,7 @@ const TenantForm: React.FC = () => {
     }
 
     return (
-        <Form data={tenant} onSubmit={onSubmit}>
+        <Form data={{ tags: [], ...tenant }} onSubmit={onSubmit}>
             {({ data, form, Bind }) => (
                 <SimpleForm data-testid={"tenant-form"}>
                     {loading && <CircularProgress />}
@@ -56,26 +51,22 @@ const TenantForm: React.FC = () => {
                                     <Input label={"Name"} />
                                 </Bind>
                             </Cell>
-                        </Grid>
-                        <Grid>
                             <Cell span={12}>
                                 <Bind name="description" validators={validation.create("required")}>
                                     <Input label={"Description"} rows={4} />
                                 </Bind>
                             </Cell>
+                            <Cell span={12}>
+                                <Bind name="tags" validators={validation.create("required")}>
+                                    <Tags label={"Tags"} />
+                                </Bind>
+                            </Cell>
                         </Grid>
-
                         <TenantFormFields />
                     </SimpleFormContent>
                     <SimpleFormFooter>
-                        <ButtonWrapper>
-                            <ButtonDefault onClick={cancelEditing}>{t`Cancel`}</ButtonDefault>
-                            <ButtonPrimary
-                                onClick={ev => {
-                                    form.submit(ev);
-                                }}
-                            >{t`Save tenant`}</ButtonPrimary>
-                        </ButtonWrapper>
+                        <ButtonDefault onClick={cancelEditing}>{t`Cancel`}</ButtonDefault>
+                        <ButtonPrimary onClick={form.submit}>{t`Save tenant`}</ButtonPrimary>
                     </SimpleFormFooter>
                 </SimpleForm>
             )}

--- a/packages/app-tenant-manager/src/types.ts
+++ b/packages/app-tenant-manager/src/types.ts
@@ -2,8 +2,10 @@ export interface TenantItem {
     id: string;
     name: string;
     description: string;
+    tags: string[];
     parent: string | null;
     settings?: {
+        domains?: { fqdn: string };
         themes?: string[];
     };
 }


### PR DESCRIPTION
## Changes
This PR adds a `tags` attribute to Tenant entity, API, and Tenant Manager.

![image](https://user-images.githubusercontent.com/3920893/229106298-fed17bb2-a82c-4668-a1a7-8f95e4ed0a42.png)


## How Has This Been Tested?
Jest and manually.

