### PR TITLE
fix(app-headless-cms): entry container div covers elements below ref field

### DIFF
--- a/packages/app-headless-cms/src/admin/hooks/index.ts
+++ b/packages/app-headless-cms/src/admin/hooks/index.ts
@@ -10,4 +10,4 @@ export { useModelEditor } from "../components/ContentModelEditor";
 export { useModelField } from "../components/ModelFieldProvider";
 export { useModelFieldEditor } from "../components/FieldEditor";
 export * from "./useContentModels";
-export { useContentEntries } from "~/admin/views/contentEntries/hooks/useContentEntries";
+export * from "~/admin/views/contentEntries/hooks";

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
@@ -59,9 +59,11 @@ const Container = styled("div")({
         }
     },
     "&.single-entry": {
-        height: 295,
-        ">div": {
-            height: 270
+        "> .entries": {
+            height: "auto",
+            " > div > div": {
+                position: "relative !important" as any
+            }
         }
     }
 });

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
@@ -18,10 +18,7 @@ import { CmsReferenceValue } from "~/admin/plugins/fieldRenderers/ref/components
 import { Loader } from "./Loader";
 import { NewReferencedEntryDialog } from "~/admin/plugins/fieldRenderers/ref/advanced/components/NewReferencedEntryDialog";
 
-const Container = styled("div")({
-    borderLeft: "3px solid var(--mdc-theme-background)"
-    //paddingLeft: "10px"
-});
+const Container = styled("div")({});
 
 const FieldLabel = styled("h3")({
     fontSize: 24,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entries.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entries.tsx
@@ -8,7 +8,6 @@ import { positionValues as PositionValues } from "react-custom-scrollbars";
 const Container = styled("div")(() => ({
     minWidth: "100%",
     height: "460px",
-    maxHeight: 460,
     backgroundColor: "var(--mdc-theme-background)",
     boxSizing: "border-box",
     display: "flex",
@@ -47,7 +46,7 @@ export const Entries: React.VFC<Props> = props => {
         return null;
     }
     return (
-        <Container>
+        <Container className={"entries"}>
             <Scrollbar data-testid="advanced-ref-field-entries" onScrollFrame={loadMoreOnScroll}>
                 {entries.map((entry, index) => {
                     return (

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelList.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelList.tsx
@@ -17,7 +17,7 @@ const Container = styled("span")({
 });
 const ModelsContainer = styled(Elevation)({
     position: "absolute",
-    zIndex: 1,
+    zIndex: 2,
     top: "40px",
     left: 0,
     width: "215px",

--- a/packages/app-headless-cms/src/admin/views/contentEntries/hooks/index.ts
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from "./useContentEntries";
+export * from "./useContentEntriesList";
+export * from "./useContentEntry";


### PR DESCRIPTION
## Changes
PR fixes entry container div, in the detailed reference field, which gets over the next fields in the CMS Entry Editor.

## How Has This Been Tested?
Manually.