### PR TITLE
fix: add limit to LIST_FOLDERS query

### DIFF
--- a/packages/app-aco/src/graphql/folders.gql.ts
+++ b/packages/app-aco/src/graphql/folders.gql.ts
@@ -36,9 +36,9 @@ export const CREATE_FOLDER = gql`
 `;
 
 export const LIST_FOLDERS = gql`
-    query ListFolders ($type: String!) {
+    query ListFolders ($type: String!, $limit: Int!) {
         aco {
-            listFolders(where: { type: $type }) {
+            listFolders(where: { type: $type }, limit: $limit) {
                 data ${DATA_FIELD}
                 error ${ERROR_FIELD}
             }


### PR DESCRIPTION
## Changes
With this PR we add the missing `$limit` param to `LIST_FOLDERS` query, fixing the bug found while listing the folders shown in ACO tables and the `FolderTree` component.

## How Has This Been Tested?
Manually