### PR TITLE
fix(app-headless-cms): adjustments to the image field renderer

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
@@ -7,7 +7,16 @@ import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 
 const imagePreviewProps = {
     transform: { width: 300 },
-    style: { width: "100%", height: 232, objectFit: "cover" }
+    style: {
+        width: "100%",
+        height: "100%",
+        maxHeight: "160px",
+        background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        objectFit: "contain"
+    }
 };
 
 const defaultStyles = {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileField.tsx
@@ -1,9 +1,42 @@
 import React from "react";
 import { CmsEditorFieldRendererPlugin } from "~/types";
 import { i18n } from "@webiny/app/i18n";
-import { Cell, Grid } from "@webiny/ui/Grid";
 import { FileManager } from "@webiny/app-admin/components";
 import File from "./File";
+import styled from "@emotion/styled";
+import { Typography } from "@webiny/ui/Typography";
+
+const ImageFieldWrapper = styled("div")({
+    background: "var(--mdc-theme-on-background)",
+    borderBottom: "1px solid rgba(0, 0, 0, 0.42)",
+    height: "100%",
+    padding: "25px 15px",
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    span: {
+        color: "var(--mdc-theme-text-primary-on-background)"
+    }
+});
+
+const InnerImageFieldWrapper = styled("div")({
+    background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+    height: "100%",
+    width: "100%",
+    boxSizing: "border-box",
+    backgroundColor: "#fff",
+    border: "1px solid var(--mdc-theme-background)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexBasis: "100%",
+    maxHeight: "180px",
+    ">div": {
+        minWidth: "200px",
+        maxHeight: "180px",
+        padding: "30px"
+    }
+});
 
 const t = i18n.ns("app-headless-cms/admin/fields/file");
 
@@ -22,14 +55,16 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
             const imagesOnly = field.settings && field.settings.imagesOnly;
             return (
-                <Grid>
-                    <Cell span={12}>
-                        <Label>{field.label}</Label>
-                        <Bind>
-                            {bind => {
-                                const { value, onChange } = bind;
+                <ImageFieldWrapper>
+                    <Label>
+                        <Typography use="body1">{field.label}</Typography>
+                    </Label>
+                    <Bind>
+                        {bind => {
+                            const { value, onChange } = bind;
 
-                                return (
+                            return (
+                                <InnerImageFieldWrapper>
                                     <FileManager
                                         images={imagesOnly}
                                         render={({ showFileManager }) => {
@@ -49,11 +84,11 @@ const plugin: CmsEditorFieldRendererPlugin = {
                                             );
                                         }}
                                     />
-                                );
-                            }}
-                        </Bind>
-                    </Cell>
-                </Grid>
+                                </InnerImageFieldWrapper>
+                            );
+                        }}
+                    </Bind>
+                </ImageFieldWrapper>
             );
         }
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -22,6 +22,27 @@ const FileUploadWrapper = styled("div")({
     }
 });
 
+const InnerImageFieldWrapper = styled("div")({
+    background: "repeating-conic-gradient(#efefef 0% 25%, transparent 0% 50%) 50%/25px 25px",
+    height: "100%",
+    width: "100%",
+    boxSizing: "border-box",
+    backgroundColor: "#fff",
+    border: "1px solid var(--mdc-theme-background)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexBasis: "100%",
+    maxHeight: "180px",
+    padding: "30px",
+    ">div": {
+        maxHeight: "180px",
+        img: {
+            padding: "15px"
+        }
+    }
+});
+
 interface FieldRendererProps {
     getBind: GetBindCallable;
     Label: React.FC;
@@ -71,30 +92,38 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) 
                                         <>
                                             {value.map((url: string, index: number) => (
                                                 <Cell span={3} key={url}>
-                                                    <File
-                                                        url={url}
-                                                        showFileManager={() => selectFiles(index)}
-                                                        onRemove={() =>
-                                                            onChange(dotProp.delete(value, index))
-                                                        }
-                                                        placeholder={t`Select a file"`}
-                                                        data-testid={`fr.input.file.${field.label}.${index}`}
-                                                    />
+                                                    <InnerImageFieldWrapper>
+                                                        <File
+                                                            url={url}
+                                                            showFileManager={() =>
+                                                                selectFiles(index)
+                                                            }
+                                                            onRemove={() =>
+                                                                onChange(
+                                                                    dotProp.delete(value, index)
+                                                                )
+                                                            }
+                                                            placeholder={t`Select a file"`}
+                                                            data-testid={`fr.input.file.${field.label}.${index}`}
+                                                        />
+                                                    </InnerImageFieldWrapper>
                                                 </Cell>
                                             ))}
                                         </>
 
                                         <Cell span={3}>
-                                            <File
-                                                url={""}
-                                                onRemove={() => {
-                                                    return void 0;
-                                                }}
-                                                {...bind}
-                                                showFileManager={() => selectFiles()}
-                                                placeholder={t`Select a file"`}
-                                                data-testid={`fr.input.file.${field.label}`}
-                                            />
+                                            <InnerImageFieldWrapper>
+                                                <File
+                                                    url={""}
+                                                    onRemove={() => {
+                                                        return void 0;
+                                                    }}
+                                                    {...bind}
+                                                    showFileManager={() => selectFiles()}
+                                                    placeholder={t`Select a file"`}
+                                                    data-testid={`fr.input.file.${field.label}`}
+                                                />
+                                            </InnerImageFieldWrapper>
                                         </Cell>
                                     </GridInner>
                                 );


### PR DESCRIPTION
## Changes
When you have an cover image for an entry that is not of 4:3 aspect ration we would streach that image to fill the space of the image preview box inside the advance ref field. This is not good because in many cases where images are not of that aspect ratio we lose a lot of the image details. This PR fixes this so that we always show the full image.

Old:
<img width="778" alt="CleanShot 2023-06-27 at 20 27 40@2x" src="https://github.com/webiny/webiny-js/assets/3808420/51c2cb10-cfb9-4cfc-9f3d-c11a0f8c0121">


New:
<img width="748" alt="CleanShot 2023-06-27 at 20 25 50@2x" src="https://github.com/webiny/webiny-js/assets/3808420/9ae0a797-0e32-443e-840f-f18ea2a6c7ea">


## How Has This Been Tested?
Manually