### PR TITLE
Always Assign Project App Plugins when Running Pulumi Commands

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
@@ -62,9 +62,7 @@ const createPulumiCommand = ({
         const cwd = path.join(process.cwd(), inputs.folder);
 
         // Get project application metadata.
-        const projectApplication = getProjectApplication({
-            cwd: path.join(cwd, inputs.folder)
-        });
+        const projectApplication = getProjectApplication({ cwd });
 
         if (projectApplication.type === "v5-workspaces") {
             // If needed, let's create a project application workspace.

--- a/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/createPulumiCommand.js
@@ -66,20 +66,21 @@ const createPulumiCommand = ({
             cwd: path.join(cwd, inputs.folder)
         });
 
-        // If needed, let's create a project application workspace.
-        if (createProjectApplicationWorkspaceParam !== false) {
-            if (projectApplication.type === "v5-workspaces") {
+        if (projectApplication.type === "v5-workspaces") {
+            // If needed, let's create a project application workspace.
+            if (createProjectApplicationWorkspaceParam !== false) {
                 await createProjectApplicationWorkspace({
                     projectApplication,
                     context,
                     inputs,
                     env: inputs.env
                 });
+            }
 
-                // Check if there are any plugins that need to be registered.
-                if (projectApplication.config.plugins) {
-                    context.plugins.register(projectApplication.config.plugins);
-                }
+            // Check if there are any plugins that need to be registered. This needs to happen
+            // always, no matter the value of `createProjectApplicationWorkspaceParam` parameter.
+            if (projectApplication.config.plugins) {
+                context.plugins.register(projectApplication.config.plugins);
             }
         }
 


### PR DESCRIPTION
## Changes
Prior to this PR, if the `--no-build` flag was passed upon running the `webiny deploy` command, the internal project app plugins would not get applied ([example](https://github.com/webiny/webiny-js/blob/dev/packages/serverless-cms-aws/src/createWebsiteApp.ts#L12-L17)).

This is not the expected behaviour. If required, the plugins themselves should check if they need to be run depending on the `build` flag.

## How Has This Been Tested?
Manually.

## Documentation
None, internal fix.