### PR TITLE
Fix/5.36.x aco file migration empty index

### DIFF
--- a/packages/migrations/src/migrations/5.36.0/001/ddb-es/FileDataMigration.ts
+++ b/packages/migrations/src/migrations/5.36.0/001/ddb-es/FileDataMigration.ts
@@ -111,7 +111,7 @@ export class AcoRecords_5_36_0_001_FileData implements DataMigration<FileDataMig
                         },
                         sort: [
                             {
-                                "id.keyword": "asc"
+                                "id.keyword": { order: "asc", unmapped_type: "keyword" }
                             }
                         ]
                     }


### PR DESCRIPTION
## Changes
With this PR we fix 5.36.0/001 migration bug, preventing migration failure in the case of an empty file-manager index.

## How Has This Been Tested?
Jest