### PR TITLE
fix: move cms entry to another folder

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -112,6 +112,11 @@ export default /* GraphQL */ `
         error: CmsError
     }
     
+    type CategoryApiNameWhichIsABitDifferentThanModelIdMoveResponse {
+        data: Boolean
+        error: CmsError
+    }
+    
     type CategoryApiNameWhichIsABitDifferentThanModelIdArrayResponse {
         data: [CategoryApiNameWhichIsABitDifferentThanModelId]
         error: CmsError
@@ -157,6 +162,8 @@ export default /* GraphQL */ `
         createCategoryApiNameWhichIsABitDifferentThanModelIdFrom(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
 
         updateCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
+    
+        moveCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, folderId: ID!): CategoryApiNameWhichIsABitDifferentThanModelIdMoveResponse
 
         deleteCategoryApiNameWhichIsABitDifferentThanModelId(
             revision: ID!

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -320,6 +320,11 @@ export default /* GraphQL */ `
         data: PageModelApiName
         error: CmsError
     }
+    
+    type PageModelApiNameMoveResponse {
+        data: Boolean
+        error: CmsError
+    }
 
     type PageModelApiNameArrayResponse {
         data: [PageModelApiName]
@@ -372,7 +377,9 @@ export default /* GraphQL */ `
             revision: ID!
             data: PageModelApiNameInput!
         ): PageModelApiNameResponse
-
+    
+        movePageModelApiName(revision: ID!, folderId: ID!): PageModelApiNameMoveResponse
+    
         deletePageModelApiName(
             revision: ID!
             options: CmsDeleteEntryOptions

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -92,7 +92,7 @@ export default /* GraphQL */ `
         category: RefField
         options: [ProductApiSingular_Variant_Options!]
     }
-        
+    
     input ProductApiSingular_VariantWhereInput {
         name: String
         name_not: String
@@ -304,6 +304,11 @@ export default /* GraphQL */ `
         error: CmsError
     }
     
+    type ProductApiSingularMoveResponse {
+        data: Boolean
+        error: CmsError
+    }
+    
     type ProductApiSingularArrayResponse {
         data: [ProductApiSingular]
         error: CmsError
@@ -359,6 +364,8 @@ export default /* GraphQL */ `
         createProductApiSingularFrom(revision: ID!, data: ProductApiSingularInput): ProductApiSingularResponse
 
         updateProductApiSingular(revision: ID!, data: ProductApiSingularInput!): ProductApiSingularResponse
+        
+        moveProductApiSingular(revision: ID!, folderId: ID!): ProductApiSingularMoveResponse
 
         deleteProductApiSingular(
             revision: ID!

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -123,6 +123,11 @@ export default /* GraphQL */ `
         data: ReviewApiModel
         error: CmsError
     }
+
+    type ReviewApiModelMoveResponse {
+        data: Boolean
+        error: CmsError
+    }
     
     type ReviewApiModelArrayResponse {
         data: [ReviewApiModel]
@@ -169,6 +174,8 @@ export default /* GraphQL */ `
         createReviewApiModelFrom(revision: ID!, data: ReviewApiModelInput): ReviewApiModelResponse
 
         updateReviewApiModel(revision: ID!, data: ReviewApiModelInput!): ReviewApiModelResponse
+        
+        moveReviewApiModel(revision: ID!, folderId: ID!): ReviewApiModelMoveResponse
 
         deleteReviewApiModel(
             revision: ID!

--- a/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateModelFields.ts
@@ -351,7 +351,7 @@ export const validateModelFields = async (params: ValidateModelFieldsParams): Pr
             continue;
         }
 
-        if (lockedField.multipleValues !== existingField.multipleValues) {
+        if (Boolean(lockedField.multipleValues) !== Boolean(existingField.multipleValues)) {
             throw new WebinyError(
                 `Cannot change "multipleValues" for the "${lockedField.fieldId}" field because it's already in use in created content.`,
                 "ENTRY_FIELD_USED",

--- a/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentEntries.ts
@@ -1,6 +1,6 @@
 import WebinyError from "@webiny/error";
 import { ErrorResponse, Response } from "@webiny/handler-graphql";
-import { CmsEntry, CmsContext, CmsModel, CmsEntryListWhere, CmsIdentity } from "~/types";
+import { CmsContext, CmsEntry, CmsEntryListWhere, CmsIdentity, CmsModel } from "~/types";
 import { NotAuthorizedResponse } from "@webiny/api-security";
 import { getEntryTitle } from "~/utils/getEntryTitle";
 import { CmsGraphQLSchemaPlugin } from "~/plugins";
@@ -40,6 +40,9 @@ interface CmsEntryRecord {
      */
     createdOn: Date;
     savedOn: Date;
+    wbyAco_location?: {
+        folderId?: string | null;
+    };
 }
 
 const createCmsEntryRecord = (model: CmsModel, entry: CmsEntry): CmsEntryRecord => {
@@ -57,7 +60,10 @@ const createCmsEntryRecord = (model: CmsModel, entry: CmsEntry): CmsEntryRecord 
         createdBy: entry.createdBy,
         modifiedBy: entry.modifiedBy,
         createdOn: createDate(entry.createdOn),
-        savedOn: createDate(entry.savedOn)
+        savedOn: createDate(entry.savedOn),
+        wbyAco_location: {
+            folderId: entry.location?.folderId || null
+        }
     };
 };
 
