### PR TITLE
feat: add tags to search records

### DIFF
--- a/packages/api-aco/__tests__/graphql/record.gql.ts
+++ b/packages/api-aco/__tests__/graphql/record.gql.ts
@@ -8,6 +8,7 @@ const DATA_FIELD = /* GraphQL */ `
             folderId
         }
         data
+        tags
     }
 `;
 

--- a/packages/api-aco/__tests__/mocks/record.mock.ts
+++ b/packages/api-aco/__tests__/mocks/record.mock.ts
@@ -8,8 +8,9 @@ export const recordMocks = {
             folderId: "folder-1"
         },
         data: {
-            tags: ["tag1", "tag2"]
-        }
+            any: "data"
+        },
+        tags: ["page-tag1", "page-tag2", "scope:page"]
     },
     recordB: {
         id: "page-b",
@@ -20,8 +21,9 @@ export const recordMocks = {
             folderId: "folder-1"
         },
         data: {
-            tags: ["tag1"]
-        }
+            any: 1
+        },
+        tags: ["page-tag1"]
     },
     recordC: {
         id: "page-c",
@@ -32,8 +34,9 @@ export const recordMocks = {
             folderId: "folder-2"
         },
         data: {
-            tags: ["tag1"]
-        }
+            any: "data"
+        },
+        tags: ["page-tag3"]
     },
     recordD: {
         id: "post-d",
@@ -44,19 +47,16 @@ export const recordMocks = {
             folderId: "folder-1"
         },
         data: {
-            any: "string"
-        }
+            any: "data"
+        },
+        tags: ["post-tag1", "post-tag2", "scope:post"]
     },
     recordE: {
         id: "post-e",
         type: "post",
         title: "Post e",
-        content: "Lorem ipsum docet",
         location: {
             folderId: "folder-1"
-        },
-        data: {
-            any: 1
         }
     }
 };

