### PR TITLE
fix(api-aco): models for multiple tenants and locales

### DIFF
--- a/packages/api-aco/src/createAcoModels.ts
+++ b/packages/api-aco/src/createAcoModels.ts
@@ -1,11 +1,9 @@
 import { CmsGroupPlugin } from "@webiny/api-headless-cms";
 import { CmsContext } from "@webiny/api-headless-cms/types";
-import WebinyError from "@webiny/error";
-
 import { createFolderModelDefinition } from "~/folder/folder.model";
 import { createSearchModelDefinition } from "~/record/record.model";
-import { modelFactory } from "~/utils/modelFactory";
 import { isInstallationPending } from "~/utils/isInstallationPending";
+import { modelFactory } from "~/utils/modelFactory";
 
 export const createAcoModels = (context: CmsContext) => {
     /**
@@ -19,14 +17,6 @@ export const createAcoModels = (context: CmsContext) => {
 
     if (isInstallationPending({ tenancy: context.tenancy, i18n: context.i18n })) {
         return;
-    }
-
-    const locale = context.i18n.getContentLocale();
-    if (!locale) {
-        throw new WebinyError(
-            "Missing content locale in api-aco/storageOperations/index.ts",
-            "LOCALE_ERROR"
-        );
     }
 
     const groupId = "contentModelGroup_aco";
@@ -50,8 +40,6 @@ export const createAcoModels = (context: CmsContext) => {
     const cmsModelPlugins = modelDefinitions.map(modelDefinition => {
         return modelFactory({
             group: cmsGroupPlugin.contentModelGroup,
-            tenant: context.tenancy.getCurrentTenant().id,
-            locale: locale.code,
             modelDefinition
         });
     });


### PR DESCRIPTION
## Changes
This PR removes the default tenant and locales added to the ACO models as they are not working when switching the tenant and locale in the code.

## How Has This Been Tested?
Jest.