### PR TITLE
Fix button with named element reference

### DIFF
--- a/packages/lexical-editor/src/nodes/link-node.ts
+++ b/packages/lexical-editor/src/nodes/link-node.ts
@@ -1,0 +1,97 @@
+import {
+    LinkAttributes,
+    LinkNode as BaseLinkNode,
+    SerializedAutoLinkNode,
+    SerializedLinkNode as BaseSerializedLinkNode
+} from "@lexical/link";
+import { DOMConversionMap, DOMConversionOutput, EditorConfig, NodeKey, Spread } from "lexical";
+import { addClassNamesToElement, isHTMLAnchorElement } from "@lexical/utils";
+import { sanitizeUrl } from "~/utils/sanitizeUrl";
+
+export type SerializedLinkNode = Spread<
+    {
+        type: "link-node";
+        version: 1;
+    },
+    Spread<LinkAttributes, BaseSerializedLinkNode>
+>;
+
+export class LinkNode extends BaseLinkNode {
+    constructor(url: string, attributes: LinkAttributes = {}, key?: NodeKey) {
+        super(url, attributes, key);
+    }
+
+    static override getType(): string {
+        return "link-node";
+    }
+
+    override createDOM(config: EditorConfig): HTMLAnchorElement {
+        const element = document.createElement("a");
+        element.href = sanitizeUrl(this.__url);
+        if (this.__target !== null) {
+            element.target = this.__target;
+        }
+        if (this.__rel !== null) {
+            element.rel = this.__rel;
+        }
+        if (this.__title !== null) {
+            element.title = this.__title;
+        }
+        addClassNamesToElement(element, config.theme.link);
+        return element;
+    }
+
+    static override importDOM(): DOMConversionMap | null {
+        return {
+            a: () => ({
+                conversion: convertAnchorElement,
+                priority: 1
+            })
+        };
+    }
+
+    static override importJSON(
+        serializedNode: BaseSerializedLinkNode | SerializedLinkNode | SerializedAutoLinkNode
+    ): LinkNode {
+        const node = $createLinkNode(serializedNode.url, {
+            rel: serializedNode.rel,
+            target: serializedNode.target,
+            title: serializedNode.title
+        });
+        node.setFormat(serializedNode.format);
+        node.setIndent(serializedNode.indent);
+        node.setDirection(serializedNode.direction);
+        return node;
+    }
+
+    override exportJSON(): BaseSerializedLinkNode | SerializedLinkNode | SerializedAutoLinkNode {
+        return {
+            ...super.exportJSON(),
+            type: "link-node",
+            version: 1
+        };
+    }
+}
+
+function convertAnchorElement(domNode: Node): DOMConversionOutput {
+    let node = null;
+    if (isHTMLAnchorElement(domNode)) {
+        const content = domNode.textContent;
+        if (content !== null && content !== "") {
+            node = $createLinkNode(domNode.getAttribute("href") || "", {
+                rel: domNode.getAttribute("rel"),
+                target: domNode.getAttribute("target"),
+                title: domNode.getAttribute("title")
+            });
+        }
+    }
+    return { node };
+}
+
+export const $isLinkNode = (node: any): node is LinkNode => {
+    return node instanceof LinkNode;
+};
+
+export const $createLinkNode = (url: string, attributes: LinkAttributes = {}, key?: KeyType) => {
+    return new LinkNode(url, attributes, key);
+};

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -2,7 +2,7 @@ import type { Klass, LexicalNode } from "lexical";
 
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { HashtagNode } from "@lexical/hashtag";
-import { AutoLinkNode, LinkNode } from "@lexical/link";
+import { AutoLinkNode, LinkNode as BaseLinkNode } from "@lexical/link";
 import { MarkNode } from "@lexical/mark";
 import { OverflowNode } from "@lexical/overflow";
 import { FontColorNode } from "~/nodes/FontColorNode";
@@ -15,6 +15,7 @@ import { ParagraphNode } from "~/nodes/ParagraphNode";
 import { HeadingNode as BaseHeadingNode, QuoteNode as BaseQuoteNode } from "@lexical/rich-text";
 import { QuoteNode } from "~/nodes/QuoteNode";
 import { ImageNode } from "~/nodes/ImageNode";
