### PR TITLE
fix(app-admin): file manager overlay z-index

### DIFF
--- a/packages/app-admin/src/components/OverlayLayout/OverlayLayout.tsx
+++ b/packages/app-admin/src/components/OverlayLayout/OverlayLayout.tsx
@@ -19,7 +19,7 @@ const OverlayLayoutWrapper = styled("div")({
      * Has to be higher than 5 so it's above advanced settings dialog,
      * and below 20, so the image editor & Dialogs can be displayed above.
      */
-    zIndex: 18,
+    zIndex: 21,
     paddingTop: 65,
     top: 0,
     left: 0

--- a/packages/app-admin/src/ui/views/OverlayView.tsx
+++ b/packages/app-admin/src/ui/views/OverlayView.tsx
@@ -18,7 +18,7 @@ const OverlayLayoutWrapper = styled("div")({
      * Has to be higher than 5 so it's above advanced settings dialog,
      * and below 20, so the image editor & Dialogs can be displayed above.
      */
-    zIndex: 18,
+    zIndex: 21,
     top: 0,
     left: 0
 });


### PR DESCRIPTION
## Changes
This PR fixes a overlay z-index issues where the File Manager is displayed below the new entry dialog in the reference field.

## How Has This Been Tested?
Manually.