### PR TITLE
refactor(api-page-builder): page validation

### DIFF
--- a/packages/api-page-builder/src/graphql/crud/pages/validation.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/validation.ts
@@ -1,93 +1,97 @@
 import normalizePath from "./normalizePath";
 import zod from "zod";
 
+export const createPageValidation = zod.object({
+    category: zod.string().max(500)
+});
+
 export const createPageCreateValidation = () => {
-    return zod.object({
-        category: zod.string().max(100)
-    });
+    return createPageValidation;
 };
 
-export const createPageUpdateValidation = () => {
-    return zod
-        .object({
-            title: zod.string().max(150),
-            path: zod
-                .string()
-                .min(2)
-                .max(100)
-                .nullish()
-                .transform(value => {
-                    if (!value) {
-                        return undefined;
-                    }
-                    return normalizePath(value);
-                }),
-            category: zod.string().max(100),
-            /**
-             * We need to allow everything through the content object.
-             */
-            settings: createPageSettingsUpdateValidation(),
-            content: zod
-                .union([zod.object({}).passthrough(), zod.array(zod.object({}).passthrough())])
-                .optional()
-                .nullish()
-        })
-        .partial();
-};
-
-export const createPageSettingsUpdateValidation = () => {
-    return zod
-        .object({
-            general: zod
-                .object({
-                    tags: zod
-                        .array(zod.string().max(50))
-                        .max(30, "Cannot store more than 30 tags."),
-                    snippet: zod.string().max(500),
-                    layout: zod.string().max(50),
-                    image: zod
-                        .object({
-                            id: zod.string(),
-                            src: zod.string()
-                        })
-                        .passthrough()
-                })
-                .partial(),
-            seo: zod.object({
-                title: zod.string().max(500).optional().nullish(),
-                description: zod.string().max(500).optional().nullish(),
-                meta: zod
-                    .array(
-                        zod.object({
-                            name: zod.string().max(100),
-                            content: zod.string().max(200)
-                        })
-                    )
-                    .max(30, "Cannot store more than 30 SEO tags.")
-                    .default([])
-            }),
-            social: zod.object({
-                title: zod.string().max(500).optional().nullish(),
-                description: zod.string().max(500).optional().nullish(),
-                meta: zod
-                    .array(
-                        zod.object({
-                            property: zod.string().max(100),
-                            content: zod.string().max(200)
-                        })
-                    )
-                    .max(30, "Cannot store more than 30 social tags.")
-                    .default([]),
+export const updatePageSettingsValidation = zod
+    .object({
+        general: zod
+            .object({
+                tags: zod.array(zod.string().max(50)).max(30, "Cannot store more than 30 tags."),
+                snippet: zod.string().max(500),
+                layout: zod.string().max(50),
                 image: zod
                     .object({
                         id: zod.string(),
                         src: zod.string()
                     })
                     .passthrough()
-                    .optional()
-                    .nullish()
             })
+            .partial(),
+        seo: zod.object({
+            title: zod.string().max(500).optional().nullish(),
+            description: zod.string().max(500).optional().nullish(),
+            meta: zod
+                .array(
+                    zod.object({
+                        name: zod.string().max(100),
+                        content: zod.string().max(200)
+                    })
+                )
+                .max(30, "Cannot store more than 30 SEO tags.")
+                .default([])
+        }),
+        social: zod.object({
+            title: zod.string().max(500).optional().nullish(),
+            description: zod.string().max(500).optional().nullish(),
+            meta: zod
+                .array(
+                    zod.object({
+                        property: zod.string().max(100),
+                        content: zod.string().max(200)
+                    })
+                )
+                .max(30, "Cannot store more than 30 social tags.")
+                .default([]),
+            image: zod
+                .object({
+                    id: zod.string(),
+                    src: zod.string()
+                })
+                .passthrough()
+                .optional()
+                .nullish()
         })
-        .passthrough()
-        .partial();
+    })
+    .passthrough()
+    .partial();
+
+export const updatePageValidation = zod
+    .object({
+        title: zod.string().max(150),
+        path: zod
+            .string()
+            .min(2)
+            .max(500)
+            .nullish()
+            .transform(value => {
+                if (!value) {
+                    return undefined;
+                }
+                return normalizePath(value);
+            }),
+        category: zod.string().max(500),
+        /**
+         * We need to allow everything through the content object.
+         */
+        settings: updatePageSettingsValidation,
+        content: zod
+            .union([zod.object({}).passthrough(), zod.array(zod.object({}).passthrough())])
+            .optional()
+            .nullish()
+    })
+    .partial();
+
+export const createPageUpdateValidation = () => {
+    return updatePageValidation;
+};
+
+export const createPageSettingsUpdateValidation = () => {
+    return updatePageSettingsValidation;
 };

--- a/packages/api-page-builder/src/graphql/crud/pages/validation.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/validation.ts
@@ -64,7 +64,7 @@ export const updatePageSettingsValidation = zod
 
 export const updatePageValidation = zod
     .object({
-        title: zod.string().max(150),
+        title: zod.string().max(500),
         path: zod
             .string()
             .min(2)

--- a/packages/api-page-builder/src/plugins/PageBuilderPageValidationModifierPlugin.ts
+++ b/packages/api-page-builder/src/plugins/PageBuilderPageValidationModifierPlugin.ts
@@ -1,0 +1,39 @@
+import zod from "zod";
+import { Plugin } from "@webiny/plugins";
+import {
+    createPageValidation,
+    updatePageValidation,
+    updatePageSettingsValidation
+} from "~/graphql/crud/pages/validation";
+
+export interface PageBuilderPageValidationModifierPluginParams {
+    onCreate?: (
+        schema: typeof createPageValidation
+    ) => zod.infer<typeof createPageValidation & zod.Schema>;
+    onUpdate?: (
+        schema: typeof updatePageValidation
+    ) => zod.infer<typeof updatePageValidation & zod.Schema>;
+    onSettings?: (
+        schema: typeof updatePageSettingsValidation
+    ) => zod.infer<typeof updatePageSettingsValidation & zod.Schema>;
+}
+
+/**
+ * Undocumented plugin - internal use only.
+ */
+export class PageBuilderPageValidationModifierPlugin extends Plugin {
+    public static override readonly type: string = "pb.page.validation.modifier";
+
+    private readonly options: PageBuilderPageValidationModifierPluginParams;
+
+    public constructor(options: PageBuilderPageValidationModifierPluginParams) {
+        super();
+        this.options = options;
+    }
+}
+
+export const createPageBuilderPageValidationModifierPluginParams = (
+    options: PageBuilderPageValidationModifierPluginParams
+) => {
+    return new PageBuilderPageValidationModifierPlugin(options);
+};

--- a/packages/api-page-builder/src/plugins/index.ts
+++ b/packages/api-page-builder/src/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from "./ContentCompressionPlugin";
 export * from "./JsonpackContentCompressionPlugin";
+export * from "./PageBuilderPageValidationModifierPlugin";


### PR DESCRIPTION
## Changes
This PR changes the max lenght in validation of category and page path and sets it to 500 characters.

## How Has This Been Tested?
Jest.