### PR TITLE
chore: move @webiny/react-composition dependency

### DIFF
--- a/packages/react-properties/package.json
+++ b/packages/react-properties/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.22.6",
     "@types/react": "17.0.39",
+    "@webiny/react-composition": "0.0.0",
     "nanoid": "^3.3.4",
     "react": "17.0.2"
   },
@@ -19,7 +20,6 @@
     "@testing-library/react": "^12.1.5",
     "@webiny/cli": "0.0.0",
     "@webiny/project-utils": "0.0.0",
-    "@webiny/react-composition": "0.0.0",
     "prettier": "^2.8.3"
   },
   "publishConfig": {


### PR DESCRIPTION
## Changes
In this pull request, we are making a change to the `@webiny/react-properties` package by moving `react-composition` from `devDependencies` to `dependencies`.
