### PR TITLE
fix: page revision / aco search record removal 

### DIFF
--- a/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
+++ b/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
@@ -17,10 +17,11 @@ describe("Pages -> Search records", () => {
         });
     };
 
-    const createDummyPage = async (pageBuilder: any) => {
+    const createDummyPage = async (pageBuilder: any, from?: string) => {
         await createDummyCategory(pageBuilder);
         const [response] = await pageBuilder.createPage({
-            category: categorySlug
+            ...(from && { from }),
+            ...(!from && { category: categorySlug })
         });
 
         const page = response.data?.pageBuilder?.createPage?.data;
@@ -383,23 +384,23 @@ describe("Pages -> Search records", () => {
         });
     });
 
-    it("should delete a search record on page deletion", async () => {
+    it("should delete a search record in case a page has been deleted via page pid", async () => {
         const { pageBuilder, search } = useGraphQlHandler({
             plugins: [assignPageLifecycleEvents()]
         });
-        const dummyPage = await createDummyPage(pageBuilder);
-        const { pid, id } = dummyPage;
+        const pageV1 = await createDummyPage(pageBuilder);
+        await createDummyPage(pageBuilder, pageV1.id);
 
         await pageBuilder.deletePage({
-            id
+            id: pageV1.pid
         });
 
-        expect(tracker.isExecutedOnce("page:beforeDelete")).toEqual(true);
-        expect(tracker.isExecutedOnce("page:afterDelete")).toEqual(true);
+        expect(tracker.isExecuted("page:beforeDelete")).toEqual(true);
+        expect(tracker.isExecuted("page:afterDelete")).toEqual(true);
 
-        const [deletedResponse] = await search.getRecord({ id: pid });
+        const [getResponse] = await search.getRecord({ id: pageV1.pid });
 
-        expect(deletedResponse).toMatchObject({
+        expect(getResponse).toMatchObject({
             data: {
                 search: {
                     getRecord: {
@@ -407,12 +408,94 @@ describe("Pages -> Search records", () => {
                         error: {
                             code: "NOT_FOUND",
                             data: {
-                                id: pid
+                                id: pageV1.pid
                             }
                         }
                     }
                 }
             }
         });
+    });
+
+    it("should delete a search record in case all page revisions has been deleted", async () => {
+        const { pageBuilder, search } = useGraphQlHandler({
+            plugins: [assignPageLifecycleEvents()]
+        });
+        const pageV1 = await createDummyPage(pageBuilder);
+        const pageV2 = await createDummyPage(pageBuilder, pageV1.id);
+
+        await pageBuilder.deletePage({
+            id: pageV1.id
+        });
+
+        await pageBuilder.deletePage({
+            id: pageV2.id
+        });
+
+        expect(tracker.isExecuted("page:beforeDelete")).toEqual(true);
+        expect(tracker.isExecuted("page:afterDelete")).toEqual(true);
+
+        const [getResponse] = await search.getRecord({ id: pageV1.pid });
+
+        expect(getResponse).toMatchObject({
+            data: {
+                search: {
+                    getRecord: {
+                        data: null,
+                        error: {
+                            code: "NOT_FOUND",
+                            data: {
+                                id: pageV1.pid
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it("should update a search record in case a page revisions has been deleted, but there are other page revisions available", async () => {
+        const { pageBuilder, search } = useGraphQlHandler({
+            plugins: [assignPageLifecycleEvents()]
+        });
+        const pageV1 = await createDummyPage(pageBuilder);
+        const pageV2 = await createDummyPage(pageBuilder, pageV1.id);
+
+        expect(pageV2.pid).toEqual(pageV1.pid);
+
+        {
+            // Testing to find v2 id within the search record
+            const [response] = await search.getRecord({ id: pageV1.pid });
+            const searchRecord = response.data?.search?.getRecord?.data;
+
+            expect(searchRecord).toMatchObject({
+                id: pageV2.pid,
+                data: {
+                    id: pageV2.id,
+                    version: pageV2.version
+                }
+            });
+        }
+
+        await pageBuilder.deletePage({
+            id: pageV2.id
+        });
+
+        expect(tracker.isExecuted("page:beforeDelete")).toEqual(true);
+        expect(tracker.isExecuted("page:afterDelete")).toEqual(true);
+
+        {
+            // Testing the search record update with v1 data
+            const [response] = await search.getRecord({ id: pageV1.pid });
+            const searchRecord = response.data?.search?.getRecord?.data;
+
+            expect(searchRecord).toMatchObject({
+                id: pageV1.pid,
+                data: {
+                    id: pageV1.id,
+                    version: pageV1.version
+                }
+            });
+        }
     });
 });

--- a/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
+++ b/packages/api-page-builder-aco/__tests__/page.hooks.test.ts
@@ -454,7 +454,7 @@ describe("Pages -> Search records", () => {
         });
     });
 
-    it("should update a search record in case a page revisions has been deleted, but there are other page revisions available", async () => {
+    it("should update a search record in case a page revision has been deleted, but there are other page revisions available", async () => {
         const { pageBuilder, search } = useGraphQlHandler({
             plugins: [assignPageLifecycleEvents()]
         });

--- a/packages/api-page-builder-aco/src/page/hooks/onPageAfterDelete.hook.ts
+++ b/packages/api-page-builder-aco/src/page/hooks/onPageAfterDelete.hook.ts
@@ -1,24 +1,44 @@
 import WebinyError from "@webiny/error";
 
-import { PbAcoContext } from "~/types";
+import { PbAcoContext, PbPageRecordData } from "~/types";
 import { PB_PAGE_TYPE } from "~/contants";
+import { updatePageRecordPayload } from "~/utils/createRecordPayload";
 
-export const onPageAfterDeleteHook = ({ pageBuilder, aco }: PbAcoContext) => {
+export const onPageAfterDeleteHook = (context: PbAcoContext) => {
+    const { aco, pageBuilder } = context;
     const app = aco.getApp(PB_PAGE_TYPE);
-    /**
-     * Intercept page deletion and delete the related search record.
-     */
-    pageBuilder.onPageAfterDelete.subscribe(async ({ page }) => {
-        try {
-            await app.search.delete(page.pid);
-        } catch (error) {
-            if (error.code === "NOT_FOUND") {
-                return;
-            }
 
+    /**
+     * Intercept page deletion and delete or update the related search record.
+     */
+    pageBuilder.onPageAfterDelete.subscribe(async ({ page, deleteMethod, latestPage }) => {
+        // If the deleteMethod is "deleteAll" delete the search record.
+        if (deleteMethod === "deleteAll") {
+            try {
+                await app.search.delete(page.pid);
+            } catch (error) {
+                // If the search record is not found, return without further action.
+                if (error.code === "NOT_FOUND") {
+                    return;
+                }
+                throw WebinyError.from(error, {
+                    message: "Error while executing onPageAfterDeleteHook hook",
+                    code: "ACO_AFTER_PAGE_DELETE_HOOK"
+                });
+            }
+            return;
+        }
+
+        try {
+            if (latestPage) {
+                // Update the search record with the latest page data.
+                const payload = await updatePageRecordPayload(context, latestPage);
+                await app.search.update<PbPageRecordData>(page.pid, payload);
+            }
+        } catch (error) {
             throw WebinyError.from(error, {
-                message: "Error while executing onPageAfterDeleteHook hook",
-                code: "ACO_AFTER_PAGE_DELETE_HOOK"
+                message: "Error while executing onPageAfterUpdateHook hook",
+                code: "ACO_AFTER_PAGE_UPDATE_HOOK"
             });
         }
     });

--- a/packages/api-page-builder-aco/src/page/hooks/onPageAfterDelete.hook.ts
+++ b/packages/api-page-builder-aco/src/page/hooks/onPageAfterDelete.hook.ts
@@ -22,7 +22,7 @@ export const onPageAfterDeleteHook = (context: PbAcoContext) => {
                     return;
                 }
                 throw WebinyError.from(error, {
-                    message: "Error while executing onPageAfterDeleteHook hook",
+                    message: "Error while executing onPageAfterDeleteHook hook.",
                     code: "ACO_AFTER_PAGE_DELETE_HOOK"
                 });
             }
@@ -37,8 +37,8 @@ export const onPageAfterDeleteHook = (context: PbAcoContext) => {
             }
         } catch (error) {
             throw WebinyError.from(error, {
-                message: "Error while executing onPageAfterUpdateHook hook",
-                code: "ACO_AFTER_PAGE_UPDATE_HOOK"
+                message: "Error while executing onPageAfterDeleteHook hook.",
+                code: "ACO_AFTER_PAGE_DELETE_HOOK"
             });
         }
     });

--- a/packages/api-page-builder/__tests__/graphql/pages.deletion.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.deletion.test.ts
@@ -38,7 +38,7 @@ describe("deleting pages", () => {
         await waitPage(handler, p1v3);
     });
 
-    test("deleting v1 page should delete all related DB / index entries", async () => {
+    test("deleting page via `pid` should delete all related DB / index entries", async () => {
         await publishPage({ id: p1v3.id });
         await until(
             () =>
@@ -58,13 +58,13 @@ describe("deleting pages", () => {
             }
         );
 
-        await deletePage({ id: p1v1.id }).then(([res]) => {
+        await deletePage({ id: p1v1.pid }).then(([res]) => {
             expect(res.data.pageBuilder.deletePage).toMatchObject({
                 error: null,
                 data: {
                     latestPage: null,
                     page: {
-                        version: 1
+                        version: 3
                     }
                 }
             });
@@ -76,14 +76,14 @@ describe("deleting pages", () => {
                 return res.data.pageBuilder.listPages.data.length === 0;
             },
             {
-                name: "list all pages after deleting p1v1"
+                name: "list all pages after deleting the page via pid"
             }
         );
         await until(
             listPublishedPages,
             ([res]) => res.data.pageBuilder.listPublishedPages.data.length === 0,
             {
-                name: "list published pages after deleting p1v1"
+                name: "list published pages after deleting the page via pid"
             }
         );
     });
@@ -267,5 +267,28 @@ describe("deleting pages", () => {
         );
 
         expect(page.revisions.length).toBe(2);
+    });
+
+    test("deleting all revisions should delete all related DB / index entries", async () => {
+        await deletePage({ id: p1v3.id });
+        await deletePage({ id: p1v2.id });
+        await deletePage({ id: p1v1.id });
+
+        await until(
+            () => listPages({}),
+            ([res]) => {
+                return res.data.pageBuilder.listPages.data.length === 0;
+            },
+            {
+                name: "list all pages after deleting p1 via pid"
+            }
+        );
+        await until(
+            listPublishedPages,
+            ([res]) => res.data.pageBuilder.listPublishedPages.data.length === 0,
+            {
+                name: "list published pages after deleting p1 via pid"
+            }
+        );
     });
 });

--- a/packages/api-page-builder/src/graphql/types.ts
+++ b/packages/api-page-builder/src/graphql/types.ts
@@ -115,6 +115,7 @@ export interface OnPageBeforeDeleteTopicParams<TPage extends Page = Page> {
     page: TPage;
     latestPage: TPage;
     publishedPage: TPage | null;
+    deleteMethod: "deleteAll" | "delete";
 }
 /**
  * @category Lifecycle events
@@ -123,6 +124,7 @@ export interface OnPageAfterDeleteTopicParams<TPage extends Page = Page> {
     page: TPage;
     latestPage: TPage | null;
     publishedPage: TPage | null;
+    deleteMethod: "deleteAll" | "delete";
 }
 /**
  * @category Lifecycle events

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/useRevisionHandlers.ts
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/useRevisionHandlers.ts
@@ -8,6 +8,7 @@ import * as GQLCache from "~/admin/views/Pages/cache";
 import { useAdminPageBuilder } from "~/admin/hooks/useAdminPageBuilder";
 import { PbPageData, PbPageRevision } from "~/types";
 import { useNavigatePage } from "~/admin/hooks/useNavigatePage";
+import { useRecords } from "@webiny/app-aco";
 
 interface UseRevisionHandlersProps {
     page: PbPageData;
@@ -21,6 +22,7 @@ export function useRevisionHandlers(props: UseRevisionHandlersProps) {
     const { publishRevision, unpublishRevision } = usePublishRevisionHandler();
     const pageBuilder = useAdminPageBuilder();
     const { navigateToPageEditor } = useNavigatePage();
+    const { getRecord } = useRecords();
 
     const createRevision = useCallback(async () => {
         const { data: res } = await client.mutate({
@@ -75,6 +77,10 @@ export function useRevisionHandlers(props: UseRevisionHandlersProps) {
                 }
             }
         });
+
+        // Sync ACO record - retrieve the most updated record and update table
+        await getRecord(page.pid);
+
         if (response) {
             const { error } = response;
             if (error) {

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/useDeletePage.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/useDeletePage.tsx
@@ -4,6 +4,7 @@ import { PbPageData } from "~/types";
 import { useConfirmationDialog, useDialog, useSnackbar } from "@webiny/app-admin";
 import { useAdminPageBuilder } from "~/admin/hooks/useAdminPageBuilder";
 import { useRecords } from "@webiny/app-aco";
+import { parseIdentifier } from "@webiny/utils";
 
 const t = i18n.ns("app-headless-cms/app-page-builder/dialogs/dialog-delete-page");
 
@@ -35,8 +36,7 @@ export const useDeletePage = ({ page, onDelete }: UseDeletePageParams) => {
     const openDialogDeletePage = useCallback(
         () =>
             showConfirmation(async () => {
-                const [uniquePageId] = page.id.split("#");
-                const id = `${uniquePageId}#0001`;
+                const { id } = parseIdentifier(page.id);
                 /**
                  * Delete page using pageBuilder deletePage hook.
                  */
@@ -64,7 +64,7 @@ export const useDeletePage = ({ page, onDelete }: UseDeletePageParams) => {
                 }
 
                 // Sync ACO record - retrieve the most updated record from network
-                await getRecord(uniquePageId);
+                await getRecord(id);
 
                 showSnackbar(
                     t`The page "{title}" was deleted successfully.`({


### PR DESCRIPTION
## Changes
With this PR, we aim to solve the following bug discovered in Page Builder.

### Steps to reproduce the bug
- Access to the Page Builder app
- Create a page and add one or more revisions
- From the page list, click on a page title: the preview drawer will open
- Click on the "Revisions" tab: from the Menu next to each revisions item, click "Delete Revision".
- The page won't be visible anymore inside the list


### Solution
Previously, to delete the page and all the revisions, we were targeting revision `#0001`: this could end in a bug in case a user decides to delete the first revision but keep all the others.

With this PR, we allow to pass both `id` and `pid` to the `deletePage` mutation.
If the `pid` has been passed as a param or the page has no other revisions, we trigger the `deleteAll` storage operation.

A similar logic has been added to the `api-page-builder-aco` package: we will delete the search record only when the `deleteAll` storage operation has been triggered. 

Otherwise, we update the record with information from the latest page revision available.


## How Has This Been Tested?
Manually + Jest

## Documentation
Inline
