### PR TITLE
Content Models List - Do Not Show "Clone Content Model" Button If User Doesn't Have Permissions

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -302,17 +302,21 @@ const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
                                                         />
                                                     </Tooltip>
                                                 )}
+                                                <Tooltip
+                                                    content={"Clone content model"}
+                                                    placement={"top"}
+                                                >
+                                                    <IconButton
+                                                        data-testid={
+                                                            "cms-clone-content-model-button"
+                                                        }
+                                                        icon={<CloneIcon />}
+                                                        label={t`View entries`}
+                                                        onClick={() => onClone(contentModel)}
+                                                    />
+                                                </Tooltip>
                                             </>
                                         )}
-
-                                        <Tooltip content={"Clone content model"} placement={"top"}>
-                                            <IconButton
-                                                data-testid={"cms-clone-content-model-button"}
-                                                icon={<CloneIcon />}
-                                                label={t`View entries`}
-                                                onClick={() => onClone(contentModel)}
-                                            />
-                                        </Tooltip>
 
                                         {canDelete(contentModel, "cms.contentModel") && (
                                             <>


### PR DESCRIPTION
## Changes
This PR ensures the "Clone Content Model" button is hidden if the user doesn't have the appropriate permissions.

![image](https://github.com/webiny/webiny-js/assets/5121148/5e99c597-e5cd-4321-a0f5-347e89b7e098)


## How Has This Been Tested?
Manual.

## Documentation
Changelog.