### PR TITLE
fix(api-elasticsearch): filtering via startsWith and notStartsWith

### DIFF
--- a/packages/api-elasticsearch/src/plugins/operator/notStartsWith.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/notStartsWith.ts
@@ -13,6 +13,9 @@ export class ElasticsearchQueryBuilderOperatorNotStartsWithPlugin extends Elasti
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
+        if (value === "" || value === null || value === undefined) {
+            return;
+        }
         query.must_not.push({
             match_phrase_prefix: {
                 [basePath]: value

--- a/packages/api-elasticsearch/src/plugins/operator/startsWith.ts
+++ b/packages/api-elasticsearch/src/plugins/operator/startsWith.ts
@@ -13,6 +13,9 @@ export class ElasticsearchQueryBuilderOperatorStartsWithPlugin extends Elasticse
         params: ElasticsearchQueryBuilderArgsPlugin
     ): void {
         const { value, basePath } = params;
+        if (value === "" || value === null || value === undefined) {
+            return;
+        }
         query.filter.push({
             match_phrase_prefix: {
                 [basePath]: value

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/filter.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/filter.ts
@@ -16,6 +16,18 @@ interface ExecuteFilterParams {
 const executeFilter = (params: ExecuteFilterParams) => {
     const { value, filter } = params;
 
+    /**
+     * We need to check if the filter can be used.
+     * If it cannot, we will just return true.
+     */
+    const canUse = filter.plugin.canUse({
+        value,
+        compareValue: filter.compareValue
+    });
+    if (!canUse) {
+        return true;
+    }
+
     const matched = filter.plugin.matches({
         value,
         compareValue: filter.compareValue

--- a/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/filtering.test.ts
@@ -1926,4 +1926,94 @@ describe("filtering", () => {
             }
         });
     });
+
+    it("should filter via startsWith", async () => {
+        const { apple, banana, strawberry } = await setupFruits();
+        const { listFruits } = useFruitReadHandler({
+            ...readOpts
+        });
+
+        const [filteredResponse] = await listFruits({
+            where: {
+                name_startsWith: "ap"
+            }
+        });
+        expect(filteredResponse).toMatchObject({
+            data: {
+                listFruits: {
+                    data: [apple],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [response] = await listFruits({
+            where: {
+                name_startsWith: ""
+            }
+        });
+        expect(response).toMatchObject({
+            data: {
+                listFruits: {
+                    data: [banana, strawberry, apple],
+                    meta: {
+                        totalCount: 3,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should filter via not_startsWith", async () => {
+        const { apple, banana, strawberry } = await setupFruits();
+        const { listFruits } = useFruitReadHandler({
+            ...readOpts
+        });
+
+        const [filteredResponse] = await listFruits({
+            where: {
+                name_not_startsWith: "ap"
+            }
+        });
+        expect(filteredResponse).toMatchObject({
+            data: {
+                listFruits: {
+                    data: [banana, strawberry],
+                    meta: {
+                        totalCount: 2,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [response] = await listFruits({
+            where: {
+                name_not_startsWith: ""
+            }
+        });
+        expect(response).toMatchObject({
+            data: {
+                listFruits: {
+                    data: [banana, strawberry, apple],
+                    meta: {
+                        totalCount: 3,
+                        hasMoreItems: false,
+                        cursor: null
+                    },
+                    error: null
+                }
+            }
+        });
+    });
 });

--- a/packages/db-dynamodb/src/plugins/definitions/ValueFilterPlugin.ts
+++ b/packages/db-dynamodb/src/plugins/definitions/ValueFilterPlugin.ts
@@ -12,6 +12,7 @@ export interface ValueFilterPluginParamsMatches {
 
 export interface ValueFilterPluginParams {
     operation: string;
+    canUse?: (params: ValueFilterPluginParamsMatchesParams) => boolean;
     matches: ValueFilterPluginParamsMatches;
 }
 export class ValueFilterPlugin extends Plugin {
@@ -25,6 +26,13 @@ export class ValueFilterPlugin extends Plugin {
     public constructor(params: ValueFilterPluginParams) {
         super();
         this._params = params;
+    }
+
+    public canUse(params: ValueFilterPluginParamsMatchesParams): boolean {
+        if (!this._params.canUse) {
+            return true;
+        }
+        return this._params.canUse(params);
     }
 
     public matches(params: ValueFilterPluginParamsMatchesParams): boolean {

--- a/packages/db-dynamodb/src/plugins/filters/startsWith.ts
+++ b/packages/db-dynamodb/src/plugins/filters/startsWith.ts
@@ -2,6 +2,12 @@ import { ValueFilterPlugin } from "../definitions/ValueFilterPlugin";
 
 const plugin = new ValueFilterPlugin({
     operation: "startsWith",
+    canUse: ({ compareValue }) => {
+        if (compareValue === "" || compareValue === null || compareValue === undefined) {
+            return false;
+        }
+        return true;
+    },
     matches: ({ value, compareValue }) => {
         /**
          * We do "case-insensitive" comparison.
@@ -10,9 +16,9 @@ const plugin = new ValueFilterPlugin({
 
         if (typeof value !== "string") {
             if (Array.isArray(value) === true) {
-                return value.some((v: string) =>
-                    v.toLowerCase().startsWith(compareValueInLowerCase)
-                );
+                return value.some((v: string) => {
+                    return v.toLowerCase().startsWith(compareValueInLowerCase);
+                });
             }
             return false;
         }


### PR DESCRIPTION
## Changes
This PR fixes the Elasticsearch `startsWith` and `notStartsWith` operator in a way that it checks for empty value before applying the operator to the Elasticsearch query.

It also includes a Headless CMS API test for the `startsWith` and `notStartsWith` conditions.

## How Has This Been Tested?
Jest.
