### PR TITLE
fix(headless-cms): various simple issues

### DIFF
--- a/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
@@ -41,9 +41,12 @@ interface CmsModelFieldInput extends Omit<CmsModelFieldBase, "storageId" | "sett
     settings?: CmsModelFieldSettings;
 }
 
-export interface CmsApiModel extends Omit<CmsModel, "isPrivate" | "fields"> {
+export interface CmsApiModel
+    extends Omit<CmsModel, "isPrivate" | "fields" | "singularApiName" | "pluralApiName"> {
     isPrivate?: never;
     noValidate?: never;
+    singularApiName?: string;
+    pluralApiName?: string;
     fields: CmsModelFieldInput[];
 }
 

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -51,7 +51,6 @@
     "graphql": "^15.7.2",
     "graphql-tag": "^2.12.6",
     "lodash": "^4.17.10",
-    "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "raw.macro": "^0.4.2",
     "react": "17.0.2",

--- a/packages/app-headless-cms/src/admin/components/Dialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/Dialog.tsx
@@ -10,7 +10,7 @@ export const Dialog = styled(BaseDialog)`
     }
 
     .mdc-dialog__content {
-        overflow: initial !important;
+        overflow: auto;
         .mdc-list:first-of-type {
             padding: 0;
         }

--- a/packages/app-headless-cms/src/admin/menus/ContentGroupsMenuItems.tsx
+++ b/packages/app-headless-cms/src/admin/menus/ContentGroupsMenuItems.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import get from "lodash/get";
-import pluralize from "pluralize";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     LIST_MENU_CONTENT_GROUPS_MODELS,
@@ -89,7 +88,7 @@ export const ContentGroupsMenuItems: React.FC = () => {
                                     >
                                         <Menu
                                             name={contentModel.modelId}
-                                            label={pluralize(contentModel.name)}
+                                            label={contentModel.name}
                                             path={`/cms/content-entries/${contentModel.modelId}`}
                                         />
                                     </HasContentEntryPermissions>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import debounce from "lodash/debounce";
 import { css } from "emotion";
 /**
@@ -6,7 +6,6 @@ import { css } from "emotion";
  */
 // @ts-ignore
 import TimeAgo from "timeago-react";
-import pluralize from "pluralize";
 import styled from "@emotion/styled";
 import { i18n } from "@webiny/app/i18n";
 import { Form } from "@webiny/form";
@@ -21,13 +20,12 @@ import { ReactComponent as AddIcon } from "@webiny/app-admin/assets/icons/add-18
 import { ReactComponent as FilterIcon } from "@webiny/app-admin/assets/icons/filter-24px.svg";
 import SearchUI from "@webiny/app-admin/components/SearchUI";
 import statusLabels from "../../constants/statusLabels";
-import { useCallback } from "react";
 import { useContentEntriesList } from "~/admin/views/contentEntries/hooks/useContentEntriesList";
 import { positionValues as PositionValues } from "react-custom-scrollbars";
 import { CmsEditorContentEntry } from "~/types";
 import {
-    useContentEntriesViewConfig,
-    ContentEntriesViewConfigFilter
+    ContentEntriesViewConfigFilter,
+    useContentEntriesViewConfig
 } from "./experiment/ContentEntriesViewConfig";
 import { Link } from "@webiny/react-router";
 
@@ -153,7 +151,7 @@ const ContentEntriesList: React.FC = () => {
             data={data}
             title={
                 <span>
-                    {pluralize(contentModel.name)}
+                    {contentModel.name}
                     <br />
                     <Typography use={"subtitle1"}>
                         <ModelId>
@@ -189,7 +187,7 @@ const ContentEntriesList: React.FC = () => {
                 <SearchUI
                     value={filter}
                     onChange={setFilter}
-                    inputPlaceholder={t`Search {title}`({ title: pluralize(contentModel.name) })}
+                    inputPlaceholder={t`Search {title}`({ title: contentModel.name })}
                 />
             }
             modalOverlay={entriesDataListModalOverlay}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13410,7 +13410,6 @@ __metadata:
     graphql: ^15.7.2
     graphql-tag: ^2.12.6
     lodash: ^4.17.10
-    pluralize: ^8.0.0
     prop-types: ^15.7.2
     raw.macro: ^0.4.2
     react: 17.0.2


### PR DESCRIPTION
## Changes
This PR fixes:
* api-headless-cms - CmsModel plugin to have single and plural api name optional
* app-headless-cms - when creating / cloning model, dialog content did not scroll if the screen is small
* app-headless-cms - remove pluralize usage

## How Has This Been Tested?
Manually.