@@ -285,6 +291,7 @@ export const createContentEntriesSchema = ({
                 published: CmsPublishedContentEntry
                 createdOn: DateTime!
                 savedOn: DateTime!
+                wbyAco_location: WbyAcoLocation
             }
 
             type CmsContentEntriesResponse {

--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -6,6 +6,7 @@ import { resolveGetRevisions } from "./resolvers/manage/resolveGetRevisions";
 import { resolveGetByIds } from "./resolvers/manage/resolveGetByIds";
 import { resolveCreate } from "./resolvers/manage/resolveCreate";
 import { resolveUpdate } from "./resolvers/manage/resolveUpdate";
+import { resolveMove } from "./resolvers/manage/resolveMove";
 import { resolveDelete } from "./resolvers/manage/resolveDelete";
 import { resolveDeleteMultiple } from "./resolvers/manage/resolveDeleteMultiple";
 import { resolvePublish } from "./resolvers/manage/resolvePublish";
@@ -77,6 +78,7 @@ export const createManageResolvers: CreateManageResolvers = ({
         Mutation: {
             [`create${model.singularApiName}`]: resolveCreate({ model }),
             [`update${model.singularApiName}`]: resolveUpdate({ model }),
+            [`move${model.singularApiName}`]: resolveMove({ model }),
             [`delete${model.singularApiName}`]: resolveDelete({ model }),
             [`deleteMultiple${model.pluralApiName}`]: resolveDeleteMultiple({ model }),
             [`publish${model.singularApiName}`]: resolvePublish({ model }),

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -126,6 +126,11 @@ export const createManageSDL: CreateManageSDL = ({
             data: ${singularName}
             error: CmsError
         }
+        
+        type ${singularName}MoveResponse {
+            data: Boolean
+            error: CmsError
+        }
 
         type ${singularName}ArrayResponse {
             data: [${singularName}]
@@ -164,6 +169,8 @@ export const createManageSDL: CreateManageSDL = ({
             create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
     
             update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
+            
+            move${singularName}(revision: ID!, folderId: ID!): ${singularName}MoveResponse
 
             delete${singularName}(revision: ID!, options: CmsDeleteEntryOptions): CmsDeleteResponse
 

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
@@ -1,0 +1,29 @@
+import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
+import { CmsEntryResolverFactory as ResolverFactory } from "~/types";
+
+interface ResolveMoveArgs {
+    revision: string;
+    folderId: string;
+}
+
+type ResolveMove = ResolverFactory<any, ResolveMoveArgs>;
+
+export const resolveMove: ResolveMove =
+    ({ model }) =>
+    async (_, args: any, context) => {
+        const { revision, folderId } = args;
+        try {
+            if (!folderId) {
+                throw new Error(`The input value "folderId" is required!`);
+            }
+            const entry = await context.cms.updateEntry(model, revision, {
+                wbyAco_location: {
+                    folderId
+                }
+            });
+
+            return new Response(entry.location?.folderId === folderId);
+        } catch (e) {
+            return new ErrorResponse(e);
+        }
+    };

--- a/packages/app-aco/src/contexts/navigateFolder.tsx
+++ b/packages/app-aco/src/contexts/navigateFolder.tsx
@@ -24,7 +24,7 @@ export interface NavigateFolderProviderProps {
 }
 
 export const NavigateFolderProvider: React.VFC<NavigateFolderProviderProps> = ({
-    folderId,
+    folderId: currentFolderId,
     children,
     createStorageKey,
     ...props
@@ -53,15 +53,23 @@ export const NavigateFolderProvider: React.VFC<NavigateFolderProviderProps> = ({
      */
     const navigateToLatestFolder = useCallback(() => {
         const folderId = store.get(createStorageKey());
+        /**
+         * We need to check if the stored folderId is the same as the current one or the current one is the root folder.
+         * We must skip the navigation to the latest folder in these cases as it will cause a bug where
+         * a user cannot access a CMS entry or page via the direct URL.
+         */
+        if (folderId === currentFolderId || currentFolderId === ROOT_FOLDER) {
+            return;
+        }
         props.navigateToLatestFolder(folderId || ROOT_FOLDER);
-    }, [createStorageKey, folderId]);
+    }, [createStorageKey, currentFolderId]);
 
     const navigateToFolder = useCallback(
         (folderId?: string) => {
             setFolderToStorage(folderId);
             props.navigateToFolder(folderId || ROOT_FOLDER);
         },
-        [folderId]
+        [currentFolderId]
     );
 
     const navigateToListHome = () => {
@@ -70,7 +78,7 @@ export const NavigateFolderProvider: React.VFC<NavigateFolderProviderProps> = ({
     };
 
     const context: NavigateFolderContext = {
-        currentFolderId: folderId || store.get(createStorageKey()),
+        currentFolderId: currentFolderId || store.get(createStorageKey()),
         setFolderToStorage,
         navigateToListHome,
         navigateToFolder,

--- a/packages/app-aco/src/contexts/records.tsx
+++ b/packages/app-aco/src/contexts/records.tsx
@@ -158,7 +158,7 @@ export const SearchRecordsProvider: React.VFC<Props> = ({ children }) => {
         return {
             LIST_RECORDS: createListRecords(model, mode),
             UPDATE_RECORD: createUpdateRecord(model, mode),
-            MOVE_RECORD: createMoveRecord(model),
+            MOVE_RECORD: createMoveRecord(model, mode),
             GET_RECORD: createGetRecord(model, mode),
             LIST_TAGS: createListTags(model, mode),
             DELETE_RECORD: createDeleteRecord(model, mode),
@@ -462,13 +462,16 @@ export const SearchRecordsProvider: React.VFC<Props> = ({ children }) => {
                 setRecords(prev => {
                     return prev.filter(record => record.id !== id);
                 });
-                setMeta(meta => ({
-                    ...meta,
-                    [folderId]: {
-                        ...meta[folderId],
-                        totalCount: --meta[folderId].totalCount
-                    }
-                }));
+                // setMeta(meta => {
+                //     const folder = meta[folderId] || {};
+                //     return {
+                //         ...meta,
+                //         [folderId]: {
+                //             ...folder,
+                //             totalCount: (folder?.totalCount || 0) + 1
+                //         }
+                //     };
+                // });
             },
             async deleteRecord(record) {
                 if (!DELETE_RECORD) {

--- a/packages/app-aco/src/graphql/records/moveRecord.ts
+++ b/packages/app-aco/src/graphql/records/moveRecord.ts
@@ -1,9 +1,19 @@
 import gql from "graphql-tag";
-import { AcoModel } from "~/types";
+import { AcoAppMode, AcoModel } from "~/types";
 import { ERROR_FIELD } from "./common";
 
-export const createMoveRecord = (model: AcoModel) => {
+export const createMoveRecord = (model: AcoModel, mode: AcoAppMode) => {
     const { singularApiName } = model;
+    if (mode === "cms") {
+        return gql`
+            mutation Move${singularApiName}($id: ID!, $folderId: ID!) {
+                content: move${singularApiName}(revision: $id, folderId: $folderId) {
+                    data
+                    ${ERROR_FIELD}
+                }
+            }
+        `;
+    }
     return gql`
         mutation Move${singularApiName}($id: ID!, $folderId: ID!) {
             search {

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
@@ -145,7 +145,7 @@ export const Table = forwardRef<HTMLDivElement, Props>((props, ref) => {
                                             return null;
                                         }
                                         return {
-                                            id: entryId,
+                                            id: record.id,
                                             location: {
                                                 folderId: currentFolderId as string
                                             }

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
@@ -95,7 +95,7 @@ export const ContentEntriesProvider: React.FC<ContentEntriesContextProviderProps
     }, [viewConfig.sorters, contentModel.modelId]);
 
     const [listQueryVariables, setListQueryVariables] = useState<ListQueryVariables>({
-        sort: [sorters[0].value],
+        sort: sorters[0]?.value ? [sorters[0].value] : [],
         where: {}
     });
 


### PR DESCRIPTION
## Changes
This PR fixes the "Move" (to another folder) operation for the CMS entries.

## How Has This Been Tested?
Jest and manually.