### PR TITLE
fix(api-headless-cms): graphql schema cache does not work when no database models

### DIFF
--- a/packages/api-headless-cms/src/crud/settings.crud.ts
+++ b/packages/api-headless-cms/src/crud/settings.crud.ts
@@ -1,9 +1,9 @@
 import {
     CmsContext,
-    CmsSettingsPermission,
     CmsSettings,
-    HeadlessCmsStorageOperations,
-    CmsSettingsContext
+    CmsSettingsContext,
+    CmsSettingsPermission,
+    HeadlessCmsStorageOperations
 } from "~/types";
 import { Tenant } from "@webiny/api-tenancy/types";
 import { I18NLocale } from "@webiny/api-i18n/types";
@@ -23,14 +23,14 @@ export const createSettingsCrud = (params: CreateSettingsCrudParams): CmsSetting
     };
 
     return {
-        getSettings: async (): Promise<CmsSettings | null> => {
+        getSettings: async () => {
             await checkPermissions();
             return await storageOperations.settings.get({
                 tenant: getTenant().id,
                 locale: getLocale().code
             });
         },
-        updateModelLastChange: async (): Promise<void> => {
+        updateModelLastChange: async () => {
             const original = await storageOperations.settings.get({
                 tenant: getTenant().id,
                 locale: getLocale().code
@@ -52,26 +52,22 @@ export const createSettingsCrud = (params: CreateSettingsCrudParams): CmsSetting
                 settings
             });
         },
-        getModelLastChange: async (): Promise<Date> => {
+        getModelLastChange: async () => {
             try {
                 const settings = await storageOperations.settings.get({
                     tenant: getTenant().id,
                     locale: getLocale().code
                 });
-                if (!settings?.contentModelLastChange) {
-                    return new Date();
-                }
-                return settings.contentModelLastChange;
+
+                return settings?.contentModelLastChange || null;
             } catch (ex) {
                 console.log({
-                    error: {
-                        message: ex.message,
-                        code: ex.code || "COULD_NOT_FETCH_CONTENT_MODEL_LAST_CHANGE",
-                        data: ex
-                    }
+                    message: ex.message,
+                    code: ex.code || "COULD_NOT_FETCH_CONTENT_MODEL_LAST_CHANGE",
+                    data: ex
                 });
             }
-            return new Date();
+            return null;
         }
     };
 };

--- a/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
+++ b/packages/api-headless-cms/src/graphql/graphQLHandlerFactory.ts
@@ -173,6 +173,10 @@ const cmsRoutes = new RoutePlugin<CmsContext>(({ onPost, onOptions, context }) =
             return context.tenancy.getCurrentTenant();
         };
 
+        const getLocale = () => {
+            return context.cms.getLocale();
+        };
+
         const getLastModifiedTime = async () => {
             return context.cms.getModelLastChange();
         };
@@ -185,9 +189,7 @@ const cmsRoutes = new RoutePlugin<CmsContext>(({ onPost, onOptions, context }) =
                         context,
                         getTenant,
                         getLastModifiedTime,
-                        getLocale: () => {
-                            return context.cms.getLocale();
-                        },
+                        getLocale,
                         type: context.cms.type as ApiEndpoint
                     });
                 } catch (ex) {

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -943,7 +943,7 @@ export interface CmsSettingsContext {
     /**
      * Get the datetime when content model last changed.
      */
-    getModelLastChange: () => Promise<Date>;
+    getModelLastChange: () => Promise<Date | null>;
 }
 
 export interface OnSystemBeforeInstallTopicParams {


### PR DESCRIPTION
## Changes
This PR addresses the issue with the GraphQL Schema cache when no database models exist.
This is possible in systems where users have only code CMS models.

## How Has This Been Tested?
Jest and manually.