### PR TITLE
fix(api-headless-cms-ddb-es): values to elasticsearch

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/helpers/fieldIdentifier.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/fieldIdentifier.ts
@@ -1,0 +1,42 @@
+import { CmsEntryValues, CmsModelField } from "@webiny/api-headless-cms/types";
+
+const hasOwnProperty = (values: CmsEntryValues, property: string): boolean => {
+    if (values.hasOwnProperty) {
+        return values.hasOwnProperty(property);
+    }
+    return values[property] !== undefined;
+};
+
+export const getFieldIdentifier = (
+    values: CmsEntryValues,
+    field: CmsModelField
+): string | undefined => {
+    if (field.storageId && hasOwnProperty(values, field.storageId)) {
+        return field.storageId;
+    } else if (hasOwnProperty(values, field.fieldId)) {
+        return field.fieldId;
+    }
+    return undefined;
+};
+
+export const getFieldIdentifiers = (
+    values: CmsEntryValues,
+    rawValues: CmsEntryValues,
+    field: CmsModelField
+) => {
+    let valueIdentifier = getFieldIdentifier(values, field);
+    let rawValueIdentifier = getFieldIdentifier(rawValues, field);
+    if (!valueIdentifier && !rawValueIdentifier) {
+        return null;
+    }
+    if (!valueIdentifier) {
+        valueIdentifier = rawValueIdentifier as string;
+    }
+    if (!rawValueIdentifier) {
+        rawValueIdentifier = valueIdentifier as string;
+    }
+    return {
+        valueIdentifier,
+        rawValueIdentifier
+    };
+};

--- a/packages/api-headless-cms-ddb-es/src/helpers/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from "./entryIndexHelpers";
+export * from "./fieldIdentifier";

--- a/packages/api-headless-cms/src/utils/converters/valueKeyStorageConverter.ts
+++ b/packages/api-headless-cms/src/utils/converters/valueKeyStorageConverter.ts
@@ -12,8 +12,10 @@ const featureVersion = semver.coerce("5.33.0") as SemVer;
 const isBetaOrNext = (model: CmsModel): boolean => {
     if (!model.webinyVersion) {
         return false;
+    } else if (model.webinyVersion.startsWith("0.0.0")) {
+        return true;
     }
-    return model.webinyVersion.match(/next|beta/) !== null;
+    return model.webinyVersion.match(/next|beta|unstable/) !== null;
 };
 
 const isFeatureEnabled = (model: CmsModel): boolean => {
@@ -21,7 +23,8 @@ const isFeatureEnabled = (model: CmsModel): boolean => {
      * In case of disabled webinyVersion value, we disable this feature.
      * This is only for testing...
      */
-    if (model.webinyVersion === "disable") {
+    const disableConversion = !!process.env.WEBINY_API_TEST_STORAGE_ID_CONVERSION_DISABLE;
+    if (model.webinyVersion === "disable" || disableConversion) {
         return false;
     }
     /**

--- a/packages/api-page-builder-aco/__tests__/graphql/record.gql.ts
+++ b/packages/api-page-builder-aco/__tests__/graphql/record.gql.ts
@@ -31,3 +31,19 @@ export const GET_RECORD = /* GraphQL */ `
         }
     }
 `;
+
+export const LIST_RECORDS = /* GraphQL */ `
+    query ListRecords {
+        search {
+            listRecords {
+                data  ${DATA_FIELD()}
+                error ${ERROR_FIELD}
+                meta {
+                    hasMoreItems
+                    totalCount
+                    cursor
+                }
+            }
+        }
+    }
+`;

--- a/packages/api-page-builder-aco/__tests__/utils/useGraphQlHandler.ts
+++ b/packages/api-page-builder-aco/__tests__/utils/useGraphQlHandler.ts
@@ -19,7 +19,7 @@ import {
 } from "~tests/graphql/page.gql";
 import { CREATE_CATEGORY } from "~tests/graphql/categories.gql";
 
-import { GET_RECORD } from "~tests/graphql/record.gql";
+import { GET_RECORD, LIST_RECORDS } from "~tests/graphql/record.gql";
 
 import { createAcoPageBuilderContext } from "~/index";
 import { createStorageOperations } from "~tests/utils/storageOperations";
@@ -143,6 +143,9 @@ export const useGraphQlHandler = (params: UseGQLHandlerParams = {}) => {
     const search = {
         async getRecord(variables = {}) {
             return invoke({ body: { query: GET_RECORD, variables } });
+        },
+        async listRecords(variables = {}) {
+            return invoke({ body: { query: LIST_RECORDS, variables } });
         }
     };
 


### PR DESCRIPTION
## Changes
This PR fixes the issue of the fieldId to storageId (and reverse) conversion in the unstable or development versions (0.0.0 or unstable).

## How Has This Been Tested?
Jest.