### PR TITLE
Build Script - Introduce `-p` Flag

### DIFF
--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -11,6 +11,7 @@ import { MetaJSON, Package } from "./types";
 import { getHardwareInfo } from "./getHardwareInfo";
 
 interface BuildOptions {
+    p?: string | string[];
     debug?: boolean;
     cache?: boolean;
     buildOverrides?: string;
@@ -25,8 +26,18 @@ export const buildPackages = async () => {
 
     printHardwareReport();
 
+    let packagesWhitelist: string[] = [];
+    if (options.p) {
+        if (Array.isArray(options.p)) {
+            packagesWhitelist = options.p;
+        } else {
+            packagesWhitelist = [options.p];
+        }
+    }
+
     const { batches, packagesNoCache, allPackages } = await getBatches({
-        cache: options.cache ?? true
+        cache: options.cache ?? true,
+        packagesWhitelist
     });
 
     if (!packagesNoCache.length) {


### PR DESCRIPTION
## Changes
This PR introduces the `-p` flag to our `webiny-js` repo's `build` command. With it, you can quickly build just one or more packages that you're interested in.

![image](https://user-images.githubusercontent.com/5121148/232145023-48d808c8-3c1e-4f71-a869-d1065bce01fa.png)

## How Has This Been Tested?
Manual.

## Documentation
None.