### PR TITLE
ES Service Role Checking - Improve Error Logging

### DIFF
--- a/packages/cwp-template-aws/cli/aws/checkEsServiceRole.js
+++ b/packages/cwp-template-aws/cli/aws/checkEsServiceRole.js
@@ -2,6 +2,8 @@ const IAM = require("aws-sdk/clients/iam");
 const ora = require("ora");
 const { green } = require("chalk");
 
+const NO_SUCH_ENTITY_IAM_ERROR = "NoSuchEntity";
+
 module.exports = {
     type: "hook-before-deploy",
     name: "hook-before-deploy-es-service-role",
@@ -24,6 +26,18 @@ module.exports = {
             });
             context.success(`Found Elastic Search service role!`);
         } catch (err) {
+            // We've seen cases where the `iam.getRole` call fails because of an issue
+            // other than not being able to retrieve the service role. Let's print
+            // additional info if that's the case. Will make debugging a bit easier.
+            if (err.code !== NO_SUCH_ENTITY_IAM_ERROR) {
+                spinner.fail(
+                    "Tried retrieving Elastic Search service role but failed with the following error: " +
+                        err.message
+                );
+                context.debug(err);
+                process.exit(1);
+            }
+
             spinner.text = "Creating Elastic Search service role...";
 
             try {
@@ -32,6 +46,7 @@ module.exports = {
                 spinner.stop();
             } catch (err) {
                 spinner.fail(err.message);
+                context.debug(err);
                 process.exit(1);
             }
         }


### PR DESCRIPTION
## Changes
With this PR, we're trying to improve error logging for the `hook-before-deploy-es-service-role` deploy hook, which checks if the user's AWS account already contains the `AWSServiceRoleForAmazonElasticsearchService` IAM service role.

This small improvement my help us with debugging some of the errors that we've seen pop up from time to time when users are trying to deploy a Webiny project into their AWS account.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.