### PR TITLE
feat(api-headless-cms): disable full text search on certain field

### DIFF
--- a/packages/api-headless-cms/src/crud/contentEntry/searchableFields.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/searchableFields.ts
@@ -38,7 +38,7 @@ const buildSearchableFieldList = (params: BuildParams): string[] => {
         /**
          * If not searchable, continue further.
          */
-        if (!plugin.fullTextSearch) {
+        if (!plugin.fullTextSearch || field.settings?.disableFullTextSearch === true) {
             return result;
         }
 

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -152,6 +152,10 @@ export interface CmsModelFieldSettings {
      */
     type?: string;
     /**
+     * Disable full text search explicitly on this field.
+     */
+    disableFullTextSearch?: boolean;
+    /**
      * There are a lot of other settings that are possible to add, so we keep the type opened.
      */
     [key: string]: any;


### PR DESCRIPTION
## Changes
It is now possible for users to disable the Full Text Search on per field basis. Currently Full Text Search can only be disabled on per field type.

## How Has This Been Tested?
Jest and manually.