### PR TITLE
Page Builder - Fixed Drag and Drop-related Issues

### DIFF
--- a/packages/app-page-builder/src/editor/helpers.ts
+++ b/packages/app-page-builder/src/editor/helpers.ts
@@ -13,6 +13,7 @@ import {
 } from "~/types";
 import {
     CreateElementActionEvent,
+    DeleteElementActionEvent,
     updateElementAction,
     UpdateElementActionArgsType
 } from "~/editor/recoil/actions";
@@ -287,29 +288,26 @@ export const moveInPlace = (
 export const onReceived: PbEditorPageElementPlugin["onReceived"] = props => {
     const { source, target, position, state, meta } = props;
 
-    // Create a copy of the element with a new ID.
     const element = createDroppedElement(source as any, target);
+    const parent = addElementToParent(element, target, position);
 
-    // Add the copy into the parent (into the new position),
-    // and also delete the old one.
-    let parent = addElementToParent(element, target, position);
-    parent = removeElementFromParent(parent, source.id);
-
-    // Update parent element.
     const result = executeAction<UpdateElementActionArgsType>(state, meta, updateElementAction, {
         element: parent,
         history: true
     });
 
-    // If we're just changing the position of an existing element,
-    // then we can exit here (no need to fire the below events).
-    const isDropOfAnExistingElement = !!source.id;
-    if (isDropOfAnExistingElement) {
+    result.actions.push(new AfterDropElementActionEvent({ element }));
+
+    if (source.id) {
+        // Delete source element
+        result.actions.push(
+            new DeleteElementActionEvent({
+                element: source as PbEditorElement
+            })
+        );
+
         return result;
     }
-
-    // Trigger drop and create-element events.
-    result.actions.push(new AfterDropElementActionEvent({ element }));
 
     result.actions.push(
         new CreateElementActionEvent({

--- a/packages/app-page-builder/src/editor/helpers.ts
+++ b/packages/app-page-builder/src/editor/helpers.ts
@@ -293,7 +293,7 @@ export const onReceived: PbEditorPageElementPlugin["onReceived"] = props => {
 
     const result = executeAction<UpdateElementActionArgsType>(state, meta, updateElementAction, {
         element: parent,
-        history: true
+        history: false
     });
 
     result.actions.push(new AfterDropElementActionEvent({ element }));

--- a/packages/app-page-builder/src/editor/recoil/actions/afterDropElement/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/afterDropElement/action.ts
@@ -40,10 +40,6 @@ export const afterDropElementAction: EventActionCallable<AfterDropElementActionA
     return {
         state: {
             ...state,
-            ui: {
-                ...state.ui,
-                isDragging: false
-            },
             activeElement: element.id,
             sidebar: {
                 activeTabIndex: 0,

--- a/packages/app-page-builder/src/editor/recoil/actions/drag/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/drag/action.ts
@@ -4,6 +4,7 @@ import { EventActionCallable } from "~/types";
 export const dragStartAction: EventActionCallable<DragStartActionEvent> = state => {
     return {
         state: {
+            ...state,
             ui: {
                 ...state.ui,
                 isDragging: true
@@ -16,6 +17,7 @@ export const dragStartAction: EventActionCallable<DragStartActionEvent> = state 
 export const dragEndAction: EventActionCallable<DragEndActionEvent> = state => {
     return {
         state: {
+            ...state,
             ui: {
                 ...state.ui,
                 isDragging: false

--- a/packages/app-page-builder/src/editor/recoil/actions/dropElement/action.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/dropElement/action.ts
@@ -55,13 +55,7 @@ export const dropElementAction: EventActionCallable<DropElementActionArgsType> =
     const onReceivedCallback = plugin.onReceived || onReceived;
 
     return onReceivedCallback!({
-        state: {
-            ...state,
-            ui: {
-                ...state.ui,
-                isDragging: false
-            }
-        },
+        state,
         meta,
         source: sourceElement,
         target: targetElement,


### PR DESCRIPTION
## Changes
This PR addresses two PB editor / drag-and-drop-related issues.

1. When creating a new page and immediately dropping the default block and any page element into its grid > cell page elements, the dropped page element would not be selectable. Only after a full page refresh, the interactivity would work as expected. With this PR, this is no longer the case.

2. Sometimes, dragging and dropping an element above or below an existing element would simply make the element disappear. This was also resolved with this PR.

## How Has This Been Tested?
Manual.

## Documentation
N/A