### PR TITLE
Website App's Origin Request Router: Added Missing `isLambdaFunctionRole` Meta Property

### DIFF
--- a/packages/pulumi-aws/src/apps/tenantRouter.ts
+++ b/packages/pulumi-aws/src/apps/tenantRouter.ts
@@ -81,7 +81,8 @@ export function applyTenantRouter(
                     }
                 ]
             }
-        }
+        },
+        meta: { isLambdaFunctionRole: true }
     });
 
     const awsUsEast1 = new aws.Provider("us-east-1", { region: "us-east-1" });


### PR DESCRIPTION
## Changes
This PR adds the missing `isLambdaFunctionRole` meta property to the role that's used with origin-request Lambda function's role. This will ensure that the `AWSLambdaVPCAccessExecutionRole` policy is properly attached when the user is using "existing VPCs" EE feature.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.