### PR TITLE
fix(api-headless-cms): graphql plugins loading

### DIFF
--- a/packages/api-headless-cms/__tests__/testHelpers/acceptIncommingChanges.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/acceptIncommingChanges.ts
@@ -1,0 +1,23 @@
+import { Response, GraphQLSchemaPlugin } from "@webiny/handler-graphql";
+import { CmsContext } from "~/types";
+
+export const acceptIncomingChanges = () => {
+    const plugin = new GraphQLSchemaPlugin<CmsContext>({
+        typeDefs: /* GraphQL */ `
+            extend type CmsMutation {
+                acceptIncomingChanges(modelId: String!, entryId: String!): CmsBooleanResponse
+            }
+        `,
+        resolvers: {
+            CmsMutation: {
+                acceptIncomingChanges: async () => {
+                    return new Response(true);
+                }
+            }
+        }
+    });
+
+    plugin.name = "graphql.schema.accept-incomming-changes";
+
+    return plugin;
+};

--- a/packages/api-headless-cms/__tests__/testHelpers/useGraphQLHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useGraphQLHandler.ts
@@ -33,6 +33,7 @@ import {
     SearchContentEntriesVariables
 } from "./graphql/contentEntry";
 import { createHandlerCore, CreateHandlerCoreParams } from "~tests/testHelpers/plugins";
+import { acceptIncomingChanges } from "~tests/testHelpers/acceptIncommingChanges";
 
 export type GraphQLHandlerParams = CreateHandlerCoreParams;
 
@@ -51,7 +52,7 @@ export const useGraphQLHandler = (params: GraphQLHandlerParams = {}) => {
     const core = createHandlerCore(params);
 
     const handler = createHandler({
-        plugins: core.plugins,
+        plugins: core.plugins.concat([acceptIncomingChanges()]),
         http: {
             debug: false
         }

--- a/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
@@ -16,10 +16,9 @@ import { getBaseFieldType } from "~/utils/getBaseFieldType";
 import { getContentModelTitleFieldId } from "./fields/titleField";
 import { getContentModelDescriptionFieldId } from "./fields/descriptionField";
 import { getContentModelImageFieldId } from "./fields/imageField";
-import { CmsGraphQLSchemaSorterPlugin } from "~/plugins";
+import { CmsGraphQLSchemaPlugin, CmsGraphQLSchemaSorterPlugin } from "~/plugins";
 import { buildSchemaPlugins } from "~/graphql/buildSchemaPlugins";
 import { createExecutableSchema } from "~/graphql/createExecutableSchema";
-import { GraphQLSchemaPlugin } from "@webiny/handler-graphql";
 import { generateAlphaNumericId } from "@webiny/utils";
 
 const extractInvalidField = (model: CmsModel, err: GraphQLError) => {
@@ -228,9 +227,10 @@ const createGraphQLSchema = async (params: CreateGraphQLSchemaParams): Promise<a
     });
 
     const plugins = context.plugins
-        .byType<GraphQLSchemaPlugin<CmsContext>>(GraphQLSchemaPlugin.type)
-        .reduce<Record<string, GraphQLSchemaPlugin<CmsContext>>>((collection, plugin) => {
-            const name = plugin.name || `${plugin.type}-${generateAlphaNumericId(16)}`;
+        .byType<CmsGraphQLSchemaPlugin>(CmsGraphQLSchemaPlugin.type)
+        .reduce<Record<string, CmsGraphQLSchemaPlugin>>((collection, plugin) => {
+            const name =
+                plugin.name || `${CmsGraphQLSchemaPlugin.type}-${generateAlphaNumericId(16)}`;
             collection[name] = plugin;
             return collection;
         }, {});

--- a/packages/api-headless-cms/src/graphql/createExecutableSchema.ts
+++ b/packages/api-headless-cms/src/graphql/createExecutableSchema.ts
@@ -1,10 +1,10 @@
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import { GraphQLSchemaPlugin } from "@webiny/handler-graphql";
-import { CmsContext } from "~/types";
+import { CmsGraphQLSchemaPlugin } from "~/plugins";
 
 interface Params {
-    plugins: GraphQLSchemaPlugin<CmsContext>[];
+    plugins: CmsGraphQLSchemaPlugin[];
 }
+
 export const createExecutableSchema = (params: Params) => {
     const { plugins } = params;
     /**


### PR DESCRIPTION
## Changes
This PR fixes wrong plugins being loaded for the model schema validation.

## How Has This Been Tested?
Jest.