### PR TITLE
Fix Creation of a Page From a Blank Template

### DIFF
--- a/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
@@ -50,7 +50,11 @@ const getDefaultContent = () => {
     return {
         id: uniqid.time(),
         type: "document",
-        data: {},
+        data: {
+            template: {
+                variables: []
+            }
+        },
         elements: []
     };
 };


### PR DESCRIPTION
## Changes
This PR updates the default value of the `content` field of a page template:

```ts
const getDefaultContent = () => {
    return {
        id: uniqid.time(),
        type: "document",
        data: {
            // ℹ️ Added `template.variables` array here.
            template: {
                variables: []
            }
        },
        elements: []
    };
};
```

Without this, the template content resolution happening in the `content` GraphQL field would fail, because the process is expecting the `template.variables` array to be present.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.