### PR TITLE
fix(app-headless-cms): adjustments to the image preview of the adv re…

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Image.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Image.tsx
@@ -9,11 +9,15 @@ const Container = styled("div")({
     borderRight: "1px solid var(--mdc-theme-on-background)",
     borderBottom: "1px solid var(--mdc-theme-on-background)",
     backgroundRepeat: "no-repeat",
-    backgroundSize: "cover",
+    backgroundSize: "contain",
+    backgroundOrigin: 'content-box',
+    backgroundPosition: "center",
+    padding: 5,
     minHeight: 140,
     display: "flex",
     justifyContent: "center",
-    alignItems: "center"
+    alignItems: "center",
+    boxSizing: "border-box",
 });
 
 const Icon = styled("div")({


### PR DESCRIPTION
When you have an cover image for an entry that is not of 4:3 aspect ration we would stretch that image to fill the space of the image preview box inside the advance ref field. This is not good because in many cases where images are not of that aspect ratio we lose a lot of the image details. This PR fixes this so that we always show the full image.


How Has This Been Tested?
Manually