### PR TITLE
APW(wip): Creator can edit or delete the change request 

### DIFF
--- a/packages/api-apw/README.md
+++ b/packages/api-apw/README.md
@@ -24,11 +24,11 @@ To run tests api-apw tests with targeted storage operations loaded use:
 #### DynamoDB
 
 ```
-yarn test packages/api-apw --keyword=apw:ddb --keyword=apw:base
+yarn test packages/api-apw --storage:ddb --keyword=apw:ddb --keyword=apw:base
 ```
 
 #### Note
 
 > All the tests in `@webiny/api-apw` package are being tested against ddb-only storage operations because
-current jest setup doesn't allow usage of more than one storage operations at a time with the help of --keyword flag.
-We should revisit these tests once we have the ability to load multiple storage operations in the jest setup.
+> current jest setup doesn't allow usage of more than one storage operations at a time with the help of --keyword flag.
+> We should revisit these tests once we have the ability to load multiple storage operations in the jest setup.

--- a/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
+++ b/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
@@ -92,7 +92,7 @@ export const createChangeRequestStorageOperations = (
              */
             if (existingEntry.createdBy.id !== security?.getIdentity()?.id) {
                 throw new WebinyError(
-                    "Could not edit the change request. Only the creator can edit it."
+                    "Could not update the change request. Only the creator can update it."
                 );
             }
 

--- a/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
+++ b/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
@@ -92,7 +92,7 @@ export const createChangeRequestStorageOperations = (
              */
             if (existingEntry.createdBy.id !== security?.getIdentity()?.id) {
                 throw new WebinyError(
-                    "Could not update the change request. Only owner can update the change request"
+                    "Could not edit the change request. Only the creator can edit it."
                 );
             }
 
@@ -113,17 +113,16 @@ export const createChangeRequestStorageOperations = (
             const model = await getChangeRequestModel();
             if (security.getIdentity()) {
                 /**
-                 * We're fetching the existing entry here because we're not accepting "app" field as input,
-                 * but, we still need to retain its value after the "update" operation.
+                 * We're fetching the existing entry
                  */
                 const existingEntry = await getChangeRequest({ id: params.id });
 
                 /**
-                 * Only creator can update the change request
+                 * Only creator can delete the change request
                  */
-                if (existingEntry.createdBy.id !== security?.getIdentity()?.id) {
+                if (existingEntry.createdBy.id !== security.getIdentity().id) {
                     throw new WebinyError(
-                        "Could not update the change request. Only owner can update the change request"
+                        "Could not delete the change request. Only the creator can delete it."
                     );
                 }
 

--- a/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
+++ b/packages/api-apw/src/storageOperations/changeRequestStorageOperations.ts
@@ -88,7 +88,7 @@ export const createChangeRequestStorageOperations = (
             const existingEntry = await getChangeRequest({ id: params.id });
 
             /**
-             * Only owner can update the change request
+             * Only creator can update the change request
              */
             if (existingEntry.createdBy.id !== security?.getIdentity()?.id) {
                 throw new WebinyError(
@@ -111,8 +111,22 @@ export const createChangeRequestStorageOperations = (
         },
         async deleteChangeRequest(params) {
             const model = await getChangeRequestModel();
-
             if (security.getIdentity()) {
+                /**
+                 * We're fetching the existing entry here because we're not accepting "app" field as input,
+                 * but, we still need to retain its value after the "update" operation.
+                 */
+                const existingEntry = await getChangeRequest({ id: params.id });
+
+                /**
+                 * Only creator can update the change request
+                 */
+                if (existingEntry.createdBy.id !== security?.getIdentity()?.id) {
+                    throw new WebinyError(
+                        "Could not update the change request. Only owner can update the change request"
+                    );
+                }
+
                 await security.withoutAuthorization(async () => {
                     return cms.deleteEntry(model, params.id);
                 });

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -142,9 +142,12 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                         <DefaultButton
                             onClick={() => {
                                 if (!canEditChangeRequest()) {
-                                    showDialog("Change request can be edited by the owner.", {
-                                        title: "Edit change request"
-                                    });
+                                    showDialog(
+                                        "You cannot edit the change request. Only the creator can edit it.",
+                                        {
+                                            title: "Edit change request"
+                                        }
+                                    );
                                     return;
                                 }
                                 setOpen(true);
@@ -159,9 +162,12 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                         <DefaultButton
                             onClick={() => {
                                 if (!canEditChangeRequest()) {
-                                    showDialog("Change request can be deleted by the owner.", {
-                                        title: "Deleted change request"
-                                    });
+                                    showDialog(
+                                        "You cannot delete the change request. Only the creator can delete it.",
+                                        {
+                                            title: "Deleted change request"
+                                        }
+                                    );
                                     return;
                                 }
 

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -129,6 +129,7 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                     <RichTextBox>
                         <TypographyBody use={"body2"}>
                             <RichTextEditor
+                                elementId={id}
                                 key={richTextEditorKey}
                                 className={cx(richTextWrapperStyles, textStyles)}
                                 readOnly={true}

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import React from "react";
-import { cx, css } from "emotion";
+import { css, cx } from "emotion";
 import { ButtonDefault, ButtonIcon } from "@webiny/ui/Button";
 import { RichTextEditor } from "@webiny/ui/RichTextEditor";
 import { Box, Columns, Stack } from "~/components/Layout";
@@ -8,13 +8,14 @@ import { ReactComponent as EditIcon } from "~/assets/icons/edit_24dp.svg";
 import { ReactComponent as DeleteIcon } from "~/assets/icons/delete_24dp.svg";
 import { ReactComponent as MarkTaskIcon } from "~/assets/icons/task_alt_24dp.svg";
 import { useChangeRequest } from "~/hooks/useChangeRequest";
-import { useConfirmationDialog } from "@webiny/app-admin";
+import { useConfirmationDialog, useDialog } from "@webiny/app-admin";
 import { i18n } from "@webiny/app/i18n";
 import { DefaultRenderImagePreview } from "./ApwFile";
 import { useChangeRequestDialog } from "./useChangeRequestDialog";
 import { richTextWrapperStyles, TypographyBody, TypographyTitle } from "../Styled";
 import { FileWithOverlay, Media } from "./ChangeRequestMedia";
 import { CircularProgress } from "@webiny/ui/Progress";
+import { useSecurity } from "@webiny/app-security";
 
 const t = i18n.ns("app-apw/content-reviews/editor/steps/changeRequest");
 
@@ -80,7 +81,9 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
     const { id } = props;
     const { deleteChangeRequest, changeRequest, markResolved, loading } = useChangeRequest({ id });
     const { setOpen, setChangeRequestId } = useChangeRequestDialog();
+    const { identity } = useSecurity();
 
+    const { showDialog } = useDialog();
     const { showConfirmation } = useConfirmationDialog({
         title: t`Delete change request`,
         message: (
@@ -97,6 +100,10 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
 
     const handleResolve = async (resolved: boolean) => {
         await markResolved(!resolved);
+    };
+
+    const canEditChangeRequest = (): boolean => {
+        return changeRequest.createdBy.id === identity?.id;
     };
 
     if (!changeRequest) {
@@ -134,6 +141,12 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                     <ButtonBox paddingY={1}>
                         <DefaultButton
                             onClick={() => {
+                                if (!canEditChangeRequest()) {
+                                    showDialog("Change request can be edited by the owner.", {
+                                        title: "Edit change request"
+                                    });
+                                    return;
+                                }
                                 setOpen(true);
                                 setChangeRequestId(id);
                             }}
@@ -144,11 +157,19 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                     </ButtonBox>
                     <ButtonBox paddingY={1} border={true}>
                         <DefaultButton
-                            onClick={() =>
+                            disabled={identity?.id !== changeRequest.createdBy.id}
+                            onClick={() => {
+                                if (!canEditChangeRequest()) {
+                                    showDialog("Change request can be deleted by the owner.", {
+                                        title: "Deleted change request"
+                                    });
+                                    return;
+                                }
+
                                 showConfirmation(async () => {
                                     await deleteChangeRequest(id);
-                                })
-                            }
+                                });
+                            }}
                         >
                             <ButtonIcon icon={<DeleteIcon />} />
                             Delete

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -157,7 +157,6 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                     </ButtonBox>
                     <ButtonBox paddingY={1} border={true}>
                         <DefaultButton
-                            disabled={identity?.id !== changeRequest.createdBy.id}
                             onClick={() => {
                                 if (!canEditChangeRequest()) {
                                     showDialog("Change request can be deleted by the owner.", {

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -170,7 +170,6 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                                     );
                                     return;
                                 }
-
                                 showConfirmation(async () => {
                                     await deleteChangeRequest(id);
                                 });

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequest.tsx
@@ -144,9 +144,9 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                             onClick={() => {
                                 if (!canEditChangeRequest()) {
                                     showDialog(
-                                        "You cannot edit the change request. Only the creator can edit it.",
+                                        t`You cannot edit the change request. Only the creator can edit it.`,
                                         {
-                                            title: "Edit change request"
+                                            title: t`Edit change request`
                                         }
                                     );
                                     return;
@@ -164,9 +164,9 @@ export const ChangeRequest: React.FC<ChangeRequestProps> = props => {
                             onClick={() => {
                                 if (!canEditChangeRequest()) {
                                     showDialog(
-                                        "You cannot delete the change request. Only the creator can delete it.",
+                                        t`You cannot delete the change request. Only the creator can delete it.`,
                                         {
-                                            title: "Deleted change request"
+                                            title: t`Deleted change request`
                                         }
                                     );
                                     return;

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequestListItem.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequestListItem.tsx
@@ -83,6 +83,7 @@ export const ChangeRequestListItem: React.FC<ChangeRequestItemProps> = props => 
                 <Box>
                     <TypographySecondary use={"caption"}>
                         <RichTextEditor
+                            elementId={id}
                             readOnly={true}
                             className={richTextWrapperStyles}
                             value={getTrimmedBody(body)}

--- a/packages/app-apw/src/components/ContentReviewEditor/Comment/Comments.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/Comment/Comments.tsx
@@ -6,7 +6,7 @@ import { Box, Columns, Stack } from "~/components/Layout";
 import { fromNow } from "~/utils";
 import { Avatar } from "~/views/publishingWorkflows/components/ReviewersList";
 import { useCommentsList } from "~/hooks/useCommentsList";
-import { TypographyBody, TypographySecondary, AuthorName, richTextWrapperStyles } from "../Styled";
+import { AuthorName, richTextWrapperStyles, TypographyBody, TypographySecondary } from "../Styled";
 import { CommentFile } from "../ChangeRequest/ApwFile";
 import { FileWithOverlay } from "../ChangeRequest/ChangeRequestMedia";
 
@@ -46,6 +46,7 @@ const Comment: React.FC<CommentProps> = props => {
             <CommentBox paddingX={3.5} paddingY={5}>
                 <TypographyBody use={"caption"}>
                     <RichTextEditor
+                        elementId={comment.id}
                         readOnly={true}
                         className={richTextWrapperStyles}
                         value={comment.body}

--- a/packages/ui/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/RichTextEditor/RichTextEditor.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useEffect, useRef } from "react";
 import shortid from "shortid";
-import EditorJS from "@editorjs/editorjs";
-import {
+import EditorJS, {
     LogLevels,
     OutputBlockData,
     OutputData,
@@ -58,10 +57,11 @@ export interface RichTextEditorProps {
     disabled?: boolean;
     validation?: FormComponentProps["validation"];
     className?: string;
+    elementId?: string;
 }
 
 export const RichTextEditor: React.FC<RichTextEditorProps> = props => {
-    const elementId = useRef("rte-" + shortid.generate());
+    const elementId = useRef("rte-" + (props?.elementId ? props.elementId : shortid.generate()));
     const editorRef = useRef<EditorJSType>();
 
     useEffect(() => {


### PR DESCRIPTION
With this PR we want to add permission change on change requests editing and deleting. Only the creator or owner of a change request can edit or delete it.

## Changes

## app-apw

#### Prevent and inform the users who cannot edit or delete change requests.
 - `ChangeRequest` Componetnt
 - show alert dialog for editing the change request
 - show alert dialog for deleting the change request

 Check tests `UC1` and `UC4`

## api-apw

#### Storage operations
- updateChangeRequest  - prevent a user who is not the creator of the change request to updating it.
- deleteChangeRequest  - prevent a user who is not the creator of the change request to delete it.

#### Tests
- Two tests that prove that if the user is not the creator of the change request, can update or delete the change request. 

## How Has This Been Tested?
Manually.

### Edit change request

**UC1: The user is the not creator of the change request**

https://github.com/webiny/webiny-js/assets/82515066/da64c624-2d61-4620-a0f3-cac4f7c90950

**UC2: Bypass the UI - back-end response**
<img width="945" alt="bypass-the-dalog-back-end-edit-error" src="https://github.com/webiny/webiny-js/assets/82515066/737b6135-cd55-4067-bd61-782e669abaf8">

**UC3: Creator of the change request can edit**

https://github.com/webiny/webiny-js/assets/82515066/c242a73c-23a9-4624-9ebb-0b460dc58d71


### Delete change request

**UC4: The user is the not creator of the change request**

https://github.com/webiny/webiny-js/assets/82515066/d48aa1f3-c5ae-425a-9e77-7bca49a5aa4b

**UC5: Bypass the UI - back-end response**
<img width="976" alt="bypass-the-dalog-back-end-delete-error" src="https://github.com/webiny/webiny-js/assets/82515066/1c6602d3-f719-4da3-ac6c-39c3c9687254">

**UC6: Creator of the change request can edit**

https://github.com/webiny/webiny-js/assets/82515066/8723ad30-7fa3-4f2f-9272-8c8efd32452a



