### PR TITLE
Do Not Allow Dropping Page Elements Into Saved Blocks

### DIFF
--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControls.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControls.tsx
@@ -89,7 +89,16 @@ export const ElementControls = () => {
             render = (
                 <>
                     <Droppable
-                        onDrop={source => dropElementAction(source)}
+                        onDrop={source => {
+                            // When dragging elements, we don't want to allow dropping them into saved blocks. Note
+                            // the `blockId` only exists in the page editor. It doesn't exist in the block editor.
+                            const isBlock = element.data.blockId;
+                            if (isBlock) {
+                                return null;
+                            }
+
+                            return dropElementAction(source);
+                        }}
                         type={element.type}
                         isVisible={() => true}
                     >


### PR DESCRIPTION
## Changes
Before this PR, users would be able to drop page elements into blocks (created via the Block editor), which should not be allowed. This PR addresses this.

## How Has This Been Tested?
Manual.

## Documentation
N/A