### PR TITLE
refactor(api): benchmark categorization

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/benchmark.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/benchmark.test.ts
@@ -10,7 +10,7 @@ describe("benchmark points", () => {
             new ContextPlugin(async context => {
                 context.benchmark.enable();
 
-                context.benchmark.onOutput(async benchmark => {
+                context.benchmark.onOutput(async ({ benchmark }) => {
                     elapsed = benchmark.elapsed;
                 });
             })

--- a/packages/api-headless-cms/__tests__/contentAPI/benchmark.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/benchmark.test.ts
@@ -58,6 +58,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.createContext",
+                    category: "webiny",
                     start: expect.any(Date)
                 },
                 {
@@ -65,6 +66,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.crud.models.listModels",
+                    category: "webiny",
                     start: expect.any(Date)
                 },
                 {
@@ -72,6 +74,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.graphql.getSchema",
+                    category: "webiny",
                     start: expect.any(Date)
                 },
                 {
@@ -79,6 +82,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.graphql.createRequestBody",
+                    category: "webiny",
                     start: expect.any(Date)
                 },
                 {
@@ -86,6 +90,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.crud.groups.createGroup",
+                    category: "webiny",
                     start: expect.any(Date)
                 },
                 {
@@ -93,6 +98,7 @@ describe("benchmark points", () => {
                     end: expect.any(Date),
                     memory: expect.any(Number),
                     name: "headlessCms.graphql.processRequestBody",
+                    category: "webiny",
                     start: expect.any(Date)
                 }
             ]

--- a/packages/api-tenant-manager/src/types.ts
+++ b/packages/api-tenant-manager/src/types.ts
@@ -1,4 +1,4 @@
-import { Context } from "@webiny/api/types";
+import { Context } from "@webiny/handler/types";
 
 export interface TenantManagerContext extends Context {
     tenantManager: boolean;

--- a/packages/api/__tests__/benchmark.test.ts
+++ b/packages/api/__tests__/benchmark.test.ts
@@ -94,8 +94,8 @@ describe("benchmark", () => {
         expect(context.benchmark.measurements[1].elapsed).toBeGreaterThanOrEqual(50);
         expect(context.benchmark.measurements[2].elapsed).toBeGreaterThanOrEqual(50);
         expect(context.benchmark.runs).toEqual({
-            test: 2,
-            "another test": 1
+            "webiny#test": 2,
+            "webiny#another test": 1
         });
         expect(context.benchmark.elapsed).toBeGreaterThanOrEqual(150);
     });

--- a/packages/api/__tests__/benchmark.test.ts
+++ b/packages/api/__tests__/benchmark.test.ts
@@ -37,6 +37,7 @@ describe("benchmark", () => {
         const expected: BenchmarkMeasurement[] = [
             {
                 name: "test",
+                category: "webiny",
                 start: expect.any(Date),
                 end: expect.any(Date),
                 elapsed: expect.any(Number),
@@ -73,6 +74,7 @@ describe("benchmark", () => {
 
         expected.push({
             name: "test",
+            category: "webiny",
             start: expect.any(Date),
             end: expect.any(Date),
             elapsed: expect.any(Number),
@@ -80,6 +82,7 @@ describe("benchmark", () => {
         });
         expected.push({
             name: "another test",
+            category: "webiny",
             start: expect.any(Date),
             end: expect.any(Date),
             elapsed: expect.any(Number),
@@ -112,6 +115,7 @@ describe("benchmark", () => {
         const expected: BenchmarkMeasurement[] = [
             {
                 name: "test",
+                category: "webiny",
                 start: expect.any(Date),
                 end: expect.any(Date),
                 elapsed: expect.any(Number),
@@ -164,6 +168,7 @@ describe("benchmark", () => {
         const expected: BenchmarkMeasurement[] = [
             {
                 name: "test",
+                category: "webiny",
                 start: expect.any(Date),
                 end: expect.any(Date),
                 elapsed: expect.any(Number),
@@ -205,6 +210,7 @@ describe("benchmark", () => {
         const expected: BenchmarkMeasurement[] = [
             {
                 name: "test",
+                category: "webiny",
                 start: expect.any(Date),
                 end: expect.any(Date),
                 elapsed: expect.any(Number),
@@ -228,6 +234,7 @@ describe("benchmark", () => {
         const expected: BenchmarkMeasurement[] = [
             {
                 name: "test",
+                category: "webiny",
                 start: expect.any(Date),
                 end: expect.any(Date),
                 elapsed: expect.any(Number),

--- a/packages/api/__tests__/benchmark.test.ts
+++ b/packages/api/__tests__/benchmark.test.ts
@@ -1,5 +1,5 @@
 import { Context } from "~/Context";
-import { BenchmarkMeasurement, BenchmarkOutputCallableResponse } from "~/types";
+import { BenchmarkMeasurement } from "~/types";
 import { BenchmarkPlugin } from "~/plugins/BenchmarkPlugin";
 import { ContextPlugin } from "~/plugins/ContextPlugin";
 
@@ -310,7 +310,7 @@ describe("benchmark", () => {
             log.push(...args);
         });
 
-        context.benchmark.onOutput(async benchmark => {
+        context.benchmark.onOutput(async ({ benchmark }) => {
             outsideSystemLog.push(...benchmark.measurements);
         });
 
@@ -359,7 +359,7 @@ describe("benchmark", () => {
         ]);
     });
 
-    it("should output measurements to some outside system and not our default because of the break", async () => {
+    it("should output measurements to some outside system and not our default because of the stop", async () => {
         context.benchmark.enable();
         for (let i = 1; i <= 5; i++) {
             await context.benchmark.measure(`test ${i}`, async () => {
@@ -375,10 +375,10 @@ describe("benchmark", () => {
             log.push(...args);
         });
 
-        context.benchmark.onOutput(async benchmark => {
+        context.benchmark.onOutput(async ({ benchmark, stop }) => {
             outsideSystemLog.push(...benchmark.measurements);
 
-            return BenchmarkOutputCallableResponse.BREAK;
+            return stop();
         });
 
         await context.benchmark.output();

--- a/packages/api/src/Benchmark.ts
+++ b/packages/api/src/Benchmark.ts
@@ -4,7 +4,6 @@ import {
     BenchmarkMeasurement,
     BenchmarkMeasureOptions,
     BenchmarkOutputCallable,
-    BenchmarkOutputCallableResponse,
     BenchmarkRuns
 } from "~/types";
 
@@ -76,8 +75,11 @@ export class Benchmark implements BenchmarkInterface {
         }
         const callables = this.onOutputCallables.reverse();
         for (const cb of callables) {
-            const result = await cb(this);
-            if (result === BenchmarkOutputCallableResponse.BREAK) {
+            const result = await cb({
+                benchmark: this,
+                stop: () => "stop"
+            });
+            if (result === "stop") {
                 return;
             }
         }

--- a/packages/api/src/Benchmark.ts
+++ b/packages/api/src/Benchmark.ts
@@ -100,7 +100,7 @@ export class Benchmark implements BenchmarkInterface {
         } finally {
             const measurementEnded = this.stopMeasurement(measurement);
             this.measurements.push(measurementEnded);
-            this.addRun(measurementEnded.name);
+            this.addRun(measurementEnded);
             /**
              * Only add to total time if this run is not a child of another run.
              * And then end running.
@@ -144,7 +144,8 @@ export class Benchmark implements BenchmarkInterface {
         this.totalElapsed = this.totalElapsed + measurement.elapsed;
     }
 
-    private addRun(name: string): void {
+    private addRun(measurement: Pick<BenchmarkMeasurement, "name" | "category">): void {
+        const name = `${measurement.category}#${measurement.name}`;
         if (!this.runs[name]) {
             this.runs[name] = 0;
         }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -6,6 +6,7 @@ export interface BenchmarkRuns {
 
 export interface BenchmarkMeasurement {
     name: string;
+    category: string;
     start: Date;
     end: Date;
     elapsed: number;
@@ -23,7 +24,10 @@ export enum BenchmarkOutputCallableResponse {
 export interface BenchmarkOutputCallable {
     (benchmark: Benchmark): Promise<BenchmarkOutputCallableResponse | undefined | null | void>;
 }
-
+export interface BenchmarkMeasureOptions {
+    name: string;
+    category: string;
+}
 export interface Benchmark {
     elapsed: number;
     runs: BenchmarkRuns;
@@ -31,7 +35,10 @@ export interface Benchmark {
     output: () => Promise<void>;
     onOutput: (cb: BenchmarkOutputCallable) => void;
     enableOn: (cb: BenchmarkEnableOnCallable) => void;
-    measure: <T = any>(name: string, cb: () => Promise<T>) => Promise<T>;
+    measure: <T = any>(
+        options: BenchmarkMeasureOptions | string,
+        cb: () => Promise<T>
+    ) => Promise<T>;
     enable: () => void;
     disable: () => void;
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -17,12 +17,12 @@ export interface BenchmarkEnableOnCallable {
     (): Promise<boolean>;
 }
 
-export enum BenchmarkOutputCallableResponse {
-    BREAK = "break"
+export interface BenchmarkOutputCallableParams {
+    benchmark: Benchmark;
+    stop: () => "stop";
 }
-
 export interface BenchmarkOutputCallable {
-    (benchmark: Benchmark): Promise<BenchmarkOutputCallableResponse | undefined | null | void>;
+    (params: BenchmarkOutputCallableParams): Promise<"stop" | undefined | null | void>;
 }
 export interface BenchmarkMeasureOptions {
     name: string;

--- a/packages/handler-aws/src/index.ts
+++ b/packages/handler-aws/src/index.ts
@@ -54,4 +54,4 @@ export {
     RawEventHandler
 } from "~/raw";
 
-export { ContextPlugin, createContextPlugin } from "@webiny/handler";
+export { ContextPlugin, createContextPlugin, ContextPluginCallable } from "@webiny/handler";

--- a/packages/handler/src/Context.ts
+++ b/packages/handler/src/Context.ts
@@ -34,7 +34,8 @@ export class Context extends BaseContext implements ContextInterface {
  *
  * This can be removed when we introduce the type augmentation.
  */
-export type ContextPluginCallable<T extends ContextInterface = ContextInterface> = BaseContextPluginCallable<T>
+export type ContextPluginCallable<T extends ContextInterface = ContextInterface> =
+    BaseContextPluginCallable<T>;
 
 export class ContextPlugin<
     T extends ContextInterface = ContextInterface

--- a/packages/handler/src/Context.ts
+++ b/packages/handler/src/Context.ts
@@ -1,20 +1,26 @@
-import { Context as BaseContext, ContextParams as BaseContextParams } from "@webiny/api";
-import { Context as BaseContextType } from "~/types";
+import {
+    Context as BaseContext,
+    ContextParams as BaseContextParams,
+    ContextPlugin as BaseContextPlugin,
+    ContextPluginCallable as BaseContextPluginCallable,
+    createContextPlugin as baseCreateContextPlugin
+} from "@webiny/api";
+import { Context as ContextInterface } from "~/types";
 
 export interface ContextParams extends BaseContextParams {
-    server: BaseContextType["server"];
-    routes: BaseContextType["routes"];
+    server: ContextInterface["server"];
+    routes: ContextInterface["routes"];
 }
 
-export class Context extends BaseContext implements BaseContextType {
-    public readonly server: BaseContextType["server"];
-    public readonly routes: BaseContextType["routes"];
+export class Context extends BaseContext implements ContextInterface {
+    public readonly server: ContextInterface["server"];
+    public readonly routes: ContextInterface["routes"];
     // @ts-ignore
-    public handlerClient: BaseContextType["handlerClient"];
+    public handlerClient: ContextInterface["handlerClient"];
     // @ts-ignore
-    public request: BaseContextType["request"];
+    public request: ContextInterface["request"];
     // @ts-ignore
-    public reply: BaseContextType["reply"];
+    public reply: ContextInterface["reply"];
 
     public constructor(params: ContextParams) {
         super(params);
@@ -22,3 +28,20 @@ export class Context extends BaseContext implements BaseContextType {
         this.routes = params.routes;
     }
 }
+
+/**
+ * We need to extend and reexport the ContextPlugin, ContextPluginCallable and createContextPlugin to support extended context.
+ *
+ * This can be removed when we introduce the type augmentation.
+ */
+export type ContextPluginCallable<T extends ContextInterface = ContextInterface> = BaseContextPluginCallable<T>
+
+export class ContextPlugin<
+    T extends ContextInterface = ContextInterface
+> extends BaseContextPlugin<T> {}
+
+export const createContextPlugin = <T extends ContextInterface = ContextInterface>(
+    callable: ContextPluginCallable<T>
+) => {
+    return baseCreateContextPlugin<T>(callable);
+};

--- a/packages/handler/src/index.ts
+++ b/packages/handler/src/index.ts
@@ -1,4 +1,3 @@
-export * from "@webiny/api/plugins/ContextPlugin";
 export * from "~/fastify";
 export * from "~/Context";
 export * from "~/plugins/EventPlugin";


### PR DESCRIPTION
## Changes

When writing the article about benchmarking tool I noticed we are missing the measurment categorization. This PR adds the possibility to categorize the measurements.

## How Has This Been Tested?
Jest and manually.
