### PR TITLE
fix(app-aco): fetch only simple fields when listing entries

### DIFF
--- a/packages/app-aco/src/graphql/records/listRecords.ts
+++ b/packages/app-aco/src/graphql/records/listRecords.ts
@@ -5,7 +5,25 @@ import { createListQuery } from "@webiny/app-headless-cms-common";
 
 export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
     if (mode === "cms") {
-        return createListQuery(model, model.fields);
+        return createListQuery(
+            model,
+            /**
+             * We will include only the simplest fields.
+             * TODO: possibly have only searchable / sortable fields here?
+             * We could do that if we fetched the information from the API side - we do not have that information in the UI.
+             */
+            model.fields.filter(field => {
+                return [
+                    "text",
+                    "number",
+                    "boolean",
+                    "file",
+                    "long-text",
+                    "ref",
+                    "datetime"
+                ].includes(field.type);
+            })
+        );
     }
     const { singularApiName, pluralApiName } = model;
     return gql`


### PR DESCRIPTION
## Changes
A workaround fix for an issue where ACO cannot list CMS entries which have dynamic zone fields in it.

## How Has This Been Tested?
Manually.