### PR TITLE
Add ElasticSearch IAM Permissions to Export-related Lambda Functions

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
@@ -166,16 +166,16 @@ function createExportLambdaPolicy(app: PulumiApp) {
                     // Attach permissions for elastic search domain as well (if ES is enabled).
                     ...(core.elasticsearchDomainArn
                         ? [
-                            {
-                                Sid: "PermissionForES",
-                                Effect: "Allow" as const,
-                                Action: "es:*",
-                                Resource: [
-                                    pulumi.interpolate`${core.elasticsearchDomainArn}`,
-                                    pulumi.interpolate`${core.elasticsearchDomainArn}/*`
-                                ]
-                            }
-                        ]
+                              {
+                                  Sid: "PermissionForES",
+                                  Effect: "Allow" as const,
+                                  Action: "es:*",
+                                  Resource: [
+                                      pulumi.interpolate`${core.elasticsearchDomainArn}`,
+                                      pulumi.interpolate`${core.elasticsearchDomainArn}/*`
+                                  ]
+                              }
+                          ]
                         : [])
                 ]
             }

--- a/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
@@ -162,7 +162,21 @@ function createExportLambdaPolicy(app: PulumiApp) {
                         Effect: "Allow",
                         Action: ["lambda:InvokeFunction"],
                         Resource: pulumi.interpolate`arn:aws:lambda:${awsRegion}:${awsAccountId}:function:*`
-                    }
+                    },
+                    // Attach permissions for elastic search domain as well (if ES is enabled).
+                    ...(core.elasticsearchDomainArn
+                        ? [
+                            {
+                                Sid: "PermissionForES",
+                                Effect: "Allow" as const,
+                                Action: "es:*",
+                                Resource: [
+                                    pulumi.interpolate`${core.elasticsearchDomainArn}`,
+                                    pulumi.interpolate`${core.elasticsearchDomainArn}/*`
+                                ]
+                            }
+                        ]
+                        : [])
                 ]
             }
         }
@@ -311,8 +325,8 @@ function createImportLambdaPolicy(app: PulumiApp) {
                                       Effect: "Allow" as const,
                                       Action: "es:*",
                                       Resource: [
-                                          `${core.elasticsearchDomainArn}`,
-                                          `${core.elasticsearchDomainArn}/*`
+                                          pulumi.interpolate`${core.elasticsearchDomainArn}`,
+                                          pulumi.interpolate`${core.elasticsearchDomainArn}/*`
                                       ]
                                   }
                               ]


### PR DESCRIPTION
## Changes
This PR adds missing ElasticSearch IAM permissions to export-related Lambda functions.

## How Has This Been Tested?
Manually.

## Documentation
N/A