### PR TITLE
refactor(api-headless-cms): remove unnecessary typename [no ci]

### DIFF
--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
@@ -8,12 +8,12 @@ import {
     CmsFieldTypePlugins,
     CmsModelFieldToGraphQLCreateResolver
 } from "~/types";
-import { createReadTypeName, createTypeName } from "~/utils/createTypeName";
+import { createTypeName } from "~/utils/createTypeName";
 import { createTypeFromFields } from "~/utils/createTypeFromFields";
 import { createGraphQLInputField } from "../helpers";
 
 const createUnionTypeName = (model: CmsModel, field: CmsModelField) => {
-    return `${model.singularApiName}_${createReadTypeName(field.fieldId)}`;
+    return `${model.singularApiName}_${createTypeName(field.fieldId)}`;
 };
 
 const getFieldTemplates = (field: CmsModelDynamicZoneField): CmsDynamicZoneTemplate[] => {

--- a/packages/api-headless-cms/src/graphqlFields/ref.ts
+++ b/packages/api-headless-cms/src/graphqlFields/ref.ts
@@ -1,12 +1,12 @@
 import WebinyError from "@webiny/error";
 import {
-    CmsEntry,
     CmsContext,
-    CmsModelFieldToGraphQLPlugin,
+    CmsEntry,
     CmsModel,
-    CmsModelField
+    CmsModelField,
+    CmsModelFieldToGraphQLPlugin
 } from "~/types";
-import { createReadTypeName } from "~/utils/createTypeName";
+import { createTypeName } from "~/utils/createTypeName";
 import { parseIdentifier } from "@webiny/utils";
 import { createGraphQLInputField } from "./helpers";
 
@@ -20,7 +20,7 @@ interface RefFieldValue {
 }
 
 const createUnionTypeName = (model: CmsModel, field: CmsModelField) => {
-    return `${model.singularApiName}_${createReadTypeName(field.fieldId)}`;
+    return `${model.singularApiName}_${createTypeName(field.fieldId)}`;
 };
 
 interface CreateListFilterParams {
@@ -109,20 +109,15 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                 const gqlType =
                     fieldModels.length > 1
                         ? createUnionTypeName(model, field)
-                        : createReadTypeName(
-                              getModelSingularApiName({ models, modelId: fieldModels[0].modelId })
-                          );
-
+                        : getModelSingularApiName({ models, modelId: fieldModels[0].modelId });
                 const typeDefs =
                     fieldModels.length > 1
                         ? `union ${gqlType} = ${getFieldModels(field)
                               .map(({ modelId }) =>
-                                  createReadTypeName(
-                                      getModelSingularApiName({
-                                          models,
-                                          modelId
-                                      })
-                                  )
+                                  getModelSingularApiName({
+                                      models,
+                                      modelId
+                                  })
                               )
                               .join(" | ")}`
                         : "";
@@ -147,12 +142,10 @@ export const createRefField = (): CmsModelFieldToGraphQLPlugin => {
                 for (const item of fieldModels) {
                     modelIdToTypeName.set(
                         item.modelId,
-                        createReadTypeName(
-                            getModelSingularApiName({
-                                models,
-                                modelId: item.modelId
-                            })
-                        )
+                        getModelSingularApiName({
+                            models,
+                            modelId: item.modelId
+                        })
                     );
                 }
 

--- a/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
@@ -11,12 +11,12 @@ import {
 } from "~/types";
 import { createFieldStorageId } from "~/crud/contentModel/createFieldStorageId";
 
-const transformNameToSingularApiName = (name: string) => {
+const createApiName = (name: string) => {
     return upperFirst(camelCase(name));
 };
 
-const transformNameToPluralApiName = (name: string) => {
-    return pluralize(transformNameToSingularApiName(name));
+const createPluralApiName = (name: string) => {
+    return pluralize(createApiName(name));
 };
 
 interface CmsModelFieldSettings extends Omit<BaseCmsModelFieldSettings, "fields"> {
@@ -91,8 +91,12 @@ export class CmsModelPlugin extends Plugin {
 
     private buildModel(input: CmsModelInput): CmsModel {
         const isPrivate = input.isPrivate || false;
-        const singularApiName = input.singularApiName || transformNameToSingularApiName(input.name);
-        const pluralApiName = input.pluralApiName || transformNameToPluralApiName(input.name);
+        const singularApiName = input.singularApiName
+            ? createApiName(input.singularApiName)
+            : createApiName(input.name);
+        const pluralApiName = input.pluralApiName
+            ? createApiName(input.pluralApiName)
+            : createPluralApiName(input.name);
 
         if (input.noValidate) {
             /**

--- a/packages/api-headless-cms/src/utils/createTypeFromFields.ts
+++ b/packages/api-headless-cms/src/utils/createTypeFromFields.ts
@@ -1,4 +1,3 @@
-import { createTypeName } from "~/utils/createTypeName";
 import { renderField } from "~/utils/renderFields";
 import { renderInputField } from "~/utils/renderInputFields";
 import { ApiEndpoint, CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types";
@@ -21,10 +20,10 @@ interface TypeFromFieldResponse {
 export const createTypeFromFields = (params: TypeFromFieldParams): TypeFromFieldResponse | null => {
     const { typeOfType, model, models, type, typeNamePrefix, fields, fieldTypePlugins } = params;
     const typeSuffix = typeOfType === "input" ? "Input" : "";
-    const mTypeName = createTypeName(model.singularApiName);
+    const mTypeName = model.singularApiName;
 
-    const typeFields = [];
-    const nestedTypes = [];
+    const typeFields: string[] = [];
+    const nestedTypes: string[] = [];
 
     // Once the loop below starts, we'll be executing a recursive "object" type generation.
     // The main trick here is that nested objects don't know who the parent is, and will generate

--- a/packages/api-headless-cms/src/utils/createTypeName.ts
+++ b/packages/api-headless-cms/src/utils/createTypeName.ts
@@ -4,11 +4,3 @@ import camelCase from "lodash/camelCase";
 export const createTypeName = (modelId: string): string => {
     return upperFirst(camelCase(modelId));
 };
-
-export const createReadTypeName = (baseTypeName: string): string => {
-    return createTypeName(baseTypeName);
-};
-
-export const createManageTypeName = (baseTypeName: string): string => {
-    return createTypeName(baseTypeName);
-};


### PR DESCRIPTION
## Changes
This PR removes unnecessary conversions of the singular and plural api name with upperFirst and camelCase transformers.

## How Has This Been Tested?
Jest and manually.
