### PR TITLE
Button Page Element's Icon DOM Element Now Contains A CSS Class That Indicated Button Position

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -130,7 +130,7 @@ export const createButton = (params: CreateButtonParams = {}) => {
 
                 buttonInnerContent = (
                     <>
-                        <StyledButtonIcon svg={icon.svg} />
+                        <StyledButtonIcon svg={icon.svg} className={`button-icon-${position}`} />
                         {buttonInnerContent}
                     </>
                 );


### PR DESCRIPTION
## Changes
This PR adds a class to the button icon DOM element, indicating icon's position (selected in the page editor). This enables developers to apply different CSS rules based on the position of the icon.

![image](https://github.com/webiny/webiny-js/assets/5121148/50e09216-63b5-4891-a524-e816cbe30df8)

## How Has This Been Tested?
Manually.

## Documentation
Changelog.