### PR TITLE
fix(api-headless-cms): models and group loaders

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -965,6 +965,10 @@ describe("content model test", () => {
 
         const { listContentModelsQuery: listModels } = useGraphQLHandler({
             ...manageHandlerOpts,
+            identity: {
+                ...helpers.identity,
+                id: "identityWithSpecificModelPermissions"
+            },
             permissions: createPermissions({ models: [createdContentModels[0].modelId] })
         });
 

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -662,6 +662,8 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
                 );
             }
 
+            clearModelsCache();
+
             await onModelAfterDelete.publish({
                 model
             });

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1096,7 +1096,6 @@ export interface CmsGroupListParams {
     where: {
         tenant: string;
         locale: string;
-        [key: string]: any;
     };
 }
 

--- a/packages/api-headless-cms/src/utils/filterAsync.ts
+++ b/packages/api-headless-cms/src/utils/filterAsync.ts
@@ -2,15 +2,15 @@ export const filterAsync = async <T = Record<string, any>>(
     items: T[],
     predicate: (param: T) => Promise<boolean>
 ): Promise<T[]> => {
-    const filteredItems = [];
+    const filteredItems = await Promise.all(
+        items.map(async item => {
+            const valid = await predicate(item);
+            if (!valid) {
+                return null;
+            }
+            return item;
+        })
+    );
 
-    for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        const valid = await predicate(item);
-        if (valid) {
-            filteredItems.push(item);
-        }
-    }
-
-    return filteredItems;
+    return filteredItems.filter(Boolean) as T[];
 };

--- a/packages/api-security/src/createSecurity.ts
+++ b/packages/api-security/src/createSecurity.ts
@@ -86,6 +86,9 @@ export const createSecurity = async (config: SecurityConfig): Promise<Security> 
             authentication.setIdentity(identity);
             this.onIdentity.publish({ identity });
         },
+        isAuthorizationEnabled: () => {
+            return performAuthorization;
+        },
         async withoutAuthorization<T = any>(cb: () => Promise<T>): Promise<T> {
             const isAuthorizationEnabled = performAuthorization;
             performAuthorization = false;

--- a/packages/api-security/src/types.ts
+++ b/packages/api-security/src/types.ts
@@ -85,6 +85,8 @@ export interface Security<TIdentity = SecurityIdentity> extends Authentication<T
 
     getStorageOperations(): SecurityStorageOperations;
 
+    isAuthorizationEnabled(): boolean;
+
     withoutAuthorization<T = any>(cb: () => Promise<T>): Promise<T>;
 
     /**


### PR DESCRIPTION
## Changes
This PR adds cached model and group lists.
The model and group list method will now always return a cached promise - so it can either be running or resolved. 

## How Has This Been Tested?
Jest and manually.