### PR TITLE
Page Builder Pages - Use `@webiny/router`'s `Link` Component Upon Rendering Links

### DIFF
--- a/packages/app-page-builder/src/render/plugins/elements/button/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/button/index.tsx
@@ -9,6 +9,7 @@ import { createButton } from "@webiny/app-page-builder-elements/renderers/button
 import { plugins } from "@webiny/plugins";
 import { isLegacyRenderingEngine } from "~/utils";
 import React from "react";
+import { Link } from "@webiny/react-router";
 
 // @ts-ignore Resolve once we deprecate legacy rendering engine.
 const render: PbRenderElementPlugin["render"] = isLegacyRenderingEngine
@@ -27,6 +28,13 @@ const render: PbRenderElementPlugin["render"] = isLegacyRenderingEngine
                       variables: plugin.variables
                   };
               });
+          },
+          linkComponent: ({ href, children, ...rest }) => {
+              return (
+                  <Link to={href!} {...rest}>
+                      {children}
+                  </Link>
+              );
           }
       });
 

--- a/packages/app-page-builder/src/render/plugins/elements/image/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/image/index.tsx
@@ -4,11 +4,20 @@ import { PbRenderElementPluginArgs, PbRenderElementPlugin } from "~/types";
 import { createImage } from "@webiny/app-page-builder-elements/renderers/image";
 import { isLegacyRenderingEngine } from "~/utils";
 import React from "react";
+import { Link } from "@webiny/react-router";
 
 // @ts-ignore Resolve once we deprecate legacy rendering engine.
 const render: PbRenderElementPlugin["render"] = isLegacyRenderingEngine
     ? props => <Image {...props} />
-    : createImage();
+    : createImage({
+          linkComponent: ({ href, children, ...rest }) => {
+              return (
+                  <Link to={href!} {...rest}>
+                      {children}
+                  </Link>
+              );
+          }
+      });
 
 export default (args: PbRenderElementPluginArgs = {}): PbRenderElementPlugin => {
     const elementType = kebabCase(args.elementType || "image");

--- a/packages/app-page-builder/src/render/plugins/elements/pagesList/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/pagesList/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import kebabCase from "lodash/kebabCase";
 import PagesList from "./PagesList";
 import GridPageList from "./components/GridPageList";
+import { Link } from "@webiny/react-router";
+
 import {
     PbRenderElementPluginArgs,
     PbRenderElementPlugin,
@@ -35,7 +37,17 @@ export default (args: PbRenderElementPluginArgs = {}): PluginCollection => {
             type: "pb-page-element-pages-list-component",
             title: "Grid list",
             componentName: "default",
-            component: isLegacyRenderingEngine ? GridPageList : createDefaultPagesListComponent()
+            component: isLegacyRenderingEngine
+                ? GridPageList
+                : createDefaultPagesListComponent({
+                      linkComponent: ({ href, children, ...rest }) => {
+                          return (
+                              <Link to={href!} {...rest}>
+                                  {children}
+                              </Link>
+                          );
+                      }
+                  })
         } as PbPageElementPagesListComponentPlugin
     ];
 };


### PR DESCRIPTION
## Changes
Prior to this PR, links rendered by Pages List, Button, and Image page elements were rendered via the standard `a` HTML tag. But that's problematic because once a user clicks on the link, the whole website gets refreshed, essentially making the overall UX not pleasant.

We've now switched the link component that gets used with the above three page elements. With the `Link` component from the `@webiny/router` now being used, clicking on links doesn't cause a full page refresh. 

## How Has This Been Tested?
Manually.

## Documentation
Changelog.