### PR TITLE
Button Page Element - Address "New Tab" and "Scroll To Element" Options Issues

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { usePageElements } from "~/hooks/usePageElements";
 import { LinkComponent } from "~/types";
 import styled, { CSSObject } from "@emotion/styled";
@@ -137,8 +137,13 @@ export const createButton = (params: CreateButtonParams = {}) => {
                 );
             }
 
-            const linkActions = ["link", "scrollToElement"];
-            if (link?.href || linkActions.includes(action?.actionType)) {
+            // The `link` property is a legacy property, and it's not used anymore,
+            // but we still need to support it in order to not break existing pages.
+            const isLinkAction = useMemo(() => {
+                return link?.href || ["link", "scrollToElement"].includes(action?.actionType);
+            }, [link?.href, action?.actionType]);
+
+            if (isLinkAction) {
                 let href = "";
                 if (link?.href) {
                     href = link.href;

--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -81,6 +81,7 @@ export interface ButtonElementData {
         href: string;
         clickHandler?: string;
         variables?: Record<string, any>;
+        scrollToElement?: string;
     };
 }
 
@@ -100,7 +101,7 @@ export const createButton = (params: CreateButtonParams = {}) => {
             const { link, icon } = element.data;
 
             const buttonText = props.buttonText || element.data.buttonText;
-            const action = props.action || element.data.action;
+            const action = props.action?.href ? props.action : element.data.action;
 
             let buttonInnerContent = <ButtonText text={buttonText} />;
 
@@ -138,9 +139,19 @@ export const createButton = (params: CreateButtonParams = {}) => {
 
             const linkActions = ["link", "scrollToElement"];
             if (link?.href || linkActions.includes(action?.actionType)) {
-                const href = link?.href || action?.href;
-                const newTab = link?.newTab || action?.newTab;
+                let href = "";
+                if (link?.href) {
+                    href = link.href;
+                } else {
+                    if (action.actionType === "link") {
+                        href = action.href;
+                    }
+                    if (action.actionType === "scrollToElement" && action?.scrollToElement) {
+                        href = "#" + action.scrollToElement;
+                    }
+                }
 
+                const newTab = link?.newTab || action?.newTab;
                 return (
                     <LinkComponent href={href} target={newTab ? "_blank" : "_self"}>
                         <StyledButtonBody>{buttonInnerContent}</StyledButtonBody>

--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -145,18 +145,24 @@ export const createButton = (params: CreateButtonParams = {}) => {
 
             if (isLinkAction) {
                 let href = "";
+
+                // In case the `action.actionType` is `scrollToElement`, the flag will remain false.
+                let newTab = false;
+
                 if (link?.href) {
                     href = link.href;
+                    newTab = link?.newTab;
                 } else {
                     if (action.actionType === "link") {
                         href = action.href;
+                        newTab = action.newTab;
                     }
-                    if (action.actionType === "scrollToElement" && action?.scrollToElement) {
+
+                    if (action.actionType === "scrollToElement") {
                         href = "#" + action.scrollToElement;
                     }
                 }
 
-                const newTab = link?.newTab || action?.newTab;
                 return (
                     <LinkComponent href={href} target={newTab ? "_blank" : "_self"}>
                         <StyledButtonBody>{buttonInnerContent}</StyledButtonBody>


### PR DESCRIPTION
With this PR we are fixing the bug with the button action type selection.

In the page builder editor, when the user clicks on the button and tries to select an action type, for example, `Scroll to an element`, the selected value is not updated correctly to the button.

## Changes
- Assign the correct href value by action type. File `renderers/Button.tsx` in `@webiny/app-page-builder-elements` package

## How Has This Been Tested?
Manually.

## Test video

https://github.com/webiny/webiny-js/assets/82515066/acc68ae8-e486-43c6-8a56-a726cc049a01


