### PR TITLE
fix: decrease api-migration memorySize

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiMigration.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiMigration.ts
@@ -26,7 +26,7 @@ export const ApiMigration = createAppModule({
                 handler: "handler.handler",
                 timeout: 900,
                 runtime: "nodejs14.x",
-                memorySize: 3072,
+                memorySize: 3008,
                 role: role.output.arn,
                 description: "Performs data migrations.",
                 code: new pulumi.asset.AssetArchive({


### PR DESCRIPTION
## Changes
With this PR we reduce the `memorySize` to `3008` in order to fix error while deploying in case of newly created AWS accounts.

## How Has This Been Tested?
Manually

