### PR TITLE
fix(app-aco): use form data to bypass the event execution order problem

### DIFF
--- a/packages/app-aco/src/components/Dialogs/DialogCreate.tsx
+++ b/packages/app-aco/src/components/Dialogs/DialogCreate.tsx
@@ -37,10 +37,10 @@ export const FolderDialogCreate: React.VFC<FolderDialogCreateProps> = ({
     const { showSnackbar } = useSnackbar();
 
     const onSubmit: FormOnSubmit<SubmitData> = useCallback(
-        async data => {
+        async (_, form) => {
             try {
                 await createFolder({
-                    ...data,
+                    ...form.data,
                     parentId: parentId === ROOT_FOLDER ? null : parentId
                 });
                 setDialogOpen(false);


### PR DESCRIPTION
## Changes
This PR fixes a bug in Folder creation form, which would only manifest if you used Cmd/Ctrl+Enter to submit a form. In case of using the keyboard shortcuts to submit the form, the `onBlur` event, and subsequently the form state update would happen "too late" for data changes to be applied to the `data` object passed to the `onSubmit` handler.

To bypass this problem, which is effectively caused by the nature of React rendering cycles, we grab the form data from the form instance itself, and not from the `data` object which was passed to the callback _before_ other UI events were processed.

![CleanShot 2023-08-21 at 17 10 04](https://github.com/webiny/webiny-js/assets/3920893/c763854a-d9c4-4ebb-937e-b1aa406378a8)


## How Has This Been Tested?
Manually.
