### PR TITLE
fix: reset table data in case of empty response from the API

### DIFF
--- a/packages/app-aco/src/contexts/records.tsx
+++ b/packages/app-aco/src/contexts/records.tsx
@@ -219,11 +219,6 @@ export const SearchRecordsProvider: React.VFC<Props> = ({ children }) => {
                 }
 
                 setRecords(prev => {
-                    // If no data received, return the previous state
-                    if (!data.length) {
-                        return prev;
-                    }
-
                     // If there's no cursor, it means we're receiving a new list of records from scratch.
                     if (!after) {
                         return data;


### PR DESCRIPTION
## Changes
This PR aims to solve a bug reported where, in case of an empty response from the APIs, the ACO UI would continue showing previously fetched entries.

Closes [WEB-3169](https://webiny.atlassian.net/browse/WEB-3169)


https://github.com/webiny/webiny-js/assets/2866531/611f4e9d-1a9c-4499-8b62-d56f13417c4d



## How Has This Been Tested?
Manually
