### PR TITLE
fix(api-headless-cms): data loader cache clear

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/index.ts
@@ -118,6 +118,13 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         ...(userPlugins || [])
     ]);
 
+    const entries = createEntriesStorageOperations({
+        entity: entities.entries,
+        esEntity: entities.entriesEs,
+        plugins,
+        elasticsearch
+    });
+
     return {
         name: "dynamodb:elasticsearch",
         beforeInit: async context => {
@@ -154,6 +161,7 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             for (const type of types) {
                 plugins.mergeByType(context.plugins, type);
             }
+            entries.dataLoaders.clearAll();
         },
         init: async context => {
             /**
@@ -206,11 +214,6 @@ export const createStorageOperations: StorageOperationsFactory = params => {
             entity: entities.models,
             elasticsearch
         }),
-        entries: createEntriesStorageOperations({
-            entity: entities.entries,
-            esEntity: entities.entriesEs,
-            plugins,
-            elasticsearch
-        })
+        entries
     };
 };

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoader/DataLoaderCache.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoader/DataLoaderCache.ts
@@ -25,7 +25,13 @@ export class DataLoaderCache {
         this.cache[key] = dataLoader;
     }
 
-    public clearAll(params: ClearAllParams): void {
+    public clearAll(params?: ClearAllParams): void {
+        if (!params) {
+            for (const current in this.cache) {
+                this.cache[current].clearAll();
+            }
+            return;
+        }
         const key = this.createKey({
             ...params,
             name: ""

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
@@ -5,6 +5,7 @@ import { CacheKeyParams, DataLoaderCache } from "~/operations/entry/dataLoader/D
 import { Entity } from "dynamodb-toolbox";
 import { DataLoaders, getDataLoaderFactory } from "~/operations/entry/dataLoader";
 import { parseIdentifier } from "@webiny/utils";
+import { DataLoadersHandlerInterface, DataLoadersHandlerInterfaceClearAllParams } from "~/types";
 
 interface DataLoaderParams {
     model: Pick<CmsModel, "tenant" | "locale" | "modelId">;
@@ -23,7 +24,7 @@ export interface ClearAllParams {
     model: Pick<CmsModel, "tenant" | "locale" | "modelId">;
 }
 
-export class DataLoadersHandler {
+export class DataLoadersHandler implements DataLoadersHandlerInterface {
     private readonly entity: Entity<any>;
     private readonly cache: DataLoaderCache = new DataLoaderCache();
 
@@ -139,10 +140,7 @@ export class DataLoadersHandler {
         );
     }
 
-    public clearAll({ model }: ClearAllParams): void {
-        this.cache.clearAll({
-            tenant: model.tenant,
-            locale: model.locale
-        });
+    public clearAll(params?: DataLoadersHandlerInterfaceClearAllParams): void {
+        this.cache.clearAll(params?.model);
     }
 }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -2,7 +2,6 @@ import lodashCloneDeep from "lodash/cloneDeep";
 import WebinyError from "@webiny/error";
 import {
     CmsEntry,
-    CmsEntryStorageOperations,
     CmsModel,
     CmsStorageEntry,
     CONTENT_ENTRY_STATUS,
@@ -33,7 +32,7 @@ import { get as getRecord } from "@webiny/db-dynamodb/utils/get";
 import { zeroPad } from "@webiny/utils";
 import { cleanupItem } from "@webiny/db-dynamodb/utils/cleanup";
 import { ElasticsearchSearchResponse } from "@webiny/api-elasticsearch/types";
-import { CmsIndexEntry } from "~/types";
+import { CmsEntryStorageOperations, CmsIndexEntry } from "~/types";
 import { createElasticsearchBody } from "~/operations/entry/elasticsearch/body";
 import { createLatestRecordType, createPublishedRecordType, createRecordType } from "./recordType";
 import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
@@ -1526,6 +1525,7 @@ export const createEntriesStorageOperations = (
         getByIds,
         getLatestByIds,
         getPublishedByIds,
-        getPreviousRevision
+        getPreviousRevision,
+        dataLoaders
     };
 };

--- a/packages/api-headless-cms-ddb-es/src/types.ts
+++ b/packages/api-headless-cms-ddb-es/src/types.ts
@@ -2,6 +2,7 @@ import { Plugin, PluginCollection } from "@webiny/plugins/types";
 import {
     CmsContext as BaseCmsContext,
     CmsEntry,
+    CmsEntryStorageOperations as BaseCmsEntryStorageOperations,
     CmsModel,
     CmsModelField,
     CmsModelFieldToGraphQLPlugin,
@@ -186,4 +187,15 @@ export interface StorageOperationsFactory {
 
 export interface CmsContext extends BaseCmsContext {
     [key: string]: any;
+}
+
+export interface CmsEntryStorageOperations extends BaseCmsEntryStorageOperations {
+    dataLoaders: DataLoadersHandlerInterface;
+}
+
+export interface DataLoadersHandlerInterfaceClearAllParams {
+    model: Pick<CmsModel, "tenant" | "locale">;
+}
+export interface DataLoadersHandlerInterface {
+    clearAll: (params?: DataLoadersHandlerInterfaceClearAllParams) => void;
 }

--- a/packages/api-headless-cms-ddb/src/index.ts
+++ b/packages/api-headless-cms-ddb/src/index.ts
@@ -81,6 +81,11 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         ...(userPlugins || [])
     ]);
 
+    const entries = createEntriesStorageOperations({
+        entity: entities.entries,
+        plugins
+    });
+
     return {
         name: "dynamodb",
         beforeInit: async context => {
@@ -103,6 +108,8 @@ export const createStorageOperations: StorageOperationsFactory = params => {
              * Pass the plugins to the parent context.
              */
             context.plugins.register([dynamoDbPlugins()]);
+
+            entries.dataLoaders.clearAll();
         },
         getEntities: () => entities,
         getTable: () => tableInstance,
@@ -119,9 +126,6 @@ export const createStorageOperations: StorageOperationsFactory = params => {
         models: createModelsStorageOperations({
             entity: entities.models
         }),
-        entries: createEntriesStorageOperations({
-            entity: entities.entries,
-            plugins
-        })
+        entries
     };
 };

