### PR TITLE
fix: own permission in case of full access

### DIFF
--- a/packages/app-page-builder/src/hooks/permissions/createUsePermissions.ts
+++ b/packages/app-page-builder/src/hooks/permissions/createUsePermissions.ts
@@ -111,7 +111,7 @@ export const createUsePermissions = (permissionName: string) => (): UsePermissio
 
     const canAccessOnlyOwn = useCallback<UsePermission["canAccessOnlyOwn"]>(() => {
         if (hasFullAccess) {
-            return true;
+            return false;
         }
 
         return permissionsByName.some(({ own }) => {


### PR DESCRIPTION
## Changes
In case of full access, `canAccessOnlyOwn` should return `false`. This PR fixes this behaviour. 

## How Has This Been Tested?
Manually
