### PR TITLE
Lexical link to support reference to element in the same page

### DIFF
--- a/packages/lexical-editor/src/nodes/link-node.ts
+++ b/packages/lexical-editor/src/nodes/link-node.ts
@@ -1,0 +1,97 @@
+import {
+    LinkAttributes,
+    LinkNode as BaseLinkNode,
+    SerializedAutoLinkNode,
+    SerializedLinkNode as BaseSerializedLinkNode
+} from "@lexical/link";
+import { DOMConversionMap, DOMConversionOutput, EditorConfig, NodeKey, Spread } from "lexical";
+import { addClassNamesToElement, isHTMLAnchorElement } from "@lexical/utils";
+import { sanitizeUrl } from "~/utils/sanitizeUrl";
+
+export type SerializedLinkNode = Spread<
+    {
+        type: "link-node";
+        version: 1;
+    },
+    Spread<LinkAttributes, BaseSerializedLinkNode>
+>;
+
+export class LinkNode extends BaseLinkNode {
+    constructor(url: string, attributes: LinkAttributes = {}, key?: NodeKey) {
+        super(url, attributes, key);
+    }
+
+    static override getType(): string {
+        return "link-node";
+    }
+
+    override createDOM(config: EditorConfig): HTMLAnchorElement {
+        const element = document.createElement("a");
+        element.href = sanitizeUrl(this.__url);
+        if (this.__target !== null) {
+            element.target = this.__target;
+        }
+        if (this.__rel !== null) {
+            element.rel = this.__rel;
+        }
+        if (this.__title !== null) {
+            element.title = this.__title;
+        }
+        addClassNamesToElement(element, config.theme.link);
+        return element;
+    }
+
+    static override importDOM(): DOMConversionMap | null {
+        return {
+            a: () => ({
+                conversion: convertAnchorElement,
+                priority: 1
+            })
+        };
+    }
+
+    static override importJSON(
+        serializedNode: BaseSerializedLinkNode | SerializedLinkNode | SerializedAutoLinkNode
+    ): LinkNode {
+        const node = $createLinkNode(serializedNode.url, {
+            rel: serializedNode.rel,
+            target: serializedNode.target,
+            title: serializedNode.title
+        });
+        node.setFormat(serializedNode.format);
+        node.setIndent(serializedNode.indent);
+        node.setDirection(serializedNode.direction);
+        return node;
+    }
+
+    override exportJSON(): BaseSerializedLinkNode | SerializedLinkNode | SerializedAutoLinkNode {
+        return {
+            ...super.exportJSON(),
+            type: "link-node",
+            version: 1
+        };
+    }
+}
+
+function convertAnchorElement(domNode: Node): DOMConversionOutput {
+    let node = null;
+    if (isHTMLAnchorElement(domNode)) {
+        const content = domNode.textContent;
+        if (content !== null && content !== "") {
+            node = $createLinkNode(domNode.getAttribute("href") || "", {
+                rel: domNode.getAttribute("rel"),
+                target: domNode.getAttribute("target"),
+                title: domNode.getAttribute("title")
+            });
+        }
+    }
+    return { node };
+}
+
+export const $isLinkNode = (node: any): node is LinkNode => {
+    return node instanceof LinkNode;
+};
+
+export const $createLinkNode = (url: string, attributes: LinkAttributes = {}, key?: KeyType) => {
+    return new LinkNode(url, attributes, key);
+};

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -43,7 +43,7 @@ export const WebinyNodes: ReadonlyArray<
     FontColorNode,
     TypographyElementNode,
 
-    // The following code replaces the built-in Lexical nodes with our custom nodes. The built-in nodes are
+    // The following code replaces the built-in Lexical nodes with our custom ones. The built-in nodes are
     // imported from the Lexical package, and then replaced with our custom nodes. This is the only way to
     // replace the built-in nodes.
     // https://lexical.dev/docs/concepts/node-replacement

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -16,9 +16,7 @@ import { QuoteNode } from "~/nodes/QuoteNode";
 import { ImageNode } from "~/nodes/ImageNode";
 import { LinkNode } from "~/nodes/link-node";
 
