### PR TITLE
Page Builder/Page Editor - Ensure Canvas Width Is Calculated Correctly

### DIFF
--- a/packages/app-page-builder/src/editor/components/Editor/Content.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/Content.tsx
@@ -90,36 +90,36 @@ const Content: React.FC = () => {
     const [{ displayMode }, setUiAtomValue] = useRecoilState(uiAtom);
     const pagePreviewRef = useRef<HTMLDivElement>(null);
 
-    if (isLegacyRenderingEngine) {
-        const setPagePreviewDimension = useCallback(
-            pagePreviewDimension => {
-                setUiAtomValue(prev => setPagePreviewDimensionMutation(prev, pagePreviewDimension));
-            },
-            [uiAtom]
-        );
+    const setPagePreviewDimension = useCallback(
+        pagePreviewDimension => {
+            setUiAtomValue(prev => setPagePreviewDimensionMutation(prev, pagePreviewDimension));
+        },
+        [uiAtom]
+    );
 
-        const resizeObserver = useMemo(() => {
-            return new ResizeObserver((entries: ResizeObserverEntry[]) => {
-                for (const entry of entries) {
-                    const { width, height } = entry.contentRect;
-                    setPagePreviewDimension({ width, height });
-                }
-            });
-        }, []);
-
-        // Set resize observer
-        useEffect(() => {
-            if (pagePreviewRef.current) {
-                // Add resize observer
-                resizeObserver.observe(pagePreviewRef.current);
+    const resizeObserver = useMemo(() => {
+        return new ResizeObserver((entries: ResizeObserverEntry[]) => {
+            for (const entry of entries) {
+                const { width, height } = entry.contentRect;
+                setPagePreviewDimension({ width, height });
             }
+        });
+    }, []);
 
-            // Cleanup
-            return () => {
-                resizeObserver.disconnect();
-            };
-        }, []);
+    // Set resize observer
+    useEffect(() => {
+        if (pagePreviewRef.current) {
+            // Add resize observer
+            resizeObserver.observe(pagePreviewRef.current);
+        }
 
+        // Cleanup
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, []);
+
+    if (isLegacyRenderingEngine) {
         const { theme } = usePageBuilder();
         return (
             <Elevation className={contentContainerWrapper} z={0}>


### PR DESCRIPTION
## Changes
Prior to this PR, the canvas width label would always stay at 100px, which was not correct.

![image](https://user-images.githubusercontent.com/5121148/232140718-09517d93-d1cd-4e1b-b6da-fa684cb7436b.png)

This has now been addressed. The value correctly shows the canvas width, even when choosing different breakpoints.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.