### PR TITLE
feat: add eslint rule to prevent importing from @aws-sdk

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,18 @@ module.exports = {
         "jest/no-conditional-expect": 0,
         "jest/no-commented-out-tests": 0,
         "jest/no-disabled-tests": 0,
-        "lodash/import-scope": [2, "method"]
+        "lodash/import-scope": [2, "method"],
+        "no-restricted-imports": [
+            "error",
+            {
+                patterns: [
+                    {
+                        group: ["@aws-sdk/*"],
+                        message: "Please use @webiny/aws-sdk instead."
+                    }
+                ]
+            }
+        ]
     },
     settings: {
         react: {

--- a/packages/aws-sdk/.eslintrc.js
+++ b/packages/aws-sdk/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        "no-restricted-imports": 0
+    }
+};


### PR DESCRIPTION
## Changes
Add an `eslint` rule to prevent developers from importing directly from `@aws-sdk` unless it’s our own `@webiny/aws-sdk` wrapper package.

## How Has This Been Tested?
Manual

## Documentation
None
