### PR TITLE
fix(ui): add missing useCallback dependency to Input onKeyDown handler

### DIFF
--- a/packages/ui/src/Input/Input.tsx
+++ b/packages/ui/src/Input/Input.tsx
@@ -139,7 +139,7 @@ export const Input: React.FC<InputProps> = props => {
                 return rest.onKeyDown(e);
             }
         },
-        [rest.onKeyDown]
+        [rest.onKeyDown, onEnter]
     );
 
     return (


### PR DESCRIPTION
## Changes
This PR adds the missing useCallback dependency to Input component's `onKeyDown` handler. This bug is only noticeable when used with CMS multiple values fields, like `text`, for example.

## How Has This Been Tested?
Manually.
