### PR TITLE
fix: 5.35.x pages migration

### DIFF
--- a/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
+++ b/packages/migrations/src/migrations/5.35.0/006/ddb-es/PageDataMigration.ts
@@ -119,7 +119,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                         },
                         sort: [
                             {
-                                "id.keyword": "asc"
+                                "id.keyword": { order: "asc", unmapped_type: "keyword" }
                             }
                         ]
                     }
@@ -204,7 +204,7 @@ export class AcoRecords_5_35_0_006_PageData implements DataMigration<PageDataMig
                         size: 500,
                         sort: [
                             {
-                                "id.keyword": "asc"
+                                "id.keyword": { order: "asc", unmapped_type: "keyword" }
                             }
                         ],
                         search_after: status


### PR DESCRIPTION
## Changes
With this PR we fix `5.35.0/006` migration bug. The page builder migration was failing in the case of an empty `page-builder` index.

## How Has This Been Tested?
Jest

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
