### PR TITLE
fix(app-file-manager): expose basic fields via configuration

### DIFF
--- a/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
@@ -9,9 +9,6 @@ import { Drawer, DrawerContent } from "@webiny/ui/Drawer";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Tab, Tabs } from "@webiny/ui/Tabs";
-import { Aliases } from "./components/Aliases";
-import { Name } from "./components/Name";
-import { Tags } from "./components/Tags";
 import { FileDetailsProvider } from "~/components/FileDetails/FileDetailsProvider";
 import { Preview } from "./components/Preview";
 import { PreviewMeta } from "./components/PreviewMeta";
@@ -57,6 +54,7 @@ const FileDetailsInner: React.FC<FileDetailsInnerProps> = ({ file }) => {
     const fileModel = useFileModel();
     const { updateFile } = useFileManagerView();
     const { close } = useFileDetails();
+    const { fileDetails } = useFileManagerViewConfig();
 
     const hasExtensions = useMemo(() => {
         return fileModel.fields.find(field => field.fieldId === "extensions");
@@ -89,15 +87,11 @@ const FileDetailsInner: React.FC<FileDetailsInnerProps> = ({ file }) => {
                                 <Tabs>
                                     <Tab label={"Basic Details"}>
                                         <Grid>
-                                            <Cell span={12}>
-                                                <Name />
-                                            </Cell>
-                                            <Cell span={12}>
-                                                <Tags />
-                                            </Cell>
-                                            <Cell span={12}>
-                                                <Aliases />
-                                            </Cell>
+                                            {fileDetails.fields.map(field => (
+                                                <Cell span={12} key={field.name}>
+                                                    {field.element}
+                                                </Cell>
+                                            ))}
                                         </Grid>
                                     </Tab>
                                     {hasExtensions ? (

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
@@ -20,7 +20,7 @@ import { Tooltip } from "@webiny/ui/Tooltip";
 import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerViewProvider";
 import { outputFileSelectionError } from "./outputFileSelectionError";
 import { LeftSidebar } from "./LeftSidebar";
-import { useFileManagerApi } from "~/index";
+import { useFileManagerApi, useFileManagerViewConfig } from "~/index";
 import { FileItem } from "@webiny/app-admin/types";
 import { BottomInfoBar } from "~/components/BottomInfoBar";
 import { DropFilesHere } from "~/components/DropFilesHere";
@@ -73,6 +73,7 @@ const createSort = (sorting?: Sorting): ListFilesSort | undefined => {
 const FileManagerView = () => {
     const view = useFileManagerView();
     const fileManager = useFileManagerApi();
+    const { browser } = useFileManagerViewConfig();
     const { showSnackbar } = useSnackbar();
 
     const uploader = useMemo<BatchFileUploader>(
@@ -317,12 +318,14 @@ const FileManagerView = () => {
                                 currentFolder={view.folderId}
                                 onFolderClick={view.setFolderId}
                             >
-                                <TagsList
-                                    loading={view.tags.loading}
-                                    activeTags={view.tags.activeTags}
-                                    tags={view.tags.allTags}
-                                    onActivatedTagsChange={view.tags.setActiveTags}
-                                />
+                                {browser.filterByTags ? (
+                                    <TagsList
+                                        loading={view.tags.loading}
+                                        activeTags={view.tags.activeTags}
+                                        tags={view.tags.allTags}
+                                        onActivatedTagsChange={view.tags.setActiveTags}
+                                    />
+                                ) : null}
                             </LeftSidebar>
                             <FileListWrapper
                                 {...getDropZoneProps({

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.tsx
@@ -22,11 +22,13 @@ export function useFileManagerViewConfig() {
         () => ({
             browser: {
                 ...browser,
+                filterByTags: browser.filterByTags ?? false,
                 filters: [...(browser.filters || [])],
                 filtersToWhere: [...(browser.filtersToWhere || [])]
             },
-            fileDetails: config.fileDetails || {
-                width: "1000px"
+            fileDetails: {
+                width: config.fileDetails?.width ?? "1000px",
+                fields: config.fileDetails?.fields ?? []
             }
         }),
         [config]

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
@@ -38,7 +38,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                 enableActions={true}
                 enableCreate={true}
             />
-            <Divider />
+            {children ? <Divider /> : null}
             {children}
         </LeftSidebarContainer>
     );

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FilterByTags.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FilterByTags.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Property } from "@webiny/react-properties";
+
+export interface FilterByTagProps {
+    remove?: boolean;
+}
+
+export const FilterByTags = ({ remove }: FilterByTagProps) => {
+    return (
+        <Property id="browser" name={"browser"}>
+            <Property id="filterByTags" name={"filterByTags"} value={true} remove={remove} />
+        </Property>
+    );
+};

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
@@ -1,12 +1,15 @@
 import { Filter, FilterConfig } from "./Filter";
 import { FiltersToWhere, FiltersToWhereConverter } from "./FiltersToWhere";
+import { FilterByTags } from "./FilterByTags";
 
 export interface BrowserConfig {
     filters: FilterConfig[];
     filtersToWhere: FiltersToWhereConverter[];
+    filterByTags: Boolean;
 }
 
 export const Browser = {
     Filter,
-    FiltersToWhere
+    FiltersToWhere,
+    FilterByTags
 };

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/Field.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/Field.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Property, useIdGenerator } from "@webiny/react-properties";
+import { makeComposable, createDecoratorFactory } from "@webiny/app-admin";
+
+export interface FieldConfig {
+    name: string;
+    element: React.ReactElement;
+}
+
+export interface FieldProps {
+    name: string;
+    element?: React.ReactElement<unknown>;
+    remove?: boolean;
+    before?: string;
+    after?: string;
+}
+
+const BaseField = makeComposable<FieldProps>(
+    "Field",
+    ({ name, element, after = undefined, before = undefined, remove = false }) => {
+        const getId = useIdGenerator("field");
+        const placeAfter = after !== undefined ? getId(after) : undefined;
+        const placeBefore = before !== undefined ? getId(before) : undefined;
+
+        return (
+            <Property id="fileDetails" name={"fileDetails"}>
+                <Property
+                    id={getId(name)}
+                    name={"fields"}
+                    array={true}
+                    before={placeBefore}
+                    after={placeAfter}
+                    remove={remove}
+                >
+                    <Property id={getId(name, "name")} name={"name"} value={name} />
+                    {element ? (
+                        <Property id={getId(name, "element")} name={"element"} value={element} />
+                    ) : null}
+                </Property>
+            </Property>
+        );
+    }
+);
+
+const createDecorator = createDecoratorFactory<{ name: string }>()(
+    BaseField,
+    (decoratorProps, componentProps) => {
+        if (decoratorProps.name === "*") {
+            return true;
+        }
+
+        return decoratorProps.name === componentProps.name;
+    }
+);
+
+export const Field = Object.assign(BaseField, { createDecorator });

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/index.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/index.ts
@@ -1,12 +1,15 @@
+import { Field, FieldConfig } from "./Field";
 import { createScopedFieldDecorator } from "./FieldDecorator";
 import { Width } from "./Width";
 
 export interface FileDetailsConfig {
     width: string;
+    fields: FieldConfig[];
 }
 
 export const FileDetails = {
     Width,
+    Field,
     ExtensionField: {
         createDecorator: createScopedFieldDecorator("fm.fileDetails.extensionFields")
     }

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
@@ -2,15 +2,22 @@ import React from "react";
 import { FileManagerViewConfig as FileManagerConfig } from "~/index";
 import { FileManagerRenderer } from "./FileManagerView";
 import { FilterByType } from "./filters/FilterByType";
+import { Name } from "~/components/FileDetails/components/Name";
+import { Tags } from "~/components/FileDetails/components/Tags";
+import { Aliases } from "~/components/FileDetails/components/Aliases";
 
-const { Browser } = FileManagerConfig;
+const { Browser, FileDetails } = FileManagerConfig;
 
 export const FileManagerRendererModule = () => {
     return (
         <>
             <FileManagerRenderer />
             <FileManagerConfig>
+                <Browser.FilterByTags />
                 <Browser.Filter name={"type"} element={<FilterByType />} />
+                <FileDetails.Field name={"name"} element={<Name />} />
+                <FileDetails.Field name={"tags"} element={<Tags />} />
+                <FileDetails.Field name={"aliases"} element={<Aliases />} />
             </FileManagerConfig>
         </>
     );


### PR DESCRIPTION
## Changes
This PR exposes 2 new configuration components to allow developers to:
1) Show/Hide the `Filter by tag` widget in the file browser
2) Add/Remove/Replace/Position fields in the Basic Details tab

Demo video:

https://github.com/webiny/webiny-js/assets/3920893/701b882c-70cc-47a4-ba7f-d2474365b159

## How Has This Been Tested?
Manually.

## Documentation

```tsx
<FileManagerConfig>
    <Browser.FilterByTags remove />
    <FileDetails.Field name={"tags"} remove />
    <FileDetails.Field name={"aliases"} element={<div>My new element!</div>} />
</FileManagerConfig>
```