### PR TITLE
Form Builder - Sync URL Validators

### DIFF
--- a/packages/api-form-builder/src/plugins/validators/patternPlugins/url.ts
+++ b/packages/api-form-builder/src/plugins/validators/patternPlugins/url.ts
@@ -5,7 +5,7 @@ const plugin: FbFormFieldPatternValidatorPlugin = {
     name: "form-field-validator-pattern-url",
     pattern: {
         name: "url",
-        regex: "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$",
+        regex: "^((ftp|http|https):\\/\\/)?([a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)+.*)$",
         flags: "i"
     }
 };


### PR DESCRIPTION
## Changes
This PR addresses the difference in how the URLs are validated on the frontend and backend. 

More specifically, the frontend URL validator would allow users to enter `www.webiny.com` as the URL. But, when the form is submitted, backend would respond with an error, saying that the provided URL was invalid. It was actually expecting the URL to be prefixed with the protocol. So, if you were to type `https://www.webiny.com`, then all would work.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.