### PR TITLE
fix(hcms): Show legacy Rich Text Editor for old models

### DIFF
--- a/packages/app-headless-cms-common/src/types/index.ts
+++ b/packages/app-headless-cms-common/src/types/index.ts
@@ -240,7 +240,6 @@ export interface CmsModelFieldRendererPlugin extends Plugin {
      * a plugin type
      */
     type: "cms-editor-field-renderer";
-    isDisabled?: (field: CmsModelField) => boolean;
     renderer: {
         /**
          * Name of the renderer to match the one from `createField()` method in `CmsModelFieldTypePlugin`.
@@ -277,7 +276,11 @@ export interface CmsModelFieldRendererPlugin extends Plugin {
          * }
          * ```
          */
-        canUse(props: { field: CmsModelField; fieldPlugin: CmsModelFieldTypePlugin }): boolean;
+        canUse(props: {
+            field: CmsModelField;
+            fieldPlugin: CmsModelFieldTypePlugin;
+            model: CmsModel;
+        }): boolean;
         /**
          * Renders a field in the UI.
          *
@@ -301,16 +304,6 @@ export interface CmsModelFieldRendererPlugin extends Plugin {
          * ```
          */
         render(props: CmsModelFieldRendererProps): React.ReactNode;
-        /**
-         * Check if the renderer is disabled for use.
-         *
-         * ```tsx
-         * isDisabled({ field }) {
-            ...
-         * }
-         * ```
-         */
-        isDisabled?: (field: CmsModelField) => boolean;
     };
 }
 

--- a/packages/app-headless-cms-common/src/types/index.ts
+++ b/packages/app-headless-cms-common/src/types/index.ts
@@ -240,6 +240,7 @@ export interface CmsModelFieldRendererPlugin extends Plugin {
      * a plugin type
      */
     type: "cms-editor-field-renderer";
+    isDisabled?: (field: CmsModelField) => boolean;
     renderer: {
         /**
          * Name of the renderer to match the one from `createField()` method in `CmsModelFieldTypePlugin`.
@@ -300,6 +301,16 @@ export interface CmsModelFieldRendererPlugin extends Plugin {
          * ```
          */
         render(props: CmsModelFieldRendererProps): React.ReactNode;
+        /**
+         * Check if the renderer is disabled for use.
+         *
+         * ```tsx
+         * isDisabled({ field }) {
+            ...
+         * }
+         * ```
+         */
+        isDisabled?: (field: CmsModelField) => boolean;
     };
 }
 

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
@@ -17,7 +17,7 @@ import AppearanceTab from "./EditFieldDialog/AppearanceTab";
 import PredefinedValues from "./EditFieldDialog/PredefinedValues";
 import { ValidatorsList } from "./EditFieldDialog/ValidatorsList";
 import { ButtonDefault, ButtonPrimary } from "@webiny/ui/Button";
-import { useModelField, useModelEditor } from "~/admin/hooks";
+import { useModelField, useModelEditor, useModel } from "~/admin/hooks";
 import { ModelFieldProvider } from "~/admin/components/ModelFieldProvider";
 import { ValidationsSection } from "~/admin/components/FieldEditor/EditFieldDialog/ValidationsSection";
 import { getFieldValidators, getListValidators } from "./EditFieldDialog/getValidators";
