### PR TITLE
fix(app-apw): dialog to initialize content review

### DIFF
--- a/packages/app-admin-rmwc/src/modules/Overlays/Dialog.tsx
+++ b/packages/app-admin-rmwc/src/modules/Overlays/Dialog.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { get } from "lodash";
 import { useUi } from "@webiny/app/hooks/useUi";
-import { Dialog, DialogAccept, DialogTitle, DialogActions, DialogContent } from "@webiny/ui/Dialog";
+import { Dialog, DialogAccept, DialogActions, DialogContent, DialogTitle } from "@webiny/ui/Dialog";
 import { ButtonPrimary } from "@webiny/ui/Button";
 
 export const DialogContainer: React.FC = () => {
@@ -19,8 +19,23 @@ export const DialogContainer: React.FC = () => {
     const hideDialog = useCallback(() => {
         ui.setState(ui => ({ ...ui, dialog: null }));
     }, [ui]);
+    /**
+     * We need this part because message can change while the dialog is opened and in loading state.
+     */
+    useEffect(() => {
+        setIsLoading(false);
+    }, [ui?.dialog?.message]);
 
     const handleConfirm = async () => {
+        if (!actions.accept.onClick) {
+            /**
+             * Should not happen as users should define "accept.onClick" function, but just in case lets show the information.
+             * Possible to happen in development process.
+             */
+            console.info("There is no actions.accept.onClick callback defined.");
+            hideDialog();
+            return;
+        }
         setIsLoading(true);
         await actions.accept.onClick();
         setIsLoading(false);

--- a/packages/app-admin/src/hooks/useConfirmationDialog.tsx
+++ b/packages/app-admin/src/hooks/useConfirmationDialog.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useUi } from "@webiny/app/hooks/useUi";
 import { i18n } from "@webiny/app/i18n";
 import { CircularProgress } from "@webiny/ui/Progress";
+
 const t = i18n.ns("app-admin/hooks/use-confirmation-dialog");
 
 interface Params {
@@ -13,8 +14,10 @@ interface Params {
     [key: string]: any;
 }
 
-interface UseConfirmationDialogResponse {
-    showConfirmation: (onAccept: () => void, onCancel?: () => void) => void;
+export type ShowConfirmationOnAccept = (() => void) | (() => Promise<void>);
+
+export interface UseConfirmationDialogResponse {
+    showConfirmation: (onAccept: ShowConfirmationOnAccept, onCancel?: () => void) => void;
 }
 
 const useConfirmationDialog = ({


### PR DESCRIPTION
## Changes
This PR fixes a bug where the dialog for the content review confirmation did not show up.
The issue was with the async nature of the onAccept method.

## How Has This Been Tested?
Manually.