### PR TITLE
fix: skip aco search record creation for private files

### DIFF
--- a/packages/api-file-manager-aco/package.json
+++ b/packages/api-file-manager-aco/package.json
@@ -41,6 +41,7 @@
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/plugins": "0.0.0",
     "@webiny/project-utils": "0.0.0",
+    "mdbid": "^1.0.0",
     "ttypescript": "^1.5.13",
     "typescript": "^4.7.4"
   },

--- a/packages/api-file-manager-aco/src/file/hooks/onFileAfterBatchCreate.hook.ts
+++ b/packages/api-file-manager-aco/src/file/hooks/onFileAfterBatchCreate.hook.ts
@@ -11,6 +11,12 @@ export const onFileAfterBatchCreateHook = ({ fileManager, aco }: FmAcoContext) =
     fileManager.onFileAfterBatchCreate.subscribe(async ({ files, meta }) => {
         try {
             for (const file of files) {
+                if (file.meta.private) {
+                    console.log(
+                        `Skipping ACO search record, the file ${file.name} is marked as "private"`
+                    );
+                    continue;
+                }
                 const payload = createFileRecordPayload(file, meta);
                 await aco.search.create<FmFileRecordData>(payload);
             }

--- a/packages/api-file-manager-aco/src/file/hooks/onFileAfterBatchCreate.hook.ts
+++ b/packages/api-file-manager-aco/src/file/hooks/onFileAfterBatchCreate.hook.ts
@@ -12,9 +12,7 @@ export const onFileAfterBatchCreateHook = ({ fileManager, aco }: FmAcoContext) =
         try {
             for (const file of files) {
                 if (file.meta.private) {
-                    console.log(
-                        `Skipping ACO search record, the file ${file.name} is marked as "private"`
-                    );
+                    // Skipping ACO search record creation while file is marked as private
                     continue;
                 }
                 const payload = createFileRecordPayload(file, meta);

--- a/packages/api-file-manager-aco/src/file/hooks/onFileAfterCreate.hook.ts
+++ b/packages/api-file-manager-aco/src/file/hooks/onFileAfterCreate.hook.ts
@@ -11,9 +11,7 @@ export const onFileAfterCreateHook = ({ fileManager, aco }: FmAcoContext) => {
     fileManager.onFileAfterCreate.subscribe(async ({ file, meta }) => {
         try {
             if (file.meta.private) {
-                console.log(
-                    `Skipping ACO search record, the file ${file.name} is marked as "private"`
-                );
+                // Skipping ACO search record creation while file is marked as private
                 return;
             }
             const payload = createFileRecordPayload(file, meta);

--- a/packages/api-file-manager-aco/src/file/hooks/onFileAfterCreate.hook.ts
+++ b/packages/api-file-manager-aco/src/file/hooks/onFileAfterCreate.hook.ts
@@ -10,6 +10,12 @@ export const onFileAfterCreateHook = ({ fileManager, aco }: FmAcoContext) => {
      */
     fileManager.onFileAfterCreate.subscribe(async ({ file, meta }) => {
         try {
+            if (file.meta.private) {
+                console.log(
+                    `Skipping ACO search record, the file ${file.name} is marked as "private"`
+                );
+                return;
+            }
             const payload = createFileRecordPayload(file, meta);
             await aco.search.create<FmFileRecordData>(payload);
         } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11768,6 +11768,7 @@ __metadata:
     "@webiny/handler-graphql": 0.0.0
     "@webiny/plugins": 0.0.0
     "@webiny/project-utils": 0.0.0
+    mdbid: ^1.0.0
     ttypescript: ^1.5.13
     typescript: ^4.7.4
   languageName: unknown


### PR DESCRIPTION
## Changes
With this PR, we skip ACO search record creation in case of file marked as `private`.
Closes [WEB-2516](https://webiny.atlassian.net/browse/WEB-2516)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually + Jest

## Documentation
Inline
