### PR TITLE
Avoid file duplicates on import

### DIFF
--- a/packages/api-file-manager/__tests__/mocks/file.sdl.ts
+++ b/packages/api-file-manager/__tests__/mocks/file.sdl.ts
@@ -18,6 +18,7 @@ export default /* GraphQL */ `
         private: Boolean
         width: Number
         height: Number
+        originalKey: String
     }
 
     input FmFile_MetaWhereInput {
@@ -49,6 +50,15 @@ export default /* GraphQL */ `
         height_between: [Number!]
         # there must be two numbers sent in the array
         height_not_between: [Number!]
+        
+        originalKey: String
+        originalKey_not: String
+        originalKey_in: [String]
+        originalKey_not_in: [String]
+        originalKey_contains: String
+        originalKey_not_contains: String
+        originalKey_startsWith: String
+        originalKey_not_startsWith: String
     }
 
     type FmFile_Extensions {
@@ -105,6 +115,7 @@ export default /* GraphQL */ `
         private: Boolean
         width: Number
         height: Number
+        originalKey: String
     }
 
     input FmFile_ExtensionsInput {

--- a/packages/api-file-manager/__tests__/mocks/file.sdl.ts
+++ b/packages/api-file-manager/__tests__/mocks/file.sdl.ts
@@ -50,7 +50,7 @@ export default /* GraphQL */ `
         height_between: [Number!]
         # there must be two numbers sent in the array
         height_not_between: [Number!]
-        
+
         originalKey: String
         originalKey_not: String
         originalKey_in: [String]

--- a/packages/api-file-manager/src/cmsFileStorage/file.model.ts
+++ b/packages/api-file-manager/src/cmsFileStorage/file.model.ts
@@ -62,12 +62,24 @@ const metaPrivateField = () => {
     });
 };
 
+const metaOriginalKeyField = () => {
+    return createModelField({
+        label: "Original Key",
+        type: "text"
+    });
+};
+
 const metaField = () => {
     return createModelField({
         label: "Meta",
         type: "object",
         settings: {
-            fields: [metaPrivateField(), metaWidthField(), metaHeightField()]
+            fields: [
+                metaPrivateField(),
+                metaWidthField(),
+                metaHeightField(),
+                metaOriginalKeyField()
+            ]
         }
     });
 };

--- a/packages/api-page-builder-import-export/src/import/utils/updateFilesInData.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/updateFilesInData.ts
@@ -14,7 +14,7 @@ export function updateFilesInData({
     if (!data || typeof data !== "object") {
         return;
     }
-    // Recursively call function if data is array
+    // Recursively call function if data is an array.
     if (Array.isArray(data)) {
         for (let i = 0; i < data.length; i++) {
             const element = data[i];
@@ -35,6 +35,7 @@ export function updateFilesInData({
 
             const cleanSrcPrefix = srcPrefix.endsWith("/") ? srcPrefix.slice(0, -1) : srcPrefix;
 
+            value.id = newFile.id;
             value.key = newFile.key;
             value.name = newFile.name;
             value.src = `${cleanSrcPrefix}/${newFile.key}`;

--- a/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
@@ -10,6 +10,20 @@ interface UploadAssetsParams {
     fileUploadsData: FileUploadsData;
 }
 
+function notAPreviouslyImportedFile(importedImages: File[]) {
+    return (file: File) => {
+        return !importedImages.some(
+            existingImportedImage => existingImportedImage.meta.originalKey === file.key
+        );
+    };
+}
+
+function notAnExistingFile(existingFiles: File[]) {
+    return (file: File) => {
+        return !existingFiles.some(existingFile => existingFile.key === file.key);
+    };
+}
+
 export const uploadAssets = async (params: UploadAssetsParams) => {
     const { context, files, fileUploadsData } = params;
 
@@ -24,21 +38,49 @@ export const uploadAssets = async (params: UploadAssetsParams) => {
         return oldIdToNewFileMap;
     }
 
+    // Check if the requested files were already imported in the past.
+    const [importedImages] = await context.fileManager.listFiles({
+        where: { meta: { originalKey_in: files.map(file => file.key) } }
+    });
+
+    // Link files that were already imported.
+    for (const importedImage of importedImages) {
+        const fileBeingImported = files.find(file => file.key === importedImage.meta.originalKey);
+
+        if (fileBeingImported) {
+            oldIdToNewFileMap.set(fileBeingImported.id, importedImage);
+        }
+    }
+
+    // Check if files with such IDs already exist.
+    const [existingFiles] = await context.fileManager.listFiles({
+        where: { id_in: files.map(file => file.id) }
+    });
+
+    const newFilesToImport = files
+        .filter(notAnExistingFile(existingFiles))
+        .filter(notAPreviouslyImportedFile(importedImages));
+
     // A map of temporary file keys (created during ZIP upload) to permanent file keys.
     const uploadFileMap: UploadFileMap = new Map();
 
     // Array of file inputs, to insert into the DB.
     const createFilesInput: FileInput[] = [];
 
-    for (const oldFile of files) {
+    for (const toImport of newFilesToImport) {
+        // We generate a new file id, key, and add `meta.originalKey` property to prevent duplicates on future imports.
         const id = mdbid();
-        // We replace the old file ID with a new one.
-        const newKey = `${id}/${oldFile.key.replace(`${oldFile.id}/`, "")}`;
-        const newFile: FileInput = { ...oldFile, id, key: newKey };
+        const newKey = `${id}/${toImport.key.replace(`${toImport.id}/`, "")}`;
+        const newFile: FileInput = {
+            ...toImport,
+            id,
+            key: newKey,
+            meta: { ...toImport.meta, originalKey: toImport.key }
+        };
 
         createFilesInput.push(newFile);
-        oldIdToNewFileMap.set(oldFile.id, newFile);
-        uploadFileMap.set(fileUploadsData.assets[oldFile.key], newFile);
+        oldIdToNewFileMap.set(toImport.id, newFile);
+        uploadFileMap.set(fileUploadsData.assets[toImport.key], newFile);
     }
 
     await uploadFilesFromS3(uploadFileMap);


### PR DESCRIPTION
## Changes
This PR adds a `meta.originalKey` field to the file model, which holds the key of the original imported file, so it can be referenced in the future, when pages/blocks/templates are being imported into the system. If a file being imported already has its counterpart in the FM, the content element will be modified to reference the existing file.

## How Has This Been Tested?
Manually, by exporting and importing pages, and verifying that the existing files get assigned to the imported page elements, as well as making sure that no new files get created in the File Manager.
