### PR TITLE
feat: remove min and max chars validation for folder title and slug fields

### DIFF
--- a/packages/api-aco/__tests__/folder.so.test.ts
+++ b/packages/api-aco/__tests__/folder.so.test.ts
@@ -245,11 +245,11 @@ describe("`folder` CRUD", () => {
         });
     });
 
-    it("should not allow creating a `folder` with `title` too short (min. 3 chars)", async () => {
+    it("should not allow creating a `folder` with no `title` provided", async () => {
         const [response] = await aco.createFolder({
             data: {
                 ...folderMocks.folderA,
-                title: "a"
+                title: ""
             }
         });
 
@@ -263,7 +263,7 @@ describe("`folder` CRUD", () => {
                             message: "Validation failed.",
                             data: [
                                 {
-                                    error: "Value is too short.",
+                                    error: "Value is required.",
                                     fieldId: "title",
                                     storageId: "text@title"
                                 }
@@ -275,11 +275,11 @@ describe("`folder` CRUD", () => {
         });
     });
 
-    it("should not allow creating a `folder` with `slug` too short (min. 3 chars)", async () => {
+    it("should not allow creating a `folder` with no `slug` provided", async () => {
         const [response] = await aco.createFolder({
             data: {
                 ...folderMocks.folderA,
-                slug: "a"
+                slug: ""
             }
         });
 
@@ -293,37 +293,7 @@ describe("`folder` CRUD", () => {
                             message: "Validation failed.",
                             data: [
                                 {
-                                    error: "Value is too short.",
-                                    fieldId: "slug",
-                                    storageId: "text@slug"
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        });
-    });
-
-    it("should not allow creating a `folder` with `slug` too long (max. 100 chars)", async () => {
-        const [response] = await aco.createFolder({
-            data: {
-                ...folderMocks.folderA,
-                slug: "GpfyMLeacJyRzF5SmXhK9ytFf0UVtkzB0IORUwiPbqnXLyXBZX88tfy92vsnOEF87IVW0DnYDQLLlCl09hN3tcdKGAaO0oLh2bJrE"
-            }
-        });
-
-        expect(response).toEqual({
-            data: {
-                aco: {
-                    createFolder: {
-                        data: null,
-                        error: {
-                            code: "VALIDATION_FAILED",
-                            message: "Validation failed.",
-                            data: [
-                                {
-                                    error: "Value is too long.",
+                                    error: "Value is required.",
                                     fieldId: "slug",
                                     storageId: "text@slug"
                                 }

--- a/packages/api-aco/src/folder/folder.model.ts
+++ b/packages/api-aco/src/folder/folder.model.ts
@@ -11,13 +11,6 @@ const titleField = () =>
             {
                 name: "required",
                 message: "Value is required."
-            },
-            {
-                name: "minLength",
-                settings: {
-                    value: "3"
-                },
-                message: "Value is too short."
             }
         ]
     });
@@ -30,20 +23,6 @@ const slugField = () =>
             {
                 name: "required",
                 message: "Value is required."
-            },
-            {
-                name: "minLength",
-                settings: {
-                    value: "3"
-                },
-                message: "Value is too short."
-            },
-            {
-                name: "maxLength",
-                settings: {
-                    value: "100"
-                },
-                message: "Value is too long."
             },
             {
                 name: "pattern",

--- a/packages/app-aco/src/components/Dialogs/DialogCreate.tsx
+++ b/packages/app-aco/src/components/Dialogs/DialogCreate.tsx
@@ -101,7 +101,7 @@ export const FolderDialogCreate: React.VFC<FolderDialogCreateProps> = ({
                                 <Cell span={12}>
                                     <Bind
                                         name={"title"}
-                                        validators={[validation.create("required,minLength:3")]}
+                                        validators={[validation.create("required")]}
                                     >
                                         <Input label={t`Title`} onBlur={generateSlug(form)} />
                                     </Bind>
@@ -109,9 +109,7 @@ export const FolderDialogCreate: React.VFC<FolderDialogCreateProps> = ({
                                 <Cell span={12}>
                                     <Bind
                                         name={"slug"}
-                                        validators={[
-                                            validation.create("required,minLength:3,slug")
-                                        ]}
+                                        validators={[validation.create("required,slug")]}
                                     >
                                         <Input label={t`Slug`} />
                                     </Bind>

--- a/packages/app-aco/src/components/Dialogs/DialogUpdate.tsx
+++ b/packages/app-aco/src/components/Dialogs/DialogUpdate.tsx
@@ -85,9 +85,7 @@ export const FolderDialogUpdate: React.VFC<FolderDialogUpdateProps> = ({
                                         <Cell span={12}>
                                             <Bind
                                                 name={"title"}
-                                                validators={[
-                                                    validation.create("required,minLength:3")
-                                                ]}
+                                                validators={[validation.create("required")]}
                                             >
                                                 <Input label={t`Title`} />
                                             </Bind>
@@ -95,9 +93,7 @@ export const FolderDialogUpdate: React.VFC<FolderDialogUpdateProps> = ({
                                         <Cell span={12}>
                                             <Bind
                                                 name={"slug"}
-                                                validators={[
-                                                    validation.create("required,minLength:3,slug")
-                                                ]}
+                                                validators={[validation.create("required,slug")]}
                                             >
                                                 <Input label={t`Slug`} value={folder.slug} />
                                             </Bind>

--- a/packages/validation/src/validators/slug.ts
+++ b/packages/validation/src/validators/slug.ts
@@ -6,11 +6,11 @@ export default (value: any) => {
     }
     value = value + "";
 
-    if (value.match(/^[a-z0-9]+(-[a-z0-9]+)*$/) && value.length <= 100) {
+    if (value.match(/^[a-z0-9]+(-[a-z0-9]+)*$/)) {
         return;
     }
 
     throw new ValidationError(
-        "Slug must consist of only 'a-z', '0-9' and '-' and be max 100 characters long (for example: 'some-slug' or 'some-slug-2')"
+        "Slug must consist of only 'a-z', '0-9' and '-' (for example: 'some-slug' or 'some-slug-2')"
     );
 };


### PR DESCRIPTION
## Changes
With this PR we remove the folder `title` and `slug` min and max chars validation. These 2 fields remain `required`. 

## How Has This Been Tested?
Manually + Jest
