### PR TITLE
fix: fix form fields options editing

### DIFF
--- a/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
@@ -163,7 +163,7 @@ const OptionsList: React.FC<OptionsListProps> = ({ form, multiple, otherOption }
                         setOptionsValue(newValue);
                         clearEditOption();
                     },
-                    [optionsValue, setOptionsValue]
+                    [optionsValue, editOption, setOptionsValue]
                 );
                 return (
                     <>

--- a/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import camelCase from "lodash/camelCase";
@@ -156,15 +156,12 @@ const OptionsList: React.FC<OptionsListProps> = ({ form, multiple, otherOption }
                     value: optionsValue,
                     onChange: setOptionsValue
                 } = bind;
-                const onSubmit = useCallback(
-                    (data: FieldOption): void => {
-                        const newValue = [...optionsValue];
-                        newValue.splice(editOption.index as number, 1, data);
-                        setOptionsValue(newValue);
-                        clearEditOption();
-                    },
-                    [optionsValue, editOption, setOptionsValue]
-                );
+                const onSubmit = (data: FieldOption): void => {
+                    const newValue = [...optionsValue];
+                    newValue.splice(editOption.index as number, 1, data);
+                    setOptionsValue(newValue);
+                    clearEditOption();
+                };
                 return (
                     <>
                         <div>Options</div>


### PR DESCRIPTION
## Changes
Resolve issue "Incorrect option changes on dropdown/checkbox/radio field edit".
Task provided by @SvenAlHamad  no reference to issue or Notion.

There was missed `useCallback` dependency that cause updating of wrong field option inside `Form Editor`.

![image](https://github.com/webiny/webiny-js/assets/77202393/e63b6733-484a-40a2-9eea-42f6e2a772f1)


## How Has This Been Tested?
Manual

## Documentation
None
