### PR TITLE
fix(file-manager): tags

### DIFF
--- a/packages/api-elasticsearch/src/types.ts
+++ b/packages/api-elasticsearch/src/types.ts
@@ -82,6 +82,7 @@ export interface ElasticsearchSearchResponseHit<T> {
 }
 export interface ElasticsearchSearchResponseAggregationBucket<T> {
     key: T;
+    doc_count: number;
 }
 export interface ElasticsearchSearchResponse<T = any> {
     body: {

--- a/packages/api-file-manager-ddb-es/__tests__/crud/mocks/data.ts
+++ b/packages/api-file-manager-ddb-es/__tests__/crud/mocks/data.ts
@@ -1,0 +1,51 @@
+export const richTextData = {
+    editor: "webiny",
+    data: [
+        {
+            tag: "h1",
+            content: "h1 title"
+        },
+        {
+            tag: "p",
+            content: "paragraph text"
+        },
+        {
+            tag: "div",
+            content: [
+                {
+                    tag: "p",
+                    content: "content paragraph text"
+                },
+                {
+                    tag: "a",
+                    content: "some url",
+                    href: "https://www.webiny.com/"
+                }
+            ]
+        }
+    ]
+};
+export const simpleRichTextData = {
+    editor: "webiny",
+    data: [
+        {
+            tag: "h1",
+            content: "title"
+        }
+    ]
+};
+
+export const fileData = {
+    id: "12345678",
+    key: "12345678/filenameA.png",
+    name: "filenameA.png",
+    size: 123456,
+    type: "image/png",
+    tags: ["sketch"],
+    aliases: [],
+    richText: richTextData
+};
+/**
+ * Add fields that are added via the plugins, so we get them back in the result.
+ */
+export const extraFields = ["richText {editor data}"];

--- a/packages/api-file-manager-ddb-es/__tests__/crud/mocks/file.ts
+++ b/packages/api-file-manager-ddb-es/__tests__/crud/mocks/file.ts
@@ -1,0 +1,71 @@
+import { File } from "@webiny/api-file-manager/types/file";
+import { ListTagsResponse } from "@webiny/api-file-manager/types";
+
+interface Params {
+    index: number;
+    tenant: string;
+    locale: string;
+}
+
+const createTags = (params: Params): string[] => {
+    const { index, tenant, locale } = params;
+    const tags = [`tag-${index}`, `tag-${tenant}`, `tag-${locale}`];
+    if (index % 2 === 0) {
+        tags.push(`tag-${index + 1}`);
+    }
+    return Array.from(new Set<string>(tags));
+};
+
+export const createExpectedTags = (
+    params: Omit<Params, "index"> & { amount: number }
+): ListTagsResponse[] => {
+    const { amount } = params;
+    const result: Record<string, ListTagsResponse> = {};
+
+    for (let index = 0; index < amount; index++) {
+        const tags = createTags({
+            ...params,
+            index
+        });
+        for (const tag of tags) {
+            result[tag] = {
+                tag,
+                count: (result[tag]?.count || 0) + 1
+            };
+        }
+    }
+
+    return Object.values(result)
+        .sort((a, b) => {
+            return a.tag < b.tag ? -1 : 1;
+        })
+        .sort((a, b) => {
+            return a.count > b.count ? -1 : 1;
+        });
+};
+
+export const createMockFileData = (params: Params): File => {
+    const { index, tenant, locale } = params;
+    return {
+        id: `file-${index}`,
+        key: `file-${index}.png`,
+        name: `file-${index}.png`,
+        size: 100,
+        type: "image/png",
+        tags: createTags(params),
+        createdOn: new Date().toISOString(),
+        createdBy: {
+            id: "a",
+            displayName: "a",
+            type: "admin"
+        },
+        meta: {
+            private: true,
+            public: false
+        },
+        aliases: [],
+        locale,
+        tenant,
+        webinyVersion: "0.0.0"
+    };
+};

--- a/packages/api-file-manager/__tests__/files.test.ts
+++ b/packages/api-file-manager/__tests__/files.test.ts
@@ -387,13 +387,51 @@ describe("Files CRUD test", () => {
             }
         });
 
-        const tags = ["art", "file-a", "file-b", "file-c", "sketch", "webiny"];
-        const scopedTags = ["scope:apw", "scope:apw:file-d", "scope:apw:media"];
+        const tags = [
+            {
+                tag: "art",
+                count: 2
+            },
+            {
+                tag: "sketch",
+                count: 2
+            },
+            {
+                tag: "webiny",
+                count: 2
+            },
+            {
+                tag: "file-a",
+                count: 1
+            },
+            {
+                tag: "file-b",
+                count: 1
+            },
+            {
+                tag: "file-c",
+                count: 1
+            }
+        ];
+        const scopedTags = [
+            {
+                tag: "scope:apw",
+                count: 1
+            },
+            {
+                tag: "scope:apw:file-d",
+                count: 1
+            },
+            {
+                tag: "scope:apw:media",
+                count: 1
+            }
+        ];
 
         await until(
             () => listTags({ where: { tag_not_startsWith: "scope:apw" } }).then(([data]) => data),
             ({ data }: any) => {
-                return data.fileManager.listTags.length === tags.length;
+                return data.fileManager.listTags.data.length === tags.length;
             },
             { name: "bulk list all tags", tries: 10 }
         );
@@ -407,7 +445,10 @@ describe("Files CRUD test", () => {
         expect(response).toEqual({
             data: {
                 fileManager: {
-                    listTags: tags
+                    listTags: {
+                        data: tags,
+                        error: null
+                    }
                 }
             }
         });
@@ -421,7 +462,10 @@ describe("Files CRUD test", () => {
         expect(scopedListTagsResponse).toEqual({
             data: {
                 fileManager: {
-                    listTags: scopedTags
+                    listTags: {
+                        data: scopedTags,
+                        error: null
+                    }
                 }
             }
         });
@@ -684,7 +728,10 @@ describe("Files CRUD test", () => {
         expect(tagsResponse).toEqual({
             data: {
                 fileManager: {
-                    listTags: []
+                    listTags: {
+                        data: [],
+                        error: null
+                    }
                 }
             }
         });

--- a/packages/api-file-manager/__tests__/graphql/file.ts
+++ b/packages/api-file-manager/__tests__/graphql/file.ts
@@ -121,7 +121,13 @@ export const LIST_FILES = (fields: string[]) => {
 export const LIST_TAGS = /* GraphQL */ `
     query ListTags($where: TagWhereInput) {
         fileManager {
-            listTags(where: $where)
+            listTags(where: $where) {
+                data {
+                    tag
+                    count
+                }
+                error ${ERROR_FIELD}
+            }
         }
     }
 `;

--- a/packages/api-file-manager/src/createFileManager/files.crud.ts
+++ b/packages/api-file-manager/src/createFileManager/files.crud.ts
@@ -351,19 +351,12 @@ export const createFilesCrud = (config: FileManagerConfig): FilesCRUD => {
 
             const params = {
                 where,
-                limit: limit || 100000,
+                limit: limit || 1000000,
                 after
             };
 
             try {
-                const [tags] = await storageOperations.files.tags(params);
-                if (Array.isArray(tags) === false) {
-                    return [];
-                }
-                /**
-                 * just to keep it standardized, sort by the tag ASC
-                 */
-                return tags.sort();
+                return await storageOperations.files.tags(params);
             } catch (ex) {
                 throw new WebinyError(
                     ex.message || "Could not search for tags.",

--- a/packages/api-file-manager/src/graphql/index.ts
+++ b/packages/api-file-manager/src/graphql/index.ts
@@ -151,6 +151,16 @@ export const createGraphQLSchemaPlugin = () => {
                 tag_not_startsWith: String
             }
 
+            type ListTagResponseItem {
+                tag: String!
+                count: Number!
+            }
+
+            type ListTagsResponse {
+                data: [ListTagResponseItem!]
+                error: FileError
+            }
+
             type FmQuery {
                 getFile(id: ID, where: JSON, sort: String): FileResponse
 
@@ -164,7 +174,7 @@ export const createGraphQLSchemaPlugin = () => {
                     where: FileWhereInput
                 ): FileListResponse
 
-                listTags(where: TagWhereInput): [String]
+                listTags(where: TagWhereInput): ListTagsResponse!
 
                 # Get installed version
                 version: String
@@ -225,7 +235,9 @@ export const createGraphQLSchemaPlugin = () => {
                 },
                 async listTags(_, args: any, context) {
                     try {
-                        return await context.fileManager.listTags(args || {});
+                        const tags = await context.fileManager.listTags(args || {});
+
+                        return new Response(tags);
                     } catch (error) {
                         return new ErrorResponse(error);
                     }

--- a/packages/api-file-manager/src/types.ts
+++ b/packages/api-file-manager/src/types.ts
@@ -74,10 +74,14 @@ interface FilesCrudListTagsParams {
     after?: string;
 }
 
+export interface ListTagsResponse {
+    tag: string;
+    count: number;
+}
 export interface FilesCRUD extends FileLifecycleEvents {
     getFile(id: string): Promise<File>;
     listFiles(opts?: FilesListOpts): Promise<[File[], FileListMeta]>;
-    listTags(params: FilesCrudListTagsParams): Promise<string[]>;
+    listTags(params: FilesCrudListTagsParams): Promise<ListTagsResponse[]>;
     createFile(data: FileInput): Promise<File>;
     updateFile(id: string, data: Partial<FileInput>): Promise<File>;
     deleteFile(id: string): Promise<boolean>;
@@ -323,10 +327,10 @@ export type FileManagerFilesStorageOperationsListResponse = [
     FileManagerFilesStorageOperationsListResponseMeta
 ];
 
-export type FileManagerFilesStorageOperationsTagsResponse = [
-    string[],
-    FileManagerFilesStorageOperationsListResponseMeta
-];
+export interface FileManagerFilesStorageOperationsTagsResponse {
+    tag: string;
+    count: number;
+}
 
 export interface FileManagerFilesStorageOperationsTagsParamsWhere extends FilesCrudListTagsWhere {
     locale: string;
@@ -378,7 +382,7 @@ export interface FileManagerFilesStorageOperations {
      */
     tags: (
         params: FileManagerFilesStorageOperationsTagsParams
-    ) => Promise<FileManagerFilesStorageOperationsTagsResponse>;
+    ) => Promise<FileManagerFilesStorageOperationsTagsResponse[]>;
 }
 
 export interface FileManagerStorageOperations<TContext = FileManagerContext> {

--- a/packages/app-file-manager/src/modules/FileManagerApiProvider/FileManagerApiContext/FileManagerApiContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerApiProvider/FileManagerApiContext/FileManagerApiContext.tsx
@@ -8,6 +8,7 @@ import {
     DELETE_FILE,
     DeleteFileMutationResponse,
     DeleteFileMutationVariables,
+    GET_FILE_SETTINGS,
     GetFileManagerSettingsQueryResponse,
     LIST_FILES,
     LIST_TAGS,
@@ -18,12 +19,16 @@ import {
     ListFileTagsQueryVariables,
     UPDATE_FILE,
     UpdateFileMutationResponse,
-    UpdateFileMutationVariables,
-    GET_FILE_SETTINGS
+    UpdateFileMutationVariables
 } from "../graphql";
 import { FileItem, FileManagerSecurityPermission } from "@webiny/app-admin/types";
 import { getFileUploader } from "./getFileUploader";
 import { Settings } from "~/types";
+
+export interface ListTagsResponseItem {
+    tag: string;
+    count: number;
+}
 
 export interface FileManagerApiContextData<TFileItem extends FileItem = FileItem> {
     canRead: boolean;
@@ -37,7 +42,7 @@ export interface FileManagerApiContextData<TFileItem extends FileItem = FileItem
     listFiles: (
         params?: ListFilesQueryVariables
     ) => Promise<{ files: TFileItem[]; meta: ListFilesListFilesResponse["meta"] }>;
-    listTags: (params?: ListTagsOptions) => Promise<string[]>;
+    listTags: (params?: ListTagsOptions) => Promise<ListTagsResponseItem[]>;
     getSettings(): Promise<Settings>;
 }
 
@@ -174,13 +179,13 @@ const FileManagerApiProvider = ({ children }: FileManagerApiProviderProps) => {
         return { files, meta };
     };
 
-    const listTags: FileManagerApiContextData["listTags"] = async (params = {}) => {
+    const listTags = async (params = {}) => {
         const { data } = await client.query<ListFileTagsQueryResponse>({
             query: LIST_TAGS,
             variables: params
         });
 
-        return data.fileManager.listTags;
+        return data.fileManager.listTags.data;
     };
 
     /**

--- a/packages/app-file-manager/src/modules/FileManagerApiProvider/graphql.ts
+++ b/packages/app-file-manager/src/modules/FileManagerApiProvider/graphql.ts
@@ -1,6 +1,7 @@
 import { FileItem } from "@webiny/app-admin/types";
 import gql from "graphql-tag";
 import { Settings } from "~/types";
+import { ListTagsResponseItem } from "~/modules/FileManagerApiProvider/FileManagerApiContext/FileManagerApiContext";
 
 const FILE_FIELDS = /* GraphQL */ `
     {
@@ -93,7 +94,10 @@ export const LIST_FILES = gql`
 
 export interface ListFileTagsQueryResponse {
     fileManager: {
-        listTags: string[];
+        listTags: {
+            data: ListTagsResponseItem[];
+            error: Error | null;
+        };
     };
 }
 
@@ -107,7 +111,13 @@ export interface ListFileTagsQueryVariables {
 export const LIST_TAGS = gql`
     query ListTags($where: TagWhereInput) {
         fileManager {
-            listTags(where: $where)
+            listTags(where: $where) {
+                data {
+                    tag
+                    count
+                }
+                error ${ERROR_FIELDS}
+            }
         }
     }
 `;

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
@@ -120,7 +120,11 @@ export const FileManagerViewProvider = ({ children, ...props }: FileManagerViewP
             where: getWhere(props.scope)
         });
 
-        setTags(tags);
+        setTags(
+            tags.map(tag => {
+                return tag.tag;
+            })
+        );
     };
 
     const getSettings = async () => {


### PR DESCRIPTION
## Changes
This PR is a collection of refactoring the API and the UI side of the File Manager.

The underlying issue was that the Elasticsearch project did not return the file tags correctly. While fixing that issue I noticed that the File Manager `listTags` GraphQL query returns only an array of strings as a result - so upgraded it as well to contain tags as an object (tag and count - amount times used) and an error object.


## How Has This Been Tested?
Jest and manually.

## Documentation
Put in the changelog info about the GraphQL Schema changes for the the File Manager.