### PR TITLE
refactor(api-headless-cms): remove manually adding model storage converter

### DIFF
--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -1,34 +1,23 @@
-import { attachCmsModelFieldConverters } from "@webiny/api-headless-cms/utils/converters/valueKeyStorageConverter";
-
 import WebinyError from "@webiny/error";
-
 import { SEARCH_RECORD_MODEL_ID } from "./record.model";
 import { baseFields, CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
 import { createListSort } from "~/utils/createListSort";
 import { createOperationsWrapper } from "~/utils/createOperationsWrapper";
 import { getFieldValues } from "~/utils/getFieldValues";
-
 import { AcoSearchRecordStorageOperations } from "./record.types";
 import { CmsModel } from "@webiny/api-headless-cms/types";
 
 export const createSearchRecordOperations = (
     params: CreateAcoStorageOperationsParams
 ): AcoSearchRecordStorageOperations => {
-    const { cms, getCmsContext } = params;
+    const { cms } = params;
 
     const { withModel } = createOperationsWrapper({
         ...params,
         modelName: SEARCH_RECORD_MODEL_ID
     });
 
-    const getRecord = async (initialModel: CmsModel, id: string) => {
-        const context = getCmsContext();
-
-        const model = attachCmsModelFieldConverters({
-            model: initialModel,
-            plugins: context.plugins
-        });
-
+    const getRecord = async (model: CmsModel, id: string) => {
         /**
          * The record "id" has been passed by the original entry.
          * We need to retrieve it via `cms.storageOperations.entries.getLatestByIds()` method and return the first one.

--- a/packages/api-headless-cms-ddb-es/src/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from "~/plugins";
 import { createFilterPlugins } from "~/operations/entry/elasticsearch/filtering/plugins";
 import { CmsEntryFilterPlugin } from "~/plugins/CmsEntryFilterPlugin";
+import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
 
 export * from "./plugins";
 
@@ -147,7 +148,8 @@ export const createStorageOperations: StorageOperationsFactory = params => {
                 CmsEntryElasticsearchQueryBuilderValueSearchPlugin.type,
                 CmsEntryElasticsearchQueryModifierPlugin.type,
                 CmsEntryElasticsearchSortModifierPlugin.type,
-                CmsEntryElasticsearchFieldPlugin.type
+                CmsEntryElasticsearchFieldPlugin.type,
+                StorageOperationsCmsModelPlugin.type
             ];
             for (const type of types) {
                 plugins.mergeByType(context.plugins, type);

--- a/packages/api-headless-cms-ddb/src/index.ts
+++ b/packages/api-headless-cms-ddb/src/index.ts
@@ -22,6 +22,7 @@ import {
     CmsFieldFilterValueTransformPlugin
 } from "~/plugins";
 import { ValueFilterPlugin } from "@webiny/db-dynamodb/plugins/definitions/ValueFilterPlugin";
+import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
 
 export * from "./plugins";
 
@@ -89,7 +90,8 @@ export const createStorageOperations: StorageOperationsFactory = params => {
                 CmsFieldFilterValueTransformPlugin.type,
                 CmsEntryFieldFilterPlugin.type,
                 CmsEntryFieldSortingPlugin.type,
-                ValueFilterPlugin.type
+                ValueFilterPlugin.type,
+                StorageOperationsCmsModelPlugin.type
             ];
             /**
              * Collect all required plugins from parent context.

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntryMetaField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntryMetaField.test.ts
@@ -2,10 +2,9 @@
  * There must be the "until" in this file because we are using storage operations directly.
  */
 import models from "./mocks/contentModels";
-import { CmsEntry, CmsGroup, StorageOperationsCmsModel } from "~/types";
+import { CmsEntry, CmsGroup, CmsModel } from "~/types";
 import { useCategoryManageHandler } from "../testHelpers/useCategoryManageHandler";
 import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
-import { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 
 const manageOpts = {
     path: "manage/en-US"
@@ -45,8 +44,7 @@ describe("Content Entry Meta Field", () => {
         updateContentModelMutation,
         createContentModelGroupMutation,
         storageOperations,
-        until,
-        plugins
+        until
     } = useCategoryManageHandler(manageOpts);
 
     const setup = async () => {
@@ -81,14 +79,11 @@ describe("Content Entry Meta Field", () => {
                 layout: targetModel.layout
             }
         });
-        const model: StorageOperationsCmsModel = attachCmsModelFieldConverters({
-            plugins,
-            model: {
-                ...updateModelResponse.data.updateContentModel.data,
-                tenant: "root",
-                locale: "en-US"
-            }
-        });
+        const model: CmsModel = {
+            ...updateModelResponse.data.updateContentModel.data,
+            tenant: "root",
+            locale: "en-US"
+        };
 
         return {
             model,

--- a/packages/api-headless-cms/__tests__/contentAPI/entryPagination.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/entryPagination.test.ts
@@ -1,12 +1,11 @@
+// @ts-ignore
+import mdbid from "mdbid";
 /**
  * We need the "until" because we are using storage operations directly.
  */
 import { useFruitManageHandler } from "../testHelpers/useFruitManageHandler";
-// @ts-ignore
-import mdbid from "mdbid";
-import { CmsEntry, CmsModel, StorageOperationsCmsModel } from "~/types";
+import { CmsEntry, CmsModel } from "~/types";
 import { setupContentModelGroup, setupContentModels } from "../testHelpers/setup";
-import { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 
 const NUMBER_OF_FRUITS = 200;
 
@@ -60,10 +59,8 @@ const createFruitData = (counter: number): CmsEntry => {
 describe("entry pagination", () => {
     const manageOpts = { path: "manage/en-US" };
 
-    let fruitContentModel: StorageOperationsCmsModel;
-
     const manager = useFruitManageHandler(manageOpts);
-    const { storageOperations, until, plugins } = manager;
+    const { storageOperations, until } = manager;
     /**
      * We need to create N fruit entries
      */
@@ -75,13 +72,9 @@ describe("entry pagination", () => {
             tenant: "root",
             modelId: "fruit"
         })) as CmsModel;
-        fruitContentModel = attachCmsModelFieldConverters({
-            plugins,
-            model
-        });
         for (let i = 1; i <= NUMBER_OF_FRUITS; i++) {
             const fruit = createFruitData(i);
-            await storageOperations.entries.create(fruitContentModel, {
+            await storageOperations.entries.create(model, {
                 storageEntry: fruit,
                 entry: fruit
             });

--- a/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/helpers.ts
@@ -5,15 +5,14 @@
 import mdbid from "mdbid";
 import {
     CmsEntry,
-    CmsModelField,
     CmsIdentity,
-    HeadlessCmsStorageOperations,
-    StorageOperationsCmsModel
+    CmsModel,
+    CmsModelField,
+    HeadlessCmsStorageOperations
 } from "~/types";
 import { CmsGroupPlugin } from "~/plugins/CmsGroupPlugin";
 import { createIdentifier, generateAlphaNumericLowerCaseId } from "@webiny/utils";
 import crypto from "crypto";
-import { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 import { PluginsContainer } from "@webiny/plugins";
 
 const cliPackageJson = require("@webiny/cli/package.json");
@@ -82,29 +81,26 @@ const personModelFields: Record<string, CmsModelField> = {
     }
 };
 
-export const createPersonModel = (plugins: PluginsContainer): StorageOperationsCmsModel => {
-    return attachCmsModelFieldConverters({
-        plugins,
-        model: {
-            name: "Person Model",
-            singularApiName: "PersonModel",
-            pluralApiName: "PersonModels",
-            group: {
-                id: baseGroup.contentModelGroup.id,
-                name: baseGroup.contentModelGroup.name
-            },
-            modelId: "personEntriesModel",
-            locale: "en-US",
-            tenant: "root",
-            titleFieldId: personModelFields.name.id,
-            fields: Object.values(personModelFields),
-            layout: Object.values(personModelFields).map(field => {
-                return [field.id];
-            }),
-            description: "",
-            webinyVersion
-        }
-    });
+export const createPersonModel = (): CmsModel => {
+    return {
+        name: "Person Model",
+        singularApiName: "PersonModel",
+        pluralApiName: "PersonModels",
+        group: {
+            id: baseGroup.contentModelGroup.id,
+            name: baseGroup.contentModelGroup.name
+        },
+        modelId: "personEntriesModel",
+        locale: "en-US",
+        tenant: "root",
+        titleFieldId: personModelFields.name.id,
+        fields: Object.values(personModelFields),
+        layout: Object.values(personModelFields).map(field => {
+            return [field.id];
+        }),
+        description: "",
+        webinyVersion
+    };
 };
 
 const createdBy: CmsIdentity = {
@@ -135,8 +131,8 @@ export interface PersonEntriesResult {
 export const createPersonEntries = async (
     params: CreatePersonEntriesParams
 ): Promise<PersonEntriesResult> => {
-    const { amount, storageOperations, maxRevisions = 1, plugins } = params;
-    const personModel = createPersonModel(plugins);
+    const { amount, storageOperations, maxRevisions = 1 } = params;
+    const personModel = createPersonModel();
 
     const entries: CmsEntry[] = [];
 
@@ -237,13 +233,12 @@ export const createPersonEntries = async (
 
 interface DeletePersonModelParams {
     storageOperations: HeadlessCmsStorageOperations;
-    plugins: PluginsContainer;
 }
 export const deletePersonModel = async (params: DeletePersonModelParams) => {
-    const { storageOperations, plugins } = params;
+    const { storageOperations } = params;
     try {
         await storageOperations.models.delete({
-            model: createPersonModel(plugins)
+            model: createPersonModel()
         });
     } catch (ex) {
         console.log("Trying to delete person model... failed...");

--- a/packages/api-headless-cms/src/context.ts
+++ b/packages/api-headless-cms/src/context.ts
@@ -7,6 +7,8 @@ import { createSettingsCrud } from "~/crud/settings.crud";
 import { createModelGroupsCrud } from "~/crud/contentModelGroup.crud";
 import { createModelsCrud } from "~/crud/contentModel.crud";
 import { createContentEntryCrud } from "~/crud/contentEntry.crud";
+import { StorageOperationsCmsModelPlugin } from "~/plugins";
+import { createCmsModelFieldConvertersAttachFactory } from "~/utils/converters/valueKeyStorageConverter";
 
 const getParameters = async (context: CmsContext): Promise<CmsParametersPluginResponse> => {
     const plugins = context.plugins.byType<CmsParametersPlugin>(CmsParametersPlugin.type);
@@ -47,10 +49,14 @@ export const createContextPlugin = ({ storageOperations }: CrudParams) => {
             return context.tenancy.getCurrentTenant();
         };
 
+        context.plugins.register(
+            new StorageOperationsCmsModelPlugin(
+                createCmsModelFieldConvertersAttachFactory(context.plugins)
+            )
+        );
+
         await context.benchmark.measure("headlessCms.createContext", async () => {
-            if (storageOperations.beforeInit) {
-                await storageOperations.beforeInit(context);
-            }
+            await storageOperations.beforeInit(context);
 
             context.cms = {
                 type,

--- a/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
@@ -1,9 +1,8 @@
 import { Topic } from "@webiny/pubsub/types";
-import { OnModelBeforeDeleteTopicParams, HeadlessCmsStorageOperations } from "~/types";
+import { HeadlessCmsStorageOperations, OnModelBeforeDeleteTopicParams } from "~/types";
 import { PluginsContainer } from "@webiny/plugins";
 import WebinyError from "@webiny/error";
 import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
-import { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 
 interface AssignBeforeModelDeleteParams {
     onModelBeforeDelete: Topic<OnModelBeforeDeleteTopicParams>;
@@ -32,18 +31,12 @@ export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) =
 
         let entries = [];
         try {
-            const result = await storageOperations.entries.list(
-                attachCmsModelFieldConverters({
-                    model,
-                    plugins
-                }),
-                {
-                    where: {
-                        latest: true
-                    },
-                    limit: 1
-                }
-            );
+            const result = await storageOperations.entries.list(model, {
+                where: {
+                    latest: true
+                },
+                limit: 1
+            });
             entries = result.items;
         } catch (ex) {
             throw new WebinyError(

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -100,8 +100,10 @@ const fieldSchema = zod.object({
                     .default({})
             })
         )
+        .nullish()
         .optional()
-        .default([]),
+        .default([])
+        .transform(value => value || []),
     listValidation: zod
         .array(
             zod.object({
@@ -118,8 +120,10 @@ const fieldSchema = zod.object({
                     .default({})
             })
         )
+        .nullish()
         .optional()
-        .default([]),
+        .default([])
+        .transform(value => value || []),
     settings: zod
         .object({})
         .passthrough()

--- a/packages/api-headless-cms/src/index.ts
+++ b/packages/api-headless-cms/src/index.ts
@@ -53,5 +53,4 @@ export const createHeadlessCmsContext = (params: ContentContextParams) => {
 export * from "~/graphqlFields";
 export * from "~/plugins";
 export * from "~/utils/incrementEntryIdVersion";
-export { attachCmsModelFieldConverters } from "~/utils/converters/valueKeyStorageConverter";
 export { entryToStorageTransform, entryFieldFromStorageTransform, entryFromStorageTransform };

--- a/packages/api-headless-cms/src/plugins/StorageOperationsCmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/StorageOperationsCmsModelPlugin.ts
@@ -1,0 +1,44 @@
+import { Plugin } from "@webiny/plugins";
+import { CmsModel, StorageOperationsCmsModel } from "~/types";
+
+export interface StorageOperationsCmsModelPluginCallable {
+    (model: CmsModel): StorageOperationsCmsModel;
+}
+
+/**
+ * This plugin should be initialized only once and hence the name.
+ */
+export class StorageOperationsCmsModelPlugin extends Plugin {
+    public static override readonly type: string = "cms.storageOperations.model";
+    public override name = "cms.storageOperations.model";
+
+    private readonly models: Record<string, StorageOperationsCmsModel> = {};
+    private readonly cb: StorageOperationsCmsModelPluginCallable;
+
+    public constructor(cb: StorageOperationsCmsModelPluginCallable) {
+        super();
+        this.cb = cb;
+    }
+
+    public getModel(input: CmsModel) {
+        const cacheKey = this.createCacheKey(input);
+        if (this.models[cacheKey]) {
+            return this.models[cacheKey];
+        }
+        const model = this.cb(input);
+
+        this.models[cacheKey] = model;
+
+        return model;
+    }
+
+    /**
+     * We can cache the converters by having a cache key that is a combination of model ID and savedOn.
+     * The models created via the code will not have savedOn, so they will be unknown - and that is ok as they cannot change in the middle of the call.
+     *
+     * The models created via the CRUD operations might get changed in the middle of the call, so we need to re-create the SO model.
+     */
+    private createCacheKey(model: CmsModel): string {
+        return [model.tenant, model.locale, model.modelId, model.savedOn || "unknown"].join("#");
+    }
+}

--- a/packages/api-headless-cms/src/plugins/index.ts
+++ b/packages/api-headless-cms/src/plugins/index.ts
@@ -5,3 +5,4 @@ export * from "./CmsParametersPlugin";
 export * from "./CmsModelFieldConverterPlugin";
 export * from "./CmsGraphQLSchemaPlugin";
 export * from "./CmsGraphQLSchemaSorterPlugin";
+export * from "./StorageOperationsCmsModelPlugin";

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1992,13 +1992,13 @@ export interface CmsEntryMeta {
 export interface OnEntryBeforeCreateTopicParams {
     input: CreateCmsEntryInput;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterCreateTopicParams {
     input: CreateCmsEntryInput;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
@@ -2016,14 +2016,14 @@ export interface OnEntryRevisionBeforeCreateTopicParams {
     input: CreateFromCmsEntryInput;
     entry: CmsEntry;
     original: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryRevisionAfterCreateTopicParams {
     input: CreateFromCmsEntryInput;
     entry: CmsEntry;
     original: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
@@ -2042,14 +2042,14 @@ export interface OnEntryBeforeUpdateTopicParams {
     input: UpdateCmsEntryInput;
     original: CmsEntry;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterUpdateTopicParams {
     input: UpdateCmsEntryInput;
     original: CmsEntry;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
@@ -2066,19 +2066,19 @@ export interface OnEntryUpdateErrorTopicParams {
 
 export interface OnEntryBeforePublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterPublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
 export interface OnEntryPublishErrorTopicParams {
     error: Error;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 /**
@@ -2086,19 +2086,19 @@ export interface OnEntryPublishErrorTopicParams {
  */
 export interface OnEntryBeforeRepublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterRepublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
 export interface OnEntryRepublishErrorTopicParams {
     error: Error;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 /**
@@ -2107,12 +2107,12 @@ export interface OnEntryRepublishErrorTopicParams {
 
 export interface OnEntryBeforeUnpublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterUnpublishTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     storageEntry: CmsEntry;
 }
 
@@ -2124,44 +2124,44 @@ export interface OnEntryUnpublishErrorTopicParams {
 
 export interface OnEntryBeforeDeleteTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryAfterDeleteTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryDeleteErrorTopicParams {
     error: Error;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryRevisionBeforeDeleteTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryRevisionAfterDeleteTopicParams {
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryRevisionDeleteErrorTopicParams {
     error: Error;
     entry: CmsEntry;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 export interface OnEntryBeforeGetTopicParams {
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
     where: CmsEntryListWhere;
 }
 
 export interface EntryBeforeListTopicParams {
     where: CmsEntryListWhere;
-    model: StorageOperationsCmsModel;
+    model: CmsModel;
 }
 
 /**
@@ -2773,122 +2773,101 @@ export interface CmsEntryStorageOperations<T extends CmsStorageEntry = CmsStorag
     /**
      * Get all the entries of the ids.
      */
-    getByIds: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsGetByIdsParams
-    ) => Promise<T[]>;
+    getByIds: (model: CmsModel, params: CmsEntryStorageOperationsGetByIdsParams) => Promise<T[]>;
     /**
      * Get all the published entries of the ids.
      */
     getPublishedByIds: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetPublishedByIdsParams
     ) => Promise<T[]>;
     /**
      * Get all the latest entries of the ids.
      */
     getLatestByIds: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetLatestByIdsParams
     ) => Promise<T[]>;
     /**
      * Get all revisions of the given entry id.
      */
     getRevisions: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetRevisionsParams
     ) => Promise<T[]>;
     /**
      * Get the entry by the given revision id.
      */
     getRevisionById: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetRevisionParams
     ) => Promise<T | null>;
     /**
      * Get the published entry by given entryId.
      */
     getPublishedRevisionByEntryId: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetPublishedRevisionParams
     ) => Promise<T | null>;
     /**
      * Get the latest entry by given entryId.
      */
     getLatestRevisionByEntryId: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetLatestRevisionParams
     ) => Promise<T | null>;
     /**
      * Get the revision of the entry before given one.
      */
     getPreviousRevision: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsGetPreviousRevisionParams
     ) => Promise<T | null>;
     /**
      * Gets entry by given params.
      */
-    get: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsGetParams
-    ) => Promise<T | null>;
+    get: (model: CmsModel, params: CmsEntryStorageOperationsGetParams) => Promise<T | null>;
     /**
      * List all entries. Filterable via params.
      */
     list: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsListParams
     ) => Promise<CmsEntryStorageOperationsListResponse<T>>;
     /**
      * Create a new entry.
      */
-    create: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsCreateParams<T>
-    ) => Promise<T>;
+    create: (model: CmsModel, params: CmsEntryStorageOperationsCreateParams<T>) => Promise<T>;
     /**
      * Create a new entry from existing one.
      */
     createRevisionFrom: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsCreateRevisionFromParams<T>
     ) => Promise<T>;
     /**
      * Update existing entry.
      */
-    update: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsUpdateParams<T>
-    ) => Promise<T>;
+    update: (model: CmsModel, params: CmsEntryStorageOperationsUpdateParams<T>) => Promise<T>;
     /**
      * Delete the entry revision.
      */
     deleteRevision: (
-        model: StorageOperationsCmsModel,
+        model: CmsModel,
         params: CmsEntryStorageOperationsDeleteRevisionParams<T>
     ) => Promise<void>;
     /**
      * Delete the entry.
      */
-    delete: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsDeleteParams
-    ) => Promise<void>;
+    delete: (model: CmsModel, params: CmsEntryStorageOperationsDeleteParams) => Promise<void>;
     /**
      * Publish the entry.
      */
-    publish: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsPublishParams<T>
-    ) => Promise<T>;
+    publish: (model: CmsModel, params: CmsEntryStorageOperationsPublishParams<T>) => Promise<T>;
     /**
      * Unpublish the entry.
      */
-    unpublish: (
-        model: StorageOperationsCmsModel,
-        params: CmsEntryStorageOperationsUnpublishParams<T>
-    ) => Promise<T>;
+    unpublish: (model: CmsModel, params: CmsEntryStorageOperationsUnpublishParams<T>) => Promise<T>;
 }
 
 export enum CONTENT_ENTRY_STATUS {
@@ -2971,6 +2950,6 @@ export interface HeadlessCmsStorageOperations<C = CmsContext> {
     /**
      * Either attach something from the storage operations or run something in it.
      */
-    beforeInit?: (context: C) => Promise<void>;
+    beforeInit: (context: C) => Promise<void>;
     init?: (context: C) => Promise<void>;
 }

--- a/packages/api-headless-cms/src/utils/converters/valueKeyStorageConverter.ts
+++ b/packages/api-headless-cms/src/utils/converters/valueKeyStorageConverter.ts
@@ -112,30 +112,22 @@ export const createValueKeyFromStorageConverter = (params: Params): CmsModelConv
     };
 };
 
-export interface AttachConvertersParams {
-    plugins: PluginsContainer;
-    model: CmsModel | StorageOperationsCmsModel;
-}
-
-export const attachCmsModelFieldConverters = (
-    params: AttachConvertersParams
-): StorageOperationsCmsModel => {
-    const { model, plugins } = params;
-    /**
-     * We can safely return the model as it already has the converters attached.
-     */
-    if ((model as any).convertValueKeyToStorage && (model as any).convertValueKeyFromStorage) {
-        return model as StorageOperationsCmsModel;
-    }
-    return {
-        ...model,
-        convertValueKeyToStorage: createValueKeyToStorageConverter({
-            model,
-            plugins
-        }),
-        convertValueKeyFromStorage: createValueKeyFromStorageConverter({
-            model,
-            plugins
-        })
+export const createCmsModelFieldConvertersAttachFactory = (plugins: PluginsContainer) => {
+    return (model: StorageOperationsCmsModel | CmsModel): StorageOperationsCmsModel => {
+        const storageModel = model as Partial<StorageOperationsCmsModel>;
+        if (!!storageModel.convertValueKeyToStorage && !!storageModel.convertValueKeyFromStorage) {
+            return storageModel as StorageOperationsCmsModel;
+        }
+        return {
+            ...model,
+            convertValueKeyToStorage: createValueKeyToStorageConverter({
+                model,
+                plugins
+            }),
+            convertValueKeyFromStorage: createValueKeyFromStorageConverter({
+                model,
+                plugins
+            })
+        };
     };
 };


### PR DESCRIPTION
## Changes
This PR removes the `attachCmsModelFieldConverters`, which needed to be called manually for fieldId to storageId (and reverse) to work. That is now done automatically through a plugin, which is initialized with the CMS context.

## How Has This Been Tested?
Jest.