### PR TITLE
Do Not Delete Lambda@Edge Function when Destroying the Website Application

### DIFF
--- a/packages/pulumi-aws/src/apps/tenantRouter.ts
+++ b/packages/pulumi-aws/src/apps/tenantRouter.ts
@@ -129,4 +129,6 @@ export function applyTenantRouter(
             ]
         };
     });
+
+    return { originLambda };
 }

--- a/packages/pulumi-aws/src/apps/tenantRouter.ts
+++ b/packages/pulumi-aws/src/apps/tenantRouter.ts
@@ -102,7 +102,11 @@ export function applyTenantRouter(
                 });
             })
         },
-        opts: { provider: awsUsEast1 }
+        // With the `retainOnDelete` option set to `true`, the Lambda function will not be deleted when
+        // the environment is destroyed. Users need to delete the function manually. We decided to use
+        // this option here because it enables us to avoid annoying AWS Lambda function replication
+        // errors upon destroying the stack (see https://github.com/pulumi/pulumi-aws/issues/2178).
+        opts: { provider: awsUsEast1, retainOnDelete: true }
     });
 
     cloudfront.config.defaultCacheBehavior(value => {

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -227,7 +227,13 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 process.env.WCP_PROJECT_ENVIRONMENT ||
                 process.env.WEBINY_MULTI_TENANCY === "true"
             ) {
-                applyTenantRouter(app, deliveryCloudfront);
+                const { originLambda } = applyTenantRouter(app, deliveryCloudfront);
+
+                app.addHandler(() => {
+                    app.addOutputs({
+                        websiteRouterOriginRequestFunction: originLambda.output.name
+                    });
+                });
             }
 
             app.addOutputs({

--- a/packages/serverless-cms-aws/src/createWebsiteApp.ts
+++ b/packages/serverless-cms-aws/src/createWebsiteApp.ts
@@ -1,6 +1,6 @@
 import { createWebsitePulumiApp, CreateWebsitePulumiAppParams } from "@webiny/pulumi-aws";
 import { PluginCollection } from "@webiny/plugins/types";
-import { generateCommonHandlers, renderWebsite } from "./website/plugins";
+import { generateCommonHandlers, lambdaEdgeWarning, renderWebsite } from "./website/plugins";
 import { uploadAppToS3 } from "./react/plugins";
 import { pbLegacyRenderingWarningPlugins } from "~/utils/pbLegacyRenderingWarning";
 
@@ -13,7 +13,8 @@ export function createWebsiteApp(projectAppParams: CreateWebsiteAppParams = {}) 
         uploadAppToS3({ folder: "apps/website" }),
         generateCommonHandlers,
         renderWebsite,
-        pbLegacyRenderingWarningPlugins
+        pbLegacyRenderingWarningPlugins,
+        lambdaEdgeWarning
     ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];

--- a/packages/serverless-cms-aws/src/enterprise/createWebsiteApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createWebsiteApp.ts
@@ -3,7 +3,7 @@ import {
     CreateWebsitePulumiAppParams
 } from "@webiny/pulumi-aws/enterprise";
 import { PluginCollection } from "@webiny/plugins/types";
-import { generateCommonHandlers, renderWebsite } from "~/website/plugins";
+import { generateCommonHandlers, lambdaEdgeWarning, renderWebsite } from "~/website/plugins";
 import { uploadAppToS3 } from "~/react/plugins";
 import { pbLegacyRenderingWarningPlugins } from "~/utils/pbLegacyRenderingWarning";
 
@@ -16,7 +16,8 @@ export function createWebsiteApp(projectAppParams: CreateWebsiteAppParams = {}) 
         uploadAppToS3({ folder: "apps/website" }),
         generateCommonHandlers,
         renderWebsite,
-        pbLegacyRenderingWarningPlugins
+        pbLegacyRenderingWarningPlugins,
+        lambdaEdgeWarning
     ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];

--- a/packages/serverless-cms-aws/src/website/plugins/index.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from "./renderWebsite";
 export * from "./generateCommonHandlers";
+export * from "./lambdaEdgeWarning";

--- a/packages/serverless-cms-aws/src/website/plugins/lambdaEdgeWarning.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/lambdaEdgeWarning.ts
@@ -1,19 +1,40 @@
 import { CliContext } from "@webiny/cli/types";
+import { getStackOutput } from "@webiny/cli-plugin-deploy-pulumi/utils";
 
 /**
  * This hook is used to display a warning message to the user, that notifies
  * the user that the Lambda@Edge functions are not automatically deleted.
  * Deletion should be done manually.
  */
-export const lambdaEdgeWarning = {
-    type: "hook-after-destroy",
-    name: "hook-after-destroy-lambda-edge-warning",
-    hook(params: Record<string, any>, context: CliContext) {
-        if (process.env.WCP_PROJECT_ENVIRONMENT || process.env.WEBINY_MULTI_TENANCY === "true") {
-            context.warning(
-                "Lambda@Edge function %s was not automatically deleted. Make sure to delete it manually. Learn more: https://webiny.link/lambda-edge-warning",
-                "website-router-origin-request"
-            );
+
+let websiteRouterOriginRequestFunction = "";
+
+export const lambdaEdgeWarning = [
+    // The reason we're retrieving `websiteRouterOriginRequestFunction` before destroy is because
+    // when trying to do it afterwards, the stack is already deleted, and we can't retrieve the
+    // stack output anymore.
+    {
+        type: "hook-before-destroy",
+        name: "hook-before-destroy-lambda-edge-warning",
+        hook(params: Record<string, any>) {
+            const websiteOutput = getStackOutput({ folder: "apps/website", env: params.env });
+
+            if (websiteOutput && websiteOutput.websiteRouterOriginRequestFunction) {
+                websiteRouterOriginRequestFunction =
+                    websiteOutput.websiteRouterOriginRequestFunction;
+            }
+        }
+    },
+    {
+        type: "hook-after-destroy",
+        name: "hook-after-destroy-lambda-edge-warning",
+        hook(params: Record<string, any>, context: CliContext) {
+            if (websiteRouterOriginRequestFunction) {
+                context.warning(
+                    "Lambda@Edge function %s was not automatically deleted. Make sure to delete it manually. Learn more: https://webiny.link/lambda-edge-warning",
+                    websiteRouterOriginRequestFunction
+                );
+            }
         }
     }
-};
+];

--- a/packages/serverless-cms-aws/src/website/plugins/lambdaEdgeWarning.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/lambdaEdgeWarning.ts
@@ -1,0 +1,19 @@
+import { CliContext } from "@webiny/cli/types";
+
+/**
+ * This hook is used to display a warning message to the user, that notifies
+ * the user that the Lambda@Edge functions are not automatically deleted.
+ * Deletion should be done manually.
+ */
+export const lambdaEdgeWarning = {
+    type: "hook-after-destroy",
+    name: "hook-after-destroy-lambda-edge-warning",
+    hook(params: Record<string, any>, context: CliContext) {
+        if (process.env.WCP_PROJECT_ENVIRONMENT || process.env.WEBINY_MULTI_TENANCY === "true") {
+            context.warning(
+                "Lambda@Edge function %s was not automatically deleted. Make sure to delete it manually. Learn more: https://webiny.link/lambda-edge-warning",
+                "website-router-origin-request"
+            );
+        }
+    }
+};


### PR DESCRIPTION
## Changes
Closes #2694 

With this PR, the Lambda@Edge function that's deployed as part of multi-tenancy enabled Website app won't get deleted. Users will have to delete the function manually.

To improve DX, we've added a warning message and a dedicated article that explains why we're doing this (the warning is printed out at the very bottom in the sshot).

![image](https://user-images.githubusercontent.com/5121148/236185229-7e470efa-2299-48f6-a5c6-37c8cd499515.png)

By clicking on the link below, user will be taken to a docs article, explaining what's happening in more details:

![image](https://user-images.githubusercontent.com/5121148/236187984-6f9cec5d-7936-4990-b3d5-ec1de6f0c6b8.png)

## How Has This Been Tested?
Manually.

## Documentation
Changelog, will see if there's a place where this piece of info can be added in our docs.