### PR TITLE
fix(api-page-builder-so-ddb-es): add missing GSI index definition

### DIFF
--- a/packages/api-page-builder-so-ddb-es/src/definitions/table.ts
+++ b/packages/api-page-builder-so-ddb-es/src/definitions/table.ts
@@ -1,7 +1,7 @@
-import { TableModifier } from "~/types";
-import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { Table } from "dynamodb-toolbox";
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { TableConstructor } from "dynamodb-toolbox/dist/classes/Table";
+import { TableModifier } from "~/types";
 
 interface Params {
     table?: TableModifier;
@@ -12,7 +12,13 @@ export const createTable = ({ table, documentClient }: Params): Table => {
         name: process.env.DB_PAGE_BUILDER || (process.env.DB_TABLE as string),
         partitionKey: "PK",
         sortKey: "SK",
-        DocumentClient: documentClient
+        DocumentClient: documentClient,
+        indexes: {
+            GSI1: {
+                partitionKey: "GSI1_PK",
+                sortKey: "GSI1_SK"
+            }
+        }
     };
 
     const config = typeof table === "function" ? table(tableConfig) : tableConfig;


### PR DESCRIPTION
## Changes
This PR adds the missing GSI index definition to Table definition of the DDB+ES storage driver of the Page Builder.

## How Has This Been Tested?
Manually.

