### PR TITLE
fix(app-headless-cms): adjustments to the image field renderer

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
@@ -7,7 +7,16 @@ import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 
 const imagePreviewProps = {
     transform: { width: 300 },
-    style: { width: "100%", height: 232, objectFit: "cover" }
+    style: {
+        width: "100%",
+        height: "100%",
+        maxHeight: "160px",
+        background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        objectFit: "contain"
+    }
 };
 
 const defaultStyles = {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
@@ -1,9 +1,42 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import { i18n } from "@webiny/app/i18n";
-import { Cell, Grid } from "@webiny/ui/Grid";
 import { FileManager } from "@webiny/app-admin/components";
 import File from "./File";
+import styled from "@emotion/styled";
+import { Typography } from "@webiny/ui/Typography";
+
+const ImageFieldWrapper = styled("div")({
+    background: "var(--mdc-theme-on-background)",
+    borderBottom: "1px solid rgba(0, 0, 0, 0.42)",
+    height: "100%",
+    padding: "25px 15px",
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    span: {
+        color: "var(--mdc-theme-text-primary-on-background)"
+    }
+});
+
+const InnerImageFieldWrapper = styled("div")({
+    background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+    height: "100%",
+    width: "100%",
+    boxSizing: "border-box",
+    backgroundColor: "#fff",
+    border: "1px solid var(--mdc-theme-background)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexBasis: "100%",
+    maxHeight: "180px",
+    ">div": {
+        minWidth: "200px",
+        maxHeight: "180px",
+        padding: "30px"
+    }
+});
 
 const t = i18n.ns("app-headless-cms/admin/fields/file");
 
@@ -22,14 +55,16 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
             const imagesOnly = field.settings && field.settings.imagesOnly;
             return (
-                <Grid>
-                    <Cell span={12}>
-                        <Label>{field.label}</Label>
-                        <Bind>
-                            {bind => {
-                                const { value, onChange } = bind;
+                <ImageFieldWrapper>
+                    <Label>
+                        <Typography use="body1">{field.label}</Typography>
+                    </Label>
+                    <Bind>
+                        {bind => {
+                            const { value, onChange } = bind;
 
-                                return (
+                            return (
+                                <InnerImageFieldWrapper>
                                     <FileManager
                                         images={imagesOnly}
                                         render={({ showFileManager }) => {
@@ -49,11 +84,11 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                             );
                                         }}
                                     />
-                                );
-                            }}
-                        </Bind>
-                    </Cell>
-                </Grid>
+                                </InnerImageFieldWrapper>
+                            );
+                        }}
+                    </Bind>
+                </ImageFieldWrapper>
             );
         }
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -22,6 +22,27 @@ const FileUploadWrapper = styled("div")({
     }
 });
 
+const InnerImageFieldWrapper = styled("div")({
+    background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+    height: "100%",
+    width: "100%",
+    boxSizing: "border-box",
+    backgroundColor: "#fff",
+    border: "1px solid var(--mdc-theme-background)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexBasis: "100%",
+    maxHeight: "180px",
+    padding: "30px",
+    ">div": {
+        maxHeight: "180px",
+        img: {
+            padding: "15px"
+        }
+    }
+});
+
 interface FieldRendererProps {
     getBind: GetBindCallable;
     Label: React.FC;
@@ -71,30 +92,38 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
                                         <>
                                             {value.map((url: string, index: number) => (
                                                 <Cell span={3} key={url}>
-                                                    <File
-                                                        url={url}
-                                                        showFileManager={() => selectFiles(index)}
-                                                        onRemove={() =>
-                                                            onChange(dotProp.delete(value, index))
-                                                        }
-                                                        placeholder={t`Select a file"`}
-                                                        data-testid={`fr.input.file.${field.label}.${index}`}
-                                                    />
+                                                    <InnerImageFieldWrapper>
+                                                        <File
+                                                            url={url}
+                                                            showFileManager={() =>
+                                                                selectFiles(index)
+                                                            }
+                                                            onRemove={() =>
+                                                                onChange(
+                                                                    dotProp.delete(value, index)
+                                                                )
+                                                            }
+                                                            placeholder={t`Select a file"`}
+                                                            data-testid={`fr.input.file.${field.label}.${index}`}
+                                                        />
+                                                    </InnerImageFieldWrapper>
                                                 </Cell>
                                             ))}
                                         </>
 
                                         <Cell span={3}>
-                                            <File
-                                                url={""}
-                                                onRemove={() => {
-                                                    return void 0;
-                                                }}
-                                                {...bind}
-                                                showFileManager={() => selectFiles()}
-                                                placeholder={t`Select a file"`}
-                                                data-testid={`fr.input.file.${field.label}`}
-                                            />
+                                            <InnerImageFieldWrapper>
+                                                <File
+                                                    url={""}
+                                                    onRemove={() => {
+                                                        return void 0;
+                                                    }}
+                                                    {...bind}
+                                                    showFileManager={() => selectFiles()}
+                                                    placeholder={t`Select a file"`}
+                                                    data-testid={`fr.input.file.${field.label}`}
+                                                />
+                                            </InnerImageFieldWrapper>
                                         </Cell>
                                     </GridInner>
                                 );


### PR DESCRIPTION
## Changes
Made adjustments to the image field rendered so it looks nicer and that it no longer crops the images. 

Old:
<img width="1130" alt="CleanShot 2023-06-27 at 13 59 21@2x" src="https://github.com/webiny/webiny-js/assets/3808420/464bb3b1-2bc5-431e-bd08-d50fd53dc9b2">
<img width="1169" alt="CleanShot 2023-06-27 at 13 58 54@2x" src="https://github.com/webiny/webiny-js/assets/3808420/5c9efd99-d124-485a-8a45-7aa37c4c6b18">

New:
<img width="781" alt="CleanShot 2023-06-27 at 14 13 51@2x" src="https://github.com/webiny/webiny-js/assets/3808420/8f83db80-80bd-4f13-9406-9d032794ed55">
<img width="742" alt="CleanShot 2023-06-27 at 14 14 23@2x" src="https://github.com/webiny/webiny-js/assets/3808420/18125afd-db82-4a10-b4b9-ad23a953d567">
<img width="751" alt="CleanShot 2023-06-27 at 14 14 05@2x" src="https://github.com/webiny/webiny-js/assets/3808420/d0e53fa1-c5e6-4c9a-b2de-98b58f2ccb86">



## How Has This Been Tested?
Manually

