### PR TITLE
feat(api-headless-cms): optional validation graphql

### DIFF
--- a/apps/api/graphql/src/test.ts
+++ b/apps/api/graphql/src/test.ts
@@ -1,0 +1,403 @@
+import { createCmsGroup, createCmsModel } from "@webiny/api-headless-cms";
+
+export const createTestStructure = () => {
+    return [createTestGroup(), createTestModel()];
+};
+const createTestGroup = () => {
+    return createCmsGroup({
+        id: "homepage",
+        name: "Homepage",
+        description: "Homepage content model group",
+        slug: "homepage",
+        icon: "fas/house"
+    });
+};
+const createTestModel = () => {
+    return createCmsModel({
+        name: "homepage",
+        modelId: "homepage",
+        description: "Homepage content model",
+        group: {
+            id: "homepage",
+            name: "Homepage"
+        },
+        fields: [
+            {
+                id: "homepageTitle",
+                fieldId: "homepageTitle",
+                type: "text",
+                label: "Title",
+                multipleValues: false,
+                renderer: {
+                    name: "text-input"
+                },
+                validation: [],
+                settings: {}
+                // storageId: "text@homepageTitle"
+            },
+            {
+                id: "items",
+                fieldId: "items",
+                type: "dynamicZone",
+                label: "Items on the homepage",
+                multipleValues: true,
+                renderer: {
+                    name: "dynamicZone"
+                },
+                validation: [],
+                settings: {
+                    templates: [
+                        {
+                            description: "List of customer reviews",
+                            icon: "far/face-smile",
+                            id: "homepage_customer_reviews",
+                            name: "CustomerReviews",
+                            fields: [
+                                {
+                                    id: "customerReview",
+                                    fieldId: "customerReview",
+                                    type: "object",
+                                    label: "Customer Review",
+                                    multipleValues: true,
+                                    renderer: {
+                                        name: "objects"
+                                    },
+                                    validation: [],
+                                    layout: [
+                                        ["customerReviewCustomerName"],
+                                        ["customerReviewMessage"],
+                                        ["customerReviewRating"]
+                                    ],
+                                    settings: {
+                                        fields: [
+                                            {
+                                                id: "customerReviewCustomerName",
+                                                fieldId: "customerReviewCustomerName",
+                                                type: "text",
+                                                label: "Name of the customer",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [
+                                                    {
+                                                        name: "Value is required."
+                                                    }
+                                                ],
+                                                settings: {}
+                                                // storageId: "text@customerReviewCustomerName"
+                                            },
+                                            {
+                                                id: "customerReviewMessage",
+                                                fieldId: "customerReviewMessage",
+                                                type: "text",
+                                                label: "Message of the customer",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [
+                                                    {
+                                                        name: "Value is required."
+                                                    }
+                                                ],
+                                                settings: {}
+                                                // storageId: "text@customerReviewMessage"
+                                            },
+                                            {
+                                                id: "customerReviewRating",
+                                                fieldId: "customerReviewRating",
+                                                type: "number",
+                                                label: "Customer Review Rating",
+                                                helpText: "Rating from 1 to 5",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "number-input"
+                                                },
+                                                validation: [
+                                                    {
+                                                        name: "Value is required."
+                                                    }
+                                                ],
+                                                settings: {}
+                                                // storageId: "number@customerReviewRating"
+                                            }
+                                        ]
+                                    }
+                                    // storageId: "object@customerReview"
+                                },
+                                {
+                                    id: "customerReviewsTitle",
+                                    fieldId: "customerReviewsTitle",
+                                    type: "text",
+                                    label: "CustomerReviewsTitle",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [
+                                        {
+                                            name: "Value is required."
+                                        }
+                                    ],
+                                    settings: {}
+                                    // storageId: "text@customerReviewsTitle"
+                                }
+                            ],
+                            validation: []
+                        },
+                        {
+                            description: "Hero component",
+                            icon: "fas/bolt-lightning",
+                            id: "homepage_hero",
+                            name: "Hero",
+                            fields: [
+                                {
+                                    id: "heroTitle",
+                                    fieldId: "heroTitle",
+                                    type: "text",
+                                    label: "HeroTitle",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [
+                                        {
+                                            name: "Value is required."
+                                        }
+                                    ],
+                                    settings: {}
+                                    // storageId: "text@heroTitle"
+                                },
+                                {
+                                    id: "heroBenefit",
+                                    fieldId: "heroBenefit",
+                                    type: "text",
+                                    label: "Benefit",
+                                    multipleValues: true,
+                                    renderer: {
+                                        name: "text-inputs"
+                                    },
+                                    validation: [],
+                                    settings: {}
+                                    // storageId: "text@heroBenefit"
+                                },
+                                {
+                                    id: "heroImage",
+                                    fieldId: "heroImage",
+                                    type: "file",
+                                    label: "Image",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "file-input"
+                                    },
+                                    validation: [],
+                                    settings: {}
+                                    // storageId: "file@heroImage"
+                                }
+                            ],
+                            validation: []
+                        },
+                        {
+                            description: "Compare the good and bad",
+                            icon: "fas/table",
+                            id: "homepage_compare_table",
+                            name: "CompareTable",
+                            fields: [
+                                {
+                                    id: "compareTableTitle",
+                                    fieldId: "compareTableTitle",
+                                    type: "text",
+                                    label: "CompareTableTitle",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [
+                                        {
+                                            name: "Value is required."
+                                        }
+                                    ],
+                                    settings: {}
+                                    // storageId: "text@compareTableTitle"
+                                },
+                                {
+                                    id: "compareTableCategory",
+                                    fieldId: "compareTableCategory",
+                                    type: "object",
+                                    label: "Compare Category",
+                                    helpText: "The category for which to compare the two sides",
+                                    multipleValues: true,
+                                    renderer: {
+                                        name: "objects"
+                                    },
+                                    validation: [],
+                                    settings: {
+                                        fields: [
+                                            {
+                                                id: "compareCategoryTitle",
+                                                fieldId: "compareCategoryTitle",
+                                                type: "text",
+                                                label: "title",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "text@compareCategoryTitle"
+                                            },
+                                            {
+                                                id: "good",
+                                                fieldId: "good",
+                                                type: "text",
+                                                label: "Description of the good side",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "text@good"
+                                            },
+                                            {
+                                                id: "bad",
+                                                fieldId: "bad",
+                                                type: "text",
+                                                label: "Description of the bad side",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "text@bad"
+                                            }
+                                        ]
+                                    }
+                                    // storageId: "object@compareTableCategory"
+                                },
+                                {
+                                    id: "comparisonTableNameOfGoodSide",
+                                    fieldId: "comparisonTableNameOfGoodSide",
+                                    type: "text",
+                                    label: "Name of Good Side",
+                                    helpText: "E.g. Utisha",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [],
+                                    settings: {}
+                                    // storageId: "text@comparisonTableNameOfGoodSide"
+                                },
+                                {
+                                    id: "comparisonTableNameOfBadSide",
+                                    fieldId: "comparisonTableNameOfBadSide",
+                                    type: "text",
+                                    label: "Name of Bad Side",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [],
+                                    settings: {}
+                                    // storageId: "text@comparisonTableNameOfBadSide"
+                                }
+                            ],
+                            validation: []
+                        },
+                        {
+                            description: "List of teachers on the homepage",
+                            icon: "fas/chalkboard-teacher",
+                            id: "homepage_teachers",
+                            name: "Teachers",
+                            fields: [
+                                {
+                                    id: "teacher",
+                                    fieldId: "teacher",
+                                    type: "object",
+                                    label: "Teacher",
+                                    multipleValues: true,
+                                    renderer: {
+                                        name: "objects"
+                                    },
+                                    validation: [],
+                                    layout: [["name"], ["expertiseArea"], ["image"]],
+                                    settings: {
+                                        fields: [
+                                            {
+                                                id: "teacherName",
+                                                fieldId: "teacherName",
+                                                type: "text",
+                                                label: "Name of the teacher",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "text-input"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "text@teacherName"
+                                            },
+                                            {
+                                                id: "teacherExpertiseArea",
+                                                fieldId: "teacherExpertiseArea",
+                                                type: "text",
+                                                label: "Expertise Area",
+                                                helpText: "E.g. fitness, yoga, strength training",
+                                                multipleValues: true,
+                                                renderer: {
+                                                    name: "text-inputs"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "text@teacherExpertiseArea"
+                                            },
+                                            {
+                                                id: "teacherImage",
+                                                fieldId: "teacherImage",
+                                                type: "file",
+                                                label: "TeacherImage",
+                                                multipleValues: false,
+                                                renderer: {
+                                                    name: "file-input"
+                                                },
+                                                validation: [],
+                                                settings: {}
+                                                // storageId: "file@teacherImage"
+                                            }
+                                        ]
+                                    }
+                                    // storageId: "object@teacher"
+                                },
+                                {
+                                    id: "title",
+                                    fieldId: "title",
+                                    type: "text",
+                                    label: "Title",
+                                    multipleValues: false,
+                                    renderer: {
+                                        name: "text-input"
+                                    },
+                                    validation: [
+                                        {
+                                            name: "Value is required."
+                                        }
+                                    ],
+                                    settings: {}
+                                    // storageId: "text@title"
+                                }
+                            ],
+                            validation: []
+                        }
+                    ]
+                }
+                // storageId: "dynamicZone@items"
+            }
+        ],
+        layout: [["homepageTitle"], ["items"]],
+        titleFieldId: "homepageTitle",
+        singularApiName: "Homepage",
+        pluralApiName: "Homepages"
+    });
+};

