### PR TITLE
fix: FolderTree performance

### DIFF
--- a/packages/app-aco/src/components/FolderTree/List/index.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import {
     DropOptions,
@@ -94,9 +94,12 @@ export const List: React.VFC<ListProps> = ({
         }
     };
 
-    const sort = (a: NodeModel<DndItemData>, b: NodeModel<DndItemData>) => {
-        return a.data!.title.localeCompare(b.data!.title, undefined, { numeric: true });
-    };
+    const sort = useMemo(
+        () => (a: NodeModel<DndItemData>, b: NodeModel<DndItemData>) => {
+            return a.data!.title.localeCompare(b.data!.title, undefined, { numeric: true });
+        },
+        []
+    );
 
     const handleChangeOpen = (folderIds: NodeModel["id"][]) => {
         setOpenFolderIds(folderIds);

--- a/packages/app-aco/src/components/FolderTree/List/utils.ts
+++ b/packages/app-aco/src/components/FolderTree/List/utils.ts
@@ -54,34 +54,33 @@ export const createInitialOpenList = (
     openIds: NodeModel<DndItemData>["id"][] = [],
     focusedId?: string
 ): InitialOpen | undefined => {
-    const focusedFolder = folders.find(folder => {
-        return folder.id === focusedId;
-    });
-
-    if (!focusedId || !focusedFolder?.parentId) {
+    // In case of no focused folder, return the current open folders
+    if (!focusedId) {
         return openIds;
     }
 
-    const findParents = (
-        acc: string[],
-        folder: FolderItem,
-        index: number,
-        folders: FolderItem[]
-    ): string[] => {
-        if (folder.parentId && acc.some(el => el === folder.id)) {
-            acc.push(folder.parentId);
+    // Create a Map with folders, using folderId as key
+    const folderMap = new Map<string, FolderItem>();
+    folders.forEach(folder => folderMap.set(folder.id, folder));
 
-            const newArr = folders.filter((_, i) => {
-                return i !== index;
-            });
-
-            return newArr.reduce(findParents, acc);
+    // Recursive function that drill up the folderMap and includes the folderId above a given folder (identified by folderId)
+    const findParents = (acc: string[], folderId: string): string[] => {
+        const folder = folderMap.get(folderId);
+        if (!folder || !folder.parentId || acc.includes(folder.parentId)) {
+            return acc;
         }
 
-        return acc;
+        acc.push(folder.parentId);
+        return findParents(acc, folder.parentId);
     };
 
-    const result = folders.reduce(findParents, [focusedId]);
+    // In case there is not focused folder or has no parent, return the current open folders
+    const focusedFolder = folderMap.get(focusedId);
+    if (!focusedFolder || !focusedFolder.parentId) {
+        return openIds;
+    }
 
+    // Remove duplicates and return
+    const result = findParents([focusedId], focusedId);
     return [...new Set([...result, ...openIds])];
 };

--- a/packages/app-aco/src/contexts/folders.tsx
+++ b/packages/app-aco/src/contexts/folders.tsx
@@ -61,7 +61,7 @@ export const FoldersProvider = ({ children }: Props) => {
     const context: FoldersContext = {
         folders,
         loading,
-        async listFolders(type: string) {
+        async listFolders(type: string, limit = 10000) {
             if (!type) {
                 throw new Error("Folder `type` is mandatory");
             }
@@ -71,7 +71,7 @@ export const FoldersProvider = ({ children }: Props) => {
                 () =>
                     client.query<ListFoldersResponse, ListFoldersQueryVariables>({
                         query: LIST_FOLDERS,
-                        variables: { type }
+                        variables: { type, limit }
                     })
             );
 

--- a/packages/app-aco/src/graphql/folders.gql.ts
+++ b/packages/app-aco/src/graphql/folders.gql.ts
@@ -36,9 +36,9 @@ export const CREATE_FOLDER = gql`
 `;
 
 export const LIST_FOLDERS = gql`
-    query ListFolders ($type: String!) {
+    query ListFolders ($type: String!, $limit: Int) {
         aco {
-            listFolders(where: { type: $type }) {
+            listFolders(where: { type: $type }, limit: $limit) {
                 data ${DATA_FIELD}
                 error ${ERROR_FIELD}
             }

--- a/packages/app-aco/src/types.ts
+++ b/packages/app-aco/src/types.ts
@@ -80,6 +80,7 @@ export interface ListFoldersResponse {
 
 export interface ListFoldersQueryVariables {
     type: string;
+    limit: number;
 }
 
 export interface GetFolderResponse {


### PR DESCRIPTION
## Changes
This PR:
- optimize sorting function within `FolderTree` component using `useMemo`
- solves a performance issue within `FolderTree` component  generated by 8+ nested folders (now tested up to 50)
- increases to 10.000 the `listFolders` limit, instead of the default provided by `cms.listLatestEntries`



## How Has This Been Tested?
Manually

