### PR TITLE
Remove and Update `merge` Dependency Where Appropriate

### DIFF
--- a/packages/cwp-template-aws/template/ddb-es/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-es/dependencies.json
@@ -43,7 +43,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "execa": "^5.0.0",
     "jest": "^28.1.0",
-    "merge": "^1.2.1",
+    "merge": "^2.0.0",
     "prettier": "^2.3.2",
     "ts-jest": "^28.0.5",
     "typescript": "4.7.4"

--- a/packages/cwp-template-aws/template/ddb/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb/dependencies.json
@@ -44,7 +44,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "execa": "^5.0.0",
     "jest": "^28.1.0",
-    "merge": "^1.2.1",
+    "merge": "^2.0.0",
     "prettier": "^2.3.2",
     "ts-jest": "^28.0.5",
     "typescript": "4.7.4"

--- a/packages/handler-client/package.json
+++ b/packages/handler-client/package.json
@@ -28,7 +28,6 @@
     "@webiny/project-utils": "0.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "jest": "^28.1.0",
-    "merge": "^1.2.1",
     "rimraf": "^3.0.2",
     "typescript": "4.7.4"
   },

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -30,7 +30,6 @@
     "@webiny/cli": "0.0.0",
     "@webiny/project-utils": "0.0.0",
     "babel-plugin-lodash": "^3.3.4",
-    "merge": "^1.2.1",
     "rimraf": "^3.0.2",
     "ttypescript": "^1.5.13",
     "typescript": "4.7.4"

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -28,7 +28,6 @@
     "@webiny/project-utils": "0.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "jest": "^28.1.0",
-    "merge": "^1.2.1",
     "rimraf": "^3.0.2",
     "ttypescript": "^1.5.13",
     "typescript": "4.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14707,7 +14707,6 @@ __metadata:
     "@webiny/project-utils": 0.0.0
     babel-plugin-lodash: ^3.3.4
     jest: ^28.1.0
-    merge: ^1.2.1
     rimraf: ^3.0.2
     typescript: 4.7.4
   languageName: unknown
@@ -14798,7 +14797,6 @@ __metadata:
     "@webiny/utils": 0.0.0
     babel-plugin-lodash: ^3.3.4
     fastify: 4.11.0
-    merge: ^1.2.1
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.7.4
@@ -15497,7 +15495,6 @@ __metadata:
     isnumeric: ^0.3.3
     jest: ^28.1.0
     lodash: ^4.17.4
-    merge: ^1.2.1
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.7.4
@@ -31145,7 +31142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge@npm:^1.2.0, merge@npm:^1.2.1":
+"merge@npm:^1.2.0":
   version: 1.2.1
   resolution: "merge@npm:1.2.1"
   checksum: 2298c4fdcf64561f320b92338681f7ffcafafb579a6e294066ae3e7bd10ae25df363903d2f028072733b9f79a1f75d2b999aef98ad5d73de13641da39cda0913


### PR DESCRIPTION
## Changes
This PR remove and update `merge` dependency where appropriate.

We're removing this because NPM reports 1.2.x versions as a security vulnerability.

The package can be removed in three of our packages (not actually used). For user's projects, we've bumped it to v2.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.