### PR TITLE
feat(api-headless-cms): validate entry mutation

### DIFF
--- a/packages/api-aco/__tests__/folder.so.test.ts
+++ b/packages/api-aco/__tests__/folder.so.test.ts
@@ -265,7 +265,9 @@ describe("`folder` CRUD", () => {
                                 {
                                     error: "Value is required.",
                                     fieldId: "title",
-                                    storageId: "text@title"
+                                    storageId: "text@title",
+                                    id: "title",
+                                    parents: []
                                 }
                             ]
                         }
@@ -295,7 +297,9 @@ describe("`folder` CRUD", () => {
                                 {
                                     error: "Value is required.",
                                     fieldId: "slug",
-                                    storageId: "text@slug"
+                                    storageId: "text@slug",
+                                    id: "slug",
+                                    parents: []
                                 }
                             ]
                         }
@@ -325,7 +329,9 @@ describe("`folder` CRUD", () => {
                                 {
                                     error: "Value must consist of only 'a-z', '0-9' and '-'.",
                                     fieldId: "slug",
-                                    storageId: "text@slug"
+                                    storageId: "text@slug",
+                                    id: "slug",
+                                    parents: []
                                 }
                             ]
                         }

--- a/packages/api-apw/__tests__/graphql/entryPublishingWorkflow.test.ts
+++ b/packages/api-apw/__tests__/graphql/entryPublishingWorkflow.test.ts
@@ -438,6 +438,16 @@ describe("Cms Entry Publishing Workflow", () => {
                 }
             }
         });
