### PR TITLE
fix(api-file-manager): cms fields graphql definitions

### DIFF
--- a/packages/api-file-manager/__tests__/file.extensions.test.ts
+++ b/packages/api-file-manager/__tests__/file.extensions.test.ts
@@ -1,0 +1,114 @@
+import useGqlHandler from "~tests/utils/useGqlHandler";
+import { createFileModelModifier } from "~/modelModifier/CmsModelModifier";
+import { fileAData } from "./mocks/files";
+
+describe("File Model Extensions", () => {
+    const { listFiles, createFile } = useGqlHandler({
+        plugins: [
+            // Add custom fields that will be assigned to the `extensions` object field.
+            createFileModelModifier(({ modifier }) => {
+                modifier.addField({
+                    id: "carMake",
+                    fieldId: "carMake",
+                    label: "Car Make",
+                    type: "text"
+                });
+
+                modifier.addField({
+                    id: "year",
+                    fieldId: "year",
+                    label: "Year of manufacturing",
+                    type: "number"
+                });
+                modifier.addField({
+                    id: "aDateTime",
+                    fieldId: "aDateTime",
+                    type: "datetime",
+                    label: "A date time field",
+                    renderer: {
+                        name: "date-time-input"
+                    },
+                    settings: {
+                        type: "dateTimeWithoutTimezone",
+                        defaultSetValue: "current"
+                    }
+                });
+                modifier.addField({
+                    id: "article",
+                    fieldId: "article",
+                    label: "Article",
+                    type: "ref",
+                    renderer: {
+                        name: "ref-advanced-single"
+                    },
+                    settings: {
+                        models: [
+                            {
+                                modelId: "article"
+                            }
+                        ]
+                    }
+                });
+            })
+        ]
+    });
+
+    it("should add custom fields to `extensions` object field", async () => {
+        const extensions = {
+            carMake: "Honda",
+            year: 2018,
+            aDateTime: "2020-01-01T00:00:00.000Z",
+            article: {
+                modelId: "article",
+                id: "abcdefg#0001"
+            }
+        };
+        const fields = ["extensions { carMake year aDateTime article { id modelId } }"];
+
+        const [createAResponse] = await createFile(
+            {
+                data: {
+                    ...fileAData,
+                    extensions
+                }
+            },
+            fields
+        );
+        expect(createAResponse).toEqual({
+            data: {
+                fileManager: {
+                    createFile: {
+                        data: {
+                            ...fileAData,
+                            extensions
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+
+        const [listResponse] = await listFiles({}, fields);
+
+        expect(listResponse).toEqual({
+            data: {
+                fileManager: {
+                    listFiles: {
+                        data: [
+                            {
+                                ...fileAData,
+                                extensions
+                            }
+                        ],
+                        meta: {
+                            totalCount: 1,
+                            hasMoreItems: false,
+                            cursor: null
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-file-manager/__tests__/fileSchema.test.ts
+++ b/packages/api-file-manager/__tests__/fileSchema.test.ts
@@ -27,6 +27,22 @@ describe("File Model Modifier test", () => {
                         label: "Year of manufacturing",
                         type: "number"
                     });
+                    modifier.addField({
+                        id: "article",
+                        fieldId: "article",
+                        label: "Article",
+                        type: "ref",
+                        renderer: {
+                            name: "ref-advanced-single"
+                        },
+                        settings: {
+                            models: [
+                                {
+                                    modelId: "article"
+                                }
+                            ]
+                        }
+                    });
                 })
             ]
         });

--- a/packages/api-file-manager/__tests__/mocks/file.sdl.ts
+++ b/packages/api-file-manager/__tests__/mocks/file.sdl.ts
@@ -64,6 +64,7 @@ export default /* GraphQL */ `
     type FmFile_Extensions {
         carMake: String
         year: Number
+        article: RefField
     }
 
     input FmFile_ExtensionsWhereInput {
@@ -88,6 +89,8 @@ export default /* GraphQL */ `
         year_between: [Number!]
         # there must be two numbers sent in the array
         year_not_between: [Number!]
+
+        article: RefFieldWhereInput
     }
 
     type FmFile {
@@ -121,6 +124,7 @@ export default /* GraphQL */ `
     input FmFile_ExtensionsInput {
         carMake: String
         year: Number
+        article: RefFieldInput
     }
 
     input FmFileCreateInput {

--- a/packages/api-file-manager/src/graphql/index.ts
+++ b/packages/api-file-manager/src/graphql/index.ts
@@ -5,6 +5,8 @@ import { CmsModel } from "@webiny/api-headless-cms/types";
 import { createFieldTypePluginRecords } from "@webiny/api-headless-cms/graphql/schema/createFieldTypePluginRecords";
 import { createFilesSchema } from "~/graphql/filesSchema";
 import { isInstallationPending } from "~/cmsFileStorage/isInstallationPending";
+import { createGraphQLSchemaPluginFromFieldPlugins } from "@webiny/api-headless-cms/utils/getSchemaFromFieldPlugins";
+import { GraphQLSchemaPlugin } from "@webiny/handler-graphql";
 
 export const createGraphQLSchemaPlugin = () => {
     return [
@@ -20,6 +22,19 @@ export const createGraphQLSchemaPlugin = () => {
                 const fileModel = (await context.cms.getModel("fmFile")) as CmsModel;
                 const models = await context.cms.listModels();
                 const fieldPlugins = createFieldTypePluginRecords(context.plugins);
+                /**
+                 * We need to register all plugins for all the CMS fields.
+                 */
+                const plugins = createGraphQLSchemaPluginFromFieldPlugins({
+                    models,
+                    type: "manage",
+                    fieldTypePlugins: fieldPlugins,
+                    createPlugin: ({ schema, type, fieldType }) => {
+                        const plugin = new GraphQLSchemaPlugin(schema);
+                        plugin.name = `fm.graphql.schema.${type}.field.${fieldType}`;
+                        return plugin;
+                    }
+                });
 
                 const graphQlPlugin = createFilesSchema({
                     model: fileModel,
@@ -27,7 +42,7 @@ export const createGraphQLSchemaPlugin = () => {
                     plugins: fieldPlugins
                 });
 
-                context.plugins.register(graphQlPlugin);
+                context.plugins.register([...plugins, graphQlPlugin]);
             });
         })
     ];


### PR DESCRIPTION
## Changes
When adding custom fields to the File model, specifically, a reference field - we are missing GraphQL types for that field.

This PR adds the CMS Field GraphQL types to the `/graphql` endpoint.

## How Has This Been Tested?
Manually and jest.