### PR TITLE
fix(api-headless-cms): ensure _templateId exists on mutation return value

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/dynamicZoneField.test.ts
@@ -6,6 +6,13 @@ import { useAuthorManageHandler } from "~tests/testHelpers/useAuthorManageHandle
 
 const singularPageApiName = pageModel.singularApiName;
 
+const withTemplateId = (data: Record<string, any>) => {
+    return {
+        ...data,
+        content: data.content.map((obj: any) => ({ ...obj, _templateId: expect.any(String) }))
+    };
+};
+
 const contentEntryQueryData = {
     content: [
         {
@@ -218,7 +225,7 @@ describe("dynamicZone field", () => {
                 createPage: {
                     data: {
                         id: expect.any(String),
-                        ...contentEntryQueryData
+                        ...withTemplateId(contentEntryQueryData)
                     },
                     error: null
                 }
@@ -234,7 +241,7 @@ describe("dynamicZone field", () => {
                     data: [
                         {
                             id: page.id,
-                            ...contentEntryQueryData
+                            ...withTemplateId(contentEntryQueryData)
                         }
                     ],
                     meta: {
@@ -257,7 +264,7 @@ describe("dynamicZone field", () => {
                 getPage: {
                     data: {
                         id: page.id,
-                        ...contentEntryQueryData
+                        ...withTemplateId(contentEntryQueryData)
                     },
                     error: null
                 }

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
@@ -9,10 +9,12 @@ const pageFields = `
     content {
         ...on ${singularPageApiName}_Content_Hero {
             title
+            _templateId
             __typename
         }
         ...on ${singularPageApiName}_Content_SimpleText {
             text
+            _templateId
             __typename
         }
         ...on ${singularPageApiName}_Content_Objecting {
@@ -22,6 +24,7 @@ const pageFields = `
                     nestedObjectNestedTitle
                 }
             }
+            _templateId
             __typename
         }
     }

--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneStorage.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneStorage.ts
@@ -1,6 +1,13 @@
 import { CmsDynamicZoneTemplate, CmsModelDynamicZoneField } from "~/types";
 import { StorageTransformPlugin } from "~/plugins";
 
+function valueWithTemplateId(
+    value: Record<string, any>,
+    { id, gqlTypeName }: CmsDynamicZoneTemplate
+) {
+    return { [gqlTypeName]: { ...value[gqlTypeName], _templateId: id } };
+}
+
 const convertToStorage = (value: Record<string, any>, templates: CmsDynamicZoneTemplate[]) => {
     // Only one key is allowed in the input object.
     const inputType = Object.keys(value)[0];
@@ -39,28 +46,31 @@ const convertFromStorage = (
         // We keep the `_templateId` property, to simplify further processing.
         return { [template.gqlTypeName]: value };
     }
+
     /**
-     * There is a possibility that the template was not found because value is in the original format.
-     * We are going to check:
-     * 1. value is an object
-     * 2. it contains a key - only one
-     * 3. the key is a valid template gqlTypeName
+     * When the `value` is in the original input format (during GraphQL mutations), `_templateId` will not be present
+     * in the `value` object (because this internal property is added by `toStorage` storage transform method, and since
+     * we simply return the input from the CRUD methods, this property will be missing).
+     * For that reason, we need to run some extra logic, to acquire the `_templateId`.
      */
-    /**
-     * Value must be an object
-     */
+
     if (!value || typeof value !== "object") {
         return undefined;
     }
+
+    /**
+     * `value` object must have exactly one none-empty key.
+     */
     const keys = Object.keys(value);
-    if (keys.length !== 1) {
+    if (keys.length !== 1 || !keys[0]) {
         return undefined;
     }
-    if (!keys[0]) {
-        return undefined;
-    }
+
+    /**
+     * Find a template that matches the first (and only) key of the `value` object by template's `gqlTypeName`.
+     */
     const tpl = templates.find(tpl => tpl.gqlTypeName === keys[0]);
-    return tpl ? value : undefined;
+    return tpl ? valueWithTemplateId(value, tpl) : undefined;
 };
 
 export const createDynamicZoneStorageTransform = () => {


### PR DESCRIPTION
## Changes
This PR fixes a problem with create/update mutations which query for DZ template `_templateId` field. This regression was introduced in one of the earlier 5.37.x releases.

## How Has This Been Tested?
By adding `_templateId` into our integration Jest tests for dynamic zone field.
