### PR TITLE
Temporary Add `api-admin-users-cognito` Packages

### DIFF
--- a/packages/api-admin-users-cognito-so-ddb/LICENSE
+++ b/packages/api-admin-users-cognito-so-ddb/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/api-admin-users-cognito-so-ddb/README.md
+++ b/packages/api-admin-users-cognito-so-ddb/README.md
@@ -1,0 +1,1 @@
+This package was deprecated with the 5.38.0 release of Webiny.

--- a/packages/api-admin-users-cognito-so-ddb/index.js
+++ b/packages/api-admin-users-cognito-so-ddb/index.js
@@ -1,0 +1,1 @@
+export const dummyObject = {};

--- a/packages/api-admin-users-cognito-so-ddb/package.json
+++ b/packages/api-admin-users-cognito-so-ddb/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@webiny/api-admin-users-cognito-so-ddb",
+  "version": "0.0.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "."
+  }
+}

--- a/packages/api-admin-users-cognito/LICENSE
+++ b/packages/api-admin-users-cognito/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Webiny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/api-admin-users-cognito/README.md
+++ b/packages/api-admin-users-cognito/README.md
@@ -1,0 +1,1 @@
+This package was deprecated with the 5.38.0 release of Webiny.

--- a/packages/api-admin-users-cognito/index.js
+++ b/packages/api-admin-users-cognito/index.js
@@ -1,0 +1,1 @@
+export const dummyObject = {};

--- a/packages/api-admin-users-cognito/package.json
+++ b/packages/api-admin-users-cognito/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@webiny/api-admin-users-cognito",
+  "version": "0.0.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webiny/webiny-js.git"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "."
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12966,6 +12966,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webiny/api-admin-users-cognito-so-ddb@workspace:packages/api-admin-users-cognito-so-ddb":
+  version: 0.0.0-use.local
+  resolution: "@webiny/api-admin-users-cognito-so-ddb@workspace:packages/api-admin-users-cognito-so-ddb"
+  languageName: unknown
+  linkType: soft
+
+"@webiny/api-admin-users-cognito@workspace:packages/api-admin-users-cognito":
+  version: 0.0.0-use.local
+  resolution: "@webiny/api-admin-users-cognito@workspace:packages/api-admin-users-cognito"
+  languageName: unknown
+  linkType: soft
+
 "@webiny/api-admin-users-so-ddb@0.0.0, @webiny/api-admin-users-so-ddb@workspace:packages/api-admin-users-so-ddb":
   version: 0.0.0-use.local
   resolution: "@webiny/api-admin-users-so-ddb@workspace:packages/api-admin-users-so-ddb"


### PR DESCRIPTION
## Changes
The `api-admin-users-cognito` and `api-admin-users-cognito-so-ddb` packages were deprecated with 5.38.0 release. But, we still need to have them here in order for the 5.37.x -> 5.38.x project upgrade to succeed.

We'll remove these packages in 5.39.0 release.

## How Has This Been Tested?
Manually.

## Documentation
N/A