### PR TITLE
Ensure GraphQL Schema Cache Key Also Includes Current Tenant ID and Locale Code

### DIFF
--- a/packages/handler-graphql/src/createGraphQLHandler.ts
+++ b/packages/handler-graphql/src/createGraphQLHandler.ts
@@ -13,9 +13,22 @@ const DEFAULT_CACHE_MAX_AGE = 30758400; // 1 year
 
 const createCacheKey = (context: Context) => {
     const plugins = getSchemaPlugins(context);
-    // TODO: in the near future, we have to assign a fixed name to every GraphQLSchema plugin,
-    // to be able to create a reliable cache key.
-    return plugins.length.toString();
+    // TODO: in the near future, we have to assign a fixed name to every
+    // TODO: GraphQLSchema plugin, to be able to create a reliable cache key.
+
+    // @ts-ignore TODO: `getCurrentTenant` should be injected as a parameter.
+    // @ts-ignore TODO: We should not be accessing `context` like this here.
+    const { getCurrentTenant } = context.tenancy;
+
+    // @ts-ignore TODO: `getContentLocale` should be injected as a parameter.
+    // @ts-ignore TODO: We should not be accessing `context` like this here.
+    const { getContentLocale } = context.i18n;
+
+    return [
+        `tenant:${getCurrentTenant().id}`,
+        `locale:${getContentLocale().code}`,
+        plugins.length.toString()
+    ].join("#");
 };
 
 const createRequestBody = (body: unknown): GraphQLRequestBody | GraphQLRequestBody[] => {


### PR DESCRIPTION
## Changes
With this PR, we're ensuring the GraphQL schema's cache key also includes the current tenant ID and locale code. Without this fix, users might end up with the exact same GraphQL schema and resolvers being used with different tenants. This causes problem if we need to have different resolvers on different tenants.

This is what ultimately also caused an issue with ACO and list of PB pages, which is how we discovered this issue. Users would open one tenant, see pages for it, and then once switched to another tenant, they would still see pages from the previous tenant. 

What's even more interesting here is that only if the AWS Lambda function's container would be reinitialized by AWS (cold start), the returned list of pages would again be correct. This is because the GraphQL schema would be reconstructed, thus correct resolvers would be used.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.