### PR TITLE
fix(api-aco): flp entry decorator

### DIFF
--- a/packages/api-aco/__tests__/record.so.test.ts
+++ b/packages/api-aco/__tests__/record.so.test.ts
@@ -582,7 +582,7 @@ describe("`search` CRUD", () => {
             ]
         });
 
-        // Creating a record with same "id"
+        // Let's create a record into folder1
         const [createResponse] = await search.createRecord({
             data: {
                 ...recordMocks.recordA,
@@ -592,6 +592,7 @@ describe("`search` CRUD", () => {
 
         const record = createResponse.data.search.createRecord.data;
 
+        // Let's move the record to folder2
         const [moveResponse] = await search.moveRecord({
             id: record.id,
             folderId: folder2.id
@@ -608,9 +609,33 @@ describe("`search` CRUD", () => {
             }
         });
 
-        const [listMovedRecords] = await search.listRecords();
+        // Let's list records for folder1
+        const [listFolder1] = await search.listRecords({
+            where: { type: "page", location: { folderId: folder1.id } }
+        });
 
-        expect(listMovedRecords).toMatchObject({
+        expect(listFolder1).toMatchObject({
+            data: {
+                search: {
+                    listRecords: {
+                        data: [],
+                        error: null,
+                        meta: {
+                            cursor: null,
+                            hasMoreItems: false,
+                            totalCount: 0
+                        }
+                    }
+                }
+            }
+        });
+
+        // Let's list records for folder2
+        const [listFolder2] = await search.listRecords({
+            where: { type: "page", location: { folderId: folder2.id } }
+        });
+
+        expect(listFolder2).toMatchObject({
             data: {
                 search: {
                     listRecords: {
@@ -633,6 +658,7 @@ describe("`search` CRUD", () => {
             }
         });
 
+        // Let's check the record itself
         const [movedRecord] = await search.getRecord({ id: record.id });
         expect(movedRecord).toMatchObject({
             data: {

--- a/packages/api-aco/src/utils/decorators/CmsEntriesCrudDecorators.ts
+++ b/packages/api-aco/src/utils/decorators/CmsEntriesCrudDecorators.ts
@@ -128,11 +128,11 @@ export class CmsEntriesCrudDecorators {
         };
 
         const originalCmsCreateEntry = context.cms.createEntry.bind(context.cms);
-        context.cms.createEntry = async (model, params) => {
+        context.cms.createEntry = async (model, params, options) => {
             const folderId = params.wbyAco_location?.folderId || params.location?.folderId;
 
             if (!folderId || folderId === ROOT_FOLDER) {
-                return originalCmsCreateEntry(model, params);
+                return originalCmsCreateEntry(model, params, options);
             }
 
             const folder = await context.aco.folder.get(folderId);
@@ -141,18 +141,18 @@ export class CmsEntriesCrudDecorators {
                 rwd: "w"
             });
 
-            return originalCmsCreateEntry(model, params);
+            return originalCmsCreateEntry(model, params, options);
         };
 
         const originalCmsUpdateEntry = context.cms.updateEntry.bind(context.cms);
-        context.cms.updateEntry = async (model, id, input, meta) => {
+        context.cms.updateEntry = async (model, id, input, meta, options) => {
             const entry = await context.cms.storageOperations.entries.getRevisionById(model, {
                 id
             });
 
             const folderId = entry?.location?.folderId;
             if (!folderId || folderId === ROOT_FOLDER) {
-                return originalCmsUpdateEntry(model, id, input, meta);
+                return originalCmsUpdateEntry(model, id, input, meta, options);
             }
 
             const folder = await context.aco.folder.get(folderId);
@@ -161,18 +161,18 @@ export class CmsEntriesCrudDecorators {
                 rwd: "w"
             });
 
-            return originalCmsUpdateEntry(model, id, input, meta);
+            return originalCmsUpdateEntry(model, id, input, meta, options);
         };
 
         const originalCmsDeleteEntry = context.cms.deleteEntry.bind(context.cms);
-        context.cms.deleteEntry = async (model, id) => {
+        context.cms.deleteEntry = async (model, id, options) => {
             const entry = await context.cms.storageOperations.entries.getRevisionById(model, {
                 id
             });
 
             const folderId = entry?.location?.folderId;
             if (!folderId || folderId === ROOT_FOLDER) {
-                return originalCmsDeleteEntry(model, id);
+                return originalCmsDeleteEntry(model, id, options);
             }
 
             const folder = await context.aco.folder.get(folderId);
@@ -181,7 +181,7 @@ export class CmsEntriesCrudDecorators {
                 rwd: "d"
             });
 
-            return originalCmsDeleteEntry(model, id);
+            return originalCmsDeleteEntry(model, id, options);
         };
 
         const originalCmsDeleteEntryRevision = context.cms.deleteEntryRevision.bind(context.cms);

--- a/packages/api-aco/src/utils/decorators/constants.ts
+++ b/packages/api-aco/src/utils/decorators/constants.ts
@@ -1,0 +1,1 @@
+export const ROOT_FOLDER = "root";

--- a/packages/api-aco/src/utils/decorators/where.ts
+++ b/packages/api-aco/src/utils/decorators/where.ts
@@ -1,0 +1,53 @@
+import { CmsEntryListWhere } from "@webiny/api-headless-cms/types";
+import { Folder } from "~/folder/folder.types";
+import { ROOT_FOLDER } from "./constants";
+
+interface Params {
+    where: CmsEntryListWhere | undefined;
+    folders: Folder[];
+}
+
+/**
+ * There are multiple cases that we need to handle:
+ * * existing location with no AND conditional
+ * * existing location with AND conditional
+ * * no existing location with no AND conditional + with AND conditional
+ */
+export const createWhere = (params: Params): CmsEntryListWhere | undefined => {
+    const { where, folders } = params;
+    if (!where) {
+        return undefined;
+    }
+    const whereLocation = {
+        wbyAco_location: {
+            // At the moment, all users can access entries in the root folder.
+            // Root folder level permissions cannot be set yet.
+            folderId_in: [ROOT_FOLDER, ...folders.map(folder => folder.id)]
+        }
+    };
+    const whereAnd = where.AND;
+    if (where.wbyAco_location && !whereAnd) {
+        return {
+            ...where,
+            AND: [
+                {
+                    ...whereLocation
+                }
+            ]
+        };
+    } else if (where.wbyAco_location && whereAnd) {
+        return {
+            ...where,
+            AND: [
+                {
+                    ...whereLocation
+                },
+                ...whereAnd
+            ]
+        };
+    }
+    return {
+        ...where,
+        ...whereLocation
+    };
+};

--- a/packages/api-headless-cms/src/crud/contentEntry.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry.crud.ts
@@ -1056,6 +1056,12 @@ export const createContentEntryCrud = (params: CreateContentEntryCrudParams): Cm
         }
 
         const entry = await entryFromStorageTransform(context, model, originalStorageEntry);
+        /**
+         * No need to continue if the entry is already in the requested folder.
+         */
+        if (entry.location?.folderId === folderId) {
+            return entry;
+        }
 
         try {
             await onEntryBeforeMove.publish({

--- a/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveUpdate.ts
+++ b/packages/api-headless-cms/src/graphql/schema/resolvers/manage/resolveUpdate.ts
@@ -14,7 +14,7 @@ type ResolveUpdate = ResolverFactory<any, ResolveUpdateArgs>;
 
 export const resolveUpdate: ResolveUpdate =
     ({ model }) =>
-    async (_, args: any, context) => {
+    async (_, args, context) => {
         try {
             const entry = await context.cms.updateEntry(
                 model,

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1845,6 +1845,8 @@ export interface CmsEntryListWhere {
         folderId_not?: string;
         folderId_in?: string[];
         folderId_not_in?: string[];
+        AND?: CmsEntryListWhere[];
+        OR?: CmsEntryListWhere[];
     };
     /**
      * This is to allow querying by any content model field defined by the user.

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -1838,6 +1838,15 @@ export interface CmsEntryListWhere {
      */
     latest?: boolean;
     /**
+     * ACO related parameters.
+     */
+    wbyAco_location?: {
+        folderId?: string;
+        folderId_not?: string;
+        folderId_in?: string[];
+        folderId_not_in?: string[];
+    };
+    /**
      * This is to allow querying by any content model field defined by the user.
      */
     [key: string]:


### PR DESCRIPTION
## Changes
Fix for CMS Entry CRUD decorator:
* not all variables are passed into the original method
* move entry method not implemented
* create entry revision method not implemented
* listing entries with correct folder types

## How Has This Been Tested?
Jest and manually.