### PR TITLE
fix(api-aco): prefix search record

### DIFF
--- a/packages/api-aco/src/folder/folder.so.ts
+++ b/packages/api-aco/src/folder/folder.so.ts
@@ -4,7 +4,7 @@ import { FOLDER_MODEL_ID } from "./folder.model";
 import { baseFields, CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
 import { createListSort } from "~/utils/createListSort";
 import { createOperationsWrapper } from "~/utils/createOperationsWrapper";
-import { getFieldValues } from "~/utils/getFieldValues";
+import { getFolderFieldValues } from "~/utils/getFieldValues";
 
 import { AcoFolderStorageOperations } from "./folder.types";
 
@@ -48,7 +48,7 @@ export const createFolderOperations = (
                 });
             }
 
-            return getFieldValues(entry, baseFields);
+            return getFolderFieldValues(entry, baseFields);
         });
     };
 
@@ -95,7 +95,7 @@ export const createFolderOperations = (
                     }
                 });
 
-                return [entries.map(entry => getFieldValues(entry, baseFields)), meta];
+                return [entries.map(entry => getFolderFieldValues(entry, baseFields)), meta];
             });
         },
         createFolder({ data }) {
@@ -113,7 +113,7 @@ export const createFolderOperations = (
                     parentId: data.parentId || null
                 });
 