--- a/packages/api-headless-cms-ddb/src/operations/entry/dataLoader/DataLoaderCache.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/dataLoader/DataLoaderCache.ts
@@ -25,7 +25,13 @@ export class DataLoaderCache {
         this.cache[key] = dataLoader;
     }
 
-    public clearAll(params: ClearAllParams): void {
+    public clearAll(params?: ClearAllParams): void {
+        if (!params) {
+            for (const current in this.cache) {
+                this.cache[current].clearAll();
+            }
+            return;
+        }
         const key = this.createKey({
             ...params,
             name: ""

--- a/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
@@ -5,6 +5,7 @@ import { CacheKeyParams, DataLoaderCache } from "~/operations/entry/dataLoader/D
 import { Entity } from "dynamodb-toolbox";
 import { DataLoaders, getDataLoaderFactory } from "~/operations/entry/dataLoader";
 import { parseIdentifier } from "@webiny/utils";
+import { DataLoadersHandlerInterface, DataLoadersHandlerInterfaceClearAllParams } from "~/types";
 
 interface DataLoaderParams {
     model: Pick<CmsModel, "tenant" | "locale" | "modelId">;
@@ -19,11 +20,7 @@ interface DataLoadersHandlerParams {
     entity: Entity<any>;
 }
 
-export interface ClearAllParams {
-    model: Pick<CmsModel, "tenant" | "locale" | "modelId">;
-}
-
-export class DataLoadersHandler {
+export class DataLoadersHandler implements DataLoadersHandlerInterface {
     private readonly entity: Entity<any>;
     private readonly cache: DataLoaderCache = new DataLoaderCache();
 
@@ -139,10 +136,7 @@ export class DataLoadersHandler {
         );
     }
 
-    public clearAll({ model }: ClearAllParams): void {
-        this.cache.clearAll({
-            tenant: model.tenant,
-            locale: model.locale
-        });
+    public clearAll(params?: DataLoadersHandlerInterfaceClearAllParams): void {
+        this.cache.clearAll(params?.model);
     }
 }

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -3,7 +3,6 @@ import { DataLoadersHandler } from "./dataLoaders";
 import {
     CmsEntry,
     CmsEntryListWhere,
-    CmsEntryStorageOperations,
     CmsModel,
     CmsStorageEntry,
     CONTENT_ENTRY_STATUS,
@@ -35,6 +34,7 @@ import { FilterItemFromStorage } from "./filtering/types";
 import { createFields } from "~/operations/entry/filtering/createFields";
 import { filter, sort } from "~/operations/entry/filtering";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
+import { CmsEntryStorageOperations } from "~/types";
 
 const createType = (): string => {
     return "cms.entry";
@@ -1075,6 +1075,7 @@ export const createEntriesStorageOperations = (
         getRevisions,
         publish,
         list,
-        unpublish
+        unpublish,
+        dataLoaders
     };
 };

--- a/packages/api-headless-cms-ddb/src/types.ts
+++ b/packages/api-headless-cms-ddb/src/types.ts
@@ -1,5 +1,7 @@
 import { Plugin } from "@webiny/plugins/types";
 import {
+    CmsEntryStorageOperations as BaseCmsEntryStorageOperations,
+    CmsModel,
     CmsModelField,
     HeadlessCmsStorageOperations as BaseHeadlessCmsStorageOperations
 } from "@webiny/api-headless-cms/types";
@@ -65,4 +67,15 @@ export interface HeadlessCmsStorageOperations extends BaseHeadlessCmsStorageOper
 
 export interface StorageOperationsFactory {
     (params: StorageOperationsFactoryParams): HeadlessCmsStorageOperations;
+}
+
+export interface CmsEntryStorageOperations extends BaseCmsEntryStorageOperations {
+    dataLoaders: DataLoadersHandlerInterface;
+}
+
+export interface DataLoadersHandlerInterfaceClearAllParams {
+    model: Pick<CmsModel, "tenant" | "locale">;
+}
+export interface DataLoadersHandlerInterface {
+    clearAll: (params?: DataLoadersHandlerInterfaceClearAllParams) => void;
 }


### PR DESCRIPTION
## Changes
This PR adds a piece of code which clears DataLoader cache on each request (storage operations `beforeInit` method).

## How Has This Been Tested?
Jest.