### PR TITLE
fix(db-dynamodb): scan result next method provides exact interface as scan

### DIFF
--- a/packages/db-dynamodb/src/utils/scan.ts
+++ b/packages/db-dynamodb/src/utils/scan.ts
@@ -18,15 +18,39 @@ export interface ScanResponse<T> {
     error: any;
 }
 
-const convertResult = <T>(result: any): ScanResponse<T> => {
+interface DdbScanResult<T> {
+    Items: T[];
+    Count: number;
+    ScannedCount: number;
+    LastEvaluatedKey?: DocumentClient.Key;
+    next?: () => Promise<DdbScanResult<T>>;
+    error?: any;
+    $response?: {
+        requestId: string;
+    };
+}
+
+type NextCb<T> = () => Promise<ScanResponse<T>>;
+
+const createNext = <T>(result: DdbScanResult<T>): NextCb<T> | undefined => {
+    if (!result?.LastEvaluatedKey || !result.next) {
+        return undefined;
+    }
+    return async () => {
+        const response = await result!.next!();
+        return convertResult(response);
+    };
+};
+
+const convertResult = <T>(result: DdbScanResult<T>): ScanResponse<T> => {
     return {
-        items: result.Items as T[],
+        items: result.Items,
         count: result.Count,
         scannedCount: result.ScannedCount,
-        lastEvaluatedKey: result.LastEvaluatedKey,
-        next: result.LastEvaluatedKey ? result.next : undefined,
+        lastEvaluatedKey: result.LastEvaluatedKey || undefined,
+        next: createNext<T>(result),
         error: result.error,
-        requestId: result.$response.requestId
+        requestId: result.$response?.requestId || ""
     };
 };
 
@@ -56,7 +80,7 @@ export const scanWithCallback = async <T>(
     await callback(result);
 
     while (result.next) {
-        result = convertResult(await result.next());
+        result = await result.next();
         await callback(result);
         if (!result.next) {
             return;


### PR DESCRIPTION
## Changes
When using the scan from the `@webiny/db-dynamodb`, the next method did not return the same interface and user needed to use the different properties on that result.
Method now automatically converts the `result.next()` response into same interface as the `scan()`.

## How Has This Been Tested?
Jest and manually.