### PR TITLE
fix(api-file-manager-s3): improve extension handling

### DIFF
--- a/packages/api-file-manager-s3/src/utils/prepareFileData.ts
+++ b/packages/api-file-manager-s3/src/utils/prepareFileData.ts
@@ -4,36 +4,63 @@ import sanitizeFilename from "sanitize-filename";
 import { PresignedPostPayloadData, FileData } from "~/types";
 import { mimeTypes } from "./mimeTypes";
 
+class FileKey {
+    private readonly name: string;
+    private readonly type: string;
+    private prefix: string | undefined;
+    private id: string | undefined;
+    private extension = "";
+
+    constructor(name: string, type: string) {
+        this.type = type;
+        this.name = name;
+    }
+
+    setId(id: string) {
+        if (!this.name.startsWith(`${id}/`)) {
+            this.id = id;
+        }
+    }
+
+    setPrefix(prefix: string) {
+        this.prefix = prefix;
+    }
+
+    getKey() {
+        const key = sanitizeFilename(this.name).replace(/\s/g, "");
+        const maybeHasExtension = key.toLowerCase().includes(".");
+
+        if (maybeHasExtension) {
+            const maybeExt = key.toLowerCase().split(".").pop() as string;
+            const extensions = mimeTypes[this.type];
+            if (extensions && !extensions.includes(maybeExt)) {
+                this.extension = extensions[0];
+            }
+        }
+
+        const keyWithExt = [key, this.extension].filter(Boolean).join(".");
+        return [this.prefix, this.id, keyWithExt].filter(Boolean).join("/");
+    }
+}
+
 export const prepareFileData = (data: PresignedPostPayloadData): FileData => {
     // If type is missing, let's use the default "application/octet-stream" type,
     // which is also the default type that the Amazon S3 would use.
     const contentType = data.type || "application/octet-stream";
 
     const id = data.id || mdbid();
-    let key = data.key || sanitizeFilename(data.name);
+    const key = new FileKey(data.key || data.name, data.type);
 
-    // We must prefix file key with file ID.
-    if (!key.startsWith(id)) {
-        key = id + "/" + key;
-    }
+    key.setId(id);
 
     if (data.keyPrefix) {
-        key = data.keyPrefix + key;
-    }
-
-    // Replace all whitespace.
-    key = key.replace(/\s/g, "");
-
-    // Make sure file key contains a file extension
-    const extensions = mimeTypes[data.type];
-    if (extensions && !extensions.some(ext => key.endsWith(`.${ext}`))) {
-        key = key + `.${extensions[0]}`;
+        key.setPrefix(data.keyPrefix);
     }
 
     return {
         id,
         name: data.name,
-        key,
+        key: key.getKey(),
         type: contentType,
         size: data.size
     };


### PR DESCRIPTION
## Changes
This PR fixes an issue with files that have an upper case file extension. This would cause an extra file extension, detected using file's mime type, to be appended to the file name.

With this fix, you can now upload files with upper case file extensions:
![CleanShot 2023-05-09 at 20 57 50](https://github.com/webiny/webiny-js/assets/3920893/ccf33c2f-dbdc-45df-887d-ad999f384d8c)


## How Has This Been Tested?
Manually.
