### PR TITLE
Page Builder - Fix Images on the Welcome To Webiny Page

### DIFF
--- a/packages/api-page-builder/src/graphql/crud/install/utils/savePageAssets.ts
+++ b/packages/api-page-builder/src/graphql/crud/install/utils/savePageAssets.ts
@@ -51,7 +51,7 @@ export const savePageAssets = async ({
                 size: buffer.length,
                 type: file.type,
                 hideInFileManager: Boolean(file.meta.private),
-                keyPrefix: "demo-pages/"
+                keyPrefix: "demo-pages"
             };
         });
 


### PR DESCRIPTION
## Changes
This PR ensures the images included in the default Welcome to Webiny page are working. Prior to this PR, the images would not resolve correctly.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.