### PR TITLE
fix(Lexical): Lexical toolbar is not visible for PB block variable inputs

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/heading/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/heading/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { PbEditorPageElementVariableRendererPlugin } from "~/types";
 import RichVariableInput from "~/editor/plugins/elementSettings/variable/RichVariableInput";
 import { useElementVariables } from "~/editor/hooks/useElementVariableValue";
+import { CompositionScope } from "@webiny/react-composition";
 
 export default {
     name: "pb-editor-page-element-variable-renderer-heading",
@@ -12,7 +13,11 @@ export default {
         return variables?.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
-        return <RichVariableInput variableId={variableId} />;
+        return (
+            <CompositionScope name={"pb.heading"}>
+                <RichVariableInput variableId={variableId} />
+            </CompositionScope>
+        );
     },
     setElementValue(element, variables) {
         const newText = variables?.length > 0 ? variables[0].value : null;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/paragraph/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/paragraph/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { PbEditorPageElementVariableRendererPlugin } from "~/types";
 import RichVariableInput from "~/editor/plugins/elementSettings/variable/RichVariableInput";
 import { useElementVariables } from "~/editor/hooks/useElementVariableValue";
+import { CompositionScope } from "@webiny/react-composition";
 
 export default {
     name: "pb-editor-page-element-variable-renderer-paragraph",
@@ -12,7 +13,11 @@ export default {
         return variables?.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
-        return <RichVariableInput variableId={variableId} />;
+        return (
+            <CompositionScope name={"pb.paragraph"}>
+                <RichVariableInput variableId={variableId} />
+            </CompositionScope>
+        );
     },
     setElementValue(element, variables) {
         const newText = variables?.length > 0 ? variables[0].value : null;


### PR DESCRIPTION
With this PR fixing the missing lexical toolbar in the PB block inputs.

## Changes
Add PB scope to the pb variable renderers in `app-page-builder `package
Element variables
- paragraph/index - added composable scope `pb.paragraph`
- header/index - added composable scope `pb.header`

## How Has This Been Tested?
Manually.

## Test video

https://github.com/webiny/webiny-js/assets/82515066/24e583cc-958b-486f-91ec-169f2568d1de

