### PR TITLE
fix: various aco 

### DIFF
--- a/packages/api-page-builder-aco/__tests__/mocks/page.mocks.ts
+++ b/packages/api-page-builder-aco/__tests__/mocks/page.mocks.ts
@@ -150,7 +150,7 @@ export const pageLegacyContentMock = {
                                                 tag: "p"
                                             },
                                             data: {
-                                                text: "Demo Content"
+                                                text: "Demo Content with multiple    spaces and \n new line"
                                             }
                                         },
                                         settings: {
@@ -425,7 +425,7 @@ export const pageContentMock = {
                                                 tag: "p"
                                             },
                                             data: {
-                                                text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Demo Content","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+                                                text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Demo Content with multiple    spaces and \\n new line","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
                                             }
                                         },
                                         settings: {

--- a/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
+++ b/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
@@ -130,7 +130,7 @@ describe("Pages -> Search records", () => {
         expect(searchRecord).toMatchObject({
             id: pid,
             title: updatePage.title,
-            content: `${updatePage.title} Demo Heading Demo Content Demo button Demo Image 1 Demo Image 2 Demo Image 3`,
+            content: `${updatePage.title} Demo Heading Demo Content with multiple spaces and new line Demo button Demo Image 1 Demo Image 2 Demo Image 3`,
             data: {
                 title: updatePage.title,
                 savedOn: updatePage.savedOn
@@ -160,7 +160,7 @@ describe("Pages -> Search records", () => {
         expect(searchRecord).toMatchObject({
             id: pid,
             title: updatePage.title,
-            content: `${updatePage.title} Demo Heading Demo Content Demo button Demo Image 1 Demo Image 2 Demo Image 3`,
+            content: `${updatePage.title} Demo Heading Demo Content with multiple spaces and new line Demo button Demo Image 1 Demo Image 2 Demo Image 3`,
             data: {
                 title: updatePage.title,
                 savedOn: updatePage.savedOn

--- a/packages/api-page-builder-aco/src/page/hooks/onPageAfterCreateFrom.hook.ts
+++ b/packages/api-page-builder-aco/src/page/hooks/onPageAfterCreateFrom.hook.ts
@@ -11,13 +11,9 @@ export const onPageAfterCreateFromHook = (context: PbAcoContext) => {
      * Intercept page revision creation and update the related record.
      * Here we perform an update since all the page revisions are related to the same search record entry.
      */
-    pageBuilder.onPageAfterCreateFrom.subscribe(async ({ original, page }) => {
+    pageBuilder.onPageAfterCreateFrom.subscribe(async ({ page }) => {
         try {
-            const { location } = await aco.search.get<PbPageRecordData>(original.pid);
-
-            const payload = await updatePageRecordPayload(context, page, {
-                location
-            });
+            const payload = await updatePageRecordPayload(context, page);
             await aco.search.update<PbPageRecordData>(page.pid, payload);
         } catch (error) {
             throw WebinyError.from(error, {

--- a/packages/api-page-builder-aco/src/page/hooks/onPageAfterUpdate.hook.ts
+++ b/packages/api-page-builder-aco/src/page/hooks/onPageAfterUpdate.hook.ts
@@ -10,9 +10,9 @@ export const onPageAfterUpdateHook = (context: PbAcoContext) => {
     /**
      * Intercept page update event and update the related search record.
      */
-    pageBuilder.onPageAfterUpdate.subscribe(async ({ page, meta }) => {
+    pageBuilder.onPageAfterUpdate.subscribe(async ({ page }) => {
         try {
-            const payload = await updatePageRecordPayload(context, page, meta);
+            const payload = await updatePageRecordPayload(context, page);
             await aco.search.update<PbPageRecordData>(page.pid, payload);
         } catch (error) {
             throw WebinyError.from(error, {

--- a/packages/api-page-builder-aco/src/page/processors/paragraph.ts
+++ b/packages/api-page-builder-aco/src/page/processors/paragraph.ts
@@ -15,9 +15,11 @@ export const paragraphProcessor = (context: PbAcoContext) => {
         const value = get(element, "data.text.data.text");
         // Get text from Lexical Editor JSON string.
         const text = getLexicalContentText(value);
-        // Remove any HTML tag
-        const regex = /(<([^>]+)>)/gi;
 
-        return text.replace(regex, "").trim();
+        return text
+            .replace(/(<([^>]+)>)/gi, "") // Remove any HTML tag
+            .replace(/(\n)|(\r)|(\r\n)/gi, "") // Remove any new line char
+            .replace(/([ ]{2,})/gi, " ") // Replace multiple spaces with one space only
+            .trim();
     });
 };

--- a/packages/api-page-builder-aco/src/utils/createRecordPayload.ts
+++ b/packages/api-page-builder-aco/src/utils/createRecordPayload.ts
@@ -41,8 +41,7 @@ export const createPageRecordPayload = async (
 
 export const updatePageRecordPayload = async (
     context: PbAcoContext,
-    page: Page,
-    meta?: Record<string, any>
+    page: Page
 ): Promise<UpdateSearchRecordParams<PbPageRecordData>> => {
     const { id, pid, title, createdOn, createdBy, savedOn, status, version, locked, path } = page;
     const content = await context.pageBuilderAco.getSearchablePageContent(page);
@@ -61,7 +60,6 @@ export const updatePageRecordPayload = async (
             version,
             locked,
             path
-        },
-        ...(meta && { ...meta })
+        }
     };
 };

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -523,7 +523,7 @@ export const createPageCrud = (params: CreatePageCrudParams): PagesCrud => {
             }
         },
 
-        async updatePage(id, input, meta): Promise<any> {
+        async updatePage(id, input): Promise<any> {
             const permission = await checkBasePermissions(context, PERMISSION_NAME, {
                 rwd: "w"
             });
@@ -581,8 +581,7 @@ export const createPageCrud = (params: CreatePageCrudParams): PagesCrud => {
                 await onPageBeforeUpdate.publish({
                     original,
                     page,
-                    input,
-                    meta
+                    input
                 });
 
                 const result = await storageOperations.pages.update({
@@ -594,8 +593,7 @@ export const createPageCrud = (params: CreatePageCrudParams): PagesCrud => {
                 await onPageAfterUpdate.publish({
                     original,
                     page: result,
-                    input,
-                    meta
+                    input
                 });
 
                 /**

--- a/packages/api-page-builder/src/graphql/graphql/pages.gql.ts
+++ b/packages/api-page-builder/src/graphql/graphql/pages.gql.ts
@@ -238,7 +238,7 @@ const createBasePageGraphQL = (): GraphQLSchemaPlugin<PbContext> => {
                     createPage(from: ID, category: String, meta: JSON): PbPageResponse
 
                     # Update page by given ID.
-                    updatePage(id: ID!, data: PbUpdatePageInput!, meta: JSON): PbPageResponse
+                    updatePage(id: ID!, data: PbUpdatePageInput!): PbPageResponse
 
                     # Duplicate page by given ID.
                     duplicatePage(id: ID!): PbPageResponse

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -85,7 +85,6 @@ export interface OnPageBeforeUpdateTopicParams<TPage extends Page = Page> {
     original: TPage;
     page: TPage;
     input: Record<string, any>;
-    meta?: Record<string, any>;
 }
 /**
  * @category Lifecycle events
@@ -94,7 +93,6 @@ export interface OnPageAfterUpdateTopicParams<TPage extends Page = Page> {
     original: TPage;
     page: TPage;
     input: Record<string, any>;
-    meta?: Record<string, any>;
 }
 /**
  * @category Lifecycle events
@@ -213,11 +211,7 @@ export interface PagesCrud {
         page: string,
         meta?: Record<string, any>
     ): Promise<TPage>;
-    updatePage<TPage extends Page = Page>(
-        id: string,
-        data: PbUpdatePageInput,
-        meta?: Record<string, any>
-    ): Promise<TPage>;
+    updatePage<TPage extends Page = Page>(id: string, data: PbUpdatePageInput): Promise<TPage>;
     deletePage<TPage extends Page = Page>(id: string): Promise<[TPage, TPage]>;
     publishPage<TPage extends Page = Page>(id: string): Promise<TPage>;
     unpublishPage<TPage extends Page = Page>(id: string): Promise<TPage>;


### PR DESCRIPTION
## Changes
With this PR we fix a couple of minor bugs: 
- While updating a page/aco record we are creating an empty `meta` property.
- We don't need to have `meta` param on `updatePage` storage operation: this is useful to set page location (aka `folderId`) on page creation.
- Remove new lines (`\n`) and multiple spaces while we create or update a search record `content`.

## How Has This Been Tested?
Jest