### PR TITLE
fix(lexical): initial lexical value

### DIFF
--- a/packages/lexical-editor/src/utils/generateInitialLexicalValue.ts
+++ b/packages/lexical-editor/src/utils/generateInitialLexicalValue.ts
@@ -13,7 +13,7 @@ export const generateInitialLexicalValue = (): LexicalValue => {
                     format: "",
                     indent: 0,
                     styles: [],
-                    type: "base-paragraph-node",
+                    type: "paragraph-element",
                     version: 1
                 }
             ],


### PR DESCRIPTION
## Changes
helper function: `utils/generateInitialLexicalValue`
- changed the name of the node type from legacy `base-paragraph-node` to `paragraph-element`

## How Has This Been Tested?
Manually.



### Test with an initial lexical empty value. 
info: For the purpose of the testing and demo the default `"lorem ipsum"` text is removed.

### bug reproduced
![image](https://github.com/webiny/webiny-js/assets/82515066/460ccbd3-a927-43f9-aba6-193fca5b7371)

### after the fix
https://github.com/webiny/webiny-js/assets/82515066/4c67f3e0-c498-4d64-ac57-53bf988fa7e9
