### PR TITLE
Always Use Locale in Index Name for CMS Models

### DIFF
--- a/packages/migrations/src/utils/elasticsearch/esGetIndexName.ts
+++ b/packages/migrations/src/utils/elasticsearch/esGetIndexName.ts
@@ -28,7 +28,7 @@ export const esGetIndexName = (params: EsGetIndexNameParams) => {
 
     const tenantId = sharedIndex ? "root" : tenant;
     let localeCode: string | null = null;
-    if (process.env.WEBINY_ELASTICSEARCH_INDEX_LOCALE === "true") {
+    if (isHeadlessCmsModel || process.env.WEBINY_ELASTICSEARCH_INDEX_LOCALE === "true") {
         if (!locale) {
             throw new WebinyError(
                 `Missing "locale" parameter when trying to create Elasticsearch index name.`,


### PR DESCRIPTION
## Changes
This PR ensures that the locale is always included in the ES index name. This is because these indexes always have locale in them, no matter what the value of the `WEBINY_ELASTICSEARCH_INDEX_LOCALE` env var is.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.