### PR TITLE
Moved ES param handling into Pulumi program

### DIFF
--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -62,6 +62,19 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
         path: "apps/api",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.elasticSearch) {
+                const elasticSearch = app.getParam(projectAppParams.elasticSearch);
+                if (typeof elasticSearch === "object") {
+                    if (elasticSearch.domainName) {
+                        process.env.AWS_ELASTIC_SEARCH_DOMAIN_NAME = elasticSearch.domainName;
+                    }
+
+                    if (elasticSearch.indexPrefix) {
+                        process.env.ELASTIC_SEARCH_INDEX_PREFIX = elasticSearch.indexPrefix;
+                    }
+                }
+            }
+
             const pulumiResourceNamePrefix = app.getParam(
                 projectAppParams.pulumiResourceNamePrefix
             );
@@ -242,19 +255,6 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
             };
         }
     });
-
-    if (projectAppParams.elasticSearch) {
-        const elasticSearch = app.getParam(projectAppParams.elasticSearch);
-        if (typeof elasticSearch === "object") {
-            if (elasticSearch.domainName) {
-                process.env.AWS_ELASTIC_SEARCH_DOMAIN_NAME = elasticSearch.domainName;
-            }
-
-            if (elasticSearch.indexPrefix) {
-                process.env.ELASTIC_SEARCH_INDEX_PREFIX = elasticSearch.indexPrefix;
-            }
-        }
-    }
 
     return withCommonLambdaEnvVariables(app);
 };

--- a/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/core/createCorePulumiApp.ts
@@ -68,6 +68,19 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         path: "apps/core",
         config: projectAppParams,
         program: async app => {
+            if (projectAppParams.elasticSearch) {
+                const elasticSearch = app.getParam(projectAppParams.elasticSearch);
+                if (typeof elasticSearch === "object") {
+                    if (elasticSearch.domainName) {
+                        process.env.AWS_ELASTIC_SEARCH_DOMAIN_NAME = elasticSearch.domainName;
+                    }
+
+                    if (elasticSearch.indexPrefix) {
+                        process.env.ELASTIC_SEARCH_INDEX_PREFIX = elasticSearch.indexPrefix;
+                    }
+                }
+            }
+
             const pulumiResourceNamePrefix = app.getParam(
                 projectAppParams.pulumiResourceNamePrefix
             );
@@ -144,19 +157,6 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
             };
         }
     });
-
-    if (projectAppParams.elasticSearch) {
-        const elasticSearch = app.getParam(projectAppParams.elasticSearch);
-        if (typeof elasticSearch === "object") {
-            if (elasticSearch.domainName) {
-                process.env.AWS_ELASTIC_SEARCH_DOMAIN_NAME = elasticSearch.domainName;
-            }
-
-            if (elasticSearch.indexPrefix) {
-                process.env.ELASTIC_SEARCH_INDEX_PREFIX = elasticSearch.indexPrefix;
-            }
-        }
-    }
 
     return app;
 }


### PR DESCRIPTION
## Changes
This PR moves the handling of ES shared cluster-related params into the Pulumi program. Previously, the handling was located outside of the program, and was executed not only when the program was run, but also even when the `webiny.application.ts` file was required internally upon executing Webiny CLI commands.

This is also caused an issue where the `params.env` would in one case be correct, but in other would be just `undefined`.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.