### PR TITLE
fix: folder navigation on application load

### DIFF
--- a/packages/app-aco/src/components/FolderTree/List/index.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/index.tsx
@@ -53,7 +53,7 @@ export const List: React.VFC<ListProps> = ({
             return;
         }
         setInitialOpenList(createInitialOpenList(folders, openFolderIds, focusedFolderId));
-    }, []);
+    }, [focusedFolderId]);
 
     const handleDrop = async (
         newTree: NodeModel<DndFolderItem>[],

--- a/packages/app-aco/src/contexts/navigateFolder.tsx
+++ b/packages/app-aco/src/contexts/navigateFolder.tsx
@@ -52,16 +52,8 @@ export const NavigateFolderProvider: React.VFC<NavigateFolderProviderProps> = ({
      * Navigate to the latest folder, considering the latest visited folder.
      */
     const navigateToLatestFolder = useCallback(() => {
-        const folderId = store.get(createStorageKey());
-        /**
-         * We need to check if the stored folderId is the same as the current one or the current one is the root folder.
-         * We must skip the navigation to the latest folder in these cases as it will cause a bug where
-         * a user cannot access a CMS entry or page via the direct URL.
-         */
-        if (folderId === currentFolderId || currentFolderId === ROOT_FOLDER) {
-            return;
-        }
-        props.navigateToLatestFolder(folderId || ROOT_FOLDER);
+        const storageFolderId = store.get(createStorageKey()) as string | undefined;
+        props.navigateToLatestFolder(currentFolderId || storageFolderId || ROOT_FOLDER);
     }, [createStorageKey, currentFolderId]);
 
     const navigateToFolder = useCallback(

--- a/packages/app-aco/src/contexts/navigateFolder.tsx
+++ b/packages/app-aco/src/contexts/navigateFolder.tsx
@@ -70,7 +70,7 @@ export const NavigateFolderProvider: React.VFC<NavigateFolderProviderProps> = ({
     };
 
     const context: NavigateFolderContext = {
-        currentFolderId,
+        currentFolderId: currentFolderId || store.get(createStorageKey()),
         setFolderToStorage,
         navigateToListHome,
         navigateToFolder,

--- a/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
+++ b/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
@@ -22,6 +22,7 @@ export const NavigateFolderWithRouterProvider: React.VFC<NavigateFolderProviderP
     const [currentFolderId, setCurrentFolderId] = useState<string | undefined>(folderId);
 
     useEffect(() => {
+        debugger;
         setCurrentFolderId(folderId);
     }, [folderId]);
 
@@ -67,6 +68,15 @@ export const NavigateFolderWithRouterProvider: React.VFC<NavigateFolderProviderP
      */
     const navigateToLatestFolder = useCallback(
         folderId => {
+            /**
+             * We need to check if the stored folderId is the same as the current one.
+             * We must skip the navigation to the latest folder in these cases as it will cause a bug where
+             * a user cannot access a CMS entry or page via the direct URL.
+             */
+            if (folderId === currentFolderId) {
+                return;
+            }
+
             const query = new URLSearchParams(location.search);
             query.set(folderIdQueryString, folderId);
 

--- a/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
+++ b/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
@@ -68,9 +68,7 @@ export const NavigateFolderWithRouterProvider: React.VFC<NavigateFolderProviderP
     const navigateToLatestFolder = useCallback(
         folderId => {
             /**
-             * We need to check if the stored folderId is the same as the current one.
-             * We must skip the navigation to the latest folder in these cases as it will cause a bug where
-             * a user cannot access a CMS entry or page via the direct URL.
+             * We need to check if the stored folderId is the same as the current one, in this case we skip the navigation.
              */
             if (folderId === currentFolderId) {
                 return;

--- a/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
+++ b/packages/app-aco/src/contexts/navigateFolderWithRouter.tsx
@@ -22,7 +22,6 @@ export const NavigateFolderWithRouterProvider: React.VFC<NavigateFolderProviderP
     const [currentFolderId, setCurrentFolderId] = useState<string | undefined>(folderId);
 
     useEffect(() => {
-        debugger;
         setCurrentFolderId(folderId);
     }, [folderId]);
 


### PR DESCRIPTION
## Changes
With this PR, we fix a bug that has been introduced on aco navigation refactor by: 

- moving some routing-related logic from `navigateFolder.tsx` to `navigateFolderWithRouter.tsx`
- adding `focusedFolderId` as dependency of the `useEffect` that handles highlighted and the open folders within `FolderTree` component.

The bug encountered occurred when the last visited folder id had not yet been saved in the localStorage.

## How Has This Been Tested?
Manually

## Documentation
Inline