### PR TITLE
Page Editor Element Overlay and Plugins Registration Fixes

### DIFF
--- a/packages/app-page-builder-elements/src/components/Element.tsx
+++ b/packages/app-page-builder-elements/src/components/Element.tsx
@@ -23,9 +23,15 @@ export const Element: React.FC<Props> = props => {
         return null;
     }
 
+    const meta = {
+        ...props.meta,
+        templateBlockId: element.data.templateBlockId,
+        blockId: element.data.blockId
+    };
+
     return (
         <ErrorBoundary>
-            <ElementRenderer {...props} />
+            <ElementRenderer {...props} meta={meta} />
         </ErrorBoundary>
     );
 };

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControlsOverlay.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControlsOverlay.tsx
@@ -128,12 +128,21 @@ const StyledPbElementControlsOverlay = styled(
                 // We are putting it "in front of the user", above the element controls overlay.
                 // This enables us to actually interact with the page element. For example, when
                 // activating a paragraph page element, we get to type the paragraph text.
-                Object.assign(activeStyles, {
-                    "& + *": {
-                        zIndex: zIndex + 5,
-                        position: "relative"
-                    }
-                });
+
+                // Note that we don't want to assign the z-index to the element if it's part of
+                // a block (created via Block module or if it's a page created from a template).
+                // In that case, we want the block to be on top of the element at all times. No
+                // need to increase the z-index of the element and make it interactive.
+                const isSavedBlock =
+                    elementRendererMeta.blockId || elementRendererMeta.templateBlockId;
+                if (!isSavedBlock) {
+                    Object.assign(activeStyles, {
+                        "& + *": {
+                            zIndex: zIndex + 5,
+                            position: "relative"
+                        }
+                    });
+                }
 
                 // Note that we don't apply active border styles here. We do that via the `pb-eco-border`
                 // elements, rendered within the `PbElementControlsOverlayBaseComponent` component.

--- a/packages/plugins/src/PluginsContainer.ts
+++ b/packages/plugins/src/PluginsContainer.ts
@@ -24,6 +24,20 @@ const assign = (
             continue;
         }
 
+        if (typeof plugin !== "object") {
+            throw new Error(
+                `Could not register plugin. Expected an object, but got ${typeof plugin}.`
+            );
+        }
+
+        if (!plugin.type) {
+            let name = "";
+            if (plugin.name) {
+                name = ` "${plugin.name}"`;
+            }
+            throw new Error(`Could not register plugin${name}. Missing "type" definition.`);
+        }
+
         let name = plugin._name || plugin.name;
         if (!name) {
             plugin.name = name = uniqid(plugin.type + "-");


### PR DESCRIPTION
## Changes
This PR adds two fixes.

1. When having a page that's created out of a template, users should not be able to interact with page elements that are contained in the template. Prior to this PR, this was possible when having an empty cell in the template.

2. We've improved validation that's happening upon plugin registration. From now on, if a passed value is not an object or is missing the `type`, an error will be thrown.

## How Has This Been Tested?
Manually, existing tests.

## Documentation
N/A