### PR TITLE
Enable Pulumi resource config cloning

### DIFF
--- a/packages/pulumi/package.json
+++ b/packages/pulumi/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@pulumi/pulumi": "^3.34.0",
-    "find-up": "^5.0.0"
+    "find-up": "^5.0.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/pulumi/src/PulumiAppResource.ts
+++ b/packages/pulumi/src/PulumiAppResource.ts
@@ -28,6 +28,8 @@ export interface PulumiAppResourceConfigSetter<T> {
 
 export type PulumiAppResourceConfigProxy<T extends object> = {
     readonly [K in keyof T]-?: PulumiAppResourceConfigSetter<T[K]>;
+} & {
+    clone(): T;
 };
 
 export interface PulumiAppResource<T extends PulumiAppResourceConstructor> {

--- a/packages/pulumi/src/createPulumiApp.ts
+++ b/packages/pulumi/src/createPulumiApp.ts
@@ -20,6 +20,7 @@ import {
     ResourceHandler
 } from "~/types";
 import { PulumiAppRemoteResource } from "~/PulumiAppRemoteResource";
+import cloneDeep from "lodash/cloneDeep";
 
 export function createPulumiApp<TResources extends Record<string, unknown>>(
     params: CreatePulumiAppParams<TResources>
@@ -219,6 +220,10 @@ export function createPulumiApp<TResources extends Record<string, unknown>>(
 function createPulumiAppResourceConfigProxy<T extends object>(obj: T) {
     return new Proxy(obj, {
         get(target, p: string) {
+            if (p === "clone") {
+                return () => cloneDeep(obj);
+            }
+
             type V = T[keyof T];
             const key = p as keyof T;
             const setter: PulumiAppResourceConfigSetter<V> = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -16506,6 +16506,7 @@ __metadata:
     "@webiny/cli": 0.0.0
     "@webiny/project-utils": 0.0.0
     find-up: ^5.0.0
+    lodash: ^4.17.21
     rimraf: ^3.0.2
     typescript: 4.7.4
   languageName: unknown


### PR DESCRIPTION
## Changes
This PR adds an ability to clone a config of an existing Pulumi resource.

Code sample:

```ts
import * as aws from "@pulumi/aws";
import { createApiApp } from "@webiny/serverless-cms-aws";

export default createApiApp({
    pulumiResourceNamePrefix: "wby-",
    pulumi(app) {
        const resource = app.resources.graphql.functions.graphql;

        /**
         * Create a clone of the main `graphql` function, but more powerful, and with maximum timeout.
         */
        const internalWorkerFn = app.addResource(aws.lambda.Function, {
            name: "wby-internal-worker",
            config: {
                ...resource.config.clone(),
                timeout: 900,
                memorySize: 3008
            }
        });

        /**
         * Assign the new worker function ARN to the main `graphql` function.
         */
        resource.config.environment(env => {
            return {
                variables: {
                    ...env?.variables,
                    WORKER_FUNCTION: internalWorkerFn.output.arn
                }
            };
        });
    }
});

```

## How Has This Been Tested?
Manually.
