### PR TITLE
Various Minor Fixes (Page Builder and `webiny info` CLI Command)

### DIFF
--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
@@ -74,7 +74,7 @@ export const EditorPageElementsProvider: React.FC = ({ children }) => {
         // On a couple of occasions, we've seen the `theme` object being `null` for a brief moment. This
         // would happen when the theme is being loaded via a dynamic import, e.g. in a multi-theme setup.
         if (!theme) {
-            return null
+            return null;
         }
 
         return {

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider.tsx
@@ -71,6 +71,12 @@ export const EditorPageElementsProvider: React.FC = ({ children }) => {
     const containerizedTheme = useMemo(() => {
         const theme = pageBuilder.theme as Theme;
 
+        // On a couple of occasions, we've seen the `theme` object being `null` for a brief moment. This
+        // would happen when the theme is being loaded via a dynamic import, e.g. in a multi-theme setup.
+        if (!theme) {
+            return null
+        }
+
         return {
             ...pageBuilder.theme,
             breakpoints: Object.keys(theme.breakpoints).reduce((result, breakpointName) => {
@@ -85,7 +91,7 @@ export const EditorPageElementsProvider: React.FC = ({ children }) => {
 
     return (
         <PbPageElementsProvider
-            theme={containerizedTheme}
+            theme={containerizedTheme!}
             renderers={renderers}
             modifiers={modifiers}
             beforeRenderer={ElementControls}

--- a/packages/app-page-builder/src/render/plugins/elements/button/index.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/button/index.tsx
@@ -31,7 +31,9 @@ const render: PbRenderElementPlugin["render"] = isLegacyRenderingEngine
           },
           linkComponent: ({ href, children, ...rest }) => {
               return (
-                  <Link to={href!} {...rest}>
+                  // While testing, we noticed that the `href` prop is sometimes `null` or `undefined`.
+                  // Hence the `href || ""` part. This fixes the issue.
+                  <Link to={href || ""} {...rest}>
                       {children}
                   </Link>
               );

--- a/packages/app-theme-manager/src/modules/themes/index.tsx
+++ b/packages/app-theme-manager/src/modules/themes/index.tsx
@@ -4,7 +4,7 @@ import { Provider, Plugins } from "@webiny/app-admin";
 import { AddPbWebsiteSettings } from "@webiny/app-page-builder";
 import { AddTenantFormField, IsRootTenant, IsNotRootTenant } from "@webiny/app-tenant-manager";
 import { useBind } from "@webiny/form";
-import { Select } from "@webiny/ui/Select";
+import { AutoComplete } from "@webiny/ui/AutoComplete";
 import { validation } from "@webiny/validation";
 import { ThemeCheckboxGroup } from "~/components/ThemeCheckboxGroup";
 import { ThemeManagerProviderHOC } from "~/components/ThemeManagerProvider";
@@ -48,26 +48,24 @@ const TenantThemes = () => {
 interface ThemeSelectProps {
     themes: ThemeSource[];
 }
+
 const ThemeSelect: React.FC<ThemeSelectProps> = ({ themes }) => {
     const bind = useBind({
         name: "theme",
-        defaultValue: "",
         validators: validation.create("required")
     });
 
+    const options = themes.map(theme => ({ id: theme.name, name: theme.label || theme.name }));
+    const value = options.find(option => option.id === bind.value) || { id: "", name: "" };
+
     return (
-        <Select
+        <AutoComplete
+            {...bind}
             label="Theme"
             description={"Select a theme to use for your website."}
-            {...bind}
-            value={bind.value || ""}
-        >
-            {[{ name: "", label: null, hidden: true }, ...themes].map(theme => (
-                <option key={theme.name} value={theme.name} hidden={theme.hidden}>
-                    {theme.label}
-                </option>
-            ))}
-        </Select>
+            options={options}
+            value={value}
+        />
     );
 };
 
@@ -76,6 +74,7 @@ const WebsiteSettingsSelection = gql`
         theme
     }
 `;
+
 const WebsiteSettings: React.FC = () => {
     return (
         <Fragment>

--- a/packages/cwp-template-aws/cli/info/index.js
+++ b/packages/cwp-template-aws/cli/info/index.js
@@ -96,7 +96,7 @@ module.exports = {
                     // We just get stack files for deployed Admin apps. That's enough to determine
                     // into which environments the user has deployed their Webiny project.
                     const pulumiAdminStackFilesPaths = glob.sync(
-                        ".pulumi/**/apps/admin/.pulumi/stacks/*.json",
+                        ".pulumi/**/apps/core/.pulumi/stacks/**/*.json",
                         {
                             cwd: context.project.root,
                             onlyFiles: true,

--- a/packages/cwp-template-aws/cli/info/index.js
+++ b/packages/cwp-template-aws/cli/info/index.js
@@ -93,8 +93,8 @@ module.exports = {
                     // Get all existing environments
                     const glob = require("fast-glob");
 
-                    // We just get stack files for deployed Admin apps. That's enough to determine
-                    // into which environments the user has deployed their Webiny project.
+                    // We just get stack files for deployed Core application. That's enough
+                    // to determine into which environments the user has deployed their project.
                     const pulumiAdminStackFilesPaths = glob.sync(
                         ".pulumi/**/apps/core/.pulumi/stacks/**/*.json",
                         {


### PR DESCRIPTION
## Changes
This PR addresses one CLI issue and a couple of PB-related issues.

#### 1. `webiny info` Command Not Working

For some time, the `webiny info` command would not work if an environment wasn't specified (in which case the command should internally get a list of all environments user currently has locally set up). This has now been addressed.

#### 2. Button Page Element Crashing On Empty Link URL

In some cases, a `null` value would end up being passed to the Button page element's Link component, which would cause an error being thrown. With this PR, falsy values have been taken into consideration, in which case href will be set simply to an empty string.

#### 3. Website Settings - Theme Selector Not Working Properly

In a multi-theme setup, in the website settings form, at the end of the form, the select component that would enable users to pick a theme for the current tenant wasn't working as expected. On page load, the select component would be empty, which is not good DX (ideally the select component should show the selected value).

Since this is a bug in the Select component, which we've seen before, as a quick fix, we've just replaced it with an Autocomplete component. This might even work better in cases users has more themes set up in his project.

#### 4. Intermittent Errors When Refreshing the Page Builder

Intermittently, the page builder would break upon refreshing the page. Essentially, this happened because of the async nature of the way the theme is loaded. This would only happen in multi-theme projects.

This has now been addressed.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.
