### PR TITLE
In Local Development, If Tenant ID Is Missing, Show An Informative Error Message

### DIFF
--- a/packages/app-website/src/Page/ErrorPage.tsx
+++ b/packages/app-website/src/Page/ErrorPage.tsx
@@ -2,59 +2,41 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import styled from "@emotion/styled";
 import { makeComposable } from "@webiny/app";
+import { errorMessages } from "./ErrorPage/errorMessages";
 
-const Wrapper = styled.div({
-    padding: 50,
-    textAlign: "center",
-    fontSize: 18,
-    h1: {
-        fontSize: 30,
-        fontWeight: "bold",
-        padding: 50
-    },
-    p: {
-        lineHeight: 1.5
-    }
-});
+const Wrapper = styled.div`
+    padding: 50px;
+    text-align: center;
+    font-size: 18px;
 
-const getPbNotInstalledErrorMessage = () => {
-    // Check if window exists first (does not exist while doing SSR).
-    const isLocalhost = typeof window === "object" && window.location.hostname === "localhost";
-    let adminUi = <a href="/admin">Admin UI</a>;
-    if (isLocalhost) {
-        adminUi = <strong>Admin UI</strong>;
+    h1 {
+        font-size: 30px;
+        font-weight: bold;
+        padding: 50px;
     }
 
-    return {
-        title: "Installation incomplete",
-        message: (
-            <>
-                <p>Page Builder is not installed!</p>
-                <p>
-                    Before you continue, please open up the {adminUi} and complete the installation
-                    wizard.
-                </p>
-            </>
-        )
-    };
-};
+    p {
+        line-height: 1.5;
+    }
+
+    code {
+        font-family: monospace;
+    }
+`;
 
 interface ErrorPageProps {
     error?: any;
 }
 
-const DEFAULT_ERROR_INFO = {
-    title: "An error occurred",
-    message: <>The link is either broken or the page has been removed.</>
-};
-
 export const ErrorPage = makeComposable<ErrorPageProps>("ErrorPage", props => {
-    let errorInfo = DEFAULT_ERROR_INFO;
-    if (props?.error?.code === "PB_NOT_INSTALLED") {
-        errorInfo = getPbNotInstalledErrorMessage();
+    // Try retrieving the error code from standard `{ data, error }` Webiny GraphQL response.
+    let errorCode: keyof typeof errorMessages = props?.error?.code;
+    if (!errorCode) {
+        // Alternatively, try reading the code from the network error result.
+        errorCode = props?.error?.networkError?.result?.code;
     }
 
-    const { title, message } = errorInfo;
+    const { title, message } = errorMessages[errorCode] || errorMessages.DEFAULT;
 
     return (
         <Wrapper>

--- a/packages/app-website/src/Page/ErrorPage/errorMessages.tsx
+++ b/packages/app-website/src/Page/ErrorPage/errorMessages.tsx
@@ -1,0 +1,49 @@
+import { isLocalhost } from "@webiny/app/utils";
+import React from "react";
+
+const PB_NOT_INSTALLED = {
+    title: "Installation incomplete",
+    message: (
+        <>
+            <p>Looks like the Page Builder application is not installed.</p>
+            <p>
+                Before you continue, please open up the Admin application and complete the
+                installation wizard.
+            </p>
+        </>
+    )
+};
+
+const MISSING_TENANT_HEADER = {
+    title: "Missing x-tenant HTTP header",
+    message: (
+        <>
+            <p>
+                Looks like the multi-tenancy feature is enabled, but current tenant could not be
+                detected.
+            </p>
+            {isLocalhost() && (
+                <p>
+                    When developing locally, the easiest way to set the tenant is by adding the{" "}
+                    <code>
+                        <a href={"?__tenant=root"}>__tenant</a>
+                    </code>{" "}
+                    query parameter, or by assigning the <br />
+                    <code>WEBINY_WEBSITE_TENANT_ID</code> environment variable via the{" "}
+                    <code>.env</code> file, for example: <code>WEBINY_WEBSITE_TENANT_ID=root</code>.
+                </p>
+            )}
+        </>
+    )
+};
+
+const DEFAULT = {
+    title: "An error occurred",
+    message: <>The link is either broken or the page has been removed.</>
+};
+
+export const errorMessages = {
+    PB_NOT_INSTALLED,
+    MISSING_TENANT_HEADER,
+    DEFAULT
+};

--- a/packages/app-website/src/Page/PageRenderer.tsx
+++ b/packages/app-website/src/Page/PageRenderer.tsx
@@ -13,6 +13,7 @@ import { WebsiteScripts } from "./WebsiteScripts";
 import { MainContent } from "./MainContent";
 import { Layout } from "./Layout";
 import { PageProvider } from "@webiny/app-page-builder-elements";
+import { ApolloError } from "apollo-client";
 
 interface Head {
     favicon?: {
@@ -28,7 +29,7 @@ interface Head {
  */
 interface PageRendererProps {
     page: PbPageData | null;
-    error: PbErrorResponse | null;
+    error: ApolloError | PbErrorResponse | null;
     settings: SettingsQueryResponseData;
 }
 

--- a/packages/app-website/src/Page/index.tsx
+++ b/packages/app-website/src/Page/index.tsx
@@ -69,7 +69,7 @@ export const Page: React.FC = () => {
     // Here we get all site data like website name, favicon image, social links etc.
     const getSettingsQuery = useQuery<SettingsQueryResponse>(GET_SETTINGS);
 
-    const { data: page = null, error = null } =
+    const { data: page = null, error = getPublishedPageQuery.error } =
         getPublishedPageQuery.data?.pageBuilder?.getPublishedPage || {};
     const settings =
         getSettingsQuery.data?.pageBuilder?.getSettings?.data || ({} as SettingsQueryResponseData);

--- a/packages/app-website/src/Page/index.tsx
+++ b/packages/app-website/src/Page/index.tsx
@@ -69,7 +69,7 @@ export const Page: React.FC = () => {
     // Here we get all site data like website name, favicon image, social links etc.
     const getSettingsQuery = useQuery<SettingsQueryResponse>(GET_SETTINGS);
 
-    const { data: page = null, error = getPublishedPageQuery.error } =
+    const { data: page = null, error = getPublishedPageQuery.error || null } =
         getPublishedPageQuery.data?.pageBuilder?.getPublishedPage || {};
     const settings =
         getSettingsQuery.data?.pageBuilder?.getSettings?.data || ({} as SettingsQueryResponseData);


### PR DESCRIPTION
## Changes
Prior to this PR, if a user would open their website in local development and their project had MT enabled, if the tenant ID hasn't been passed correctly, then they would just see a blank screen, with no instructions on how to proceed. No errors would be shown in the browser console too. 

Apart from no informative error message, additional point of pain would be the fact that setting the tenant ID is also something that is not that obvious and would left users further confused.

Ultimately, this PR improves DX by displaying an informative message in that case:

![Snipaste_2023-04-11_22-29-08](https://user-images.githubusercontent.com/5121148/231282014-400413ba-7d7c-4b79-a213-8353c6f1dc43.png)

## How Has This Been Tested?
Manual.

## Documentation
Changelog. Will add this environment variable in MT docs as well.