### PR TITLE
feat(ui): move timeago-react to ui package

### DIFF
--- a/packages/app-aco/package.json
+++ b/packages/app-aco/package.json
@@ -40,7 +40,6 @@
     "react-hotkeyz": "^1.0.4",
     "slugify": "^1.2.9",
     "store": "^2.0.12",
-    "timeago-react": "^2.0.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/app-aco/src/components/AdvancedSearch/QueryManagerDialog/components/Description.tsx
+++ b/packages/app-aco/src/components/AdvancedSearch/QueryManagerDialog/components/Description.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { ListItemTextSecondary } from "@webiny/ui/List";
-
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 
 export interface DescriptionProps {
     children?: string;

--- a/packages/app-file-manager/package.json
+++ b/packages/app-file-manager/package.json
@@ -52,8 +52,7 @@
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "17.0.2",
     "react-hotkeyz": "^1.0.4",
-    "react-lazy-load": "^3.1.14",
-    "timeago-react": "^2.0.0"
+    "react-lazy-load": "^3.1.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/app-file-manager/src/components/Grid/File.tsx
+++ b/packages/app-file-manager/src/components/Grid/File.tsx
@@ -4,11 +4,7 @@ import React, { useCallback } from "react";
  */
 // @ts-ignore
 import LazyLoad from "react-lazy-load";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { IconButton } from "@webiny/ui/Button";
 import { Typography } from "@webiny/ui/Typography";
 import { ReactComponent as SettingsIcon } from "@material-design-icons/svg/filled/settings.svg";

--- a/packages/app-file-manager/src/components/Table/Table.tsx
+++ b/packages/app-file-manager/src/components/Table/Table.tsx
@@ -2,19 +2,15 @@ import React, { forwardRef, useMemo, useState } from "react";
 import { ReactComponent as MoreIcon } from "@material-design-icons/svg/filled/more_vert.svg";
 import {
     FolderDialogDelete,
-    FolderDialogUpdate,
-    FolderDialogManagePermissions
+    FolderDialogManagePermissions,
+    FolderDialogUpdate
 } from "@webiny/app-aco";
 import { FolderItem, Location } from "@webiny/app-aco/types";
 import { IconButton } from "@webiny/ui/Button";
 import { Columns, DataTable, OnSortingChange, Sorting } from "@webiny/ui/DataTable";
 import { Menu } from "@webiny/ui/Menu";
 import bytes from "bytes";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { FileName, FolderName } from "./Name";
 import { FolderActionDelete } from "./FolderActionDelete";
 import { FolderActionEdit } from "./FolderActionEdit";

--- a/packages/app-form-builder/package.json
+++ b/packages/app-form-builder/package.json
@@ -54,8 +54,7 @@
     "react-google-recaptcha": "^1.1.0",
     "react-hotkeyz": "^1.0.4",
     "react-sortable-hoc": "^1.9.1",
-    "shortid": "^2.2.14",
-    "timeago-react": "^2.0.0"
+    "shortid": "^2.2.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/app-form-builder/src/admin/plugins/formDetails/formRevisions/Revision.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formRevisions/Revision.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import {
     ListItem,
     ListItemText,

--- a/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
@@ -1,9 +1,5 @@
 import React, { useState } from "react";
-/**
- * Package timeago-react does not have types
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import { i18n } from "@webiny/app/i18n";

--- a/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
@@ -1,9 +1,5 @@
 import React, { useRef, useCallback, useState, useMemo } from "react";
-/**
- * Package timeago-react does not have types
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import orderBy from "lodash/orderBy";

--- a/packages/app-headless-cms/package.json
+++ b/packages/app-headless-cms/package.json
@@ -72,7 +72,6 @@
     "react-helmet": "^6.1.0",
     "react-hotkeyz": "^1.0.4",
     "react-virtualized": "^9.21.2",
-    "timeago-react": "^2.0.0",
     "use-deep-compare-effect": "^1.6.1"
   },
   "devDependencies": {

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/index.tsx
@@ -10,11 +10,7 @@ import { FolderItem } from "@webiny/app-aco/types";
 import { IconButton } from "@webiny/ui/Button";
 import { Columns, DataTable, OnSortingChange, Sorting } from "@webiny/ui/DataTable";
 import { Menu } from "@webiny/ui/Menu";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { EntryName, FolderName } from "./Row/Name";
 import { FolderActionDelete } from "./Row/Folder/FolderActionDelete";
 import { FolderActionEdit } from "./Row/Folder/FolderActionEdit";

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/CreatedBy.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/CreatedBy.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { CmsIdentity } from "~/types";
 import { Box } from "./Box";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 
 interface Props {
     createdBy: CmsIdentity;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModifiedBy.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModifiedBy.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { CmsIdentity } from "~/types";
 import { Box } from "./Box";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 
 interface Props {
     modifiedBy?: CmsIdentity | null;

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { css } from "emotion";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import {
     ListItem,
     ListItemText,

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -1,9 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { css } from "emotion";
 import { useRouter } from "@webiny/react-router";
 import { DeleteIcon, EditIcon } from "@webiny/ui/List/DataList/icons";

--- a/packages/app-page-builder/package.json
+++ b/packages/app-page-builder/package.json
@@ -79,7 +79,6 @@
     "slugify": "^1.2.9",
     "store": "^2.0.12",
     "swiper": "^9.3.2",
-    "timeago-react": "^2.0.0",
     "uniqid": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/app-page-builder/src/admin/components/Table/Table/index.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/index.tsx
@@ -9,11 +9,7 @@ import { FolderItem, Location, SearchRecordItem } from "@webiny/app-aco/types";
 import { IconButton } from "@webiny/ui/Button";
 import { Columns, DataTable, OnSortingChange, Sorting } from "@webiny/ui/DataTable";
 import { Menu } from "@webiny/ui/Menu";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import { FolderName, PageName } from "./Row/Name";
 import { FolderActionDelete } from "./Row/Folder/FolderActionDelete";
 import { FolderActionEdit } from "./Row/Folder/FolderActionEdit";

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/Revision.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/pageRevisions/Revision.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback } from "react";
 import { css } from "emotion";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 import {
     ListItem,
     ListItemText,

--- a/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplatesDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/PageTemplates/PageTemplatesDataList.tsx
@@ -4,11 +4,7 @@ import { i18n } from "@webiny/app/i18n";
 import { useRouter } from "@webiny/react-router";
 import { useQuery } from "@apollo/react-hooks";
 import orderBy from "lodash/orderBy";
-/**
- * Package timeago-react does not have types.
- */
-// @ts-ignore
-import TimeAgo from "timeago-react";
+import { TimeAgo } from "@webiny/ui/TimeAgo";
 
 import {
     DataList,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,7 +64,8 @@
     "react-loading-skeleton": "^3.1.0",
     "react-spinner-material": "1.1.4",
     "react-transition-group": "^4.3.0",
-    "shortid": "^2.2.16"
+    "shortid": "^2.2.16",
+    "timeago-react": "^3.0.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/ui/src/TimeAgo/index.ts
+++ b/packages/ui/src/TimeAgo/index.ts
@@ -1,0 +1,5 @@
+import TimeAgo from "timeago-react";
+
+export type { TimeAgoProps, Opts, TDate } from "timeago-react";
+
+export { TimeAgo };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14331,7 +14331,6 @@ __metadata:
     rimraf: ^3.0.2
     slugify: ^1.2.9
     store: ^2.0.12
-    timeago-react: ^2.0.0
     ttypescript: ^1.5.12
     typescript: 4.7.4
     zod: ^3.21.4
@@ -14792,7 +14791,6 @@ __metadata:
     react-hotkeyz: ^1.0.4
     react-lazy-load: ^3.1.14
     rimraf: ^3.0.2
-    timeago-react: ^2.0.0
     ttypescript: ^1.5.13
     typescript: 4.7.4
   languageName: unknown
@@ -14856,7 +14854,6 @@ __metadata:
     react-sortable-hoc: ^1.9.1
     rimraf: ^3.0.2
     shortid: ^2.2.14
-    timeago-react: ^2.0.0
     ttypescript: ^1.5.12
     typescript: 4.7.4
   languageName: unknown
@@ -15001,7 +14998,6 @@ __metadata:
     react-hotkeyz: ^1.0.4
     react-virtualized: ^9.21.2
     rimraf: ^3.0.2
-    timeago-react: ^2.0.0
     ttypescript: ^1.5.12
     typescript: 4.7.4
     use-deep-compare-effect: ^1.6.1
@@ -15299,7 +15295,6 @@ __metadata:
     slugify: ^1.2.9
     store: ^2.0.12
     swiper: ^9.3.2
-    timeago-react: ^2.0.0
     ttypescript: ^1.5.12
     typescript: 4.7.4
     uniqid: ^5.0.3
@@ -17068,6 +17063,7 @@ __metadata:
     sass: ^1.38.0
     sass-loader: ^12.1.0
     shortid: ^2.2.16
+    timeago-react: ^3.0.6
     ttypescript: ^1.5.13
     typescript: 4.7.4
     webpack: ^4.46.0
@@ -42044,19 +42040,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeago-react@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "timeago-react@npm:2.0.1"
+"timeago-react@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "timeago-react@npm:3.0.6"
   dependencies:
-    timeago.js: ^4.0.0-beta.2
+    timeago.js: ^4.0.0
   peerDependencies:
-    prop-types: ^15.0.0
-    react: ">=0.13.2 || ^0.14.0 || ^15.0.0 || ^16.0.0"
-  checksum: c3bbfb3fdf7c9226d9c1fb536bc61e71f040f5d901b6ad374672ba9d9ea1847346b3e286e314f87634c8d0569c2008877903c18ea016f02bfb608919c98d8e11
+    react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: be9945194eca4ae01fc5d3d15b9d84dcf4d2cf5fe52f7956d8163842bf03d055a6bec3d347b33cf5fc26c88b571edcd4a2cf2dab55442cd1f197abdd339ba2f7
   languageName: node
   linkType: hard
 
-"timeago.js@npm:^4.0.0-beta.2":
+"timeago.js@npm:^4.0.0":
   version: 4.0.2
   resolution: "timeago.js@npm:4.0.2"
   checksum: c785a06988717cb5a00bb96b00ebaa56e83f4b5ed5d87c4c3931fb1bb2591a0e13a7ddc4b6c12c6ee7de64b440ed903c7bd4e0edddb37aade9bfc9ceab5d0db3


### PR DESCRIPTION
## Changes
This PR moves the `timeago-react` package to our UI package and updates the version of the `timeago-react` to `^3.0.6`.

## How Has This Been Tested?
Manually.