### PR TITLE
fix: folder creation in root

### DIFF
--- a/packages/app-aco/src/components/FolderTree/List/utils.ts
+++ b/packages/app-aco/src/components/FolderTree/List/utils.ts
@@ -21,7 +21,7 @@ export const createTreeData = (
 
             return {
                 id,
-                parent: parentId || ROOT_ID,
+                parent: parentId?.toLowerCase() || ROOT_ID, // toLowerCase() fixes a bug introduced by 5.36.0: accidentally we stored "ROOT" as parentId, instead of null
                 text: title,
                 droppable: true,
                 data: {

--- a/packages/app-aco/src/hooks/useAcoList.ts
+++ b/packages/app-aco/src/hooks/useAcoList.ts
@@ -47,7 +47,8 @@ export const useAcoList = (params: UseAcoListParams) => {
             return [];
         }
         if (!folderId || folderId === "ROOT") {
-            return folders.filter(folder => !folder.parentId);
+            // checking for parentId value fixes a bug introduced by 5.36.0: accidentally we stored "ROOT" as parentId, instead of null
+            return folders.filter(folder => !folder.parentId || folder.parentId === "ROOT");
         } else {
             return folders.filter(folder => folder.parentId === currentFolderId);
         }

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/AcoRenderer/FileManagerAcoView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/AcoRenderer/FileManagerAcoView.tsx
@@ -28,7 +28,7 @@ import { useFileManagerApi } from "~/index";
 import { FileItem } from "@webiny/app-admin/types";
 import { ListMeta, SearchRecordItem } from "@webiny/app-aco/types";
 
-import { ACO_TYPE } from "~/constants";
+import { ACO_TYPE, FOLDER_ID_DEFAULT } from "~/constants";
 
 import { BottomInfoBar } from "~/components/BottomInfoBar";
 import { DropFilesHere } from "~/components/DropFilesHere";
@@ -144,7 +144,11 @@ const FileManagerAcoView: React.FC<FileManagerAcoViewProps> = props => {
         listTitle = defaultFolderName,
         meta,
         records
-    } = useAcoList({ type: ACO_TYPE, folderId, ...listWhere });
+    } = useAcoList({
+        type: ACO_TYPE,
+        ...listWhere,
+        folderId: folderId || FOLDER_ID_DEFAULT
+    });
 
     const uploader = useMemo<BatchFileUploader>(
         () => new BatchFileUploader(uploadFile),

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/AcoRenderer/LeftSidebar.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/AcoRenderer/LeftSidebar.tsx
@@ -5,7 +5,7 @@ import { FolderTree, TagList } from "@webiny/app-aco";
 import { css } from "emotion";
 
 import { getTagsInitialParams, tagsModifier } from "~/tagsHelpers";
-import { ACO_TYPE, FOLDER_ID_DEFAULT } from "~/constants";
+import { ACO_TYPE } from "~/constants";
 
 import { TagItem } from "@webiny/app-aco/types";
 
@@ -37,7 +37,7 @@ interface LeftSidebarProps {
     currentFolder?: string;
     scope?: string;
     own?: boolean;
-    onFolderClick: (folderId: string | undefined) => void;
+    onFolderClick: (folderId?: string) => void;
 }
 
 const LeftSidebar: React.FC<LeftSidebarProps> = ({
@@ -55,7 +55,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                     type={ACO_TYPE}
                     title={title}
                     focusedFolderId={currentFolder}
-                    onTitleClick={() => onFolderClick(FOLDER_ID_DEFAULT)}
+                    onTitleClick={() => onFolderClick(undefined)}
                     onFolderClick={data => data?.id && onFolderClick(data?.id)}
                     enableActions={true}
                     enableCreate={true}

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerAcoViewProvider/FileManagerAcoViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerAcoViewProvider/FileManagerAcoViewContext.tsx
@@ -46,7 +46,7 @@ export interface FileManagerAcoViewContextData<TFileItem extends FileItem = File
     loadingFileDetails: boolean;
     hideFileDetails: () => void;
     folderId?: string;
-    setFolderId: (folderId: string | undefined) => void;
+    setFolderId: (folderId?: string) => void;
     listTable: boolean;
     setListTable: (mode: boolean) => void;
 }

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerAcoViewProvider/stateReducer.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerAcoViewProvider/stateReducer.ts
@@ -1,6 +1,5 @@
 import { FileItem } from "@webiny/app-admin/types";
 import { ListDbSort } from "@webiny/app-aco/types";
-import { FOLDER_ID_DEFAULT } from "~/constants";
 import isEqual from "lodash/isEqual";
 
 interface BaseStateListWhere {
@@ -17,7 +16,7 @@ export interface StateListWhere extends BaseStateListWhere {
 }
 
 export interface State {
-    folderId: string | undefined;
+    folderId?: string;
     showingFileDetails: string | null;
     loadingFileDetails: boolean;
     selected: FileItem[];
@@ -102,7 +101,7 @@ export const getMimeTypeWhereParams = (mimes: string[] | undefined) => {
 
 export const initializeState = ({ accept, scope, own, identity }: InitParams): State => {
     return {
-        folderId: FOLDER_ID_DEFAULT,
+        folderId: undefined,
         showingFileDetails: null,
         loadingFileDetails: false,
         selected: [],

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -20,7 +20,7 @@ import { LoadMoreButton } from "~/admin/components/Table/LoadMoreButton";
 import { Preview } from "~/admin/components/Table/Preview";
 import { Table } from "~/admin/components/Table/Table";
 
-import { FOLDER_TYPE } from "~/admin/constants/folders";
+import { FOLDER_TYPE, FOLDER_ID_DEFAULT } from "~/admin/constants/folders";
 
 import { MainContainer, Wrapper } from "./styled";
 
@@ -47,7 +47,7 @@ export const Main = ({ folderId, defaultFolderName }: Props) => {
         isListLoading,
         isListLoadingMore,
         listItems
-    } = useAcoList({ type: FOLDER_TYPE, folderId });
+    } = useAcoList({ type: FOLDER_TYPE, folderId: folderId || FOLDER_ID_DEFAULT });
 
     const [isCreateLoading, setIsCreateLoading] = useState<boolean>(false);
     const [showCategoriesDialog, setCategoriesDialog] = useState(false);
@@ -87,14 +87,14 @@ export const Main = ({ folderId, defaultFolderName }: Props) => {
         setLoading: () => setIsCreateLoading(true),
         clearLoading: () => setIsCreateLoading(false),
         closeDialog: closeCategoriesDialog,
-        folderId
+        folderId: folderId || FOLDER_ID_DEFAULT
     });
 
     const { createPageMutation } = useCreatePage({
         setLoading: () => setIsCreateLoading(true),
         clearLoading: () => setIsCreateLoading(false),
         closeDialog: closeTemplatesDialog,
-        folderId
+        folderId: folderId || FOLDER_ID_DEFAULT
     });
 
     useEffect(() => {

--- a/packages/app-page-builder/src/admin/views/Pages/Table/index.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/index.tsx
@@ -6,8 +6,6 @@ import { Sidebar } from "~/admin/views/Pages/Table/Sidebar";
 import { Main } from "~/admin/views/Pages/Table/Main";
 import { usePageViewNavigation } from "~/hooks/usePageViewNavigation";
 
-import { FOLDER_ID_DEFAULT } from "~/admin/constants/folders";
-
 const t = i18n.ns("app-page-builder/admin/views/pages/table");
 
 const Index: React.FC = () => {
@@ -25,10 +23,7 @@ const Index: React.FC = () => {
                 <Sidebar folderId={currentFolderId} defaultFolderName={defaultFolderName} />
             </LeftPanel>
             <RightPanel span={10}>
-                <Main
-                    folderId={currentFolderId || FOLDER_ID_DEFAULT}
-                    defaultFolderName={defaultFolderName}
-                />
+                <Main folderId={currentFolderId} defaultFolderName={defaultFolderName} />
             </RightPanel>
         </SplitView>
     );


### PR DESCRIPTION
## Changes
With this PR we fix a bug introduced by the 5.36.0 version: creating a folder in the root using the "Create folder" button in the top right corner. After completing the folder creation process, this was not saved with the right `parentId`.

## How Has This Been Tested?
Manually