### PR TITLE
fix(data-migration): logger with trace level

### DIFF
--- a/packages/data-migration/package.json
+++ b/packages/data-migration/package.json
@@ -24,6 +24,7 @@
     "dynamodb-toolbox": "^0.3.5",
     "minimatch": "^5.1.6",
     "pino": "^8.11.0",
+    "pino-pretty": "^9.4.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/packages/data-migration/package.json
+++ b/packages/data-migration/package.json
@@ -17,13 +17,13 @@
     "@webiny/db-dynamodb": "0.0.0",
     "@webiny/handler-aws": "0.0.0",
     "@webiny/ioc": "0.0.0",
+    "@webiny/logger": "0.0.0",
     "@webiny/utils": "0.0.0",
     "center-align": "^1.0.1",
     "chalk": "^4.1.2",
     "dynamodb-toolbox": "^0.3.5",
     "minimatch": "^5.1.6",
     "pino": "^8.11.0",
-    "pino-pretty": "^9.4.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/packages/data-migration/package.json
+++ b/packages/data-migration/package.json
@@ -23,7 +23,6 @@
     "chalk": "^4.1.2",
     "dynamodb-toolbox": "^0.3.5",
     "minimatch": "^5.1.6",
-    "pino": "^8.11.0",
     "pino-pretty": "^9.4.0",
     "semver": "^6.3.0"
   },

--- a/packages/data-migration/src/MigrationRunner.ts
+++ b/packages/data-migration/src/MigrationRunner.ts
@@ -1,5 +1,5 @@
 import { coerce } from "semver";