--- a/packages/api-aco/__tests__/snapshots/customAppsSchema.ts
+++ b/packages/api-aco/__tests__/snapshots/customAppsSchema.ts
@@ -134,7 +134,7 @@ export const createCustomAppsSchemaSnapshot = () => {
         }
 
         input AcoSearchRecordCustomTestingApp_LocationInput {
-          folderId: String!
+          folderId: String
         }
 
         input AcoSearchRecordCustomTestingApp_Data_IdentityInput {
@@ -155,11 +155,11 @@ export const createCustomAppsSchemaSnapshot = () => {
 
         input AcoSearchRecordCustomTestingAppCreateInput {
           id: ID
-          type: String!
-          title: String!
+          type: String
+          title: String
           content: String
-          location: AcoSearchRecordCustomTestingApp_LocationInput!
-          data: AcoSearchRecordCustomTestingApp_DataInput!
+          location: AcoSearchRecordCustomTestingApp_LocationInput
+          data: AcoSearchRecordCustomTestingApp_DataInput
           tags: [String!]
         }
         

--- a/packages/api-aco/__tests__/snapshots/defaultAppsSchema.ts
+++ b/packages/api-aco/__tests__/snapshots/defaultAppsSchema.ts
@@ -110,7 +110,7 @@ export const createDefaultAppsSchemaSnapshot = () => {
         }
 
         input AcoSearchRecordWebiny_LocationInput {
-          folderId: String!
+          folderId: String
         }
 
         input AcoSearchRecordWebiny_Data_IdentityInput {
@@ -129,11 +129,11 @@ export const createDefaultAppsSchemaSnapshot = () => {
 
         input AcoSearchRecordWebinyCreateInput {
           id: ID
-          type: String!
-          title: String!
+          type: String
+          title: String
           content: String
-          location: AcoSearchRecordWebiny_LocationInput!
-          data: AcoSearchRecordWebiny_DataInput!
+          location: AcoSearchRecordWebiny_LocationInput
+          data: AcoSearchRecordWebiny_DataInput
           tags: [String!]
         }
         

--- a/packages/api-file-manager/__tests__/mocks/file.sdl.ts
+++ b/packages/api-file-manager/__tests__/mocks/file.sdl.ts
@@ -130,10 +130,10 @@ export default /* GraphQL */ `
     input FmFileCreateInput {
         id: ID!
         location: FmFile_LocationInput
-        name: String!
-        key: String!
-        type: String!
-        size: Number!
+        name: String
+        key: String
+        type: String
+        size: Number
         meta: FmFile_MetaInput
         tags: [String!]
         aliases: [String!]

--- a/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
@@ -140,30 +140,6 @@ describe("fieldValidations", () => {
                 }
             }
         });
-
-        /**
-         * GraphQL response must break when not sending required value.
-         */
-        const [requiredResponse] = await createFruit({
-            data: {
-                ...defaultFruitData,
-                name: undefined
-            }
-        });
-
-        expect(requiredResponse).toEqual({
-            errors: [
-                {
-                    message: expect.any(String),
-                    locations: [
-                        {
-                            column: expect.any(Number),
-                            line: expect.any(Number)
-                        }
-                    ]
-                }
-            ]
-        });
     });
     /**
      * testing minLength and maxLength of the array

--- a/packages/api-headless-cms/__tests__/contentAPI/republish.entries.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/republish.entries.test.ts
@@ -296,7 +296,10 @@ describe("Republish entries", () => {
             category: {
                 entryId: applePublished.id,
                 modelId: categoryModel.modelId
-            }
+            },
+            price: 1,
+            color: "red",
+            image: "https://webiny.com/gala.png"
         });
         const { entry: goldenEntry } = createEntry(
             productModel,
@@ -305,7 +308,10 @@ describe("Republish entries", () => {
                 category: {
                     entryId: bananaPublished.id,
                     modelId: categoryModel.modelId
-                }
+                },
+                price: 1,
+                color: "white",
+                image: "https://webiny.com/golden.png"
             },
             5
         );

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -37,8 +37,8 @@ export default /* GraphQL */ `
     input CategoryApiNameWhichIsABitDifferentThanModelIdInput {
         id: ID
         wbyAco_location: WbyAcoLocationInput
-        title: String!
-        slug: String!
+        title: String
+        slug: String
     }
 
     input CategoryApiNameWhichIsABitDifferentThanModelIdGetWhereInput {
@@ -158,11 +158,11 @@ export default /* GraphQL */ `
     }
 
     extend type Mutation {
-        createCategoryApiNameWhichIsABitDifferentThanModelId(data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
+        createCategoryApiNameWhichIsABitDifferentThanModelId(data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!, options: CreateCmsEntryOptionsInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
 
-        createCategoryApiNameWhichIsABitDifferentThanModelIdFrom(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
+        createCategoryApiNameWhichIsABitDifferentThanModelIdFrom(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput, options: CreateRevisionCmsEntryOptionsInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
 
-        updateCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
+        updateCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!, options: UpdateCmsEntryOptionsInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
     
         moveCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, folderId: ID!): CategoryApiNameWhichIsABitDifferentThanModelIdMoveResponse
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -227,7 +227,7 @@ export default /* GraphQL */ `
     }
 
     input PageModelApiName_Content_HeroInput {
-        title: String!
+        title: String
     }
 
     input PageModelApiName_Content_SimpleTextInput {
@@ -257,7 +257,7 @@ export default /* GraphQL */ `
     }
 
     input PageModelApiName_Content_AuthorInput {
-        author: RefFieldInput!
+        author: RefFieldInput
         authors: [RefFieldInput!]
     }
 
@@ -437,16 +437,18 @@ export default /* GraphQL */ `
     }
 
     extend type Mutation {
-        createPageModelApiName(data: PageModelApiNameInput!): PageModelApiNameResponse
+        createPageModelApiName(data: PageModelApiNameInput!, options: CreateCmsEntryOptionsInput): PageModelApiNameResponse
 
         createPageModelApiNameFrom(
             revision: ID!
             data: PageModelApiNameInput
+            options: CreateRevisionCmsEntryOptionsInput
         ): PageModelApiNameResponse
 
         updatePageModelApiName(
             revision: ID!
             data: PageModelApiNameInput!
+            options: UpdateCmsEntryOptionsInput
         ): PageModelApiNameResponse
 
         movePageModelApiName(revision: ID!, folderId: ID!): PageModelApiNameMoveResponse

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -140,7 +140,7 @@ export default /* GraphQL */ `
         name: String
         price: Number
         image: String
-        category: RefFieldInput!
+        category: RefFieldInput
         categories: [RefFieldInput]
         longText: [String]
     }
@@ -149,27 +149,27 @@ export default /* GraphQL */ `
         name: String
         price: Number
         images: [String]
-        category: RefFieldInput!
+        category: RefFieldInput
         options: [ProductApiSingular_Variant_OptionsInput!]
     }
 
     input ProductApiSingular_FieldsObjectInput {
-        text: String!
+        text: String
     }
 
 
     input ProductApiSingularInput {
         id: ID
         wbyAco_location: WbyAcoLocationInput
-        title: String!
-        category: RefFieldInput!
-        price: Number!
+        title: String
+        category: RefFieldInput
+        price: Number
         inStock: Boolean
         itemsInStock: Number
         availableOn: Date
-        color: String!
+        color: String
         availableSizes: [String!]
-        image: String!
+        image: String
         richText: JSON
         variant: ProductApiSingular_VariantInput
         fieldsObject: ProductApiSingular_FieldsObjectInput
@@ -360,11 +360,11 @@ export default /* GraphQL */ `
     }
 
     extend type Mutation {
-        createProductApiSingular(data: ProductApiSingularInput!): ProductApiSingularResponse
+        createProductApiSingular(data: ProductApiSingularInput!, options: CreateCmsEntryOptionsInput): ProductApiSingularResponse
 
-        createProductApiSingularFrom(revision: ID!, data: ProductApiSingularInput): ProductApiSingularResponse
+        createProductApiSingularFrom(revision: ID!, data: ProductApiSingularInput, options: CreateRevisionCmsEntryOptionsInput): ProductApiSingularResponse
 
-        updateProductApiSingular(revision: ID!, data: ProductApiSingularInput!): ProductApiSingularResponse
+        updateProductApiSingular(revision: ID!, data: ProductApiSingularInput!, options: UpdateCmsEntryOptionsInput): ProductApiSingularResponse
         
         moveProductApiSingular(revision: ID!, folderId: ID!): ProductApiSingularMoveResponse
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -39,7 +39,7 @@ export default /* GraphQL */ `
     input ReviewApiModelInput {
         id: ID
         wbyAco_location: WbyAcoLocationInput
-        text: String!
+        text: String
         product: RefFieldInput
         rating: Number
         author: RefFieldInput
@@ -170,11 +170,11 @@ export default /* GraphQL */ `
     }
 
     extend type Mutation {
-        createReviewApiModel(data: ReviewApiModelInput!): ReviewApiModelResponse
+        createReviewApiModel(data: ReviewApiModelInput!, options: CreateCmsEntryOptionsInput): ReviewApiModelResponse
 
-        createReviewApiModelFrom(revision: ID!, data: ReviewApiModelInput): ReviewApiModelResponse
+        createReviewApiModelFrom(revision: ID!, data: ReviewApiModelInput, options: CreateRevisionCmsEntryOptionsInput): ReviewApiModelResponse
 
-        updateReviewApiModel(revision: ID!, data: ReviewApiModelInput!): ReviewApiModelResponse
+        updateReviewApiModel(revision: ID!, data: ReviewApiModelInput!, options: UpdateCmsEntryOptionsInput): ReviewApiModelResponse
         
         moveReviewApiModel(revision: ID!, folderId: ID!): ReviewApiModelMoveResponse
 

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -644,7 +644,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             );
         }
     };
-    const createEntry: CmsEntryContext["createEntry"] = async (model, inputData) => {
+    const createEntry: CmsEntryContext["createEntry"] = async (model, inputData, options) => {
         await entriesPermissions.ensure({ rwd: "w" });
         await modelsPermissions.ensureCanAccessModel({
             model
@@ -655,11 +655,13 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
          */
         const initialInput = mapAndCleanCreateInputData(model, inputData);
 
-        await validateModelEntryData({
-            context,
-            model,
-            data: initialInput
-        });
+        if (options?.validate !== false) {
+            await validateModelEntryData({
+                context,
+                model,
+                data: initialInput
+            });
+        }
 
         const input = await referenceFieldsMapping({
             context,
@@ -743,7 +745,8 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
     const createEntryRevisionFrom: CmsEntryContext["createEntryRevisionFrom"] = async (
         model,
         sourceId,
-        inputData
+        inputData,
+        options
     ) => {
         await entriesPermissions.ensure({ rwd: "w" });
         await modelsPermissions.ensureCanAccessModel({
@@ -786,12 +789,14 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             ...input
         };
 
-        await validateModelEntryData({
-            context,
-            model,
-            data: initialValues,
-            entry: originalEntry
-        });
+        if (options?.validate !== false) {
+            await validateModelEntryData({
+                context,
+                model,
+                data: initialValues,
+                entry: originalEntry
+            });
+        }
 
         const values = await referenceFieldsMapping({
             context,
@@ -871,7 +876,13 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
             );
         }
     };
-    const updateEntry: CmsEntryContext["updateEntry"] = async (model, id, inputData, metaInput) => {
+    const updateEntry: CmsEntryContext["updateEntry"] = async (
+        model,
+        id,
+        inputData,
+        metaInput,
+        options
+    ) => {
         await entriesPermissions.ensure({ rwd: "w" });
         await modelsPermissions.ensureCanAccessModel({
             model
@@ -902,12 +913,14 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
-        await validateModelEntryData({
-            context,
-            model,
-            data: input,
-            entry: originalEntry
-        });
+        if (options?.validate !== false) {
+            await validateModelEntryData({
+                context,
+                model,
+                data: input,
+                entry: originalEntry
+            });
+        }
 
         await entriesPermissions.ensure({ owns: originalEntry.createdBy });
 
@@ -1358,6 +1371,13 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
+        await validateModelEntryData({
+            context,
+            model,
+            data: originalEntry.values,
+            entry: originalEntry
+        });
+
         const currentDate = new Date().toISOString();
         const entry: CmsEntry = {
             ...originalEntry,
@@ -1735,22 +1755,22 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 }
             });
         },
-        async createEntry(model, input) {
+        async createEntry(model, input, options) {
             return context.benchmark.measure("headlessCms.crud.entries.createEntry", async () => {
-                return createEntry(model, input);
+                return createEntry(model, input, options);
             });
         },
-        async createEntryRevisionFrom(model, sourceId, input) {
+        async createEntryRevisionFrom(model, sourceId, input, options) {
             return context.benchmark.measure(
                 "headlessCms.crud.entries.createEntryRevisionFrom",
                 async () => {
-                    return createEntryRevisionFrom(model, sourceId, input);
+                    return createEntryRevisionFrom(model, sourceId, input, options);
                 }
             );
         },
-        async updateEntry(model, id, input, meta) {
+        async updateEntry(model, id, input, meta, options) {
             return context.benchmark.measure("headlessCms.crud.entries.updateEntry", async () => {
-                return updateEntry(model, id, input, meta);
+                return updateEntry(model, id, input, meta, options);
             });
         },
         async moveEntry(model, id, folderId) {

--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -63,6 +63,18 @@ export const createBaseSchema = (): GraphQLSchemaPlugin<CmsContext>[] => {
                 folderId_not: ID
                 folderId_not_in: [ID!]
             }
+
+            input CreateCmsEntryOptionsInput {
+                validate: Boolean
+            }
+
+            input CreateRevisionCmsEntryOptionsInput {
+                validate: Boolean
+            }
+
+            input UpdateCmsEntryOptionsInput {
+                validate: Boolean
+            }
         `,
         resolvers: {}
     });

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -165,11 +165,11 @@ export const createManageSDL: CreateManageSDL = ({
         }
 
         extend type Mutation {
-            create${singularName}(data: ${singularName}Input!): ${singularName}Response
+            create${singularName}(data: ${singularName}Input!, options: CreateCmsEntryOptionsInput): ${singularName}Response
 
-            create${singularName}From(revision: ID!, data: ${singularName}Input): ${singularName}Response
+            create${singularName}From(revision: ID!, data: ${singularName}Input, options: CreateRevisionCmsEntryOptionsInput): ${singularName}Response
     
-            update${singularName}(revision: ID!, data: ${singularName}Input!): ${singularName}Response
+            update${singularName}(revision: ID!, data: ${singularName}Input!, options: UpdateCmsEntryOptionsInput): ${singularName}Response
             
             move${singularName}(revision: ID!, folderId: ID!): ${singularName}MoveResponse
 

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveCreate.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveCreate.ts
@@ -1,8 +1,13 @@
-import { Response, ErrorResponse } from "@webiny/handler-graphql/responses";
-import { CmsEntryResolverFactory as ResolverFactory, CreateCmsEntryInput } from "~/types";
+import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
+import {
+    CmsEntryResolverFactory as ResolverFactory,
+    CreateCmsEntryInput,
+    CreateCmsEntryOptionsInput
+} from "~/types";
 
 interface ResolveCreateArgs {
     data: CreateCmsEntryInput;
+    options?: CreateCmsEntryOptionsInput;
 }
 type ResolveCreate = ResolverFactory<any, ResolveCreateArgs>;
 
@@ -10,7 +15,7 @@ export const resolveCreate: ResolveCreate =
     ({ model }) =>
     async (_, args: any, context) => {
         try {
-            const entry = await context.cms.createEntry(model, args.data);
+            const entry = await context.cms.createEntry(model, args.data, args.options);
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveCreateFrom.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveCreateFrom.ts
@@ -1,9 +1,14 @@
-import { Response, ErrorResponse } from "@webiny/handler-graphql/responses";
-import { CmsEntryResolverFactory as ResolverFactory, CreateFromCmsEntryInput } from "~/types";
+import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
+import {
+    CmsEntryResolverFactory as ResolverFactory,
+    CreateFromCmsEntryInput,
+    CreateRevisionCmsEntryOptionsInput
+} from "~/types";
 
 interface ResolveCreateFromArgs {
     revision: string;
     data: CreateFromCmsEntryInput;
+    options?: CreateRevisionCmsEntryOptionsInput;
 }
 type ResolveCreateFrom = ResolverFactory<any, ResolveCreateFromArgs>;
 
@@ -14,7 +19,8 @@ export const resolveCreateFrom: ResolveCreateFrom =
             const newRevision = await context.cms.createEntryRevisionFrom(
                 model,
                 args.revision,
-                args.data || {}
+                args.data || {},
+                args.options
             );
             return new Response(newRevision);
         } catch (e) {

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveUpdate.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveUpdate.ts
@@ -1,9 +1,14 @@
-import { Response, ErrorResponse } from "@webiny/handler-graphql/responses";
-import { CmsEntryResolverFactory as ResolverFactory, UpdateCmsEntryInput } from "~/types";
+import { ErrorResponse, Response } from "@webiny/handler-graphql/responses";
+import {
+    CmsEntryResolverFactory as ResolverFactory,
+    UpdateCmsEntryInput,
+    UpdateCmsEntryOptionsInput
+} from "~/types";
 
 interface ResolveUpdateArgs {
     revision: string;
     data: UpdateCmsEntryInput;
+    options?: UpdateCmsEntryOptionsInput;
 }
 type ResolveUpdate = ResolverFactory<any, ResolveUpdateArgs>;
 
@@ -11,7 +16,12 @@ export const resolveUpdate: ResolveUpdate =
     ({ model }) =>
     async (_, args: any, context) => {
         try {
-            const entry = await context.cms.updateEntry(model, args.revision, args.data);
+            const entry = await context.cms.updateEntry(
+                model,
+                args.revision,
+                args.data,
+                args.options
+            );
 
             return new Response(entry);
         } catch (e) {

--- a/packages/api-headless-cms/src/graphqlFields/datetime.ts
+++ b/packages/api-headless-cms/src/graphqlFields/datetime.ts
@@ -1,5 +1,5 @@
 import { CmsModelField, CmsModelFieldToGraphQLPlugin } from "~/types";
-import { attachRequiredFieldValue, createGraphQLInputField } from "./helpers";
+import { createGraphQLInputField } from "./helpers";
 
 const fieldGraphQLTypes = {
     time: "Time",
@@ -58,8 +58,7 @@ export const createDateTimeField = (): CmsModelFieldToGraphQLPlugin => {
             createListFilters,
             createTypeField({ field }) {
                 if (field.multipleValues) {
-                    const def = attachRequiredFieldValue(getFieldGraphQLType(field), field);
-                    return `${field.fieldId}: [${def}]`;
+                    return `${field.fieldId}: [${getFieldGraphQLType(field)}]`;
                 }
                 return `${field.fieldId}: ${getFieldGraphQLType(field)}`;
             },

--- a/packages/api-headless-cms/src/graphqlFields/helpers.ts
+++ b/packages/api-headless-cms/src/graphqlFields/helpers.ts
@@ -31,11 +31,13 @@ const envVars: string[] = [
 export const createGraphQLInputField = (field: CmsModelField, graphQlType: string): string => {
     const singleRequired = getIsRequired(field.validation) ? "!" : "";
     if (!field.multipleValues) {
-        return `${field.fieldId}: ${graphQlType}${singleRequired}`;
+        // return `${field.fieldId}: ${graphQlType}${singleRequired}`;
+        return `${field.fieldId}: ${graphQlType}`;
     }
     const multipleRequired = getIsRequired(field.listValidation) ? "!" : "";
 
     const itemRequired = envVars.some(v => process.env[v] === "false") ? "" : singleRequired;
 
-    return `${field.fieldId}: [${graphQlType}${itemRequired}]${multipleRequired}`;
+    return `${field.fieldId}: [${graphQlType}${itemRequired}]`;
+    // return `${field.fieldId}: [${graphQlType}${itemRequired}]${multipleRequired}`;
 };

--- a/packages/api-headless-cms/src/graphqlFields/helpers.ts
+++ b/packages/api-headless-cms/src/graphqlFields/helpers.ts
@@ -8,19 +8,6 @@ const getIsRequired = (validations?: CmsModelFieldValidation[]): boolean => {
     });
 };
 
-export const attachRequiredFieldValue = (def: string, field: CmsModelField): string => {
-    if (!field.validation || field.validation.length === 0) {
-        return def;
-    }
-    const isRequired = field.validation.some(validation => {
-        return validation.name === "required";
-    });
-    if (!isRequired) {
-        return def;
-    }
-    return `${def}!`;
-};
-
 const envVars: string[] = [
     "HEADLESS_CMS_GRAPHQL_INPUT_REQUIRE_ARRAY_ITEM",
     "WEBINY_HEADLESS_CMS_GRAPHQL_INPUT_REQUIRE_ARRAY_ITEM"
@@ -31,13 +18,10 @@ const envVars: string[] = [
 export const createGraphQLInputField = (field: CmsModelField, graphQlType: string): string => {
     const singleRequired = getIsRequired(field.validation) ? "!" : "";
     if (!field.multipleValues) {
-        // return `${field.fieldId}: ${graphQlType}${singleRequired}`;
         return `${field.fieldId}: ${graphQlType}`;
     }
-    const multipleRequired = getIsRequired(field.listValidation) ? "!" : "";
 
     const itemRequired = envVars.some(v => process.env[v] === "false") ? "" : singleRequired;
 
     return `${field.fieldId}: [${graphQlType}${itemRequired}]`;
-    // return `${field.fieldId}: [${graphQlType}${itemRequired}]${multipleRequired}`;
 };

--- a/packages/api-headless-cms/src/graphqlFields/object.ts
+++ b/packages/api-headless-cms/src/graphqlFields/object.ts
@@ -1,12 +1,11 @@
 import upperFirst from "lodash/upperFirst";
+import lodashUpperFirst from "lodash/upperFirst";
 import {
     CmsFieldTypePlugins,
     CmsModel,
     CmsModelField,
     CmsModelFieldToGraphQLPlugin
 } from "~/types";
-import { attachRequiredFieldValue } from "./helpers";
-import lodashUpperFirst from "lodash/upperFirst";
 import { createTypeFromFields } from "~/utils/createTypeFromFields";
 
 interface AttachTypeDefinitionsParams {
@@ -209,10 +208,9 @@ export const createObjectField = (): CmsModelFieldToGraphQLPlugin => {
                 const { fieldType, typeDefs } = result;
 
                 return {
-                    fields: attachRequiredFieldValue(
-                        `${field.fieldId}: ${field.multipleValues ? `[${fieldType}!]` : fieldType}`,
-                        field
-                    ),
+                    fields: `${field.fieldId}: ${
+                        field.multipleValues ? `[${fieldType}!]` : fieldType
+                    }`,
                     typeDefs
                 };
             },

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2244,12 +2244,20 @@ export interface CreateCmsEntryInput {
     [key: string]: any;
 }
 
+export interface CreateCmsEntryOptionsInput {
+    validate?: boolean;
+}
+
 /**
  * @category Context
  * @category CmsEntry
  */
 export interface CreateFromCmsEntryInput {
     [key: string]: any;
+}
+
+export interface CreateRevisionCmsEntryOptionsInput {
+    validate?: boolean;
 }
 
 /**
@@ -2261,6 +2269,10 @@ export interface UpdateCmsEntryInput {
         folderId?: string | null;
     };
     [key: string]: any;
+}
+
+export interface UpdateCmsEntryOptionsInput {
+    validate?: boolean;
 }
 
 /**
@@ -2344,14 +2356,19 @@ export interface CmsEntryContext {
     /**
      * Create a new content entry.
      */
-    createEntry: (model: CmsModel, input: CreateCmsEntryInput) => Promise<CmsEntry>;
+    createEntry: (
+        model: CmsModel,
+        input: CreateCmsEntryInput,
+        options?: CreateCmsEntryOptionsInput
+    ) => Promise<CmsEntry>;
     /**
      * Create a new entry from already existing entry.
      */
     createEntryRevisionFrom: (
         model: CmsModel,
         id: string,
-        input: CreateFromCmsEntryInput
+        input: CreateFromCmsEntryInput,
+        options?: CreateRevisionCmsEntryOptionsInput
     ) => Promise<CmsEntry>;
     /**
      * Update existing entry.
@@ -2360,7 +2377,8 @@ export interface CmsEntryContext {
         model: CmsModel,
         id: string,
         input: UpdateCmsEntryInput,
-        meta?: Record<string, any>
+        meta?: Record<string, any>,
+        options?: UpdateCmsEntryOptionsInput
     ) => Promise<CmsEntry>;
     /**
      * Move entry, and all its revisions, to a new folder.


### PR DESCRIPTION
## Changes

We need to have optional validation of created entries. When user sends validate: false, we do not validate the data - just store it.
Validation is now executed on publish mutation - always.

## How Has This Been Tested?
Jest.