### PR TITLE
test: fix tracking of numberOfGeneratedFiles across multiple tests

### DIFF
--- a/packages/migrations/__tests__/migrations/5.36.0/001/ddb/001.test.ts
+++ b/packages/migrations/__tests__/migrations/5.36.0/001/ddb/001.test.ts
@@ -34,6 +34,7 @@ describe("5.36.0-001", () => {
         skipLocales = 0
     ) => {
         ddbFiles.length = 0;
+        numberOfGeneratedFiles = 0;
 
         const tenants = createTenantsData().map(tenant => tenant.data.id);
         const testLocales = createLocalesData();


### PR DESCRIPTION
## Changes
With this PR we fix migrations tests clearing the `numberOfGeneratedFiles` before inserting new records.

## How Has This Been Tested?
Jest
