### PR TITLE
fix(api-elasticsearch): allow numbers in fields when filtering

### DIFF
--- a/packages/api-elasticsearch/__tests__/where.test.ts
+++ b/packages/api-elasticsearch/__tests__/where.test.ts
@@ -45,7 +45,10 @@ describe("where", () => {
         }
     );
 
-    test("should throw error when malformed field is parsed out", () => {
+    /**
+     * Skipped because fields can contain numbers.
+     */
+    test.skip("should throw error when malformed field is parsed out", () => {
         const key = "a0_in";
         expect(() => {
             parseWhereKey(key);

--- a/packages/api-elasticsearch/src/where.ts
+++ b/packages/api-elasticsearch/src/where.ts
@@ -28,7 +28,7 @@ export const parseWhereKey = (key: string): ParseWhereKeyResult => {
 
     const [, field, operation = "eq"] = match;
 
-    if (!field.match(/^([a-zA-Z]+)$/)) {
+    if (!field.match(/^([a-zA-Z0-9]+)$/)) {
         throw new Error(`Cannot filter by "${field}".`);
     }
 

--- a/packages/api-headless-cms/__tests__/contentAPI/deepNestedObject.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/deepNestedObject.test.ts
@@ -5,8 +5,8 @@ import { ContextPlugin } from "@webiny/api";
 import { CmsContext } from "~/types";
 
 const LIST_CARS_QUERY = `
-    query ListCarsQuery {
-        listCars {
+    query ListCarsQuery($where: CarsListWhereInput, $sort: [CarsListSorter], $limit: Int, $after: String) {
+        listCars(where: $where, sort: $sort, limit: $limit, after: $after) {
             data {
                 id
                 carsVehicle
@@ -587,6 +587,55 @@ describe("Cars Model Deep Nested Object Fields", () => {
                             carsVehicle: "Acura-ILX-2019--"
                         }
                     ],
+                    error: null
+                }
+            }
+        });
+
+        const [listSpecificationsHeroLabelResult] = await handler.invoke({
+            body: {
+                query: LIST_CARS_QUERY,
+                variables: {
+                    where: {
+                        specifications: {
+                            heroLabel1: "N/A"
+                        }
+                    }
+                }
+            }
+        });
+
+        expect(listSpecificationsHeroLabelResult).toEqual({
+            data: {
+                listCars: {
+                    data: [
+                        {
+                            id: mutationResult.data.createCars.data.id,
+                            carsVehicle: "Acura-ILX-2019--"
+                        }
+                    ],
+                    error: null
+                }
+            }
+        });
+
+        const [listSpecificationsHeroLabelNoResult] = await handler.invoke({
+            body: {
+                query: LIST_CARS_QUERY,
+                variables: {
+                    where: {
+                        specifications: {
+                            heroLabel1: "N/AB"
+                        }
+                    }
+                }
+            }
+        });
+
+        expect(listSpecificationsHeroLabelNoResult).toEqual({
+            data: {
+                listCars: {
+                    data: [],
                     error: null
                 }
             }


### PR DESCRIPTION
## Changes
Allow filtering by a field which contains a number in the `fieldId`.

## How Has This Been Tested?
Jest.