### PR TITLE
feat(api-headless-cms): import groups and models

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -86,7 +86,7 @@ describe("content model test", () => {
 
         expect(getTypeFields(ReadQuery)).toEqual(["getContentModel", "listContentModels"]);
         expect(getTypeFields(ManageQuery)).toEqual([
-            "exportCmsStructure",
+            "exportStructure",
             "getContentModel",
             "listContentModels",
             "searchContentEntries",
@@ -101,6 +101,8 @@ describe("content model test", () => {
         ]);
         expect(getTypeFields(ReadMutation)).toEqual([]);
         expect(getTypeFields(ManageMutation)).toEqual([
+            "validateImportStructure",
+            "importStructure",
             "createContentModel",
             "createContentModelFrom",
             "updateContentModel",

--- a/packages/api-headless-cms/__tests__/contentAPI/export.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/export.structure.test.ts
@@ -23,7 +23,7 @@ const groups: Omit<CmsGroup, "id">[] = [
     }
 ];
 
-const fixFieldsNullTexts = (fields: CmsModelField[]): CmsModelField[] => {
+const fixFields = (fields: CmsModelField[]): CmsModelField[] => {
     return fields.map(field => {
         const result = {
             ...field,
@@ -31,7 +31,18 @@ const fixFieldsNullTexts = (fields: CmsModelField[]): CmsModelField[] => {
             placeholderText: field.placeholderText || null
         };
         if (result.settings?.fields) {
-            result.settings.fields = fixFieldsNullTexts(result.settings.fields);
+            result.settings.fields = fixFields(result.settings.fields);
+        }
+        if (result.predefinedValues) {
+            result.predefinedValues = {
+                ...result.predefinedValues,
+                values: (result.predefinedValues.values || []).map(value => {
+                    return {
+                        ...value,
+                        selected: value.selected || false
+                    };
+                })
+            };
         }
         return result;
     });
@@ -51,12 +62,11 @@ describe("export cms structure", () => {
 
     it("should export all groups and models", async () => {
         const {
-            exportCmsStructureQuery,
+            exportStructureQuery,
             createContentModelGroupMutation,
             createContentModelMutation
         } = useGraphQLHandler({
-            path: "manage/en-US",
-            plugins: []
+            path: "manage/en-US"
         });
 
         const createdGroups = await insertGroups(createContentModelGroupMutation);
@@ -88,17 +98,17 @@ describe("export cms structure", () => {
 
         expect(createdModels.length).toBe(models.length);
 
-        const [result] = await exportCmsStructureQuery();
+        const [result] = await exportStructureQuery();
 
         expect(result).toEqual({
             data: {
-                exportCmsStructure: {
+                exportStructure: {
                     data: expect.any(String),
                     error: null
                 }
             }
         });
-        const json = JSON.parse(result.data.exportCmsStructure.data) as JsonResult;
+        const json = JSON.parse(result.data.exportStructure.data) as JsonResult;
         expect(json.groups.length).toBe(groups.length);
         expect(json.models.length).toBe(models.length);
         expect(json).toMatchObject({
@@ -121,11 +131,8 @@ describe("export cms structure", () => {
                 description: model.description,
                 titleFieldId: model.titleFieldId,
                 icon: model.icon,
-                group: {
-                    id: group.id,
-                    name: group.name
-                },
-                fields: fixFieldsNullTexts(model.fields),
+                group: group.id,
+                fields: fixFields(model.fields),
                 layout: model.layout
             });
             expect(jsonModel.imageFieldId).toEqual(model.imageFieldId || undefined);

--- a/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
@@ -1,0 +1,479 @@
+import { useGraphQLHandler } from "~tests/testHelpers/useGraphQLHandler";
+import { createCmsGroup } from "~/plugins";
+import { exportedGroupsAndModels } from "~tests/contentAPI/mocks/exportedGroupsAndModels";
+
+describe("import cms structure", () => {
+    const { validateCmsStructureMutation } = useGraphQLHandler({
+        path: "manage/en-US"
+    });
+    it("should return error as there are no groups to validate", async () => {
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [],
+                models: []
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [],
+                        models: [],
+                        message: "No groups to import."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should return error as there are no models to validate", async () => {
+        const group = {
+            id: "group-1",
+            name: "Group 1",
+            slug: "group-1",
+            icon: "fas/star",
+            description: "Group 1 description"
+        };
+
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group],
+                models: []
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group.id,
+                                    name: group.name
+                                },
+                                error: null
+                            }
+                        ],
+                        models: [],
+                        message: "No models to import."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show errors when trying to validate faulty groups", async () => {
+        const group1 = {
+            id: "group-1",
+            slug: "",
+            name: "Group 1",
+            icon: "fa/fas"
+        };
+        const group2 = {
+            id: "",
+            slug: "group-2",
+            name: "Group 2",
+            icon: "fa/fas"
+        };
+
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group1, group2],
+                models: []
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group1.id,
+                                    name: group1.name
+                                },
+                                error: {
+                                    code: "GROUP_SLUG_MISSING",
+                                    data: null,
+                                    message: "Group is missing slug."
+                                }
+                            },
+                            {
+                                group: {
+                                    id: "",
+                                    name: group2.name
+                                },
+                                error: {
+                                    code: "GROUP_ID_MISSING",
+                                    data: null,
+                                    message: "Group is missing ID."
+                                }
+                            }
+                        ],
+                        models: [],
+                        message: "No models to import."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show errors when trying to validate groups which already exist in the system", async () => {
+        const { validateCmsStructureMutation } = useGraphQLHandler({
+            path: "manage/en-US",
+            plugins: [
+                createCmsGroup({
+                    id: "group-1-original",
+                    slug: "group-1",
+                    name: "Group 1 Original",
+                    icon: "fa/fas",
+                    description: ""
+                }),
+                createCmsGroup({
+                    id: "group-2",
+                    slug: "group-2-original",
+                    name: "Group 2 Original",
+                    icon: "fa/fas",
+                    description: ""
+                })
+            ]
+        });
+
+        const group1 = {
+            id: "group-1",
+            slug: "group-1",
+            name: "Group 1",
+            icon: "fa/fas"
+        };
+        const group2 = {
+            id: "group-2",
+            slug: "group-2",
+            name: "Group 2",
+            icon: "fa/fas"
+        };
+        const group3 = {
+            id: "group-3",
+            slug: "group-3",
+            name: "Group 3",
+            icon: "fa/fas"
+        };
+
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group1, group2, group3],
+                models: []
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group1.id,
+                                    name: group1.name
+                                },
+                                error: {
+                                    code: "GROUP_SLUG_EXISTS",
+                                    data: null,
+                                    message: `Group with slug "group-1" already exists.`
+                                }
+                            },
+                            {
+                                group: {
+                                    id: group2.id,
+                                    name: group2.name
+                                },
+                                error: {
+                                    code: "GROUP_ID_EXISTS",
+                                    data: null,
+                                    message: `Group with ID "group-2" already exists.`
+                                }
+                            },
+                            {
+                                group: {
+                                    id: group3.id,
+                                    name: group3.name
+                                },
+                                error: null
+                            }
+                        ],
+                        models: [],
+                        message: "No models to import."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show no errors when trying to validate valid groups", async () => {
+        const group1 = {
+            id: "group-1",
+            slug: "group-1",
+            name: "Group 1",
+            icon: "fa/fas"
+        };
+        const group2 = {
+            id: "group-2",
+            slug: "group-2",
+            name: "Group 2",
+            icon: "fa/fas"
+        };
+
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group1, group2],
+                models: []
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group1.id,
+                                    name: group1.name
+                                },
+                                error: null
+                            },
+                            {
+                                group: {
+                                    id: group2.id,
+                                    name: group2.name
+                                },
+                                error: null
+                            }
+                        ],
+                        models: [],
+                        message: "No models to import."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show errors when trying to validate empty model values", async () => {
+        const group = {
+            id: "group-1",
+            slug: "group-1",
+            name: "Group 1",
+            icon: "fa/fas"
+        };
+
+        const model = {
+            modelId: "",
+            name: "",
+            group: "",
+            fields: [],
+            layout: [],
+            singularApiName: "",
+            pluralApiName: "",
+            titleFieldId: ""
+        };
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group],
+                models: [model]
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group.id,
+                                    name: group.name
+                                },
+                                error: null
+                            }
+                        ],
+                        models: [
+                            {
+                                model: {
+                                    modelId: "",
+                                    name: ""
+                                },
+                                error: {
+                                    code: "VALIDATION_FAILED_INVALID_FIELDS",
+                                    data: {
+                                        invalidFields: {
+                                            modelId: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            name: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            singularApiName: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            pluralApiName: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            fields: {
+                                                code: "too_small",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            layout: {
+                                                code: "too_small",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            }
+                                        }
+                                    },
+                                    message: "Validation failed."
+                                }
+                            }
+                        ],
+                        message: "Validation done."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show errors when trying to validate invalid model values", async () => {
+        const group = {
+            id: "group-1",
+            slug: "group-1",
+            name: "Group 1",
+            icon: "fa/fas"
+        };
+
+        const model = {
+            modelId: "1",
+            name: "2",
+            group: "3",
+            fields: [],
+            layout: [],
+            singularApiName: "4",
+            pluralApiName: "5",
+            titleFieldId: "6"
+        };
+        const [result] = await validateCmsStructureMutation({
+            data: {
+                groups: [group],
+                models: [model]
+            }
+        });
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: [
+                            {
+                                group: {
+                                    id: group.id,
+                                    name: group.name
+                                },
+                                error: null
+                            }
+                        ],
+                        models: [
+                            {
+                                model: {
+                                    modelId: "1",
+                                    name: "2"
+                                },
+                                error: {
+                                    code: "VALIDATION_FAILED_INVALID_FIELDS",
+                                    data: {
+                                        invalidFields: {
+                                            modelId: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            name: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            singularApiName: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            pluralApiName: {
+                                                code: "custom",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            fields: {
+                                                code: "too_small",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            },
+                                            layout: {
+                                                code: "too_small",
+                                                data: expect.any(Object),
+                                                message: expect.any(String)
+                                            }
+                                        }
+                                    },
+                                    message: "Validation failed."
+                                }
+                            }
+                        ],
+                        message: "Validation done."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should show no errors when groups and models are valid - exported data", async () => {
+        const [result] = await validateCmsStructureMutation({
+            data: exportedGroupsAndModels
+        });
+
+        expect(result).toEqual({
+            data: {
+                validateImportStructure: {
+                    data: {
+                        groups: exportedGroupsAndModels.groups.map(group => {
+                            return {
+                                group: {
+                                    id: group.id,
+                                    name: group.name
+                                },
+                                error: null
+                            };
+                        }),
+                        models: exportedGroupsAndModels.models.map(model => {
+                            return {
+                                model: {
+                                    modelId: model.modelId,
+                                    name: model.name
+                                },
+                                error: null
+                            };
+                        }),
+                        message: "Validation done."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
@@ -3,7 +3,7 @@ import { createCmsGroup } from "~/plugins";
 import { exportedGroupsAndModels } from "~tests/contentAPI/mocks/exportedGroupsAndModels";
 
 describe("import cms structure", () => {
-    const { validateCmsStructureMutation } = useGraphQLHandler({
+    const { validateCmsStructureMutation, importCmsStructureMutation } = useGraphQLHandler({
         path: "manage/en-US"
     });
     it("should return error as there are no groups to validate", async () => {
@@ -470,6 +470,42 @@ describe("import cms structure", () => {
                             };
                         }),
                         message: "Validation done."
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should import valid groups and models - exported data", async () => {
+        const [result] = await importCmsStructureMutation({
+            data: exportedGroupsAndModels,
+            models: exportedGroupsAndModels.models.map(model => model.modelId)
+        });
+
+        expect(result).toEqual({
+            data: {
+                importStructure: {
+                    data: {
+                        groups: exportedGroupsAndModels.groups.map(group => {
+                            return {
+                                group: {
+                                    id: group.id,
+                                    name: group.name
+                                },
+                                error: null
+                            };
+                        }),
+                        models: exportedGroupsAndModels.models.map(model => {
+                            return {
+                                model: {
+                                    modelId: model.modelId,
+                                    name: model.name
+                                },
+                                error: null
+                            };
+                        }),
+                        message: "Import done."
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
@@ -3,9 +3,15 @@ import { createCmsGroup } from "~/plugins";
 import { exportedGroupsAndModels } from "~tests/contentAPI/mocks/exportedGroupsAndModels";
 
 describe("import cms structure", () => {
-    const { validateCmsStructureMutation, importCmsStructureMutation } = useGraphQLHandler({
+    const {
+        validateCmsStructureMutation,
+        importCmsStructureMutation,
+        listContentModelsQuery,
+        listContentModelGroupsQuery
+    } = useGraphQLHandler({
         path: "manage/en-US"
     });
+
     it("should return error as there are no groups to validate", async () => {
         const [result] = await validateCmsStructureMutation({
             data: {
@@ -511,5 +517,45 @@ describe("import cms structure", () => {
                 }
             }
         });
+
+        const expectedGroups = exportedGroupsAndModels.groups.map(group => {
+            return {
+                id: group.id,
+                slug: group.slug
+            };
+        });
+        const [listGroupsResponse] = await listContentModelGroupsQuery();
+        expect(listGroupsResponse).toMatchObject({
+            data: {
+                listContentModelGroups: {
+                    data: expectedGroups,
+                    error: null
+                }
+            }
+        });
+        const listedGroups = listGroupsResponse.data.listContentModelGroups.data;
+        expect(listedGroups).toHaveLength(expectedGroups.length);
+        expect(listedGroups).toMatchObject(expectedGroups);
+
+        const expectedModels = exportedGroupsAndModels.models.map(model => {
+            return {
+                modelId: model.modelId,
+                singularApiName: model.singularApiName,
+                pluralApiName: model.pluralApiName
+            };
+        });
+
+        const [listModelsResponse] = await listContentModelsQuery();
+        expect(listModelsResponse).toMatchObject({
+            data: {
+                listContentModels: {
+                    data: expectedModels,
+                    error: null
+                }
+            }
+        });
+        const listedModels = listModelsResponse.data.listContentModels.data;
+        expect(listedModels).toHaveLength(expectedModels.length);
+        expect(listedModels).toMatchObject(expectedModels);
     });
 });

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/exportedGroupsAndModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/exportedGroupsAndModels.ts
@@ -1,0 +1,229 @@
+export const exportedGroupsAndModels = {
+    groups: [
+        {
+            id: "64d4c105110b570008736515",
+            name: "Blog",
+            slug: "blog",
+            description: null,
+            icon: "fab/blogger-b"
+        }
+    ],
+    models: [
+        {
+            modelId: "article",
+            name: "Article",
+            group: "64d4c105110b570008736515",
+            icon: "far/newspaper",
+            singularApiName: "Article",
+            pluralApiName: "Articles",
+            fields: [
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "text-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Title",
+                    type: "text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "s0due9k2",
+                    validation: [{ name: "required", message: "Value is required.", settings: {} }],
+                    storageId: "text@s0due9k2",
+                    fieldId: "title"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "long-text-text-area" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Description",
+                    type: "long-text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "f0aqavgm",
+                    validation: [],
+                    storageId: "long-text@f0aqavgm",
+                    fieldId: "description"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "lexical-text-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Body",
+                    type: "rich-text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "jkldufuq",
+                    validation: [],
+                    storageId: "rich-text@jkldufuq",
+                    fieldId: "body"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: { models: [{ modelId: "author" }] },
+                    renderer: { name: "ref-advanced-single" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Author",
+                    type: "ref",
+                    tags: [],
+                    placeholderText: null,
+                    id: "ucuyyn1j",
+                    validation: [],
+                    storageId: "ref@ucuyyn1j",
+                    fieldId: "author"
+                },
+                {
+                    multipleValues: true,
+                    listValidation: [],
+                    settings: { models: [{ modelId: "category" }] },
+                    renderer: { name: "ref-advanced-multiple" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Categories",
+                    type: "ref",
+                    tags: [],
+                    placeholderText: null,
+                    id: "d5zkt06f",
+                    validation: [],
+                    storageId: "ref@d5zkt06f",
+                    fieldId: "categories"
+                }
+            ],
+            layout: [["s0due9k2"], ["f0aqavgm"], ["jkldufuq"], ["ucuyyn1j", "d5zkt06f"]],
+            titleFieldId: "title",
+            descriptionFieldId: "description"
+        },
+        {
+            modelId: "author",
+            name: "Author",
+            group: "64d4c105110b570008736515",
+            icon: "fas/person",
+            singularApiName: "Author",
+            pluralApiName: "Authors",
+            fields: [
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "text-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Name",
+                    type: "text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "dtaqd9fp",
+                    validation: [{ name: "required", message: "Value is required.", settings: {} }],
+                    storageId: "text@dtaqd9fp",
+                    fieldId: "name"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "long-text-text-area" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "About",
+                    type: "long-text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "2sof6i8i",
+                    validation: [],
+                    storageId: "long-text@2sof6i8i",
+                    fieldId: "about"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "lexical-text-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Biography",
+                    type: "rich-text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "n6uxjar7",
+                    validation: [],
+                    storageId: "rich-text@n6uxjar7",
+                    fieldId: "biography"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: { type: "date" },
+                    renderer: { name: "date-time-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Date Of Birth",
+                    type: "datetime",
+                    tags: [],
+                    placeholderText: null,
+                    id: "w44xgwwr",
+                    validation: [],
+                    storageId: "datetime@w44xgwwr",
+                    fieldId: "dateOfBirth"
+                },
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "boolean-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Is Married",
+                    type: "boolean",
+                    tags: [],
+                    placeholderText: null,
+                    id: "b2a35yc7",
+                    validation: [],
+                    storageId: "boolean@b2a35yc7",
+                    fieldId: "isMarried"
+                }
+            ],
+            layout: [["dtaqd9fp"], ["2sof6i8i"], ["n6uxjar7"], ["w44xgwwr", "b2a35yc7"]],
+            titleFieldId: "name",
+            descriptionFieldId: "about"
+        },
+        {
+            modelId: "category",
+            name: "Category",
+            group: "64d4c105110b570008736515",
+            icon: "fas/location-dot",
+            singularApiName: "Category",
+            pluralApiName: "Categories",
+            fields: [
+                {
+                    multipleValues: false,
+                    listValidation: [],
+                    settings: {},
+                    renderer: { name: "text-input" },
+                    helpText: null,
+                    predefinedValues: { enabled: false, values: [] },
+                    label: "Title",
+                    type: "text",
+                    tags: [],
+                    placeholderText: null,
+                    id: "3oqcch5d",
+                    validation: [
+                        { name: "required", message: "Title is a required field.", settings: {} }
+                    ],
+                    storageId: "text@3oqcch5d",
+                    fieldId: "title"
+                }
+            ],
+            layout: [["3oqcch5d"]],
+            titleFieldId: "title"
+        }
+    ]
+};

--- a/packages/api-headless-cms/__tests__/testHelpers/graphql/structure.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/graphql/structure.ts
@@ -1,13 +1,48 @@
-export interface ExportCmsStructureQueryVariables {
-    code?: boolean;
-    targets?: {
-        [group: string]: string[];
-    };
+import { CmsImportStructureParamsData } from "~/export/types";
+
+export interface CmsExportStructureQueryVariables {
+    models?: string[];
 }
 
-export const EXPORT_CMS_STRUCTURE_QUERY = /* GraphQL */ `
-    query ExportContentModelGroupsQuery($models: [String!]) {
-        exportCmsStructure(models: $models) {
+export interface CmsImportStructureMutationVariables {
+    data: CmsImportStructureParamsData;
+    models: string[];
+}
+
+export interface CmsValidateStructureMutationVariables {
+    data: CmsImportStructureParamsData;
+}
+
+const ERROR_FIELD = /* GraphQL */ `
+    error {
+        message
+        code
+        data
+    }
+`;
+
+const GROUPS_FIELD = /* GraphQL */ `
+    groups {
+        group {
+            id
+            name
+        }
+        ${ERROR_FIELD}
+    }
+`;
+const MODELS_FIELD = /* GraphQL */ `
+    models {
+        model {
+            modelId
+            name
+        }
+        ${ERROR_FIELD}
+    }
+`;
+
+export const CMS_EXPORT_STRUCTURE_QUERY = /* GraphQL */ `
+    query CmsExportStructureQuery($models: [String!]) {
+        exportStructure(models: $models) {
             data
             error {
                 message
@@ -15,6 +50,35 @@ export const EXPORT_CMS_STRUCTURE_QUERY = /* GraphQL */ `
                 data
                 stack
             }
+        }
+    }
+`;
+
+export const CMS_VALIDATE_STRUCTURE_MUTATION = /* GraphQL */ `
+    mutation CmsValidateStructureMutation($data: CmsImportStructureInput!) {
+        validateImportStructure(data: $data) {
+            data {
+                ${GROUPS_FIELD}
+                ${MODELS_FIELD}
+                message
+            }
+            ${ERROR_FIELD}
+        }
+    }
+`;
+
+export const CMS_IMPORT_STRUCTURE_MUTATION = /* GraphQL */ `
+    mutation CmsImportStructureMutation(
+        $data: CmsImportStructureInput!
+        $models: [String!]!
+    ) {
+        importStructure(data: $data, models: $models) {
+            data {
+                ${GROUPS_FIELD}
+                ${MODELS_FIELD}
+                message
+            }
+            ${ERROR_FIELD}
         }
     }
 `;

--- a/packages/api-headless-cms/__tests__/testHelpers/graphql/structure.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/graphql/structure.ts
@@ -27,6 +27,7 @@ const GROUPS_FIELD = /* GraphQL */ `
             id
             name
         }
+        action
         ${ERROR_FIELD}
     }
 `;
@@ -36,6 +37,8 @@ const MODELS_FIELD = /* GraphQL */ `
             modelId
             name
         }
+        related
+        action
         ${ERROR_FIELD}
     }
 `;

--- a/packages/api-headless-cms/__tests__/testHelpers/useGraphQLHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useGraphQLHandler.ts
@@ -39,8 +39,12 @@ import { StorageOperationsCmsModelPlugin } from "~/plugins";
 import { createCmsModelFieldConvertersAttachFactory } from "~/utils/converters/valueKeyStorageConverter";
 import { createOutputBenchmarkLogs } from "~tests/testHelpers/outputBenchmarkLogs";
 import {
-    EXPORT_CMS_STRUCTURE_QUERY,
-    ExportCmsStructureQueryVariables
+    CMS_EXPORT_STRUCTURE_QUERY,
+    CmsExportStructureQueryVariables,
+    CMS_IMPORT_STRUCTURE_MUTATION,
+    CmsImportStructureMutationVariables,
+    CMS_VALIDATE_STRUCTURE_MUTATION,
+    CmsValidateStructureMutationVariables
 } from "~tests/testHelpers/graphql/structure";
 
 export type GraphQLHandlerParams = CreateHandlerCoreParams;
@@ -121,11 +125,27 @@ export const useGraphQLHandler = (params: GraphQLHandlerParams = {}) => {
         async installMutation() {
             return invoke({ body: { query: INSTALL_MUTATION } });
         },
-        //
-        async exportCmsStructureQuery(variables?: ExportCmsStructureQueryVariables) {
+        // export / import
+        async exportStructureQuery(variables?: CmsExportStructureQueryVariables) {
             return invoke({
                 body: {
-                    query: EXPORT_CMS_STRUCTURE_QUERY,
+                    query: CMS_EXPORT_STRUCTURE_QUERY,
+                    variables
+                }
+            });
+        },
+        async importCmsStructureMutation(variables: CmsImportStructureMutationVariables) {
+            return invoke({
+                body: {
+                    query: CMS_IMPORT_STRUCTURE_MUTATION,
+                    variables
+                }
+            });
+        },
+        async validateCmsStructureMutation(variables: CmsValidateStructureMutationVariables) {
+            return invoke({
+                body: {
+                    query: CMS_VALIDATE_STRUCTURE_MUTATION,
                     variables
                 }
             });

--- a/packages/api-headless-cms/src/context.ts
+++ b/packages/api-headless-cms/src/context.ts
@@ -14,6 +14,7 @@ import { ModelGroupsPermissions } from "./utils/permissions/ModelGroupsPermissio
 import { EntriesPermissions } from "./utils/permissions/EntriesPermissions";
 import { SettingsPermissions } from "./utils/permissions/SettingsPermissions";
 import { createExportCrud } from "~/export";
+import { createImportCrud } from "~/export/crud/importing";
 
 const getParameters = async (context: CmsContext): Promise<CmsParametersPluginResponse> => {
     const plugins = context.plugins.byType<CmsParametersPlugin>(CmsParametersPlugin.type);
@@ -143,6 +144,9 @@ export const createContextPlugin = ({ storageOperations }: CrudParams) => {
                 }),
                 export: {
                     ...createExportCrud(context)
+                },
+                importing: {
+                    ...createImportCrud(context)
                 }
             };
 

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -196,7 +196,7 @@ export const createModelImportValidation = () => {
                 if (value.match(/^[a-zA-Z]/) === null) {
                     return false;
                 }
-                return camelCase(value) === value;
+                return true;
             },
             value => {
                 return {

--- a/packages/api-headless-cms/src/crud/contentModelGroup/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModelGroup/validation.ts
@@ -4,7 +4,7 @@ import { toSlug } from "~/utils/toSlug";
 const str = zod.string().trim();
 
 const name = str.max(100);
-const description = str.max(255).optional();
+const description = str.max(255).optional().nullish();
 const icon = str.min(1).max(255);
 
 export const createGroupCreateValidation = () => {

--- a/packages/api-headless-cms/src/export/crud/exporting.ts
+++ b/packages/api-headless-cms/src/export/crud/exporting.ts
@@ -15,7 +15,11 @@ export const createExportStructureContext = (context: CmsContext): HeadlessCmsEx
          */
         const models = (await context.cms.listModels())
             .filter(model => {
-                if (!modelIdList?.length) {
+                if (model.isPrivate) {
+                    return false;
+                } else if (!model.fields?.length) {
+                    return false;
+                } else if (!modelIdList?.length) {
                     return true;
                 }
                 return modelIdList.includes(model.modelId);
@@ -28,12 +32,12 @@ export const createExportStructureContext = (context: CmsContext): HeadlessCmsEx
                 return sanitizeModel(group, model);
             })
             .filter((model): model is SanitizedCmsModel => {
-                return model !== null;
+                return !!model;
             });
 
         return {
             groups: groups.filter(group => {
-                return models.some(model => model.group.id === group.id);
+                return models.some(model => model.group === group.id);
             }),
             models
         };

--- a/packages/api-headless-cms/src/export/crud/importing.ts
+++ b/packages/api-headless-cms/src/export/crud/importing.ts
@@ -1,0 +1,91 @@
+import { HeadlessCmsImport, ValidCmsGroupResult, ValidCmsModelResult } from "~/export/types";
+import { CmsContext } from "~/types";
+import { importData } from "./imports/importData";
+import { validateInput } from "./imports/validateInput";
+
+const fetchGroupsAndModels = async (context: CmsContext) => {
+    const groups = await context.security.withoutAuthorization(async () => {
+        return await context.cms.listGroups();
+    });
+    const models = await context.security.withoutAuthorization(async () => {
+        return await context.cms.listModels();
+    });
+    return {
+        groups,
+        models
+    };
+};
+
+export const createImportCrud = (context: CmsContext): HeadlessCmsImport => {
+    return {
+        validate: async params => {
+            const { data } = params;
+
+            const { groups, models } = await fetchGroupsAndModels(context);
+
+            const validated = await validateInput({
+                groups,
+                models,
+                data
+            });
+            if (validated.error) {
+                return {
+                    groups: validated.groups,
+                    models: validated.models,
+                    message: validated.error
+                };
+            }
+
+            return {
+                groups: validated.groups,
+                models: validated.models,
+                message: "Validation done."
+            };
+        },
+        structure: async params => {
+            const { data, models: importModelsList } = params;
+
+            const { groups, models } = await fetchGroupsAndModels(context);
+
+            const validated = await validateInput({
+                groups,
+                models,
+                data
+            });
+            if (validated.error) {
+                return {
+                    groups: validated.groups.map(result => {
+                        return {
+                            ...result,
+                            imported: false
+                        };
+                    }),
+                    models: validated.models.map(result => {
+                        return {
+                            ...result,
+                            imported: false
+                        };
+                    }),
+                    message: null,
+                    error: validated.error
+                };
+            }
+
+            const imported = await importData({
+                context,
+                groups: validated.groups as ValidCmsGroupResult[],
+                models: (validated.models as ValidCmsModelResult[]).filter(model => {
+                    if (!model.model.modelId) {
+                        return false;
+                    }
+                    return importModelsList.includes(model.model.modelId);
+                })
+            });
+
+            return {
+                ...imported,
+                message: imported.error ? null : "Import done."
+            };
+        }
+    };
+};

--- a/packages/api-headless-cms/src/export/crud/importing.ts
+++ b/packages/api-headless-cms/src/export/crud/importing.ts
@@ -4,16 +4,12 @@ import { importData } from "./imports/importData";
 import { validateInput } from "./imports/validateInput";
 
 const fetchGroupsAndModels = async (context: CmsContext) => {
-    const groups = await context.security.withoutAuthorization(async () => {
-        return await context.cms.listGroups();
+    return await context.security.withoutAuthorization(async () => {
+        return {
+            groups: await context.cms.listGroups(),
+            models: await context.cms.listModels()
+        };
     });
-    const models = await context.security.withoutAuthorization(async () => {
-        return await context.cms.listModels();
-    });
-    return {
-        groups,
-        models
-    };
 };
 
 export const createImportCrud = (context: CmsContext): HeadlessCmsImport => {

--- a/packages/api-headless-cms/src/export/crud/imports/importData.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/importData.ts
@@ -1,0 +1,64 @@
+import {
+    CmsGroupImportResult,
+    CmsModelImportResult,
+    ValidCmsGroupResult,
+    ValidCmsModelResult
+} from "~/export/types";
+import { CmsContext } from "~/types";
+
+interface Params {
+    context: CmsContext;
+    groups: ValidCmsGroupResult[];
+    models: ValidCmsModelResult[];
+}
+
+interface Response {
+    groups: CmsGroupImportResult[];
+    models: CmsModelImportResult[];
+    error?: string;
+}
+
+export const importData = async (params: Params): Promise<Response> => {
+    const { context } = params;
+
+    const groups: CmsGroupImportResult[] = [];
+    const models: CmsModelImportResult[] = [];
+
+    for (const group of params.groups) {
+        try {
+            const result = await context.cms.createGroup(group.group);
+            groups.push({
+                group: {
+                    ...result
+                },
+                imported: true
+            });
+        } catch (ex) {
+            groups.push({
+                group: group.group,
+                imported: false,
+                error: {
+                    message: ex.message,
+                    code: ex.code || "CREATE_GROUP_ERROR",
+                    data: {
+                        ...ex.data,
+                        group
+                    }
+                }
+            });
+        }
+    }
+    const importedGroups = groups.filter(g => g.imported).map(g => g.group);
+    if (importedGroups.length === 0) {
+        return {
+            groups,
+            models,
+            error: "No groups were imported. Aborting."
+        };
+    }
+
+    return {
+        groups,
+        models
+    };
+};

--- a/packages/api-headless-cms/src/export/crud/imports/importGroups.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/importGroups.ts
@@ -1,0 +1,61 @@
+import { CmsContext } from "~/types";
+import { CmsGroupImportResult, ValidCmsGroupResult } from "~/export/types";
+
+interface Params {
+    context: CmsContext;
+    groups: ValidCmsGroupResult[];
+}
+
+export const importGroups = async (params: Params) => {
+    const { context, groups } = params;
+
+    const existingGroups = await context.security.withoutAuthorization(async () => {
+        return context.cms.listGroups();
+    });
+
+    const results: CmsGroupImportResult[] = [];
+    for (const group of groups) {
+        const existingGroup = existingGroups.find(g => {
+            return g.slug === group.group.slug || g.id === group.group.id;
+        });
+        if (existingGroup) {
+            results.push({
+                group: group.group,
+                imported: false,
+                error: {
+                    message: `Group already exists.`,
+                    code: "GROUP_EXISTS",
+                    data: {
+                        existing: existingGroup
+                    }
+                }
+            });
+            continue;
+        }
+
+        try {
+            const result = await context.cms.createGroup(group.group);
+            results.push({
+                group: {
+                    ...result
+                },
+                imported: true
+            });
+        } catch (ex) {
+            results.push({
+                group: group.group,
+                imported: false,
+                error: {
+                    message: ex.message,
+                    code: ex.code || "CREATE_GROUP_ERROR",
+                    data: {
+                        ...ex.data,
+                        group
+                    }
+                }
+            });
+        }
+    }
+
+    return results;
+};

--- a/packages/api-headless-cms/src/export/crud/imports/importModels.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/importModels.ts
@@ -1,0 +1,93 @@
+import { CmsContext } from "~/types";
+import { CmsModelImportResult, ValidCmsModelResult } from "~/export/types";
+
+interface Params {
+    context: CmsContext;
+    models: ValidCmsModelResult[];
+}
+
+export const importModels = async (params: Params) => {
+    const { context, models } = params;
+
+    const groups = await context.cms.listGroups();
+    const existingModels = await context.security.withoutAuthorization(async () => {
+        return context.cms.listModels();
+    });
+
+    const results: CmsModelImportResult[] = [];
+
+    for (const model of models) {
+        /**
+         * There is a possibility that group does not exist.
+         */
+        const group = groups.find(group => {
+            return group.id === model.model.group;
+        });
+        if (!group) {
+            results.push({
+                model: model.model,
+                imported: false,
+                error: {
+                    message: `Group "${model.model.group}" does not exist.`,
+                    code: "GROUP_NOT_FOUND",
+                    data: {
+                        model
+                    }
+                }
+            });
+            continue;
+        }
+        /**
+         * There is a possibility that model with unique values already exists.
+         */
+        const existingModel = existingModels.find(m => {
+            return (
+                m.modelId === model.model.modelId ||
+                m.singularApiName === model.model.singularApiName ||
+                m.pluralApiName === model.model.pluralApiName
+            );
+        });
+        if (existingModel) {
+            results.push({
+                model: model.model,
+                imported: false,
+                error: {
+                    message: `Model already exists.`,
+                    code: "MODEL_EXISTS",
+                    data: {
+                        existing: {
+                            modelId: existingModel.modelId,
+                            singularApiName: existingModel.singularApiName,
+                            pluralApiName: existingModel.pluralApiName
+                        }
+                    }
+                }
+            });
+            continue;
+        }
+        try {
+            const result = await context.cms.createModel(model.model);
+            results.push({
+                model: {
+                    ...result
+                },
+                imported: true
+            });
+        } catch (ex) {
+            results.push({
+                model: model.model,
+                imported: false,
+                error: {
+                    message: ex.message,
+                    code: ex.code || "CREATE_MODEL_ERROR",
+                    data: {
+                        model: model.model,
+                        ...ex.data
+                    }
+                }
+            });
+        }
+    }
+
+    return results;
+};

--- a/packages/api-headless-cms/src/export/crud/imports/validateGroups.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateGroups.ts
@@ -1,0 +1,75 @@
+import { CmsGroup } from "~/types";
+import { createGroupCreateValidation } from "~/crud/contentModelGroup/validation";
+import { createZodError } from "@webiny/utils";
+import { ValidatedCmsGroupResult } from "~/export/types";
+
+interface Params {
+    groups: Pick<CmsGroup, "id" | "slug">[];
+    input: Partial<CmsGroup>[];
+}
+
+export const validateGroups = async (params: Params): Promise<ValidatedCmsGroupResult[]> => {
+    const { groups, input } = params;
+
+    const validation = createGroupCreateValidation();
+
+    return await Promise.all(
+        input.map(async group => {
+            const result = await validation.safeParseAsync(group);
+            if (!result.success) {
+                const error = createZodError(result.error);
+                return {
+                    group: group as CmsGroup,
+                    error: {
+                        message: error.message,
+                        code: error.code,
+                        data: error.data
+                    }
+                };
+            }
+            const data = result.data as CmsGroup;
+            if (!data.id) {
+                return {
+                    group: data,
+                    error: {
+                        message: `Group is missing ID.`,
+                        code: "GROUP_ID_MISSING"
+                    }
+                };
+            }
+            if (!data.slug) {
+                return {
+                    group: data,
+                    error: {
+                        message: `Group is missing slug.`,
+                        code: "GROUP_SLUG_MISSING"
+                    }
+                };
+            }
+            const groupWithIdExists = groups.some(g => g.id === data.id);
+            if (groupWithIdExists) {
+                return {
+                    group: data,
+                    error: {
+                        message: `Group with ID "${data.id}" already exists.`,
+                        code: "GROUP_ID_EXISTS"
+                    }
+                };
+            }
+            const groupWithSlugExists = groups.some(g => g.slug === data.slug);
+            if (groupWithSlugExists) {
+                return {
+                    group: data,
+                    error: {
+                        message: `Group with slug "${data.slug}" already exists.`,
+                        code: "GROUP_SLUG_EXISTS"
+                    }
+                };
+            }
+
+            return {
+                group: data
+            };
+        })
+    );
+};

--- a/packages/api-headless-cms/src/export/crud/imports/validateInput.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateInput.ts
@@ -8,8 +8,8 @@ import { validateGroups } from "~/export/crud/imports/validateGroups";
 import { validateModels } from "~/export/crud/imports/validateModels";
 
 interface Params {
-    groups: Pick<CmsGroup, "id" | "slug">[];
-    models: Pick<CmsModel, "modelId" | "singularApiName" | "pluralApiName">[];
+    groups: CmsGroup[];
+    models: CmsModel[];
     data: CmsImportStructureParamsData;
 }
 

--- a/packages/api-headless-cms/src/export/crud/imports/validateInput.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateInput.ts
@@ -1,0 +1,70 @@
+import { CmsGroup, CmsModel } from "~/types";
+import {
+    CmsImportStructureParamsData,
+    ValidatedCmsGroupResult,
+    ValidatedCmsModelResult
+} from "~/export/types";
+import { validateGroups } from "~/export/crud/imports/validateGroups";
+import { validateModels } from "~/export/crud/imports/validateModels";
+
+interface Params {
+    groups: Pick<CmsGroup, "id" | "slug">[];
+    models: Pick<CmsModel, "modelId" | "singularApiName" | "pluralApiName">[];
+    data: CmsImportStructureParamsData;
+}
+
+interface ValidResponse {
+    groups: ValidatedCmsGroupResult[];
+    models: ValidatedCmsModelResult[];
+    error?: never;
+}
+
+interface InvalidResponse {
+    groups: ValidatedCmsGroupResult[];
+    models: ValidatedCmsModelResult[];
+    error?: string;
+}
+
+export const validateInput = async (params: Params): Promise<ValidResponse | InvalidResponse> => {
+    const { groups, models, data } = params;
+
+    const validatedGroups = await validateGroups({
+        groups,
+        input: data.groups
+    });
+
+    const ids = validatedGroups
+        .map(data => {
+            if (!data.group?.id) {
+                return null;
+            }
+            return {
+                id: data.group?.id
+            };
+        })
+        .filter(Boolean) as Pick<CmsGroup, "id">[];
+    if (ids.length === 0) {
+        return {
+            groups: validatedGroups,
+            models: [],
+            error: "No groups to import."
+        };
+    }
+
+    const validatedModels = await validateModels({
+        groups: groups.map(g => ({ id: g.id })).concat(ids),
+        models,
+        input: data.models
+    });
+    if (validatedModels.length === 0) {
+        return {
+            groups: validatedGroups,
+            models: validatedModels,
+            error: "No models to import."
+        };
+    }
+    return {
+        groups: validatedGroups,
+        models: validatedModels
+    };
+};

--- a/packages/api-headless-cms/src/export/crud/imports/validateModels.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateModels.ts
@@ -199,27 +199,6 @@ export const validateModels = async (params: Params): Promise<ValidatedCmsModelR
 
     const validation = createModelImportValidation();
 
-    // const getRelatedModels = (fields: CmsModelField[]): string[] => {
-    //     const results = fields.reduce<string[]>((related, field) => {
-    //         if (field.type === "ref") {
-    //             for (const model of field.settings?.models || []) {
-    //                 related.push(model.modelId);
-    //             }
-    //             return related;
-    //         } else if (field.type === "object") {
-    //             return [...related, ...getRelatedModels(field.settings?.fields || [])];
-    //         } else if (field.type === "dynamicZone") {
-    //             const templates = (field.settings?.templates || []) as CmsDynamicZoneTemplate[];
-    //             for (const tpl of templates) {
-    //                 related.push(...getRelatedModels(tpl.fields || []));
-    //             }
-    //             return related;
-    //         }
-    //         return related;
-    //     }, []);
-    //     return Array.from(new Set(...results));
-    // };
-
     return await Promise.all(
         input.map(async (model): Promise<ValidatedCmsModelResult> => {
             const result = await validation.safeParseAsync(model);

--- a/packages/api-headless-cms/src/export/crud/imports/validateModels.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateModels.ts
@@ -1,0 +1,79 @@
+import { createModelImportValidation } from "~/crud/contentModel/validation";
+import { HeadlessCmsImportStructureParamsDataModel, ValidatedCmsModelResult } from "~/export/types";
+import { CmsGroup, CmsModel } from "~/types";
+import { createZodError } from "@webiny/utils";
+
+const modelFieldsToCheck = ["modelId", "singularApiName", "pluralApiName"];
+
+interface Params {
+    groups: Pick<CmsGroup, "id">[];
+    models: Pick<CmsModel, "modelId" | "singularApiName" | "pluralApiName">[];
+    input: HeadlessCmsImportStructureParamsDataModel[];
+}
+
+export const validateModels = async (params: Params): Promise<ValidatedCmsModelResult[]> => {
+    const { groups, models, input } = params;
+
+    const validation = createModelImportValidation();
+
+    return await Promise.all(
+        input.map(async model => {
+            const result = await validation.safeParseAsync(model);
+            if (!result.success) {
+                const error = createZodError(result.error);
+                return {
+                    model,
+                    error: {
+                        message: error.message,
+                        code: error.code,
+                        data: error.data
+                    }
+                };
+            }
+            const data = result.data;
+            const group = groups.find(g => g.id === data.group);
+            if (!group) {
+                return {
+                    model: data,
+                    error: {
+                        message: `The model group "${data.group}" does not exist.`,
+                        code: "MODEL_GROUP_NOT_FOUND"
+                    }
+                };
+            } else if (!model.fields?.length) {
+                return {
+                    model: data,
+                    error: {
+                        message: `Model is missing fields.`,
+                        code: "MODEL_FIELDS_MISSING"
+                    }
+                };
+            }
+            for (const field of modelFieldsToCheck) {
+                const fieldValue = (
+                    (data[field as keyof typeof data] as string) || ""
+                ).toLowerCase();
+
+                const existing = models.find(m => {
+                    const value = (m[field as keyof typeof m] || "").toLowerCase();
+
+                    return value === fieldValue;
+                });
+                if (!existing) {
+                    continue;
+                }
+                return {
+                    model: data,
+                    error: {
+                        message: `The model "${data.modelId}" with ${field} "${fieldValue}" exists.`,
+                        code: "MODEL_EXISTS"
+                    }
+                };
+            }
+
+            return {
+                model: data
+            };
+        })
+    );
+};

--- a/packages/api-headless-cms/src/export/crud/index.ts
+++ b/packages/api-headless-cms/src/export/crud/index.ts
@@ -1,5 +1,5 @@
 import { CmsContext } from "~/types";
-import { createExportStructureContext } from "./structure";
+import { createExportStructureContext } from "./exporting";
 
 export const createExportCrud = (context: CmsContext) => {
     return {

--- a/packages/api-headless-cms/src/export/crud/sanitize.ts
+++ b/packages/api-headless-cms/src/export/crud/sanitize.ts
@@ -18,10 +18,7 @@ export const sanitizeModel = (
     return {
         modelId: model.modelId,
         name: model.name,
-        group: {
-            id: group.id,
-            name: group.name
-        },
+        group: group.id,
         icon: model.icon,
         description: model.description,
         singularApiName: model.singularApiName,

--- a/packages/api-headless-cms/src/export/graphql/index.ts
+++ b/packages/api-headless-cms/src/export/graphql/index.ts
@@ -5,23 +5,144 @@ import { CmsContext } from "~/types";
 
 const plugin = new CmsGraphQLSchemaPlugin({
     typeDefs: /* GraphQL */ `
-        type ExportCmsStructureResponse {
+        type CmsExportStructureResponse {
             data: String
             error: CmsError
         }
 
+        input CmsImportStructureGroupInput {
+            id: ID!
+            name: String!
+            slug: String
+            description: String
+            icon: String!
+        }
+
+        input CmsImportStructureModelInput {
+            name: String!
+            singularApiName: String!
+            pluralApiName: String!
+            modelId: String!
+            group: String!
+            icon: String
+            description: String
+            layout: [[ID!]!]!
+            fields: [CmsContentModelFieldInput!]!
+            titleFieldId: String!
+            descriptionFieldId: String
+            imageFieldId: String
+            tags: [String!]
+        }
+
+        input CmsImportStructureInput {
+            groups: [CmsImportStructureGroupInput!]!
+            models: [CmsImportStructureModelInput!]!
+        }
+
+        type CmsImportValidateResponseDataGroupResultItem {
+            id: String
+            name: String
+        }
+
+        type CmsImportValidateResponseDataGroupResult {
+            group: CmsImportValidateResponseDataGroupResultItem!
+            error: CmsError
+        }
+
+        type CmsImportValidateResponseDataModelResultItem {
+            modelId: String
+            name: String
+        }
+
+        type CmsImportValidateResponseDataModelResult {
+            model: CmsImportValidateResponseDataModelResultItem!
+            error: CmsError
+        }
+
+        type CmsImportValidateResponseData {
+            groups: [CmsImportValidateResponseDataGroupResult!]!
+            models: [CmsImportValidateResponseDataModelResult!]!
+            message: String!
+        }
+
+        type CmsImportValidateResponse {
+            data: CmsImportValidateResponseData
+            error: CmsError
+        }
+
+        type CmsImportStructureResponseDataGroupResultItem {
+            id: String!
+            name: String!
+        }
+        type CmsImportStructureResponseDataGroupResult {
+            group: CmsImportStructureResponseDataGroupResultItem!
+            error: CmsError
+        }
+
+        type CmsImportStructureResponseDataResultItem {
+            modelId: String!
+            name: String!
+        }
+
+        type CmsImportStructureResponseDataResult {
+            model: CmsImportStructureResponseDataResultItem!
+            error: CmsError
+        }
+
+        type CmsImportStructureResponseData {
+            groups: [CmsImportStructureResponseDataGroupResult!]!
+            models: [CmsImportStructureResponseDataResult!]!
+            message: String!
+        }
+
+        type CmsImportStructureResponse {
+            data: CmsImportStructureResponseData
+            error: CmsError
+        }
+
         extend type Query {
-            exportCmsStructure(models: [String!]): ExportCmsStructureResponse!
+            exportStructure(models: [String!]): CmsExportStructureResponse!
+        }
+
+        extend type Mutation {
+            validateImportStructure(data: CmsImportStructureInput!): CmsImportValidateResponse!
+            importStructure(
+                data: CmsImportStructureInput!
+                models: [String!]!
+            ): CmsImportStructureResponse!
         }
     `,
     resolvers: {
         Query: {
-            exportCmsStructure: async (_, args, context) => {
+            exportStructure: async (_, args, context) => {
                 try {
                     const result = await context.cms.export.structure({
                         models: args.models
                     });
                     return new Response(JSON.stringify(result));
+                } catch (ex) {
+                    return new ErrorResponse(ex);
+                }
+            }
+        },
+        Mutation: {
+            validateImportStructure: async (_, args, context) => {
+                try {
+                    const result = await context.cms.importing.validate({
+                        data: args.data
+                    });
+                    return new Response(result);
+                } catch (ex) {
+                    return new ErrorResponse(ex);
+                }
+            },
+            importStructure: async (_, args, context) => {
+                try {
+                    const result = await context.cms.importing.structure({
+                        data: args.data,
+                        models: args.models
+                    });
+                    return new Response(result);
                 } catch (ex) {
                     return new ErrorResponse(ex);
                 }

--- a/packages/api-headless-cms/src/export/graphql/index.ts
+++ b/packages/api-headless-cms/src/export/graphql/index.ts
@@ -34,6 +34,19 @@ const plugin = new CmsGraphQLSchemaPlugin({
             tags: [String!]
         }
 
+        enum CmsImportGroupStructureAction {
+            create
+            update
+            code
+        }
+
+        enum CmsImportModelStructureAction {
+            create
+            update
+            code
+            none
+        }
+
         input CmsImportStructureInput {
             groups: [CmsImportStructureGroupInput!]!
             models: [CmsImportStructureModelInput!]!
@@ -47,16 +60,20 @@ const plugin = new CmsGraphQLSchemaPlugin({
         type CmsImportValidateResponseDataGroupResult {
             group: CmsImportValidateResponseDataGroupResultItem!
             error: CmsError
+            action: CmsImportGroupStructureAction
         }
 
         type CmsImportValidateResponseDataModelResultItem {
             modelId: String
             name: String
+            group: String
         }
 
         type CmsImportValidateResponseDataModelResult {
             model: CmsImportValidateResponseDataModelResultItem!
+            related: [String!]
             error: CmsError
+            action: CmsImportModelStructureAction
         }
 
         type CmsImportValidateResponseData {
@@ -77,21 +94,25 @@ const plugin = new CmsGraphQLSchemaPlugin({
         type CmsImportStructureResponseDataGroupResult {
             group: CmsImportStructureResponseDataGroupResultItem!
             error: CmsError
+            action: CmsImportGroupStructureAction
         }
 
         type CmsImportStructureResponseDataResultItem {
             modelId: String!
             name: String!
+            group: String!
         }
 
-        type CmsImportStructureResponseDataResult {
+        type CmsImportStructureResponseDataModelResult {
             model: CmsImportStructureResponseDataResultItem!
+            related: [String!]
             error: CmsError
+            action: CmsImportModelStructureAction
         }
 
         type CmsImportStructureResponseData {
             groups: [CmsImportStructureResponseDataGroupResult!]!
-            models: [CmsImportStructureResponseDataResult!]!
+            models: [CmsImportStructureResponseDataModelResult!]!
             message: String!
         }
 

--- a/packages/api-headless-cms/src/export/types.ts
+++ b/packages/api-headless-cms/src/export/types.ts
@@ -7,6 +7,12 @@ export interface CmsImportError {
     stack?: any;
 }
 
+export enum CmsImportAction {
+    CREATE = "create",
+    UPDATE = "update",
+    CODE = "code",
+    NONE = "none"
+}
 /**
  * Structure export - groups and models.
  */
@@ -88,11 +94,13 @@ export interface HeadlessCmsImportStructure {
 
 export interface ValidCmsGroupResult {
     group: CmsGroup;
+    action: CmsImportAction;
     error?: never;
 }
 
 export interface InvalidCmsGroupResult {
     group: CmsGroup;
+    action?: CmsImportAction;
     error: CmsImportError;
 }
 
@@ -101,13 +109,14 @@ export interface ValidatedCmsModel extends Omit<CmsModel, "group"> {
 }
 export interface ValidCmsModelResult {
     model: ValidatedCmsModel;
-    action: string;
+    related: string[];
+    action: CmsImportAction;
     error?: never;
 }
 
 export interface InvalidCmsModelResult {
     model: ValidatedCmsModel;
-    action?: never;
+    action?: CmsImportAction;
     error: CmsImportError;
 }
 

--- a/packages/api-headless-cms/src/export/types.ts
+++ b/packages/api-headless-cms/src/export/types.ts
@@ -101,11 +101,13 @@ export interface ValidatedCmsModel extends Omit<CmsModel, "group"> {
 }
 export interface ValidCmsModelResult {
     model: ValidatedCmsModel;
+    action: string;
     error?: never;
 }
 
 export interface InvalidCmsModelResult {
     model: ValidatedCmsModel;
+    action?: never;
     error: CmsImportError;
 }
 

--- a/packages/api-headless-cms/src/export/types.ts
+++ b/packages/api-headless-cms/src/export/types.ts
@@ -1,5 +1,12 @@
 import { CmsGroup, CmsModel } from "~/types";
 
+export interface CmsImportError {
+    message: string;
+    code: string | null;
+    data?: Record<string, any> | null;
+    stack?: any;
+}
+
 /**
  * Structure export - groups and models.
  */
@@ -25,7 +32,7 @@ export interface SanitizedCmsModel
         | "name"
         | "description"
     > {
-    group: Pick<CmsGroup, "id" | "name">;
+    group: string;
 }
 
 export interface HeadlessCmsExportStructureResponse {
@@ -37,9 +44,89 @@ export interface HeadlessCmsExportStructure {
     (params: HeadlessCmsExportStructureParams): Promise<HeadlessCmsExportStructureResponse>;
 }
 
+export interface HeadlessCmsImportStructureParamsDataModel
+    extends Omit<Partial<CmsModel>, "group"> {
+    group?: string;
+}
+
+export interface CmsImportStructureParamsData {
+    groups: Partial<CmsGroup>[];
+    models: HeadlessCmsImportStructureParamsDataModel[];
+}
+
+export interface HeadlessCmsImportStructureParams {
+    data: CmsImportStructureParamsData;
+    models: string[];
+}
+
+export interface HeadlessCmsImportValidateParams {
+    data: CmsImportStructureParamsData;
+}
+
+export interface CmsGroupImportResult {
+    group: Partial<Pick<CmsGroup, "id" | "name">>;
+    error?: CmsImportError;
+    imported: boolean;
+}
+
+export interface CmsModelImportResult {
+    model: Partial<Pick<CmsModel, "modelId" | "name">>;
+    error?: CmsImportError;
+    imported: boolean;
+}
+
+export interface HeadlessCmsImportStructureResponse {
+    groups: CmsGroupImportResult[];
+    models: CmsModelImportResult[];
+    message?: string | null;
+    error?: string;
+}
+
+export interface HeadlessCmsImportStructure {
+    (params: HeadlessCmsImportStructureParams): Promise<HeadlessCmsImportStructureResponse>;
+}
+
+export interface ValidCmsGroupResult {
+    group: CmsGroup;
+    error?: never;
+}
+
+export interface InvalidCmsGroupResult {
+    group: CmsGroup;
+    error: CmsImportError;
+}
+
+export interface ValidCmsModelResult {
+    model: Partial<Pick<CmsModel, "modelId" | "name">>;
+    error?: never;
+}
+
+export interface InvalidCmsModelResult {
+    model: Partial<Pick<CmsModel, "modelId" | "name">>;
+    error: CmsImportError;
+}
+
+export type ValidatedCmsGroupResult = ValidCmsGroupResult | InvalidCmsGroupResult;
+export type ValidatedCmsModelResult = ValidCmsModelResult | InvalidCmsModelResult;
+
+export interface HeadlessCmsImportValidateResponse {
+    groups: ValidatedCmsGroupResult[];
+    models: ValidatedCmsModelResult[];
+    message: string;
+}
+
+export interface HeadlessCmsImportValidate {
+    (params: HeadlessCmsImportValidateParams): Promise<HeadlessCmsImportValidateResponse>;
+}
+
 /**
  * Interface for the main context interface.
  */
 export interface HeadlessCmsExport {
     structure: HeadlessCmsExportStructure;
+}
+
+export interface HeadlessCmsImport {
+    validate: HeadlessCmsImportValidate;
+    structure: HeadlessCmsImportStructure;
 }

--- a/packages/api-headless-cms/src/export/types.ts
+++ b/packages/api-headless-cms/src/export/types.ts
@@ -96,13 +96,16 @@ export interface InvalidCmsGroupResult {
     error: CmsImportError;
 }
 
+export interface ValidatedCmsModel extends Omit<CmsModel, "group"> {
+    group: string;
+}
 export interface ValidCmsModelResult {
-    model: Partial<Pick<CmsModel, "modelId" | "name">>;
+    model: ValidatedCmsModel;
     error?: never;
 }
 
 export interface InvalidCmsModelResult {
-    model: Partial<Pick<CmsModel, "modelId" | "name">>;
+    model: ValidatedCmsModel;
     error: CmsImportError;
 }
 

--- a/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
@@ -1,17 +1,27 @@
 import { Plugin } from "@webiny/plugins";
 import { CmsGroup as BaseCmsGroup } from "~/types";
 
-interface CmsGroup extends Omit<BaseCmsGroup, "locale" | "tenant" | "webinyVersion"> {
+export interface CmsGroupInput
+    extends Omit<BaseCmsGroup, "locale" | "tenant" | "webinyVersion" | "isPlugin"> {
     tenant?: string;
     locale?: string;
 }
+
+export interface CmsGroup extends Omit<BaseCmsGroup, "locale" | "tenant" | "webinyVersion"> {
+    tenant?: string;
+    locale?: string;
+}
+
 export class CmsGroupPlugin extends Plugin {
     public static override readonly type: string = "cms-content-model-group";
     public readonly contentModelGroup: CmsGroup;
 
-    constructor(contentModelGroup: CmsGroup) {
+    constructor(contentModelGroup: CmsGroupInput) {
         super();
-        this.contentModelGroup = contentModelGroup;
+        this.contentModelGroup = {
+            ...contentModelGroup,
+            isPlugin: true
+        };
     }
 }
 

--- a/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
@@ -42,7 +42,10 @@ interface CmsModelFieldInput extends Omit<CmsModelFieldBase, "storageId" | "sett
 }
 
 export interface CmsApiModel
-    extends Omit<CmsModel, "isPrivate" | "fields" | "singularApiName" | "pluralApiName"> {
+    extends Omit<
+        CmsModel,
+        "isPrivate" | "fields" | "singularApiName" | "pluralApiName" | "isPlugin"
+    > {
     isPrivate?: never;
     noValidate?: never;
     singularApiName?: string;
@@ -56,7 +59,10 @@ export interface CmsApiModelFull extends Omit<CmsApiModel, "fields" | "noValidat
 }
 
 interface CmsPrivateModel
-    extends Omit<CmsModel, "isPrivate" | "singularApiName" | "pluralApiName" | "fields"> {
+    extends Omit<
+        CmsModel,
+        "isPrivate" | "singularApiName" | "pluralApiName" | "fields" | "isPlugin"
+    > {
     noValidate?: never;
     singularApiName?: never;
     pluralApiName?: never;
@@ -105,10 +111,11 @@ export class CmsModelPlugin extends Plugin {
             /**
              * We can safely ignore this error, because we are sure noValidate is not a model field.
              */
-            // @ts-ignore
+            // @ts-expect-error
             delete input["noValidate"];
             return {
                 ...input,
+                isPlugin: true,
                 isPrivate,
                 singularApiName,
                 pluralApiName
@@ -117,6 +124,7 @@ export class CmsModelPlugin extends Plugin {
 
         const model: CmsModel = {
             ...input,
+            isPlugin: true,
             isPrivate,
             singularApiName,
             pluralApiName,

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -14,7 +14,7 @@ import { ModelGroupsPermissions } from "~/utils/permissions/ModelGroupsPermissio
 import { ModelsPermissions } from "~/utils/permissions/ModelsPermissions";
 import { EntriesPermissions } from "~/utils/permissions/EntriesPermissions";
 import { SettingsPermissions } from "~/utils/permissions/SettingsPermissions";
-import { HeadlessCmsExport } from "~/export/types";
+import { HeadlessCmsExport, HeadlessCmsImport } from "~/export/types";
 
 export type ApiEndpoint = "manage" | "preview" | "read";
 
@@ -69,6 +69,7 @@ export interface HeadlessCms
      * Export operations.
      */
     export: HeadlessCmsExport;
+    importing: HeadlessCmsImport;
 }
 
 /**
@@ -1016,7 +1017,7 @@ export interface CmsGroupCreateInput {
     id?: string;
     name: string;
     slug?: string;
-    description?: string;
+    description?: string | null;
     icon: string;
 }
 
@@ -1063,7 +1064,7 @@ export interface CmsGroup {
     /**
      * Description for the group.
      */
-    description: string;
+    description: string | null;
     /**
      * Icon for the group. In a form of "ico/ico".
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -553,6 +553,10 @@ export interface CmsModel {
      * Only available for the plugin constructed models.
      */
     isPrivate?: boolean;
+    /**
+     * Is this model created via plugin?
+     */
+    isPlugin?: boolean;
 }
 
 /**
@@ -1091,6 +1095,10 @@ export interface CmsGroup {
      * Only available for the plugin constructed groups.
      */
     isPrivate?: boolean;
+    /**
+     * Is this group created via plugin?
+     */
+    isPlugin?: boolean;
 }
 
 /**

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -212,7 +212,7 @@ const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
     const filteredData = filter === "" ? models : models.filter(filterData);
     const contentModels = sortData(filteredData);
 
-    const { handleModelsExport, handleModelExport } = useModelExport(contentModels);
+    const { handleModelsExport, handleModelExport } = useModelExport();
 
     const onRefreshClick = useCallback(() => {
         refresh();

--- a/packages/app-headless-cms/src/admin/views/contentModels/exporting/graphql.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/exporting/graphql.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
 
-export const EXPORT_MODELS_QUERY = gql`
-    query ExportCmsStructure($models: [String!]) {
-        exportCmsStructure(models: $models) {
+export const CMS_EXPORT_STRUCTURE_QUERY = gql`
+    query CmsExportStructure($models: [String!]) {
+        exportStructure(models: $models) {
             data
             error {
                 message

--- a/packages/app-headless-cms/src/admin/views/contentModels/exporting/runExport.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/exporting/runExport.ts
@@ -1,6 +1,6 @@
 import ApolloClient from "apollo-client";
 import { CmsGroup, CmsModel } from "@webiny/app-headless-cms-common/types";
-import { EXPORT_MODELS_QUERY } from "./graphql";
+import { CMS_EXPORT_STRUCTURE_QUERY } from "./graphql";
 
 interface Params {
     client: ApolloClient<any>;
@@ -18,11 +18,13 @@ interface Response {
 }
 
 export const runExport = async ({ client, models }: Params): Promise<Response> => {
+    const variables: Record<string, any> = {};
+    if (models?.length) {
+        variables.models = models;
+    }
     const result = await client.query({
-        query: EXPORT_MODELS_QUERY,
-        variables: {
-            models
-        }
+        query: CMS_EXPORT_STRUCTURE_QUERY,
+        variables
     });
 
     if (result.errors?.length) {
@@ -30,8 +32,8 @@ export const runExport = async ({ client, models }: Params): Promise<Response> =
         return {
             error: result.errors[0]
         };
-    } else if (!result.data?.exportCmsStructure) {
-        const message = `There is no object returned from the exportCmsStructure query.`;
+    } else if (!result.data?.exportStructure) {
+        const message = `There is no object returned from the exportStructure query.`;
         console.error(message);
         return {
             error: {
@@ -39,14 +41,14 @@ export const runExport = async ({ client, models }: Params): Promise<Response> =
             }
         };
     }
-    const { data, error } = result.data.exportCmsStructure;
+    const { data, error } = result.data.exportStructure;
     if (error) {
         console.error(error.message);
         return {
             error
         };
     } else if (!data) {
-        const message = `There is no data returned from the exportCmsStructure query.`;
+        const message = `There is no data returned from the exportStructure query.`;
         return {
             error: {
                 message

--- a/packages/app-headless-cms/src/admin/views/contentModels/exporting/useModelExport.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/exporting/useModelExport.ts
@@ -5,27 +5,24 @@ import { runExport } from "./runExport";
 import { useSnackbar } from "@webiny/app-admin";
 import { download } from "./download";
 
-export const useModelExport = (models: CmsModel[]) => {
+export const useModelExport = () => {
     const client = useApolloClient();
     const { showSnackbar } = useSnackbar();
 
-    const handleModelsExport = useCallback(
-        (models?: string[]) => {
-            (async () => {
-                const result = await runExport({
-                    client,
-                    models
-                });
-                if (result.error) {
-                    return showSnackbar(result.error.message);
-                } else if (!result.data?.models?.length) {
-                    return showSnackbar("No data returned from the exportCmsStructure query.");
-                }
-                download(result.data);
-            })();
-        },
-        [models]
-    );
+    const handleModelsExport = useCallback((models?: string[]) => {
+        (async () => {
+            const result = await runExport({
+                client,
+                models
+            });
+            if (result.error) {
+                return showSnackbar(result.error.message);
+            } else if (!result.data?.models?.length) {
+                return showSnackbar("No data returned from the exportStructure query.");
+            }
+            download(result.data);
+        })();
+    }, []);
 
     const handleModelExport = useCallback(
         (model: CmsModel) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14825,7 +14825,6 @@ __metadata:
     prop-types: ^15.7.2
     raw.macro: ^0.4.2
     react: 17.0.2
-    react-butterfiles: ^1.3.3
     react-custom-scrollbars: ^4.2.1
     react-dnd: ^11.1.3
     react-dnd-html5-backend: ^11.1.3
@@ -37302,7 +37301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1, react-butterfiles@npm:^1.3.3":
+"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
   version: 1.3.3
   resolution: "react-butterfiles@npm:1.3.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14825,6 +14825,7 @@ __metadata:
     prop-types: ^15.7.2
     raw.macro: ^0.4.2
     react: 17.0.2
+    react-butterfiles: ^1.3.3
     react-custom-scrollbars: ^4.2.1
     react-dnd: ^11.1.3
     react-dnd-html5-backend: ^11.1.3
@@ -37301,7 +37302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1":
+"react-butterfiles@npm:^1.3.0, react-butterfiles@npm:^1.3.1, react-butterfiles@npm:^1.3.3":
   version: 1.3.3
   resolution: "react-butterfiles@npm:1.3.3"
   dependencies:


### PR DESCRIPTION
## Changes
API for the import of the exported groups and models.

## How Has This Been Tested?
Jest and manually.