### PR TITLE
feat(api-security): without authorization wrapper

### DIFF
--- a/packages/api-security/__tests__/withoutAuthorization.test.ts
+++ b/packages/api-security/__tests__/withoutAuthorization.test.ts
@@ -1,0 +1,114 @@
+import { createSecurity } from "~/createSecurity";
+import { Security, SecurityConfig } from "~/types";
+
+const fullPermissions = {
+    name: "*"
+};
+
+describe("without authorization", function () {
+    let security: Security;
+    const config: SecurityConfig = {
+        storageOperations: {} as any,
+        getTenant: () => {
+            return "root";
+        }
+    };
+
+    beforeEach(async () => {
+        security = await createSecurity(config);
+    });
+
+    it("should disable authorization inside the withoutAuthorization method", async () => {
+        /**
+         * Should not return permission as user does not have it (not defined in this case)
+         */
+        const noPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(noPermissionCheck).toEqual(null);
+        /**
+         * Should return full permission as we are disabling authorization.
+         */
+        const result = await security.withoutAuthorization(async () => {
+            return security.getPermission("some-unknown-permission");
+        });
+
+        expect(result).toEqual(fullPermissions);
+        /**
+         * Should not have permission again.
+         */
+        const noPermissionCheckAfterWithoutAuthorization = await security.getPermission(
+            "some-unknown-permission"
+        );
+        expect(noPermissionCheckAfterWithoutAuthorization).toEqual(null);
+    });
+
+    it("should not enable authorization if it was disabled before the withoutAuthorization method", async () => {
+        security.disableAuthorization();
+        /**
+         * Should have full permission as we are disabling authorization.
+         */
+        const noPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(noPermissionCheck).toEqual(fullPermissions);
+        /**
+         * Should return full permission as we are disabling authorization.
+         */
+        const result = await security.withoutAuthorization(async () => {
+            return security.getPermission("some-unknown-permission");
+        });
+
+        expect(result).toEqual(fullPermissions);
+        /**
+         * Should have full permission as the authorization is not still enabled.
+         */
+        const hasPermissionsCheckAfterWithoutAuthorization = await security.getPermission(
+            "some-unknown-permission"
+        );
+        expect(hasPermissionsCheckAfterWithoutAuthorization).toEqual(fullPermissions);
+        security.enableAuthorization();
+        /**
+         * Should not have permission again.
+         */
+        const noPermissionCheckAfterEnabling = await security.getPermission(
+            "some-unknown-permission"
+        );
+        expect(noPermissionCheckAfterEnabling).toEqual(null);
+    });
+
+    it("should enable authorization if there is an exception in the function - previously enabled authorization", async () => {
+        let error: Error | null = null;
+        let result: any = null;
+        const noPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(noPermissionCheck).toEqual(null);
+        try {
+            result = await security.withoutAuthorization(async () => {
+                throw new Error("Some error");
+            });
+        } catch (ex) {
+            error = ex;
+        }
+        expect(result).toBeNull();
+        expect(error?.message).toEqual("Some error");
+
+        const stillNoPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(stillNoPermissionCheck).toEqual(null);
+    });
+
+    it("should not enable authorization if there is an exception in the function - previously disabled authorization", async () => {
+        let error: Error | null = null;
+        let result: any = null;
+        security.disableAuthorization();
+        const hasPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(hasPermissionCheck).toEqual(fullPermissions);
+        try {
+            result = await security.withoutAuthorization(async () => {
+                throw new Error("Some error");
+            });
+        } catch (ex) {
+            error = ex;
+        }
+        expect(result).toBeNull();
+        expect(error?.message).toEqual("Some error");
+
+        const stillHasPermissionCheck = await security.getPermission("some-unknown-permission");
+        expect(stillHasPermissionCheck).toEqual(fullPermissions);
+    });
+});

--- a/packages/api-security/src/createSecurity.ts
+++ b/packages/api-security/src/createSecurity.ts
@@ -88,8 +88,6 @@ export const createSecurity = async (config: SecurityConfig): Promise<Security> 
             performAuthorization = false;
             try {
                 return await cb();
-            } catch (ex) {
-                throw ex;
             } finally {
                 if (isAuthorizationEnabled) {
                     performAuthorization = true;

--- a/packages/api-security/src/createSecurity.ts
+++ b/packages/api-security/src/createSecurity.ts
@@ -83,6 +83,19 @@ export const createSecurity = async (config: SecurityConfig): Promise<Security> 
             authentication.setIdentity(identity);
             this.onIdentity.publish({ identity });
         },
+        async withoutAuthorization<T = any>(cb: () => Promise<T>): Promise<T> {
+            const isAuthorizationEnabled = performAuthorization;
+            performAuthorization = false;
+            try {
+                return await cb();
+            } catch (ex) {
+                throw ex;
+            } finally {
+                if (isAuthorizationEnabled) {
+                    performAuthorization = true;
+                }
+            }
+        },
         async getPermission<TPermission extends SecurityPermission = SecurityPermission>(
             this: Security,
             permission: string

--- a/packages/api-security/src/types.ts
+++ b/packages/api-security/src/types.ts
@@ -16,6 +16,7 @@ export interface SecurityAuthorizationPlugin extends Plugin {
     type: "security-authorization";
     getPermissions(context: SecurityContext): Promise<SecurityPermission[]>;
 }
+
 // Backwards compatibility - END
 
 export type GetPermission = <T extends SecurityPermission = SecurityPermission>(
@@ -71,6 +72,7 @@ export interface Security<TIdentity = SecurityIdentity> extends Authentication<T
     onAfterLogin: Topic<LoginEvent<TIdentity>>;
     onIdentity: Topic<IdentityEvent<TIdentity>>;
     getStorageOperations(): SecurityStorageOperations;
+    withoutAuthorization<T = any>(cb: () => Promise<T>): Promise<T>;
     enableAuthorization(): void;
     disableAuthorization(): void;
     addAuthorizer(authorizer: Authorizer): void;
@@ -341,10 +343,12 @@ export type StorageOperationsDeleteGroupParams = DeleteGroupParams;
 export type StorageOperationsGetSystemParams = GetSystemParams;
 export type StorageOperationsCreateSystemParams = CreateSystemParams;
 export type StorageOperationsUpdateSystemParams = UpdateSystemParams;
+
 export interface StorageOperationsCreateTenantLinkParams extends CreateTenantLinkParams {
     createdOn: string;
     webinyVersion: string;
 }
+
 export type StorageOperationsUpdateTenantLinkParams = UpdateTenantLinkParams;
 export type StorageOperationsDeleteTenantLinkParams = DeleteTenantLinkParams;
 export type StorageOperationsListTenantLinksParams = ListTenantLinksParams;


### PR DESCRIPTION
## Changes
This PR adds security.withoutAuthorization wrapper so users can disable security checks for blocks of code and be positive that it will not be enabled until the end of that wrapper execution.

## How Has This Been Tested?
Jest.