### PR TITLE
fix(Lexical): Header input reset to paragraph

### DIFF
--- a/packages/lexical-editor/src/nodes/HeadingNode.ts
+++ b/packages/lexical-editor/src/nodes/HeadingNode.ts
@@ -10,7 +10,7 @@ import {
     HeadingTagType,
     SerializedHeadingNode as BaseSerializedHeadingNode
 } from "@lexical/rich-text";
-import { $createParagraphNode, ParagraphNode } from "~/nodes/ParagraphNode";
+import { ParagraphNode } from "~/nodes/ParagraphNode";
 
 export type SerializeHeadingNode = Spread<
     {
@@ -152,9 +152,7 @@ export class HeadingNode
     }
 
     override collapseAtStart(): true {
-        const newElement = !this.isEmpty()
-            ? $createHeadingNode(this.getTag())
-            : $createParagraphNode();
+        const newElement = $createHeadingNode(this.getTag());
         const children = this.getChildren();
         children.forEach(child => newElement.append(child));
         this.replace(newElement);


### PR DESCRIPTION
With this PR we want to fix the issue when the text in the header input is reset to the text with the paragraph tag when the user completely removes the text from the input.

Where this bug occurred: PB, PB variable inputs, and HCMS.

## Changes
Changes in the method `collapseAtStart`. Remove the reset to paragraph tag when the text is empty.

## How Has This Been Tested?
Manually. Check the videos below.

## Tests

### Page Builder test - block variable inputs included in this test.
https://github.com/webiny/webiny-js/assets/82515066/a76096d3-e7bf-43c9-84ea-5c365fa7b966


### Headless CMS test case
https://github.com/webiny/webiny-js/assets/82515066/22aff7d2-7b67-4769-ae90-9988bfdc3cbe



