### PR TITLE
fix(app-form-builder): added timeout limit to ipify xhr request

### DIFF
--- a/packages/app-form-builder/src/components/Form/functions/getClientIp.ts
+++ b/packages/app-form-builder/src/components/Form/functions/getClientIp.ts
@@ -2,6 +2,7 @@ export default (): Promise<string> => {
     return new Promise((resolve: (value: string) => void) => {
         try {
             const xhr = new window.XMLHttpRequest();
+            xhr.timeout = 1500;
             xhr.open("GET", "https://api.ipify.org/?format=json", true);
             xhr.setRequestHeader("Content-Type", "application/json");
             xhr.send();
@@ -13,6 +14,9 @@ export default (): Promise<string> => {
                 resolve("0.0.0.0");
             };
             xhr.onerror = function () {
+                resolve("0.0.0.0");
+            };
+            xhr.ontimeout = function () {
                 resolve("0.0.0.0");
             };
         } catch (e) {

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/functions/getClientIp.ts
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/functions/getClientIp.ts
@@ -2,6 +2,7 @@ export default (): Promise<string> => {
     return new Promise((resolve: (value: string) => void) => {
         try {
             const xhr = new window.XMLHttpRequest();
+            xhr.timeout = 1500;
             xhr.open("GET", "https://api.ipify.org/?format=json", true);
             xhr.setRequestHeader("Content-Type", "application/json");
             xhr.send();
@@ -13,6 +14,9 @@ export default (): Promise<string> => {
                 resolve("0.0.0.0");
             };
             xhr.onerror = function () {
+                resolve("0.0.0.0");
+            };
+            xhr.ontimeout = function () {
                 resolve("0.0.0.0");
             };
         } catch (e) {


### PR DESCRIPTION
## Changes
Added a timeout of 1.5s to the ipify API request. We use the ipify API to get the client's IP address when they submit the form. The problem is that ipify API sometimes takes even 20s to respond or it times out. Long waiting times could lead to abandoned form submissions. To get around that we've added the timeout limit, so if ipify doesn't respond within 1.5s, we submit the form and log `0.0.0.0` as. the client's ip.

## How Has This Been Tested?
Manually
