### PR TITLE
fix: add PbAcoContext type

### DIFF
--- a/packages/cwp-template-aws/template/ddb-es/apps/api/graphql/src/types.ts
+++ b/packages/cwp-template-aws/template/ddb-es/apps/api/graphql/src/types.ts
@@ -10,6 +10,7 @@ import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { FormBuilderContext } from "@webiny/api-form-builder/types";
 import { CmsContext } from "@webiny/api-headless-cms/types";
 import { AcoContext } from "@webiny/api-aco/types";
+import { PbAcoContext } from "@webiny/api-page-builder-aco/types";
 
 // When working with the `context` object (for example while defining a new GraphQL resolver function),
 // you can import this interface and assign it to it. This will give you full autocomplete functionality
@@ -29,4 +30,5 @@ export interface Context
         FileManagerContext,
         FormBuilderContext,
         AcoContext,
+        PbAcoContext,
         CmsContext {}

--- a/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/types.ts
+++ b/packages/cwp-template-aws/template/ddb/apps/api/graphql/src/types.ts
@@ -9,6 +9,7 @@ import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { FormBuilderContext } from "@webiny/api-form-builder/types";
 import { CmsContext } from "@webiny/api-headless-cms/types";
 import { AcoContext } from "@webiny/api-aco/types";
+import { PbAcoContext } from "@webiny/api-page-builder-aco/types";
 
 // When working with the `context` object (for example while defining a new GraphQL resolver function),
 // you can import this interface and assign it to it. This will give you full autocomplete functionality
@@ -27,4 +28,5 @@ export interface Context
         FileManagerContext,
         FormBuilderContext,
         AcoContext,
+        PbAcoContext,
         CmsContext {}


### PR DESCRIPTION
## Changes
With this PR, we add the missing type `PbAcoContext` to the `cwp-template-aws` package, which will be available in newly created user projects.


