### PR TITLE
Upgrade Theme Code (Use Theme via Newly Introduced Emotion Context)

### DIFF
--- a/apps/theme/layouts/forms/DefaultFormLayout.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout.tsx
@@ -10,13 +10,11 @@ import { SubmitButton } from "./DefaultFormLayout/SubmitButton";
 import { TermsOfServiceSection } from "./DefaultFormLayout/TermsOfServiceSection";
 import { ReCaptchaSection } from "./DefaultFormLayout/ReCaptchaSection";
 
-import theme from "../../theme";
-
 const Wrapper = styled.div`
     width: 100%;
     padding: 0 5px 5px 5px;
     box-sizing: border-box;
-    background-color: ${theme.styles.colors["color6"]};
+    background-color: ${props => props.theme.styles.colors["color6"]};
 `;
 
 /**

--- a/apps/theme/layouts/forms/DefaultFormLayout/Cell.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/Cell.tsx
@@ -1,12 +1,11 @@
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 export const Cell = styled.div`
   width: 100%;
-  background-color: ${theme.styles.colors["color6"]};
+  background-color: ${props => props.theme.styles.colors["color6"]};
   padding: 15px;
 
-  ${theme.breakpoints["desktop"]} {
+  ${props => props.theme.breakpoints["desktop"]} {
     &:first-of-type {
       padding-left: 0;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/Row.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/Row.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 export const Row = styled.div`
     display: flex;
     width: 100%;
     padding: 0;
-    background-color: ${theme.styles.colors["color6"]};
+    background-color: ${props => props.theme.styles.colors["color6"]};
 `;

--- a/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { FormRenderPropParamsSubmit } from "@webiny/form";
 import styled from "@emotion/styled";
-import theme from "./../../../theme";
 
 export const Wrapper = styled.div<{ fullWidth: boolean }>`
-    ${theme.styles.elements.button.primary}
+    ${props => props.theme.styles.elements["button"]["primary"]}
     .button-body {
         width: ${props => (props.fullWidth ? "100%" : "auto")};
         margin-left: auto;
+
         &:disabled {
             opacity: 0.5;
         }
     }
-]);
 `;
 
 interface Props {

--- a/apps/theme/layouts/forms/DefaultFormLayout/SuccessMessage.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/SuccessMessage.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { FbFormModel } from "@webiny/app-form-builder/types";
 import { RichTextRenderer } from "@webiny/react-rich-text-renderer";
 import styled from "@emotion/styled";
-import theme from "./../../../theme";
 
 const DEFAULT_MESSAGE = "Thank you for your submission!";
 
@@ -28,8 +27,8 @@ const CheckmarkIcon = styled(({ className }: { className?: string }) => (
     height: 100px;
 `;
 
-const Heading = styled.div(theme.styles.typography["heading1"]);
-const Message = styled.div(theme.styles.typography["paragraph1"]);
+const Heading = styled.div(props => props.theme.styles.typography["heading1"]);
+const Message = styled.div(props => props.theme.styles.typography["paragraph1"]);
 
 const Wrapper = styled.div`
     width: 100%;

--- a/apps/theme/layouts/forms/DefaultFormLayout/TermsOfServiceSection.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/TermsOfServiceSection.tsx
@@ -13,7 +13,6 @@ import {
     TermsOfServiceChildrenFunction
 } from "@webiny/app-page-builder-elements/renderers/form/types";
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 interface Props {
     component: TermsOfServiceComponent;
@@ -21,7 +20,7 @@ interface Props {
 
 const RteFieldLabel = styled(FieldLabelStyled)`
     .rte-block-paragraph {
-        ${theme.styles.typography["paragraph1"]};
+        ${props => props.theme.styles.typography["paragraph1"]};
         margin: 0;
     }
 `;

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
@@ -7,7 +7,6 @@ import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { StyledInput } from "./Input";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 export const CheckboxGroup = styled.div`
     align-items: center;
@@ -18,15 +17,15 @@ export const CheckboxGroup = styled.div`
 
 export const CheckboxButton = styled.input`
     margin-left: 0;
-    background-color: ${theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     min-width: 25px;
     width: 25px;
     height: 25px;
     -webkit-appearance: none;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
@@ -115,7 +115,7 @@ export const CheckboxField: React.FC<CheckboxProps> = ({ field }) => {
                     <label htmlFor={"checkbox-" + fieldId + option.value}>{option.label}</label>
                 </CheckboxGroup>
             ))}
-            {field.settings.otherOption && (
+            {field.settings["otherOption"] && (
                 <CheckboxGroup>
                     <CheckboxButton
                         name={fieldId}

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Input.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Input.tsx
@@ -7,7 +7,6 @@ import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { Field } from "./components/Field";
-import theme from "../../../../theme";
 
 interface InputProps {
     field: FormRenderFbFormModelField;
@@ -15,17 +14,17 @@ interface InputProps {
 }
 
 export const StyledInput = styled.input`
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    ${theme.styles.typography["paragraph1"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
@@ -7,7 +7,6 @@ import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { StyledInput } from "./Input";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 interface RadioProps {
     field: FormRenderFbFormModelField;
@@ -23,7 +22,7 @@ const RadioGroup = styled.div`
 const RadioButton = styled.input`
     margin-left: 0;
     line-height: 100%;
-    background-color: ${theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     min-width: 25px;
     width: 25px;
     height: 25px;
@@ -31,7 +30,7 @@ const RadioButton = styled.input`
     -webkit-appearance: none;
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
@@ -86,7 +86,7 @@ export const RadioField: React.FC<RadioProps> = ({ field }) => {
                     </RadioGroup>
                 );
             })}
-            {field.settings.otherOption && (
+            {field.settings["otherOption"] && (
                 <RadioGroup>
                     <RadioButton
                         name={fieldId}

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Select.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Select.tsx
@@ -6,19 +6,18 @@ import { Field } from "./components/Field";
 import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
-import theme from "../../../../theme";
 
 interface SelectProps {
     field: FormRenderFbFormModelField;
 }
 
 const StyledSelect = styled.select`
-    ${theme.styles.typography["paragraph1"]};
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     height: 40px;
@@ -29,7 +28,7 @@ const StyledSelect = styled.select`
     background-position: center right;
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/Textarea.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/Textarea.tsx
@@ -6,24 +6,23 @@ import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 interface TextareaProps {
     field: FormRenderFbFormModelField;
 }
 
 const StyledTextarea = styled.textarea`
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    ${theme.styles.typography["paragraph1"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/components/Field.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/components/Field.tsx
@@ -1,9 +1,7 @@
 import styled from "@emotion/styled";
-import theme from "../../../../../theme";
 
 export const Field = styled.div`
     width: 100%;
     box-sizing: border-box;
-    ${theme.styles.typography["paragraph1"]};
-    background-color: var(--webiny-theme-color-surface, #ffffff);
+    ${props => props.theme.styles.typography["paragraph1"]};
 `;

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldErrorMessage.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldErrorMessage.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import theme from "../../../../../theme";
 
 const Wrapper = styled.div`
-  margin-left: 2px;
-  margin-top: 5px;
-  ${theme.styles.typography.paragraph2};
-  color: ${theme.styles.colors.color1};
+    margin-left: 2px;
+    margin-top: 5px;
+    ${props => props.theme.styles.typography["paragraph2"]};
+    color: ${props => props.theme.styles.colors["color1"]};
 
-  ${theme.breakpoints["mobile-landscape"]} {
-    text-align: left !important;
-  }
-}
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
+        text-align: left !important;
+    }
 `;
 
 interface FieldErrorMessageProps {

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
@@ -1,15 +1,13 @@
 import styled from "@emotion/styled";
-import theme from "../../../../../theme";
 
 export const FieldHelperMessage = styled.div`
-  margin-left: 2px;
-  margin-top: -5px;
-  margin-bottom: 5px;
-  ${theme.styles.typography.paragraph2};
-  color: ${theme.styles.colors.color2};
+    margin-left: 2px;
+    margin-top: -5px;
+    margin-bottom: 5px;
+    ${props => props.theme.styles.typography["paragraph2"]};
+    color: ${props => props.theme.styles.colors["color2"]};
 
-  ${theme.breakpoints["mobile-landscape"]} {
-    text-align: left !important;
-  }
-}
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
+        text-align: left !important;
+    }
 `;

--- a/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldLabel.tsx
+++ b/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldLabel.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
 import styled from "@emotion/styled";
 import { FormRenderFbFormModelField } from "@webiny/app-form-builder/types";
-import theme from "../../../../../theme";
 
 export const FieldLabelStyled = styled.label`
     width: 100%;
     display: inline-block;
     margin: 0 0 5px 1px;
-    ${theme.breakpoints["mobile-landscape"]} {
+
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
         text-align: left !important;
     }
 
     .asterisk {
         margin-left: 5px;
-        color: ${theme.styles.colors.color1};
+        color: ${props => props.theme.styles.colors["color1"]};
     }
 `;
 

--- a/apps/theme/layouts/pages/Static/Footer.tsx
+++ b/apps/theme/layouts/pages/Static/Footer.tsx
@@ -57,7 +57,7 @@ const FooterBody = styled.div`
     margin: 0 auto;
     max-width: 1200px;
 
-    ${props => props.theme.breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         flex-direction: column;
     }
 `;

--- a/apps/theme/layouts/pages/Static/Footer.tsx
+++ b/apps/theme/layouts/pages/Static/Footer.tsx
@@ -4,7 +4,6 @@ import { ReactComponent as FacebookIcon } from "./assets/facebook-square-brands.
 import { ReactComponent as TwitterIcon } from "./assets/twitter-square-brands.svg";
 import { ReactComponent as InstagramIcon } from "./assets/instagram-brands.svg";
 import styled from "@emotion/styled";
-import { breakpoints, colors, typography } from "../../../theme";
 import { usePage } from "@webiny/app-page-builder-elements";
 
 export const Footer: React.FC = () => {
@@ -45,7 +44,7 @@ export const Footer: React.FC = () => {
 };
 
 const FooterWrapper = styled.footer`
-    background-color: ${colors.color5};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     height: 100px;
 `;
 
@@ -58,7 +57,7 @@ const FooterBody = styled.div`
     margin: 0 auto;
     max-width: 1200px;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints.tablet} {
         flex-direction: column;
     }
 `;
@@ -78,15 +77,15 @@ const FooterLogo = styled.div`
     }
 
     .copy {
-        ${typography.paragraph2}
-        color: ${colors.color4}
+        ${props => props.theme.styles.typography["paragraph2"]}
+        color: ${props => props.theme.styles.colors["color4"]}
     }
 `;
 
 const FooterSocial = styled.div`
     text-align: right;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         margin-bottom: 15px;
     }
 
@@ -98,7 +97,7 @@ const FooterSocial = styled.div`
             margin-left: 10px;
             opacity: 0.6;
             transition: opacity 0.3s;
-            color: ${colors.color4};
+            color: ${props => props.theme.styles.colors["color4"]};
 
             &:hover {
                 opacity: 1;

--- a/apps/theme/layouts/pages/Static/Header.tsx
+++ b/apps/theme/layouts/pages/Static/Header.tsx
@@ -3,8 +3,6 @@ import { HeaderDesktop } from "./HeaderDesktop";
 import { HeaderMobile } from "./HeaderMobile";
 import styled from "@emotion/styled";
 
-import { colors, typography } from "../../../theme";
-
 export const Header: React.FC = () => {
     return (
         <HeaderWrapper data-testid={"pb-desktop-mobile-headers"}>
@@ -26,8 +24,8 @@ const HeaderWrapper = styled.header`
     top: 0;
 
     a {
-        ${typography.paragraph1}
-        color: ${colors.color1};
+        ${props => props.theme.styles.typography["paragraph1"]}
+        color: ${props => props.theme.styles.colors["color1"]};
         text-decoration: none;
     }
 `;

--- a/apps/theme/layouts/pages/Static/HeaderDesktop.tsx
+++ b/apps/theme/layouts/pages/Static/HeaderDesktop.tsx
@@ -3,7 +3,6 @@ import { Link } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { usePage } from "@webiny/app-page-builder-elements";
 import { Menu } from "@webiny/app-website";
-import { fonts, breakpoints } from "../../../theme";
 import { Navigation } from "./Navigation";
 
 export const HeaderDesktop: React.FC = () => {
@@ -34,7 +33,7 @@ const HeaderDesktopWrapper = styled.div`
     margin: 0 auto;
     max-width: 1200px;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         display: none;
     }
 
@@ -48,6 +47,5 @@ const HeaderDesktopWrapper = styled.div`
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         flex: 1;
-        font-family: ${fonts.font1};
     }
 `;

--- a/apps/theme/layouts/pages/Static/HeaderMobile.tsx
+++ b/apps/theme/layouts/pages/Static/HeaderMobile.tsx
@@ -7,7 +7,6 @@ import { Menu, GET_PUBLIC_MENU, hasMenuItems } from "@webiny/app-website";
 import { ClassNames } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Navigation } from "./Navigation";
-import { colors, fonts, breakpoints } from "../../../theme";
 
 export const HeaderMobile: React.FC = () => {
     const { data } = useQuery(GET_PUBLIC_MENU, { variables: { slug: "main-menu" } });
@@ -79,7 +78,7 @@ const HeaderMobileWrapper = styled.div`
         }
     }
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         align-items: center;
         display: flex;
         height: 35px;
@@ -88,7 +87,7 @@ const HeaderMobileWrapper = styled.div`
         max-width: 1200px;
 
         > .logo {
-            ${breakpoints.tablet} {
+            ${props => props.theme.breakpoints["tablet"]} {
                 margin-left: 25px;
                 width: 50%;
             }
@@ -103,9 +102,8 @@ const HeaderMobileWrapper = styled.div`
             -webkit-font-smoothing: antialiased;
             animation: slide-out 0.5s forwards;
             animation-timing-function: ease-in-out;
-            background: ${colors.color5};
-            color: ${colors.color1};
-            font-family: ${fonts.font1};
+            background: ${props => props.theme.styles.colors["color5"]};
+            color: ${props => props.theme.styles.colors["color1"]};
             height: 100%;
             position: fixed;
             right: 0;
@@ -142,7 +140,6 @@ const HeaderMobileWrapper = styled.div`
         }
 
         .mobile-overlay {
-            background-color: var(--webiny-theme-color-on-background, #131313);
             opacity: 0;
             transition: opacity 0.25s ease-in-out;
 

--- a/apps/theme/layouts/pages/Static/Navigation.tsx
+++ b/apps/theme/layouts/pages/Static/Navigation.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Link } from "@webiny/react-router";
 import { PublishedMenuData } from "@webiny/app-website/";
 import styled from "@emotion/styled";
-import { colors, borderRadius, breakpoints } from "../../../theme";
 
 export const Navigation: React.ComponentType<{ data?: PublishedMenuData }> = ({ data }) => {
     if (!data) {
@@ -55,12 +54,12 @@ const NavigationUl = styled.ul`
         transition: background-color 0.2s;
 
         &:hover {
-            background-color: ${colors.color5};
-            border-radius: ${borderRadius};
+            background-color: ${props => props.theme.styles.colors["color5"]};
+            border-radius: ${props => props.theme.styles.borderRadius};
         }
     }
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         display: block;
         margin: 75px 0 0 35px;
         text-transform: uppercase;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout.tsx
@@ -10,13 +10,11 @@ import { SubmitButton } from "./DefaultFormLayout/SubmitButton";
 import { TermsOfServiceSection } from "./DefaultFormLayout/TermsOfServiceSection";
 import { ReCaptchaSection } from "./DefaultFormLayout/ReCaptchaSection";
 
-import theme from "../../theme";
-
 const Wrapper = styled.div`
     width: 100%;
     padding: 0 5px 5px 5px;
     box-sizing: border-box;
-    background-color: ${theme.styles.colors["color6"]};
+    background-color: ${props => props.theme.styles.colors["color6"]};
 `;
 
 /**

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/Cell.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/Cell.tsx
@@ -1,12 +1,11 @@
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 export const Cell = styled.div`
   width: 100%;
-  background-color: ${theme.styles.colors["color6"]};
+  background-color: ${props => props.theme.styles.colors["color6"]};
   padding: 15px;
 
-  ${theme.breakpoints["desktop"]} {
+  ${props => props.theme.breakpoints["desktop"]} {
     &:first-of-type {
       padding-left: 0;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/Row.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/Row.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 export const Row = styled.div`
     display: flex;
     width: 100%;
     padding: 0;
-    background-color: ${theme.styles.colors["color6"]};
+    background-color: ${props => props.theme.styles.colors["color6"]};
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
@@ -3,15 +3,15 @@ import { FormRenderPropParamsSubmit } from "@webiny/form";
 import styled from "@emotion/styled";
 
 export const Wrapper = styled.div<{ fullWidth: boolean }>`
-  ${props => props.theme.styles.elements["button"]["primary"]}
-  .button-body {
-    width: ${props => (props.fullWidth ? "100%" : "auto")};
-    margin-left: auto;
+    ${props => props.theme.styles.elements["button"]["primary"]}
+    .button-body {
+        width: ${props => (props.fullWidth ? "100%" : "auto")};
+        margin-left: auto;
 
-    &:disabled {
-      opacity: 0.5;
+        &:disabled {
+            opacity: 0.5;
+        }
     }
-  }
 `;
 
 interface Props {

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SubmitButton.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { FormRenderPropParamsSubmit } from "@webiny/form";
 import styled from "@emotion/styled";
-import theme from "./../../../theme";
 
 export const Wrapper = styled.div<{ fullWidth: boolean }>`
-    ${theme.styles.elements["button"]["primary"]}
-    .button-body {
-        width: ${props => (props.fullWidth ? "100%" : "auto")};
-        margin-left: auto;
-        &:disabled {
-            opacity: 0.5;
-        }
+  ${props => props.theme.styles.elements["button"]["primary"]}
+  .button-body {
+    width: ${props => (props.fullWidth ? "100%" : "auto")};
+    margin-left: auto;
+
+    &:disabled {
+      opacity: 0.5;
     }
-]);
+  }
 `;
 
 interface Props {

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SuccessMessage.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/SuccessMessage.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { FbFormModel } from "@webiny/app-form-builder/types";
 import { RichTextRenderer } from "@webiny/react-rich-text-renderer";
 import styled from "@emotion/styled";
-import theme from "./../../../theme";
 
 const DEFAULT_MESSAGE = "Thank you for your submission!";
 
@@ -28,8 +27,8 @@ const CheckmarkIcon = styled(({ className }: { className?: string }) => (
     height: 100px;
 `;
 
-const Heading = styled.div(theme.styles.typography["heading1"]);
-const Message = styled.div(theme.styles.typography["paragraph1"]);
+const Heading = styled.div(props => props.theme.styles.typography["heading1"]);
+const Message = styled.div(props => props.theme.styles.typography["paragraph1"]);
 
 const Wrapper = styled.div`
     width: 100%;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/TermsOfServiceSection.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/TermsOfServiceSection.tsx
@@ -13,7 +13,6 @@ import {
     TermsOfServiceChildrenFunction
 } from "@webiny/app-page-builder-elements/renderers/form/types";
 import styled from "@emotion/styled";
-import theme from "../../../theme";
 
 interface Props {
     component: TermsOfServiceComponent;
@@ -21,7 +20,7 @@ interface Props {
 
 const RteFieldLabel = styled(FieldLabelStyled)`
     .rte-block-paragraph {
-        ${theme.styles.typography["paragraph1"]};
+        ${props => props.theme.styles.typography["paragraph1"]};
         margin: 0;
     }
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Checkbox.tsx
@@ -7,7 +7,6 @@ import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { StyledInput } from "./Input";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 export const CheckboxGroup = styled.div`
     align-items: center;
@@ -18,15 +17,15 @@ export const CheckboxGroup = styled.div`
 
 export const CheckboxButton = styled.input`
     margin-left: 0;
-    background-color: ${theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     min-width: 25px;
     width: 25px;
     height: 25px;
     -webkit-appearance: none;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Input.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Input.tsx
@@ -7,7 +7,6 @@ import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { Field } from "./components/Field";
-import theme from "../../../../theme";
 
 interface InputProps {
     field: FormRenderFbFormModelField;
@@ -15,17 +14,17 @@ interface InputProps {
 }
 
 export const StyledInput = styled.input`
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    ${theme.styles.typography["paragraph1"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Radio.tsx
@@ -7,7 +7,6 @@ import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import { StyledInput } from "./Input";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 interface RadioProps {
     field: FormRenderFbFormModelField;
@@ -23,7 +22,7 @@ const RadioGroup = styled.div`
 const RadioButton = styled.input`
     margin-left: 0;
     line-height: 100%;
-    background-color: ${theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     min-width: 25px;
     width: 25px;
     height: 25px;
@@ -31,7 +30,7 @@ const RadioButton = styled.input`
     -webkit-appearance: none;
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Select.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Select.tsx
@@ -6,19 +6,18 @@ import { Field } from "./components/Field";
 import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
-import theme from "../../../../theme";
 
 interface SelectProps {
     field: FormRenderFbFormModelField;
 }
 
 const StyledSelect = styled.select`
-    ${theme.styles.typography["paragraph1"]};
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     height: 40px;
@@ -29,7 +28,7 @@ const StyledSelect = styled.select`
     background-position: center right;
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Textarea.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/Textarea.tsx
@@ -6,24 +6,23 @@ import { FieldErrorMessage } from "./components/FieldErrorMessage";
 import { FieldHelperMessage } from "./components/FieldHelperMessage";
 import { FieldLabel } from "./components/FieldLabel";
 import styled from "@emotion/styled";
-import theme from "../../../../theme";
 
 interface TextareaProps {
     field: FormRenderFbFormModelField;
 }
 
 const StyledTextarea = styled.textarea`
-    border: 1px solid ${theme.styles.colors["color5"]};
-    background-color: ${theme.styles.colors["color5"]};
+    border: 1px solid ${props => props.theme.styles.colors["color5"]};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     width: 100%;
     padding: 10px;
-    border-radius: ${theme.styles.borderRadius};
+    border-radius: ${props => props.theme.styles.borderRadius};
     box-sizing: border-box;
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    ${theme.styles.typography["paragraph1"]};
+    ${props => props.theme.styles.typography["paragraph1"]};
 
     &:focus {
-        border-color: ${theme.styles.colors["color2"]};
+        border-color: ${props => props.theme.styles.colors["color2"]};
         box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
         outline: none;
     }

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/Field.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/Field.tsx
@@ -1,9 +1,7 @@
 import styled from "@emotion/styled";
-import theme from "../../../../../theme";
 
 export const Field = styled.div`
     width: 100%;
     box-sizing: border-box;
-    ${theme.styles.typography["paragraph1"]};
-    background-color: var(--webiny-theme-color-surface, #ffffff);
+    ${props => props.theme.styles.typography["paragraph1"]};
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldErrorMessage.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldErrorMessage.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import styled from "@emotion/styled";
-import { breakpoints, typography, colors } from "../../../../../theme";
 
 const Wrapper = styled.div`
-  margin-left: 2px;
-  margin-top: 5px;
-  ${typography.paragraph2};
-  color: ${colors.color1};
+    margin-left: 2px;
+    margin-top: 5px;
+    ${props => props.theme.styles.typography["paragraph2"]};
+    color: ${props => props.theme.styles.colors["color1"]};
 
-  ${breakpoints["mobile-landscape"]} {
-    text-align: left !important;
-  }
-}
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
+        text-align: left !important;
+    }
 `;
 
 interface FieldErrorMessageProps {

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
@@ -1,14 +1,13 @@
 import styled from "@emotion/styled";
-import { breakpoints, typography, colors } from "../../../../../theme";
 
 export const FieldHelperMessage = styled.div`
   margin-left: 2px;
+  margin-top: -5px;
   margin-bottom: 5px;
-  ${typography.paragraph2};
-  color: ${colors.color2};
+  ${props => props.theme.styles.typography["paragraph2"]};
+  color: ${props => props.theme.styles.colors["color2"]};
 
-  ${breakpoints["mobile-landscape"]} {
+  ${props => props.theme.breakpoints["mobile-landscape"]} {
     text-align: left !important;
   }
-}
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldHelperMessage.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 
 export const FieldHelperMessage = styled.div`
-  margin-left: 2px;
-  margin-top: -5px;
-  margin-bottom: 5px;
-  ${props => props.theme.styles.typography["paragraph2"]};
-  color: ${props => props.theme.styles.colors["color2"]};
+    margin-left: 2px;
+    margin-top: -5px;
+    margin-bottom: 5px;
+    ${props => props.theme.styles.typography["paragraph2"]};
+    color: ${props => props.theme.styles.colors["color2"]};
 
-  ${props => props.theme.breakpoints["mobile-landscape"]} {
-    text-align: left !important;
-  }
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
+        text-align: left !important;
+    }
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldLabel.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/forms/DefaultFormLayout/fields/components/FieldLabel.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
 import styled from "@emotion/styled";
 import { FormRenderFbFormModelField } from "@webiny/app-form-builder/types";
-import { breakpoints, colors } from "../../../../../theme";
 
 export const FieldLabelStyled = styled.label`
     width: 100%;
     display: inline-block;
     margin: 0 0 5px 1px;
-    ${breakpoints["mobile-landscape"]} {
+
+    ${props => props.theme.breakpoints["mobile-landscape"]} {
         text-align: left !important;
     }
 
     .asterisk {
         margin-left: 5px;
-        color: ${colors.color1};
+        color: ${props => props.theme.styles.colors["color1"]};
     }
 `;
 

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Footer.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Footer.tsx
@@ -4,7 +4,6 @@ import { ReactComponent as FacebookIcon } from "./assets/facebook-square-brands.
 import { ReactComponent as TwitterIcon } from "./assets/twitter-square-brands.svg";
 import { ReactComponent as InstagramIcon } from "./assets/instagram-brands.svg";
 import styled from "@emotion/styled";
-import { breakpoints, colors, typography } from "../../../theme";
 import { usePage } from "@webiny/app-page-builder-elements";
 
 export const Footer: React.FC = () => {
@@ -45,7 +44,7 @@ export const Footer: React.FC = () => {
 };
 
 const FooterWrapper = styled.footer`
-    background-color: ${colors.color5};
+    background-color: ${props => props.theme.styles.colors["color5"]};
     height: 100px;
 `;
 
@@ -58,7 +57,7 @@ const FooterBody = styled.div`
     margin: 0 auto;
     max-width: 1200px;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         flex-direction: column;
     }
 `;
@@ -78,15 +77,15 @@ const FooterLogo = styled.div`
     }
 
     .copy {
-        ${typography.paragraph2}
-        color: ${colors.color4}
+        ${props => props.theme.styles.typography["paragraph2"]}
+        color: ${props => props.theme.styles.colors["color4"]}
     }
 `;
 
 const FooterSocial = styled.div`
     text-align: right;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         margin-bottom: 15px;
     }
 
@@ -98,7 +97,7 @@ const FooterSocial = styled.div`
             margin-left: 10px;
             opacity: 0.6;
             transition: opacity 0.3s;
-            color: ${colors.color4};
+            color: ${props => props.theme.styles.colors["color4"]};
 
             &:hover {
                 opacity: 1;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Header.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Header.tsx
@@ -3,8 +3,6 @@ import { HeaderDesktop } from "./HeaderDesktop";
 import { HeaderMobile } from "./HeaderMobile";
 import styled from "@emotion/styled";
 
-import { colors, typography } from "../../../theme";
-
 export const Header: React.FC = () => {
     return (
         <HeaderWrapper data-testid={"pb-desktop-mobile-headers"}>
@@ -26,8 +24,8 @@ const HeaderWrapper = styled.header`
     top: 0;
 
     a {
-        ${typography.paragraph1}
-        color: ${colors.color1};
+        ${props => props.theme.styles.typography["paragraph1"]}
+        color: ${props => props.theme.styles.colors["color1"]};
         text-decoration: none;
     }
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/HeaderDesktop.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/HeaderDesktop.tsx
@@ -3,7 +3,6 @@ import { Link } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { usePage } from "@webiny/app-page-builder-elements";
 import { Menu } from "@webiny/app-website";
-import { fonts, breakpoints } from "../../../theme";
 import { Navigation } from "./Navigation";
 
 export const HeaderDesktop: React.FC = () => {
@@ -34,7 +33,7 @@ const HeaderDesktopWrapper = styled.div`
     margin: 0 auto;
     max-width: 1200px;
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         display: none;
     }
 
@@ -48,6 +47,5 @@ const HeaderDesktopWrapper = styled.div`
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         flex: 1;
-        font-family: ${fonts.font1};
     }
 `;

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/HeaderMobile.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/HeaderMobile.tsx
@@ -7,7 +7,6 @@ import { Menu, GET_PUBLIC_MENU, hasMenuItems } from "@webiny/app-website";
 import { ClassNames } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Navigation } from "./Navigation";
-import { colors, fonts, breakpoints } from "../../../theme";
 
 export const HeaderMobile: React.FC = () => {
     const { data } = useQuery(GET_PUBLIC_MENU, { variables: { slug: "main-menu" } });
@@ -79,7 +78,7 @@ const HeaderMobileWrapper = styled.div`
         }
     }
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         align-items: center;
         display: flex;
         height: 35px;
@@ -88,7 +87,7 @@ const HeaderMobileWrapper = styled.div`
         max-width: 1200px;
 
         > .logo {
-            ${breakpoints.tablet} {
+            ${props => props.theme.breakpoints["tablet"]} {
                 margin-left: 25px;
                 width: 50%;
             }
@@ -103,9 +102,8 @@ const HeaderMobileWrapper = styled.div`
             -webkit-font-smoothing: antialiased;
             animation: slide-out 0.5s forwards;
             animation-timing-function: ease-in-out;
-            background: ${colors.color5};
-            color: ${colors.color1};
-            font-family: ${fonts.font1};
+            background: ${props => props.theme.styles.colors["color5"]};
+            color: ${props => props.theme.styles.colors["color1"]};
             height: 100%;
             position: fixed;
             right: 0;
@@ -142,7 +140,6 @@ const HeaderMobileWrapper = styled.div`
         }
 
         .mobile-overlay {
-            background-color: var(--webiny-theme-color-on-background, #131313);
             opacity: 0;
             transition: opacity 0.25s ease-in-out;
 

--- a/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Navigation.tsx
+++ b/packages/cwp-template-aws/template/common/apps/theme/layouts/pages/Static/Navigation.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Link } from "@webiny/react-router";
 import { PublishedMenuData } from "@webiny/app-website/";
 import styled from "@emotion/styled";
-import { colors, borderRadius, breakpoints } from "../../../theme";
 
 export const Navigation: React.ComponentType<{ data?: PublishedMenuData }> = ({ data }) => {
     if (!data) {
@@ -55,12 +54,12 @@ const NavigationUl = styled.ul`
         transition: background-color 0.2s;
 
         &:hover {
-            background-color: ${colors.color5};
-            border-radius: ${borderRadius};
+            background-color: ${props => props.theme.styles.colors["color5"]};
+            border-radius: ${props => props.theme.styles.borderRadius};
         }
     }
 
-    ${breakpoints.tablet} {
+    ${props => props.theme.breakpoints["tablet"]} {
         display: block;
         margin: 75px 0 0 35px;
         text-transform: uppercase;

--- a/typings/emotion/index.d.ts
+++ b/typings/emotion/index.d.ts
@@ -45,3 +45,11 @@ export interface Theme {
     breakpoints: ThemeBreakpoints;
     styles: ThemeStyles;
 }
+
+type WTheme = Theme;
+
+declare module "@emotion/react" {
+    // Ignoring "@typescript-eslint/no-empty-interface" rule here.
+    // eslint-disable-next-line
+    export interface Theme extends WTheme {}
+}


### PR DESCRIPTION
## Changes
This PR upgrades existing `apps/theme` code so that it uses the new approach of accessing the central theme object, and that is via Emotion's theme context. In other words, theme object is never imported directly via an import statement, but it's accessed via the `theme` prop that the Emotion passes to styled components.

## How Has This Been Tested?
Manual.

## Documentation
Potentially update changelog. But will revisit the upgrade process.