-/*
- * This is a list of all the nodes that Webiny's Lexical implementation supports OOTB.
- * */
+// This is a list of all the nodes that our Lexical implementation supports OOTB.
 export const WebinyNodes: ReadonlyArray<
     | Klass<LexicalNode>
     | {
@@ -26,50 +24,29 @@ export const WebinyNodes: ReadonlyArray<
           with: <T extends { new (...args: any): any }>(node: InstanceType<T>) => LexicalNode;
       }
 > = [
-    /*
-     * This custom nodes are copy-pasted from Lexical's code and modified to fit Webiny's needs.
-     * PLease check Lexical playground nodes for more information: https://github.com/facebook/lexical/tree/main/packages/lexical-playground/src/nodes
-     * Please check Lexical node packages for more information: https://github.com/facebook/lexical/tree/main/packages.
-     * */
+    // These nodes are copy-pasted from Lexical and modified to fit our needs.
+    // https://github.com/facebook/lexical/tree/main/packages/lexical-playground/src/nodes
+    // https://github.com/facebook/lexical/tree/main/packages
     ImageNode,
     ListNode,
     ListItemNode,
-    /*
-     * Direct imports from the Lexical's maintained nodes.
-     **/
+
+    // These nodes are directly imported from Lexical.
     CodeNode,
     HashtagNode,
     CodeHighlightNode,
     AutoLinkNode,
     OverflowNode,
     MarkNode,
-    /*
-     * Custom build Webiny nodes.
-     */
+
+    // Our custom nodes.
     FontColorNode,
     TypographyElementNode,
-    /*
-     * Node overrides
-     *
-     * We have improved Webiny's features by extending the node classes from the Lexical core library.
-     * In the code below we are registering our extended class separately from the parent classes.
-     * Parent classes need to be registered in the "replace" property. In this way, we use the Lexical's "Node overrides"
-     *  mechanism to apply our custom node behavior. It's the only way to tell Lexical to use subclasses instead of parent classes.
-     *
-     * As mentioned in the docs, "Node Overrides" allow you to replace all instances of a given node in your editor with instances of a different node class.
-     * Now, for example, our extended  LinkNode instance will replace the BaseLinkNode instance whenever a link is created.
-     *
-     * We extended following Lexical's maintained nodes:
-     * 1. BaseParagraphNode - control the paragraphs (p)
-     * 2. BaseHeadingNode - control the headings (h1, h2, h3, etc.)
-     * 3. BaseQuoteNode - control how quotes are displayed (blockquote)
-     * 4. BaseLinkNode - control the behavior of the links (a)
-     *
-     * Please check the Lexical documentation for more information on how to override and replace lexical's nodes:
-     * https://lexical.dev/docs/concepts/node-replacement
-     *
-     * Please check the Lexical documentation how you can create custom nodes: https://lexical.dev/docs/concepts/nodes#creating-custom-nodes
-     * */
+
+    // The following code replaces the built-in Lexical nodes with our custom nodes. The built-in nodes are
+    // imported from the Lexical package, and then replaced with our custom nodes. This is the only way to
+    // replace the built-in nodes.
+    // https://lexical.dev/docs/concepts/node-replacement
     ParagraphNode,
     {
         replace: BaseParagraphNode,

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -1,5 +1,5 @@
 import type { Klass, LexicalNode } from "lexical";
-
+import { ParagraphNode as BaseParagraphNode } from "lexical";
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { HashtagNode } from "@lexical/hashtag";
 import { AutoLinkNode, LinkNode as BaseLinkNode } from "@lexical/link";
@@ -9,7 +9,6 @@ import { FontColorNode } from "~/nodes/FontColorNode";
 import { TypographyElementNode } from "~/nodes/TypographyElementNode";
 import { ListNode } from "~/nodes/ListNode";
 import { ListItemNode } from "~/nodes/ListItemNode";
-import { ParagraphNode as BaseParagraphNode } from "lexical";
 import { HeadingNode } from "~/nodes/HeadingNode";
 import { ParagraphNode } from "~/nodes/ParagraphNode";
 import { HeadingNode as BaseHeadingNode, QuoteNode as BaseQuoteNode } from "@lexical/rich-text";
@@ -27,20 +26,49 @@ export const WebinyNodes: ReadonlyArray<
           with: <T extends { new (...args: any): any }>(node: InstanceType<T>) => LexicalNode;
       }
 > = [
+    /*
+     * This custom nodes are copy-pasted from Lexical's code and modified to fit Webiny's needs.
+     * PLease check Lexical playground nodes for more information: https://github.com/facebook/lexical/tree/main/packages/lexical-playground/src/nodes
+     * Please check Lexical node packages for more information: https://github.com/facebook/lexical/tree/main/packages.
+     * */
     ImageNode,
     ListNode,
     ListItemNode,
+    /*
+     * Direct imports from the Lexical's maintained nodes.
+     **/
     CodeNode,
     HashtagNode,
     CodeHighlightNode,
     AutoLinkNode,
     OverflowNode,
     MarkNode,
+    /*
+     * Custom build Webiny nodes.
+     */
     FontColorNode,
     TypographyElementNode,
     /*
-     * In order to provide additional Webiny-related functionality, we override Lexical's ParagraphNode and HeadingNode nodes.
-     * More info on overriding can be found here: https://lexical.dev/docs/concepts/node-replacement.
+     * Node overrides
+     *
+     * We have improved Webiny's features by extending the node classes from the Lexical core library.
+     * In the code below we are registering our extended class separately from the parent classes.
+     * Parent classes need to be registered in the "replace" property. In this way, we use the Lexical's "Node overrides"
+     *  mechanism to apply our custom node behavior. It's the only way to tell Lexical to use subclasses instead of parent classes.
+     *
+     * As mentioned in the docs, "Node Overrides" allow you to replace all instances of a given node in your editor with instances of a different node class.
+     * Now, for example, our extended  LinkNode instance will replace the BaseLinkNode instance whenever a link is created.
+     *
+     * We extended following Lexical's maintained nodes:
+     * 1. BaseParagraphNode - control the paragraphs (p)
+     * 2. BaseHeadingNode - control the headings (h1, h2, h3, etc.)
+     * 3. BaseQuoteNode - control how quotes are displayed (blockquote)
+     * 4. BaseLinkNode - control the behavior of the links (a)
+     *
+     * Please check the Lexical documentation for more information on how to override and replace lexical's nodes:
+     * https://lexical.dev/docs/concepts/node-replacement
+     *
+     * Please check the Lexical documentation how you can create custom nodes: https://lexical.dev/docs/concepts/nodes#creating-custom-nodes
      * */
     ParagraphNode,
     {

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -43,9 +43,7 @@ export const WebinyNodes: ReadonlyArray<
     FontColorNode,
     TypographyElementNode,
 
-    // The following code replaces the built-in Lexical nodes with our custom ones. The built-in nodes are
-    // imported from the Lexical package, and then replaced with our custom nodes. This is the only way to
-    // replace the built-in nodes.
+    // The following code replaces the built-in Lexical nodes with our custom ones.
     // https://lexical.dev/docs/concepts/node-replacement
     ParagraphNode,
     {

--- a/packages/lexical-editor/src/nodes/webinyNodes.ts
+++ b/packages/lexical-editor/src/nodes/webinyNodes.ts
@@ -2,7 +2,7 @@ import type { Klass, LexicalNode } from "lexical";
 
 import { CodeHighlightNode, CodeNode } from "@lexical/code";
 import { HashtagNode } from "@lexical/hashtag";
-import { AutoLinkNode, LinkNode } from "@lexical/link";
+import { AutoLinkNode, LinkNode as BaseLinkNode } from "@lexical/link";
 import { MarkNode } from "@lexical/mark";
 import { OverflowNode } from "@lexical/overflow";
 import { FontColorNode } from "~/nodes/FontColorNode";
@@ -15,6 +15,7 @@ import { ParagraphNode } from "~/nodes/ParagraphNode";
 import { HeadingNode as BaseHeadingNode, QuoteNode as BaseQuoteNode } from "@lexical/rich-text";
 import { QuoteNode } from "~/nodes/QuoteNode";
 import { ImageNode } from "~/nodes/ImageNode";
+import { LinkNode } from "~/nodes/link-node";
 
 /*
  * This is a list of all the nodes that Webiny's Lexical implementation supports OOTB.
@@ -33,7 +34,6 @@ export const WebinyNodes: ReadonlyArray<
     HashtagNode,
     CodeHighlightNode,
     AutoLinkNode,
-    LinkNode,
     OverflowNode,
     MarkNode,
     FontColorNode,
@@ -61,6 +61,21 @@ export const WebinyNodes: ReadonlyArray<
         replace: BaseQuoteNode,
         with: () => {
             return new QuoteNode();
+        }
+    },
+    LinkNode,
+    {
+        replace: BaseLinkNode,
+        with: (node: BaseLinkNode) => {
+            return new LinkNode(
+                node.getURL(),
+                {
+                    rel: node.getRel(),
+                    title: node.getTitle(),
+                    target: node.getTarget()
+                },
+                node.getKey()
+            );
         }
     }
 ];

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
@@ -20,6 +20,7 @@ import { LinkPreview } from "../../ui/LinkPreview";
 import { getSelectedNode } from "../../utils/getSelectedNode";
 import { sanitizeUrl } from "../../utils/sanitizeUrl";
 import { setFloatingElemPosition } from "../../utils/setFloatingElemPosition";
+import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
 
 function FloatingLinkEditor({
     editor,
@@ -162,6 +163,7 @@ function FloatingLinkEditor({
                         <input
                             type={"checkbox"}
                             checked={linkUrl.target === "_blank"}
+                            disabled={isUrlLinkReference(linkUrl.url)}
                             onChange={() =>
                                 setLinkUrl({ ...linkUrl, target: linkUrl.target ? null : "_blank" })
                             }

--- a/packages/lexical-editor/src/utils/getLexicalTextSelectionState.ts
+++ b/packages/lexical-editor/src/utils/getLexicalTextSelectionState.ts
@@ -11,7 +11,7 @@ import {
 } from "lexical";
 import { $findMatchingParent, $getNearestNodeOfType } from "@lexical/utils";
 import { getSelectedNode } from "~/utils/getSelectedNode";
-import { $isLinkNode } from "@lexical/link";
+import { $isLinkNode as $isBaseLinkNode } from "@lexical/link";
 import { $isListNode, ListNode } from "~/nodes/ListNode";
 import { $isHeadingNode as $isBaseHeadingNode } from "@lexical/rich-text";
 import { $isTypographyElementNode } from "~/nodes/TypographyElementNode";
@@ -20,6 +20,7 @@ import { $isParagraphNode } from "~/nodes/ParagraphNode";
 import { $isHeadingNode } from "~/nodes/HeadingNode";
 import { $isQuoteNode } from "~/nodes/QuoteNode";
 import { $isParentElementRTL } from "@lexical/selection";
+import { $isLinkNode } from "~/nodes/link-node";
 
 export const getSelectionTextFormat = (selection: RangeSelection | undefined): TextFormatting => {
     return !$isRangeSelection(selection)
@@ -75,7 +76,12 @@ export const getToolbarState = (
     state.isRTL = $isParentElementRTL(selection);
 
     // link
-    state.link.isSelected = $isLinkNode(parent) || $isLinkNode(node);
+    state.link.isSelected =
+        $isBaseLinkNode(parent) ||
+        $isBaseLinkNode(node) ||
+        // custom link node
+        $isLinkNode(parent) ||
+        $isLinkNode(node);
     if (state.link.isSelected) {
         state.textType = "link";
     }

--- a/packages/lexical-editor/src/utils/isUrlLinkReference.ts
+++ b/packages/lexical-editor/src/utils/isUrlLinkReference.ts
@@ -1,0 +1,4 @@
+export const isUrlLinkReference = (url: string) => {
+    const match = url.match(/^#/);
+    return match != null;
+};

--- a/packages/lexical-editor/src/utils/isUrlLinkReference.ts
+++ b/packages/lexical-editor/src/utils/isUrlLinkReference.ts
@@ -1,4 +1,3 @@
 export const isUrlLinkReference = (url: string) => {
-    const match = url.match(/^#/);
-    return match != null;
+    return url.startsWith("#");
 };

--- a/packages/lexical-editor/src/utils/sanitizeUrl.ts
+++ b/packages/lexical-editor/src/utils/sanitizeUrl.ts
@@ -18,9 +18,6 @@ export const sanitizeUrl = (url: string): string => {
     url = String(url).trim();
 
     if (isUrlLinkReference(url)) {
-        console.clear();
-        console.log("url", url);
-        console.log("isUrlLinkReference", isUrlLinkReference(url));
         return url;
     }
 

--- a/packages/lexical-editor/src/utils/sanitizeUrl.ts
+++ b/packages/lexical-editor/src/utils/sanitizeUrl.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
 
 export const sanitizeUrl = (url: string): string => {
     /** A pattern that matches safe  URLs. */
@@ -15,6 +16,13 @@ export const sanitizeUrl = (url: string): string => {
         /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+/]+=*$/i;
 
     url = String(url).trim();
+
+    if (isUrlLinkReference(url)) {
+        console.clear();
+        console.log("url", url);
+        console.log("isUrlLinkReference", isUrlLinkReference(url));
+        return url;
+    }
 
     if (url.match(SAFE_URL_PATTERN) || url.match(DATA_URL_PATTERN)) {
         return url;


### PR DESCRIPTION
With this PR we fixed the problem of creating a reference link to the same page using Lexical editor. Now users can link elements to the same page.

## Changes
- New custom Lexical `LinkNode` class that overrides default link node.
   - In [createDOM](https://github.com/webiny/webiny-js/pull/3474/files#diff-40531d17943b6f9bc2f010a2769055a6050e37c456d0ee41e0ed98bc1631c20f) method, we sanitize the URL with our custom method.
- New `isUrlLinkReference` method  - detect link reference - checks if URL is starting with (#) hashtag
- Update to existing `sanitize` method to recognize the URLs that are link references to other elements on the page.
- In the Lexical link floating popup, when the user enters the link reference, the checkbox "Open in new page" will be disabled (check the test video). 

## Technical problem with the current lexical solution
- Default link [sanitizer method](https://github.com/facebook/lexical/blob/cf0b053a9694af3a6beac42f5fd581c01e5c7a6a/packages/lexical-link/src/index.ts#L165) in Lexical `LinkNode` class, doesn't allow reference links like `#link-to-my-title` to be set in the `href` attribute.
- `LexicalHtmlRenderer` uses the same default `LinkNode` node so the component can't render the link references.

## How Has This Been Tested?
Manually.

## Tests

https://github.com/webiny/webiny-js/assets/82515066/1cfb5595-e486-47b3-8866-36a4d1530710