--- a/packages/api-aco/__tests__/record.so.test.ts
+++ b/packages/api-aco/__tests__/record.so.test.ts
@@ -24,7 +24,13 @@ describe("`search` CRUD", () => {
 
         const [responseE] = await search.createRecord({ data: recordMocks.recordE });
         const recordE = responseE.data.search.createRecord.data;
-        expect(recordE).toEqual({ ...recordMocks.recordE, id: recordE.id });
+        expect(recordE).toEqual({
+            ...recordMocks.recordE,
+            id: recordE.id,
+            content: null,
+            data: {},
+            tags: []
+        });
 
         // Let's check whether both of the record exists, listing them by `type` and `location`.
         // List records -> type: "page" / folderId: "folder-1"
@@ -63,18 +69,24 @@ describe("`search` CRUD", () => {
         );
 
         // List records -> type: "post" / folderId: "folder-1"
-        const [listResponsePostFolder1] = await search.listRecords({
+        const [listResponsePost] = await search.listRecords({
             where: { type: "post" },
             sort: {
                 createdOn: "ASC"
             }
         });
 
-        expect(listResponsePostFolder1.data.search.listRecords).toEqual(
+        expect(listResponsePost.data.search.listRecords).toEqual(
             expect.objectContaining({
                 data: expect.arrayContaining([
                     expect.objectContaining({ ...recordMocks.recordD, id: recordD.id }),
-                    expect.objectContaining({ ...recordMocks.recordE, id: recordE.id })
+                    expect.objectContaining({
+                        ...recordMocks.recordE,
+                        id: recordE.id,
+                        content: null,
+                        data: {},
+                        tags: []
+                    })
                 ]),
                 error: null
             })
@@ -146,6 +158,49 @@ describe("`search` CRUD", () => {
                 data: expect.arrayContaining([
                     expect.objectContaining({ ...recordMocks.recordB, id: recordB.id }),
                     expect.objectContaining({ ...recordMocks.recordC, id: recordC.id })
+                ]),
+                error: null
+            })
+        );
+
+        // Let's filter records using `tags_in`
+        const [tagsInResponse] = await search.listRecords({
+            where: { type: "page", tags_in: ["page-tag1"] }
+        });
+
+        expect(tagsInResponse.data.search.listRecords).toEqual(
+            expect.objectContaining({
+                data: expect.arrayContaining([
+                    expect.objectContaining({ ...recordMocks.recordA, id: recordA.id }),
+                    expect.objectContaining({ ...recordMocks.recordB, id: recordB.id })
+                ]),
+                error: null
+            })
+        );
+
+        // Let's filter records using `tags_startsWith`
+        const [tagsStartsWithResponse] = await search.listRecords({
+            where: { type: "page", tags_startsWith: "scope:" }
+        });
+
+        expect(tagsStartsWithResponse.data.search.listRecords).toEqual(
+            expect.objectContaining({
+                data: expect.arrayContaining([
+                    expect.objectContaining({ ...recordMocks.recordA, id: recordA.id })
+                ]),
+                error: null
+            })
+        );
+
+        // Let's filter records using `tags_not_startsWith`
+        const [tagsNotStartsWithResponse] = await search.listRecords({
+            where: { type: "page", tags_not_startsWith: "scope:" }
+        });
+
+        expect(tagsNotStartsWithResponse.data.search.listRecords).toEqual(
+            expect.objectContaining({
+                data: expect.arrayContaining([
+                    expect.objectContaining({ ...recordMocks.recordB, id: recordB.id })
                 ]),
                 error: null
             })

--- a/packages/api-aco/src/record/record.gql.ts
+++ b/packages/api-aco/src/record/record.gql.ts
@@ -13,7 +13,8 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
             location: SearchLocationType!
             title: String!
             content: String
-            data: JSON
+            data: JSON!
+            tags: [String!]!
             savedOn: DateTime
             createdOn: DateTime
             createdBy: AcoUser
@@ -34,6 +35,7 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
             content: String
             location: SearchLocationInput!
             data: JSON
+            tags: [String!]
         }
 
         input SearchRecordUpdateInput {
@@ -41,11 +43,15 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
             content: String
             location: SearchLocationInput
             data: JSON
+            tags: [String!]
         }
 
         input SearchRecordListWhereInput {
             type: String!
             location: SearchLocationInput
+            tags_in: [String!]
+            tags_startsWith: String
+            tags_not_startsWith: String
         }
 
         type SearchRecordResponse {

--- a/packages/api-aco/src/record/record.model.ts
+++ b/packages/api-aco/src/record/record.model.ts
@@ -54,6 +54,13 @@ const dataField = () =>
         type: "wby-aco-json"
     });
 
+const tagsField = () =>
+    createModelField({
+        label: "Tags",
+        type: "text",
+        multipleValues: true
+    });
+
 export const SEARCH_RECORD_MODEL_ID = "acoSearchRecord";
 
 export const createSearchModelDefinition = (): SearchRecordModelDefinition => {
@@ -61,13 +68,14 @@ export const createSearchModelDefinition = (): SearchRecordModelDefinition => {
         name: "ACO - Search Record",
         modelId: SEARCH_RECORD_MODEL_ID,
         titleFieldId: "title",
-        layout: [["type"], ["title"], ["content"], ["location"], ["data"]],
+        layout: [["type"], ["title"], ["content"], ["location"], ["data"], ["tags"]],
         fields: [
             typeField(),
             titleField(),
             contentField(),
             locationField([locationFolderIdField()]),
-            dataField()
+            dataField(),
+            tagsField()
         ],
         description: "ACO - Search record model",
         isPrivate: true

--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -59,7 +59,11 @@ export const createSearchRecordOperations = (
         },
         createRecord({ data }) {
             return withModel(async model => {
-                const entry = await cms.createEntry(model, data);
+                const defaultData = {
+                    data: {},
+                    tags: []
+                };
+                const entry = await cms.createEntry(model, { ...defaultData, ...data });
 
                 return getFieldValues(entry, baseFields, true);
             });

--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -57,13 +57,10 @@ export const createSearchRecordOperations = (
                 return [entries.map(entry => getFieldValues(entry, baseFields, true)), meta];
             });
         },
-        createRecord({ data }) {
+        createRecord({ data: SearchRecordData }) {
             return withModel(async model => {
-                const defaultData = {
-                    data: {},
-                    tags: []
-                };
-                const entry = await cms.createEntry(model, { ...defaultData, ...data });
+                const { tags = [], data = {}, ...rest } = SearchRecordData;
+                const entry = await cms.createEntry(model, { tags, data, ...rest });
 
                 return getFieldValues(entry, baseFields, true);
             });

--- a/packages/api-aco/src/record/record.types.ts
+++ b/packages/api-aco/src/record/record.types.ts
@@ -12,10 +12,11 @@ export interface Location {
 export interface SearchRecord<TData extends GenericSearchData = GenericSearchData>
     extends AcoBaseFields {
     type: string;
-    title?: string;
+    title: string;
     content?: string;
-    location?: Location;
-    data?: TData;
+    location: Location;
+    data: TData;
+    tags: string[];
 }
 
 export interface ListSearchRecordsWhere {
@@ -23,6 +24,9 @@ export interface ListSearchRecordsWhere {
     location?: {
         folderId: string;
     };
+    tags_in?: string[];
+    tags_startsWith?: string;
+    tags_not_startsWith?: string;
 }
 
 export interface ListSearchRecordsParams {
@@ -43,6 +47,7 @@ export interface UpdateSearchRecordParams<TData extends GenericSearchData> {
     content?: string;
     location?: Location;
     data?: TData;
+    tags?: string[];
 }
 
 export interface DeleteSearchRecordParams {

--- a/packages/api-aco/src/record/record.types.ts
+++ b/packages/api-aco/src/record/record.types.ts
@@ -39,7 +39,7 @@ export interface ListSearchRecordsParams {
 
 export type CreateSearchRecordParams<TData> = Pick<
     SearchRecord<TData>,
-    "id" | "title" | "content" | "type" | "location" | "data"
+    "id" | "title" | "content" | "type" | "location" | "data" | "tags"
 >;
 
 export interface UpdateSearchRecordParams<TData extends GenericSearchData> {

--- a/packages/api-page-builder-aco/__tests__/graphql/record.gql.ts
+++ b/packages/api-page-builder-aco/__tests__/graphql/record.gql.ts
@@ -4,6 +4,7 @@ const DATA_FIELD = (extra = "") => /* GraphQL */ `
         type
         title
         content
+        tags
         location {
             folderId
         }

--- a/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
+++ b/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
@@ -65,6 +65,7 @@ describe("Pages -> Search records", () => {
             location: {
                 folderId: ROOT_FOLDER
             },
+            tags: [],
             data: {
                 id,
                 pid,
@@ -115,7 +116,12 @@ describe("Pages -> Search records", () => {
             id,
             data: {
                 title: `${title} + update`,
-                content: pageContentMock
+                content: pageContentMock,
+                settings: {
+                    general: {
+                        tags: ["tag1"]
+                    }
+                }
             }
         });
 
@@ -131,6 +137,7 @@ describe("Pages -> Search records", () => {
             id: pid,
             title: updatePage.title,
             content: `${updatePage.title} Demo Heading Demo Content with multiple spaces and new line Demo button Demo Image 1 Demo Image 2 Demo Image 3`,
+            tags: ["tag1"],
             data: {
                 title: updatePage.title,
                 savedOn: updatePage.savedOn

--- a/packages/api-page-builder-aco/src/types.ts
+++ b/packages/api-page-builder-aco/src/types.ts
@@ -44,11 +44,13 @@ export interface PbCreatePayload {
     title: string;
     content: string;
     location: PbPayloadLocation;
+    tags: string[];
     data: PbPageRecordData;
 }
 
 export interface PbUpdatePayload {
     title: string;
     content: string;
+    tags: string[];
     data: PbPageRecordData;
 }

--- a/packages/api-page-builder-aco/src/utils/createRecordPayload.ts
+++ b/packages/api-page-builder-aco/src/utils/createRecordPayload.ts
@@ -16,7 +16,19 @@ export const createPageRecordPayload = async (
     page: Page,
     meta?: Record<string, any>
 ): Promise<CreateSearchRecordParams<PbPageRecordData>> => {
-    const { id, pid, title, createdOn, createdBy, savedOn, status, version, locked, path } = page;
+    const {
+        id,
+        pid,
+        title,
+        createdOn,
+        createdBy,
+        savedOn,
+        status,
+        version,
+        locked,
+        path,
+        settings
+    } = page;
     const content = await context.pageBuilderAco.getSearchablePageContent(page);
     const location = {
         folderId: meta?.location?.folderId || ROOT_FOLDER
@@ -28,6 +40,7 @@ export const createPageRecordPayload = async (
         title,
         content,
         location,
+        tags: settings.general?.tags || [],
         data: {
             id,
             pid,
@@ -58,12 +71,25 @@ export const updatePageRecordPayload = async (
     context: PbAcoContext,
     page: Page
 ): Promise<UpdateSearchRecordParams<PbPageRecordData>> => {
-    const { id, pid, title, createdOn, createdBy, savedOn, status, version, locked, path } = page;
+    const {
+        id,
+        pid,
+        title,
+        createdOn,
+        createdBy,
+        savedOn,
+        status,
+        version,
+        locked,
+        path,
+        settings
+    } = page;
     const content = await context.pageBuilderAco.getSearchablePageContent(page);
 
     const payload: PbUpdatePayload = {
         title,
         content,
+        tags: settings.general?.tags || [],
         data: {
             id,
             pid,

--- a/packages/migrations/__tests__/migrations/5.35.0/006/ddb-es/006.test.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0/006/ddb-es/006.test.ts
@@ -96,7 +96,7 @@ describe("5.35.0-006", () => {
                                 image: null,
                                 layout: "static",
                                 snippet: null,
-                                tags: null
+                                tags: [`tag-${pid}-1`, `tag-${pid}-2`]
                             },
                             seo: {
                                 description: null,
@@ -303,6 +303,7 @@ describe("5.35.0-006", () => {
                     "object@location": {
                         "text@folderId": ROOT_FOLDER
                     },
+                    "text@tags": [`tag-${pid}-1`, `tag-${pid}-2`],
                     "wby-aco-json@data": {
                         createdBy,
                         createdOn,
@@ -328,6 +329,7 @@ describe("5.35.0-006", () => {
                     "text@type": PB_PAGE_TYPE,
                     "text@title": title,
                     "text@content": `${title} Heading ${pid} Lorem ipsum dolor sit amet.`,
+                    "text@tags": [`tag-${pid}-1`, `tag-${pid}-2`],
                     "object@location": {
                         "text@folderId": ROOT_FOLDER
                     }

--- a/packages/migrations/__tests__/migrations/5.35.0/006/ddb/006.test.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0/006/ddb/006.test.ts
@@ -68,7 +68,7 @@ describe("5.35.0-006", () => {
                                 image: null,
                                 layout: "static",
                                 snippet: null,
-                                tags: null
+                                tags: [`tag-${pid}`]
                             },
                             seo: {
                                 description: null,
@@ -201,6 +201,7 @@ describe("5.35.0-006", () => {
                 "object@location": {
                     "text@folderId": ROOT_FOLDER
                 },
+                "text@tags": [`tag-${pid}`],
                 "wby-aco-json@data": {
                     createdBy,
                     createdOn,

--- a/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
@@ -238,7 +238,8 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                                 status,
                                 tenant: pageTenant,
                                 title,
-                                version
+                                version,
+                                settings
                             } = ddbPage;
 
                             const entry = await this.createSearchRecordCommonFields(ddbPage);
@@ -254,6 +255,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                                     "text@type": PB_PAGE_TYPE,
                                     "text@title": title,
                                     "text@content": content,
+                                    "text@tags": settings.general?.tags || [],
                                     "object@location": {
                                         "text@folderId": ROOT_FOLDER
                                     }
@@ -405,7 +407,8 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
             status,
             tenant,
             title,
-            version
+            version,
+            settings
         } = page;
 
         const content = await getSearchablePageContent(page);
@@ -443,6 +446,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                 "object@location": {
                     "text@folderId": ROOT_FOLDER
                 },
+                "text@tags": settings.general?.tags || [],
                 "text@type": PB_PAGE_TYPE
             }
         };

--- a/packages/migrations/src/migrations/5.35.0/006/ddb/PageDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/ddb/PageDataMigration.ts
@@ -224,7 +224,8 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
             status,
             tenant,
             title,
-            version
+            version,
+            settings
         } = page;
 
         const content = await getSearchablePageContent(page);
@@ -262,6 +263,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                 "object@location": {
                     "text@folderId": ROOT_FOLDER
                 },
+                "text@tags": settings.general?.tags || [],
                 "text@type": PB_PAGE_TYPE
             }
         };

--- a/packages/migrations/src/migrations/5.35.0/006/types.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/types.ts
@@ -79,7 +79,7 @@ export interface Page {
     content: Record<string, any> | null;
     publishedOn: string | null;
     version: number;
-    settings: Record<string, any>;
+    settings: PageSettings;
     locked: boolean;
     status: string;
     createdOn: string;


### PR DESCRIPTION
## Changes
With this PR: 

- we add `tags` to ACO search records - via `api-aco` package
- add page builder `tags` to ACO search records - via `api-page-builder-aco` package
- fix migration script for pages -> aco - via `migrations` package

## How Has This Been Tested?
Jest

