### PR TITLE
Page Builder - Fixed Flushing of Pages

### DIFF
--- a/packages/api-page-builder/src/prerendering/prerenderingHandlers.ts
+++ b/packages/api-page-builder/src/prerendering/prerenderingHandlers.ts
@@ -1,4 +1,3 @@
-import lodashGet from "lodash/get";
 import WebinyError from "@webiny/error";
 import { FlushEvent, RenderEvent, QueueAddJob } from "@webiny/api-prerendering-service/types";
 import { ContextPlugin } from "@webiny/api";

--- a/packages/api-page-builder/src/prerendering/prerenderingHandlers.ts
+++ b/packages/api-page-builder/src/prerendering/prerenderingHandlers.ts
@@ -89,14 +89,8 @@ export const prerenderingHandlers = new ContextPlugin<PbContext>(context => {
         },
 
         async flush(args): Promise<void> {
-            const current = await context.pageBuilder.getCurrentSettings();
             const tenant = context.tenancy.getCurrentTenant().id;
             const locale = context.i18n.getContentLocale()!;
-            const storageName = lodashGet(current, "prerendering.storage.name");
-
-            if (!storageName) {
-                return;
-            }
 
             const { paths, tags } = args;
 


### PR DESCRIPTION
## Changes
The `flush` method of the prerendering service's handler was reading storage name from the prerendering service settings (`prerendering.storage.name`). But, since these settings don't exist for a long time, the flush logic below the if condition would never be executed.

Not sure why this was still here, probably it was left by an accident? @Pavel910 

## How Has This Been Tested?
Manually.

## Documentation
Changelog.