### PR TITLE
fix(api-headless-cms): permissions checks

### DIFF
--- a/packages/api-headless-cms/src/context.ts
+++ b/packages/api-headless-cms/src/context.ts
@@ -96,10 +96,10 @@ export const createContextPlugin = ({ storageOperations }: CrudParams) => {
                 MANAGE: type === "manage",
                 storageOperations,
                 permissions: {
-                    modelGroupsPermissions,
-                    modelsPermissions,
-                    entriesPermissions,
-                    settingsPermissions
+                    groups: modelGroupsPermissions,
+                    models: modelsPermissions,
+                    entries: entriesPermissions,
+                    settings: settingsPermissions
                 },
                 ...createSystemCrud({
                     context,

--- a/packages/api-headless-cms/src/context.ts
+++ b/packages/api-headless-cms/src/context.ts
@@ -95,6 +95,12 @@ export const createContextPlugin = ({ storageOperations }: CrudParams) => {
                 PREVIEW: type === "preview",
                 MANAGE: type === "manage",
                 storageOperations,
+                permissions: {
+                    modelGroupsPermissions,
+                    modelsPermissions,
+                    entriesPermissions,
+                    settingsPermissions
+                },
                 ...createSystemCrud({
                     context,
                     getTenant,

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -412,37 +412,35 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
      * A helper to delete the entire entry.
      */
     const deleteEntryHelper = async (params: DeleteEntryParams): Promise<void> => {
-        return context.benchmark.measure("headlessCms.crud.entries.deleteEntry", async () => {
-            const { model, entry } = params;
-            try {
-                await onEntryBeforeDelete.publish({
-                    entry,
-                    model
-                });
+        const { model, entry } = params;
+        try {
+            await onEntryBeforeDelete.publish({
+                entry,
+                model
+            });
 
-                await storageOperations.entries.delete(model, {
+            await storageOperations.entries.delete(model, {
+                entry
+            });
+
+            await onEntryAfterDelete.publish({
+                entry,
+                model
+            });
+        } catch (ex) {
+            await onEntryDeleteError.publish({
+                entry,
+                model,
+                error: ex
+            });
+            throw new WebinyError(
+                ex.message || "Could not delete entry.",
+                ex.code || "DELETE_ERROR",
+                {
                     entry
-                });
-
-                await onEntryAfterDelete.publish({
-                    entry,
-                    model
-                });
-            } catch (ex) {
-                await onEntryDeleteError.publish({
-                    entry,
-                    model,
-                    error: ex
-                });
-                throw new WebinyError(
-                    ex.message || "Could not delete entry.",
-                    ex.code || "DELETE_ERROR",
-                    {
-                        entry
-                    }
-                );
-            }
-        });
+                }
+            );
+        }
     };
     /**
      * A helper to get entries by revision IDs
@@ -450,14 +448,23 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     const getEntriesByIds: CmsEntryContext["getEntriesByIds"] = async (model, ids) => {
         return context.benchmark.measure("headlessCms.crud.entries.getEntriesByIds", async () => {
             await entriesPermissions.ensure({ rwd: "r" });
-            await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+            await modelsPermissions.ensureCanAccessModel({
+                model
+            });
 
             const entries = await storageOperations.entries.getByIds(model, {
                 ids
             });
 
             return filterAsync(entries, async entry => {
-                return entriesPermissions.ensure({ owns: entry.createdBy }, { throw: false });
+                return entriesPermissions.ensure(
+                    {
+                        owns: entry.createdBy
+                    },
+                    {
+                        throw: false
+                    }
+                );
             });
         });
     };
@@ -480,7 +487,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         ids
     ) => {
         await entriesPermissions.ensure({ rwd: "r" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const entries = await storageOperations.entries.getPublishedByIds(model, {
             ids
@@ -492,7 +501,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     };
     const getLatestEntriesByIds: CmsEntryContext["getLatestEntriesByIds"] = async (model, ids) => {
         await entriesPermissions.ensure({ rwd: "r" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const entries = await storageOperations.entries.getLatestByIds(model, {
             ids
@@ -544,7 +555,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 }
             });
         }
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const { where: initialWhere, limit: initialLimit } = params;
         const limit = initialLimit && initialLimit > 0 ? initialLimit : 50;
@@ -633,7 +646,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     };
     const createEntry: CmsEntryContext["createEntry"] = async (model, inputData) => {
         await entriesPermissions.ensure({ rwd: "w" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         /**
          * Make sure we only work with fields that are defined in the model.
@@ -730,7 +745,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         inputData
     ) => {
         await entriesPermissions.ensure({ rwd: "w" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         /**
          * Make sure we only work with fields that are defined in the model.
@@ -855,7 +872,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     };
     const updateEntry: CmsEntryContext["updateEntry"] = async (model, id, inputData, metaInput) => {
         await entriesPermissions.ensure({ rwd: "w" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         /**
          * Make sure we only work with fields that are defined in the model.
@@ -978,7 +997,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
     const moveEntry: CmsEntryContext["moveEntry"] = async (model, id, folderId) => {
         await entriesPermissions.ensure({ rwd: "w" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
         /**
          * The entry we are going to move to another folder.
          */
@@ -1021,7 +1042,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
     const republishEntry: CmsEntryContext["republishEntry"] = async (model, id) => {
         await entriesPermissions.ensure({ rwd: "w" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         /**
          * Fetch the entry from the storage.
@@ -1116,7 +1139,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         revisionId
     ) => {
         await entriesPermissions.ensure({ rwd: "d" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const { id: entryId, version } = parseIdentifier(revisionId);
 
@@ -1224,7 +1249,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         }
 
         await entriesPermissions.ensure({ rwd: "d" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const { items: entries } = await storageOperations.entries.list(model, {
             where: {
@@ -1277,7 +1304,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
     const deleteEntry: CmsEntryContext["deleteEntry"] = async (model, id, options) => {
         await entriesPermissions.ensure({ rwd: "d" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const { force } = options || {};
 
@@ -1319,7 +1348,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     };
     const publishEntry: CmsEntryContext["publishEntry"] = async (model, id) => {
         await entriesPermissions.ensure({ pw: "p" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
             id
@@ -1455,7 +1486,9 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
     const getUniqueFieldValues: CmsEntryContext["getUniqueFieldValues"] = async (model, params) => {
         await entriesPermissions.ensure({ rwd: "r" });
-        await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
 
         const { where: initialWhere, fieldId } = params;
 

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -4,23 +4,23 @@ import {
     CmsContext,
     CmsModel,
     CmsModelContext,
+    CmsModelGroup,
     CmsModelManager,
-    HeadlessCmsStorageOperations,
-    OnModelBeforeCreateTopicParams,
-    OnModelAfterCreateTopicParams,
-    OnModelBeforeUpdateTopicParams,
-    OnModelAfterUpdateTopicParams,
-    OnModelBeforeDeleteTopicParams,
-    OnModelAfterDeleteTopicParams,
-    OnModelInitializeParams,
-    OnModelBeforeCreateFromTopicParams,
-    OnModelAfterCreateFromTopicParams,
     CmsModelUpdateInput,
+    HeadlessCmsStorageOperations,
+    OnModelAfterCreateFromTopicParams,
+    OnModelAfterCreateTopicParams,
+    OnModelAfterDeleteTopicParams,
+    OnModelAfterUpdateTopicParams,
+    OnModelBeforeCreateFromTopicParams,
+    OnModelBeforeCreateTopicParams,
+    OnModelBeforeDeleteTopicParams,
+    OnModelBeforeUpdateTopicParams,
     OnModelCreateErrorTopicParams,
     OnModelCreateFromErrorParams,
-    OnModelUpdateErrorTopicParams,
     OnModelDeleteErrorTopicParams,
-    CmsModelGroup
+    OnModelInitializeParams,
+    OnModelUpdateErrorTopicParams
 } from "~/types";
 import { NotFoundError } from "@webiny/handler-graphql";
 import { contentModelManagerFactory } from "./contentModel/contentModelManagerFactory";
@@ -42,9 +42,8 @@ import {
     createModelCreateValidation,
     createModelUpdateValidation
 } from "~/crud/contentModel/validation";
-import { createZodError } from "@webiny/utils";
+import { createZodError, removeUndefinedValues } from "@webiny/utils";
 import { assignModelDefaultFields } from "~/crud/contentModel/defaultFields";
-import { removeUndefinedValues } from "@webiny/utils";
 import {
     ensurePluralApiName,
     ensureSingularApiName
@@ -203,7 +202,9 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                     return false;
                 }
 
-                return modelsPermissions.canAccessModel({ model, locale: getLocale().code });
+                return modelsPermissions.canAccessModel({
+                    model
+                });
             });
         });
     };
@@ -215,7 +216,9 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
             const model = await modelsGet(modelId);
 
             await modelsPermissions.ensure({ owns: model.createdBy });
-            await modelsPermissions.ensureCanAccessModel({ model, locale: getLocale().code });
+            await modelsPermissions.ensureCanAccessModel({
+                model
+            });
 
             return model;
         });

--- a/packages/api-headless-cms/src/crud/contentModelGroup.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModelGroup.crud.ts
@@ -1,20 +1,20 @@
 import DataLoader from "dataloader";
 import WebinyError from "@webiny/error";
 import {
+    CmsContext,
+    CmsGroup,
     CmsGroupContext,
     CmsGroupListParams,
-    CmsGroup,
-    CmsContext,
     HeadlessCmsStorageOperations,
-    OnGroupBeforeCreateTopicParams,
     OnGroupAfterCreateTopicParams,
-    OnGroupBeforeUpdateTopicParams,
-    OnGroupAfterUpdateTopicParams,
-    OnGroupBeforeDeleteTopicParams,
     OnGroupAfterDeleteTopicParams,
+    OnGroupAfterUpdateTopicParams,
+    OnGroupBeforeCreateTopicParams,
+    OnGroupBeforeDeleteTopicParams,
+    OnGroupBeforeUpdateTopicParams,
     OnGroupCreateErrorTopicParams,
-    OnGroupUpdateErrorTopicParams,
-    OnGroupDeleteErrorTopicParams
+    OnGroupDeleteErrorTopicParams,
+    OnGroupUpdateErrorTopicParams
 } from "~/types";
 import { NotFoundError } from "@webiny/handler-graphql";
 import { CmsGroupPlugin } from "~/plugins/CmsGroupPlugin";
@@ -185,7 +185,9 @@ export const createModelGroupsCrud = (params: CreateModelGroupsCrudParams): CmsG
         const group = await getGroupViaDataLoader(id);
 
         await modelGroupsPermissions.ensure({ owns: group.createdBy });
-        await modelGroupsPermissions.ensureCanAccessGroup({ group, locale: getLocale().code });
+        await modelGroupsPermissions.ensureCanAccessGroup({
+            group
+        });
 
         return group;
     };
@@ -216,8 +218,7 @@ export const createModelGroupsCrud = (params: CreateModelGroupsCrudParams): CmsG
             }
 
             return await modelGroupsPermissions.canAccessGroup({
-                group,
-                locale: getLocale().code
+                group
             });
         });
     };

--- a/packages/api-headless-cms/src/index.ts
+++ b/packages/api-headless-cms/src/index.ts
@@ -53,5 +53,6 @@ export const createHeadlessCmsContext = (params: ContentContextParams) => {
 export * from "~/graphqlFields";
 export * from "~/plugins";
 export * from "~/utils/incrementEntryIdVersion";
+export * from "~/utils/access";
 export * from "./graphql/handleRequest";
 export { entryToStorageTransform, entryFieldFromStorageTransform, entryFromStorageTransform };

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -10,8 +10,19 @@ import { SecurityPermission } from "@webiny/api-security/types";
 import { DbContext } from "@webiny/handler-db/types";
 import { Topic } from "@webiny/pubsub/types";
 import { CmsModelConverterCallable } from "~/utils/converters/ConverterCollection";
+import { ModelGroupsPermissions } from "~/utils/permissions/ModelGroupsPermissions";
+import { ModelsPermissions } from "~/utils/permissions/ModelsPermissions";
+import { EntriesPermissions } from "~/utils/permissions/EntriesPermissions";
+import { SettingsPermissions } from "~/utils/permissions/SettingsPermissions";
 
 export type ApiEndpoint = "manage" | "preview" | "read";
+
+interface HeadlessCmsPermissions {
+    modelGroupsPermissions: ModelGroupsPermissions;
+    modelsPermissions: ModelsPermissions;
+    entriesPermissions: EntriesPermissions;
+    settingsPermissions: SettingsPermissions;
+}
 
 export interface HeadlessCms
     extends CmsSettingsContext,
@@ -47,6 +58,12 @@ export interface HeadlessCms
      * The storage operations loaded for current context.
      */
     storageOperations: HeadlessCmsStorageOperations;
+    /**
+     * Permissions for settings, groups, models and entries.
+     *
+     * @internal
+     */
+    permissions: HeadlessCmsPermissions;
 }
 
 /**

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -18,10 +18,10 @@ import { SettingsPermissions } from "~/utils/permissions/SettingsPermissions";
 export type ApiEndpoint = "manage" | "preview" | "read";
 
 interface HeadlessCmsPermissions {
-    modelGroupsPermissions: ModelGroupsPermissions;
-    modelsPermissions: ModelsPermissions;
-    entriesPermissions: EntriesPermissions;
-    settingsPermissions: SettingsPermissions;
+    groups: ModelGroupsPermissions;
+    models: ModelsPermissions;
+    entries: EntriesPermissions;
+    settings: SettingsPermissions;
 }
 
 export interface HeadlessCms

--- a/packages/api-headless-cms/src/utils/access.ts
+++ b/packages/api-headless-cms/src/utils/access.ts
@@ -1,0 +1,40 @@
+import { CmsContext, CmsGroup, CmsModel } from "~/types";
+
+interface PickedCmsContext {
+    cms: Pick<CmsContext["cms"], "permissions">;
+}
+
+type PickedCmsGroup = Pick<CmsGroup, "id" | "locale">;
+type PickedCmsModel = Pick<CmsModel, "modelId" | "locale" | "group">;
+
+export const validateGroupAccess = async (
+    context: PickedCmsContext,
+    group: PickedCmsGroup
+): Promise<boolean> => {
+    const { modelGroupsPermissions } = context.cms.permissions;
+
+    return modelGroupsPermissions.canAccessGroup({
+        group
+    });
+};
+
+export const validateModelAccess = async (
+    context: PickedCmsContext,
+    model: PickedCmsModel
+): Promise<boolean> => {
+    const { modelsPermissions } = context.cms.permissions;
+    return modelsPermissions.canAccessModel({
+        model
+    });
+};
+
+export const checkModelAccess = async (
+    context: PickedCmsContext,
+    model: PickedCmsModel
+): Promise<void> => {
+    const { modelsPermissions } = context.cms.permissions;
+
+    await modelsPermissions.ensureCanAccessModel({
+        model
+    });
+};

--- a/packages/api-headless-cms/src/utils/access.ts
+++ b/packages/api-headless-cms/src/utils/access.ts
@@ -11,9 +11,9 @@ export const validateGroupAccess = async (
     context: PickedCmsContext,
     group: PickedCmsGroup
 ): Promise<boolean> => {
-    const { modelGroupsPermissions } = context.cms.permissions;
+    const { groups } = context.cms.permissions;
 
-    return modelGroupsPermissions.canAccessGroup({
+    return groups.canAccessGroup({
         group
     });
 };
@@ -22,8 +22,8 @@ export const validateModelAccess = async (
     context: PickedCmsContext,
     model: PickedCmsModel
 ): Promise<boolean> => {
-    const { modelsPermissions } = context.cms.permissions;
-    return modelsPermissions.canAccessModel({
+    const { models } = context.cms.permissions;
+    return models.canAccessModel({
         model
     });
 };
@@ -32,9 +32,9 @@ export const checkModelAccess = async (
     context: PickedCmsContext,
     model: PickedCmsModel
 ): Promise<void> => {
-    const { modelsPermissions } = context.cms.permissions;
+    const { models } = context.cms.permissions;
 
-    await modelsPermissions.ensureCanAccessModel({
+    await models.ensureCanAccessModel({
         model
     });
 };

--- a/packages/api-headless-cms/src/utils/permissions/ModelGroupsPermissions.ts
+++ b/packages/api-headless-cms/src/utils/permissions/ModelGroupsPermissions.ts
@@ -1,22 +1,23 @@
 import { AppPermissions, NotAuthorizedError } from "@webiny/api-security";
 import { CmsGroup, CmsGroupPermission } from "~/types";
 
-interface CanAccessGroupParams {
-    group: CmsGroup;
-    locale: string;
+export interface CanAccessGroupParams {
+    group: Pick<CmsGroup, "id" | "locale">;
 }
 
 export class ModelGroupsPermissions extends AppPermissions<CmsGroupPermission> {
-    async canAccessGroup({ group, locale }: CanAccessGroupParams) {
+    async canAccessGroup({ group }: CanAccessGroupParams) {
         if (await this.hasFullAccess()) {
             return true;
         }
 
         const permissions = await this.getPermissions();
 
-        for (let i = 0; i < permissions.length; i++) {
-            const permission = permissions[i];
+        const locale = group.locale;
+
+        for (const permission of permissions) {
             const { groups } = permission;
+
             // When no groups defined on permission it means user has access to everything.
             if (!groups) {
                 return true;
@@ -28,7 +29,7 @@ export class ModelGroupsPermissions extends AppPermissions<CmsGroupPermission> {
                 Array.isArray(groups[locale]) === false ||
                 groups[locale].includes(group.id) === false
             ) {
-                return false;
+                continue;
             }
             return true;
         }


### PR DESCRIPTION
## Changes

The main part of this PR is the export of access checks for models and groups. Adrian removed those when he introduced new security stuff.

PR also includes:
* attach permissions to the CmsContext so they are available to the public
* remove unnecessary locale parameter from model and group permission checks as it already exists on both group and model
* group permission check params now require only a small part of the group object to be sent into it
* model permission check params now require only a small part of the model object to be sent into it

## How Has This Been Tested?
Jest and manually.