### PR TITLE
chore: handle listTags operation ddb+es result

### DIFF
--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -72,7 +72,7 @@ export const createSearchRecordOperations = (
 
                 const tags = Object.values(
                     items.reduce<Record<string, SearchRecordTag>>((collection, item) => {
-                        const tags = Array.isArray(item) ? item : [];
+                        const tags = Array.isArray(item) ? item : [item];
 
                         for (const tag of tags) {
                             collection[tag] = {


### PR DESCRIPTION
## Changes
With this PR we uniform the result coming from both ddb and ddb-es storage operations inside `listTags` operation

