### PR TITLE
fix(api-page-builder): data loader caching

### DIFF
--- a/packages/api-page-builder-so-ddb-es/src/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/index.ts
@@ -31,8 +31,8 @@ import { createSystemStorageOperations } from "~/operations/system";
 
 import { createPageEntity } from "~/definitions/pageEntity";
 import {
-    createPagesElasticsearchFields,
-    createPagesDynamoDbFields
+    createPagesDynamoDbFields,
+    createPagesElasticsearchFields
 } from "~/operations/pages/fields";
 import { createPageStorageOperations } from "~/operations/pages";
 import { createPageElasticsearchEntity } from "~/definitions/pageElasticsearchEntity";
@@ -188,6 +188,23 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         })
     };
 
+    const categories = createCategoryStorageOperations({
+        entity: entities.categories,
+        plugins
+    });
+    const blockCategories = createBlockCategoryStorageOperations({
+        entity: entities.blockCategories,
+        plugins
+    });
+    const pageBlocks = createPageBlockStorageOperations({
+        entity: entities.pageBlocks,
+        plugins
+    });
+    const pageTemplates = createPageTemplateStorageOperations({
+        entity: entities.pageTemplates,
+        plugins
+    });
+
     return {
         beforeInit: async (context: PbContext) => {
             const types: string[] = [
@@ -214,6 +231,10 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             for (const type of types) {
                 plugins.mergeByType(context.plugins, type);
             }
+            pageTemplates.dataLoader.clear();
+            pageBlocks.dataLoader.clear();
+            blockCategories.dataLoader.clear();
+            categories.dataLoader.clear();
         },
         init: async (context: PbContext) => {
             context.i18n.locales.onLocaleBeforeCreate.subscribe(async ({ locale, tenant }) => {
@@ -234,10 +255,6 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         settings: createSettingsStorageOperations({
             entity: entities.settings
         }),
-        categories: createCategoryStorageOperations({
-            entity: entities.categories,
-            plugins
-        }),
         menus: createMenuStorageOperations({
             entity: entities.menus,
             plugins
@@ -252,17 +269,9 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             elasticsearch,
             plugins
         }),
-        blockCategories: createBlockCategoryStorageOperations({
-            entity: entities.blockCategories,
-            plugins
-        }),
-        pageBlocks: createPageBlockStorageOperations({
-            entity: entities.pageBlocks,
-            plugins
-        }),
-        pageTemplates: createPageTemplateStorageOperations({
-            entity: entities.pageTemplates,
-            plugins
-        })
+        categories,
+        blockCategories,
+        pageBlocks,
+        pageTemplates
     };
 };

--- a/packages/api-page-builder-so-ddb-es/src/operations/blockCategory/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/blockCategory/dataLoader.ts
@@ -4,6 +4,7 @@ import { BlockCategory } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<BlockCategory, "slug" | "tenant" | "locale">;
 
-export class BlockCategoryDataLoader {
+export class BlockCategoryDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb-es/src/operations/blockCategory/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/blockCategory/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     BlockCategory,
-    BlockCategoryStorageOperations,
     BlockCategoryStorageOperationsCreateParams,
     BlockCategoryStorageOperationsDeleteParams,
     BlockCategoryStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { BlockCategoryDynamoDbElasticFieldPlugin } from "~/plugins/definitions/BlockCategoryDynamoDbElasticFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "~/operations/blockCategory/keys";
+import { BlockCategoryStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.blockCategory";
@@ -205,6 +205,7 @@ export const createBlockCategoryStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         create,
         update,

--- a/packages/api-page-builder-so-ddb-es/src/operations/category/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/category/dataLoader.ts
@@ -4,6 +4,7 @@ import { Category } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<Category, "slug" | "tenant" | "locale">;
 
-export class CategoryDataLoader {
+export class CategoryDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb-es/src/operations/category/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/category/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     Category,
-    CategoryStorageOperations,
     CategoryStorageOperationsCreateParams,
     CategoryStorageOperationsDeleteParams,
     CategoryStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { CategoryDynamoDbElasticFieldPlugin } from "~/plugins/definitions/CategoryDynamoDbElasticFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "~/operations/category/keys";
+import { CategoryStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.category";
@@ -205,6 +205,7 @@ export const createCategoryStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         create,
         update,

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageBlock/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageBlock/dataLoader.ts
@@ -4,6 +4,7 @@ import { PageBlock } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<PageBlock, "id" | "tenant" | "locale">;
 
-export class PageBlockDataLoader {
+export class PageBlockDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageBlock/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageBlock/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     PageBlock,
-    PageBlockStorageOperations,
     PageBlockStorageOperationsCreateParams,
     PageBlockStorageOperationsDeleteParams,
     PageBlockStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { PageBlockDynamoDbFieldPlugin } from "~/plugins/definitions/PageBlockDynamoDbFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "./keys";
+import { PageBlockStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.pageBlock";
@@ -205,6 +205,7 @@ export const createPageBlockStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         list,
         create,

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/dataLoader.ts
@@ -3,7 +3,7 @@ import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 import { PageTemplate } from "@webiny/api-page-builder/types";
 import { Entity } from "dynamodb-toolbox";
 import { createPrimaryPK } from "./keys";
-import { DataContainer } from "~/types";
+import { DataContainer, DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +11,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<PageTemplate, "id" | "tenant" | "locale">;
 
-export class PageTemplateDataLoader {
+export class PageTemplateDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     PageTemplate,
-    PageTemplateStorageOperations,
     PageTemplateStorageOperationsCreateParams,
     PageTemplateStorageOperationsDeleteParams,
     PageTemplateStorageOperationsGetParams,
@@ -17,7 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { PageTemplateDynamoDbElasticFieldPlugin } from "~/plugins/definitions/PageTemplateDynamoDbElasticFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createGSI1PK, createPrimaryPK } from "./keys";
-import { DataContainer } from "~/types";
+import { DataContainer, PageTemplateStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.pageTemplate";
@@ -219,6 +218,7 @@ export const createPageTemplateStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         list,
         create,

--- a/packages/api-page-builder-so-ddb-es/src/types.ts
+++ b/packages/api-page-builder-so-ddb-es/src/types.ts
@@ -1,4 +1,10 @@
-import { PageBuilderStorageOperations as BasePageBuilderStorageOperations } from "@webiny/api-page-builder/types";
+import {
+    BlockCategoryStorageOperations as BaseBlockCategoryStorageOperations,
+    CategoryStorageOperations as BaseCategoryStorageOperations,
+    PageBlockStorageOperations as BasePageBlockStorageOperations,
+    PageBuilderStorageOperations as BasePageBuilderStorageOperations,
+    PageTemplateStorageOperations as BasePageTemplateStorageOperations
+} from "@webiny/api-page-builder/types";
 import { Entity, Table } from "dynamodb-toolbox";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { Client } from "@elastic/elasticsearch";
@@ -66,4 +72,24 @@ export interface DataContainer<T> {
     SK: string;
     TYPE: string;
     data: T;
+}
+
+export interface DataLoaderInterface {
+    clear: () => void;
+}
+
+export interface PageTemplateStorageOperations extends BasePageTemplateStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface BlockCategoryStorageOperations extends BaseBlockCategoryStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface CategoryStorageOperations extends BaseCategoryStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface PageBlockStorageOperations extends BasePageBlockStorageOperations {
+    dataLoader: DataLoaderInterface;
 }

--- a/packages/api-page-builder-so-ddb/src/index.ts
+++ b/packages/api-page-builder-so-ddb/src/index.ts
@@ -144,6 +144,23 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         })
     };
 
+    const categories = createCategoryStorageOperations({
+        entity: entities.categories,
+        plugins
+    });
+    const blockCategories = createBlockCategoryStorageOperations({
+        entity: entities.blockCategories,
+        plugins
+    });
+    const pageBlocks = createPageBlockStorageOperations({
+        entity: entities.pageBlocks,
+        plugins
+    });
+    const pageTemplates = createPageTemplateStorageOperations({
+        entity: entities.pageTemplates,
+        plugins
+    });
+
     return {
         beforeInit: async (context: PbContext) => {
             const types: string[] = [
@@ -158,6 +175,10 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             for (const type of types) {
                 plugins.mergeByType(context.plugins, type);
             }
+            pageTemplates.dataLoader.clear();
+            pageBlocks.dataLoader.clear();
+            blockCategories.dataLoader.clear();
+            categories.dataLoader.clear();
         },
         getEntities: () => entities,
         getTable: () => tableInstance,
@@ -166,10 +187,6 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         }),
         settings: createSettingsStorageOperations({
             entity: entities.settings
-        }),
-        categories: createCategoryStorageOperations({
-            entity: entities.categories,
-            plugins
         }),
         menus: createMenuStorageOperations({
             entity: entities.menus,
@@ -183,17 +200,9 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             entity: entities.pages,
             plugins
         }),
-        blockCategories: createBlockCategoryStorageOperations({
-            entity: entities.blockCategories,
-            plugins
-        }),
-        pageBlocks: createPageBlockStorageOperations({
-            entity: entities.pageBlocks,
-            plugins
-        }),
-        pageTemplates: createPageTemplateStorageOperations({
-            entity: entities.pageTemplates,
-            plugins
-        })
+        categories,
+        blockCategories,
+        pageBlocks,
+        pageTemplates
     };
 };

--- a/packages/api-page-builder-so-ddb/src/operations/blockCategory/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/blockCategory/dataLoader.ts
@@ -4,6 +4,7 @@ import { BlockCategory } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<BlockCategory, "slug" | "tenant" | "locale">;
 
-export class BlockCategoryDataLoader {
+export class BlockCategoryDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb/src/operations/blockCategory/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/blockCategory/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     BlockCategory,
-    BlockCategoryStorageOperations,
     BlockCategoryStorageOperationsCreateParams,
     BlockCategoryStorageOperationsDeleteParams,
     BlockCategoryStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { BlockCategoryDynamoDbFieldPlugin } from "~/plugins/definitions/BlockCategoryDynamoDbFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "~/operations/blockCategory/keys";
+import { BlockCategoryStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.blockCategory";
@@ -205,6 +205,7 @@ export const createBlockCategoryStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         create,
         update,

--- a/packages/api-page-builder-so-ddb/src/operations/category/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/category/dataLoader.ts
@@ -4,6 +4,7 @@ import { Category } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<Category, "slug" | "tenant" | "locale">;
 
-export class CategoryDataLoader {
+export class CategoryDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb/src/operations/category/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/category/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     Category,
-    CategoryStorageOperations,
     CategoryStorageOperationsCreateParams,
     CategoryStorageOperationsDeleteParams,
     CategoryStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { CategoryDynamoDbFieldPlugin } from "~/plugins/definitions/CategoryDynamoDbFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "~/operations/category/keys";
+import { CategoryStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.category";
@@ -205,6 +205,7 @@ export const createCategoryStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         create,
         update,

--- a/packages/api-page-builder-so-ddb/src/operations/pageBlock/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageBlock/dataLoader.ts
@@ -4,6 +4,7 @@ import { PageBlock } from "@webiny/api-page-builder/types";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { Entity } from "dynamodb-toolbox";
 import { createPartitionKey, createSortKey } from "./keys";
+import { DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +12,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<PageBlock, "id" | "tenant" | "locale">;
 
-export class PageBlockDataLoader {
+export class PageBlockDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb/src/operations/pageBlock/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageBlock/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     PageBlock,
-    PageBlockStorageOperations,
     PageBlockStorageOperationsCreateParams,
     PageBlockStorageOperationsDeleteParams,
     PageBlockStorageOperationsGetParams,
@@ -17,6 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { PageBlockDynamoDbFieldPlugin } from "~/plugins/definitions/PageBlockDynamoDbFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createPartitionKey, createSortKey } from "./keys";
+import { PageBlockStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.pageBlock";
@@ -205,6 +205,7 @@ export const createPageBlockStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         list,
         create,

--- a/packages/api-page-builder-so-ddb/src/operations/pageTemplate/dataLoader.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageTemplate/dataLoader.ts
@@ -3,7 +3,7 @@ import { batchReadAll } from "@webiny/db-dynamodb/utils/batchRead";
 import { PageTemplate } from "@webiny/api-page-builder/types";
 import { Entity } from "dynamodb-toolbox";
 import { createPrimaryPK } from "./keys";
-import { DataContainer } from "~/types";
+import { DataContainer, DataLoaderInterface } from "~/types";
 
 interface Params {
     entity: Entity<any>;
@@ -11,7 +11,7 @@ interface Params {
 
 type DataLoaderGetItem = Pick<PageTemplate, "id" | "tenant" | "locale">;
 
-export class PageTemplateDataLoader {
+export class PageTemplateDataLoader implements DataLoaderInterface {
     private _getDataLoader: DataLoader<any, any> | undefined = undefined;
 
     private readonly entity: Entity<any>;

--- a/packages/api-page-builder-so-ddb/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageTemplate/index.ts
@@ -1,7 +1,6 @@
 import WebinyError from "@webiny/error";
 import {
     PageTemplate,
-    PageTemplateStorageOperations,
     PageTemplateStorageOperationsCreateParams,
     PageTemplateStorageOperationsDeleteParams,
     PageTemplateStorageOperationsGetParams,
@@ -17,7 +16,7 @@ import { createListResponse } from "@webiny/db-dynamodb/utils/listResponse";
 import { PageTemplateDynamoDbFieldPlugin } from "~/plugins/definitions/PageTemplateDynamoDbFieldPlugin";
 import { PluginsContainer } from "@webiny/plugins";
 import { createGSI1PK, createPrimaryPK } from "./keys";
-import { DataContainer } from "~/types";
+import { DataContainer, PageTemplateStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "pb.pageTemplate";
@@ -219,6 +218,7 @@ export const createPageTemplateStorageOperations = ({
     };
 
     return {
+        dataLoader,
         get,
         list,
         create,

--- a/packages/api-page-builder-so-ddb/src/types.ts
+++ b/packages/api-page-builder-so-ddb/src/types.ts
@@ -1,4 +1,10 @@
-import { PageBuilderStorageOperations as BasePageBuilderStorageOperations } from "@webiny/api-page-builder/types";
+import {
+    BlockCategoryStorageOperations as BaseBlockCategoryStorageOperations,
+    CategoryStorageOperations as BaseCategoryStorageOperations,
+    PageBlockStorageOperations as BasePageBlockStorageOperations,
+    PageBuilderStorageOperations as BasePageBuilderStorageOperations,
+    PageTemplateStorageOperations as BasePageTemplateStorageOperations
+} from "@webiny/api-page-builder/types";
 import { Entity, Table } from "dynamodb-toolbox";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { Plugin } from "@webiny/plugins/types";
@@ -60,4 +66,24 @@ export interface DataContainer<T> {
     SK: string;
     TYPE: string;
     data: T;
+}
+
+export interface DataLoaderInterface {
+    clear: () => void;
+}
+
+export interface PageTemplateStorageOperations extends BasePageTemplateStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface BlockCategoryStorageOperations extends BaseBlockCategoryStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface CategoryStorageOperations extends BaseCategoryStorageOperations {
+    dataLoader: DataLoaderInterface;
+}
+
+export interface PageBlockStorageOperations extends BasePageBlockStorageOperations {
+    dataLoader: DataLoaderInterface;
 }


### PR DESCRIPTION
## Changes
This PR adds a piece of code which clears DataLoader cache on each request (storage operations `beforeInit` method).

## How Has This Been Tested?
Jest.