### PR TITLE
Fixed Unlinking of Pages With Blocks In Them

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageBlockContent.ts
+++ b/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageBlockContent.ts
@@ -143,12 +143,7 @@ export const simplePageBlockContent = {
                                 variableId: "FDEezrJ8NH"
                             },
                             elements: [],
-                            path: [
-                                "UTaSFnVtkV",
-                                "uFzaV9SB6q",
-                                "k77Fdcod55",
-                                "BOMdKQBt23"
-                            ]
+                            path: ["UTaSFnVtkV", "uFzaV9SB6q", "k77Fdcod55", "BOMdKQBt23"]
                         },
                         {
                             type: "paragraph",
@@ -178,12 +173,7 @@ export const simplePageBlockContent = {
                                 variableId: "SezNLOdXw3"
                             },
                             elements: [],
-                            path: [
-                                "UTaSFnVtkV",
-                                "uFzaV9SB6q",
-                                "k77Fdcod55",
-                                "BOMdKQBt23"
-                            ]
+                            path: ["UTaSFnVtkV", "uFzaV9SB6q", "k77Fdcod55", "BOMdKQBt23"]
                         }
                     ],
                     path: ["UTaSFnVtkV", "uFzaV9SB6q", "k77Fdcod55"]
@@ -193,4 +183,4 @@ export const simplePageBlockContent = {
         }
     ],
     path: ["UTaSFnVtkV"]
-}
+};

--- a/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageBlockContent.ts
+++ b/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageBlockContent.ts
@@ -1,0 +1,196 @@
+/**
+ * Contains a grid > cell with a heading and a paragraph.
+ * The heading and paragraph are both editable (linked elements).
+ */
+export const simplePageBlockContent = {
+    type: "block",
+    data: {
+        settings: {
+            width: {
+                desktop: {
+                    value: "100%"
+                }
+            },
+            margin: {
+                desktop: {
+                    top: "0px",
+                    right: "0px",
+                    bottom: "0px",
+                    left: "0px",
+                    advanced: true
+                }
+            },
+            padding: {
+                desktop: {
+                    all: "10px"
+                }
+            },
+            horizontalAlignFlex: {
+                desktop: "center"
+            },
+            verticalAlign: {
+                desktop: "flex-start"
+            }
+        },
+        variables: [
+            {
+                id: "FDEezrJ8NH",
+                type: "heading",
+                label: "Heading text",
+                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+            },
+            {
+                id: "SezNLOdXw3",
+                type: "paragraph",
+                label: "Paragraph text",
+                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+            }
+        ]
+    },
+    elements: [
+        {
+            type: "grid",
+            data: {
+                settings: {
+                    width: {
+                        desktop: {
+                            value: "1100px"
+                        }
+                    },
+                    margin: {
+                        desktop: {
+                            top: "0px",
+                            right: "0px",
+                            bottom: "0px",
+                            left: "0px",
+                            advanced: true
+                        }
+                    },
+                    padding: {
+                        desktop: {
+                            all: "10px"
+                        }
+                    },
+                    grid: {
+                        cellsType: "12"
+                    },
+                    gridSettings: {
+                        desktop: {
+                            flexDirection: "row"
+                        },
+                        "mobile-landscape": {
+                            flexDirection: "column"
+                        }
+                    },
+                    horizontalAlignFlex: {
+                        desktop: "flex-start"
+                    },
+                    verticalAlign: {
+                        desktop: "flex-start"
+                    }
+                }
+            },
+            elements: [
+                {
+                    type: "cell",
+                    data: {
+                        settings: {
+                            margin: {
+                                desktop: {
+                                    top: "0px",
+                                    right: "0px",
+                                    bottom: "0px",
+                                    left: "0px",
+                                    advanced: true
+                                }
+                            },
+                            padding: {
+                                desktop: {
+                                    all: "0px"
+                                }
+                            },
+                            grid: {
+                                size: 12
+                            }
+                        }
+                    },
+                    elements: [
+                        {
+                            type: "heading",
+                            data: {
+                                text: {
+                                    desktop: {
+                                        type: "heading",
+                                        alignment: "left",
+                                        tag: "h1"
+                                    },
+                                    data: {
+                                        text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+                                    }
+                                },
+                                settings: {
+                                    margin: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    },
+                                    padding: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    }
+                                },
+                                variableId: "FDEezrJ8NH"
+                            },
+                            elements: [],
+                            path: [
+                                "UTaSFnVtkV",
+                                "uFzaV9SB6q",
+                                "k77Fdcod55",
+                                "BOMdKQBt23"
+                            ]
+                        },
+                        {
+                            type: "paragraph",
+                            data: {
+                                text: {
+                                    desktop: {
+                                        type: "paragraph",
+                                        alignment: "left",
+                                        tag: "p"
+                                    },
+                                    data: {
+                                        text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+                                    }
+                                },
+                                settings: {
+                                    margin: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    },
+                                    padding: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    }
+                                },
+                                variableId: "SezNLOdXw3"
+                            },
+                            elements: [],
+                            path: [
+                                "UTaSFnVtkV",
+                                "uFzaV9SB6q",
+                                "k77Fdcod55",
+                                "BOMdKQBt23"
+                            ]
+                        }
+                    ],
+                    path: ["UTaSFnVtkV", "uFzaV9SB6q", "k77Fdcod55"]
+                }
+            ],
+            path: ["UTaSFnVtkV", "uFzaV9SB6q"]
+        }
+    ],
+    path: ["UTaSFnVtkV"]
+}

