### PR TITLE
feat: add getAncestors folder method

### DIFF
--- a/packages/api-aco/src/folder/folder.crud.ts
+++ b/packages/api-aco/src/folder/folder.crud.ts
@@ -240,10 +240,17 @@ export const createFolderCrudMethods = ({
             return true;
         },
 
+        async getAncestors(folder: Folder) {
+            const [folders] = await this.listAll({ where: { type: folder.type } });
+            return getFolderAndItsAncestors({ folder, folders });
+        },
+
+        /**
+         * @deprecated use `getAncestors` instead
+         */
         async getFolderWithAncestors(id: string) {
-            const { type } = await this.get(id);
-            const [folders] = await this.listAll({ where: { type } });
-            return getFolderAndItsAncestors({ id, folders });
+            const folder = await this.get(id);
+            return this.getAncestors(folder);
         },
 
         async listFolderLevelPermissionsTargets() {

--- a/packages/api-aco/src/folder/folder.types.ts
+++ b/packages/api-aco/src/folder/folder.types.ts
@@ -118,6 +118,11 @@ export interface AcoFolderCrud {
 
     delete(id: string): Promise<Boolean>;
 
+    getAncestors(folder: Folder): Promise<Folder[]>;
+
+    /**
+     * @deprecated use `getAncestors` instead
+     */
     getFolderWithAncestors(id: string): Promise<Folder[]>;
 
     onFolderBeforeCreate: Topic<OnFolderBeforeCreateTopicParams>;

--- a/packages/api-aco/src/utils/getFolderAndItsAncestors.ts
+++ b/packages/api-aco/src/utils/getFolderAndItsAncestors.ts
@@ -1,39 +1,42 @@
 import { Folder } from "~/folder/folder.types";
 
 interface GetFolderAndItsAncestorsParams {
-    id: string;
+    folder: Folder;
     folders: Folder[];
 }
 
 export const getFolderAndItsAncestors = ({
-    id,
+    folder,
     folders
 }: GetFolderAndItsAncestorsParams): Folder[] => {
     // Create a Map with folders, using folder.id as key
     const folderMap = new Map<string, Folder>();
     folders.forEach(folder => folderMap.set(folder.id, folder));
 
-    const findParents = (next: Folder[], id: string): Folder[] => {
-        const folder = folderMap.get(id);
-
+    const findParents = (next: Folder[], current: Folder): Folder[] => {
         // No folder found: return the result
-        if (!folder) {
+        if (!current) {
             return next;
         }
 
         // Push the current folder into the accumulator array
-        next.push(folder);
+        next.push(current);
 
         // No parentId found: return the result
-        if (!folder.parentId) {
+        if (!current.parentId) {
+            return next;
+        }
+
+        const parent = folderMap.get(current.parentId);
+
+        // No parent found: return the result
+        if (!parent) {
             return next;
         }
 
         // Go ahead and find parent for the current parent
-        return findParents(next, folder.parentId);
+        return findParents(next, parent);
     };
-
-    const folder = folderMap.get(id);
 
     // No folder found: return an empty array
     if (!folder) {
@@ -46,5 +49,5 @@ export const getFolderAndItsAncestors = ({
     }
 
     // Recursively find parents for a given folder id
-    return findParents([], id);
+    return findParents([], folder);
 };


### PR DESCRIPTION
## Changes
With this PR, we aim to fix a common issue in `ddb-es` instances, where updates and deletions are not immediate.

We deprecate `getFolderWithAncestors` by introducing `getAncestors` that receive the whole folder as a parameter. 

By taking the entire folder, we don't rely on "not yet up to date" data from the `list` method.

## How Has This Been Tested?
Manually on ddb + es instance

## Documentation
Deprecation note inline for `getFolderWithAncestors`.