### PR TITLE
Migrations/ES Index Creation: Double Check If the ES Index Exists

### DIFF
--- a/packages/migrations/src/utils/elasticsearch/esCreateIndex.ts
+++ b/packages/migrations/src/utils/elasticsearch/esCreateIndex.ts
@@ -14,13 +14,13 @@ export interface EsCreateIndexParams {
 export const esCreateIndex = async (params: EsCreateIndexParams): Promise<string> => {
     const { elasticsearchClient, tenant, locale, type, isHeadlessCmsModel } = params;
 
-    const index = esGetIndexName({ tenant, locale, type, isHeadlessCmsModel });
+    const indexName = esGetIndexName({ tenant, locale, type, isHeadlessCmsModel });
 
     try {
         const exist = await esGetIndexExist(params);
 
         if (exist) {
-            return index;
+            return indexName;
         }
 
         // Get registered plugins
@@ -35,16 +35,16 @@ export const esCreateIndex = async (params: EsCreateIndexParams): Promise<string
             .pop();
 
         await elasticsearchClient.indices.create({
-            index,
+            index: indexName,
             ...(plugin && { body: plugin.body })
         });
-        return index;
+        return indexName;
     } catch (ex) {
         // Despite the fact the above `esGetIndexExist` check told us the index does not exist,
         // we've seen cases where the `resource_already_exists_exception` would still be thrown
         // by Elasticsearch, hence the check below.
         if (ex.message === "resource_already_exists_exception") {
-            return index;
+            return indexName;
         }
 
         throw new WebinyError(

--- a/packages/migrations/src/utils/elasticsearch/esCreateIndex.ts
+++ b/packages/migrations/src/utils/elasticsearch/esCreateIndex.ts
@@ -42,7 +42,7 @@ export const esCreateIndex = async (params: EsCreateIndexParams): Promise<string
     } catch (ex) {
         // Despite the fact the above `esGetIndexExist` check told us the index does not exist,
         // we've seen cases where the `resource_already_exists_exception` would still be thrown
-        // by Elasticsearch, hence the check below.
+        // upon index creation. That's why we're doing an additional check of the error message.
         if (ex.message === "resource_already_exists_exception") {
             return indexName;
         }


### PR DESCRIPTION
## Changes
We've seen a case where the `esCreateIndex` utility function throws the `resource_already_exists_exception` error, despite the fact the internal index existence check told us that the index does not exist.

Because of this, upon index creation, if an error is throw, we double check the error message and if it's again mentioned `resource_already_exists_exception`, we just return the index name and we don't consider this as an actual error.

## How Has This Been Tested?
Did a quick test with a local script mimicking the same index creation logic. Ensured the `ex.message` is actually the error code we're expecting.

![image](https://github.com/webiny/webiny-js/assets/5121148/2af6a370-d293-4ba0-914e-fa339ad8ada9)

## Documentation
Changelog.