### PR TITLE
Blocks Import/Export - Assign Newly Created Block Category Into `loadedCategory`

### DIFF
--- a/packages/api-page-builder-import-export/src/import/process/blocks/importBlock.ts
+++ b/packages/api-page-builder-import-export/src/import/process/blocks/importBlock.ts
@@ -93,7 +93,7 @@ export async function importBlock({
     if (category) {
         loadedCategory = await context.pageBuilder.getBlockCategory(category?.slug);
         if (!loadedCategory) {
-            await context.pageBuilder.createBlockCategory({
+            loadedCategory = await context.pageBuilder.createBlockCategory({
                 name: category.name,
                 slug: category.slug,
                 icon: category.icon,


### PR DESCRIPTION
## Changes
This PR fixes an issue where, in the import process, the newly created block category would not be assigned to the `loadedCategory`. This would cause the import blocks functionality not to work all the time.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.