### PR TITLE
fix(app-file-manager): hide drag overlay after drop

### DIFF
--- a/packages/app-file-manager/src/components/DropFilesHere/DropFilesHere.tsx
+++ b/packages/app-file-manager/src/components/DropFilesHere/DropFilesHere.tsx
@@ -18,19 +18,9 @@ export interface DropFilesHereProps {
     onClick?: (event?: React.MouseEvent<HTMLElement>) => void;
 }
 
-export const DropFilesHere: React.FC<DropFilesHereProps> = ({
-    onDrop,
-    onDragLeave,
-    empty,
-    onClick
-}) => {
+export const DropFilesHere: React.FC<DropFilesHereProps> = ({ empty, onClick }) => {
     return (
-        <DropFilesHereWrapper
-            empty={empty}
-            onDrop={onDrop}
-            onClick={onClick}
-            onDragLeave={onDragLeave}
-        >
+        <DropFilesHereWrapper empty={empty} onClick={onClick}>
             <DropFilesHereInner empty={empty}>
                 <DropFilesHereIconWrapper>
                     <Icon icon={<DropFilesHereIcon />} />

--- a/packages/app-file-manager/src/components/DropFilesHere/styled.tsx
+++ b/packages/app-file-manager/src/components/DropFilesHere/styled.tsx
@@ -6,10 +6,11 @@ type DropFilesHereWrapperProps = {
 };
 
 export const DropFilesHereWrapper = styled("div")<DropFilesHereWrapperProps>`
+    pointer-events: ${({ empty }) => (empty ? "all" : "none")};
     margin: 0 auto;
     padding-top: 0;
     height: calc(100vh - 95px);
-    z-index: 3;
+    z-index: 100;
     width: 100%;
     position: absolute;
     background: ${({ empty }) => (empty ? "transparent" : "var(--mdc-theme-text-hint-on-light)")};

--- a/packages/app-file-manager/src/components/Empty/Empty.tsx
+++ b/packages/app-file-manager/src/components/Empty/Empty.tsx
@@ -20,5 +20,6 @@ export const Empty: React.VFC<EmptyViewProps> = ({ browseFiles, isSearchResult }
     if (isSearchResult) {
         return <NoResults />;
     }
+
     return <DropFilesHere empty onClick={() => browseFiles()} />;
 };

--- a/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
@@ -30,6 +30,7 @@ import { CmsModelField } from "@webiny/app-headless-cms/types";
 type FileDetailsDrawerProps = React.ComponentProps<typeof Drawer> & { width: string };
 
 const FileDetailsDrawer = styled(Drawer)<FileDetailsDrawerProps>`
+    z-index: 70;
     &.mdc-drawer {
         width: ${props => props.width};
     }

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
@@ -39,6 +39,7 @@ const t = i18n.ns("app-admin/file-manager/file-manager-view");
 
 const FileListWrapper = styled("div")({
     float: "right",
+    zIndex: 60,
     display: "inline-block",
     width: "calc(100vw - 286px)",
     height: "calc(100vh - 94px)",
@@ -176,6 +177,8 @@ const FileManagerView = () => {
 
     const filesBeingUploaded = uploader.getJobs().length;
     const progress = uploader.progress;
+
+    const onDrop = () => view.setDragging(false);
 
     const renderList = (browseFiles: FilesRenderChildren["browseFiles"]) => {
         if (!view.isListLoading && view.isSearch && view.files.length === 0) {
@@ -319,17 +322,13 @@ const FileManagerView = () => {
                             </LeftSidebar>
                             <FileListWrapper
                                 {...getDropZoneProps({
-                                    onDragEnter: () =>
-                                        view.hasPreviouslyUploadedFiles && view.setDragging(true)
+                                    onDragOver: () => view.setDragging(true),
+                                    onDragLeave: () => view.setDragging(false),
+                                    onDrop
                                 })}
                                 data-testid={"fm-list-wrapper"}
                             >
-                                {view.dragging && view.hasPreviouslyUploadedFiles && (
-                                    <DropFilesHere
-                                        onDragLeave={() => view.setDragging(false)}
-                                        onDrop={() => view.setDragging(false)}
-                                    />
-                                )}
+                                {view.dragging && <DropFilesHere />}
                                 <BulkActions />
                                 <Filters />
                                 <Scrollbar

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/state.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/state.ts
@@ -6,7 +6,6 @@ export interface State {
     activeTags: string[];
     dragging: boolean;
     filters: Record<string, any> | undefined;
-    hasPreviouslyUploadedFiles: boolean | null;
     isSearch: boolean;
     limit: number;
     listSort?: ListFilesSort;
@@ -39,7 +38,6 @@ export const initializeState = (): State => {
         dragging: false,
         isSearch: false,
         filters: undefined,
-        hasPreviouslyUploadedFiles: null,
         limit: 50,
         listSort: [],
         listTable: false,


### PR DESCRIPTION
## Changes
This PR fixes an issue where a Drop overlay would remain visible after a file was dropped into an empty folder.


https://github.com/webiny/webiny-js/assets/3920893/8b51530e-705f-493a-8666-177e5f87525b



## How Has This Been Tested?
Manually.