-import { Logger } from "pino";
+import { Logger } from "@webiny/logger";
 import { inject, makeInjectable } from "@webiny/ioc";
 import { executeWithRetry, mdbid } from "@webiny/utils";
 import {

--- a/packages/data-migration/src/createPinoLogger.ts
+++ b/packages/data-migration/src/createPinoLogger.ts
@@ -1,11 +1,17 @@
 import chalk from "chalk";
+import pinoPretty from "pino-pretty";
 import { DataMigration } from "~/types";
 import { createPinoLogger as baseCreatePinoLogger, getLogLevel, Logger } from "@webiny/logger";
 
 export const createPinoLogger = () => {
-    return baseCreatePinoLogger({
-        level: getLogLevel(process.env.MIGRATIONS_LOG_LEVEL, "trace")
-    });
+    return baseCreatePinoLogger(
+        {
+            level: getLogLevel(process.env.MIGRATIONS_LOG_LEVEL, "trace")
+        },
+        pinoPretty({
+            ignore: "pid,hostname"
+        })
+    );
 };
 
 export const getChildLogger = (logger: Logger, migration: DataMigration) => {

--- a/packages/data-migration/src/createPinoLogger.ts
+++ b/packages/data-migration/src/createPinoLogger.ts
@@ -1,14 +1,11 @@
 import chalk from "chalk";
-import { pino, Logger } from "pino";
-import pinoPretty from "pino-pretty";
 import { DataMigration } from "~/types";
+import { createPinoLogger as baseCreatePinoLogger, getLogLevel, Logger } from "@webiny/logger";
 
 export const createPinoLogger = () => {
-    return pino(
-        pinoPretty({
-            ignore: "pid,hostname"
-        })
-    );
+    return baseCreatePinoLogger({
+        level: getLogLevel(process.env.MIGRATIONS_LOG_LEVEL, "trace")
+    });
 };
 
 export const getChildLogger = (logger: Logger, migration: DataMigration) => {

--- a/packages/data-migration/src/types.ts
+++ b/packages/data-migration/src/types.ts
@@ -1,6 +1,6 @@
-import { Logger } from "pino";
+import { Logger } from "@webiny/logger";
 
-export { Logger };
+export type { Logger };
 
 export interface MigrationItem {
     id: string;

--- a/packages/data-migration/tsconfig.build.json
+++ b/packages/data-migration/tsconfig.build.json
@@ -5,6 +5,7 @@
     { "path": "../db-dynamodb/tsconfig.build.json" },
     { "path": "../handler-aws/tsconfig.build.json" },
     { "path": "../ioc/tsconfig.build.json" },
+    { "path": "../logger/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" }
   ],
   "compilerOptions": {

--- a/packages/data-migration/tsconfig.json
+++ b/packages/data-migration/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "../db-dynamodb" },
     { "path": "../handler-aws" },
     { "path": "../ioc" },
+    { "path": "../logger" },
     { "path": "../utils" }
   ],
   "compilerOptions": {
@@ -20,6 +21,8 @@
       "@webiny/handler-aws": ["../handler-aws/src"],
       "@webiny/ioc/*": ["../ioc/src/*"],
       "@webiny/ioc": ["../ioc/src"],
+      "@webiny/logger/*": ["../logger/src/*"],
+      "@webiny/logger": ["../logger/src"],
       "@webiny/utils/*": ["../utils/src/*"],
       "@webiny/utils": ["../utils/src"]
     },

--- a/packages/logger/.babelrc.js
+++ b/packages/logger/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require("@webiny/project-utils").createBabelConfigForNode({ path: __dirname });

--- a/packages/logger/LICENSE
+++ b/packages/logger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,15 @@
+# @webiny/logger
+[![](https://img.shields.io/npm/dw/@webiny/logger.svg)](https://www.npmjs.com/package/@webiny/logger) 
+[![](https://img.shields.io/npm/v/@webiny/logger.svg)](https://www.npmjs.com/package/@webiny/logger)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+## Install
+```
+npm install --save @webiny/logger
+```
+
+Or if you prefer yarn: 
+```
+yarn add @webiny/logger
+```

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@webiny/logger",
+  "version": "0.0.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "description": "Core package for all of our API packages.",
+  "contributors": [
+    "Bruno Zorić <bruno@webiny.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.22.6"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.22.6",
+    "@babel/core": "^7.22.8",
+    "@babel/preset-env": "^7.22.7",
+    "@babel/preset-typescript": "^7.22.5",
+    "@webiny/cli": "0.0.0",
+    "@webiny/project-utils": "0.0.0",
+    "pino": "^8.11.0",
+    "pino-pretty": "^9.4.0",
+    "rimraf": "^3.0.2",
+    "ttypescript": "^1.5.13",
+    "typescript": "4.7.4"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "scripts": {
+    "build": "yarn webiny run build",
+    "watch": "yarn webiny run watch"
+  },
+  "gitHead": "8476da73b653c89cc1474d968baf55c1b0ae0e5f"
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -22,7 +22,6 @@
     "@webiny/cli": "0.0.0",
     "@webiny/project-utils": "0.0.0",
     "pino": "^8.11.0",
-    "pino-pretty": "^9.4.0",
     "rimraf": "^3.0.2",
     "ttypescript": "^1.5.13",
     "typescript": "4.7.4"

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,51 @@
+import { LevelWithSilent, Logger, LoggerOptions as BaseLoggerOptions, pino } from "pino";
+import pinoPretty from "pino-pretty";
+
+export * from "pino";
+
+export interface RedactOptions {
+    paths: string[];
+    censor?: string | ((value: any, path: string[]) => any);
+    remove?: boolean;
+}
+
+export interface LoggerOptions extends Omit<BaseLoggerOptions, "redact"> {
+    redact?: string[] | RedactOptions;
+}
+
+const levels: LevelWithSilent[] = ["fatal", "error", "warn", "info", "debug", "trace", "silent"];
+/**
+ * Gets the log level from the input or the LOG_LEVEL environment variable.
+ */
+export const getLogLevel = (input?: string, defaultLevel: LevelWithSilent = "info"): string => {
+    input = input || process.env.LOG_LEVEL;
+    if (!input || input.length === 0) {
+        return defaultLevel;
+    }
+    return levels.includes(input as LevelWithSilent) ? input : defaultLevel;
+};
+
+let logger: Logger;
+
+export const createPinoLogger = (options: LoggerOptions = {}) => {
+    return pino(
+        {
+            level: getLogLevel(options?.level),
+            ...(options || {})
+        },
+        pinoPretty({
+            ignore: "pid,hostname"
+        })
+    );
+};
+
+export const configureLogger = (options: LoggerOptions): void => {
+    logger = createPinoLogger(options);
+};
+
+export const getLogger = () => {
+    if (!logger) {
+        logger = createPinoLogger();
+    }
+    return logger;
+};

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,10 @@
-import { LevelWithSilent, Logger, LoggerOptions as BaseLoggerOptions, pino } from "pino";
-import pinoPretty from "pino-pretty";
+import {
+    DestinationStream,
+    LevelWithSilent,
+    Logger,
+    LoggerOptions as BaseLoggerOptions,
+    pino
+} from "pino";
 
 export * from "pino";
 
@@ -27,20 +32,19 @@ export const getLogLevel = (input?: string, defaultLevel: LevelWithSilent = "inf
 
 let logger: Logger;
 
-export const createPinoLogger = (options: LoggerOptions = {}) => {
-    return pino(
-        {
-            level: getLogLevel(options?.level),
-            ...(options || {})
-        },
-        pinoPretty({
-            ignore: "pid,hostname"
-        })
-    );
+export const createPinoLogger = (input?: LoggerOptions, stream?: DestinationStream) => {
+    const options = {
+        ...(input || {}),
+        level: getLogLevel(input?.level)
+    };
+    if (!stream) {
+        return pino(options);
+    }
+    return pino(options, stream);
 };
 
-export const configureLogger = (options: LoggerOptions): void => {
-    logger = createPinoLogger(options);
+export const configureLogger = (options: LoggerOptions, stream?: DestinationStream): void => {
+    logger = createPinoLogger(options, stream);
 };
 
 export const getLogger = () => {

--- a/packages/logger/tsconfig.build.json
+++ b/packages/logger/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"]
+    },
+    "baseUrl": "."
+  }
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"]
+    },
+    "baseUrl": "."
+  }
+}

--- a/packages/logger/webiny.config.js
+++ b/packages/logger/webiny.config.js
@@ -1,0 +1,8 @@
+const { createWatchPackage, createBuildPackage } = require("@webiny/project-utils");
+
+module.exports = {
+    commands: {
+        build: createBuildPackage({ cwd: __dirname }),
+        watch: createWatchPackage({ cwd: __dirname })
+    }
+};

--- a/packages/migrations/src/migrations/5.37.0/002/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.37.0/002/ddb-es/index.ts
@@ -241,12 +241,12 @@ export class CmsEntriesRootFolder_5_37_0_002
                 for (const esRecord of esRecords) {
                     const decompressedData = await getDecompressedData<CmsEntry>(esRecord.data);
                     if (!decompressedData) {
-                        logger.debug(
+                        logger.trace(
                             `Skipping record "${esRecord.PK}" as it is not a valid CMS entry...`
                         );
                         continue;
                     } else if (decompressedData.location?.folderId) {
-                        logger.debug(
+                        logger.trace(
                             `Skipping record "${decompressedData.entryId}" as it already has folderId defined...`
                         );
                         continue;

--- a/packages/migrations/src/migrations/5.37.0/002/ddb/index.ts
+++ b/packages/migrations/src/migrations/5.37.0/002/ddb/index.ts
@@ -45,6 +45,9 @@ export class CmsEntriesRootFolder_5_37_0_002
     }
 
     async shouldExecute({ logger }: DataMigrationContext): Promise<boolean> {
+        /**
+         * We will go through a larger amount of the entries, to determine if they need to be updated.
+         */
         const result = await scan<CmsEntry>({
             entity: this.entryEntity,
             options: {
@@ -55,7 +58,7 @@ export class CmsEntriesRootFolder_5_37_0_002
                         beginsWith: "cms.entry"
                     }
                 ],
-                limit: 1
+                limit: 100
             }
         });
 
@@ -66,12 +69,14 @@ export class CmsEntriesRootFolder_5_37_0_002
             logger.error(result.error);
             throw new Error(result.error);
         }
-        const [item] = result.items;
-        /**
-         * If no location.folderId was set, we need to push the upgrade.
-         */
-        if (!item.location?.folderId) {
-            return true;
+
+        for (const item of result.items) {
+            /**
+             * If no location.folderId was set, we need to push the upgrade.
+             */
+            if (!item.location?.folderId) {
+                return true;
+            }
         }
         logger.info(`CMS entries already upgraded. skipping...`);
         return false;
@@ -88,6 +93,11 @@ export class CmsEntriesRootFolder_5_37_0_002
             return;
         }
 
+        let usingKey = "";
+        if (migrationStatus?.lastEvaluatedKey) {
+            usingKey = JSON.stringify(migrationStatus.lastEvaluatedKey);
+        }
+        logger.debug(`Scanning DynamoDB table... ${usingKey}`);
         await ddbScanWithCallback<CmsEntry>(
             {
                 entity: this.entryEntity,
@@ -104,6 +114,7 @@ export class CmsEntriesRootFolder_5_37_0_002
                 }
             },
             async result => {
+                logger.debug(`Processing ${result.items.length} items...`);
                 const items: BatchWriteItem[] = [];
                 for (const item of result.items) {
                     if (!!item.location?.folderId) {
@@ -124,12 +135,14 @@ export class CmsEntriesRootFolder_5_37_0_002
                     return batchWriteAll({ table: this.entryEntity.table, items });
                 };
 
+                logger.trace("Storing the DynamoDB records...");
                 await executeWithRetry(execute, {
                     onFailedAttempt: error => {
                         logger.error(`"batchWriteAll" attempt #${error.attemptNumber} failed.`);
                         logger.error(error.message);
                     }
                 });
+                logger.trace("...stored.");
 
                 // Update checkpoint after every batch
                 migrationStatus.lastEvaluatedKey = result.lastEvaluatedKey?.PK

--- a/yarn.lock
+++ b/yarn.lock
@@ -15901,7 +15901,6 @@ __metadata:
     jest-dynalite: ^3.2.0
     jest-mock-console: ^1.0.0
     minimatch: ^5.1.6
-    pino: ^8.11.0
     pino-pretty: ^9.4.0
     rimraf: ^3.0.2
     semver: ^6.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -15902,6 +15902,7 @@ __metadata:
     jest-mock-console: ^1.0.0
     minimatch: ^5.1.6
     pino: ^8.11.0
+    pino-pretty: ^9.4.0
     rimraf: ^3.0.2
     semver: ^6.3.0
     typescript: 4.7.4
@@ -16289,7 +16290,6 @@ __metadata:
     "@webiny/cli": 0.0.0
     "@webiny/project-utils": 0.0.0
     pino: ^8.11.0
-    pino-pretty: ^9.4.0
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.7.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -15891,6 +15891,7 @@ __metadata:
     "@webiny/db-dynamodb": 0.0.0
     "@webiny/handler-aws": 0.0.0
     "@webiny/ioc": 0.0.0
+    "@webiny/logger": 0.0.0
     "@webiny/project-utils": 0.0.0
     "@webiny/utils": 0.0.0
     center-align: ^1.0.1
@@ -15901,7 +15902,6 @@ __metadata:
     jest-mock-console: ^1.0.0
     minimatch: ^5.1.6
     pino: ^8.11.0
-    pino-pretty: ^9.4.0
     rimraf: ^3.0.2
     semver: ^6.3.0
     typescript: 4.7.4
@@ -16274,6 +16274,25 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     react-style-object-to-css: ^1.1.2
+  languageName: unknown
+  linkType: soft
+
+"@webiny/logger@0.0.0, @webiny/logger@workspace:packages/logger":
+  version: 0.0.0-use.local
+  resolution: "@webiny/logger@workspace:packages/logger"
+  dependencies:
+    "@babel/cli": ^7.22.6
+    "@babel/core": ^7.22.8
+    "@babel/preset-env": ^7.22.7
+    "@babel/preset-typescript": ^7.22.5
+    "@babel/runtime": ^7.22.6
+    "@webiny/cli": 0.0.0
+    "@webiny/project-utils": 0.0.0
+    pino: ^8.11.0
+    pino-pretty: ^9.4.0
+    rimraf: ^3.0.2
+    ttypescript: ^1.5.13
+    typescript: 4.7.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Changes
PR adds a `@webiny/logger` package via which a user can configure the pino logger before it is created. Or just get the logger and use our default settings.

## How Has This Been Tested?
Jest and manually.

## Documented
Not yet. Going to keep this private for the moment.