### PR TITLE
fix(api-page-builder): add safeguards for invalid state of DB records

### DIFF
--- a/packages/api-page-builder-so-ddb-es/src/operations/pages/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pages/index.ts
@@ -438,6 +438,8 @@ export const createPageStorageOperations = (
     const publish = async (params: PageStorageOperationsPublishParams): Promise<Page> => {
         const { page, latestPage, publishedPage } = params;
 
+        page.status = "published";
+
         /**
          * Update the given revision of the page.
          */
@@ -451,9 +453,8 @@ export const createPageStorageOperations = (
         ];
         const esItems = [];
         /**
-         * If we are publishing the latest revision, let's also update the latest revision entry's
-         * status in ES. Also, if we are publishing the latest revision, we need to update the latest
-         * page revision entry in ES.
+         * If we are publishing the latest revision, update the latest revision
+         * status in ES. We also need to update the latest page revision entry in ES.
          */
         if (latestPage.id === page.id) {
             items.push(
@@ -475,11 +476,10 @@ export const createPageStorageOperations = (
             );
         }
         /**
-         * If we have already published revision of this page:
-         *  - set existing published page revision to unpublished
-         *  - remove old published path if paths are different
+         * If we already have a published revision, and it's not the revision being published:
+         *  - set the existing published revision to "unpublished"
          */
-        if (publishedPage) {
+        if (publishedPage && publishedPage.id !== page.id) {
             items.push(
                 entity.putBatch({
                     ...publishedPage,
@@ -567,6 +567,8 @@ export const createPageStorageOperations = (
 
     const unpublish = async (params: PageStorageOperationsUnpublishParams): Promise<Page> => {
         const { page, latestPage } = params;
+
+        page.status = "unpublished";
 
         const items = [
             entity.deleteBatch({

--- a/packages/api-page-builder-so-ddb/src/operations/pages/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pages/index.ts
@@ -390,15 +390,15 @@ export const createPageStorageOperations = (
     };
 
     /**
-     * We need to
-     * - update revision that it is published
-     * - if is latest update record that it is published
-     * - set status of previously published page to unpublished
-     * - create / update published record
-     * - create / update published path
+     * - update the revision record
+     * - if the revision being published is also the "latest" revision, update the "latest" record
+     * - set the status of the previously published revision to "unpublished"
+     * - create/update the "published" record
      */
     const publish = async (params: PageStorageOperationsPublishParams): Promise<Page> => {
         const { page, latestPage, publishedPage } = params;
+
+        page.status = "published";
 
         const revisionKeys = {
             PK: createRevisionPartitionKey(page),
@@ -433,10 +433,10 @@ export const createPageStorageOperations = (
             );
         }
         /**
-         * If we have already published revision of this page:
-         *  - set existing published page revision to unpublished
+         * If we already have a published revision, and it's not the revision being published:
+         *  - set the existing published revision to "unpublished"
          */
-        if (publishedPage) {
+        if (publishedPage && publishedPage.id !== page.id) {
             const publishedRevisionKeys = {
                 PK: createRevisionPartitionKey(publishedPage),
                 SK: createRevisionSortKey(publishedPage)
@@ -477,13 +477,14 @@ export const createPageStorageOperations = (
 
     /**
      * We need to
-     * - update revision record with new status
-     * - remove published record
-     * - remove published path record
-     * - update latest record with new status if is the latest
+     * - update the revision record
+     * - remove the "published" record
+     * - if the revision being unpublished is also the "latest" revision, update the "latest" record with the new status
      */
     const unpublish = async (params: PageStorageOperationsUnpublishParams): Promise<Page> => {
         const { page, latestPage } = params;
+
+        page.status = "unpublished";
 
         const revisionKeys = {
             PK: createRevisionPartitionKey(page),


### PR DESCRIPTION
## Changes
This PR adds some safeguards and assurances to the storage ops of the Page Builder, to help resolve inconsistencies in the database records.

## How Has This Been Tested?
Manually + tests.