-                return getFieldValues(entry, baseFields);
+                return getFolderFieldValues(entry, baseFields);
             });
         },
         updateFolder({ id, data }) {
@@ -137,7 +137,7 @@ export const createFolderOperations = (
                 };
 
                 const entry = await cms.updateEntry(model, id, input);
-                return getFieldValues(entry, baseFields);
+                return getFolderFieldValues(entry, baseFields);
             });
         },
         deleteFolder({ id }) {

--- a/packages/api-aco/src/record/record.gql.ts
+++ b/packages/api-aco/src/record/record.gql.ts
@@ -89,9 +89,6 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
             id: async parent => {
                 const { id } = parseIdentifier(parent.id);
                 return removeAcoRecordPrefix(id);
-            },
-            entryId: async parent => {
-                return removeAcoRecordPrefix(parent.entryId);
             }
         },
         SearchQuery: {

--- a/packages/api-aco/src/record/record.gql.ts
+++ b/packages/api-aco/src/record/record.gql.ts
@@ -89,6 +89,9 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
             id: async parent => {
                 const { id } = parseIdentifier(parent.id);
                 return removeAcoRecordPrefix(id);
+            },
+            entryId: async parent => {
+                return removeAcoRecordPrefix(parent.entryId);
             }
         },
         SearchQuery: {

--- a/packages/api-aco/src/record/record.gql.ts
+++ b/packages/api-aco/src/record/record.gql.ts
@@ -4,6 +4,8 @@ import { GraphQLSchemaPlugin } from "@webiny/handler-graphql/plugins/GraphQLSche
 import { resolve } from "~/utils/resolve";
 
 import { AcoContext } from "~/types";
+import { parseIdentifier } from "@webiny/utils";
+import { removeAcoRecordPrefix } from "~/utils/acoRecordId";
 
 export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
     typeDefs: /* GraphQL */ `
@@ -83,6 +85,12 @@ export const searchRecordSchema = new GraphQLSchemaPlugin<AcoContext>({
         }
     `,
     resolvers: {
+        SearchRecord: {
+            id: async parent => {
+                const { id } = parseIdentifier(parent.id);
+                return removeAcoRecordPrefix(id);
+            }
+        },
         SearchQuery: {
             getRecord: async (_, { id }, context) => {
                 return resolve(() => context.aco.search.get(id));

--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -3,9 +3,10 @@ import { SEARCH_RECORD_MODEL_ID } from "./record.model";
 import { baseFields, CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
 import { createListSort } from "~/utils/createListSort";
 import { createOperationsWrapper } from "~/utils/createOperationsWrapper";
-import { getFieldValues } from "~/utils/getFieldValues";
+import { getRecordFieldValues } from "~/utils/getFieldValues";
 import { AcoSearchRecordStorageOperations } from "./record.types";
 import { CmsModel } from "@webiny/api-headless-cms/types";
+import { attachAcoRecordPrefix } from "~/utils/acoRecordId";
 
 export const createSearchRecordOperations = (
     params: CreateAcoStorageOperationsParams
@@ -23,7 +24,7 @@ export const createSearchRecordOperations = (
          * We need to retrieve it via `cms.storageOperations.entries.getLatestByIds()` method and return the first one.
          */
         const revisions = await cms.storageOperations.entries.getLatestByIds(model, {
-            ids: [id]
+            ids: [attachAcoRecordPrefix(id)]
         });
 
         if (revisions.length === 0) {
@@ -39,7 +40,7 @@ export const createSearchRecordOperations = (
         async getRecord({ id }) {
             return withModel(async model => {
                 const record = await getRecord(model, id);
-                return getFieldValues(record, baseFields, true);
+                return getRecordFieldValues(record, baseFields);
             });
         },
         listRecords(params) {
@@ -54,34 +55,43 @@ export const createSearchRecordOperations = (
                     }
                 });
 
-                return [entries.map(entry => getFieldValues(entry, baseFields, true)), meta];
+                return [entries.map(entry => getRecordFieldValues(entry, baseFields)), meta];
             });
         },
         createRecord({ data: SearchRecordData }) {
             return withModel(async model => {
                 const { tags = [], data = {}, ...rest } = SearchRecordData;
-                const entry = await cms.createEntry(model, { tags, data, ...rest });
+                const entry = await cms.createEntry(model, {
+                    tags,
+                    data,
+                    ...rest,
+                    id: attachAcoRecordPrefix(rest.id)
+                });
 
-                return getFieldValues(entry, baseFields, true);
+                return getRecordFieldValues(entry, baseFields);
             });
         },
-        updateRecord({ id, data }) {
+        updateRecord(this: AcoSearchRecordStorageOperations, { id, data }) {
             return withModel(async model => {
-                const original = await getRecord(model, id);
+                const original = await this.getRecord({ id });
 
                 const input = {
                     ...original,
                     ...data
                 };
 
-                const entry = await cms.updateEntry(model, original.id, input);
+                const entry = await cms.updateEntry(
+                    model,
+                    attachAcoRecordPrefix(original.id),
+                    input
+                );
 
-                return getFieldValues(entry, baseFields, true);
+                return getRecordFieldValues(entry, baseFields);
             });
         },
         deleteRecord({ id }) {
             return withModel(async model => {
-                await cms.deleteEntry(model, id);
+                await cms.deleteEntry(model, attachAcoRecordPrefix(id));
                 return true;
             });
         }

--- a/packages/api-aco/src/utils/acoRecordId.ts
+++ b/packages/api-aco/src/utils/acoRecordId.ts
@@ -1,3 +1,10 @@
+/**
+ * !!! DO NOT CHANGE THIS !!!
+ * If this is changed, you will need to create new migration which changes the IDs for the users.
+ *
+ * packages/migrations/src/migrations/5.35.0/006/ddb/PageDataMigration.ts:236
+ * packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts:419
+ */
 const WBY_ACO_PREFIX = "wby-aco-";
 /**
  * 006

--- a/packages/api-aco/src/utils/acoRecordId.ts
+++ b/packages/api-aco/src/utils/acoRecordId.ts
@@ -1,0 +1,19 @@
+const WBY_ACO_PREFIX = "wby-aco-";
+/**
+ * 006
+ * PageDataMigration in ddb-es and ddb
+ */
+
+export const attachAcoRecordPrefix = (id: string) => {
+    if (id.startsWith(WBY_ACO_PREFIX)) {
+        return id;
+    }
+    return `${WBY_ACO_PREFIX}${id}`;
+};
+
+export const removeAcoRecordPrefix = (id: string) => {
+    if (id.startsWith(WBY_ACO_PREFIX) === false) {
+        return id;
+    }
+    return id.substring(WBY_ACO_PREFIX.length);
+};

--- a/packages/api-aco/src/utils/getFieldValues.ts
+++ b/packages/api-aco/src/utils/getFieldValues.ts
@@ -1,10 +1,15 @@
 import pick from "lodash/pick";
-
 import { CmsEntry } from "@webiny/api-headless-cms/types";
-import { parseIdentifier } from "@webiny/utils";
+import { SearchRecord } from "~/record/record.types";
+import { Folder } from "~/folder/folder.types";
 
-export function getFieldValues(entry: CmsEntry, fields: string[], useEntryId?: boolean): any {
-    // We return the `id` without version in case of `useEntryId` flag is passed.
-    const { id } = parseIdentifier(entry.id);
-    return { ...pick(entry, fields), ...entry.values, ...(useEntryId && { id }) };
+export function getRecordFieldValues(entry: CmsEntry, fields: string[]) {
+    return {
+        ...pick(entry, fields),
+        ...entry.values
+    } as SearchRecord<any>;
+}
+
+export function getFolderFieldValues(entry: CmsEntry, fields: string[]) {
+    return { ...pick(entry, fields), ...entry.values } as Folder;
 }

--- a/packages/migrations/__tests__/migrations/5.35.0/006/ddb-es/006.test.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0/006/ddb-es/006.test.ts
@@ -38,11 +38,11 @@ describe("5.35.0-006", () => {
     const ddbEsPages: Record<string, any>[] = [];
     const esPages: any[] = [];
 
-    beforeEach(() => {
+    beforeEach(async () => {
         process.env.ELASTIC_SEARCH_INDEX_PREFIX =
             new Date().toISOString().replace(/\.|\:/g, "-").toLowerCase() + "-";
 
-        elasticsearchClient.indices.deleteAll();
+        await elasticsearchClient.indices.deleteAll();
     });
     afterEach(async () => {
         await elasticsearchClient.indices.deleteAll();
@@ -285,18 +285,20 @@ describe("5.35.0-006", () => {
                 webinyVersion
             } = page;
 
-            const ddbSearchRecord = ddbSearchRecords.find(record => record.id === `${pid}#0001`);
+            const ddbSearchRecord = ddbSearchRecords.find(
+                record => record.id === `wby-aco-${pid}#0001`
+            );
             const ddbEsSearchRecord = ddbEsSearchRecords.find(
-                record => record.PK === `T#${tenant}#L#${locale}#CMS#CME#${pid}`
+                record => record.PK === `T#${tenant}#L#${locale}#CMS#CME#wby-aco-${pid}`
             );
 
             // Checking DDB ACO search record
             expect(ddbSearchRecord).toMatchObject({
-                PK: `T#${tenant}#L#${locale}#CMS#CME#${pid}`,
+                PK: `T#${tenant}#L#${locale}#CMS#CME#wby-aco-${pid}`,
                 SK: "L",
                 TYPE: "L",
-                entryId: pid,
-                id: `${pid}#0001`,
+                entryId: `wby-aco-${pid}`,
+                id: `wby-aco-${pid}#0001`,
                 locale,
                 tenant,
                 version: 1,
@@ -352,13 +354,13 @@ describe("5.35.0-006", () => {
                     }
                 },
                 createdBy,
-                entryId: pid,
+                entryId: `wby-aco-${pid}`,
                 tenant,
                 createdOn,
                 locked: false,
                 ownedBy: createdBy,
                 webinyVersion: process.env.WEBINY_VERSION,
-                id: `${pid}#0001`,
+                id: `wby-aco-${pid}#0001`,
                 modifiedBy: createdBy,
                 latest: true,
                 TYPE: "cms.entry.l",
@@ -370,7 +372,7 @@ describe("5.35.0-006", () => {
 
             // Checking DDB + ES ACO search record
             expect(ddbEsSearchRecord).toMatchObject({
-                PK: `T#${tenant}#L#${locale}#CMS#CME#${pid}`,
+                PK: `T#${tenant}#L#${locale}#CMS#CME#wby-aco-${pid}`,
                 SK: "L",
                 index: esGetIndexName({
                     tenant,

--- a/packages/migrations/__tests__/migrations/5.35.0/006/ddb/006.test.ts
+++ b/packages/migrations/__tests__/migrations/5.35.0/006/ddb/006.test.ts
@@ -188,10 +188,10 @@ describe("5.35.0-006", () => {
             } = page;
 
             const latestSearchRecord = searchRecords.find(
-                record => record.id === `${pid}#0001` && record.SK === "L"
+                record => record.id === `wby-aco-${pid}#0001` && record.SK === "L"
             );
             const revisionSearchRecord = searchRecords.find(
-                record => record.id === `${pid}#0001` && record.SK === "REV#0001"
+                record => record.id === `wby-aco-${pid}#0001` && record.SK === "REV#0001"
             );
 
             const values = {
@@ -218,12 +218,12 @@ describe("5.35.0-006", () => {
 
             // Checking latest ACO search record
             expect(latestSearchRecord).toMatchObject({
-                PK: `T#${tenant}#L#${locale}#CMS#CME#CME#${pid}`,
+                PK: `T#${tenant}#L#${locale}#CMS#CME#CME#wby-aco-${pid}`,
                 SK: "L",
-                entryId: pid,
+                id: `wby-aco-${pid}#0001`,
+                entryId: `wby-aco-${pid}`,
                 GSI1_PK: `T#${tenant}#L#${locale}#CMS#CME#M#acoSearchRecord#L`,
-                GSI1_SK: `${pid}#0001`,
-                id: `${pid}#0001`,
+                GSI1_SK: `wby-aco-${pid}#0001`,
                 locale,
                 locked: false,
                 modelId: ACO_SEARCH_MODEL_ID,
@@ -235,12 +235,12 @@ describe("5.35.0-006", () => {
 
             // Checking revision 1 ACO search record
             expect(revisionSearchRecord).toMatchObject({
-                PK: `T#${tenant}#L#${locale}#CMS#CME#CME#${pid}`,
+                PK: `T#${tenant}#L#${locale}#CMS#CME#CME#wby-aco-${pid}`,
                 SK: "REV#0001",
-                entryId: pid,
+                id: `wby-aco-${pid}#0001`,
+                entryId: `wby-aco-${pid}`,
                 GSI1_PK: `T#${tenant}#L#${locale}#CMS#CME#M#acoSearchRecord#A`,
-                GSI1_SK: `${pid}#0001`,
-                id: `${pid}#0001`,
+                GSI1_SK: `wby-aco-${pid}#0001`,
                 locale,
                 locked: false,
                 modelId: ACO_SEARCH_MODEL_ID,

--- a/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
@@ -135,7 +135,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                 // Fetch latest aco search record from DDB using latest page "pid"
                 const latestSearchRecord = await queryOne<{ id: string }>({
                     entity: this.ddbEntryEntity,
-                    partitionKey: `T#${tenant.data.id}#L#${locale.code}#CMS#CME#${latestPage.pid}`,
+                    partitionKey: `T#${tenant.data.id}#L#${locale.code}#CMS#CME#wby-aco-${latestPage.pid}`,
                     options: {
                         eq: "L"
                     }
@@ -273,13 +273,13 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                                     }
                                 },
                                 createdBy,
-                                entryId: pid,
+                                entryId: `wby-aco-${pid}`,
                                 tenant: pageTenant,
                                 createdOn,
                                 locked: false,
                                 ownedBy: createdBy,
                                 webinyVersion: process.env.WEBINY_VERSION,
-                                id: `${pid}#0001`,
+                                id: `wby-aco-${pid}#0001`,
                                 modifiedBy: createdBy,
                                 latest: true,
                                 TYPE: "cms.entry.l",
@@ -290,21 +290,21 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                             };
 
                             const latestDdb = {
-                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#${pid}`,
+                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#wby-aco-${pid}`,
                                 SK: "L",
                                 TYPE: "L",
                                 ...entry
                             };
 
                             const revisionDdb = {
-                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#${pid}`,
+                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#wby-aco-${pid}`,
                                 SK: "REV#0001",
                                 TYPE: "cms.entry",
                                 ...entry
                             };
 
                             const latestDdbEs = {
-                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#${pid}`,
+                                PK: `T#${pageTenant}#L#${pageLocale}#CMS#CME#wby-aco-${pid}`,
                                 SK: "L",
                                 data: await getCompressedData(rawDatas),
                                 index: esGetIndexName({
@@ -416,8 +416,8 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
         return {
             createdBy,
             createdOn,
-            entryId: pid,
-            id: `${pid}#0001`,
+            entryId: `wby-aco-${pid}`,
+            id: `wby-aco-${pid}#0001`,
             locale,
             locked: false,
             modelId: ACO_SEARCH_MODEL_ID,

--- a/packages/migrations/src/migrations/5.35.0/006/ddb/PageDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/ddb/PageDataMigration.ts
@@ -9,7 +9,7 @@ import { createDdbPageEntity } from "../entities/createPageEntity";
 import { createTenantEntity } from "../entities/createTenantEntity";
 import { getSearchablePageContent } from "../utils/getSearchableContent";
 
-import { I18NLocale, Page, Tenant, ListLocalesParams } from "../types";
+import { I18NLocale, ListLocalesParams, Page, Tenant } from "../types";
 import { batchWriteAll, ddbQueryAllWithCallback, queryAll, queryOne } from "~/utils";
 import { ACO_SEARCH_MODEL_ID, PB_PAGE_TYPE, ROOT_FOLDER } from "../constants";
 
@@ -73,7 +73,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
 
                 const lastSearchRecord = await queryOne<{ id: string }>({
                     entity: this.entryEntity,
-                    partitionKey: `T#${tenant.data.id}#L#${locale.code}#CMS#CME#CME#${lastPage.pid}`,
+                    partitionKey: `T#${tenant.data.id}#L#${locale.code}#CMS#CME#CME#wby-aco-${lastPage.pid}`,
                     options: {
                         eq: "L"
                     }
@@ -129,19 +129,19 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                                 const entry = await this.createSearchRecordCommonFields(current);
 
                                 const latestEntry = {
-                                    PK: `T#${tenant}#L#${locale}#CMS#CME#CME#${pid}`,
+                                    PK: `T#${tenant}#L#${locale}#CMS#CME#CME#wby-aco-${pid}`,
                                     SK: "L",
                                     GSI1_PK: `T#${tenant}#L#${locale}#CMS#CME#M#acoSearchRecord#L`,
-                                    GSI1_SK: `${pid}#0001`,
+                                    GSI1_SK: `wby-aco-${pid}#0001`,
                                     TYPE: "cms.entry.l",
                                     ...entry
                                 };
 
                                 const revisionEntry = {
-                                    PK: `T#${tenant}#L#${locale}#CMS#CME#CME#${pid}`,
+                                    PK: `T#${tenant}#L#${locale}#CMS#CME#CME#wby-aco-${pid}`,
                                     SK: "REV#0001",
                                     GSI1_PK: `T#${tenant}#L#${locale}#CMS#CME#M#acoSearchRecord#A`,
-                                    GSI1_SK: `${pid}#0001`,
+                                    GSI1_SK: `wby-aco-${pid}#0001`,
                                     TYPE: "cms.entry",
                                     ...entry
                                 };
@@ -233,8 +233,8 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
         return {
             createdBy,
             createdOn,
-            entryId: pid,
-            id: `${pid}#0001`,
+            entryId: `wby-aco-${pid}`,
+            id: `wby-aco-${pid}#0001`,
             locale,
             locked: false,
             modelId: ACO_SEARCH_MODEL_ID,


### PR DESCRIPTION
## Changes
Because the ACO uses the CMS as underlying storage an issue poped out, due to single table design, where ACO search record and the CMS Entry, being indexed for search, have same PK in both DDB and DDB+ES storage operations.

## How Has This Been Tested?
Jest and manually.
