### PR TITLE
fix: file manager listing after first paginated fetch

### DIFF
--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
@@ -242,7 +242,7 @@ const FileManagerView = () => {
                 view.loadMoreFiles();
             }
         }, 200),
-        [view.meta]
+        [view.meta, view.loadMoreFiles]
     );
 
     return (


### PR DESCRIPTION
## Changes
With this PR, we aim to fix the file manager listing issue after the initial paginated fetch: this was preventing to list more than 100 files.

## How Has This Been Tested?
Manually