### PR TITLE
Enable Calling `webiny destroy` Without Specifying the Folder

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -1,3 +1,4 @@
+const { red } = require("chalk");
 const destroy = require("./destroy");
 const deploy = require("./deploy");
 const build = require("./build");
@@ -168,7 +169,7 @@ module.exports = [
             );
 
             yargs.command(
-                "destroy <folder>",
+                "destroy [folder]",
                 `Destroys deployed cloud infrastructure for given project application`,
                 yargs => {
                     yargs.example("$0 destroy api --env=dev");
@@ -181,6 +182,38 @@ module.exports = [
                         describe: `Environment`,
                         type: "string"
                     });
+
+                    yargs
+                        .option("confirm-destroy-env", {
+                            describe: `Confirm environment name to destroy. Must be passed when destroying the whole project.`,
+                            type: "string"
+                        })
+                        .check(args => {
+                            const { folder, confirmDestroyEnv } = args;
+
+                            // If the folder is not defined, we are destroying the whole project.
+                            // In that case, we must confirm the environment name to destroy.
+                            if (!folder) {
+                                if (!confirmDestroyEnv) {
+                                    throw new Error(
+                                        `Please confirm complete project destruction by appending ${red(
+                                            `--confirm-destroy-env=${args.env}`
+                                        )} to the command.`
+                                    );
+                                }
+
+                                if (confirmDestroyEnv !== args.env) {
+                                    throw new Error(
+                                        `The ${red(
+                                            `--confirm-destroy-env`
+                                        )} option value must match the ${red("env")} option value.`
+                                    );
+                                }
+                            }
+
+                            return true;
+                        });
+
                     yargs.option("debug", {
                         default: false,
                         describe: `Turn on debug logs`,

--- a/packages/cwp-template-aws/cli/deploy/deploy.js
+++ b/packages/cwp-template-aws/cli/deploy/deploy.js
@@ -74,36 +74,36 @@ module.exports = async (inputs, context) => {
         // Deploying `core` project application.
         if (hasCore) {
             isFirstDeployment && console.log();
-            context.info(`Deploying ${green("core")} project application...`);
+            context.info(`Deploying ${green("Core")} project application...`);
 
             await deploy("apps/core", env, inputs);
-            context.success(`${green("core")} project application was deployed successfully!`);
+            context.success(`${green("Core")} project application was deployed successfully!`);
             isFirstDeployment && (await sleep(2000));
         }
 
         // Deploying `api` project application.
         console.log();
-        context.info(`Deploying ${green(apiFolder)} project application...`);
+        context.info(`Deploying ${green("API")} project application...`);
 
         await deploy(apiFolder, env, inputs);
-        context.success(`${green(apiFolder)} project application was deployed successfully!`);
+        context.success(`${green("API")} project application was deployed successfully!`);
         isFirstDeployment && (await sleep(2000));
 
         // Deploying `apps/admin` project application.
         console.log();
-        context.info(`Deploying ${green("apps/admin")} project application...`);
+        context.info(`Deploying ${green("Admin")} project application...`);
         isFirstDeployment && (await sleep());
 
         await deploy("apps/admin", env, inputs);
-        context.success(`${green("apps/admin")} project application was deployed successfully!`);
+        context.success(`${green("Admin")} project application was deployed successfully!`);
 
         // Deploying `apps/admin` project application.
         console.log();
-        context.info(`Deploying ${green("apps/website")} project application...`);
+        context.info(`Deploying ${green("Website")} project application...`);
         isFirstDeployment && (await sleep());
 
         await deploy("apps/website", env, inputs);
-        context.success(`${green("apps/website")} project application was deployed successfully!`);
+        context.success(`${green("Website")} project application was deployed successfully!`);
 
         await sendEvent({ event: "project-deploy-end" });
     } catch (e) {
@@ -157,7 +157,7 @@ module.exports = async (inputs, context) => {
                 `💡 Tip: to deploy project applications separately, use the ${green(
                     "deploy"
                 )} command (e.g. ${green(
-                    `yarn webiny deploy apps/website --env ${env}`
+                    `yarn webiny deploy website --env ${env}`
                 )}). For additional help, please run ${green("yarn webiny --help")}.`
             ].join("\n")
         );

--- a/packages/cwp-template-aws/cli/destroy/destroy.js
+++ b/packages/cwp-template-aws/cli/destroy/destroy.js
@@ -1,0 +1,57 @@
+const fs = require("fs");
+const { green } = require("chalk");
+const { getPulumi } = require("@webiny/cli-plugin-deploy-pulumi/utils");
+const { getApiProjectApplicationFolder } = require("@webiny/cli/utils");
+const path = require("path");
+const execa = require("execa");
+
+const destroy = (stack, env, inputs) =>
+    execa(
+        "yarn",
+        [
+            "webiny",
+            "destroy",
+            stack,
+            "--env",
+            env,
+            "--debug",
+            Boolean(inputs.debug),
+            "--build",
+            Boolean(inputs.build),
+            "--preview",
+            Boolean(inputs.preview)
+        ],
+        {
+            stdio: "inherit"
+        }
+    );
+
+module.exports = async (inputs, context) => {
+    const { env } = inputs;
+
+    // Ensure Pulumi is installed.
+    const pulumi = await getPulumi({ install: false });
+
+    pulumi.install();
+
+    const apiFolder = getApiProjectApplicationFolder(context.project);
+    const hasCore = fs.existsSync(path.join(context.project.root, "apps", "core"));
+
+    console.log();
+    context.info(`Destroying ${green("Website")} project application...`);
+    await destroy("apps/website", env, inputs);
+
+    console.log();
+    context.info(`Destroying ${green("Admin")} project application...`);
+    await destroy("apps/admin", env, inputs);
+
+    console.log();
+    context.info(`Destroying ${green("API")} project application...`);
+    await destroy(apiFolder, env, inputs);
+
+    if (hasCore) {
+        console.log();
+        context.info(`Destroying ${green("Core")} project application...`);
+        await destroy("apps/core", env, inputs);
+    }
+};

--- a/packages/cwp-template-aws/cli/destroy/index.js
+++ b/packages/cwp-template-aws/cli/destroy/index.js
@@ -1,0 +1,5 @@
+module.exports = () => ({
+    type: "cli-command-deployment-destroy-all",
+    name: "cli-command-deployment-destroy-all",
+    destroy: (...args) => require("./destroy")(...args)
+});

--- a/packages/cwp-template-aws/cli/index.js
+++ b/packages/cwp-template-aws/cli/index.js
@@ -1,1 +1,6 @@
-module.exports = () => [require("./deploy")(), require("./info"), require("./aws")];
+module.exports = () => [
+    require("./deploy")(),
+    require("./destroy")(),
+    require("./info"),
+    require("./aws")
+];


### PR DESCRIPTION
## Changes
With this PR, we're introducing the ability to destroy a whole Webiny project, meaning all four project applications. This is done in the following order:

1. Website
2. Admin
3. API
4. Core

## How Has This Been Tested?
Manually.

## Documentation
Changelog. Will update related doc.