+        expect(createContentReviewResponse).toEqual({
+            data: {
+                apw: {
+                    createContentReview: {
+                        data: expect.any(Object),
+                        error: null
+                    }
+                }
+            }
+        });
         const createdContentReview = createContentReviewResponse.data.apw.createContentReview.data;
 
         /*

--- a/packages/api-apw/__tests__/graphql/mocks/workflows.ts
+++ b/packages/api-apw/__tests__/graphql/mocks/workflows.ts
@@ -1,4 +1,9 @@
-import { ApwReviewer, ApwWorkflowApplications, ApwWorkflowStepTypes } from "~/types";
+import {
+    ApwReviewer,
+    ApwWorkflowApplications,
+    ApwWorkflowStepTypes,
+    WorkflowScopeTypes
+} from "~/types";
 
 import { generateAlphaNumericId } from "@webiny/utils";
 
@@ -6,7 +11,7 @@ export interface CreateWorkflowParams {
     title?: string;
     app: ApwWorkflowApplications;
     scope?: {
-        type: string;
+        type: WorkflowScopeTypes;
         data?: Record<string, any>;
     };
 }
@@ -68,24 +73,24 @@ export default {
     }),
     scopes: [
         {
-            type: "default"
+            type: WorkflowScopeTypes.DEFAULT
         },
         {
-            type: "default"
+            type: WorkflowScopeTypes.DEFAULT
         },
         {
-            type: "custom"
+            type: WorkflowScopeTypes.CUSTOM
         },
         {
-            type: "custom"
+            type: WorkflowScopeTypes.CUSTOM
         },
         {
-            type: "custom"
+            type: WorkflowScopeTypes.CUSTOM
         }
     ],
     getPageBuilderScope: (pageId: string, pageCategory?: string) => [
         {
-            type: "custom",
+            type: WorkflowScopeTypes.CUSTOM,
             data: {
                 entries: [],
                 models: [],
@@ -94,10 +99,10 @@ export default {
             }
         },
         {
-            type: "default"
+            type: WorkflowScopeTypes.DEFAULT
         },
         {
-            type: "custom",
+            type: WorkflowScopeTypes.CUSTOM,
             data: {
                 entries: [],
                 models: [],
@@ -106,7 +111,7 @@ export default {
             }
         },
         {
-            type: "custom",
+            type: WorkflowScopeTypes.CUSTOM,
             data: {
                 entries: [],
                 models: [],
@@ -115,7 +120,7 @@ export default {
             }
         },
         {
-            type: "custom",
+            type: WorkflowScopeTypes.CUSTOM,
             data: {
                 entries: [],
                 models: [],
@@ -140,7 +145,7 @@ export default {
             })
         ],
         scope: {
-            type: "custom",
+            type: WorkflowScopeTypes.CUSTOM,
             data: {
                 entries: [],
                 models: [],

--- a/packages/api-apw/src/scheduler/types.ts
+++ b/packages/api-apw/src/scheduler/types.ts
@@ -1,8 +1,7 @@
 import { Context } from "@webiny/api/types";
 import { SecurityIdentity, SecurityPermission } from "@webiny/api-security/types";
-import { I18NLocale, I18NContext } from "@webiny/api-i18n/types";
-import { Tenant } from "@webiny/api-tenancy/types";
-import { TenancyContext } from "@webiny/api-tenancy/types";
+import { I18NContext, I18NLocale } from "@webiny/api-i18n/types";
+import { TenancyContext, Tenant } from "@webiny/api-tenancy/types";
 import { ApwIdentity } from "~/types";
 
 export interface ListWhere {

--- a/packages/api-apw/src/storageOperations/models/contentReview.model.ts
+++ b/packages/api-apw/src/storageOperations/models/contentReview.model.ts
@@ -100,7 +100,7 @@ const contentTypeField = () =>
                     label: "Page",
                     value: "page"
                 },
-                { value: "cms-entry", label: "CMS Entry" }
+                { value: "cms_entry", label: "CMS Entry" }
             ]
         },
         validation: [

--- a/packages/api-apw/src/storageOperations/models/workflow.model.ts
+++ b/packages/api-apw/src/storageOperations/models/workflow.model.ts
@@ -1,6 +1,6 @@
 import { createModelField } from "./utils";
 import { CmsModelField } from "@webiny/api-headless-cms/types";
-import { WorkflowModelDefinition } from "~/types";
+import { WorkflowModelDefinition, WorkflowScopeTypes } from "~/types";
 
 const titleField = () =>
     createModelField({
@@ -131,16 +131,12 @@ const scopeTypeField = () =>
             enabled: true,
             values: [
                 {
-                    value: "default",
+                    value: WorkflowScopeTypes.DEFAULT,
                     label: "Default  - Catch all scope that applies to all content that's being published."
                 },
                 {
-                    value: "pageBuilder",
-                    label: "Page category (Page Builder only) - The workflow will apply to all pages inside specific categories."
-                },
-                {
-                    value: "cms",
-                    label: "Content model (Headless CMS only) - The workflow will apply to all the content inside the specific content models. "
+                    value: WorkflowScopeTypes.CUSTOM,
+                    label: "Custom - The workflow will be applied to all selected content."
                 }
             ]
         }

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/contentEntry.crud.validation.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/contentEntry.crud.validation.test.ts
@@ -1,0 +1,51 @@
+import { useValidationManageHandler } from "./handler";
+import { createModel, createValidationStructure } from "./mocks/structure";
+import { CmsModelFieldInput } from "~/types";
+
+interface FieldError {
+    error: string;
+    id: string;
+    fieldId: string;
+    storageId: string;
+}
+
+const createFieldErrors = (fields: Pick<CmsModelFieldInput, "id" | "fieldId" | "settings">[]) => {
+    return fields.reduce<FieldError[]>((errors, field) => {
+        if (field.settings?.fields?.length) {
+            errors.push(...createFieldErrors(field.settings.fields));
+            return errors;
+        }
+        errors.push({
+            error: expect.any(String),
+            id: field.id,
+            fieldId: field.fieldId,
+            storageId: expect.stringMatching(`@`)
+        });
+
+        return errors;
+    }, []);
+};
+
+describe("content entry validation", () => {
+    const manager = useValidationManageHandler({
+        path: "manage/en-US",
+        plugins: [createValidationStructure()]
+    });
+
+    const model = createModel();
+
+    it("should return errors for invalid entry", async () => {
+        const [response] = await manager.validate({
+            data: {}
+        });
+
+        expect(response).toEqual({
+            data: {
+                validateProduct: {
+                    data: createFieldErrors(model.fields),
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
@@ -1,0 +1,45 @@
+import { GraphQLHandlerParams, useGraphQLHandler } from "~tests/testHelpers/useGraphQLHandler";
+import { createModel } from "~tests/contentAPI/cmsEntryValidation/mocks/structure";
+import { CmsApiModel } from "~/plugins";
+
+const ERROR = `
+error {
+    message
+    data
+    code
+    stack
+}
+`;
+
+const validateMutation = (model: CmsApiModel) => {
+    return /* GraphQL */ `
+        mutation ValidateProduct($revision: ID, $data: ${model.singularApiName}Input!) {
+            validateProduct: validate${model.singularApiName}(revision: $revision, data: $data) {
+                data
+                ${ERROR}
+            }
+        }
+    `;
+};
+
+export const useValidationManageHandler = (params: Partial<GraphQLHandlerParams>) => {
+    const contentHandler = useGraphQLHandler({
+        path: "manage/en-US",
+        ...params
+    });
+
+    const model = createModel();
+
+    return {
+        ...contentHandler,
+        async validate(variables: Record<string, any>, headers: Record<string, any> = {}) {
+            return await contentHandler.invoke({
+                body: {
+                    query: validateMutation(model),
+                    variables
+                },
+                headers
+            });
+        }
+    };
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
@@ -14,7 +14,12 @@ const validateMutation = (model: Pick<CmsApiModel, "singularApiName">) => {
     return /* GraphQL */ `
         mutation ValidateProduct($revision: ID, $data: ${model.singularApiName}Input!) {
         validate: validate${model.singularApiName}(revision: $revision, data: $data) {
-                data
+                data {
+                    id
+                    fieldId
+                    error
+                    parents
+                }
                 ${ERROR}
             }
         }

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/handler.ts
@@ -1,5 +1,4 @@
 import { GraphQLHandlerParams, useGraphQLHandler } from "~tests/testHelpers/useGraphQLHandler";
-import { createModel } from "~tests/contentAPI/cmsEntryValidation/mocks/structure";
 import { CmsApiModel } from "~/plugins";
 
 const ERROR = `
@@ -11,10 +10,10 @@ error {
 }
 `;
 
-const validateMutation = (model: CmsApiModel) => {
+const validateMutation = (model: Pick<CmsApiModel, "singularApiName">) => {
     return /* GraphQL */ `
         mutation ValidateProduct($revision: ID, $data: ${model.singularApiName}Input!) {
-            validateProduct: validate${model.singularApiName}(revision: $revision, data: $data) {
+        validate: validate${model.singularApiName}(revision: $revision, data: $data) {
                 data
                 ${ERROR}
             }
@@ -22,20 +21,22 @@ const validateMutation = (model: CmsApiModel) => {
     `;
 };
 
-export const useValidationManageHandler = (params: Partial<GraphQLHandlerParams>) => {
+interface Params extends Partial<GraphQLHandlerParams> {
+    model: Pick<CmsApiModel, "singularApiName">;
+}
+
+export const useValidationManageHandler = (params: Params) => {
     const contentHandler = useGraphQLHandler({
         path: "manage/en-US",
         ...params
     });
-
-    const model = createModel();
 
     return {
         ...contentHandler,
         async validate(variables: Record<string, any>, headers: Record<string, any> = {}) {
             return await contentHandler.invoke({
                 body: {
-                    query: validateMutation(model),
+                    query: validateMutation(params.model),
                     variables
                 },
                 headers

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/errors.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/errors.ts
@@ -1,0 +1,60 @@
+import { CmsDynamicZoneTemplate, CmsModelFieldInput } from "~/types";
+
+const nestedErrorRegex = /^(nested|dz)([A-Za-z]+)$/;
+export const isNestedError = (error: FieldError): boolean => {
+    return error.fieldId.match(nestedErrorRegex) !== null;
+};
+
+export interface FieldError {
+    error: string;
+    id: string;
+    fieldId: string;
+    storageId: string;
+    parents: string[];
+}
+
+export const createFieldErrors = (
+    fields: Pick<CmsModelFieldInput, "id" | "fieldId" | "settings">[]
+) => {
+    return fields.reduce<FieldError[]>((errors, field) => {
+        /**
+         * We always push the default one.
+         */
+        errors.push(createError(field));
+        /**
+         * Object field.
+         */
+        if (field.settings?.fields?.length) {
+            errors.push(...createFieldErrors(field.settings.fields));
+        }
+        // Dynamic Zone field.
+        else if (field.settings?.templates?.length) {
+            const templates = field.settings.templates as CmsDynamicZoneTemplate[];
+            const templateFieldErrors = templates
+                .reduce<FieldError[]>((output, template) => {
+                    output.push(...createFieldErrors(template.fields));
+                    return output;
+                }, [])
+                .map(error => {
+                    // @ts-expect-error
+                    delete error["storageId"];
+                    return error;
+                });
+            errors.push(...templateFieldErrors);
+        }
+
+        return errors;
+    }, []);
+};
+
+export const createError = (
+    field: Pick<CmsModelFieldInput, "id" | "fieldId" | "settings">
+): FieldError => {
+    return {
+        error: expect.any(String),
+        id: field.id,
+        fieldId: field.fieldId,
+        storageId: expect.stringMatching(`@`),
+        parents: expect.any(Array)
+    };
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.base.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.base.ts
@@ -1,0 +1,77 @@
+import { CmsModelField } from "~/types";
+import ucFirst from "lodash/upperFirst";
+import { createMinLengthValidation, createRequiredValidation } from "./validations";
+
+export interface CreateFieldInput
+    extends Pick<
+        CmsModelField,
+        "id" | "fieldId" | "type" | "label" | "listValidation" | "validation" | "multipleValues"
+    > {
+    parentId?: string;
+}
+
+export const createLayout = (fields: Pick<CmsModelField, "id" | "settings">[]) => {
+    return fields.reduce<string[][]>((layout, field) => {
+        layout.push([field.id]);
+        // object
+        if (field.settings?.fields?.length) {
+            layout.push(...createLayout(field.settings.fields));
+        }
+        return layout;
+    }, []);
+};
+
+export const createFieldId = (
+    field: Pick<CmsModelField, "id" | "multipleValues">,
+    parentId?: string
+): string => {
+    const list = [field.id];
+    if (parentId) {
+        list[0] = ucFirst(list[0]);
+        list.unshift(parentId);
+    }
+    if (field.multipleValues) {
+        list[0] = ucFirst(list[0]);
+        list.unshift(`multiValue`);
+    }
+    return list.join("");
+};
+export const createFieldFieldId = (
+    field: Pick<CmsModelField, "fieldId" | "multipleValues">,
+    parentId?: string
+): string => {
+    const list = [field.fieldId];
+    if (parentId) {
+        list[0] = ucFirst(list[0]);
+        list.unshift(parentId);
+    }
+    if (field.multipleValues) {
+        list[0] = ucFirst(list[0]);
+        list.unshift(`multiValue`);
+    }
+    return list.join("");
+};
+
+export interface CreateFieldCb {
+    (input: Partial<CmsModelField> & CreateFieldInput): CmsModelField;
+}
+
+export const createField: CreateFieldCb = input => {
+    const { parentId, ...field } = input;
+    const id = createFieldId(field, parentId);
+    const fieldId = createFieldFieldId(field, parentId);
+    const result: Omit<CmsModelField, "storageId"> = {
+        ...field,
+        validation: [createRequiredValidation(), ...(field.validation || [])],
+        listValidation: [
+            createRequiredValidation(),
+            createMinLengthValidation(1),
+            ...(field.listValidation || [])
+        ],
+        id,
+        fieldId,
+        helpText: `Helper text for ${input.label}`,
+        placeholderText: `A ${input.label} value`
+    };
+    return result as CmsModelField;
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.boolean.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.boolean.ts
@@ -1,0 +1,11 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createBooleanField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "enabled",
+        type: "boolean",
+        fieldId: "enabled",
+        label: "Enabled",
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.date.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.date.ts
@@ -1,0 +1,16 @@
+import { createField, CreateFieldInput } from "./fields";
+import { createDateGteValidation, createDateLteValidation } from "./validations";
+
+export const createDateField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "releaseDate",
+        type: "datetime",
+        fieldId: "releaseDate",
+        label: "Release date",
+        validation: [createDateGteValidation("2020-01-01"), createDateLteValidation("2023-12-31")],
+        settings: {
+            type: "date"
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.dateTime.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.dateTime.ts
@@ -1,0 +1,14 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createDateTimeField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "lastPublishedOn",
+        type: "datetime",
+        fieldId: "lastPublishedOn",
+        label: "Last published on",
+        settings: {
+            type: "dateTimeWithTimezone"
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.dynamicZone.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.dynamicZone.ts
@@ -1,0 +1,81 @@
+import {
+    createBooleanField,
+    createDateField,
+    createDateTimeField,
+    createField,
+    CreateFieldInput,
+    createFileField,
+    createLayout,
+    createLongTextField,
+    createNumberField,
+    createObjectField,
+    createReferenceField,
+    createRichTextField,
+    createTextField,
+    createTimeField
+} from "./fields";
+import { CmsModelField } from "~/types";
+
+export const createDynamicZoneField = (params: Partial<CreateFieldInput> = {}) => {
+    const parentParams = {
+        parentId: "dz"
+    };
+    const fields: CmsModelField[] = [
+        createTextField(parentParams),
+        createLongTextField(parentParams),
+        createRichTextField(parentParams),
+        createNumberField(parentParams),
+        createBooleanField(parentParams),
+        createDateField(parentParams),
+        createTimeField(parentParams),
+        createDateTimeField(parentParams),
+        createFileField(parentParams),
+        createReferenceField(parentParams),
+        createObjectField(parentParams)
+    ];
+    return createField({
+        id: "dz",
+        fieldId: "dz",
+        type: "dynamicZone",
+        label: "Dynamic Zone",
+        renderer: {
+            name: "dynamicZone"
+        },
+        validation: [
+            {
+                name: "required",
+                message: "You need to add at least 1 template data."
+            }
+        ],
+        settings: {
+            templates: [
+                {
+                    layout: createLayout(fields),
+                    name: "Hero #1",
+                    gqlTypeName: "Hero",
+                    icon: "fas/flag",
+                    description: "",
+                    id: "abcdefgh",
+                    fields,
+                    validation: [
+                        {
+                            name: "minLength",
+                            message: "You need to add at least 1 Hero template.",
+                            settings: {
+                                value: "1"
+                            }
+                        },
+                        {
+                            name: "maxLength",
+                            message: "You are allowed to add no more than 2 Hero templates.",
+                            settings: {
+                                value: "2"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.file.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.file.ts
@@ -1,0 +1,11 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createFileField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "image",
+        type: "file",
+        fieldId: "image",
+        label: "Image",
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.longText.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.longText.ts
@@ -1,0 +1,11 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createLongTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "description",
+        type: "long-text",
+        fieldId: "description",
+        label: "Description",
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.number.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.number.ts
@@ -1,0 +1,20 @@
+import { createField, CreateFieldInput } from "./field.base";
+
+export const createNumberField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "price",
+        type: "number",
+        fieldId: "price",
+        label: "Price",
+        validation: [
+            {
+                name: "gte",
+                message: "Value must be greater than or equal to 1.",
+                settings: {
+                    value: 1
+                }
+            }
+        ],
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.object.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.object.ts
@@ -1,0 +1,54 @@
+import {
+    createBooleanField,
+    createDateField,
+    createDateTimeField,
+    createField,
+    createFieldFieldId,
+    CreateFieldInput,
+    createFileField,
+    createLongTextField,
+    createNumberField,
+    createReferenceField,
+    createRichTextField,
+    createTextField,
+    createTimeField
+} from "./fields";
+
+export const createObjectField = (params: Partial<CreateFieldInput> = {}) => {
+    const parentParams = {
+        parentId: createFieldFieldId(
+            {
+                fieldId: "nested",
+                multipleValues: params.multipleValues
+            },
+            params.parentId
+        )
+    };
+    return createField({
+        id: "nested",
+        type: "object",
+        fieldId: "nested",
+        label: "Nested",
+        validation: [
+            {
+                name: "required",
+                message: "Nested object is required."
+            }
+        ],
+        settings: {
+            fields: [
+                createTextField(parentParams),
+                createLongTextField(parentParams),
+                createRichTextField(parentParams),
+                createNumberField(parentParams),
+                createBooleanField(parentParams),
+                createDateField(parentParams),
+                createTimeField(parentParams),
+                createDateTimeField(parentParams),
+                createFileField(parentParams),
+                createReferenceField(parentParams)
+            ]
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.reference.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.reference.ts
@@ -1,0 +1,14 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createReferenceField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "category",
+        type: "ref",
+        fieldId: "category",
+        label: "Category",
+        settings: {
+            modelId: "category"
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.richText.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.richText.ts
@@ -1,0 +1,11 @@
+import { createField, CreateFieldInput } from "./fields";
+
+export const createRichTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "body",
+        type: "rich-text",
+        fieldId: "body",
+        label: "Body",
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.text.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.text.ts
@@ -1,0 +1,11 @@
+import { createField, CreateFieldInput } from "./field.base";
+
+export const createTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "title",
+        type: "text",
+        fieldId: "title",
+        label: "Title",
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.time.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/field.time.ts
@@ -1,0 +1,16 @@
+import { createField, CreateFieldInput } from "./fields";
+import { createTimeGteValidation } from "~tests/contentAPI/cmsEntryValidation/mocks/validations";
+
+export const createTimeField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "runningTime",
+        type: "datetime",
+        fieldId: "runningTime",
+        label: "Running time",
+        validation: [createTimeGteValidation("00:30")],
+        settings: {
+            type: "time"
+        },
+        ...params
+    });
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/fields.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/fields.ts
@@ -1,0 +1,57 @@
+import { createBooleanField } from "./field.boolean";
+import { createDateTimeField } from "./field.dateTime";
+import { createFileField } from "./field.file";
+import { createLongTextField } from "./field.longText";
+import { createReferenceField } from "./field.reference";
+import { createNumberField } from "./field.number";
+import { createRichTextField } from "./field.richText";
+import { createTextField } from "./field.text";
+import { createTimeField } from "./field.time";
+import { createDynamicZoneField } from "./field.dynamicZone";
+import { createObjectField } from "./field.object";
+import { createDateField } from "./field.date";
+
+export * from "./field.base";
+export * from "./field.boolean";
+export * from "./field.date";
+export * from "./field.dateTime";
+export * from "./field.dynamicZone";
+export * from "./field.file";
+export * from "./field.longText";
+export * from "./field.number";
+export * from "./field.object";
+export * from "./field.reference";
+export * from "./field.richText";
+export * from "./field.time";
+export * from "./field.text";
+
+export const createFields = () => {
+    const multipleValuesParams = {
+        multipleValues: true
+    };
+    return [
+        createTextField(),
+        createLongTextField(),
+        createRichTextField(),
+        createNumberField(),
+        createBooleanField(),
+        createDateField(),
+        createTimeField(),
+        createDateTimeField(),
+        createFileField(),
+        createReferenceField(),
+        createObjectField(),
+        createDynamicZoneField(),
+        // multiple values
+        createTextField(multipleValuesParams),
+        createLongTextField(multipleValuesParams),
+        createRichTextField(multipleValuesParams),
+        createNumberField(multipleValuesParams),
+        createBooleanField(multipleValuesParams),
+        createDateField(multipleValuesParams),
+        createTimeField(multipleValuesParams),
+        createDateTimeField(multipleValuesParams),
+        createFileField(multipleValuesParams),
+        createReferenceField(multipleValuesParams)
+    ];
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
@@ -1,331 +1,39 @@
 import { CmsApiModel, createCmsGroup, createCmsModel } from "~/plugins";
-import { CmsModelField, CmsModelFieldValidation } from "~/types";
-import ucFirst from "lodash/upperFirst";
+import { CmsModel } from "~/types";
+import { createFields, createLayout } from "./fields";
 
-interface CreateFieldInput
-    extends Pick<
-        CmsModelField,
-        "id" | "fieldId" | "type" | "label" | "listValidation" | "validation" | "multipleValues"
-    > {
-    parentId?: string;
-}
-
-const createRequiredValidation = (): CmsModelFieldValidation => {
-    return {
-        name: "required",
-        message: "Value is required."
-    };
-};
-const createLteValidation = (value: string | number) => {
-    return {
-        name: "lte",
-        message: `Value must be lesser than or equal to ${value}.`,
-        settings: {
-            value
-        }
-    };
-};
-const createGteValidation = (value: string | number) => {
-    return {
-        name: "gte",
-        message: `Value must be greater than or equal to ${value}.`,
-        settings: {
-            value
-        }
-    };
-};
-
-export const createFieldId = (id: string, parentId?: string): string => {
-    return [parentId, id].filter(Boolean).join("_");
-};
-export const createFieldFieldId = (id: string, parentId?: string): string => {
-    if (!parentId) {
-        return id;
-    }
-    return `${parentId}${ucFirst(id)}`;
-};
-
-const createField = (input: Partial<CmsModelField> & CreateFieldInput): CmsModelField => {
-    const { parentId, ...field } = input;
-    const id = createFieldId(field.id, parentId);
-    const fieldId = createFieldFieldId(field.fieldId, parentId);
-    const result: Omit<CmsModelField, "storageId"> = {
-        ...field,
-        id,
-        fieldId,
-        helpText: `Helper text for ${input.label}`,
-        placeholderText: `A ${input.label} value`
-    };
-    return result as CmsModelField;
-};
-
-const createTextField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "title",
-        type: "text",
-        fieldId: "title",
-        label: "Title",
-        validation: [createRequiredValidation()],
-        ...params
-    });
-};
-const createBooleanField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "enabled",
-        type: "boolean",
-        fieldId: "enabled",
-        label: "Enabled",
-        validation: [createRequiredValidation()],
-        ...params
-    });
-};
-const createNumberField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "price",
-        type: "number",
-        fieldId: "price",
-        label: "Price",
-        validation: [
-            createRequiredValidation(),
-            {
-                name: "gte",
-                message: "Value must be greater than or equal to 1.",
-                settings: {
-                    value: 1
-                }
-            }
-        ],
-        ...params
-    });
-};
-
-const createLongTextField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "description",
-        type: "long-text",
-        fieldId: "description",
-        label: "Description",
-        validation: [createRequiredValidation()],
-        ...params
-    });
-};
-const createRichTextField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "body",
-        type: "rich-text",
-        fieldId: "body",
-        label: "Body",
-        validation: [createRequiredValidation()],
-        ...params
-    });
-};
-const createDateField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "releaseDate",
-        type: "datetime",
-        fieldId: "releaseDate",
-        label: "Release date",
-        validation: [
-            createRequiredValidation(),
-            createGteValidation("2020-01-01"),
-            createLteValidation("2023-12-31")
-        ],
-        settings: {
-            type: "date"
-        },
-        ...params
-    });
-};
-const createTimeField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "runningTime",
-        type: "datetime",
-        fieldId: "runningTime",
-        label: "Running time",
-        validation: [createRequiredValidation(), createGteValidation("00:30")],
-        ...params
-    });
-};
-const createDateTimeField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "lastPublishedOn",
-        type: "datetime",
-        fieldId: "lastPublishedOn",
-        label: "Last published on",
-        validation: [createRequiredValidation()],
-        settings: {
-            type: "dateTimeWithTimezone"
-        },
-        ...params
-    });
-};
-const createFileField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "image",
-        type: "file",
-        fieldId: "image",
-        label: "Image",
-        validation: [createRequiredValidation()],
-        ...params
-    });
-};
-
-const createReferenceField = (params: Partial<CreateFieldInput> = {}) => {
-    return createField({
-        id: "category",
-        type: "ref",
-        fieldId: "category",
-        label: "Category",
-        validation: [createRequiredValidation()],
-        settings: {
-            modelId: "category"
-        },
-        ...params
-    });
-};
-
-const createObjectField = (params: Partial<CreateFieldInput> = {}) => {
-    const parentParams = {
-        parentId: "nested"
-    };
-    return createField({
-        id: "nested",
-        type: "object",
-        fieldId: "nested",
-        label: "Nested",
-        validation: [createRequiredValidation()],
-        settings: {
-            fields: [
-                createTextField(parentParams),
-                createLongTextField(parentParams),
-                createRichTextField(parentParams),
-                createNumberField(parentParams),
-                createBooleanField(parentParams),
-                createDateField(parentParams),
-                createTimeField(parentParams),
-                createDateTimeField(parentParams),
-                createFileField(parentParams),
-                createReferenceField(parentParams)
-            ]
-        },
-        ...params
-    });
-};
-
-const createDynamicZoneField = (params: Partial<CreateFieldInput> = {}) => {
-    const parentParams = {
-        parentId: "dynamicZone"
-    };
-    const fields = [
-        createTextField(parentParams),
-        createLongTextField(parentParams),
-        createRichTextField(parentParams),
-        createNumberField(parentParams),
-        createBooleanField(parentParams),
-        createDateField(parentParams),
-        createTimeField(parentParams),
-        createDateTimeField(parentParams),
-        createFileField(parentParams),
-        createReferenceField(parentParams),
-        createObjectField(parentParams)
-    ];
-    return createField({
-        id: "dynamicZone",
-        fieldId: "dynamicZone",
-        type: "dynamicZone",
-        label: "Dynamic Zone",
-        renderer: {
-            name: "dynamicZone"
-        },
-        validation: [],
-        settings: {
-            templates: [
-                {
-                    layout: createLayout(fields),
-                    name: "Hero #1",
-                    gqlTypeName: "Hero",
-                    icon: "fas/flag",
-                    description: "",
-                    id: "abcdefgh",
-                    fields,
-                    validation: [
-                        {
-                            name: "minLength",
-                            message: "You need to add at least 1 Hero template.",
-                            settings: {
-                                value: "1"
-                            }
-                        },
-                        {
-                            name: "maxLength",
-                            message: "You are allowed to add no more than 2 Hero templates.",
-                            settings: {
-                                value: "2"
-                            }
-                        }
-                    ]
-                }
-            ]
-        },
-        ...params
-    });
-};
-
-const createFields = () => {
-    return [
-        createTextField(),
-        createLongTextField(),
-        createRichTextField(),
-        createNumberField(),
-        createBooleanField(),
-        createDateField(),
-        createTimeField(),
-        createDateTimeField(),
-        createFileField(),
-        createReferenceField(),
-        createObjectField(),
-        createDynamicZoneField()
-    ];
-};
-
-const createLayout = (fields: Pick<CmsModelField, "id" | "settings">[]) => {
-    return fields.reduce<string[][]>((layout, field) => {
-        layout.push([field.id]);
-        // object
-        if (field.settings?.fields?.length) {
-            layout.push(...createLayout(field.settings.fields));
-        }
-        return layout;
-    }, []);
-};
-
-export const createModel = (): CmsApiModel => {
-    const fields = createFields();
+const createModel = (model: Partial<Omit<CmsModel, "group">> & Pick<CmsModel, "group">) => {
+    const fields = model.fields || createFields();
     return {
         modelId: "complexModel",
-        group: {
-            id: "validationstructuregroup",
-            name: "Validation structure"
-        },
         name: "Complex model",
         singularApiName: "ComplexModel",
         pluralApiName: "ComplexModels",
         description: "",
+        titleFieldId: "title",
+        ...model,
         fields,
-        layout: createLayout(fields),
-        titleFieldId: "title"
-    };
+        layout: createLayout(fields)
+    } as CmsApiModel;
 };
 
-export const createValidationStructure = () => {
-    return [
-        createCmsGroup({
-            id: "validationstructuregroup",
-            name: "Validation structure",
-            slug: "validationstructuregroup",
-            description: "Validation structure group description",
-            icon: "fas/star"
-        }),
-        createCmsModel(createModel())
-    ];
+export const createValidationStructure = (input: Partial<Omit<CmsModel, "group">> = {}) => {
+    const cmsGroupPlugin = createCmsGroup({
+        id: "validationstructuregroup",
+        name: "Validation structure",
+        slug: "validationstructuregroup",
+        description: "Validation structure group description",
+        icon: "fas/star"
+    });
+    const group = cmsGroupPlugin.contentModelGroup;
+    const model = createModel({
+        ...input,
+        group
+    });
+    const cmsModelPlugin = createCmsModel(model);
+    return {
+        plugins: [cmsGroupPlugin, cmsModelPlugin],
+        model,
+        group
+    };
 };

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
@@ -45,19 +45,18 @@ export const createFieldFieldId = (id: string, parentId?: string): string => {
     return `${parentId}${ucFirst(id)}`;
 };
 
-const createField = (
-    input: Partial<CmsModelField> & CreateFieldInput
-): Omit<CmsModelField, "storageId"> => {
+const createField = (input: Partial<CmsModelField> & CreateFieldInput): CmsModelField => {
     const { parentId, ...field } = input;
     const id = createFieldId(field.id, parentId);
     const fieldId = createFieldFieldId(field.fieldId, parentId);
-    return {
+    const result: Omit<CmsModelField, "storageId"> = {
         ...field,
         id,
         fieldId,
         helpText: `Helper text for ${input.label}`,
         placeholderText: `A ${input.label} value`
     };
+    return result as CmsModelField;
 };
 
 const createTextField = (params: Partial<CreateFieldInput> = {}) => {
@@ -207,7 +206,66 @@ const createObjectField = (params: Partial<CreateFieldInput> = {}) => {
                 createDateTimeField(parentParams),
                 createFileField(parentParams),
                 createReferenceField(parentParams)
-            ] as any
+            ]
+        },
+        ...params
+    });
+};
+
+const createDynamicZoneField = (params: Partial<CreateFieldInput> = {}) => {
+    const parentParams = {
+        parentId: "dynamicZone"
+    };
+    const fields = [
+        createTextField(parentParams),
+        createLongTextField(parentParams),
+        createRichTextField(parentParams),
+        createNumberField(parentParams),
+        createBooleanField(parentParams),
+        createDateField(parentParams),
+        createTimeField(parentParams),
+        createDateTimeField(parentParams),
+        createFileField(parentParams),
+        createReferenceField(parentParams),
+        createObjectField(parentParams)
+    ];
+    return createField({
+        id: "dynamicZone",
+        fieldId: "dynamicZone",
+        type: "dynamicZone",
+        label: "Dynamic Zone",
+        renderer: {
+            name: "dynamicZone"
+        },
+        validation: [],
+        settings: {
+            templates: [
+                {
+                    layout: createLayout(fields),
+                    name: "Hero #1",
+                    gqlTypeName: "Hero",
+                    icon: "fas/flag",
+                    description: "",
+                    id: "abcdefgh",
+                    fields,
+                    validation: [
+                        {
+                            name: "minLength",
+                            message: "You need to add at least 1 Hero template.",
+                            settings: {
+                                value: "1"
+                            }
+                        },
+                        {
+                            name: "maxLength",
+                            message: "You are allowed to add no more than 2 Hero templates.",
+                            settings: {
+                                value: "2"
+                            }
+                        }
+                    ]
+                }
+            ]
         },
         ...params
     });
@@ -225,7 +283,8 @@ const createFields = () => {
         createDateTimeField(),
         createFileField(),
         createReferenceField(),
-        createObjectField()
+        createObjectField(),
+        createDynamicZoneField()
     ];
 };
 

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/structure.ts
@@ -1,0 +1,272 @@
+import { CmsApiModel, createCmsGroup, createCmsModel } from "~/plugins";
+import { CmsModelField, CmsModelFieldValidation } from "~/types";
+import ucFirst from "lodash/upperFirst";
+
+interface CreateFieldInput
+    extends Pick<
+        CmsModelField,
+        "id" | "fieldId" | "type" | "label" | "listValidation" | "validation" | "multipleValues"
+    > {
+    parentId?: string;
+}
+
+const createRequiredValidation = (): CmsModelFieldValidation => {
+    return {
+        name: "required",
+        message: "Value is required."
+    };
+};
+const createLteValidation = (value: string | number) => {
+    return {
+        name: "lte",
+        message: `Value must be lesser than or equal to ${value}.`,
+        settings: {
+            value
+        }
+    };
+};
+const createGteValidation = (value: string | number) => {
+    return {
+        name: "gte",
+        message: `Value must be greater than or equal to ${value}.`,
+        settings: {
+            value
+        }
+    };
+};
+
+export const createFieldId = (id: string, parentId?: string): string => {
+    return [parentId, id].filter(Boolean).join("_");
+};
+export const createFieldFieldId = (id: string, parentId?: string): string => {
+    if (!parentId) {
+        return id;
+    }
+    return `${parentId}${ucFirst(id)}`;
+};
+
+const createField = (
+    input: Partial<CmsModelField> & CreateFieldInput
+): Omit<CmsModelField, "storageId"> => {
+    const { parentId, ...field } = input;
+    const id = createFieldId(field.id, parentId);
+    const fieldId = createFieldFieldId(field.fieldId, parentId);
+    return {
+        ...field,
+        id,
+        fieldId,
+        helpText: `Helper text for ${input.label}`,
+        placeholderText: `A ${input.label} value`
+    };
+};
+
+const createTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "title",
+        type: "text",
+        fieldId: "title",
+        label: "Title",
+        validation: [createRequiredValidation()],
+        ...params
+    });
+};
+const createBooleanField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "enabled",
+        type: "boolean",
+        fieldId: "enabled",
+        label: "Enabled",
+        validation: [createRequiredValidation()],
+        ...params
+    });
+};
+const createNumberField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "price",
+        type: "number",
+        fieldId: "price",
+        label: "Price",
+        validation: [
+            createRequiredValidation(),
+            {
+                name: "gte",
+                message: "Value must be greater than or equal to 1.",
+                settings: {
+                    value: 1
+                }
+            }
+        ],
+        ...params
+    });
+};
+
+const createLongTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "description",
+        type: "long-text",
+        fieldId: "description",
+        label: "Description",
+        validation: [createRequiredValidation()],
+        ...params
+    });
+};
+const createRichTextField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "body",
+        type: "rich-text",
+        fieldId: "body",
+        label: "Body",
+        validation: [createRequiredValidation()],
+        ...params
+    });
+};
+const createDateField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "releaseDate",
+        type: "datetime",
+        fieldId: "releaseDate",
+        label: "Release date",
+        validation: [
+            createRequiredValidation(),
+            createGteValidation("2020-01-01"),
+            createLteValidation("2023-12-31")
+        ],
+        settings: {
+            type: "date"
+        },
+        ...params
+    });
+};
+const createTimeField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "runningTime",
+        type: "datetime",
+        fieldId: "runningTime",
+        label: "Running time",
+        validation: [createRequiredValidation(), createGteValidation("00:30")],
+        ...params
+    });
+};
+const createDateTimeField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "lastPublishedOn",
+        type: "datetime",
+        fieldId: "lastPublishedOn",
+        label: "Last published on",
+        validation: [createRequiredValidation()],
+        settings: {
+            type: "dateTimeWithTimezone"
+        },
+        ...params
+    });
+};
+const createFileField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "image",
+        type: "file",
+        fieldId: "image",
+        label: "Image",
+        validation: [createRequiredValidation()],
+        ...params
+    });
+};
+
+const createReferenceField = (params: Partial<CreateFieldInput> = {}) => {
+    return createField({
+        id: "category",
+        type: "ref",
+        fieldId: "category",
+        label: "Category",
+        validation: [createRequiredValidation()],
+        settings: {
+            modelId: "category"
+        },
+        ...params
+    });
+};
+
+const createObjectField = (params: Partial<CreateFieldInput> = {}) => {
+    const parentParams = {
+        parentId: "nested"
+    };
+    return createField({
+        id: "nested",
+        type: "object",
+        fieldId: "nested",
+        label: "Nested",
+        validation: [createRequiredValidation()],
+        settings: {
+            fields: [
+                createTextField(parentParams),
+                createLongTextField(parentParams),
+                createRichTextField(parentParams),
+                createNumberField(parentParams),
+                createBooleanField(parentParams),
+                createDateField(parentParams),
+                createTimeField(parentParams),
+                createDateTimeField(parentParams),
+                createFileField(parentParams),
+                createReferenceField(parentParams)
+            ] as any
+        },
+        ...params
+    });
+};
+
+const createFields = () => {
+    return [
+        createTextField(),
+        createLongTextField(),
+        createRichTextField(),
+        createNumberField(),
+        createBooleanField(),
+        createDateField(),
+        createTimeField(),
+        createDateTimeField(),
+        createFileField(),
+        createReferenceField(),
+        createObjectField()
+    ];
+};
+
+const createLayout = (fields: Pick<CmsModelField, "id" | "settings">[]) => {
+    return fields.reduce<string[][]>((layout, field) => {
+        layout.push([field.id]);
+        // object
+        if (field.settings?.fields?.length) {
+            layout.push(...createLayout(field.settings.fields));
+        }
+        return layout;
+    }, []);
+};
+
+export const createModel = (): CmsApiModel => {
+    const fields = createFields();
+    return {
+        modelId: "complexModel",
+        group: {
+            id: "validationstructuregroup",
+            name: "Validation structure"
+        },
+        name: "Complex model",
+        singularApiName: "ComplexModel",
+        pluralApiName: "ComplexModels",
+        description: "",
+        fields,
+        layout: createLayout(fields),
+        titleFieldId: "title"
+    };
+};
+
+export const createValidationStructure = () => {
+    return [
+        createCmsGroup({
+            id: "validationstructuregroup",
+            name: "Validation structure",
+            slug: "validationstructuregroup",
+            description: "Validation structure group description",
+            icon: "fas/star"
+        }),
+        createCmsModel(createModel())
+    ];
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/validations.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/cmsEntryValidation/mocks/validations.ts
@@ -1,0 +1,45 @@
+import { CmsModelFieldValidation } from "~/types";
+
+export const createRequiredValidation = (): CmsModelFieldValidation => {
+    return {
+        name: "required",
+        message: "Value is required."
+    };
+};
+export const createDateGteValidation = (value: string) => {
+    return {
+        name: "dateGte",
+        message: `Date must be greater than or equal to ${value}.`,
+        settings: {
+            value
+        }
+    };
+};
+export const createDateLteValidation = (value: string) => {
+    return {
+        name: "dateLte",
+        message: `Date must be lesser than or equal to ${value}.`,
+        settings: {
+            value
+        }
+    };
+};
+export const createTimeGteValidation = (value: string) => {
+    return {
+        name: "timeGte",
+        message: `Time must be greater than or equal to ${value}.`,
+        settings: {
+            value
+        }
+    };
+};
+
+export const createMinLengthValidation = (value: number) => {
+    return {
+        name: "minLength",
+        message: `Value must have at least ${value} items.`,
+        settings: {
+            value
+        }
+    };
+};

--- a/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
@@ -108,7 +108,8 @@ describe("fieldValidations", () => {
                                 fieldId: "name",
                                 id: "name",
                                 storageId: expect.stringMatching("text@"),
-                                error: "Min length is 2."
+                                error: "Min length is 2.",
+                                parents: []
                             }
                         ]
                     }
@@ -135,7 +136,8 @@ describe("fieldValidations", () => {
                                 fieldId: "name",
                                 id: "name",
                                 storageId: expect.stringMatching("text@"),
-                                error: "Max length is 15."
+                                error: "Max length is 15.",
+                                parents: []
                             }
                         ]
                     }
@@ -174,7 +176,8 @@ describe("fieldValidations", () => {
                                 fieldId: "numbers",
                                 id: "numbers",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Numbers must contain at least 2 items."
+                                error: "Numbers must contain at least 2 items.",
+                                parents: []
                             }
                         ]
                     }
@@ -201,7 +204,8 @@ describe("fieldValidations", () => {
                                 fieldId: "numbers",
                                 id: "numbers",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Numbers can contain at most 7 items."
+                                error: "Numbers can contain at most 7 items.",
+                                parents: []
                             }
                         ]
                     }
@@ -228,7 +232,8 @@ describe("fieldValidations", () => {
                                 fieldId: "numbers",
                                 id: "numbers",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Number must be greater or equal 5."
+                                error: "Number must be greater or equal 5.",
+                                parents: []
                             }
                         ]
                     }
@@ -255,7 +260,8 @@ describe("fieldValidations", () => {
                                 fieldId: "numbers",
                                 id: "numbers",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Number be less or equal 15."
+                                error: "Number be less or equal 15.",
+                                parents: []
                             }
                         ]
                     }
@@ -309,7 +315,8 @@ describe("fieldValidations", () => {
                                     fieldId: "email",
                                     id: "email",
                                     storageId: expect.stringMatching("text@"),
-                                    error: "Must be in a form of an email."
+                                    error: "Must be in a form of an email.",
+                                    parents: []
                                 }
                             ]
                         }
@@ -364,7 +371,8 @@ describe("fieldValidations", () => {
                                     fieldId: "url",
                                     id: "url",
                                     storageId: expect.stringMatching("text@"),
-                                    error: "Must be in a form of a url."
+                                    error: "Must be in a form of a url.",
+                                    parents: []
                                 }
                             ]
                         }
@@ -413,7 +421,8 @@ describe("fieldValidations", () => {
                                     fieldId: "lowerCase",
                                     id: "lowerCase",
                                     storageId: expect.stringMatching("text@"),
-                                    error: "Everything must be lowercase."
+                                    error: "Everything must be lowercase.",
+                                    parents: []
                                 }
                             ]
                         }
@@ -461,7 +470,8 @@ describe("fieldValidations", () => {
                                     fieldId: "upperCase",
                                     id: "upperCase",
                                     storageId: expect.stringMatching("text@"),
-                                    error: "Everything must be uppercase."
+                                    error: "Everything must be uppercase.",
+                                    parents: []
                                 }
                             ]
                         }
@@ -505,7 +515,8 @@ describe("fieldValidations", () => {
                                     fieldId: "date",
                                     id: "date",
                                     storageId: expect.stringMatching("datetime@"),
-                                    error: message
+                                    error: message,
+                                    parents: []
                                 }
                             ]
                         }
@@ -549,7 +560,8 @@ describe("fieldValidations", () => {
                                     fieldId: "dateTime",
                                     id: "dateTime",
                                     storageId: expect.stringMatching("datetime@"),
-                                    error: message
+                                    error: message,
+                                    parents: []
                                 }
                             ]
                         }
@@ -596,7 +608,8 @@ describe("fieldValidations", () => {
                                     fieldId: "dateTimeZ",
                                     id: "dateTimeZ",
                                     storageId: expect.stringMatching("datetime@"),
-                                    error: message
+                                    error: message,
+                                    parents: []
                                 }
                             ]
                         }
@@ -640,7 +653,8 @@ describe("fieldValidations", () => {
                                     fieldId: "time",
                                     id: "time",
                                     storageId: expect.stringMatching("datetime@"),
-                                    error: message
+                                    error: message,
+                                    parents: []
                                 }
                             ]
                         }
@@ -692,7 +706,8 @@ describe("fieldValidations", () => {
                                 fieldId: "slug",
                                 id: "slug",
                                 error: "Field value must be unique.",
-                                storageId: "text@slug"
+                                storageId: "text@slug",
+                                parents: []
                             }
                         ]
                     }

--- a/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/fieldValidations.test.ts
@@ -106,6 +106,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "name",
+                                id: "name",
                                 storageId: expect.stringMatching("text@"),
                                 error: "Min length is 2."
                             }
@@ -132,6 +133,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "name",
+                                id: "name",
                                 storageId: expect.stringMatching("text@"),
                                 error: "Max length is 15."
                             }
@@ -170,6 +172,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "numbers",
+                                id: "numbers",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Numbers must contain at least 2 items."
                             }
@@ -196,6 +199,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "numbers",
+                                id: "numbers",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Numbers can contain at most 7 items."
                             }
@@ -222,6 +226,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "numbers",
+                                id: "numbers",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Number must be greater or equal 5."
                             }
@@ -248,6 +253,7 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "numbers",
+                                id: "numbers",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Number be less or equal 15."
                             }
@@ -301,6 +307,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "email",
+                                    id: "email",
                                     storageId: expect.stringMatching("text@"),
                                     error: "Must be in a form of an email."
                                 }
@@ -355,6 +362,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "url",
+                                    id: "url",
                                     storageId: expect.stringMatching("text@"),
                                     error: "Must be in a form of a url."
                                 }
@@ -403,6 +411,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "lowerCase",
+                                    id: "lowerCase",
                                     storageId: expect.stringMatching("text@"),
                                     error: "Everything must be lowercase."
                                 }
@@ -450,6 +459,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "upperCase",
+                                    id: "upperCase",
                                     storageId: expect.stringMatching("text@"),
                                     error: "Everything must be uppercase."
                                 }
@@ -493,6 +503,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "date",
+                                    id: "date",
                                     storageId: expect.stringMatching("datetime@"),
                                     error: message
                                 }
@@ -536,6 +547,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "dateTime",
+                                    id: "dateTime",
                                     storageId: expect.stringMatching("datetime@"),
                                     error: message
                                 }
@@ -582,6 +594,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "dateTimeZ",
+                                    id: "dateTimeZ",
                                     storageId: expect.stringMatching("datetime@"),
                                     error: message
                                 }
@@ -625,6 +638,7 @@ describe("fieldValidations", () => {
                             data: [
                                 {
                                     fieldId: "time",
+                                    id: "time",
                                     storageId: expect.stringMatching("datetime@"),
                                     error: message
                                 }
@@ -676,8 +690,9 @@ describe("fieldValidations", () => {
                         data: [
                             {
                                 fieldId: "slug",
+                                id: "slug",
                                 error: "Field value must be unique.",
-                                storageId: expect.stringMatching("text@")
+                                storageId: "text@slug"
                             }
                         ]
                     }
@@ -792,7 +807,7 @@ describe("fieldValidations", () => {
                         dateTimeZ: defaultFruitData.dateTimeZ,
                         rating: null,
                         isSomething: null,
-                        description: "",
+                        description: null,
                         slug: "apple"
                     },
                     error: null

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -561,6 +561,14 @@ describe("filtering", () => {
                 category: {
                     modelId: categoryModel.modelId,
                     id: fruitCategoryId
+                },
+                variant: {
+                    images: null,
+                    options: {
+                        categories: null,
+                        image: null,
+                        longText: null
+                    }
                 }
             }
         });
@@ -583,6 +591,14 @@ describe("filtering", () => {
                 category: {
                     modelId: categoryModel.modelId,
                     id: fruitCategoryId
+                },
+                variant: {
+                    images: null,
+                    options: {
+                        categories: null,
+                        image: null,
+                        longText: null
+                    }
                 }
             }
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/contentModels.ts
@@ -228,12 +228,12 @@ const models: CmsModel[] = [
                 storageId: "ref@categoryStorageId",
                 fieldId: "category",
                 type: "ref",
-                validation: [
-                    {
-                        name: "required",
-                        message: "Please select a category"
-                    }
-                ],
+                // validation: [
+                //     {
+                //         name: "required",
+                //         message: "Please select a category"
+                //     }
+                // ],
                 listValidation: [],
                 settings: {
                     models: [{ modelId: "category" }]
@@ -543,12 +543,12 @@ const models: CmsModel[] = [
                             storageId: "ref@categoryStorageId",
                             fieldId: "category",
                             type: "ref",
-                            validation: [
-                                {
-                                    name: "required",
-                                    message: "Please select a category"
-                                }
-                            ],
+                            // validation: [
+                            //     {
+                            //         name: "required",
+                            //         message: "Please select a category"
+                            //     }
+                            // ],
                             listValidation: [],
                             settings: {
                                 models: [{ modelId: "category" }]
@@ -637,12 +637,12 @@ const models: CmsModel[] = [
                                         storageId: "ref@categoryStorageId",
                                         fieldId: "category",
                                         type: "ref",
-                                        validation: [
-                                            {
-                                                name: "required",
-                                                message: "Please select a category"
-                                            }
-                                        ],
+                                        // validation: [
+                                        //     {
+                                        //         name: "required",
+                                        //         message: "Please select a category"
+                                        //     }
+                                        // ],
                                         listValidation: [],
                                         settings: {
                                             models: [{ modelId: "category" }]
@@ -743,12 +743,6 @@ const models: CmsModel[] = [
                             type: "text",
                             storageId: "text@textStorageId",
                             fieldId: "text",
-                            validation: [
-                                {
-                                    name: "required",
-                                    message: "This field is required"
-                                }
-                            ],
                             listValidation: [],
                             placeholderText: "placeholder text",
                             predefinedValues: {

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/pageWithDynamicZonesModel.ts
@@ -159,7 +159,13 @@ export const pageModel: CmsModel = {
                                             id: "rt3uhvds",
                                             fieldId: "objectTitle",
                                             type: "text",
-                                            label: "Object title"
+                                            label: "Object title",
+                                            validation: [
+                                                {
+                                                    name: "required",
+                                                    message: `"nestedObject.objectTitle" is required.`
+                                                }
+                                            ]
                                         },
                                         {
                                             id: "r329gdfhsaufdsa",
@@ -173,7 +179,13 @@ export const pageModel: CmsModel = {
                                                         id: "g9huerprgds",
                                                         fieldId: "nestedObjectNestedTitle",
                                                         type: "text",
-                                                        label: "Nested object nested title"
+                                                        label: "Nested object nested title",
+                                                        validation: [
+                                                            {
+                                                                name: "required",
+                                                                message: `"nestedObject.objectNestedObject.nestedObjectNestedTitle" is required.`
+                                                            }
+                                                        ]
                                                     }
                                                 ]
                                             }
@@ -447,7 +459,13 @@ export const pageModel: CmsModel = {
                                                         id: "hpgtierghpiue",
                                                         fieldId: "nestedObjectNestedTitle",
                                                         type: "text",
-                                                        label: "Nested object nested title"
+                                                        label: "Nested object nested title",
+                                                        validation: [
+                                                            {
+                                                                name: "required",
+                                                                message: `"nestedObjectNestedTitle" is required.`
+                                                            }
+                                                        ]
                                                     }
                                                 ]
                                             }

--- a/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
@@ -135,6 +135,7 @@ describe("predefined values", () => {
                             {
                                 storageId: expect.stringMatching("text@"),
                                 fieldId: "bugType",
+                                id: "bugType",
                                 error: "Value sent does not match any of the available predefined values."
                             }
                         ]
@@ -171,6 +172,7 @@ describe("predefined values", () => {
                         data: [
                             {
                                 fieldId: "bugValue",
+                                id: "bugValue",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Value sent does not match any of the available predefined values."
                             }
@@ -208,11 +210,13 @@ describe("predefined values", () => {
                         data: [
                             {
                                 fieldId: "bugType",
+                                id: "bugType",
                                 storageId: expect.stringMatching("text@"),
                                 error: "Value sent does not match any of the available predefined values."
                             },
                             {
                                 fieldId: "bugValue",
+                                id: "bugValue",
                                 storageId: expect.stringMatching("number@"),
                                 error: "Value sent does not match any of the available predefined values."
                             }

--- a/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
@@ -1,4 +1,4 @@
-import { CmsModel, CmsGroup } from "~/types";
+import { CmsGroup, CmsModel } from "~/types";
 import models from "./mocks/contentModels";
 import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
 import { useBugManageHandler } from "../testHelpers/useBugManageHandler";
@@ -136,7 +136,8 @@ describe("predefined values", () => {
                                 storageId: expect.stringMatching("text@"),
                                 fieldId: "bugType",
                                 id: "bugType",
-                                error: "Value sent does not match any of the available predefined values."
+                                error: "Value sent does not match any of the available predefined values.",
+                                parents: []
                             }
                         ]
                     }
@@ -174,7 +175,8 @@ describe("predefined values", () => {
                                 fieldId: "bugValue",
                                 id: "bugValue",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Value sent does not match any of the available predefined values."
+                                error: "Value sent does not match any of the available predefined values.",
+                                parents: []
                             }
                         ]
                     }
@@ -212,13 +214,15 @@ describe("predefined values", () => {
                                 fieldId: "bugType",
                                 id: "bugType",
                                 storageId: expect.stringMatching("text@"),
-                                error: "Value sent does not match any of the available predefined values."
+                                error: "Value sent does not match any of the available predefined values.",
+                                parents: []
                             },
                             {
                                 fieldId: "bugValue",
                                 id: "bugValue",
                                 storageId: expect.stringMatching("number@"),
-                                error: "Value sent does not match any of the available predefined values."
+                                error: "Value sent does not match any of the available predefined values.",
+                                parents: []
                             }
                         ]
                     }

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -430,7 +430,8 @@ describe("MANAGE - Resolvers", () => {
                                 error: "This field is required",
                                 storageId: "text@slug",
                                 id: "slug",
-                                fieldId: "slug"
+                                fieldId: "slug",
+                                parents: []
                             }
                         ],
                         message: "Validation failed."

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -428,7 +428,8 @@ describe("MANAGE - Resolvers", () => {
                         data: [
                             {
                                 error: "This field is required",
-                                storageId: expect.stringMatching("text@"),
+                                storageId: "text@slug",
+                                id: "slug",
                                 fieldId: "slug"
                             }
                         ],

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -163,6 +163,8 @@ export default /* GraphQL */ `
         createCategoryApiNameWhichIsABitDifferentThanModelIdFrom(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput, options: CreateRevisionCmsEntryOptionsInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
 
         updateCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!, options: UpdateCmsEntryOptionsInput): CategoryApiNameWhichIsABitDifferentThanModelIdResponse
+        
+        validateCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID, data: CategoryApiNameWhichIsABitDifferentThanModelIdInput!): CmsEntryValidationResponse!
     
         moveCategoryApiNameWhichIsABitDifferentThanModelId(revision: ID!, folderId: ID!): CategoryApiNameWhichIsABitDifferentThanModelIdMoveResponse
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -451,6 +451,11 @@ export default /* GraphQL */ `
             options: UpdateCmsEntryOptionsInput
         ): PageModelApiNameResponse
 
+        validatePageModelApiName(
+            revision: ID
+            data: PageModelApiNameInput!
+        ): CmsEntryValidationResponse!
+
         movePageModelApiName(revision: ID!, folderId: ID!): PageModelApiNameMoveResponse
 
         deletePageModelApiName(revision: ID!, options: CmsDeleteEntryOptions): CmsDeleteResponse

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -366,6 +366,8 @@ export default /* GraphQL */ `
 
         updateProductApiSingular(revision: ID!, data: ProductApiSingularInput!, options: UpdateCmsEntryOptionsInput): ProductApiSingularResponse
         
+        validateProductApiSingular(revision: ID, data: ProductApiSingularInput!): CmsEntryValidationResponse!
+        
         moveProductApiSingular(revision: ID!, folderId: ID!): ProductApiSingularMoveResponse
 
         deleteProductApiSingular(

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -176,6 +176,8 @@ export default /* GraphQL */ `
 
         updateReviewApiModel(revision: ID!, data: ReviewApiModelInput!, options: UpdateCmsEntryOptionsInput): ReviewApiModelResponse
         
+        validateReviewApiModel(revision: ID, data: ReviewApiModelInput!): CmsEntryValidationResponse!
+        
         moveReviewApiModel(revision: ID!, folderId: ID!): ReviewApiModelMoveResponse
 
         deleteReviewApiModel(

--- a/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/usePageManageHandler.ts
@@ -5,7 +5,7 @@ import { pageModel } from "~tests/contentAPI/mocks/pageWithDynamicZonesModel";
 const singularPageApiName = pageModel.singularApiName;
 
 const pageFields = `
-    id   
+    id
     content {
         ...on ${singularPageApiName}_Content_Hero {
             title
@@ -110,6 +110,7 @@ const errorFields = `
         code
         message
         data
+        stack
     }
 `;
 

--- a/packages/api-headless-cms/__tests__/testHelpers/useProductReadHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useProductReadHandler.ts
@@ -24,6 +24,7 @@ const productFields = `
     variant {
         name
         price
+        images
         category {
             id
             title
@@ -31,7 +32,13 @@ const productFields = `
         options {
             name
             price
+            image
+            longText
             category {
+                id
+                title
+            }
+            categories {
                 id
                 title
             }

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -60,7 +60,7 @@ import {
     UpdateCmsEntryInput
 } from "~/types";
 import {
-    throwValidateModelEntryData,
+    validateModelEntryDataOrThrow,
     validateModelEntryData
 } from "./contentEntry/entryDataValidation";
 import { SecurityIdentity } from "@webiny/api-security/types";
@@ -659,7 +659,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         const initialInput = mapAndCleanCreateInputData(model, inputData);
 
         if (options?.validate !== false) {
-            await throwValidateModelEntryData({
+            await validateModelEntryDataOrThrow({
                 context,
                 model,
                 data: initialInput
@@ -793,7 +793,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         };
 
         if (options?.validate !== false) {
-            await throwValidateModelEntryData({
+            await validateModelEntryDataOrThrow({
                 context,
                 model,
                 data: initialValues,
@@ -917,7 +917,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
         if (options?.validate !== false) {
-            await throwValidateModelEntryData({
+            await validateModelEntryDataOrThrow({
                 context,
                 model,
                 data: input,
@@ -1404,7 +1404,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
-        await throwValidateModelEntryData({
+        await validateModelEntryDataOrThrow({
             context,
             model,
             data: originalEntry.values,

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -59,7 +59,10 @@ import {
     OnEntryUpdateErrorTopicParams,
     UpdateCmsEntryInput
 } from "~/types";
-import { validateModelEntryData } from "./contentEntry/entryDataValidation";
+import {
+    throwValidateModelEntryData,
+    validateModelEntryData
+} from "./contentEntry/entryDataValidation";
 import { SecurityIdentity } from "@webiny/api-security/types";
 import { createTopic } from "@webiny/pubsub";
 import { assignBeforeEntryCreate } from "./contentEntry/beforeCreate";
@@ -656,7 +659,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         const initialInput = mapAndCleanCreateInputData(model, inputData);
 
         if (options?.validate !== false) {
-            await validateModelEntryData({
+            await throwValidateModelEntryData({
                 context,
                 model,
                 data: initialInput
@@ -790,7 +793,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         };
 
         if (options?.validate !== false) {
-            await validateModelEntryData({
+            await throwValidateModelEntryData({
                 context,
                 model,
                 data: initialValues,
@@ -914,7 +917,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
         if (options?.validate !== false) {
-            await validateModelEntryData({
+            await throwValidateModelEntryData({
                 context,
                 model,
                 data: input,
@@ -1007,6 +1010,36 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
                 }
             );
         }
+    };
+
+    const validateEntry: CmsEntryContext["validateEntry"] = async (model, id, inputData) => {
+        await entriesPermissions.ensure({ rwd: "w" });
+        await modelsPermissions.ensureCanAccessModel({
+            model
+        });
+
+        const input = mapAndCleanUpdatedInputData(model, inputData || {});
+        let originalEntry: CmsEntry | undefined;
+        if (id) {
+            /**
+             * The entry we are going to update.
+             */
+            const originalStorageEntry = await storageOperations.entries.getRevisionById(model, {
+                id
+            });
+
+            if (!originalStorageEntry) {
+                throw new NotFoundError(`Entry "${id}" of model "${model.modelId}" was not found.`);
+            }
+            originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
+        }
+        const result = await validateModelEntryData({
+            context,
+            model,
+            data: input,
+            entry: originalEntry
+        });
+        return result.length > 0 ? result : [];
     };
 
     const moveEntry: CmsEntryContext["moveEntry"] = async (model, id, folderId) => {
@@ -1371,7 +1404,7 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
 
         const originalEntry = await entryFromStorageTransform(context, model, originalStorageEntry);
 
-        await validateModelEntryData({
+        await throwValidateModelEntryData({
             context,
             model,
             data: originalEntry.values,
@@ -1771,6 +1804,11 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         async updateEntry(model, id, input, meta, options) {
             return context.benchmark.measure("headlessCms.crud.entries.updateEntry", async () => {
                 return updateEntry(model, id, input, meta, options);
+            });
+        },
+        async validateEntry(model, id, input) {
+            return context.benchmark.measure("headlessCms.crud.entries.validateEntry", async () => {
+                return validateEntry(model, id, input);
             });
         },
         async moveEntry(model, id, folderId) {

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataValidation.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataValidation.ts
@@ -1,11 +1,11 @@
 import {
+    CmsContext,
+    CmsEntry,
     CmsModel,
     CmsModelField,
     CmsModelFieldValidation,
-    CmsContext,
     CmsModelFieldValidatorPlugin,
-    CmsModelFieldValidatorValidateParams,
-    CmsEntry
+    CmsModelFieldValidatorValidateParams
 } from "~/types";
 import WebinyError from "@webiny/error";
 
@@ -13,7 +13,7 @@ type PluginValidationCallable = (params: CmsModelFieldValidatorValidateParams) =
 type PluginValidationList = Record<string, PluginValidationCallable[]>;
 type InputData = Record<string, any>;
 
-interface ValidateArgs {
+interface ExecuteValidationParams {
     validatorList: PluginValidationList;
     field: CmsModelField;
     model: CmsModel;
@@ -25,7 +25,7 @@ interface ValidateArgs {
 type PossibleValue = boolean | number | string | null | undefined;
 
 const validateValue = async (
-    args: ValidateArgs,
+    params: ExecuteValidationParams,
     fieldValidators: CmsModelFieldValidation[],
     value: PossibleValue | PossibleValue[]
 ): Promise<string | null> => {
@@ -33,7 +33,7 @@ const validateValue = async (
         return null;
     }
 
-    const { validatorList, context, field, model, entry } = args;
+    const { validatorList, context, field, model, entry } = params;
     try {
         for (const fieldValidator of fieldValidators) {
             const name = fieldValidator.name;
@@ -80,18 +80,20 @@ const validatePredefinedValue = (field: CmsModelField, value: any | any[]): stri
  * When multiple values is selected we must run validations on the array containing the values
  * And then on each value in the array
  */
-const runFieldMultipleValuesValidations = async (args: ValidateArgs): Promise<string | null> => {
-    const { field, data } = args;
+const runFieldMultipleValuesValidations = async (
+    params: ExecuteValidationParams
+): Promise<string | null> => {
+    const { field, data } = params;
     const values = data[field.fieldId] || [];
     if (Array.isArray(values) === false) {
         return `Value of the field "${field.fieldId}" is not an array.`;
     }
-    const valuesError = await validateValue(args, field.listValidation || [], values);
+    const valuesError = await validateValue(params, field.listValidation || [], values);
     if (valuesError) {
         return valuesError;
     }
     for (const value of values) {
-        const valueError = await validateValue(args, field.validation || [], value);
+        const valueError = await validateValue(params, field.validation || [], value);
         if (valueError) {
             return valueError;
         }
@@ -105,21 +107,23 @@ const runFieldMultipleValuesValidations = async (args: ValidateArgs): Promise<st
 /**
  * Runs validation on given value.
  */
-const runFieldValueValidations = async (args: ValidateArgs): Promise<string | null> => {
-    const { data, field } = args;
+const runFieldValueValidations = async (
+    params: ExecuteValidationParams
+): Promise<string | null> => {
+    const { data, field } = params;
     const value = data[field.fieldId];
-    const error = await validateValue(args, field.validation || [], value);
+    const error = await validateValue(params, field.validation || [], value);
     if (error) {
         return error;
     }
     return validatePredefinedValue(field, value);
 };
 
-const execValidation = async (args: ValidateArgs): Promise<string | null> => {
-    if (args.field.multipleValues) {
-        return await runFieldMultipleValuesValidations(args);
+const execValidation = async (params: ExecuteValidationParams): Promise<string | null> => {
+    if (params.field.multipleValues) {
+        return await runFieldMultipleValuesValidations(params);
     }
-    return await runFieldValueValidations(args);
+    return await runFieldValueValidations(params);
 };
 
 export interface ValidateModelEntryDataParams {
@@ -128,6 +132,7 @@ export interface ValidateModelEntryDataParams {
     data: InputData;
     entry?: CmsEntry;
 }
+
 export const validateModelEntryData = async (params: ValidateModelEntryDataParams) => {
     const { context, model, entry, data } = params;
     /**
@@ -146,34 +151,116 @@ export const validateModelEntryData = async (params: ValidateModelEntryDataParam
             return acc;
         }, {} as PluginValidationList);
 
+    return await validate({
+        validatorList,
+        context,
+        model,
+        entry,
+        fields: model.fields,
+        data: {
+            ...entry?.values,
+            ...data
+        }
+    });
+};
+
+export const throwValidateModelEntryData = async (params: ValidateModelEntryDataParams) => {
+    const invalidFields = await validateModelEntryData(params);
+    if (invalidFields.length === 0) {
+        return;
+    }
+    throw new WebinyError("Validation failed.", "VALIDATION_FAILED", invalidFields);
+};
+
+/**
+ *
+ */
+interface FieldError {
+    id: string;
+    fieldId: string;
+    storageId: string;
+    error: any;
+}
+
+interface ValidateParams {
+    validatorList: PluginValidationList;
+    model: CmsModel;
+    data: InputData;
+    context: CmsContext;
+    fields: CmsModelField[];
+    entry?: CmsEntry;
+}
+
+const executeFieldValidation = async (
+    params: Omit<ValidateParams, "fields"> & {
+        field: CmsModelField;
+    }
+): Promise<FieldError[]> => {
     /**
-     * Loop through model fields and validate the corresponding data.
-     * Run validation only if the field has validation configured.
+     * Object field.
      */
-    const invalidFields = [];
-    for (const field of model.fields) {
-        const error = await execValidation({
-            model,
-            validatorList,
-            field,
-            data: {
-                ...(entry?.values || {}),
-                ...data
-            },
-            context,
-            entry
+    if (params.field.settings?.fields) {
+        const validations: FieldError[] = [];
+        for (const field of params.field.settings?.fields) {
+            const data = params.data?.[field.fieldId];
+            const defaultValue = field.multipleValues ? [] : {};
+            const errors = await executeFieldValidation({
+                ...params,
+                field,
+                data: data || defaultValue
+            });
+            if (errors.length === 0) {
+                continue;
+            }
+            validations.push(...errors);
+        }
+        return validations;
+    }
+    /**
+     * Dynamic Zone Field
+     */
+    //
+    else if (params.field.type === "dynamicZone") {
+        const validations: FieldError[] = [];
+        // const fields = (params.field.settings?.fields ||
+        //     []);
+        // for(const field of fields) {
+        // TODO implement dynamic zone validation
+        // const templates = (params.field.settings?.templates || []) as CmsDynamicZoneTemplate[];
+        // for(const template of templates) {
+        //     const fields = template.fields;
+        // }
+        // }
+        return validations;
+    }
+    const error = await execValidation({
+        ...params
+    });
+    if (!error) {
+        return [];
+    }
+    return [
+        {
+            id: params.field.id,
+            fieldId: params.field.fieldId,
+            storageId: params.field.storageId,
+            error
+        }
+    ];
+};
+
+const validate = async (params: ValidateParams): Promise<any[]> => {
+    const { fields } = params;
+    const errors: FieldError[] = [];
+    for (const field of fields) {
+        const results = await executeFieldValidation({
+            ...params,
+            field
         });
-        if (!error) {
+        if (results.length === 0) {
             continue;
         }
-        invalidFields.push({
-            fieldId: field.fieldId,
-            storageId: field.storageId,
-            error
-        });
+        errors.push(...results);
     }
-
-    if (invalidFields.length > 0) {
-        throw new WebinyError("Validation failed.", "VALIDATION_FAILED", invalidFields);
-    }
+    return errors;
 };

--- a/packages/api-headless-cms/src/graphql/getSchema.ts
+++ b/packages/api-headless-cms/src/graphql/getSchema.ts
@@ -1,11 +1,12 @@
-// @ts-ignore `code-frame` has no types
+// @ts-expect-error `code-frame` has no types
 import codeFrame from "code-frame";
 import WebinyError from "@webiny/error";
 import { generateSchema } from "./generateSchema";
-import { ApiEndpoint, CmsContext } from "~/types";
+import { ApiEndpoint, CmsContext, CmsModel } from "~/types";
 import { Tenant } from "@webiny/api-tenancy/types";
 import { I18NLocale } from "@webiny/api-i18n/types";
 import { GraphQLSchema } from "graphql";
+import crypto from "crypto";
 
 interface SchemaCache {
     key: string;
@@ -15,7 +16,6 @@ interface SchemaCache {
 interface GetSchemaParams {
     context: CmsContext;
     type: ApiEndpoint;
-    getLastModifiedTime: () => Promise<Date | null>;
     getTenant: () => Tenant;
     getLocale: () => I18NLocale;
 }
@@ -37,14 +37,26 @@ const generateCacheId = (params: GenerateCacheIdParams): string => {
  * Method generates cache key based on last model change time.
  * Or sets "unknown" - possible when no models in database.
  */
-type GenerateCacheKeyParams = Pick<GetSchemaParams, "getLastModifiedTime">;
+interface GenerateCacheKeyParams {
+    models: Pick<CmsModel, "modelId" | "singularApiName" | "pluralApiName" | "savedOn">[];
+}
 const generateCacheKey = async (params: GenerateCacheKeyParams): Promise<string> => {
-    const { getLastModifiedTime } = params;
-    const lastModelChange = await getLastModifiedTime();
-    if (!lastModelChange) {
-        return "unknown";
+    const { models } = params;
+
+    const keys: string[] = [];
+    for (const model of models) {
+        const savedOn = model.savedOn as any;
+        const value =
+            savedOn instanceof Date || savedOn?.toISOString
+                ? savedOn.toISOString()
+                : savedOn || "unknown";
+        keys.push(model.modelId, model.singularApiName, model.pluralApiName, value);
     }
-    return lastModelChange.toISOString();
+    const key = keys.join("#");
+
+    const hash = crypto.createHash("sha1");
+    hash.update(key);
+    return hash.digest("hex");
 };
 
 /**
@@ -53,14 +65,6 @@ const generateCacheKey = async (params: GenerateCacheKeyParams): Promise<string>
  */
 export const getSchema = async (params: GetSchemaParams): Promise<GraphQLSchema> => {
     const { context } = params;
-
-    const cacheId = generateCacheId(params);
-
-    const cacheKey = await generateCacheKey(params);
-    const cachedSchema = schemaList.get(cacheId);
-    if (cachedSchema?.key === cacheKey) {
-        return cachedSchema.schema;
-    }
 
     /**
      * We need all the API models.
@@ -71,6 +75,15 @@ export const getSchema = async (params: GetSchemaParams): Promise<GraphQLSchema>
             return model.isPrivate !== true;
         });
     });
+
+    const cacheId = generateCacheId(params);
+
+    const cacheKey = await generateCacheKey({ ...params, models });
+    const cachedSchema = schemaList.get(cacheId);
+    if (cachedSchema?.key === cacheKey) {
+        return cachedSchema.schema;
+    }
+
     try {
         const schema = await generateSchema({
             ...params,

--- a/packages/api-headless-cms/src/graphql/handleRequest.ts
+++ b/packages/api-headless-cms/src/graphql/handleRequest.ts
@@ -41,16 +41,11 @@ export const handleRequest: HandleRequest = async params => {
         return context.cms.getLocale();
     };
 
-    const getLastModifiedTime = async () => {
-        return context.cms.getModelLastChange();
-    };
-
     const schema = await context.benchmark.measure("headlessCms.graphql.getSchema", async () => {
         try {
             return await getSchema({
                 context,
                 getTenant,
-                getLastModifiedTime,
                 getLocale,
                 type: context.cms.type as ApiEndpoint
             });

--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -76,8 +76,15 @@ export const createBaseSchema = (): GraphQLSchemaPlugin<CmsContext>[] => {
                 validate: Boolean
             }
 
+            type CmsEntryValidationResponseData {
+                error: String!
+                id: String!
+                fieldId: String!
+                parents: [String!]!
+            }
+
             type CmsEntryValidationResponse {
-                data: JSON
+                data: [CmsEntryValidationResponseData!]
                 error: CmsError
             }
         `,

--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -75,6 +75,11 @@ export const createBaseSchema = (): GraphQLSchemaPlugin<CmsContext>[] => {
             input UpdateCmsEntryOptionsInput {
                 validate: Boolean
             }
+
+            type CmsEntryValidationResponse {
+                data: JSON
+                error: CmsError
+            }
         `,
         resolvers: {}
     });

--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -6,6 +6,7 @@ import { resolveGetRevisions } from "./resolvers/manage/resolveGetRevisions";
 import { resolveGetByIds } from "./resolvers/manage/resolveGetByIds";
 import { resolveCreate } from "./resolvers/manage/resolveCreate";
 import { resolveUpdate } from "./resolvers/manage/resolveUpdate";
+import { resolveValidate } from "./resolvers/manage/resolveValidate";
 import { resolveMove } from "./resolvers/manage/resolveMove";
 import { resolveDelete } from "./resolvers/manage/resolveDelete";
 import { resolveDeleteMultiple } from "./resolvers/manage/resolveDeleteMultiple";
@@ -78,6 +79,7 @@ export const createManageResolvers: CreateManageResolvers = ({
         Mutation: {
             [`create${model.singularApiName}`]: resolveCreate({ model }),
             [`update${model.singularApiName}`]: resolveUpdate({ model }),
+            [`validate${model.singularApiName}`]: resolveValidate({ model }),
             [`move${model.singularApiName}`]: resolveMove({ model }),
             [`delete${model.singularApiName}`]: resolveDelete({ model }),
             [`deleteMultiple${model.pluralApiName}`]: resolveDeleteMultiple({ model }),

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -170,6 +170,8 @@ export const createManageSDL: CreateManageSDL = ({
             create${singularName}From(revision: ID!, data: ${singularName}Input, options: CreateRevisionCmsEntryOptionsInput): ${singularName}Response
     
             update${singularName}(revision: ID!, data: ${singularName}Input!, options: UpdateCmsEntryOptionsInput): ${singularName}Response
+
+            validate${singularName}(revision: ID, data: ${singularName}Input!): CmsEntryValidationResponse!
             
             move${singularName}(revision: ID!, folderId: ID!): ${singularName}MoveResponse
 

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveValidate.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveValidate.ts
@@ -1,0 +1,20 @@
+import { Response, ErrorResponse } from "@webiny/handler-graphql/responses";
+import { CmsEntryResolverFactory as ResolverFactory, UpdateCmsEntryInput } from "~/types";
+
+interface ResolveUpdateArgs {
+    revision?: string;
+    data: UpdateCmsEntryInput;
+}
+type ResolveValidate = ResolverFactory<any, ResolveUpdateArgs>;
+
+export const resolveValidate: ResolveValidate =
+    ({ model }) =>
+    async (_, args: any, context) => {
+        try {
+            const entry = await context.cms.validateEntry(model, args.revision, args.data);
+
+            return new Response(entry);
+        } catch (e) {
+            return new ErrorResponse(e);
+        }
+    };

--- a/packages/api-headless-cms/src/graphqlFields/longText.ts
+++ b/packages/api-headless-cms/src/graphqlFields/longText.ts
@@ -1,4 +1,8 @@
-import { CmsModelField, CmsModelFieldToGraphQLPlugin } from "~/types";
+import {
+    CmsModelField,
+    CmsModelFieldToGraphQLCreateResolver,
+    CmsModelFieldToGraphQLPlugin
+} from "~/types";
 import { createGraphQLInputField } from "./helpers";
 
 interface CreateListFiltersParams {
@@ -9,6 +13,11 @@ const createListFilters = ({ field }: CreateListFiltersParams) => {
         ${field.fieldId}_contains: String
         ${field.fieldId}_not_contains: String
     `;
+};
+const createResolver: CmsModelFieldToGraphQLCreateResolver = ({ field }) => {
+    return async parent => {
+        return parent[field.fieldId] || null;
+    };
 };
 
 export const createLongTextField = (): CmsModelFieldToGraphQLPlugin => {
@@ -27,7 +36,8 @@ export const createLongTextField = (): CmsModelFieldToGraphQLPlugin => {
 
                 return `${field.fieldId}: String`;
             },
-            createListFilters
+            createListFilters,
+            createResolver
         },
         manage: {
             createListFilters,
@@ -40,7 +50,8 @@ export const createLongTextField = (): CmsModelFieldToGraphQLPlugin => {
             },
             createInputField({ field }) {
                 return createGraphQLInputField(field, "String");
-            }
+            },
+            createResolver
         }
     };
 };

--- a/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "@webiny/plugins";
 import { CmsGroup as BaseCmsGroup } from "~/types";
 
-interface CmsGroup extends Omit<BaseCmsGroup, "locale" | "tenant" | "webinyVersion"> {
+export interface CmsGroup extends Omit<BaseCmsGroup, "locale" | "tenant" | "webinyVersion"> {
     tenant?: string;
     locale?: string;
 }

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -2305,6 +2305,9 @@ export interface DeleteMultipleEntriesParams {
 
 export type DeleteMultipleEntriesResponse = { id: string }[];
 
+export interface CmsEntryValidateResponse {
+    [key: string]: any;
+}
 /**
  * Cms Entry CRUD methods in the context.
  *
@@ -2380,6 +2383,14 @@ export interface CmsEntryContext {
         meta?: Record<string, any>,
         options?: UpdateCmsEntryOptionsInput
     ) => Promise<CmsEntry>;
+    /**
+     * Validate the entry - either new one or existing one.
+     */
+    validateEntry: (
+        model: CmsModel,
+        id?: string,
+        input?: UpdateCmsEntryInput
+    ) => Promise<CmsEntryValidateResponse>;
     /**
      * Move entry, and all its revisions, to a new folder.
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -954,10 +954,12 @@ export interface CmsSettingsContext {
     getSettings: () => Promise<CmsSettings | null>;
     /**
      * Updates settings model with a new date.
+     * @deprecated
      */
     updateModelLastChange: () => Promise<void>;
     /**
      * Get the datetime when content model last changed.
+     * @deprecated
      */
     getModelLastChange: () => Promise<Date | null>;
 }


### PR DESCRIPTION
## Changes
This PR introduces a mutation to validate the CMS Entry without storing it.
It also fixes validation for object and dynamic zone fields.

## How Has This Been Tested?
Jest.