### PR TITLE
fix: fix duplicate images on import

### DIFF
--- a/packages/api-file-manager/src/graphql/index.ts
+++ b/packages/api-file-manager/src/graphql/index.ts
@@ -143,6 +143,8 @@ export const createGraphQLSchemaPlugin = () => {
                 tag_not_startsWith: String
                 id_in: [ID!]
                 id: ID
+                importedUnderKey_in: [String!]
+                importedUnderKey: String
                 createdBy: ID
             }
 

--- a/packages/api-file-manager/src/types.ts
+++ b/packages/api-file-manager/src/types.ts
@@ -32,6 +32,7 @@ export interface FileInput {
     meta: Record<string, any>;
     tags: string[];
     aliases: string[];
+    importedUnderKey?: string;
 }
 
 export interface FileListWhereParams {
@@ -43,6 +44,8 @@ export interface FileListWhereParams {
     tag_and_in?: string[];
     id_in?: string[];
     id?: string;
+    importedUnderKey_in?: string[];
+    importedUnderKey?: string;
 }
 export interface FilesListOpts {
     search?: string;


### PR DESCRIPTION
## Changes
Resolve issue "When importing pages, blocks and templates see we don’t duplicate images"

## How Has This Been Tested?
Manual

## Documentation
None