--- a/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageTemplateContent.ts
+++ b/packages/api-page-builder/__tests__/graphql/mocks/pageTemplates/simplePageTemplateContent.ts
@@ -1,3 +1,7 @@
+/**
+ * Contains a grid > cell with a heading and a paragraph.
+ * The heading and paragraph are both editable (linked elements).
+ */
 export const simplePageTemplateContent = {
     id: "lk860n5p",
     type: "document",

--- a/packages/api-page-builder/__tests__/graphql/pageTemplates.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pageTemplates.test.ts
@@ -1,5 +1,6 @@
 import useGqlHandler from "./useGqlHandler";
 import { simplePageTemplateContent } from "~tests/graphql/mocks/pageTemplates/simplePageTemplateContent";
+import { simplePageBlockContent } from "~tests/graphql/mocks/pageTemplates/simplePageBlockContent";
 
 jest.setTimeout(100000);
 
@@ -10,7 +11,9 @@ describe("Page Templates Test", () => {
         updatePage,
         unlinkPageFromTemplate,
         createPageFromTemplate,
-        createCategory
+        createCategory,
+        createBlockCategory,
+        createPageBlock
     } = useGqlHandler();
 
     test("unlinking a page from a page template should remove all template-related data", async () => {
@@ -101,20 +104,7 @@ describe("Page Templates Test", () => {
                     id: "yAOxZQgZsv",
                     type: "block",
                     data: {
-                        variables: [
-                            {
-                                id: "aAUBVaa1fB",
-                                type: "heading",
-                                label: "Heading text",
-                                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-HEADING","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
-                            },
-                            {
-                                id: "iwpP2qZAHy",
-                                type: "paragraph",
-                                label: "Paragraph text",
-                                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-PARAGRAPH","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
-                            }
-                        ]
+                        variables: []
                     },
                     elements: [
                         {
@@ -140,6 +130,231 @@ describe("Page Templates Test", () => {
                                                         text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-PARAGRAPH","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
                                                     }
                                                 }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    test("unlinking a page from a page template that contains a block should remove all template-related data", async () => {
+        await createCategory({
+            data: {
+                slug: `slug`,
+                name: `name`,
+                url: `/some-url/`,
+                layout: `layout`
+            }
+        });
+
+        await createBlockCategory({
+            data: {
+                slug: `block-category`,
+                name: `block-category-name`,
+                icon: `block-category-icon`,
+                description: `block-category-description`
+            }
+        });
+
+        const pageBlock = await createPageBlock({
+            data: {
+                name: "New block",
+                blockCategory: "block-category",
+                content: simplePageBlockContent,
+                preview: {}
+            }
+        }).then(([response]) => response.data.pageBuilder.createPageBlock.data);
+
+        const pageTemplate = await createPageTemplate({
+            data: {
+                title: "test-template",
+                slug: "test-template",
+                description: "test",
+                tags: [],
+                layout: "static",
+                pageCategory: "slug"
+            }
+        }).then(([response]) => response.data.pageBuilder.createPageTemplate.data);
+
+        // Add block to the page template.
+        await updatePageTemplate({
+            id: pageTemplate.id,
+            data: {
+                content: {
+                    id: "lkb798zg",
+                    type: "document",
+                    data: {
+                        template: {
+                            variables: [
+                                {
+                                    blockId: "DABBrS43HC",
+                                    variables: []
+                                }
+                            ]
+                        }
+                    },
+                    elements: [
+                        {
+                            id: "DABBrS43HC",
+                            type: "block",
+                            data: {
+                                templateBlockId: "DABBrS43HC",
+                                settings: {
+                                    width: {
+                                        desktop: {
+                                            value: "100%"
+                                        }
+                                    },
+                                    margin: {
+                                        desktop: {
+                                            top: "0px",
+                                            right: "0px",
+                                            bottom: "0px",
+                                            left: "0px",
+                                            advanced: true
+                                        }
+                                    },
+                                    padding: {
+                                        desktop: {
+                                            all: "10px"
+                                        }
+                                    },
+                                    horizontalAlignFlex: {
+                                        desktop: "center"
+                                    },
+                                    verticalAlign: {
+                                        desktop: "flex-start"
+                                    }
+                                },
+                                variables: [],
+                                blockId: pageBlock.id
+                            },
+                            elements: [],
+                            path: ["lkb798zg"]
+                        }
+                    ],
+                    path: []
+                }
+            }
+        });
+
+        const pageCreatedFromTemplate = await createPageFromTemplate({
+            category: "slug",
+            templateId: pageTemplate.id,
+            meta: {
+                location: {
+                    folderId: "root"
+                }
+            }
+        }).then(([response]) => response.data.pageBuilder.createPageFromTemplate.data);
+
+        // Update values of "Heading text" and "Paragraph text" variables. This how it's done in the page editor.
+        await updatePage({
+            id: pageCreatedFromTemplate.id,
+            data: {
+                content: {
+                    id: "lkb798zg",
+                    type: "document",
+                    data: {
+                        template: {
+                            variables: [
+                                {
+                                    blockId: "DABBrS43HC",
+                                    variables: [
+                                        {
+                                            id: "FDEezrJ8NH",
+                                            label: "Heading text",
+                                            type: "heading",
+                                            value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-HEADING","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                                        },
+                                        {
+                                            id: "SezNLOdXw3",
+                                            label: "Paragraph text",
+                                            type: "paragraph",
+                                            value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-PARAGRAPH","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                                        }
+                                    ]
+                                }
+                            ],
+                            slug: "test-template"
+                        }
+                    },
+                    elements: [],
+                    path: []
+                }
+            }
+        });
+
+        // Unlinked page should no longer contain template variable-related data.
+        const unlinkedPage = await unlinkPageFromTemplate({ id: pageCreatedFromTemplate.id }).then(
+            ([response]) => response.data.pageBuilder.unlinkPageFromTemplate.data
+        );
+
+        expect(unlinkedPage.content).toMatchObject({
+            id: "lkb798zg",
+            type: "document",
+            data: {},
+            elements: [
+                {
+                    data: {
+                        variables: [
+                            {
+                                id: "FDEezrJ8NH",
+                                type: "heading",
+                                label: "Heading text",
+                                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-HEADING","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                            },
+                            {
+                                id: "SezNLOdXw3",
+                                type: "paragraph",
+                                label: "Paragraph text",
+                                value: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-PARAGRAPH","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                            }
+                        ],
+                        blockId: pageBlock.id
+                    },
+                    elements: [
+                        {
+                            type: "grid",
+                            elements: [
+                                {
+                                    type: "cell",
+                                    elements: [
+                                        {
+                                            type: "heading",
+                                            data: {
+                                                text: {
+                                                    desktop: {
+                                                        type: "heading",
+                                                        alignment: "left",
+                                                        tag: "h1"
+                                                    },
+                                                    data: {
+                                                        text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-HEADING","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"heading-element","version":1,"tag":"h1","styles":[{"styleId":"heading1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                                                    }
+                                                },
+                                                variableId: "FDEezrJ8NH"
+                                            }
+                                        },
+                                        {
+                                            type: "paragraph",
+                                            data: {
+                                                text: {
+                                                    desktop: {
+                                                        type: "paragraph",
+                                                        alignment: "left",
+                                                        tag: "p"
+                                                    },
+                                                    data: {
+                                                        text: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"UPDATED-PARAGRAPH","type":"text","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph-element","version":1,"styles":[{"styleId":"paragraph1","type":"typography"}]}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+                                                    }
+                                                },
+                                                variableId: "SezNLOdXw3"
                                             }
                                         }
                                     ]


### PR DESCRIPTION
## Changes
This PR further addresses unlinking of pages created from page templates, by ensuring that both pages consisting of basic page elements and pages that include one or more blocks are unlinked correctly.

Previously, unlinking a page with one or more blocks in it (in the page template from which the page was created) would result in variables not being correctly applied to page elements and users loosing the values they entered prior to unlinking.

## How Has This Been Tested?
Manually, added a Jest test.

## Documentation
N/A