@@ -47,11 +47,12 @@ function setupState(
     contentModel: CmsEditorContentModel
 ): EditFieldState {
     const clonedField = cloneDeep(field);
+    const { model } = useModel();
 
     if (!clonedField.renderer || !clonedField.renderer.name) {
         const [renderPlugin] = plugins
             .byType<CmsEditorFieldRendererPlugin>("cms-editor-field-renderer")
-            .filter(item => item.renderer.canUse({ field, fieldPlugin }));
+            .filter(item => item.renderer.canUse({ field, fieldPlugin, model }));
 
         if (renderPlugin) {
             clonedField.renderer = { name: renderPlugin.renderer.rendererName };

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -9,6 +9,8 @@ import { css } from "emotion";
 import { validation } from "@webiny/validation";
 import { useModelField } from "~/admin/hooks";
 import { useForm, Bind } from "@webiny/form";
+import { Alert } from "@webiny/ui/Alert";
+import { allowCmsLegacyRichTextInput } from "~/utils/allowCmsLegacyRichTextInput";
 
 const t = i18n.ns("app-headless-cms/admin/content-model-editor/tabs/appearance-tab");
 
@@ -64,6 +66,26 @@ const AppearanceTab = () => {
 
     return (
         <Grid>
+            <Cell span={6}>
+                {allowCmsLegacyRichTextInput && (
+                    <Alert title={"You have legacy editor enabled"} type={"info"}>
+                        Your project has been upgraded from an older Webiny version with EditorJS as
+                        the default rich text editor. We suggest switching to the next Lexical rich
+                        text editor where possible.
+                        <br />
+                        <br />
+                        Read more about this in our
+                        <a
+                            href={"https://www.webiny.com/docs/release-notes/5.37.0/changelog"}
+                            rel="noreferrer"
+                            target={"_blank"}
+                        >
+                            change log
+                        </a>
+                        .
+                    </Alert>
+                )}
+            </Cell>
             <Cell span={12}>
                 <div
                     className={style.topLabel}

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -70,9 +70,9 @@ const AppearanceTab = () => {
             {allowCmsLegacyRichTextInput && (
                 <Cell span={6}>
                     <Alert title={"You have legacy editor enabled"} type={"info"}>
-                        Your project has been upgraded from an older Webiny version with EditorJS as
-                        the default rich text editor. We suggest switching to the new Lexical rich
-                        text editor where possible.
+                        Your project has been upgraded from an older Webiny version, with EditorJS
+                        as the default rich text editor. We recommend switching to the new Lexical
+                        rich text editor, where possible.
                         <br />
                         <br />
                         Read more about this in our{" "}

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -77,7 +77,9 @@ const AppearanceTab = () => {
                         <br />
                         Read more about this in our{" "}
                         <a
-                            href={"https://www.webiny.com/docs/release-notes/5.37.0/upgrade-guide#legacy-rich-text-editor-support-after-the-upgrade"}
+                            href={
+                                "https://www.webiny.com/docs/release-notes/5.37.0/upgrade-guide#legacy-rich-text-editor-support-after-the-upgrade"
+                            }
                             rel="noreferrer"
                             target={"_blank"}
                         >

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -77,14 +77,13 @@ const AppearanceTab = () => {
                         <br />
                         Read more about this in our{" "}
                         <a
-                            href={
-                                "https://www.webiny.com/docs/release-notes/5.37.0/upgrade-guide#legacy-rich-text-editor-support-after-the-upgrade"
-                            }
+                            href={"https://webiny.link/hcms-legacy-rte-support"}
                             rel="noreferrer"
                             target={"_blank"}
                         >
                             upgrade guide
                         </a>
+                        .
                     </Alert>
                 </Cell>
             )}

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -66,15 +66,15 @@ const AppearanceTab = () => {
 
     return (
         <Grid>
-            <Cell span={6}>
-                {allowCmsLegacyRichTextInput && (
+            {allowCmsLegacyRichTextInput && (
+                <Cell span={6}>
                     <Alert title={"You have legacy editor enabled"} type={"info"}>
                         Your project has been upgraded from an older Webiny version with EditorJS as
                         the default rich text editor. We suggest switching to the next Lexical rich
                         text editor where possible.
                         <br />
                         <br />
-                        Read more about this in our
+                        Read more about this in our{" "}
                         <a
                             href={"https://www.webiny.com/docs/release-notes/5.37.0/changelog"}
                             rel="noreferrer"
@@ -84,8 +84,8 @@ const AppearanceTab = () => {
                         </a>
                         .
                     </Alert>
-                )}
-            </Cell>
+                </Cell>
+            )}
             <Cell span={12}>
                 <div
                     className={style.topLabel}

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -31,7 +31,7 @@ const AppearanceTab = () => {
 
     const renderPlugins = plugins
         .byType<CmsEditorFieldRendererPlugin>("cms-editor-field-renderer")
-        .filter(item => item.renderer.canUse({ field, fieldPlugin }));
+        .filter(item => !item.isDisabled?.(field) && item.renderer.canUse({ field, fieldPlugin }));
 
     useEffect((): void => {
         // If the currently selected render plugin is no longer available, select the first available one.
@@ -75,6 +75,7 @@ const AppearanceTab = () => {
                                 {renderPlugins.map(item => (
                                     <div key={item.name} className={style.radioContainer}>
                                         <Radio
+                                            disabled={item.renderer.isDisabled?.(field) || false}
                                             value={getValue(item.renderer.rendererName)}
                                             onChange={onChange(item.renderer.rendererName)}
                                             label={

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -77,11 +77,11 @@ const AppearanceTab = () => {
                         <br />
                         Read more about this in our{" "}
                         <a
-                            href={"https://www.webiny.com/docs/release-notes/5.37.0/changelog"}
+                            href={"https://www.webiny.com/docs/release-notes/5.37.0/upgrade-guide#legacy-rich-text-editor-support-after-the-upgrade"}
                             rel="noreferrer"
                             target={"_blank"}
                         >
-                            change log
+                            upgrade guide
                         </a>
                     </Alert>
                 </Cell>

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect } from "react";
 import { plugins } from "@webiny/plugins";
 import { Grid, Cell } from "@webiny/ui/Grid";
-import { CmsModelField, CmsEditorFieldRendererPlugin } from "~/types";
+import { CmsEditorFieldRendererPlugin, CmsModelField } from "~/types";
 import { i18n } from "@webiny/app/i18n";
 import { Radio, RadioGroup } from "@webiny/ui/Radio";
 import { Typography } from "@webiny/ui/Typography";
 import { css } from "emotion";
 import { validation } from "@webiny/validation";
-import { useModelField } from "~/admin/hooks";
+import { useModel, useModelField } from "~/admin/hooks";
 import { useForm, Bind } from "@webiny/form";
 import { Alert } from "@webiny/ui/Alert";
 import { allowCmsLegacyRichTextInput } from "~/utils/allowCmsLegacyRichTextInput";
@@ -29,11 +29,12 @@ const style = {
 
 const AppearanceTab = () => {
     const form = useForm<CmsModelField>();
+    const { model } = useModel();
     const { field, fieldPlugin } = useModelField();
 
     const renderPlugins = plugins
         .byType<CmsEditorFieldRendererPlugin>("cms-editor-field-renderer")
-        .filter(item => !item.isDisabled?.(field) && item.renderer.canUse({ field, fieldPlugin }));
+        .filter(item => item.renderer.canUse({ field, fieldPlugin, model }));
 
     useEffect((): void => {
         // If the currently selected render plugin is no longer available, select the first available one.
@@ -70,7 +71,7 @@ const AppearanceTab = () => {
                 <Cell span={6}>
                     <Alert title={"You have legacy editor enabled"} type={"info"}>
                         Your project has been upgraded from an older Webiny version with EditorJS as
-                        the default rich text editor. We suggest switching to the next Lexical rich
+                        the default rich text editor. We suggest switching to the new Lexical rich
                         text editor where possible.
                         <br />
                         <br />
@@ -82,7 +83,6 @@ const AppearanceTab = () => {
                         >
                             change log
                         </a>
-                        .
                     </Alert>
                 </Cell>
             )}
@@ -97,7 +97,6 @@ const AppearanceTab = () => {
                                 {renderPlugins.map(item => (
                                     <div key={item.name} className={style.radioContainer}>
                                         <Radio
-                                            disabled={item.renderer.isDisabled?.(field) || false}
                                             value={getValue(item.renderer.rendererName)}
                                             onChange={onChange(item.renderer.rendererName)}
                                             label={

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
@@ -4,6 +4,7 @@ import { i18n } from "@webiny/app/i18n";
 import { CmsEditorContentEntry, CmsModelField, CmsEditorFieldRendererPlugin } from "~/types";
 import { BindComponentRenderProp } from "@webiny/form";
 import { LexicalCmsEditor } from "~/admin/components/LexicalCmsEditor/LexicalCmsEditor";
+import { modelHasLegacyRteField } from "~/admin/plugins/fieldRenderers/richText/utils";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
@@ -26,24 +27,17 @@ const plugin: CmsEditorFieldRendererPlugin = {
         rendererName: "lexical-text-input",
         name: t`Lexical Text Input`,
         description: t`Renders a lexical text editor.`,
-        isDisabled(field) {
-            const fieldModelIsUsed = !!field?.id;
-            const isLegacyRichTextInput = field.renderer.name === "rich-text-input";
-
-            // Lexical is disabled only if legacy RTE is used.
-            if (isLegacyRichTextInput && fieldModelIsUsed) {
-                return true;
-            }
-
-            // if legacy rich text editor is used, lexical input is disabled.
-            return false;
-        },
-        canUse({ field }) {
-            return (
+        canUse({ field, model }) {
+            const canUse =
                 field.type === "rich-text" &&
                 !field.multipleValues &&
-                !get(field, "predefinedValues.enabled")
-            );
+                !get(field, "predefinedValues.enabled");
+
+            if (canUse && modelHasLegacyRteField(model)) {
+                return false;
+            }
+
+            return canUse;
         },
         render({ field, getBind }) {
             const Bind = getBind();

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
@@ -19,10 +19,6 @@ const getKey = (
 const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-lexical",
-    isDisabled() {
-        // Lexical RTE is default editor in use. This plugin is always enabled by default.
-        return false;
-    },
     renderer: {
         rendererName: "lexical-text-input",
         name: t`Lexical Text Input`,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInput.tsx
@@ -18,10 +18,26 @@ const getKey = (
 const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-lexical",
+    isDisabled() {
+        // Lexical RTE is default editor in use. This plugin is always enabled by default.
+        return false;
+    },
     renderer: {
         rendererName: "lexical-text-input",
         name: t`Lexical Text Input`,
         description: t`Renders a lexical text editor.`,
+        isDisabled(field) {
+            const fieldModelIsUsed = !!field?.id;
+            const isLegacyRichTextInput = field.renderer.name === "rich-text-input";
+
+            // Lexical is disabled only if legacy RTE is used.
+            if (isLegacyRichTextInput && fieldModelIsUsed) {
+                return true;
+            }
+
+            // if legacy rich text editor is used, lexical input is disabled.
+            return false;
+        },
         canUse({ field }) {
             return (
                 field.type === "rich-text" &&

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInputs.tsx
@@ -7,6 +7,7 @@ import DynamicSection, { DynamicSectionPropsChildrenParams } from "../DynamicSec
 import { IconButton } from "@webiny/ui/Button";
 import styled from "@emotion/styled";
 import { LexicalCmsEditor } from "~/admin/components/LexicalCmsEditor/LexicalCmsEditor";
+import { modelHasLegacyRteField } from "~/admin/plugins/fieldRenderers/richText/utils";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
@@ -33,15 +34,20 @@ const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-lexical-inputs",
     renderer: {
-        rendererName: "lexical-inputs",
-        name: t`Lexical Inputs`,
+        rendererName: "lexical-text-inputs",
+        name: t`Lexical Text Inputs`,
         description: t`Renders a list of lexical editors.`,
-        canUse({ field }) {
-            return (
+        canUse({ field, model }) {
+            const canUse =
                 field.type === "rich-text" &&
                 !!field.multipleValues &&
-                !get(field, "predefinedValues.enabled")
-            );
+                !get(field, "predefinedValues.enabled");
+
+            if (canUse && modelHasLegacyRteField(model)) {
+                return false;
+            }
+
+            return canUse;
         },
         render(props) {
             const { field } = props;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
@@ -1,12 +1,8 @@
 import { CmsModel } from "@webiny/app-headless-cms-common/types";
 
-/*
+/**
  * Check if model have at least one lexical single/multiple field
- * */
+ */
 export const modelHasLexicalField = (model: CmsModel): boolean => {
-    return model.fields.some(
-        field =>
-            field.renderer.name === "lexical-text-input" ||
-            field.renderer.name === "lexical-text-inputs"
-    );
+    return model.fields.some(field => field.renderer.name.startsWith("lexical-"));
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
@@ -1,0 +1,12 @@
+import { CmsModel } from "@webiny/app-headless-cms-common/types";
+
+/*
+ * Check if model have at least one lexical single/multiple field
+ * */
+export const modelHasLexicalField = (model: CmsModel): boolean => {
+    return model.fields.some(
+        field =>
+            field.renderer.name === "lexical-text-input" ||
+            field.renderer.name === "lexical-text-inputs"
+    );
+};

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/utils.ts
@@ -1,8 +1,5 @@
 import { CmsModel } from "@webiny/app-headless-cms-common/types";
 
-/**
- * Check if model have at least one lexical single/multiple field
- */
 export const modelHasLexicalField = (model: CmsModel): boolean => {
     return model.fields.some(field => field.renderer.name.startsWith("lexical-"));
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/index.ts
@@ -1,7 +1,6 @@
 import richTextInput from "./richTextInput";
 import richTextInputs from "./richTextInputs";
-import { allowCmsLegacyRichTextInput } from "~/utils/allowCmsLegacyRichTextInput";
 
 export const createLegacyRichTextInput = () => {
-    return allowCmsLegacyRichTextInput ? [richTextInput, richTextInputs] : [];
+    return [richTextInput, richTextInputs];
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
@@ -27,8 +27,8 @@ const plugin: CmsEditorFieldRendererPlugin = {
     name: "cms-editor-field-renderer-rich-text",
     renderer: {
         rendererName: "rich-text-input",
-        name: t`Rich Text Input`,
-        description: t`Renders a rich text editor.`,
+        name: t`(Legacy) EditorJS Text Input`,
+        description: t`Renders the legacy rich text editor.`,
         canUse({ field, model }) {
             const canUse =
                 field.type === "rich-text" &&

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
@@ -54,7 +54,7 @@ const plugin: CmsEditorFieldRendererPlugin = {
 
             // Allow renderer for selection only if legacy RTE is already used.
             if (isLegacyRichTextInput && fieldModelIsUsed) {
-                return true;
+                return false;
             }
 
             // By default this renderer is disabled

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInput.tsx
@@ -5,6 +5,7 @@ import { CmsContentEntry, CmsModelField, CmsEditorFieldRendererPlugin } from "~/
 import { createPropsFromConfig, RichTextEditor } from "@webiny/app-admin/components/RichTextEditor";
 import { plugins } from "@webiny/plugins";
 import { BindComponentRenderProp } from "@webiny/form";
+import { allowCmsLegacyRichTextInput } from "~/utils/allowCmsLegacyRichTextInput";
 
 const t = i18n.ns("app-headless-cms/admin/fields/rich-text");
 
@@ -19,10 +20,46 @@ const getKey = (
 const plugin: CmsEditorFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-rich-text",
+    isDisabled(field) {
+        // When feature flag is set, plugin is always enabled.
+        if (allowCmsLegacyRichTextInput) {
+            return false;
+        }
+
+        // Plugin is enabled only when legacy RTE is used by the user
+        // before introduction of lexical RTE.
+        const isLegacyRichTextInput = field.renderer.name === "rich-text-input";
+        const fieldModelIsUsed = !!field?.id;
+        if (isLegacyRichTextInput && fieldModelIsUsed) {
+            return false;
+        }
+
+        // This legacy plugin is disabled by default.
+        return true;
+    },
     renderer: {
         rendererName: "rich-text-input",
         name: t`Rich Text Input`,
         description: t`Renders a rich text editor.`,
+        isDisabled(field) {
+            const fieldModelIsUsed = !!field?.id;
+            const isLegacyRichTextInput = field.renderer.name === "rich-text-input";
+            const isLexicalInput = field.renderer.name === "lexical-text-input";
+
+            // feature flag
+            if (allowCmsLegacyRichTextInput) {
+                // Legacy RTE will be allowed for selection only if lexical RTE is not used
+                return isLexicalInput && fieldModelIsUsed;
+            }
+
+            // Allow renderer for selection only if legacy RTE is already used.
+            if (isLegacyRichTextInput && fieldModelIsUsed) {
+                return true;
+            }
+
+            // By default this renderer is disabled
+            return true;
+        },
         canUse({ field }) {
             return (
                 field.type === "rich-text" &&

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
@@ -51,8 +51,8 @@ const plugin: CmsEditorFieldRendererPlugin = {
     name: "cms-editor-field-renderer-rich-text-inputs",
     renderer: {
         rendererName: "rich-text-inputs",
-        name: t`Rich Text Inputs`,
-        description: t`Renders a simple list of rich text editors.`,
+        name: t`(Legacy) EditorJS Text Inputs`,
+        description: t`Renders a simple list of legacy rich text editors.`,
         canUse({ field, model }) {
             const canUse =
                 field.type === "rich-text" &&

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
@@ -1,25 +1,22 @@
 import { CmsModel, CmsModelField } from "@webiny/app-headless-cms-common/types";
 
-/*
+/**
  * Model have at least one single/multiple legacy RTE field
- * */
+ */
 export const modelHasLegacyRteField = (model: CmsModel): boolean => {
-    return model.fields.some(
-        field =>
-            field.renderer.name === "rich-text-inputs" || field.renderer.name === "rich-text-input"
-    );
+    return model.fields.some(field => field.renderer.name.startsWith("rich-text-"));
 };
 
-/*
+/**
  * Check id field is legacy RTE
- * */
+ */
 export const isLegacyRteField = (field: CmsModelField): boolean => {
-    return field.renderer.name === "rich-text-input" || field.renderer.name === "rich-text-inputs";
+    return field.renderer.name.startsWith("rich-text-");
 };
 
-/*
+/**
  * Checks if the field is saved as legacy RTE
- * */
+ */
 export const isLegacyRteFieldSaved = (field: CmsModelField): boolean => {
     return !!field.id && isLegacyRteField(field);
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
@@ -1,0 +1,25 @@
+import { CmsModel, CmsModelField } from "@webiny/app-headless-cms-common/types";
+
+/*
+ * Model have at least one single/multiple legacy RTE field
+ * */
+export const modelHasLegacyRteField = (model: CmsModel): boolean => {
+    return model.fields.some(
+        field =>
+            field.renderer.name === "rich-text-inputs" || field.renderer.name === "rich-text-input"
+    );
+};
+
+/*
+ * Check id field is legacy RTE
+ * */
+export const isLegacyRteField = (field: CmsModelField): boolean => {
+    return field.renderer.name === "rich-text-input" || field.renderer.name === "rich-text-inputs";
+};
+
+/*
+ * Checks if the field is saved as legacy RTE
+ * */
+export const isLegacyRteFieldSaved = (field: CmsModelField): boolean => {
+    return !!field.id && isLegacyRteField(field);
+};

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/utils.ts
@@ -1,22 +1,13 @@
 import { CmsModel, CmsModelField } from "@webiny/app-headless-cms-common/types";
 
-/**
- * Model have at least one single/multiple legacy RTE field
- */
 export const modelHasLegacyRteField = (model: CmsModel): boolean => {
-    return model.fields.some(field => field.renderer.name.startsWith("rich-text-"));
+    return model.fields.some(isLegacyRteField);
 };
 
-/**
- * Check id field is legacy RTE
- */
 export const isLegacyRteField = (field: CmsModelField): boolean => {
     return field.renderer.name.startsWith("rich-text-");
 };
 
-/**
- * Checks if the field is saved as legacy RTE
- */
 export const isLegacyRteFieldSaved = (field: CmsModelField): boolean => {
     return !!field.id && isLegacyRteField(field);
 };


### PR DESCRIPTION
With this PR we are fixing the problem where models containing legacy RTE fields can't be rendered/edited.

## Changes
- New utils methods for lexical input and legacy RTE
- Updated `canUse` logic with additional CMS model param.
- included feature flag check - `allowCmsLegacyRichTextInput`

## How Has This Been Tested?
Manually.

## Test cases include feature flag 
- Feature flag `allowCmsLegacyRichTextInput` set to `true`

### Test case 1 - new model - add and remove lexical and legacy fields 
- legacy RTE info message is visible

https://github.com/webiny/webiny-js/assets/82515066/95210035-c869-466b-aa50-878f7f0ea746

### Test case 2 - model with a legacy rich text editor
- legacy RTE info message is visible
-  edit existing single/multi field 
-  try to add new single/multi filed

https://github.com/webiny/webiny-js/assets/82515066/188a2720-2fec-439c-a7a1-740c088b6972

### Test case 3 - model with a lexical editor
- legacy RTE info message is visible
-  edit existing single/multi field 
-  try to add new single/multi filed

https://github.com/webiny/webiny-js/assets/82515066/cd827d89-aeda-4778-b894-a1873816ab92


## Test cases without feature flag 
- Feature flag `allowCmsLegacyRichTextInput` removed from `webiny.project.ts`

### Test case 1 - new model - only lexical editor exist to add/remove fields
- legacy RTE info message is not visible

https://github.com/webiny/webiny-js/assets/82515066/e47d721d-8e43-4c27-80e1-18c1b9af0c76

### Test case 2 - model with a legacy rich text editor
-  legacy RTE info message is not visible
-  edit existing single/multi field 
-  try to add new single/multi filed

https://github.com/webiny/webiny-js/assets/82515066/06bca412-5bd5-4896-be48-8d34759984fe

### Test case 3 - model with a legacy rich text editor
-  legacy RTE info message is not visible
-  edit existing single/multi field 
-  try to add new single/multi filed

https://github.com/webiny/webiny-js/assets/82515066/fad3b044-892f-4d9d-89b1-1aec302d2ac6


## Documentation
WIP - official docs changelog