+import { LinkNode } from "~/nodes/link-node";
 
 /*
  * This is a list of all the nodes that Webiny's Lexical implementation supports OOTB.
@@ -33,7 +34,6 @@ export const WebinyNodes: ReadonlyArray<
     HashtagNode,
     CodeHighlightNode,
     AutoLinkNode,
-    LinkNode,
     OverflowNode,
     MarkNode,
     FontColorNode,
@@ -61,6 +61,21 @@ export const WebinyNodes: ReadonlyArray<
         replace: BaseQuoteNode,
         with: () => {
             return new QuoteNode();
+        }
+    },
+    LinkNode,
+    {
+        replace: BaseLinkNode,
+        with: (node: BaseLinkNode) => {
+            return new LinkNode(
+                node.getURL(),
+                {
+                    rel: node.getRel(),
+                    title: node.getTitle(),
+                    target: node.getTarget()
+                },
+                node.getKey()
+            );
         }
     }
 ];

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
@@ -20,6 +20,7 @@ import { LinkPreview } from "../../ui/LinkPreview";
 import { getSelectedNode } from "../../utils/getSelectedNode";
 import { sanitizeUrl } from "../../utils/sanitizeUrl";
 import { setFloatingElemPosition } from "../../utils/setFloatingElemPosition";
+import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
 
 function FloatingLinkEditor({
     editor,
@@ -162,6 +163,7 @@ function FloatingLinkEditor({
                         <input
                             type={"checkbox"}
                             checked={linkUrl.target === "_blank"}
+                            disabled={isUrlLinkReference(linkUrl.url)}
                             onChange={() =>
                                 setLinkUrl({ ...linkUrl, target: linkUrl.target ? null : "_blank" })
                             }

--- a/packages/lexical-editor/src/utils/getLexicalTextSelectionState.ts
+++ b/packages/lexical-editor/src/utils/getLexicalTextSelectionState.ts
@@ -11,7 +11,7 @@ import {
 } from "lexical";
 import { $findMatchingParent, $getNearestNodeOfType } from "@lexical/utils";
 import { getSelectedNode } from "~/utils/getSelectedNode";
-import { $isLinkNode } from "@lexical/link";
+import { $isLinkNode as $isBaseLinkNode } from "@lexical/link";
 import { $isListNode, ListNode } from "~/nodes/ListNode";
 import { $isHeadingNode as $isBaseHeadingNode } from "@lexical/rich-text";
 import { $isTypographyElementNode } from "~/nodes/TypographyElementNode";
@@ -20,6 +20,7 @@ import { $isParagraphNode } from "~/nodes/ParagraphNode";
 import { $isHeadingNode } from "~/nodes/HeadingNode";
 import { $isQuoteNode } from "~/nodes/QuoteNode";
 import { $isParentElementRTL } from "@lexical/selection";
+import { $isLinkNode } from "~/nodes/link-node";
 
 export const getSelectionTextFormat = (selection: RangeSelection | undefined): TextFormatting => {
     return !$isRangeSelection(selection)
@@ -75,7 +76,12 @@ export const getToolbarState = (
     state.isRTL = $isParentElementRTL(selection);
 
     // link
-    state.link.isSelected = $isLinkNode(parent) || $isLinkNode(node);
+    state.link.isSelected =
+        $isBaseLinkNode(parent) ||
+        $isBaseLinkNode(node) ||
+        // custom link node
+        $isLinkNode(parent) ||
+        $isLinkNode(node);
     if (state.link.isSelected) {
         state.textType = "link";
     }

--- a/packages/lexical-editor/src/utils/isUrlLinkReference.ts
+++ b/packages/lexical-editor/src/utils/isUrlLinkReference.ts
@@ -1,0 +1,4 @@
+export const isUrlLinkReference = (url: string) => {
+    const match = url.match(/^#/);
+    return match != null;
+};

--- a/packages/lexical-editor/src/utils/sanitizeUrl.ts
+++ b/packages/lexical-editor/src/utils/sanitizeUrl.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
 
 export const sanitizeUrl = (url: string): string => {
     /** A pattern that matches safe  URLs. */
@@ -15,6 +16,13 @@ export const sanitizeUrl = (url: string): string => {
         /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
 
     url = String(url).trim();
+
+    if (isUrlLinkReference(url)) {
+        console.clear();
+        console.log("url", url);
+        console.log("isUrlLinkReference", isUrlLinkReference(url));
+        return url;
+    }
 
     if (url.match(SAFE_URL_PATTERN) || url.match(DATA_URL_PATTERN)) {
         return url;


### PR DESCRIPTION
With this PR we fixed the problem of creating a reference link to the same page using Lexical editor. Now users can link elements to the same page.

## Changes
- New custom Lexical `LinkNode` class that overrides default link node.
   - In [createDOM](packages/lexical-editor/src/nodes/link-node.ts) method, we sanitize the URL with our custom method.
- New `isUrlLinkReference` method  - detect link reference - checks if URL is starting with (#) hashtag
- Update to existing `sanitize` method to recognize the URLs that are link references to other elements on the page.
- In the Lexical link floating popup, when the user enters the link reference, the checkbox "Open in new page" will be disabled (check the test video). 

## Technical problem with the current lexical solution
- Default link [sanitizer method](https://github.com/facebook/lexical/blob/cf0b053a9694af3a6beac42f5fd581c01e5c7a6a/packages/lexical-link/src/index.ts#L165) in Lexical `LinkNode` class, doesn't allow reference links like `#link-to-my-title` to be set in the `href` attribute.
- `LexicalHtmlRenderer` uses the same default `LinkNode` node so the component can't render the link references.

## How Has This Been Tested?
Manually.

## Tests

https://github.com/webiny/webiny-js/assets/82515066/1cfb5595-e486-47b3-8866-36a4d1530710


