### PR TITLE
Fix Page Revision Deletion / Apollo Cache Update

### DIFF
--- a/packages/app-page-builder/src/admin/graphql/pages.ts
+++ b/packages/app-page-builder/src/admin/graphql/pages.ts
@@ -28,6 +28,7 @@ export const DATA_FIELDS = `
     status
     revisions {
         id
+        pid
         savedOn
         locked
         title

--- a/packages/app-page-builder/src/admin/views/Pages/cache.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/cache.ts
@@ -16,6 +16,7 @@ interface PageListVariables {
     };
     // [key: string]: any;
 }
+
 export const readPageListVariables = (): PageListVariables => {
     let variables;
 
@@ -176,7 +177,7 @@ export const removeRevisionFromEntryCache = (
 ): PbPageRevision[] => {
     const gqlParams = {
         query: GQL.GET_PAGE,
-        variables: { id: revision.id }
+        variables: { id: revision.pid }
     };
 
     const data = cache.readQuery(gqlParams);


### PR DESCRIPTION
## Changes
This PR addresses an error that would pop up upon deleting page revision / updating of Apollo cache. The fix was needed because of changes introduced in #3468.

## How Has This Been Tested?
Manually.

## Documentation
N/A