### PR TITLE
Add Missing Page Builder Context In Jest Tests For Form Builder

### DIFF
--- a/packages/api-form-builder/__tests__/useGqlHandler.ts
+++ b/packages/api-form-builder/__tests__/useGqlHandler.ts
@@ -44,7 +44,7 @@ import { FileManagerStorageOperations } from "@webiny/api-file-manager/types";
 import { HeadlessCmsStorageOperations } from "@webiny/api-headless-cms/types";
 import { CmsParametersPlugin, createHeadlessCmsContext } from "@webiny/api-headless-cms";
 import { FormBuilderStorageOperations } from "~/types";
-import {createPageBuilderContext} from "@webiny/api-page-builder";
+import { createPageBuilderContext } from "@webiny/api-page-builder";
 
 export interface UseGqlHandlerParams {
     permissions?: SecurityPermission[];

--- a/packages/api-form-builder/__tests__/useGqlHandler.ts
+++ b/packages/api-form-builder/__tests__/useGqlHandler.ts
@@ -44,6 +44,7 @@ import { FileManagerStorageOperations } from "@webiny/api-file-manager/types";
 import { HeadlessCmsStorageOperations } from "@webiny/api-headless-cms/types";
 import { CmsParametersPlugin, createHeadlessCmsContext } from "@webiny/api-headless-cms";
 import { FormBuilderStorageOperations } from "~/types";
+import {createPageBuilderContext} from "@webiny/api-page-builder";
 
 export interface UseGqlHandlerParams {
     permissions?: SecurityPermission[];
@@ -64,6 +65,7 @@ export default (params: UseGqlHandlerParams = {}) => {
     const { permissions, identity, plugins = [] } = params;
     const i18nStorage = getStorageOps("i18n");
     const fileManagerStorage = getStorageOps<FileManagerStorageOperations>("fileManager");
+    const pageBuilderStorage = getStorageOps<FileManagerStorageOperations>("pageBuilder");
     const formBuilderStorage = getStorageOps<FormBuilderStorageOperations>("formBuilder");
     const cmsStorage = getStorageOps<HeadlessCmsStorageOperations>("cms");
 
@@ -85,9 +87,13 @@ export default (params: UseGqlHandlerParams = {}) => {
                 };
             }),
             createHeadlessCmsContext({ storageOperations: cmsStorage.storageOperations }),
+            createPageBuilderContext({
+                storageOperations: pageBuilderStorage.storageOperations
+            }),
             createFileManagerContext({
                 storageOperations: fileManagerStorage.storageOperations
             }),
+
             createFileManagerGraphQL(),
             createFormBuilder({
                 storageOperations: formBuilderStorage.storageOperations

--- a/packages/api-form-builder/jest.setup.js
+++ b/packages/api-form-builder/jest.setup.js
@@ -1,6 +1,7 @@
 const base = require("../../jest.config.base");
 const presets = require("@webiny/project-utils/testing/presets")(
     ["@webiny/api-form-builder", "storage-operations"],
+    ["@webiny/api-page-builder", "storage-operations"],
     ["@webiny/api-file-manager", "storage-operations"],
     ["@webiny/api-headless-cms", "storage-operations"],
     ["@webiny/api-i18n", "storage-operations"],


### PR DESCRIPTION
## Changes
Adds missing Page Builder context in the GQL handler setup in tests for Form Builder.

## How Has This Been Tested?
Jest.

## Documentation
N/A