### PR TITLE
fix(api-headless-cms): move published entry to another folder

### DIFF
--- a/packages/api-aco/__tests__/record.so.test.ts
+++ b/packages/api-aco/__tests__/record.so.test.ts
@@ -98,7 +98,12 @@ describe("`search` CRUD", () => {
         // Let's check whether both of the record exists, listing them by `type` and `location`.
         // List records -> type: "page" / folderId: "folder-1"
         const [listResponsePageFolder1] = await search.listRecords({
-            where: { type: "page", location: { folderId: "folder-1" } },
+            where: {
+                type: "page",
+                location: {
+                    folderId: "folder-1"
+                }
+            },
             sort: ["createdOn_ASC"]
         });
 

--- a/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
+++ b/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
@@ -79,6 +79,9 @@ module.exports = () => {
                 context.cms.onEntryAfterUpdate.subscribe(async ({ model }) => {
                     await refreshIndex(model);
                 });
+                context.cms.onEntryAfterMove.subscribe(async ({ model }) => {
+                    await refreshIndex(model);
+                });
                 context.cms.onEntryRevisionAfterCreate.subscribe(async ({ model }) => {
                     await refreshIndex(model);
                 });

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -629,9 +629,9 @@ export const createEntriesStorageOperations = (
             /**
              * We need to get the published and latest records, so we can update the Elasticsearch.
              */
-            if (record.GSI1_SK === publishedSortKey) {
+            if (record.SK === publishedSortKey) {
                 publishedRecord = record;
-            } else if (record.GSI1_SK === latestSortKey) {
+            } else if (record.SK === latestSortKey) {
                 latestRecord = record;
             }
         }
@@ -673,24 +673,24 @@ export const createEntriesStorageOperations = (
         if (esGetItems.length === 0) {
             return;
         }
+        const esRecords = await batchReadAll<ElasticsearchDbRecord>({
+            table: esEntity.table,
+            items: esGetItems
+        });
         const esItems = (
             await Promise.all(
-                (
-                    await batchReadAll<ElasticsearchDbRecord>({
-                        table: esEntity.table,
-                        items: esGetItems
-                    })
-                ).map(async item => {
-                    if (!item) {
+                esRecords.map(async record => {
+                    if (!record) {
                         return null;
                     }
                     return {
-                        ...item,
-                        data: await decompress(plugins, item.data)
+                        ...record,
+                        data: await decompress(plugins, record.data)
                     };
                 })
             )
         ).filter(Boolean) as ElasticsearchDbRecord[];
+
         if (esItems.length === 0) {
             return;
         }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -12,7 +12,7 @@ import { configurations } from "~/configurations";
 import { Entity } from "dynamodb-toolbox";
 import { Client } from "@elastic/elasticsearch";
 import { PluginsContainer } from "@webiny/plugins";
-import { batchWriteAll } from "@webiny/db-dynamodb/utils/batchWrite";
+import { batchWriteAll, BatchWriteItem } from "@webiny/db-dynamodb/utils/batchWrite";
 import { DataLoadersHandler } from "~/operations/entry/dataLoaders";
 import {
     createLatestSortKey,
@@ -20,7 +20,12 @@ import {
     createPublishedSortKey,
     createRevisionSortKey
 } from "~/operations/entry/keys";
-import { queryAll, queryOne, QueryOneParams } from "@webiny/db-dynamodb/utils/query";
+import {
+    queryAll,
+    QueryAllParams,
+    queryOne,
+    QueryOneParams
+} from "@webiny/db-dynamodb/utils/query";
 import {
     compress,
     createLimit,
@@ -40,6 +45,7 @@ import { createElasticsearchBody } from "~/operations/entry/elasticsearch/body";
 import { createLatestRecordType, createPublishedRecordType, createRecordType } from "./recordType";
 import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
 import { DocumentClient } from "aws-sdk/clients/dynamodb";
+import { batchReadAll, BatchReadItem } from "@webiny/db-dynamodb";
 
 const getEntryData = (input: CmsEntry): CmsEntry => {
     const output: any = {
@@ -103,7 +109,7 @@ const convertEntryKeysFromStorage = (params: ConvertStorageEntryParams): CmsStor
 
 interface ElasticsearchDbRecord {
     index: string;
-    data: Record<string, string>;
+    data: Record<string, any>;
 }
 
 export interface CreateEntriesStorageOperationsParams {
@@ -581,6 +587,144 @@ export const createEntriesStorageOperations = (
             );
         }
         return initialStorageEntry;
+    };
+
+    const move: CmsEntryStorageOperations["move"] = async (initialModel, id, folderId) => {
+        const model = getStorageOperationsModel(initialModel);
+
+        const partitionKey = createPartitionKey({
+            id,
+            locale: model.locale,
+            tenant: model.tenant
+        });
+        /**
+         * First we need to fetch all the records in the regular DynamoDB table.
+         */
+        const queryAllParams: QueryAllParams = {
+            entity,
+            partitionKey,
+            options: {
+                gte: " "
+            }
+        };
+        const latestSortKey = createLatestSortKey();
+        const publishedSortKey = createPublishedSortKey();
+        const records = await queryAll<CmsEntry>(queryAllParams);
+        /**
+         * Then update the folderId in each record and prepare it to be stored.
+         */
+        let latestRecord: CmsEntry | undefined = undefined;
+        let publishedRecord: CmsEntry | undefined = undefined;
+        const items: BatchWriteItem[] = [];
+        for (const record of records) {
+            items.push(
+                entity.putBatch({
+                    ...record,
+                    location: {
+                        ...record?.location,
+                        folderId
+                    }
+                })
+            );
+            /**
+             * We need to get the published and latest records, so we can update the Elasticsearch.
+             */
+            if (record.GSI1_SK === publishedSortKey) {
+                publishedRecord = record;
+            } else if (record.GSI1_SK === latestSortKey) {
+                latestRecord = record;
+            }
+        }
+        try {
+            await batchWriteAll({
+                table: entity.table,
+                items
+            });
+            dataLoaders.clearAll({
+                model
+            });
+        } catch (ex) {
+            throw new WebinyError(
+                ex.message || "Could not move all entry records from in the DynamoDB table.",
+                ex.code || "MOVE_ENTRY_ERROR",
+                {
+                    error: ex,
+                    id
+                }
+            );
+        }
+        const esGetItems: BatchReadItem[] = [];
+        if (publishedRecord) {
+            esGetItems.push(
+                esEntity.getBatch({
+                    PK: partitionKey,
+                    SK: publishedSortKey
+                })
+            );
+        }
+        if (latestRecord) {
+            esGetItems.push(
+                esEntity.getBatch({
+                    PK: partitionKey,
+                    SK: latestSortKey
+                })
+            );
+        }
+        if (esGetItems.length === 0) {
+            return;
+        }
+        const esItems = (
+            await Promise.all(
+                (
+                    await batchReadAll<ElasticsearchDbRecord>({
+                        table: esEntity.table,
+                        items: esGetItems
+                    })
+                ).map(async item => {
+                    if (!item) {
+                        return null;
+                    }
+                    return {
+                        ...item,
+                        data: await decompress(plugins, item.data)
+                    };
+                })
+            )
+        ).filter(Boolean) as ElasticsearchDbRecord[];
+        if (esItems.length === 0) {
+            return;
+        }
+        const esUpdateItems: BatchWriteItem[] = [];
+        for (const item of esItems) {
+            esUpdateItems.push(
+                esEntity.putBatch({
+                    ...item,
+                    data: await compress(plugins, {
+                        ...item.data,
+                        location: {
+                            ...item.data?.location,
+                            folderId
+                        }
+                    })
+                })
+            );
+        }
+
+        try {
+            await batchWriteAll({
+                table: esEntity.table,
+                items: esUpdateItems
+            });
+        } catch (ex) {
+            throw new WebinyError(
+                ex.message || "Could not move entry DynamoDB Elasticsearch records.",
+                ex.code || "MOVE_ES_ENTRY_ERROR",
+                {
+                    error: ex,
+                    partitionKey
+                }
+            );
+        }
     };
 
     const deleteEntry: CmsEntryStorageOperations["delete"] = async (initialModel, params) => {
@@ -1607,6 +1751,7 @@ export const createEntriesStorageOperations = (
         create,
         createRevisionFrom,
         update,
+        move,
         delete: deleteEntry,
         deleteRevision,
         deleteMultipleEntries,

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
@@ -1,0 +1,111 @@
+import { setupGroupAndModels } from "~tests/testHelpers/setup";
+import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler";
+
+interface CategoryParams {
+    title: string;
+    slug: string;
+}
+
+interface Category {
+    id: string;
+    title: string;
+    slug: string;
+    wbyAco_location: {
+        folderId: string;
+    };
+}
+
+describe("move content entry to another folder", () => {
+    const manager = useCategoryManageHandler({
+        path: "manage/en-US"
+    });
+
+    const createCategory = async (data: CategoryParams): Promise<Category> => {
+        return await manager
+            .createCategory({
+                data
+            })
+            .then(result => {
+                const [data] = result;
+                return data.data.createCategory.data;
+            });
+    };
+
+    beforeEach(async () => {
+        await setupGroupAndModels({
+            manager,
+            models: ["category"]
+        });
+    });
+
+    it("should move content entry to another folder", async () => {
+        const category = await createCategory({
+            title: "Fruits",
+            slug: "fruits"
+        });
+        expect(category).toMatchObject({
+            id: expect.any(String),
+            title: "Fruits",
+            slug: "fruits",
+            wbyAco_location: {
+                folderId: "root"
+            }
+        });
+
+        const [moveResponse] = await manager.moveCategory({
+            id: category.id,
+            folderId: "anotherFolder"
+        });
+        expect(moveResponse).toEqual({
+            data: {
+                moveCategory: {
+                    data: true,
+                    error: null
+                }
+            }
+        });
+
+        const [getCategoryResponse] = await manager.getCategory({
+            revision: category.id
+        });
+        expect(getCategoryResponse).toMatchObject({
+            data: {
+                getCategory: {
+                    data: {
+                        id: category.id,
+                        title: category.title,
+                        slug: category.slug,
+                        wbyAco_location: {
+                            folderId: "anotherFolder"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listCategoriesResponse] = await manager.listCategories({});
+        expect(listCategoriesResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            id: category.id,
+                            title: category.title,
+                            slug: category.slug,
+                            wbyAco_location: {
+                                folderId: "anotherFolder"
+                            }
+                        }
+                    ],
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 1
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
@@ -8,6 +8,7 @@ interface CategoryParams {
 
 interface Category {
     id: string;
+    entryId: string;
     title: string;
     slug: string;
     wbyAco_location: {
@@ -20,6 +21,17 @@ describe("move content entry to another folder", () => {
         path: "manage/en-US"
     });
 
+    const getCategory = async (revision: string): Promise<Category> => {
+        return await manager
+            .getCategory({
+                revision
+            })
+            .then(result => {
+                const [data] = result;
+                return data.data.getCategory.data;
+            });
+    };
+
     const createCategory = async (data: CategoryParams): Promise<Category> => {
         return await manager
             .createCategory({
@@ -28,6 +40,17 @@ describe("move content entry to another folder", () => {
             .then(result => {
                 const [data] = result;
                 return data.data.createCategory.data;
+            });
+    };
+
+    const createCategoryFrom = async (category: Category) => {
+        return await manager
+            .createCategoryFrom({
+                revision: category.id
+            })
+            .then(result => {
+                const [data] = result;
+                return data.data.createCategoryFrom.data;
             });
     };
 
@@ -65,22 +88,13 @@ describe("move content entry to another folder", () => {
             }
         });
 
-        const [getCategoryResponse] = await manager.getCategory({
-            revision: category.id
-        });
+        const getCategoryResponse = await getCategory(category.id);
         expect(getCategoryResponse).toMatchObject({
-            data: {
-                getCategory: {
-                    data: {
-                        id: category.id,
-                        title: category.title,
-                        slug: category.slug,
-                        wbyAco_location: {
-                            folderId: "anotherFolder"
-                        }
-                    },
-                    error: null
-                }
+            id: category.id,
+            title: category.title,
+            slug: category.slug,
+            wbyAco_location: {
+                folderId: "anotherFolder"
             }
         });
 
@@ -95,6 +109,111 @@ describe("move content entry to another folder", () => {
                             slug: category.slug,
                             wbyAco_location: {
                                 folderId: "anotherFolder"
+                            }
+                        }
+                    ],
+                    meta: {
+                        cursor: null,
+                        hasMoreItems: false,
+                        totalCount: 1
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should move content entry and all its revisions to another folder", async () => {
+        const category = await createCategory({
+            title: "Fruits",
+            slug: "fruits"
+        });
+        expect(category).toMatchObject({
+            id: expect.any(String),
+            title: "Fruits",
+            slug: "fruits"
+        });
+        const category2 = await createCategoryFrom(category);
+        expect(category2).toMatchObject({
+            id: `${category.entryId}#0002`,
+            title: "Fruits",
+            slug: "fruits"
+        });
+        const category3 = await createCategoryFrom(category);
+        expect(category3).toMatchObject({
+            id: `${category.entryId}#0003`,
+            title: "Fruits",
+            slug: "fruits"
+        });
+        const category4 = await createCategoryFrom(category);
+        expect(category4).toMatchObject({
+            id: `${category.entryId}#0004`,
+            title: "Fruits",
+            slug: "fruits"
+        });
+
+        const [moveResponse] = await manager.moveCategory({
+            revision: category4.id,
+            folderId: "yetAnotherFolder"
+        });
+        expect(moveResponse).toEqual({
+            data: {
+                moveCategory: {
+                    data: true,
+                    error: null
+                }
+            }
+        });
+        const getCategoryResponse = await getCategory(category.id);
+        expect(getCategoryResponse).toMatchObject({
+            id: category.id,
+            title: category.title,
+            slug: category.slug,
+            wbyAco_location: {
+                folderId: "yetAnotherFolder"
+            }
+        });
+
+        const getCategory2Response = await getCategory(category2.id);
+        expect(getCategory2Response).toMatchObject({
+            id: category2.id,
+            title: category2.title,
+            slug: category2.slug,
+            wbyAco_location: {
+                folderId: "yetAnotherFolder"
+            }
+        });
+
+        const getCategory3Response = await getCategory(category3.id);
+        expect(getCategory3Response).toMatchObject({
+            id: category3.id,
+            title: category3.title,
+            slug: category3.slug,
+            wbyAco_location: {
+                folderId: "yetAnotherFolder"
+            }
+        });
+        const getCategory4Response = await getCategory(category4.id);
+        expect(getCategory4Response).toMatchObject({
+            id: category4.id,
+            title: category4.title,
+            slug: category4.slug,
+            wbyAco_location: {
+                folderId: "yetAnotherFolder"
+            }
+        });
+
+        const [listCategoriesResponse] = await manager.listCategories({});
+        expect(listCategoriesResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            id: category4.id,
+                            title: category4.title,
+                            slug: category4.slug,
+                            wbyAco_location: {
+                                folderId: "yetAnotherFolder"
                             }
                         }
                     ],

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.move.test.ts
@@ -53,7 +53,7 @@ describe("move content entry to another folder", () => {
         });
 
         const [moveResponse] = await manager.moveCategory({
-            id: category.id,
+            revision: category.id,
             folderId: "anotherFolder"
         });
         expect(moveResponse).toEqual({

--- a/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/latestEntries.test.ts
@@ -283,7 +283,7 @@ describe("latest entries", function () {
             revision: updatedFruitCategory.id
         });
 
-        expect(publishFruitResponse).toEqual({
+        expect(publishFruitResponse).toMatchObject({
             data: {
                 publishCategory: {
                     data: {

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.apiKey.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.apiKey.manage.test.ts
@@ -131,7 +131,7 @@ describe("MANAGE - resolvers - api key", () => {
             headers
         );
 
-        expect(createResponse).toEqual({
+        expect(createResponse).toMatchObject({
             data: {
                 createCategory: {
                     data: {
@@ -181,7 +181,7 @@ describe("MANAGE - resolvers - api key", () => {
             headers
         );
 
-        expect(getResponse).toEqual({
+        expect(getResponse).toMatchObject({
             data: {
                 getCategory: {
                     data: {
@@ -233,7 +233,7 @@ describe("MANAGE - resolvers - api key", () => {
             headers
         );
 
-        expect(updateResponse).toEqual({
+        expect(updateResponse).toMatchObject({
             data: {
                 updateCategory: {
                     data: {
@@ -279,7 +279,7 @@ describe("MANAGE - resolvers - api key", () => {
         // If this `until` resolves successfully, we know entry is accessible via the "read" API
         const [listResponse] = await listCategories({}, headers);
 
-        expect(listResponse).toEqual({
+        expect(listResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -137,7 +137,7 @@ describe("MANAGE - Resolvers", () => {
 
         const [response] = await getCategory({ revision: id });
 
-        expect(response.data.getCategory.data).toEqual({
+        expect(response.data.getCategory.data).toMatchObject({
             id,
             entryId,
             createdOn: expect.stringMatching(/^20/),
@@ -218,7 +218,7 @@ describe("MANAGE - Resolvers", () => {
 
         const [response] = await getCategory({ revision: id });
 
-        expect(response.data.getCategory.data).toEqual({
+        expect(response.data.getCategory.data).toMatchObject({
             id,
             entryId,
             createdOn: expect.stringMatching(/^20/),
@@ -275,7 +275,7 @@ describe("MANAGE - Resolvers", () => {
 
         const [response] = await listCategories();
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 listCategories: {
                     data: [
@@ -361,7 +361,7 @@ describe("MANAGE - Resolvers", () => {
             revisions: [fruits.id, animals.id]
         });
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 getCategoriesByIds: {
                     data: [fruits, animals],
@@ -378,7 +378,7 @@ describe("MANAGE - Resolvers", () => {
 
         const category1 = create1.data.createCategory.data;
 
-        expect(category1).toEqual({
+        expect(category1).toMatchObject({
             id: expect.any(String),
             entryId: expect.any(String),
             createdOn: expect.stringMatching(/^20/),
@@ -448,7 +448,7 @@ describe("MANAGE - Resolvers", () => {
 
         const category = result.data.createCategory.data;
 
-        expect(category).toEqual({
+        expect(category).toMatchObject({
             id: expect.any(String),
             entryId: expect.any(String),
             createdOn: expect.stringMatching(/^20/),
@@ -515,7 +515,7 @@ describe("MANAGE - Resolvers", () => {
         const [revision] = await createCategoryFrom({ revision: id });
 
         const newEntry = revision.data.createCategoryFrom.data;
-        expect(revision).toEqual({
+        expect(revision).toMatchObject({
             data: {
                 createCategoryFrom: {
                     data: {
@@ -567,7 +567,7 @@ describe("MANAGE - Resolvers", () => {
 
         const [response] = await listCategories();
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 listCategories: {
                     data: [newEntry],
@@ -595,7 +595,7 @@ describe("MANAGE - Resolvers", () => {
             data: { title: "New title", slug: "hardware-store" }
         });
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 updateCategory: {
                     data: {
@@ -855,7 +855,7 @@ describe("MANAGE - Resolvers", () => {
 
         const [listResponse] = await listCategories(defaultQueryVars);
 
-        expect(listResponse).toEqual({
+        expect(listResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [animals, fruits, trees, vegetables],
@@ -876,7 +876,7 @@ describe("MANAGE - Resolvers", () => {
             }
         });
 
-        expect(listContainsResponse).toEqual({
+        expect(listContainsResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [trees],
@@ -896,7 +896,7 @@ describe("MANAGE - Resolvers", () => {
                 title_not_contains: "uit"
             }
         });
-        expect(listNotContainsResponse).toEqual({
+        expect(listNotContainsResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [animals, trees, vegetables],
@@ -916,7 +916,7 @@ describe("MANAGE - Resolvers", () => {
                 title_not_contains: "e"
             }
         });
-        expect(listNotContainsEResponse).toEqual({
+        expect(listNotContainsEResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [animals, fruits],
@@ -938,7 +938,7 @@ describe("MANAGE - Resolvers", () => {
             sort: ["savedOn_ASC"]
         });
 
-        expect(listInResponse).toEqual({
+        expect(listInResponse).toMatchObject({
             data: {
                 listCategories: {
                     data: [animals, vegetables],
@@ -1196,7 +1196,7 @@ describe("MANAGE - Resolvers", () => {
 
         const createdWebinyCategory = createWebinyResponse.data.createCategory.data;
 
-        expect(publishWebinyResponse).toEqual({
+        expect(publishWebinyResponse).toMatchObject({
             data: {
                 publishCategory: {
                     data: {
@@ -1234,7 +1234,7 @@ describe("MANAGE - Resolvers", () => {
                 revision: webiny.id
             });
 
-            expect(response).toEqual({
+            expect(response).toMatchObject({
                 data: {
                     createCategoryFrom: {
                         data: {
@@ -1265,7 +1265,7 @@ describe("MANAGE - Resolvers", () => {
                 revision: response.data.createCategoryFrom.data.id
             });
 
-            expect(publishResponse).toEqual({
+            expect(publishResponse).toMatchObject({
                 data: {
                     publishCategory: {
                         data: {
@@ -1315,7 +1315,7 @@ describe("MANAGE - Resolvers", () => {
             revision: id
         });
 
-        expect(getResponse).toEqual({
+        expect(getResponse).toMatchObject({
             data: {
                 getCategory: {
                     data: {
@@ -1405,7 +1405,7 @@ describe("MANAGE - Resolvers", () => {
             }
         });
 
-        expect(getReadCategoryResponse).toEqual({
+        expect(getReadCategoryResponse).toMatchObject({
             data: {
                 getCategory: {
                     data: {

--- a/packages/api-headless-cms/__tests__/testHelpers/plugins.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/plugins.ts
@@ -22,7 +22,7 @@ export interface CreateHandlerCoreParams {
     topPlugins?: Plugin | Plugin[] | Plugin[][] | PluginCollection;
     plugins?: Plugin | Plugin[] | Plugin[][] | PluginCollection;
     bottomPlugins?: Plugin | Plugin[] | Plugin[][] | PluginCollection;
-    path?: string;
+    path?: `manage/${string}-${string}}` | `read/${string}-${string}}` | string;
 }
 export const createHandlerCore = (params: CreateHandlerCoreParams) => {
     const tenant = {

--- a/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
@@ -134,13 +134,13 @@ const updateCategoryMutation = (model: CmsModel) => {
     `;
 };
 export interface MoveCategoryVariables {
-    id: string;
+    revision: string;
     folderId: string;
 }
 const moveCategoryMutation = (model: CmsModel) => {
     return /* GraphQL */ `
-        mutation MoveCategory($id: ID!, $folderId: ID!) {
-            moveCategory: move${model.singularApiName}(id: $id, folderId: $folderId) {
+        mutation MoveCategory($revision: ID!, $folderId: ID!) {
+            moveCategory: move${model.singularApiName}(revision: $revision, folderId: $folderId) {
                 data
                 ${errorFields}
             }

--- a/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
@@ -30,6 +30,9 @@ const categoryFields = `
         }
         data
     }
+    wbyAco_location {
+        folderId
+    }
     # user defined fields
     title
     slug
@@ -125,6 +128,20 @@ const updateCategoryMutation = (model: CmsModel) => {
                 data {
                     ${categoryFields}
                 }
+                ${errorFields}
+            }
+        }
+    `;
+};
+export interface MoveCategoryVariables {
+    id: string;
+    folderId: string;
+}
+const moveCategoryMutation = (model: CmsModel) => {
+    return /* GraphQL */ `
+        mutation MoveCategory($id: ID!, $folderId: ID!) {
+            moveCategory: move${model.singularApiName}(id: $id, folderId: $folderId) {
+                data
                 ${errorFields}
             }
         }
@@ -247,6 +264,15 @@ export const useCategoryManageHandler = (params: GraphQLHandlerParams) => {
             return await contentHandler.invoke({
                 body: {
                     query: updateCategoryMutation(model),
+                    variables
+                },
+                headers
+            });
+        },
+        async moveCategory(variables: MoveCategoryVariables, headers: Record<string, any> = {}) {
+            return await contentHandler.invoke({
+                body: {
+                    query: moveCategoryMutation(model),
                     variables
                 },
                 headers

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -863,7 +863,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             throw new NotFoundError(`Entry "${id}" of model "${model.modelId}" was not found.`);
         }
 
-        if (originalStorageEntry.locked) {
+        if (inputData.wbyCms_overrideLocked !== true && originalStorageEntry.locked) {
             throw new WebinyError(
                 `Cannot update entry because it's locked.`,
                 "CONTENT_ENTRY_UPDATE_ERROR"

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -29,6 +29,7 @@ import {
     OnEntryAfterCreateTopicParams,
     OnEntryAfterDeleteMultipleTopicParams,
     OnEntryAfterDeleteTopicParams,
+    OnEntryAfterMoveTopicParams,
     OnEntryAfterPublishTopicParams,
     OnEntryAfterRepublishTopicParams,
     OnEntryAfterUnpublishTopicParams,
@@ -37,6 +38,7 @@ import {
     OnEntryBeforeDeleteMultipleTopicParams,
     OnEntryBeforeDeleteTopicParams,
     OnEntryBeforeGetTopicParams,
+    OnEntryBeforeMoveTopicParams,
     OnEntryBeforePublishTopicParams,
     OnEntryBeforeRepublishTopicParams,
     OnEntryBeforeUnpublishTopicParams,
@@ -45,6 +47,7 @@ import {
     OnEntryCreateRevisionErrorTopicParams,
     OnEntryDeleteErrorTopicParams,
     OnEntryDeleteMultipleErrorTopicParams,
+    OnEntryMoveErrorTopicParams,
     OnEntryPublishErrorTopicParams,
     OnEntryRepublishErrorTopicParams,
     OnEntryRevisionAfterCreateTopicParams,
@@ -299,6 +302,13 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         createTopic<OnEntryBeforeUpdateTopicParams>("cms.onEntryBeforeUpdate");
     const onEntryAfterUpdate = createTopic<OnEntryAfterUpdateTopicParams>("cms.onEntryAfterUpdate");
     const onEntryUpdateError = createTopic<OnEntryUpdateErrorTopicParams>("cms.onEntryUpdateError");
+
+    /**
+     * Move
+     */
+    const onEntryBeforeMove = createTopic<OnEntryBeforeMoveTopicParams>("cms.onEntryBeforeMove");
+    const onEntryAfterMove = createTopic<OnEntryAfterMoveTopicParams>("cms.onEntryAfterMove");
+    const onEntryMoveError = createTopic<OnEntryMoveErrorTopicParams>("cms.onEntryMoveError");
 
     /**
      * Publish
@@ -863,7 +873,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             throw new NotFoundError(`Entry "${id}" of model "${model.modelId}" was not found.`);
         }
 
-        if (inputData.wbyCms_overrideLocked !== true && originalStorageEntry.locked) {
+        if (originalStorageEntry.locked) {
             throw new WebinyError(
                 `Cannot update entry because it's locked.`,
                 "CONTENT_ENTRY_UPDATE_ERROR"
@@ -965,6 +975,50 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             );
         }
     };
+
+    const moveEntry: CmsEntryContext["moveEntry"] = async (model, id, folderId) => {
+        await entriesPermissions.ensure({ rwd: "w" });
+        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        /**
+         * The entry we are going to move to another folder.
+         */
+        const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
+            id
+        });
+
+        if (!originalStorageEntry) {
+            throw new NotFoundError(`Entry "${id}" of model "${model.modelId}" was not found.`);
+        }
+
+        const entry = await entryFromStorageTransform(context, model, originalStorageEntry);
+
+        try {
+            await onEntryBeforeMove.publish({
+                entry,
+                model,
+                folderId
+            });
+            await storageOperations.entries.move(model, id, folderId);
+            await onEntryAfterMove.publish({
+                entry,
+                model,
+                folderId
+            });
+            return entry;
+        } catch (ex) {
+            await onEntryMoveError.publish({
+                entry,
+                model,
+                folderId,
+                error: ex
+            });
+            throw WebinyError.from(ex, {
+                message: `Could not move entry "${id}" of model "${model.modelId}".`,
+                code: "MOVE_ENTRY_ERROR"
+            });
+        }
+    };
+
     const republishEntry: CmsEntryContext["republishEntry"] = async (model, id) => {
         await entriesPermissions.ensure({ rwd: "w" });
         await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
@@ -1520,6 +1574,12 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         onEntryAfterUpdate,
         onEntryUpdateError,
         /**
+         * Move
+         */
+        onEntryBeforeMove,
+        onEntryAfterMove,
+        onEntryMoveError,
+        /**
          * Delete whole entry
          */
         onEntryBeforeDelete,
@@ -1664,6 +1724,11 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         async updateEntry(model, id, input, meta) {
             return context.benchmark.measure("headlessCms.crud.entries.updateEntry", async () => {
                 return updateEntry(model, id, input, meta);
+            });
+        },
+        async moveEntry(model, id, folderId) {
+            return context.benchmark.measure("headlessCms.crud.entries.moveEntry", async () => {
+                return moveEntry(model, id, folderId);
             });
         },
         /**

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -171,7 +171,7 @@ export const createManageSDL: CreateManageSDL = ({
     
             update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
             
-            move${singularName}(id: ID!, folderId: ID!): ${singularName}MoveResponse
+            move${singularName}(revision: ID!, folderId: ID!): ${singularName}MoveResponse
 
             delete${singularName}(revision: ID!, options: CmsDeleteEntryOptions): CmsDeleteResponse
 

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -171,7 +171,7 @@ export const createManageSDL: CreateManageSDL = ({
     
             update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
             
-            move${singularName}(revision: ID!, folderId: ID!): ${singularName}MoveResponse
+            move${singularName}(id: ID!, folderId: ID!): ${singularName}MoveResponse
 
             delete${singularName}(revision: ID!, options: CmsDeleteEntryOptions): CmsDeleteResponse
 

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
@@ -2,7 +2,7 @@ import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
 import { CmsEntryResolverFactory as ResolverFactory } from "~/types";
 
 interface ResolveMoveArgs {
-    revision: string;
+    id: string;
     folderId: string;
 }
 
@@ -11,14 +11,14 @@ type ResolveMove = ResolverFactory<any, ResolveMoveArgs>;
 export const resolveMove: ResolveMove =
     ({ model }) =>
     async (_, args: any, context) => {
-        const { revision, folderId } = args;
+        const { id, folderId } = args;
         try {
             if (!folderId) {
                 throw new Error(`The input value "folderId" is required!`);
             }
-            const entry = await context.cms.moveEntry(model, revision, folderId);
+            await context.cms.moveEntry(model, id, folderId);
 
-            return new Response(entry.location?.folderId === folderId);
+            return new Response(true);
         } catch (ex) {
             return new ErrorResponse(ex);
         }

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
@@ -17,13 +17,14 @@ export const resolveMove: ResolveMove =
                 throw new Error(`The input value "folderId" is required!`);
             }
             const entry = await context.cms.updateEntry(model, revision, {
+                wbyCms_overrideLocked: true,
                 wbyAco_location: {
                     folderId
                 }
             });
 
             return new Response(entry.location?.folderId === folderId);
-        } catch (e) {
-            return new ErrorResponse(e);
+        } catch (ex) {
+            return new ErrorResponse(ex);
         }
     };

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
@@ -2,7 +2,7 @@ import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
 import { CmsEntryResolverFactory as ResolverFactory } from "~/types";
 
 interface ResolveMoveArgs {
-    id: string;
+    revision: string;
     folderId: string;
 }
 
@@ -11,12 +11,12 @@ type ResolveMove = ResolverFactory<any, ResolveMoveArgs>;
 export const resolveMove: ResolveMove =
     ({ model }) =>
     async (_, args: any, context) => {
-        const { id, folderId } = args;
+        const { revision, folderId } = args;
         try {
             if (!folderId) {
                 throw new Error(`The input value "folderId" is required!`);
             }
-            await context.cms.moveEntry(model, id, folderId);
+            await context.cms.moveEntry(model, revision, folderId);
 
             return new Response(true);
         } catch (ex) {

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveMove.ts
@@ -16,12 +16,7 @@ export const resolveMove: ResolveMove =
             if (!folderId) {
                 throw new Error(`The input value "folderId" is required!`);
             }
-            const entry = await context.cms.updateEntry(model, revision, {
-                wbyCms_overrideLocked: true,
-                wbyAco_location: {
-                    folderId
-                }
-            });
+            const entry = await context.cms.moveEntry(model, revision, folderId);
 
             return new Response(entry.location?.folderId === folderId);
         } catch (ex) {

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2071,6 +2071,28 @@ export interface OnEntryUpdateErrorTopicParams {
 }
 
 /**
+ * Move
+ */
+export interface OnEntryBeforeMoveTopicParams {
+    folderId: string;
+    entry: CmsEntry;
+    model: CmsModel;
+}
+
+export interface OnEntryAfterMoveTopicParams {
+    folderId: string;
+    entry: CmsEntry;
+    model: CmsModel;
+}
+
+export interface OnEntryMoveErrorTopicParams {
+    error: Error;
+    folderId: string;
+    entry: CmsEntry;
+    model: CmsModel;
+}
+
+/**
  * Publish
  */
 
@@ -2218,7 +2240,6 @@ export interface CreateFromCmsEntryInput {
  * @category CmsEntry
  */
 export interface UpdateCmsEntryInput {
-    wbyCms_overrideLocked?: boolean;
     wbyAco_location?: {
         folderId?: string | null;
     };
@@ -2324,6 +2345,10 @@ export interface CmsEntryContext {
         input: UpdateCmsEntryInput,
         meta?: Record<string, any>
     ) => Promise<CmsEntry>;
+    /**
+     * Move entry, and all its revisions, to a new folder.
+     */
+    moveEntry: (model: CmsModel, id: string, folderId: string) => Promise<CmsEntry>;
     /**
      * Method that republishes entry with given identifier.
      * @internal
@@ -2446,6 +2471,10 @@ export interface CmsEntryContext {
     onEntryBeforeUpdate: Topic<OnEntryBeforeUpdateTopicParams>;
     onEntryAfterUpdate: Topic<OnEntryAfterUpdateTopicParams>;
     onEntryUpdateError: Topic<OnEntryUpdateErrorTopicParams>;
+
+    onEntryBeforeMove: Topic<OnEntryBeforeMoveTopicParams>;
+    onEntryAfterMove: Topic<OnEntryAfterMoveTopicParams>;
+    onEntryMoveError: Topic<OnEntryMoveErrorTopicParams>;
 
     onEntryBeforeDelete: Topic<OnEntryBeforeDeleteTopicParams>;
     onEntryAfterDelete: Topic<OnEntryAfterDeleteTopicParams>;
@@ -2937,6 +2966,10 @@ export interface CmsEntryStorageOperations<T extends CmsStorageEntry = CmsStorag
      * Update existing entry.
      */
     update: (model: CmsModel, params: CmsEntryStorageOperationsUpdateParams<T>) => Promise<T>;
+    /**
+     * Move entry and all its entries into a new folder.
+     */
+    move: (model: CmsModel, id: string, folderId: string) => Promise<void>;
     /**
      * Delete the entry revision.
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2218,6 +2218,7 @@ export interface CreateFromCmsEntryInput {
  * @category CmsEntry
  */
 export interface UpdateCmsEntryInput {
+    wbyCms_overrideLocked?: boolean;
     wbyAco_location?: {
         folderId?: string | null;
     };


### PR DESCRIPTION
## Issue
Currently users cannot move a published CMS entry into another folder because we are using the update method under the hood - and it does not allow any change of CMS entry which is published.

## Changes
This PR allows moving of a published CMS entry into another folder.

## How Has This Been Tested?
Jest and manually.