### PR TITLE
fix: page builder url with no website deployed

### DIFF
--- a/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
+++ b/packages/app-page-builder/src/admin/hooks/usePageBuilderSettings/usePageBuilderSettings.ts
@@ -87,7 +87,7 @@ export function usePageBuilderSettings() {
 
     const getPageUrl = (page: Pick<PbPageData, "id" | "status" | "path">): string => {
         const preview = page.status !== "published";
-        const url = getWebsiteUrl(preview) + page.path;
+        const url = [getWebsiteUrl(preview), page.path].join("");
         if (!preview) {
             return url;
         }


### PR DESCRIPTION
## Changes
With this PR we solve a visual bug appearing inside the page preview, in case the `website` has not been deployed yet. Instead of the full page URL (containing `undefined` as domain), we show the page relative path.

**Website not deployed**
<img width="247" alt="Screenshot 2023-06-07 at 22 01 25" src="https://github.com/webiny/webiny-js/assets/2866531/b4ce19bc-33c9-48c6-9a79-4e7882790036">

**Website deployed**
<img width="330" alt="Screenshot 2023-06-07 at 22 11 13" src="https://github.com/webiny/webiny-js/assets/2866531/62f71fc0-200e-40e7-9e1c-58b6a3e26c60">


## How Has This Been Tested?
Manually
