### PR TITLE
fix(api-file-manager-s3): compare extensions using lower case

### DIFF
--- a/packages/api-file-manager-s3/src/utils/getPresignedPostPayload.ts
+++ b/packages/api-file-manager-s3/src/utils/getPresignedPostPayload.ts
@@ -52,7 +52,9 @@ export const getPresignedPostPayload = (
 
     // Make sure file key contains a file extension
     const extensions = mimeTypes[contentType];
-    if (!extensions.some(ext => key.endsWith(`.${ext}`))) {
+    // We only need this variable to compare extensions in a case-insensitive way.
+    const lowerKey = key.toLowerCase();
+    if (!extensions.some(ext => lowerKey.endsWith(`.${ext}`))) {
         key = key + `.${extensions[0]}`;
     }
 


### PR DESCRIPTION
## Changes
This PR fixes an issue with files that have an upper case file extension. This would cause an extra file extension, detected using file's mime type, to be appended to the file name.

With this fix, you can now upload files with upper case file extensions:
![CleanShot 2023-05-09 at 20 57 50](https://github.com/webiny/webiny-js/assets/3920893/ccf33c2f-dbdc-45df-887d-ad999f384d8c)


## How Has This Been Tested?
Manually.
