### PR TITLE
Hide `WEBINY_ELASTICSEARCH_INDEX_LOCALE` Environment Variable

### DIFF
--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -44,3 +44,10 @@ if (project.config.featureFlags) {
     process.env.WEBINY_FEATURE_FLAGS = JSON.stringify(project.config.featureFlags);
     process.env.REACT_APP_WEBINY_FEATURE_FLAGS = JSON.stringify(project.config.featureFlags);
 }
+
+// With 5.38.0, we are hiding the `WEBINY_ELASTICSEARCH_INDEX_LOCALE` env variable and always setting it to `true`.
+// This is because this variable is not something users should be concerned with, nor should they be able to change it.
+// In order to ensure backwards compatibility, we first check if the variable is set, and if it is, we don't override it.
+if (!"WEBINY_ELASTICSEARCH_INDEX_LOCALE" in process.env) {
+    process.env.WEBINY_ELASTICSEARCH_INDEX_LOCALE = "true";
+}

--- a/packages/cwp-template-aws/template/ddb-es/example.env
+++ b/packages/cwp-template-aws/template/ddb-es/example.env
@@ -11,8 +11,3 @@ PULUMI_CONFIG_PASSPHRASE={PULUMI_CONFIG_PASSPHRASE}
 
 # Enable debugging mode.
 DEBUG=true
-
-# Feature flag to enable adding locale code into Elasticsearch index name
-# Enabled in 5.26.0
-# If users, which installed before 5.26.0, want to have different indexes per locale in PB, FB and FM please check docs on how to enable those
-WEBINY_ELASTICSEARCH_INDEX_LOCALE=true

--- a/packages/cwp-template-aws/template/ddb-es/example.keep.env
+++ b/packages/cwp-template-aws/template/ddb-es/example.keep.env
@@ -11,8 +11,3 @@ PULUMI_CONFIG_PASSPHRASE={PULUMI_CONFIG_PASSPHRASE}
 
 # Enable debugging mode.
 DEBUG=true
-
-# Feature flag to enable adding locale code into Elasticsearch index name
-# Enabled in 5.26.0
-# If users, which installed before 5.26.0, want to have different indexes per locale in PB, FB and FM please check docs on how to enable those
-WEBINY_ELASTICSEARCH_INDEX_LOCALE=true


### PR DESCRIPTION
## Changes
This PR hides the `WEBINY_ELASTICSEARCH_INDEX_LOCALE` environment variable (and sets it to `true`) from users in order to make the overall DX better.

We'll have a section in our upgrade guide that highlights this change to our users and warn them to take action if they weren't using this variable in their project.

## How Has This Been Tested?
Manually.

## Documentation
Changelog / upgrade guide.