### PR TITLE
fix: make element prop optional for BulkAction

### DIFF
--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/BulkAction.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/BulkAction.tsx
@@ -14,7 +14,7 @@ export interface BulkActionProps {
     remove?: boolean;
     before?: string;
     after?: string;
-    element: React.ReactElement;
+    element?: React.ReactElement;
 }
 
 export const BaseBulkAction: React.FC<BulkActionProps> = ({
@@ -40,7 +40,9 @@ export const BaseBulkAction: React.FC<BulkActionProps> = ({
                 after={placeAfter}
             >
                 <Property id={getId(name, "name")} name={"name"} value={name} />
-                <Property id={getId(name, "element")} name={"element"} value={element} />
+                {element ? (
+                    <Property id={getId(name, "element")} name={"element"} value={element} />
+                ) : null}
             </Property>
         </Property>
     );

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/BulkAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/BulkAction.tsx
@@ -15,7 +15,7 @@ export interface BulkActionProps {
     before?: string;
     after?: string;
     modelIds?: string[];
-    element: React.ReactElement;
+    element?: React.ReactElement;
 }
 
 export const BaseBulkAction: React.FC<BulkActionProps> = ({
@@ -47,7 +47,9 @@ export const BaseBulkAction: React.FC<BulkActionProps> = ({
                 after={placeAfter}
             >
                 <Property id={getId(name, "name")} name={"name"} value={name} />
-                <Property id={getId(name, "element")} name={"element"} value={element} />
+                {element ? (
+                    <Property id={getId(name, "element")} name={"element"} value={element} />
+                ) : null}
             </Property>
         </Property>
     );

--- a/packages/app-page-builder/src/admin/config/pages/list/Browser/BulkAction.tsx
+++ b/packages/app-page-builder/src/admin/config/pages/list/Browser/BulkAction.tsx
@@ -14,7 +14,7 @@ export interface BulkActionProps {
     remove?: boolean;
     before?: string;
     after?: string;
-    element: React.ReactElement;
+    element?: React.ReactElement;
 }
 
 export const BaseBulkAction: React.FC<BulkActionProps> = ({
@@ -40,7 +40,9 @@ export const BaseBulkAction: React.FC<BulkActionProps> = ({
                 after={placeAfter}
             >
                 <Property id={getId(name, "name")} name={"name"} value={name} />
-                <Property id={getId(name, "element")} name={"element"} value={element} />
+                {element ? (
+                    <Property id={getId(name, "element")} name={"element"} value={element} />
+                ) : null}
             </Property>
         </Property>
     );


### PR DESCRIPTION
## Changes
With this PR, we fix the `<BulkAction>` configuration property by making the `element` prop optional and allowing developers to define:

```
<ContentEntryListConfig>
  <Browser.BulkAction name={"delete"} remove />
</ContentEntryListConfig>
```
## How Has This Been Tested?
Manually


