### PR TITLE
fix: fix build after updating @types/node to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
     "@emotion/react": "11.10.8",
     "@types/react": "17.0.39",
     "@types/jsdom": "link:./typings/void",
-    "@typescript/lib-dom": "npm:@types/web@*",
     "@types/webpack": "^5.28.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,6 @@
     "@babel/runtime": "^7.22.6",
     "@emotion/styled": "^11.10.6",
     "@types/react": "17.0.39",
-    "@types/web": "^0.0.61",
     "@webiny/i18n": "0.0.0",
     "@webiny/i18n-react": "0.0.0",
     "@webiny/plugins": "0.0.0",
@@ -67,7 +66,6 @@
   "adio": {
     "ignore": {
       "dependencies": [
-        "@types/web",
         "react-dom"
       ]
     }

--- a/packages/cwp-template-aws/template/common/tsconfig.build.json
+++ b/packages/cwp-template-aws/template/common/tsconfig.build.json
@@ -6,7 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "module": "esnext",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom", "dom.iterable"],
     "esModuleInterop": true,
     "declaration": true,
     "composite": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "module": "esnext",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom", "dom.iterable"],
     "esModuleInterop": true,
     "declaration": true,
     "composite": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12898,13 +12898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/web@npm:^0.0.61":
-  version: 0.0.61
-  resolution: "@types/web@npm:0.0.61"
-  checksum: 0f56a350108606f864e029ca51566758cef672782dc5eabb01a14d67fccd3153d43faa17a023072b7e019e963149b06bfe549234acb4df8ca3ce556e84f73bb0
-  languageName: node
-  linkType: hard
-
 "@types/webpack-env@npm:1.16.3":
   version: 1.16.3
   resolution: "@types/webpack-env@npm:1.16.3"
@@ -16244,7 +16237,6 @@ __metadata:
     "@types/lodash": ^4.14.191
     "@types/react": 17.0.39
     "@types/warning": ^3.0.0
-    "@types/web": ^0.0.61
     "@webiny/cli": 0.0.0
     "@webiny/i18n": 0.0.0
     "@webiny/i18n-react": 0.0.0


### PR DESCRIPTION
## Changes
Resolves issue that caused ts errors while building most of the packages.

## How Has This Been Tested?
Manual

## Documentation
None
