### PR TITLE
Tenant Router Lambda@Edge Function - Prevent Setting VPC Configuration

### DIFF
--- a/packages/pulumi-aws/src/apps/tenantRouter.ts
+++ b/packages/pulumi-aws/src/apps/tenantRouter.ts
@@ -81,8 +81,7 @@ export function applyTenantRouter(
                     }
                 ]
             }
-        },
-        meta: { isLambdaFunctionRole: true }
+        }
     });
 
     const awsUsEast1 = new aws.Provider("us-east-1", { region: "us-east-1" });
@@ -107,7 +106,10 @@ export function applyTenantRouter(
         // the environment is destroyed. Users need to delete the function manually. We decided to use
         // this option here because it enables us to avoid annoying AWS Lambda function replication
         // errors upon destroying the stack (see https://github.com/pulumi/pulumi-aws/issues/2178).
-        opts: { provider: awsUsEast1, retainOnDelete: true }
+        opts: { provider: awsUsEast1, retainOnDelete: true },
+        meta: {
+            canUseVpc: false
+        }
     });
 
     cloudfront.config.defaultCacheBehavior(value => {

--- a/packages/pulumi-aws/src/enterprise/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createApiPulumiApp.ts
@@ -49,7 +49,10 @@ export function createApiPulumiApp(projectAppParams: CreateApiPulumiAppParams = 
 
                 onResource(resource => {
                     if (isResourceOfType(resource, aws.lambda.Function)) {
-                        resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        const canUseVpc = resource.meta.canUseVpc !== false;
+                        if (canUseVpc) {
+                            resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        }
                     }
 
                     if (isResourceOfType(resource, aws.iam.Role)) {

--- a/packages/pulumi-aws/src/enterprise/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createCorePulumiApp.ts
@@ -76,7 +76,10 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
 
                 onResource(resource => {
                     if (isResourceOfType(resource, aws.lambda.Function)) {
-                        resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        const canUseVpc = resource.meta.canUseVpc !== false;
+                        if (canUseVpc) {
+                            resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        }
                     }
 
                     if (isResourceOfType(resource, aws.iam.Role)) {

--- a/packages/pulumi-aws/src/enterprise/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createWebsitePulumiApp.ts
@@ -49,7 +49,10 @@ export function createWebsitePulumiApp(projectAppParams: CreateWebsitePulumiAppP
 
                 onResource(resource => {
                     if (isResourceOfType(resource, aws.lambda.Function)) {
-                        resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        const canUseVpc = resource.meta.canUseVpc !== false;
+                        if (canUseVpc) {
+                            resource.config.vpcConfig(useExistingVpc!.lambdaFunctionsVpcConfig);
+                        }
                     }
 
                     if (isResourceOfType(resource, aws.iam.Role)) {


### PR DESCRIPTION
## Changes
This PR ensures that VPC configuration is not assigned to the Tenant Router Lambda@Edge function. 

For context, prior to this PR, [setting up an existing VPC](https://www.webiny.com/docs/enterprise/use-existing-amazon-vpc) would cause an issue upon deploying the Website app. The issue would happen because the VPC config would also be applied to Tenant Router Lambda@Edge function, [which is not possible](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html).

## How Has This Been Tested?
Manual.

## Documentation
Changelog.