### PR TITLE
fix(serverless-cms-aws): add migrations to enterprise create api app

### DIFF
--- a/packages/serverless-cms-aws/src/createApiApp.ts
+++ b/packages/serverless-cms-aws/src/createApiApp.ts
@@ -2,11 +2,11 @@ import { PulumiAppParam } from "@webiny/pulumi";
 import { createApiPulumiApp, CreateApiPulumiAppParams } from "@webiny/pulumi-aws";
 import { PluginCollection } from "@webiny/plugins/types";
 import {
+    executeDataMigrations,
+    generateCommonHandlers,
     generateDdbHandlers,
     generateDdbEsHandlers,
-    generateCommonHandlers,
-    injectWcpTelemetryClientCode,
-    executeDataMigrations
+    injectWcpTelemetryClientCode
 } from "./api/plugins";
 
 export { ApiOutput } from "@webiny/pulumi-aws";

--- a/packages/serverless-cms-aws/src/enterprise/createApiApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createApiApp.ts
@@ -2,9 +2,10 @@ import { PulumiAppParam } from "@webiny/pulumi";
 import { createApiPulumiApp, CreateApiPulumiAppParams } from "@webiny/pulumi-aws/enterprise";
 import { PluginCollection } from "@webiny/plugins/types";
 import {
-    generateDdbHandlers,
-    generateDdbEsHandlers,
+    executeDataMigrations,
     generateCommonHandlers,
+    generateDdbEsHandlers,
+    generateDdbHandlers,
     injectWcpTelemetryClientCode
 } from "~/api/plugins";
 
@@ -21,7 +22,11 @@ export interface CreateApiAppParams extends CreateApiPulumiAppParams {
 }
 
 export function createApiApp(projectAppParams: CreateApiAppParams = {}) {
-    const builtInPlugins = [injectWcpTelemetryClientCode, generateCommonHandlers];
+    const builtInPlugins = [
+        injectWcpTelemetryClientCode,
+        generateCommonHandlers,
+        executeDataMigrations
+    ];
     if (projectAppParams.elasticSearch) {
         builtInPlugins.push(generateDdbEsHandlers);
     } else {


### PR DESCRIPTION
## Changes
Add the migration plugin to the enterprise `createApiApp` method.

## How Has This Been Tested?
Manually.