### PR TITLE
fix: re-initialize filter repository on namespace change

### DIFF
--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
-import { useApolloClient } from "@apollo/react-hooks";
 
-import { FieldRaw, FilterDTO, FilterRepositoryFactory } from "./domain";
-import { FiltersGraphQLGateway } from "./gateways";
+import { FieldRaw, FilterDTO, FilterRepository } from "./domain";
 
 import { AdvancedSearchPresenter } from "./AdvancedSearchPresenter";
 
@@ -18,23 +16,15 @@ import { AdvancedSearchContainer } from "./AdvancedSearch.styled";
 
 interface AdvancedSearchProps {
     fields: FieldRaw[];
-    namespace: string;
+    repository: FilterRepository;
     onApplyFilter: (data: FilterDTO | null) => void;
 }
 
 export const AdvancedSearch = observer(
-    ({ fields, namespace, onApplyFilter }: AdvancedSearchProps) => {
-        const client = useApolloClient();
-
-        const [repositoryFactory] = useState<FilterRepositoryFactory>(() => {
-            const gateway = new FiltersGraphQLGateway(client);
-            return new FilterRepositoryFactory(gateway);
-        });
-
+    ({ fields, repository, onApplyFilter }: AdvancedSearchProps) => {
         const presenter = useMemo<AdvancedSearchPresenter>(() => {
-            const repository = repositoryFactory.create(namespace);
             return new AdvancedSearchPresenter(repository);
-        }, [namespace]);
+        }, [FilterRepository]);
 
         useEffect(() => {
             presenter.load();

--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useApolloClient } from "@apollo/react-hooks";
 
-import { FieldRaw, FilterDTO, FilterRepository } from "./domain";
+import { FieldRaw, FilterDTO, FilterRepositoryFactory } from "./domain";
 import { FiltersGraphQLGateway } from "./gateways";
 
 import { AdvancedSearchPresenter } from "./AdvancedSearchPresenter";
@@ -26,13 +26,15 @@ export const AdvancedSearch = observer(
     ({ fields, namespace, onApplyFilter }: AdvancedSearchProps) => {
         const client = useApolloClient();
 
-        const repository = useMemo<FilterRepository>(() => {
-            return FilterRepository.getInstance(new FiltersGraphQLGateway(client), namespace);
-        }, [namespace]);
+        const [repositoryFactory] = useState<FilterRepositoryFactory>(() => {
+            const gateway = new FiltersGraphQLGateway(client);
+            return new FilterRepositoryFactory(gateway);
+        });
 
         const presenter = useMemo<AdvancedSearchPresenter>(() => {
+            const repository = repositoryFactory.create(namespace);
             return new AdvancedSearchPresenter(repository);
-        }, [repository]);
+        }, [namespace]);
 
         useEffect(() => {
             presenter.load();

--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { useApolloClient } from "@apollo/react-hooks";
 
@@ -26,12 +26,13 @@ export const AdvancedSearch = observer(
     ({ fields, namespace, onApplyFilter }: AdvancedSearchProps) => {
         const client = useApolloClient();
 
-        const [repository] = useState(
-            FilterRepository.getInstance(new FiltersGraphQLGateway(client), namespace)
-        );
-        const [presenter] = useState<AdvancedSearchPresenter>(
-            new AdvancedSearchPresenter(repository)
-        );
+        const repository = useMemo<FilterRepository>(() => {
+            return FilterRepository.getInstance(new FiltersGraphQLGateway(client), namespace);
+        }, [namespace]);
+
+        const presenter = useMemo<AdvancedSearchPresenter>(() => {
+            return new AdvancedSearchPresenter(repository);
+        }, [repository]);
 
         useEffect(() => {
             presenter.load();

--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
@@ -5,7 +5,6 @@ import {
     FilterGroupDTO,
     FilterGroupFilterDTO,
     FilterRepository,
-    FilterRepositoryFactory,
     Operation
 } from "./domain";
 import { FiltersGatewayInterface } from "./gateways";
@@ -85,14 +84,12 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     let presenter: AdvancedSearchPresenter;
-    let repositoryFactory: FilterRepositoryFactory;
     let repository: FilterRepository;
 
     beforeEach(() => {
         jest.clearAllMocks();
 
-        repositoryFactory = new FilterRepositoryFactory(gateway);
-        repository = repositoryFactory.create(namespace);
+        repository = new FilterRepository(gateway, namespace);
         presenter = new AdvancedSearchPresenter(repository);
     });
 
@@ -141,7 +138,6 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     it("should transition to loading state and then to list state", async () => {
-        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         const loadPromise = presenter.load();
@@ -680,8 +676,7 @@ describe("AdvancedSearchPresenter", () => {
             list: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repositoryFactory = new FilterRepositoryFactory(gateway);
-        const repository = repositoryFactory.create(createNamespace());
+        const repository = new FilterRepository(gateway, createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load the app, without filters
@@ -708,8 +703,7 @@ describe("AdvancedSearchPresenter", () => {
             create: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repositoryFactory = new FilterRepositoryFactory(createGateway);
-        const repository = repositoryFactory.create(createNamespace());
+        const repository = new FilterRepository(createGateway, createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -752,8 +746,7 @@ describe("AdvancedSearchPresenter", () => {
             update: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repositoryFactory = new FilterRepositoryFactory(updateGateway);
-        const repository = repositoryFactory.create(createNamespace());
+        const repository = new FilterRepository(updateGateway, createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -782,8 +775,7 @@ describe("AdvancedSearchPresenter", () => {
             delete: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repositoryFactory = new FilterRepositoryFactory(updateGateway);
-        const repository = repositoryFactory.create(createNamespace());
+        const repository = new FilterRepository(updateGateway, createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -797,34 +789,6 @@ describe("AdvancedSearchPresenter", () => {
                 message
             }
         });
-    });
-
-    it("should set the right namespace while getting the repository instance", async () => {
-        const list = jest.fn();
-
-        const gateway = createMockGateway({
-            list
-        });
-
-        const repositoryFactory = new FilterRepositoryFactory(gateway);
-
-        const namespace1 = createNamespace();
-        repository = repositoryFactory.create(namespace1);
-        presenter = new AdvancedSearchPresenter(repository);
-
-        // let's load some filters
-        await presenter.load();
-
-        expect(gateway.list).toHaveBeenLastCalledWith(namespace1);
-
-        const namespace2 = createNamespace();
-        repository = repositoryFactory.create(namespace2);
-        presenter = new AdvancedSearchPresenter(repository);
-
-        // let's load some filters
-        await presenter.load();
-
-        expect(gateway.list).toHaveBeenLastCalledWith(namespace2);
     });
 
     it("should be able to show a feedback message", async () => {

--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
@@ -1,4 +1,3 @@
-import { mdbid } from "@webiny/utils";
 import { AdvancedSearchPresenter } from "./AdvancedSearchPresenter";
 import {
     FilterDTO,
@@ -32,10 +31,8 @@ const createMockGateway = ({
     ...(deleteFn && { delete: deleteFn })
 });
 
-const createNamespace = () => mdbid();
-
 describe("AdvancedSearchPresenter", () => {
-    const namespace = createNamespace();
+    const namespace = "namespace";
 
     const demoFilter: FilterGroupFilterDTO = {
         field: "any-field",
@@ -84,12 +81,11 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     let presenter: AdvancedSearchPresenter;
-    let repository: FilterRepository;
 
     beforeEach(() => {
         jest.clearAllMocks();
 
-        repository = new FilterRepository(gateway, namespace);
+        const repository = new FilterRepository(gateway, namespace);
         presenter = new AdvancedSearchPresenter(repository);
     });
 
@@ -138,8 +134,6 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     it("should transition to loading state and then to list state", async () => {
-        const presenter = new AdvancedSearchPresenter(repository);
-
         const loadPromise = presenter.load();
 
         expect(presenter.vm.managerVm).toMatchObject({
@@ -676,7 +670,7 @@ describe("AdvancedSearchPresenter", () => {
             list: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = new FilterRepository(gateway, createNamespace());
+        const repository = new FilterRepository(gateway, namespace);
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load the app, without filters
@@ -703,7 +697,7 @@ describe("AdvancedSearchPresenter", () => {
             create: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = new FilterRepository(createGateway, createNamespace());
+        const repository = new FilterRepository(createGateway, namespace);
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -746,7 +740,7 @@ describe("AdvancedSearchPresenter", () => {
             update: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = new FilterRepository(updateGateway, createNamespace());
+        const repository = new FilterRepository(updateGateway, namespace);
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -775,7 +769,7 @@ describe("AdvancedSearchPresenter", () => {
             delete: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = new FilterRepository(updateGateway, createNamespace());
+        const repository = new FilterRepository(updateGateway, namespace);
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters

--- a/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/AdvancedSearchPresenter.test.ts
@@ -5,6 +5,7 @@ import {
     FilterGroupDTO,
     FilterGroupFilterDTO,
     FilterRepository,
+    FilterRepositoryFactory,
     Operation
 } from "./domain";
 import { FiltersGatewayInterface } from "./gateways";
@@ -84,12 +85,14 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     let presenter: AdvancedSearchPresenter;
+    let repositoryFactory: FilterRepositoryFactory;
     let repository: FilterRepository;
 
     beforeEach(() => {
         jest.clearAllMocks();
 
-        repository = FilterRepository.getInstance(gateway, namespace);
+        repositoryFactory = new FilterRepositoryFactory(gateway);
+        repository = repositoryFactory.create(namespace);
         presenter = new AdvancedSearchPresenter(repository);
     });
 
@@ -138,7 +141,7 @@ describe("AdvancedSearchPresenter", () => {
     });
 
     it("should transition to loading state and then to list state", async () => {
-        const repository = FilterRepository.getInstance(gateway, createNamespace());
+        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         const loadPromise = presenter.load();
@@ -677,7 +680,8 @@ describe("AdvancedSearchPresenter", () => {
             list: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = FilterRepository.getInstance(gateway, createNamespace());
+        const repositoryFactory = new FilterRepositoryFactory(gateway);
+        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load the app, without filters
@@ -704,7 +708,8 @@ describe("AdvancedSearchPresenter", () => {
             create: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = FilterRepository.getInstance(createGateway, createNamespace());
+        const repositoryFactory = new FilterRepositoryFactory(createGateway);
+        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -747,7 +752,8 @@ describe("AdvancedSearchPresenter", () => {
             update: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = FilterRepository.getInstance(updateGateway, createNamespace());
+        const repositoryFactory = new FilterRepositoryFactory(updateGateway);
+        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -776,7 +782,8 @@ describe("AdvancedSearchPresenter", () => {
             delete: jest.fn().mockRejectedValue(new Error(message))
         });
 
-        const repository = FilterRepository.getInstance(updateGateway, namespace);
+        const repositoryFactory = new FilterRepositoryFactory(updateGateway);
+        const repository = repositoryFactory.create(createNamespace());
         const presenter = new AdvancedSearchPresenter(repository);
 
         // Let's load some filters
@@ -799,8 +806,10 @@ describe("AdvancedSearchPresenter", () => {
             list
         });
 
+        const repositoryFactory = new FilterRepositoryFactory(gateway);
+
         const namespace1 = createNamespace();
-        repository = FilterRepository.getInstance(gateway, namespace1);
+        repository = repositoryFactory.create(namespace1);
         presenter = new AdvancedSearchPresenter(repository);
 
         // let's load some filters
@@ -809,7 +818,7 @@ describe("AdvancedSearchPresenter", () => {
         expect(gateway.list).toHaveBeenLastCalledWith(namespace1);
 
         const namespace2 = createNamespace();
-        repository = FilterRepository.getInstance(gateway, namespace2);
+        repository = repositoryFactory.create(namespace2);
         presenter = new AdvancedSearchPresenter(repository);
 
         // let's load some filters

--- a/packages/app-aco/src/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilderDrawer.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilderDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { observer } from "mobx-react-lite";
 
 import { FormAPI } from "@webiny/form";
@@ -27,9 +27,9 @@ interface QueryBuilderDrawerProps {
 }
 
 export const QueryBuilderDrawer = observer(({ filter, ...props }: QueryBuilderDrawerProps) => {
-    const [presenter] = useState<QueryBuilderDrawerPresenter>(
-        new QueryBuilderDrawerPresenter(props.fields)
-    );
+    const presenter = useMemo<QueryBuilderDrawerPresenter>(() => {
+        return new QueryBuilderDrawerPresenter(props.fields);
+    }, [props.fields]);
 
     useEffect(() => {
         presenter.load(filter);

--- a/packages/app-aco/src/components/AdvancedSearch/QuerySaverDialog/QuerySaverDialog.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/QuerySaverDialog/QuerySaverDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 
 import { Form } from "@webiny/form";
@@ -26,7 +26,9 @@ interface QuerySaverDialogProps {
 }
 
 export const QuerySaverDialog = observer(({ filter, ...props }: QuerySaverDialogProps) => {
-    const [presenter] = useState<QuerySaverDialogPresenter>(new QuerySaverDialogPresenter());
+    const presenter = useMemo<QuerySaverDialogPresenter>(() => {
+        return new QuerySaverDialogPresenter();
+    }, []);
 
     useEffect(() => {
         presenter.load(filter);

--- a/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepository.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepository.ts
@@ -22,10 +22,17 @@ export class FilterRepository {
     }
 
     static getInstance(gateway: FiltersGatewayInterface, namespace: string) {
-        if (!FilterRepository.instance) {
+        if (!FilterRepository.instance || !this.isMatchingInstance(gateway, namespace)) {
             FilterRepository.instance = new FilterRepository(gateway, namespace);
         }
         return FilterRepository.instance;
+    }
+
+    private static isMatchingInstance(
+        gateway: FiltersGatewayInterface,
+        namespace: string
+    ): boolean {
+        return this.instance.gateway === gateway && this.instance.namespace === namespace;
     }
 
     getFilters() {

--- a/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepository.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepository.ts
@@ -9,7 +9,6 @@ export class FilterRepository {
     private gateway: FiltersGatewayInterface;
     private sorter: Sorter<FilterDTO>;
     private loading: Loading;
-    private static instance: FilterRepository;
     private filters: FilterDTO[] = [];
     public readonly namespace: string;
 
@@ -19,20 +18,6 @@ export class FilterRepository {
         this.namespace = namespace;
         this.sorter = new Sorter(["createdOn_DESC"]);
         makeAutoObservable(this);
-    }
-
-    static getInstance(gateway: FiltersGatewayInterface, namespace: string) {
-        if (!FilterRepository.instance || !this.isMatchingInstance(gateway, namespace)) {
-            FilterRepository.instance = new FilterRepository(gateway, namespace);
-        }
-        return FilterRepository.instance;
-    }
-
-    private static isMatchingInstance(
-        gateway: FiltersGatewayInterface,
-        namespace: string
-    ): boolean {
-        return this.instance.gateway === gateway && this.instance.namespace === namespace;
     }
 
     getFilters() {

--- a/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepositoryFactory.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/domain/FilterRepositoryFactory.ts
@@ -1,0 +1,19 @@
+import { FiltersGatewayInterface } from "~/components/AdvancedSearch/gateways";
+import { FilterRepository } from "./FilterRepository";
+
+export class FilterRepositoryFactory {
+    private readonly gateway: FiltersGatewayInterface;
+    private repositories: { [key: string]: FilterRepository } = {};
+
+    constructor(gateway: FiltersGatewayInterface) {
+        this.gateway = gateway;
+    }
+
+    create(namespace: string): FilterRepository {
+        if (!this.repositories[namespace]) {
+            this.repositories[namespace] = new FilterRepository(this.gateway, namespace);
+        }
+
+        return this.repositories[namespace];
+    }
+}

--- a/packages/app-aco/src/components/AdvancedSearch/domain/index.ts
+++ b/packages/app-aco/src/components/AdvancedSearch/domain/index.ts
@@ -4,6 +4,7 @@ export * from "./FieldMapper";
 export * from "./Filter";
 export * from "./FilterMapper";
 export * from "./FilterRepository";
+export * from "./FilterRepositoryFactory";
 export * from "./Loading";
 export * from "./Operation";
 export * from "./Sorter";

--- a/packages/app-aco/src/components/AdvancedSearch/index.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/index.tsx
@@ -1,2 +1,3 @@
 export * from "./AdvancedSearch";
 export * from "./GraphQLInputMapper";
+export * from "./useFilterRepository";

--- a/packages/app-aco/src/components/AdvancedSearch/useFilterRepository.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/useFilterRepository.tsx
@@ -1,0 +1,8 @@
+import { useApolloClient } from "@apollo/react-hooks";
+import { filterRepositoryFactory } from "~/components/AdvancedSearch/domain";
+
+export const useFilterRepository = (namespace: string) => {
+    const client = useApolloClient();
+
+    return filterRepositoryFactory.getRepository(client, namespace);
+};

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Filters/Filters.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Filters/Filters.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Filters as BaseFilters, FiltersOnSubmit } from "@webiny/app-admin";
 import { useContentEntryListConfig } from "~/admin/config/contentEntries";
 import { useContentEntriesList } from "~/admin/views/contentEntries/hooks";
-import { AdvancedSearch, GraphQLInputMapper } from "@webiny/app-aco";
+import { AdvancedSearch, GraphQLInputMapper, useFilterRepository } from "@webiny/app-aco";
 import { useModel } from "~/admin/hooks";
 import { FieldsMapper } from "./FieldsMapper";
 import { FieldRaw, FilterDTO } from "@webiny/app-aco/components/AdvancedSearch/domain";
@@ -12,6 +12,7 @@ export const Filters = () => {
     const list = useContentEntriesList();
     const { model } = useModel();
     const [fields, setFields] = useState<FieldRaw[] | undefined>();
+    const repository = useFilterRepository(`cms:${model.modelId}`);
 
     useEffect(() => {
         setFields(FieldsMapper.toRaw(model));
@@ -55,7 +56,7 @@ export const Filters = () => {
         >
             <AdvancedSearch
                 fields={fields}
-                namespace={model.modelId}
+                repository={repository}
                 onApplyFilter={applyAdvancedSearch}
             />
         </BaseFilters>


### PR DESCRIPTION
## Changes
We addressed an issue that occurred while navigating through various HCMS entry lists. 

The issue was caused by the `FilterRepository` not being re-initialized upon a change in `namespace`. 

To fix this, we implemented a check to determine if any new `namespace` or `client` was received and used `useMemo` to memoize the returned value.

## How Has This Been Tested?
Jest
