### PR TITLE
refactor(api-headless-cms): graphql schema generators

### DIFF
--- a/packages/api-headless-cms/__tests__/helpers/renderSortEnum.test.ts
+++ b/packages/api-headless-cms/__tests__/helpers/renderSortEnum.test.ts
@@ -23,6 +23,7 @@ describe("Render GraphQL sort enum", () => {
 
         const result = renderSortEnum({
             model,
+            fields: model.fields,
             fieldTypePlugins,
             sorterPlugins: [sortPlugin]
         });
@@ -60,6 +61,7 @@ describe("Render GraphQL sort enum", () => {
 
         const result = renderSortEnum({
             model,
+            fields: model.fields,
             fieldTypePlugins,
             sorterPlugins: [sortPlugin]
         });

--- a/packages/api-headless-cms/src/graphql/schema/createFieldTypePluginRecords.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createFieldTypePluginRecords.ts
@@ -1,0 +1,11 @@
+import { CmsFieldTypePlugins, CmsModelFieldToGraphQLPlugin } from "~/types";
+import { PluginsContainer } from "@webiny/plugins";
+
+export const createFieldTypePluginRecords = (plugins: PluginsContainer) => {
+    return plugins
+        .byType<CmsModelFieldToGraphQLPlugin>("cms-model-field-to-graphql")
+        .reduce<CmsFieldTypePlugins>((acc, pl) => {
+            acc[pl.fieldType] = pl;
+            return acc;
+        }, {});
+};

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -46,7 +46,6 @@ export const createManageSDL: CreateManageSDL = ({
         sorterPlugins
     });
     const getFilterFieldsRender = renderGetFilterFields({
-        model,
         fields: model.fields,
         fieldTypePlugins
     });
@@ -76,23 +75,23 @@ export const createManageSDL: CreateManageSDL = ({
         }
 
         type ${singularName}Meta {
-        modelId: String
-        version: Int
-        locked: Boolean
-        publishedOn: DateTime
-        status: String
-        """
-        CAUTION: this field is resolved by making an extra query to DB.
-        RECOMMENDATION: Use it only with "get" queries (avoid in "list")
-        """
-        revisions: [${singularName}!]
-        title: String
-        description: String
-        image: String
-        """
-        Custom meta data stored in the root of the entry object.
-        """
-        data: JSON
+            modelId: String
+            version: Int
+            locked: Boolean
+            publishedOn: DateTime
+            status: String
+            """
+            CAUTION: this field is resolved by making an extra query to DB.
+            RECOMMENDATION: Use it only with "get" queries (avoid in "list")
+            """
+            revisions: [${singularName}!]
+            title: String
+            description: String
+            image: String
+            """
+            Custom meta data stored in the root of the entry object.
+            """
+            data: JSON
         }
 
         ${fields.map(f => f.typeDefs).join("\n")}
@@ -101,62 +100,61 @@ export const createManageSDL: CreateManageSDL = ({
 
 
         input ${singularName}Input {
-        id: ID
-        ${inputFields.map(f => f.fields).join("\n")}
-
+            id: ID
+            ${inputFields.map(f => f.fields).join("\n")}
         }
 
         input ${singularName}GetWhereInput {
-        ${getFilterFieldsRender}
+            ${getFilterFieldsRender}
         }
 
         input ${singularName}ListWhereInput {
-        ${listFilterFieldsRender}
-        AND: [${singularName}ListWhereInput!]
-        OR: [${singularName}ListWhereInput!]
+            ${listFilterFieldsRender}
+            AND: [${singularName}ListWhereInput!]
+            OR: [${singularName}ListWhereInput!]
         }
 
 
         type ${singularName}Response {
-        data: ${singularName}
-        error: CmsError
+            data: ${singularName}
+            error: CmsError
         }
 
         type ${singularName}ArrayResponse {
-        data: [${singularName}]
-        error: CmsError
+            data: [${singularName}]
+            error: CmsError
         }
 
         type ${singularName}ListResponse {
-        data: [${singularName}]
-        meta: CmsListMeta
-        error: CmsError
+            data: [${singularName}]
+            meta: CmsListMeta
+            error: CmsError
         }
 
 
         enum ${singularName}ListSorter {
-        ${sortEnumRender}
+            ${sortEnumRender}
         }
 
         extend type Query {
-        get${singularName}(revision: ID, entryId: ID, status: CmsEntryStatusType): ${singularName}Response
-
-        get${singularName}Revisions(id: ID!): ${singularName}ArrayResponse
-
-        get${pluralName}ByIds(revisions: [ID!]!): ${singularName}ArrayResponse
-
-        list${pluralName} (
-        where: ${singularName}ListWhereInput
-        sort: [${singularName}ListSorter]
-        limit: Int
-        after: String
-        ): ${singularName}ListResponse
+            get${singularName}(revision: ID, entryId: ID, status: CmsEntryStatusType): ${singularName}Response
+    
+            get${singularName}Revisions(id: ID!): ${singularName}ArrayResponse
+    
+            get${pluralName}ByIds(revisions: [ID!]!): ${singularName}ArrayResponse
+    
+            list${pluralName} (
+                where: ${singularName}ListWhereInput
+                sort: [${singularName}ListSorter]
+                limit: Int
+                after: String
+            ): ${singularName}ListResponse
         }
 
         extend type Mutation {
-        create${singularName}(data: ${singularName}Input!): ${singularName}Response
+            create${singularName}(data: ${singularName}Input!): ${singularName}Response
 
-        create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
+            create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
     
             update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
     

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -23,20 +23,41 @@ export const createManageSDL: CreateManageSDL = ({
     fieldTypePlugins,
     sorterPlugins
 }): string => {
+    const inputFields = renderInputFields({
+        models,
+        model,
+        fields: model.fields,
+        fieldTypePlugins
+    });
+    if (inputFields.length === 0) {
+        return "";
+    }
     const listFilterFieldsRender = renderListFilterFields({
         model,
+        fields: model.fields,
         type: "manage",
         fieldTypePlugins
     });
 
-    const sortEnumRender = renderSortEnum({ model, fieldTypePlugins, sorterPlugins });
-    const getFilterFieldsRender = renderGetFilterFields({ model, fieldTypePlugins });
-    const inputFields = renderInputFields({ models, model, fieldTypePlugins });
-    const fields = renderFields({ models, model, type: "manage", fieldTypePlugins });
+    const sortEnumRender = renderSortEnum({
+        model,
+        fields: model.fields,
+        fieldTypePlugins,
+        sorterPlugins
+    });
+    const getFilterFieldsRender = renderGetFilterFields({
+        model,
+        fields: model.fields,
+        fieldTypePlugins
+    });
 
-    if (inputFields.length === 0) {
-        return "";
-    }
+    const fields = renderFields({
+        models,
+        model,
+        fields: model.fields,
+        type: "manage",
+        fieldTypePlugins
+    });
 
     const { singularApiName: singularName, pluralApiName: pluralName } = model;
 
@@ -55,102 +76,87 @@ export const createManageSDL: CreateManageSDL = ({
         }
 
         type ${singularName}Meta {
-            modelId: String
-            version: Int
-            locked: Boolean
-            publishedOn: DateTime
-            status: String
-            """
-            CAUTION: this field is resolved by making an extra query to DB.
-            RECOMMENDATION: Use it only with "get" queries (avoid in "list")
-            """
-            revisions: [${singularName}!]
-            title: String
-            description: String
-            image: String
-            """
-            Custom meta data stored in the root of the entry object.
-            """
-            data: JSON
+        modelId: String
+        version: Int
+        locked: Boolean
+        publishedOn: DateTime
+        status: String
+        """
+        CAUTION: this field is resolved by making an extra query to DB.
+        RECOMMENDATION: Use it only with "get" queries (avoid in "list")
+        """
+        revisions: [${singularName}!]
+        title: String
+        description: String
+        image: String
+        """
+        Custom meta data stored in the root of the entry object.
+        """
+        data: JSON
         }
 
-        ${fields
-            .map(f => f.typeDefs)
-            .filter(Boolean)
-            .join("\n")}
+        ${fields.map(f => f.typeDefs).join("\n")}
 
-        ${inputFields
-            .map(f => f.typeDefs)
-            .filter(Boolean)
-            .join("\n")}
+        ${inputFields.map(f => f.typeDefs).join("\n")}
 
-        ${
-            inputFields &&
-            `input ${singularName}Input {
-                id: ID
-            ${inputFields.map(f => f.fields).join("\n")}
-        }`
+
+        input ${singularName}Input {
+        id: ID
+        ${inputFields.map(f => f.fields).join("\n")}
+
         }
 
-        ${
-            getFilterFieldsRender &&
-            `input ${singularName}GetWhereInput {
-            ${getFilterFieldsRender}
-        }`
+        input ${singularName}GetWhereInput {
+        ${getFilterFieldsRender}
         }
 
-
-        ${
-            listFilterFieldsRender &&
-            `input ${singularName}ListWhereInput {
-                ${listFilterFieldsRender}
-                AND: [${singularName}ListWhereInput!]
-                OR: [${singularName}ListWhereInput!]
-        }`
+        input ${singularName}ListWhereInput {
+        ${listFilterFieldsRender}
+        AND: [${singularName}ListWhereInput!]
+        OR: [${singularName}ListWhereInput!]
         }
+
 
         type ${singularName}Response {
-            data: ${singularName}
-            error: CmsError
+        data: ${singularName}
+        error: CmsError
         }
 
         type ${singularName}ArrayResponse {
-            data: [${singularName}]
-            error: CmsError
+        data: [${singularName}]
+        error: CmsError
         }
 
         type ${singularName}ListResponse {
-            data: [${singularName}]
-            meta: CmsListMeta
-            error: CmsError
+        data: [${singularName}]
+        meta: CmsListMeta
+        error: CmsError
         }
 
-        ${
-            sortEnumRender &&
-            `enum ${singularName}ListSorter {
-            ${sortEnumRender}
-        }`
+
+        enum ${singularName}ListSorter {
+        ${sortEnumRender}
         }
 
         extend type Query {
-            get${singularName}(revision: ID, entryId: ID, status: CmsEntryStatusType): ${singularName}Response
-    
-            get${singularName}Revisions(id: ID!): ${singularName}ArrayResponse
-    
-            get${pluralName}ByIds(revisions: [ID!]!): ${singularName}ArrayResponse
-    
-            list${pluralName} (
-                where: ${singularName}ListWhereInput
-                sort: [${singularName}ListSorter]
-                limit: Int
-                after: String
-            ): ${singularName}ListResponse
+        get${singularName}(revision: ID, entryId: ID, status: CmsEntryStatusType): ${singularName}Response
+
+        get${singularName}Revisions(id: ID!): ${singularName}ArrayResponse
+
+        get${pluralName}ByIds(revisions: [ID!]!): ${singularName}ArrayResponse
+
+        list${pluralName} (
+        where: ${singularName}ListWhereInput
+        sort: [${singularName}ListSorter]
+        limit: Int
+        after: String
+        ): ${singularName}ListResponse
         }
 
         extend type Mutation {
-            create${singularName}(data: ${singularName}Input!): ${singularName}Response
-    
-            create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
+        create${singularName}(data: ${singularName}Input!): ${singularName}Response
+
+        create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
     
             update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
     

--- a/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
@@ -23,24 +23,10 @@ export const createReadSDL: CreateReadSDL = ({
 }): string => {
     const type: ApiEndpoint = "read";
 
-    const listFilterFieldsRender = renderListFilterFields({
-        model,
-        type,
-        fieldTypePlugins
-    });
-
-    const sortEnumRender = renderSortEnum({
-        model,
-        fieldTypePlugins,
-        sorterPlugins
-    });
-    const getFilterFieldsRender = renderGetFilterFields({
-        model,
-        fieldTypePlugins
-    });
     const fieldsRender = renderFields({
         models,
         model,
+        fields: model.fields,
         type,
         fieldTypePlugins
     });
@@ -48,6 +34,23 @@ export const createReadSDL: CreateReadSDL = ({
     if (fieldsRender.length === 0) {
         return "";
     }
+    const listFilterFieldsRender = renderListFilterFields({
+        model,
+        fields: model.fields,
+        type,
+        fieldTypePlugins
+    });
+    const sortEnumRender = renderSortEnum({
+        model,
+        fields: model.fields,
+        fieldTypePlugins,
+        sorterPlugins
+    });
+    const getFilterFieldsRender = renderGetFilterFields({
+        model,
+        fields: model.fields,
+        fieldTypePlugins
+    });
 
     const hasModelIdField = model.fields.some(f => f.fieldId === "modelId");
 
@@ -71,29 +74,20 @@ export const createReadSDL: CreateReadSDL = ({
             .filter(Boolean)
             .join("\n")}
         
-        ${
-            getFilterFieldsRender &&
-            `input ${singularName}GetWhereInput {
+        input ${singularName}GetWhereInput {
             ${getFilterFieldsRender}
-        }`
         }
         
         
-        ${
-            listFilterFieldsRender &&
-            `input ${singularName}ListWhereInput {
-                ${listFilterFieldsRender}
-                AND: [${singularName}ListWhereInput!]
-                OR: [${singularName}ListWhereInput!]
-        }`
+        input ${singularName}ListWhereInput {
+            ${listFilterFieldsRender}
+            AND: [${singularName}ListWhereInput!]
+            OR: [${singularName}ListWhereInput!]
         }
         
         
-        ${
-            sortEnumRender &&
-            `enum ${singularName}ListSorter {
+        enum ${singularName}ListSorter {
             ${sortEnumRender}
-        }`
         }
         
         type ${singularName}Response {

--- a/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
@@ -47,7 +47,6 @@ export const createReadSDL: CreateReadSDL = ({
         sorterPlugins
     });
     const getFilterFieldsRender = renderGetFilterFields({
-        model,
         fields: model.fields,
         fieldTypePlugins
     });

--- a/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
+++ b/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
@@ -1,12 +1,12 @@
-import { CmsModelFieldToGraphQLPlugin, CmsFieldTypePlugins, CmsContext, CmsModel } from "~/types";
+import { CmsContext, CmsModel } from "~/types";
 import { createManageSDL } from "./createManageSDL";
 import { createReadSDL } from "./createReadSDL";
 import { createManageResolvers } from "./createManageResolvers";
 import { createReadResolvers } from "./createReadResolvers";
 import { createPreviewResolvers } from "./createPreviewResolvers";
 import { createGraphQLSchemaPluginFromFieldPlugins } from "~/utils/getSchemaFromFieldPlugins";
-import { CmsGraphQLSchemaSorterPlugin } from "~/plugins";
-import { CmsGraphQLSchemaPlugin } from "~/plugins";
+import { CmsGraphQLSchemaPlugin, CmsGraphQLSchemaSorterPlugin } from "~/plugins";
+import { createFieldTypePluginRecords } from "~/graphql/schema/createFieldTypePluginRecords";
 
 interface GenerateSchemaPluginsParams {
     context: CmsContext;
@@ -29,12 +29,7 @@ export const generateSchemaPlugins = async (
     }
 
     // Structure plugins for faster access
-    const fieldTypePlugins = plugins
-        .byType<CmsModelFieldToGraphQLPlugin>("cms-model-field-to-graphql")
-        .reduce<CmsFieldTypePlugins>((acc, pl) => {
-            acc[pl.fieldType] = pl;
-            return acc;
-        }, {});
+    const fieldTypePlugins = createFieldTypePluginRecords(plugins);
 
     const sorterPlugins = plugins.byType<CmsGraphQLSchemaSorterPlugin>(
         CmsGraphQLSchemaSorterPlugin.type

--- a/packages/api-headless-cms/src/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/graphqlFields/object.ts
@@ -11,7 +11,7 @@ import lodashUpperFirst from "lodash/upperFirst";
 import { createTypeFromFields } from "~/utils/createTypeFromFields";
 
 interface AttachTypeDefinitionsParams {
-    model: CmsModel;
+    model: Pick<CmsModel, "singularApiName">;
     field: CmsModelField;
     plugins: CmsFieldTypePlugins;
     endpointType: "manage" | "read";
@@ -57,7 +57,7 @@ const createChildTypeDefs = (params: AttachTypeDefinitionsParams): string => {
 };
 
 interface CreateTypeNameParams {
-    model: CmsModel;
+    model: Pick<CmsModel, "singularApiName">;
     parents?: string[];
     field: CmsModelField;
 }
@@ -75,7 +75,7 @@ const createTypeName = (params: CreateTypeNameParams): string => {
 
 interface CreateListFiltersParams {
     field: CmsModelField;
-    model: CmsModel;
+    model: Pick<CmsModel, "singularApiName">;
 }
 const createListFilters = ({ field, model }: CreateListFiltersParams) => {
     const typeName = createTypeName({

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -689,7 +689,7 @@ export interface CmsModelFieldToGraphQLPlugin<TField extends CmsModelField = Cms
          * ```
          */
         createListFilters?(params: {
-            model: CmsModel;
+            model: Pick<CmsModel, "singularApiName">;
             field: TField;
             plugins: CmsFieldTypePlugins;
         }): string;
@@ -768,7 +768,7 @@ export interface CmsModelFieldToGraphQLPlugin<TField extends CmsModelField = Cms
          * ```
          */
         createListFilters?: (params: {
-            model: CmsModel;
+            model: Pick<CmsModel, "singularApiName">;
             field: TField;
             plugins: CmsFieldTypePlugins;
         }) => string;

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -642,21 +642,6 @@ export interface CmsModelFieldToGraphQLPlugin<TField extends CmsModelField = Cms
      */
     isSortable: boolean;
     /**
-     * Optional method which creates the storageId.
-     * Primary use is for the datetime field, but if users has some specific fields, they can customize the storageId to their needs.
-     *
-     * ```ts
-     * createStorageId: ({field}) => {
-     *     if (field.settings.type === "time) {
-     *         return `${field.type}_time@${field.id}`
-     *     }
-     *     // use default method
-     *     return undefined;
-     * }
-     * ```
-     */
-    createStorageId?: (params: { model: CmsModel; field: TField }) => string | null | undefined;
-    /**
      * Read API methods.
      */
     read: {
@@ -671,7 +656,7 @@ export interface CmsModelFieldToGraphQLPlugin<TField extends CmsModelField = Cms
          * }
          * ```
          */
-        createGetFilters?(params: { model: CmsModel; field: TField }): string;
+        createGetFilters?(params: { field: TField }): string;
         /**
          * Definition for list filtering for GraphQL.
          *

--- a/packages/api-headless-cms/src/utils/getBaseFieldType.ts
+++ b/packages/api-headless-cms/src/utils/getBaseFieldType.ts
@@ -1,5 +1,5 @@
 import { CmsModelField } from "~/types";
 
-export const getBaseFieldType = (field: { type: CmsModelField["type"] }) => {
+export const getBaseFieldType = (field: Pick<CmsModelField, "type">) => {
     return field.type.split(":")[0];
 };

--- a/packages/api-headless-cms/src/utils/getEntryDescription.ts
+++ b/packages/api-headless-cms/src/utils/getEntryDescription.ts
@@ -1,6 +1,9 @@
 import { CmsEntry, CmsModel } from "~/types";
 
-export function getEntryDescription(model: CmsModel, entry: CmsEntry): string {
+export function getEntryDescription(
+    model: Pick<CmsModel, "descriptionFieldId" | "fields">,
+    entry: CmsEntry
+): string {
     if (!model.descriptionFieldId) {
         return "";
     }

--- a/packages/api-headless-cms/src/utils/getEntryImage.ts
+++ b/packages/api-headless-cms/src/utils/getEntryImage.ts
@@ -1,6 +1,9 @@
 import { CmsEntry, CmsModel } from "~/types";
 
-export function getEntryImage(model: CmsModel, entry: CmsEntry): string | null {
+export function getEntryImage(
+    model: Pick<CmsModel, "imageFieldId" | "fields">,
+    entry: CmsEntry
+): string | null {
     if (!model.imageFieldId) {
         return null;
     }

--- a/packages/api-headless-cms/src/utils/getEntryTitle.ts
+++ b/packages/api-headless-cms/src/utils/getEntryTitle.ts
@@ -1,6 +1,9 @@
 import { CmsEntry, CmsModel } from "~/types";
 
-export function getEntryTitle(model: CmsModel, entry: CmsEntry): string {
+export function getEntryTitle(
+    model: Pick<CmsModel, "titleFieldId" | "fields">,
+    entry: CmsEntry
+): string {
     if (!model.titleFieldId) {
         return entry.id;
     }

--- a/packages/api-headless-cms/src/utils/renderFields.ts
+++ b/packages/api-headless-cms/src/utils/renderFields.ts
@@ -11,6 +11,7 @@ import { getBaseFieldType } from "~/utils/getBaseFieldType";
 interface RenderFieldsParams {
     models: CmsModel[];
     model: CmsModel;
+    fields: CmsModelField[];
     type: ApiEndpoint;
     fieldTypePlugins: CmsFieldTypePlugins;
 }
@@ -22,15 +23,16 @@ interface RenderFields {
 export const renderFields: RenderFields = ({
     models,
     model,
+    fields,
     type,
     fieldTypePlugins
 }): CmsModelFieldDefinition[] => {
-    return model.fields
+    return fields
         .map(field => renderField({ models, model, type, field, fieldTypePlugins }))
         .filter(Boolean) as CmsModelFieldDefinition[];
 };
 
-interface RenderFieldParams extends RenderFieldsParams {
+interface RenderFieldParams extends Omit<RenderFieldsParams, "fields"> {
     field: CmsModelField;
 }
 
@@ -41,7 +43,7 @@ export const renderField = ({
     field,
     fieldTypePlugins
 }: RenderFieldParams): CmsModelFieldDefinition | null => {
-    const plugin: CmsModelFieldToGraphQLPlugin = fieldTypePlugins[getBaseFieldType(field)];
+    const plugin = fieldTypePlugins[getBaseFieldType(field)];
     if (!plugin) {
         // Let's not render the field if it does not exist in the field plugins.
         return null;

--- a/packages/api-headless-cms/src/utils/renderGetFilterFields.ts
+++ b/packages/api-headless-cms/src/utils/renderGetFilterFields.ts
@@ -1,49 +1,34 @@
-import { CmsFieldTypePlugins, CmsModel, CmsModelFieldToGraphQLPlugin } from "~/types";
+import { CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types";
 import { getBaseFieldType } from "~/utils/getBaseFieldType";
 
 interface RenderGetFilterFieldsParams {
     model: CmsModel;
+    fields: CmsModelField[];
     fieldTypePlugins: CmsFieldTypePlugins;
 }
 interface RenderGetFilterFields {
     (params: RenderGetFilterFieldsParams): string;
 }
 
-const getCreateFilters = (
-    plugins: CmsFieldTypePlugins,
-    fieldType: string
-): CmsModelFieldToGraphQLPlugin["read"]["createGetFilters"] | null => {
-    if (!plugins[fieldType] || !plugins[fieldType].read.createGetFilters) {
-        return null;
-    }
-    return plugins[fieldType].read.createGetFilters;
-};
-
-export const renderGetFilterFields: RenderGetFilterFields = ({ model, fieldTypePlugins }) => {
-    const fieldIdList = model.fields
-        .filter(field => {
-            // Every time a client updates content model's fields, we check the type of each field. If a field plugin
-            // for a particular "field.type" doesn't exist on the backend yet, we throw an error. But still, we also
-            // want to be careful when accessing the field plugin here too. It is still possible to have a content model
-            // that contains a field, for which we don't have a plugin registered on the backend. For example, user
-            // could've just removed the plugin from the backend.
-            const baseType = getBaseFieldType(field);
-            if (!fieldTypePlugins[baseType]) {
-                return false;
-            }
-            return fieldTypePlugins[baseType].isSearchable;
-        })
-        .map(f => f.fieldId);
-
+export const renderGetFilterFields: RenderGetFilterFields = ({
+    model,
+    fields,
+    fieldTypePlugins
+}) => {
     const filters: string[] = ["id: ID", "entryId: String"];
 
-    for (const fieldId of fieldIdList) {
-        const field = model.fields.find(item => item.fieldId === fieldId);
-        if (!field) {
+    for (const field of fields) {
+        // Every time a client updates content model's fields, we check the type of each field. If a field plugin
+        // for a particular "field.type" doesn't exist on the backend yet, we throw an error. But still, we also
+        // want to be careful when accessing the field plugin here too. It is still possible to have a content model
+        // that contains a field, for which we don't have a plugin registered on the backend. For example, user
+        // could've just removed the plugin from the backend.
+        const baseType = getBaseFieldType(field);
+        const plugin = fieldTypePlugins[baseType];
+        if (!plugin?.isSearchable) {
             continue;
         }
-        const baseType = getBaseFieldType(field);
-        const createGetFilters = getCreateFilters(fieldTypePlugins, baseType);
+        const createGetFilters = plugin.read?.createGetFilters;
         if (typeof createGetFilters !== "function") {
             continue;
         }

--- a/packages/api-headless-cms/src/utils/renderGetFilterFields.ts
+++ b/packages/api-headless-cms/src/utils/renderGetFilterFields.ts
@@ -1,8 +1,7 @@
-import { CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types";
+import { CmsFieldTypePlugins, CmsModelField } from "~/types";
 import { getBaseFieldType } from "~/utils/getBaseFieldType";
 
 interface RenderGetFilterFieldsParams {
-    model: CmsModel;
     fields: CmsModelField[];
     fieldTypePlugins: CmsFieldTypePlugins;
 }
@@ -10,11 +9,7 @@ interface RenderGetFilterFields {
     (params: RenderGetFilterFieldsParams): string;
 }
 
-export const renderGetFilterFields: RenderGetFilterFields = ({
-    model,
-    fields,
-    fieldTypePlugins
-}) => {
+export const renderGetFilterFields: RenderGetFilterFields = ({ fields, fieldTypePlugins }) => {
     const filters: string[] = ["id: ID", "entryId: String"];
 
     for (const field of fields) {
@@ -32,7 +27,7 @@ export const renderGetFilterFields: RenderGetFilterFields = ({
         if (typeof createGetFilters !== "function") {
             continue;
         }
-        filters.push(createGetFilters({ model, field }));
+        filters.push(createGetFilters({ field }));
     }
 
     return filters.filter(Boolean).join("\n");

--- a/packages/api-headless-cms/src/utils/renderListFilterFields.ts
+++ b/packages/api-headless-cms/src/utils/renderListFilterFields.ts
@@ -1,8 +1,15 @@
-import { ApiEndpoint, CmsFieldTypePlugins, CmsModel, CmsModelFieldToGraphQLPlugin } from "~/types";
+import {
+    ApiEndpoint,
+    CmsFieldTypePlugins,
+    CmsModel,
+    CmsModelField,
+    CmsModelFieldToGraphQLPlugin
+} from "~/types";
 import { getBaseFieldType } from "~/utils/getBaseFieldType";
 
 interface RenderListFilterFieldsParams {
     model: CmsModel;
+    fields: CmsModelField[];
     type: ApiEndpoint;
     fieldTypePlugins: CmsFieldTypePlugins;
 }
@@ -13,27 +20,10 @@ interface RenderListFilterFields {
 type CreateListFiltersType =
     | CmsModelFieldToGraphQLPlugin["read"]["createListFilters"]
     | CmsModelFieldToGraphQLPlugin["manage"]["createListFilters"];
-/**
- * We cast as read type, because input and output of read and manage are same. This way we ease things.
- * Internal stuff so it should be ok.
- * TODO note that if changing read/manage types, change this as well.
- */
-const getCreateListFilters = (
-    plugins: CmsFieldTypePlugins,
-    fieldType: string,
-    type: ApiEndpoint
-): CreateListFiltersType | null => {
-    if (!plugins[fieldType]) {
-        return null;
-    } else if (!plugins[fieldType][type]) {
-        return null;
-    }
-    return plugins[fieldType][type].createListFilters;
-};
 
 export const renderListFilterFields: RenderListFilterFields = (params): string => {
-    const { model, type, fieldTypePlugins } = params;
-    const fields: string[] = [
+    const { model, fields, type, fieldTypePlugins } = params;
+    const result: string[] = [
         [
             "id: ID",
             "id_not: ID",
@@ -71,33 +61,28 @@ export const renderListFilterFields: RenderListFilterFields = (params): string =
      * We can find different statuses only in the manage API endpoint.
      */
     if (type === "manage") {
-        fields.push(
-            ...[
-                "status: String",
-                "status_not: String",
-                "status_in: [String!]",
-                "status_not_in: [String!]"
-            ]
+        result.push(
+            "status: String",
+            "status_not: String",
+            "status_in: [String!]",
+            "status_not_in: [String!]"
         );
     }
 
-    for (const field of model.fields) {
+    for (const field of fields) {
         // Every time a client updates content model's fields, we check the type of each field. If a field plugin
         // for a particular "field.type" doesn't exist on the backend yet, we throw an error. But still, we also
         // want to be careful when accessing the field plugin here too. It is still possible to have a content model
         // that contains a field, for which we don't have a plugin registered on the backend. For example, user
         // could've just removed the plugin from the backend.
-
-        const createListFilters = getCreateListFilters(
-            fieldTypePlugins,
-            getBaseFieldType(field),
-            type
-        );
+        const baseType = getBaseFieldType(field);
+        const createListFilters: CreateListFiltersType | undefined =
+            fieldTypePlugins[baseType]?.[type]?.createListFilters;
         if (typeof createListFilters !== "function") {
             continue;
         }
-        fields.push(createListFilters({ model, field, plugins: fieldTypePlugins }));
+        result.push(createListFilters({ model, field, plugins: fieldTypePlugins }));
     }
 
-    return fields.filter(Boolean).join("\n");
+    return result.filter(Boolean).join("\n");
 };

--- a/packages/api-headless-cms/src/utils/renderSortEnum.ts
+++ b/packages/api-headless-cms/src/utils/renderSortEnum.ts
@@ -1,9 +1,10 @@
-import { CmsFieldTypePlugins, CmsModel } from "~/types";
+import { CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types";
 import { getBaseFieldType } from "~/utils/getBaseFieldType";
 import { CmsGraphQLSchemaSorterPlugin } from "~/plugins/CmsGraphQLSchemaSorterPlugin";
 
 interface RenderSortEnumParams {
     model: CmsModel;
+    fields: CmsModelField[];
     fieldTypePlugins: CmsFieldTypePlugins;
     sorterPlugins: CmsGraphQLSchemaSorterPlugin[];
 }
@@ -13,6 +14,7 @@ interface RenderSortEnum {
 
 export const renderSortEnum: RenderSortEnum = ({
     model,
+    fields,
     fieldTypePlugins,
     sorterPlugins
 }): string => {
@@ -25,7 +27,7 @@ export const renderSortEnum: RenderSortEnum = ({
         "createdOn_DESC"
     ];
 
-    for (const field of model.fields) {
+    for (const field of fields) {
         const plugin = fieldTypePlugins[getBaseFieldType(field)];
         if (!plugin) {
             continue;


### PR DESCRIPTION
## Changes
This PR extracts CMS GraphQL schema generators and/or changes the parameter types to make it easier, for us, to use the generators outside the CMS environment. This is required for @Pavel910 File Manager meta data with CMS models work and my changes to the ACO to use the CMS models with augmentation.

## How Has This Been Tested?
Jest.