### PR TITLE
fix(api-headless-cms): search with colon in search term

### DIFF
--- a/jest.config.base.setup.js
+++ b/jest.config.base.setup.js
@@ -3,4 +3,6 @@
 
 // Runs failed tests five times until they pass or until the max number of retries is exhausted.
 // https://jestjs.io/docs/jest-object#jestretrytimesnumretries-options
-jest.retryTimes(3);
+if (process.env.CI === "true") {
+    jest.retryTimes(3);
+}

--- a/packages/api-elasticsearch/src/normalize.ts
+++ b/packages/api-elasticsearch/src/normalize.ts
@@ -51,15 +51,11 @@ export const normalizeValue = (value: string) => {
     return result || "";
 };
 
-const isSpecialChar = (value: string, index: number): boolean | null => {
+const hasSpecialChar = (value: string): boolean | null => {
     if (!value) {
         return null;
     }
-    const char = value.charAt(index) || "";
-    if (!char) {
-        return null;
-    }
-    return char.match(/^([0-9a-zA-Z])$/i) === null;
+    return value.match(/^([0-9a-zA-Z]+)$/i) === null;
 };
 
 export const normalizeValueWithAsterisk = (initial: string) => {
@@ -71,14 +67,14 @@ export const normalizeValueWithAsterisk = (initial: string) => {
      * If there is a / in the first word, do not put asterisk in front of it.
      */
     const firstWord = results[0];
-    if (isSpecialChar(firstWord, 0) === false) {
+    if (hasSpecialChar(firstWord) === false) {
         result = `*${result}`;
     }
     /**
      * If there is a / in the last word, do not put asterisk at the end of it.
      */
     const lastWord = results[results.length - 1];
-    if (isSpecialChar(lastWord, results.length - 1) === false) {
+    if (hasSpecialChar(lastWord) === false) {
         result = `${result}*`;
     }
 

--- a/packages/api-elasticsearch/src/normalize.ts
+++ b/packages/api-elasticsearch/src/normalize.ts
@@ -12,11 +12,11 @@ const specialCharacters = [
     "\\+",
     // "\\-",
     "\\=",
-    "\\&\\&",
-    "\\|\\|",
+    `\&`,
+    `\\|`,
     ">",
     "<",
-    "\\!",
+    `\!`,
     "\\(",
     "\\)",
     "\\{",
@@ -51,6 +51,17 @@ export const normalizeValue = (value: string) => {
     return result || "";
 };
 
+const isSpecialChar = (value: string, index: number): boolean | null => {
+    if (!value) {
+        return null;
+    }
+    const char = value.charAt(index) || "";
+    if (!char) {
+        return null;
+    }
+    return char.match(/^([0-9a-zA-Z])$/i) === null;
+};
+
 export const normalizeValueWithAsterisk = (initial: string) => {
     const value = normalizeValue(initial);
     const results = value.split(" ");
@@ -60,14 +71,14 @@ export const normalizeValueWithAsterisk = (initial: string) => {
      * If there is a / in the first word, do not put asterisk in front of it.
      */
     const firstWord = results[0];
-    if (firstWord && firstWord.includes("/") === false) {
+    if (isSpecialChar(firstWord, 0) === false) {
         result = `*${result}`;
     }
     /**
      * If there is a / in the last word, do not put asterisk at the end of it.
      */
     const lastWord = results[results.length - 1];
-    if (lastWord && lastWord.includes("/") === false) {
+    if (isSpecialChar(lastWord, results.length - 1) === false) {
         result = `${result}*`;
     }
 

--- a/packages/api-elasticsearch/src/normalize.ts
+++ b/packages/api-elasticsearch/src/normalize.ts
@@ -3,6 +3,8 @@
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
  */
 
+const specialCharactersToRemove = [`\\?`];
+
 const specialCharacterToSpace = ["-"];
 
 const specialCharacters = [
@@ -25,14 +27,19 @@ const specialCharacters = [
     '\\"',
     "\\~",
     "\\*",
-    "\\?",
-    "\\:",
+    `\:`,
     `\/`,
     "\\#"
 ];
 
 export const normalizeValue = (value: string) => {
     let result = value || "";
+    if (!result) {
+        return result;
+    }
+    for (const character of specialCharactersToRemove) {
+        result = result.replace(new RegExp(character, "g"), "");
+    }
     for (const character of specialCharacterToSpace) {
         result = result.replace(new RegExp(character, "g"), " ");
     }

--- a/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/filter.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/filter.test.ts
@@ -204,9 +204,7 @@ describe("filtering", () => {
             fields
         });
 
-        expect(resultNumber3).toHaveLength(0);
-
-        expect(resultNumber3).toMatchObject([]);
+        expect(resultNumber3).toHaveLength(19);
     });
 
     it("should filter by nested options variant colors", async () => {

--- a/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
@@ -345,7 +345,9 @@ describe("search", () => {
             banana: "A Not So Tasty Fruit: Banana w/ Yellow Dots",
             orange: "Awesome Fruit: Orange w/ Leaves",
             grape: "Wine - An Autumn Fruit: Grape w/ Seeds?",
-            tangerine: "An Autumn Fruit: Tangerine w/ Seeds?"
+            tangerine: "An Autumn Fruit: Tangerine w/ Seeds?",
+            cleaning: "Clean Building Day | The Ultimate Cleaning Trick Tips!",
+            car: "2001 CarMaker Car type: SVO Reborn? - Burn Epi. 917"
         };
         const results: any[] = [];
         for (const title of Object.values(categories)) {
@@ -443,6 +445,52 @@ describe("search", () => {
                     ],
                     meta: {
                         totalCount: 2,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [cleaningListResponse] = await categoryManager.listCategories({
+            where: {
+                title_contains: "Clean Building Day | The Ultimate Cleaning Trick Tips!"
+            }
+        });
+        expect(cleaningListResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: categories.cleaning
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [carListResponse] = await categoryManager.listCategories({
+            where: {
+                title_contains: "2001 CarMaker Car type: SVO Reborn? - Burn Epi. 917"
+            }
+        });
+        expect(carListResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: categories.car
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
                         hasMoreItems: false,
                         cursor: null
                     },

--- a/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
@@ -1,7 +1,12 @@
 import { useFruitManageHandler } from "~tests/testHelpers/useFruitManageHandler";
 import { setupContentModelGroup, setupContentModels } from "~tests/testHelpers/setup";
+import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler";
+import { toSlug } from "~/utils/toSlug";
 
 describe("search", () => {
+    const categoryManager = useCategoryManageHandler({
+        path: "manage/en-US"
+    });
     const fruitManager = useFruitManageHandler({
         path: "manage/en-US"
     });
@@ -13,6 +18,7 @@ describe("search", () => {
         });
 
         if (response.data.createFruit.error) {
+            console.log(JSON.stringify(response.data.createFruit.error, null, 2));
             throw new Error(response.data.createFruit.error.message);
         }
         return response.data.createFruit.data;
@@ -41,7 +47,7 @@ describe("search", () => {
 
     const setupFruits = async (input?: string[]) => {
         const group = await setupContentModelGroup(fruitManager);
-        await setupContentModels(fruitManager, group, ["fruit"]);
+        await setupContentModels(fruitManager, group, ["fruit", "category"]);
         return createFruits(input);
     };
 
@@ -323,6 +329,120 @@ describe("search", () => {
                     ],
                     meta: {
                         totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should find a record with special characters in the title", async () => {
+        await setupFruits();
+        const categories = {
+            apple: "A Tasty Fruit: Apple w/ Black Dots?",
+            banana: "A Not So Tasty Fruit: Banana w/ Yellow Dots",
+            orange: "Awesome Fruit: Orange w/ Leaves",
+            grape: "Wine - An Autumn Fruit: Grape w/ Seeds?",
+            tangerine: "An Autumn Fruit: Tangerine w/ Seeds?"
+        };
+        const results: any[] = [];
+        for (const title of Object.values(categories)) {
+            const [result] = await categoryManager.createCategory({
+                data: {
+                    title,
+                    slug: toSlug(title)
+                }
+            });
+            results.push(result?.data?.createCategory?.data);
+        }
+        expect(results).toHaveLength(Object.values(categories).length);
+
+        const [initialResponse] = await categoryManager.listCategories({
+            sort: ["createdOn_ASC"]
+        });
+        expect(initialResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: expect.any(Array),
+                    meta: {
+                        totalCount: Object.values(categories).length,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [appleListResponse] = await categoryManager.listCategories({
+            where: {
+                title_contains: "tasty fruit: apple w/ black dots"
+            }
+        });
+        expect(appleListResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: categories.apple
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [dotsListResponse] = await categoryManager.listCategories({
+            where: {
+                title_contains: "tasty fruit: w/ dots"
+            }
+        });
+        expect(dotsListResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: categories.banana
+                        },
+                        {
+                            title: categories.apple
+                        }
+                    ],
+                    meta: {
+                        totalCount: 2,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [questionMarksListResponse] = await categoryManager.listCategories({
+            where: {
+                title_contains: "autumn fruit: seeds?"
+            }
+        });
+        expect(questionMarksListResponse).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: categories.tangerine
+                        },
+                        {
+                            title: categories.grape
+                        }
+                    ],
+                    meta: {
+                        totalCount: 2,
                         hasMoreItems: false,
                         cursor: null
                     },

--- a/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/search.test.ts
@@ -51,7 +51,7 @@ describe("search", () => {
         return createFruits(input);
     };
 
-    it.skip("should find record with dash in the middle of two words", async () => {
+    it("should find record with dash in the middle of two words", async () => {
         await setupFruits();
         const [response] = await listFruits({
             where: {

--- a/packages/db-dynamodb/src/plugins/filters/contains.ts
+++ b/packages/db-dynamodb/src/plugins/filters/contains.ts
@@ -2,18 +2,21 @@ import { ValueFilterPlugin } from "../definitions/ValueFilterPlugin";
 
 const plugin = new ValueFilterPlugin({
     operation: "contains",
-    matches: ({ value, compareValue }) => {
-        if (typeof value !== "string") {
-            if (Array.isArray(value) === true) {
-                const re = new RegExp(compareValue, "i");
-                return value.some((v: string) => {
-                    return v.match(re) !== null;
-                });
-            }
+    matches: ({ value: initialValue, compareValue: initialCompareValue }) => {
+        const isValueArray = Array.isArray(initialValue);
+        if (!initialValue || (isValueArray && initialValue.length === 0)) {
             return false;
+        } else if (initialCompareValue === undefined || initialCompareValue === null) {
+            return true;
         }
-        const re = new RegExp(compareValue, "i");
-        return value.match(re) !== null;
+        const values: string[] = isValueArray ? initialValue : [initialValue];
+        const compareValues: string[] = initialCompareValue.split(" ");
+
+        return values.some(target => {
+            return compareValues.every(compareValue => {
+                return target.match(new RegExp(compareValue, "gi")) !== null;
+            });
+        });
     }
 });
 

--- a/packages/db-dynamodb/src/plugins/filters/contains.ts
+++ b/packages/db-dynamodb/src/plugins/filters/contains.ts
@@ -1,18 +1,35 @@
 import { ValueFilterPlugin } from "../definitions/ValueFilterPlugin";
 
+const createValues = (initialValue: string | string[]) => {
+    return Array.isArray(initialValue) ? initialValue : [initialValue];
+};
+
+const createCompareValues = (value: string) => {
+    return value
+        .replace(/\s+/g, " ")
+        .trim()
+        .replaceAll(/\?/g, `\\?`)
+        .replaceAll(/\//g, `\\/`)
+        .replaceAll(/:/g, ``)
+        .replaceAll(/\-/g, `\\-`)
+        .split(" ")
+        .filter(val => {
+            return val.length > 0;
+        });
+};
+
 const plugin = new ValueFilterPlugin({
     operation: "contains",
     matches: ({ value: initialValue, compareValue: initialCompareValue }) => {
-        const isValueArray = Array.isArray(initialValue);
-        if (!initialValue || (isValueArray && initialValue.length === 0)) {
+        if (!initialValue || (Array.isArray(initialValue) && initialValue.length === 0)) {
             return false;
         } else if (initialCompareValue === undefined || initialCompareValue === null) {
             return true;
         }
-        const values: string[] = isValueArray ? initialValue : [initialValue];
-        const compareValues: string[] = initialCompareValue.split(" ");
-
+        const values = createValues(initialValue);
+        const compareValues = createCompareValues(initialCompareValue);
         return values.some(target => {
+            // return target.match(compareValues) !== null;
             return compareValues.every(compareValue => {
                 return target.match(new RegExp(compareValue, "gi")) !== null;
             });

--- a/packages/db-dynamodb/src/plugins/filters/contains.ts
+++ b/packages/db-dynamodb/src/plugins/filters/contains.ts
@@ -8,10 +8,10 @@ const createCompareValues = (value: string) => {
     return value
         .replace(/\s+/g, " ")
         .trim()
-        .replaceAll(/\?/g, `\\?`)
-        .replaceAll(/\//g, `\\/`)
-        .replaceAll(/:/g, ``)
-        .replaceAll(/\-/g, `\\-`)
+        .replace(/\?/g, `\\?`)
+        .replace(/\//g, `\\/`)
+        .replace(/:/g, ``)
+        .replace(/\-/g, `\\-`)
         .split(" ")
         .filter(val => {
             return val.length > 0;

--- a/packages/db-dynamodb/src/plugins/filters/fuzzy.ts
+++ b/packages/db-dynamodb/src/plugins/filters/fuzzy.ts
@@ -16,7 +16,8 @@ const plugin = new ValueFilterPlugin({
         const f = new Fuse([value], {
             includeScore: true,
             minMatchCharLength: 3,
-            threshold: 0.6
+            threshold: 0.6,
+            isCaseSensitive: false
         });
         const result = f.search(compareValue);
 

--- a/packages/migrations/src/migrations/5.37.0/002/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.37.0/002/ddb-es/index.ts
@@ -285,8 +285,9 @@ export class CmsEntriesRootFolder_5_37_0_002
                 logger.trace("Storing the DynamoDB records...");
                 await executeWithRetry(execute, {
                     onFailedAttempt: error => {
-                        logger.error(`"batchWriteAll" attempt #${error.attemptNumber} failed.`);
-                        logger.error(error.message);
+                        logger.error(
+                            `"batchWriteAll" attempt #${error.attemptNumber} failed: ${error.message}`
+                        );
                     }
                 });
                 logger.trace("...stored.");
@@ -295,9 +296,8 @@ export class CmsEntriesRootFolder_5_37_0_002
                 await executeWithRetry(executeDdbEs, {
                     onFailedAttempt: error => {
                         logger.error(
-                            `"batchWriteAll ddb + es" attempt #${error.attemptNumber} failed.`
+                            `"batchWriteAll ddb + es" attempt #${error.attemptNumber} failed: ${error.message}`
                         );
-                        logger.error(error.message);
                     }
                 });
                 logger.trace("...stored.");
@@ -343,12 +343,12 @@ export class CmsEntriesRootFolder_5_37_0_002
             };
         } catch (ex) {
             logger.error(`Failed to fetch original Elasticsearch settings for index "${index}".`);
-            logger.error(ex.message);
-            logger.info(ex.code);
-            logger.info(JSON.stringify(ex.data));
-            if (ex.stack) {
-                logger.info(ex.stack);
-            }
+            logger.error({
+                ...ex,
+                message: ex.message,
+                code: ex.code,
+                data: ex.data
+            });
         }
         return null;
     }
@@ -379,12 +379,12 @@ export class CmsEntriesRootFolder_5_37_0_002
                 logger.error(
                     `Failed to restore original settings for index "${index}". Please do it manually.`
                 );
-                logger.error(ex.message);
-                logger.info(ex.code);
-                logger.info(JSON.stringify(ex.data));
-                if (ex.stack) {
-                    logger.info(ex.stack);
-                }
+                logger.error({
+                    ...ex,
+                    message: ex.message,
+                    code: ex.code,
+                    data: ex.data
+                });
             }
         }
     }
@@ -405,12 +405,12 @@ export class CmsEntriesRootFolder_5_37_0_002
             });
         } catch (ex) {
             logger.error(`Failed to disable indexing for index "${index}".`);
-            logger.error(ex.message);
-            logger.info(ex.code);
-            logger.info(JSON.stringify(ex.data));
-            if (ex.stack) {
-                logger.info(ex.stack);
-            }
+            logger.error({
+                ...ex,
+                message: ex.message,
+                code: ex.code,
+                data: ex.data
+            });
         }
     }
 }


### PR DESCRIPTION
## Changes
Fix for a search via the `contains` operator where colon (:) in the search term would not produce any results.

## How Has This Been Tested?
Jest and manually.