### PR TITLE
Fix Form Field Values Not Changing When Switching Between Page Elements

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/InputField.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/InputField.tsx
@@ -91,6 +91,16 @@ const InputField: React.FC<InputBoxProps> = ({
     defaultValue = "",
     ...props
 }) => {
+    // We introduced the local value concept in order to fix the cursor positioning issue.
+    // Basically, users would type into the field, and the cursor would jump to the end of the input field.
+    // This is because the value was being set from the outside, and the component was re-rendering.
+    // By introducing the local value, we can control when the value is updated.
+    // Original PR: https://github.com/webiny/webiny-js/pull/3146
+
+    // Also note that we've tried to get rid of this and fix the root issue that's causing
+    // the cursor to jump to the end of the input field, but we couldn't find a solution.
+    // This was mainly because of the async nature of the onChange callback. For example,
+    // if we removed the async validation in PropertySettings.tsx, the cursor would no longer jump.
     const [localValue, setLocalValue] = useState(value);
 
     useEffect(() => {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/InputField.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/InputField.tsx
@@ -54,9 +54,11 @@ interface GetValueCallableParams {
     type: string;
     defaultValue: string | number;
 }
+
 interface GetValueCallable {
     (params: GetValueCallableParams): string | number;
 }
+
 const getValue: GetValueCallable = ({ value, defaultValue, type }) => {
     if (type === "number") {
         return isNaN(value as number) ? defaultValue : value;
@@ -73,8 +75,10 @@ interface InputBoxProps {
     className?: string;
     validation?: Validation;
     type?: "string" | "number";
+
     [key: string]: any;
 }
+
 const InputField: React.FC<InputBoxProps> = ({
     className,
     value,
@@ -91,7 +95,7 @@ const InputField: React.FC<InputBoxProps> = ({
 
     useEffect(() => {
         if (localValue !== value) {
-            setLocalValue(localValue);
+            setLocalValue(value);
         }
     }, [value]);
 


### PR DESCRIPTION
## Changes
When switching between page elements (clicking on them), the values in inputs (rendered via `InputField` component) would not change. Basically, once the first page element was activated, for every other element that the user would activate, the values in inputs would not change. Users would see values related to the first page element.

![image](https://github.com/webiny/webiny-js/assets/5121148/c5bb5b37-c3bb-43a5-aebe-b3d5f823544e)

This was caused by a bad value assignment. After changing it, the issue was fixed.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.