### PR TITLE
fix: add support for `titleFieldId` defined inside the HCMS model

### DIFF
--- a/packages/app-aco/src/contexts/acoList.tsx
+++ b/packages/app-aco/src/contexts/acoList.tsx
@@ -98,6 +98,7 @@ const getCurrentRecordList = <T = GenericSearchData,>(
 export interface AcoListProviderProps {
     children: React.ReactNode;
     own?: boolean;
+    titleFieldId: string | null;
 }
 
 export const AcoListProvider: React.VFC<AcoListProviderProps> = ({ children, ...props }) => {
@@ -208,7 +209,11 @@ export const AcoListProvider: React.VFC<AcoListProviderProps> = ({ children, ...
      */
     useEffect(() => {
         setFolders(prev => {
-            return sortTableItems(prev, state.listSort);
+            // We might receive a different field name as `title`, here we set it back to `title` for folders.
+            const titleField = props?.titleFieldId || "title";
+            return sortTableItems(prev, state.listSort, {
+                [titleField]: "title"
+            });
         });
     }, [state.listSort]);
 

--- a/packages/app-aco/src/contexts/acoList.tsx
+++ b/packages/app-aco/src/contexts/acoList.tsx
@@ -210,7 +210,7 @@ export const AcoListProvider: React.VFC<AcoListProviderProps> = ({ children, ...
     useEffect(() => {
         setFolders(prev => {
             // We might receive a different field name as `title`, here we set it back to `title` for folders.
-            const titleField = props?.titleFieldId || "title";
+            const titleField = props?.titleFieldId || "id";
             return sortTableItems(prev, state.listSort, {
                 [titleField]: "title"
             });

--- a/packages/app-aco/src/contexts/acoList.tsx
+++ b/packages/app-aco/src/contexts/acoList.tsx
@@ -209,7 +209,6 @@ export const AcoListProvider: React.VFC<AcoListProviderProps> = ({ children, ...
      */
     useEffect(() => {
         setFolders(prev => {
-            // We might receive a different field name as `title`, here we set it back to `title` for folders.
             const titleField = props?.titleFieldId || "id";
             return sortTableItems(prev, state.listSort, {
                 [titleField]: "title"

--- a/packages/app-aco/src/contexts/app.tsx
+++ b/packages/app-aco/src/contexts/app.tsx
@@ -252,7 +252,7 @@ export const AcoAppProvider: React.VFC<AcoAppProviderProps> = ({
                         createListLink={createNavigateFolderListLink}
                         createStorageKey={createNavigateFolderStorageKey}
                     >
-                        <AcoListProvider own={own}>
+                        <AcoListProvider own={own} titleFieldId={model.titleFieldId}>
                             <DialogsContextProvider>{children}</DialogsContextProvider>
                         </AcoListProvider>
                     </NavigateFolderWithRouterProvider>

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
@@ -75,7 +75,7 @@ export const Table = forwardRef<HTMLDivElement, Props>((props, ref) => {
     );
 
     const columns: Columns<Entry> = useMemo(() => {
-        const titleColumnId = model.titleFieldId || "title";
+        const titleColumnId = model.titleFieldId || "id";
 
         return {
             [titleColumnId]: {

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
@@ -75,8 +75,10 @@ export const Table = forwardRef<HTMLDivElement, Props>((props, ref) => {
     );
 
     const columns: Columns<Entry> = useMemo(() => {
+        const titleColumnId = model.titleFieldId || "title";
+
         return {
-            title: {
+            [titleColumnId]: {
                 header: "Name",
                 className: "cms-aco-list-title",
                 cell: (record: Entry) => {


### PR DESCRIPTION
## Changes
The pull request addresses the issue of sorting the `Name` column in the HCMS ACO table when the corresponding field is missing from the HCMS model.

We map the `Name` column with the `titleFieldId` from the content model but keep the table header title as it is because the column also contains the folder's title.

Closes [WEB-3212](https://webiny.atlassian.net/browse/WEB-3212)

## How Has This Been Tested?
Manually

## Documentation
Inline