### PR TITLE
Deploy Webiny Project CF Template: Added Missing `iam:CreateServiceLinkedRole` Permission

### DIFF
--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
@@ -227,6 +227,15 @@ Resources:
                   - arn:aws:iam::*:role/wby-*
                   - arn:aws:iam::*:policy/wby-*
 
+              # AWS Identity and Access Management (IAM) - Service-Linked Roles
+              # Only needed for the "Amazon DynamoDB + Amazon Elasticsearch" database setup.
+              # https://www.webiny.com/docs/architecture/introduction#different-database-setups
+              - Effect: Allow
+                Action:
+                  - iam:CreateServiceLinkedRole
+                Resource:
+                  - arn:aws:iam::*:role/aws-service-role/es.amazonaws.com/AWSServiceRoleForAmazonElasticsearchService
+
               # AWS Lambda
               - Effect: Allow
                 Action:


### PR DESCRIPTION
## Changes
This PR adds the `iam:CreateServiceLinkedRole` permission to our **Deploy Webiny Project** CloudFormation template. Without this permission, users using the DDB+ES version of Webiny would hit an issue upon the creation of the `AWSServiceRoleForAmazonElasticsearchService` service-linked IAM role.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.