### PR TITLE
fix: fix reCaptcha verification and settings

### DIFF
--- a/packages/api-form-builder/src/plugins/crud/submissions.crud.ts
+++ b/packages/api-form-builder/src/plugins/crud/submissions.crud.ts
@@ -184,10 +184,8 @@ export const createSubmissionsCrud = (params: CreateSubmissionsCrudParams): Subm
                     "https://www.google.com/recaptcha/api/siteverify",
                     {
                         method: "POST",
-                        body: JSON.stringify({
-                            secret: secretKey,
-                            response: reCaptchaResponseToken
-                        })
+                        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                        body: `secret=${secretKey}&response=${reCaptchaResponseToken}`
                     }
                 );
 

--- a/packages/app-form-builder/src/admin/views/Settings/FormsSettings.tsx
+++ b/packages/app-form-builder/src/admin/views/Settings/FormsSettings.tsx
@@ -32,7 +32,7 @@ const FormsSettings: React.FC = () => {
     const [updateSettings, updateSettingsMutation] = useMutation<
         UpdateFormSettingsMutationResponse,
         UpdateFormSettingsMutationVariables
-    >(graphql.mutation);
+    >(graphql.mutation, { refetchQueries: [{ query: graphql.query }] });
     const mutationInProgress = updateSettingsMutation?.loading;
 
     return (


### PR DESCRIPTION
## Changes
Resolve 2 issues: [Webiny not working with reCaptcha](https://github.com/webiny/webiny-js/issues/3461) and [reCaptcha in PageBuilder not saved](https://github.com/webiny/webiny-js/issues/3492).

1) Fixed `reCaptcha` verify query headers and body as suggested in [issue](https://github.com/webiny/webiny-js/issues/3461).
2) Fixed `GetFormSettingsQuery` was not refetched after settings update.

## How Has This Been Tested?
Manual

## Documentation
None
