### PR TITLE
fix: fix rerenders on element select

### DIFF
--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
@@ -66,7 +66,7 @@ const SaveDialog = (props: Props) => {
         setTimeout(async () => {
             setPbElement((await getElementTree({ element })) as PbElement);
         });
-    });
+    }, []);
 
     const blockCategoriesOptions = plugins
         .byType<PbEditorBlockCategoryPlugin>("pb-editor-block-category")

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/save/SaveDialog.tsx
@@ -62,11 +62,12 @@ const SaveDialog = (props: Props) => {
     const [pbElement, setPbElement] = useState<PbElement>();
     const { getElementTree } = useEventActionHandler();
 
+    // We need to get element children to show on preview.
     useEffect(() => {
         setTimeout(async () => {
             setPbElement((await getElementTree({ element })) as PbElement);
         });
-    }, []);
+    }, [element.id]);
 
     const blockCategoriesOptions = plugins
         .byType<PbEditorBlockCategoryPlugin>("pb-editor-block-category")


### PR DESCRIPTION
## Changes
Resolve issue "Continuous rerenders when selecting element inside page/block/template editors".

## How Has This Been Tested?
Manual

## Documentation
None
