### PR TITLE
Remove `elasticSearch` Type On the `CreateApiAppParams` Type

### DIFF
--- a/packages/serverless-cms-aws/src/enterprise/createApiApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createApiApp.ts
@@ -1,4 +1,3 @@
-import { PulumiAppParam } from "@webiny/pulumi";
 import { createApiPulumiApp, CreateApiPulumiAppParams } from "@webiny/pulumi-aws/enterprise";
 import { PluginCollection } from "@webiny/plugins/types";
 import {
@@ -12,12 +11,6 @@ import {
 export { ApiOutput } from "@webiny/pulumi-aws";
 
 export interface CreateApiAppParams extends CreateApiPulumiAppParams {
-    /**
-     * Enables ElasticSearch infrastructure.
-     * Note that it requires also changes in application code.
-     */
-    elasticSearch?: PulumiAppParam<boolean>;
-
     plugins?: PluginCollection;
 }
 


### PR DESCRIPTION
## Changes
This PR fixes the type of the `elasticSearch` property on the `CreateApiAppParams` type.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.