### PR TITLE
fix: optimize block variables and lexical state updates

### DIFF
--- a/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariableSettings.tsx
+++ b/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariableSettings.tsx
@@ -25,7 +25,7 @@ const VariableSettings = ({ element }: { element: PbEditorElement }) => {
             (variable: PbBlockVariable) => variable.id.split(".")[0] === element?.data?.variableId
         );
 
-        return variables;
+        return variables ?? [];
     }, [block, element]);
 
     const onChange = useCallback(
@@ -67,7 +67,8 @@ const VariableSettings = ({ element }: { element: PbEditorElement }) => {
         () =>
             showConfirmation(() => {
                 if (block && block.id) {
-                    const updatedVariables = block.data.variables.filter(
+                    const variables = block.data.variables ?? [];
+                    const updatedVariables = variables.filter(
                         (variable: PbBlockVariable) =>
                             variable.id.split(".")[0] !== element?.data?.variableId
                     );
@@ -99,7 +100,7 @@ const VariableSettings = ({ element }: { element: PbEditorElement }) => {
     return (
         <>
             <FormWrapper>
-                {elementVariables?.map((variable: PbBlockVariable, index: string) => (
+                {elementVariables.map((variable, index) => (
                     <TextInput
                         key={index}
                         label={`${capitalize(variable.type)} ${capitalize(

--- a/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariablesList.tsx
+++ b/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/VariablesList.tsx
@@ -143,7 +143,8 @@ const VariablesList = ({ block }: { block: PbEditorElement }) => {
             showConfirmation(async () => {
                 if (block && block.id) {
                     // remove variable from block
-                    const updatedVariables = block.data.variables.filter(
+                    const variables = block.data.variables ?? [];
+                    const updatedVariables = variables.filter(
                         (variable: PbBlockVariable) => variable.id !== variableId
                     );
                     updateElement({

--- a/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/variablesListHooks.ts
+++ b/packages/app-page-builder/src/blockEditor/components/elementSettingsTab/variablesListHooks.ts
@@ -9,7 +9,7 @@ interface UseMoveVariable {
 export const useMoveVariable = (element: PbEditorElement): UseMoveVariable => {
     const updateElement = useUpdateElement();
     const move = (current: number, next: number) => {
-        const reorderedVariables = moveInPlace(element?.data?.variables, current, next);
+        const reorderedVariables = moveInPlace(element?.data?.variables ?? [], current, next);
 
         updateElement({
             ...element,

--- a/packages/app-page-builder/src/editor/hooks/useElementVariableValue.ts
+++ b/packages/app-page-builder/src/editor/hooks/useElementVariableValue.ts
@@ -22,7 +22,7 @@ export function useElementVariables(element: PbEditorElement | null) {
         }
     }, [block, element]);
 
-    return variableValue;
+    return variableValue ?? [];
 }
 
 export function useElementVariableValue(element: PbEditorElement | null) {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/delete/DeleteAction.ts
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/delete/DeleteAction.ts
@@ -9,7 +9,9 @@ import { useUpdateElement } from "~/editor/hooks/useUpdateElement";
 import { useParentBlock } from "~/editor/hooks/useParentBlock";
 
 const removeVariableFromBlock = (block: PbEditorElement, variableId: string) => {
-    const updatedVariables = block.data.variables.filter(
+    const variables = block.data.variables ?? [];
+
+    const updatedVariables = variables.filter(
         (variable: PbBlockVariable) => variable.id.split(".")[0] !== variableId
     );
 

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/variable/VariableSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/variable/VariableSettings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { css } from "emotion";
 import { plugins } from "@webiny/plugins";
 import { useActiveElement } from "~/editor/hooks/useActiveElement";
@@ -21,21 +21,41 @@ const labelStyle = css({
 const VariableSettings: React.FC = () => {
     const [element] = useActiveElement();
 
-    const elementVariableRendererPlugins =
-        plugins.byType<PbEditorPageElementVariableRendererPlugin>(
+    const variableRenderers = useMemo(() => {
+        return plugins.byType<PbEditorPageElementVariableRendererPlugin>(
             "pb-editor-page-element-variable-renderer"
         );
+    }, []);
+
+    const renderVariableInput = useCallback(
+        (variable: PbBlockVariable) => {
+            const renderer = variableRenderers.find(plugin => plugin.elementType === variable.type);
+            if (!renderer) {
+                return null;
+            }
+            return renderer.renderVariableInput(variable.id);
+        },
+        [variableRenderers]
+    );
+
+    if (!element) {
+        return null;
+    }
+
+    const variables = element.data.variables;
+
+    if (!variables) {
+        return null;
+    }
 
     return (
         <div className={wrapperStyle}>
-            {element?.data?.variables?.map((variable: PbBlockVariable, index: number) => (
+            {variables.map((variable, index) => (
                 <div key={index}>
                     <div className={labelStyle}>
                         <Typography use={"body2"}>{variable.label}</Typography>
                     </div>
-                    {elementVariableRendererPlugins
-                        .find(plugin => plugin.elementType === variable?.type)
-                        ?.renderVariableInput(variable.id)}
+                    {renderVariableInput(variable)}
                 </div>
             ))}
         </div>

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/heading/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/heading/index.tsx
@@ -10,7 +10,7 @@ export default {
     elementType: "heading",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/icon/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/icon/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "icon",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return <IconVariableInput variableId={variableId} />;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/image/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/image/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "image",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return <SingleImageVariableInput variableId={variableId} />;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/images-list/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/images-list/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "images-list",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return <MultipleImageVariableInput variableId={variableId} />;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/list/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/list/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "list",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return <RichVariableInput variableId={variableId} />;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/paragraph/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/paragraph/index.tsx
@@ -10,7 +10,11 @@ export default {
     elementType: "paragraph",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        if (!variables) {
+            return null;
+        }
+
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/basic/quote/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/basic/quote/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "quote",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return <RichVariableInput variableId={variableId} />;

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/code/codesandbox/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/code/codesandbox/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "codesandbox",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/iframe/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/iframe/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "iframe",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/soundcloud/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/soundcloud/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "soundcloud",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/vimeo/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/vimeo/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "vimeo",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/youtube/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/embeds/youtube/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "youtube",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/social/pinterest/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/social/pinterest/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "pinterest",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/editor/plugins/elementVariables/social/twitter/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementVariables/social/twitter/index.tsx
@@ -9,7 +9,7 @@ export default {
     elementType: "twitter",
     getVariableValue(element) {
         const variables = useElementVariables(element);
-        return variables?.length > 0 ? variables[0].value : null;
+        return variables.length > 0 ? variables[0].value : null;
     },
     renderVariableInput(variableId: string) {
         return (

--- a/packages/app-page-builder/src/hooks/useVariable.ts
+++ b/packages/app-page-builder/src/hooks/useVariable.ts
@@ -1,44 +1,53 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useUpdateElement } from "~/editor/hooks/useUpdateElement";
 import { useActiveElement } from "~/editor/hooks/useActiveElement";
 import { PbBlockVariable } from "~/types";
 
 export function useVariable<TValue = any>(variableId: string) {
     const [element] = useActiveElement();
+    const elementRef = useRef(element);
     const updateElement = useUpdateElement();
     const variable = element?.data?.variables?.find(
         (variable: PbBlockVariable) => variable.id === variableId
     );
 
+    // We're storing a reference to an element, so we don't have to recreate the `onChange` callback on every update.
+    useEffect(() => {
+        elementRef.current = element;
+    }, [element]);
+
     const onChange = useCallback(
         (value: TValue, history = false) => {
-            if (element) {
-                const newVariables = element?.data?.variables?.map((variable: PbBlockVariable) => {
-                    if (variable?.id === variableId) {
-                        return {
-                            ...variable,
-                            value
-                        };
-                    }
-
-                    return variable;
-                });
-
-                updateElement(
-                    {
-                        ...element,
-                        data: {
-                            ...element.data,
-                            variables: newVariables
-                        }
-                    },
-                    {
-                        history
-                    }
-                );
+            const element = elementRef.current;
+            if (!element) {
+                return;
             }
+
+            const newVariables = element.data.variables?.map(variable => {
+                if (variable?.id === variableId) {
+                    return {
+                        ...variable,
+                        value
+                    };
+                }
+
+                return variable;
+            });
+
+            updateElement(
+                {
+                    ...element,
+                    data: {
+                        ...element.data,
+                        variables: newVariables
+                    }
+                },
+                {
+                    history
+                }
+            );
         },
-        [element, variableId, updateElement]
+        [variableId, updateElement]
     );
 
     const onBlur = useCallback(() => {

--- a/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
+++ b/packages/app-page-builder/src/pageEditor/config/eventActions/saveRevision/saveRevisionAction.ts
@@ -32,10 +32,11 @@ const syncTemplateVariables = (content: PbElement) => {
     const templateVariables = [];
 
     for (const block of content.elements) {
-        if (block.data.variables?.length > 0) {
+        const variables = block.data.variables ?? [];
+        if (variables.length > 0) {
             templateVariables.push({
                 blockId: block.data.templateBlockId,
-                variables: block.data.variables
+                variables: variables
             });
         }
     }
@@ -50,7 +51,7 @@ const removeTemplateBlockIds = (content: PbElement) => {
         // we need to drop templateBlockId property, when block is no longer inside template
         // we also remove variables from unlinked blocks, since they don't need them outside template
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { templateBlockId, variables, ...blockData } = block.data;
+        const { templateBlockId, variables = [], ...blockData } = block.data;
         if (block.data.blockId) {
             return {
                 ...block,

--- a/packages/app-page-builder/src/pageEditor/plugins/elementSettings/UnlinkBlockAction.ts
+++ b/packages/app-page-builder/src/pageEditor/plugins/elementSettings/UnlinkBlockAction.ts
@@ -18,7 +18,7 @@ const UnlinkBlockAction: React.FC<UnlinkBlockActionPropsType> = ({ children }) =
         if (element) {
             // we need to drop blockId and variables properties when unlinking, so they are separated from all other element data
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { blockId, variables, ...newData } = element.data;
+            const { blockId, variables = [], ...newData } = element.data;
             const pbElement = (await getElementTree({
                 element: { ...element, data: newData }
             })) as PbElement;

--- a/packages/app-page-builder/src/templateEditor/plugins/elementSettings/UnlinkBlockAction.ts
+++ b/packages/app-page-builder/src/templateEditor/plugins/elementSettings/UnlinkBlockAction.ts
@@ -18,7 +18,7 @@ const UnlinkBlockAction: React.FC<UnlinkBlockActionPropsType> = ({ children }) =
         if (element) {
             // we need to drop blockId and variables properties when unlinking, so they are separated from all other element data
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { blockId, variables, ...newData } = element.data;
+            const { blockId, variables = [], ...newData } = element.data;
             const pbElement = (await getElementTree({
                 element: { ...element, data: newData }
             })) as PbElement;

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -177,6 +177,7 @@ export interface PbElementDataTypeSource {
 
 export type PbElementDataType = {
     blockId?: string;
+    variables?: PbBlockVariable[];
     action?: {
         href: string;
         newTab: boolean;

--- a/packages/lexical-editor-pb-element/src/LexicalEditor.tsx
+++ b/packages/lexical-editor-pb-element/src/LexicalEditor.tsx
@@ -1,8 +1,7 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { HeadingEditor, ParagraphEditor } from "@webiny/lexical-editor";
 import { LexicalValue } from "@webiny/lexical-editor/types";
 import { isHeadingTag } from "~/utils/isHeadingTag";
-import { isParagraphTag } from "~/utils/isParagraphTag";
 import { usePageElements } from "@webiny/app-page-builder-elements";
 import { assignStyles } from "@webiny/app-page-builder-elements/utils";
 
@@ -18,36 +17,38 @@ interface LexicalEditorProps {
 
 export const LexicalEditor: React.FC<LexicalEditorProps> = ({ tag, value, onChange, ...rest }) => {
     const { theme } = usePageElements();
+
+    const isHeading = useMemo(() => isHeadingTag(tag), [tag]);
+
+    const themeStylesTransformer = useCallback(
+        styles => {
+            return assignStyles({
+                breakpoints: theme.breakpoints,
+                styles
+            });
+        },
+        [theme]
+    );
+
     return (
         <>
-            {isHeadingTag(tag) && (
+            {isHeading ? (
                 <HeadingEditor
                     theme={theme}
-                    themeStylesTransformer={styles => {
-                        return assignStyles({
-                            breakpoints: theme.breakpoints,
-                            styles
-                        });
-                    }}
+                    themeStylesTransformer={themeStylesTransformer}
+                    value={value}
+                    onChange={onChange}
+                    {...rest}
+                />
+            ) : (
+                <ParagraphEditor
+                    theme={theme}
+                    themeStylesTransformer={themeStylesTransformer}
                     value={value}
                     onChange={onChange}
                     {...rest}
                 />
             )}
-            {isParagraphTag(tag) ? (
-                <ParagraphEditor
-                    theme={theme}
-                    themeStylesTransformer={styles => {
-                        return assignStyles({
-                            breakpoints: theme.breakpoints,
-                            styles
-                        });
-                    }}
-                    value={value}
-                    onChange={onChange}
-                    {...rest}
-                />
-            ) : null}
         </>
     );
 };

--- a/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/LexicalVariableInputPlugin.tsx
+++ b/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/LexicalVariableInputPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { ReactComponent as ExpandIcon } from "@material-design-icons/svg/filled/fullscreen.svg";
 import { Dialog, DialogActions, DialogContent } from "@webiny/ui/Dialog";
 import { ButtonPrimary, IconButton } from "@webiny/ui/Button";
@@ -66,44 +66,40 @@ export const LexicalVariableInputPlugin: React.FC<LexicalVariableInputPlugin> = 
         }
     }, [value]);
 
-    const onInputChange = (data: LexicalValue) => {
+    const onInputChange = useCallback((data: LexicalValue) => {
         onChange(data, true);
-    };
+    }, []);
 
-    const onDialogOpenClick = () => {
+    const onDialogOpenClick = useCallback(() => {
         setDialogEditorValue(initialValue);
         setIsDialogOpen(true);
-    };
+    }, [initialValue]);
 
-    const onDialogOpenedEvent = () => {
+    const onDialogOpenedEvent = useCallback(() => {
         setDialogInputFocused(true);
-    };
+    }, []);
 
-    const onDialogClose = () => {
+    const onDialogClose = useCallback(() => {
         setIsDialogOpen(false);
         setDialogInputFocused(false);
-    };
+    }, []);
 
-    const onDialogSave = () => {
+    const onDialogSave = useCallback(() => {
         onChange(dialogEditorValue, true);
         setIsDialogOpen(false);
         setDialogInputFocused(false);
-    };
+    }, [dialogEditorValue]);
 
     return (
         <InputWrapper>
             <IconButton icon={<ExpandIcon />} onClick={onDialogOpenClick} />
             <EditorWrapper className="webiny-pb-page-element-text">
-                <LexicalEditor
-                    tag={tag}
-                    value={initialValue}
-                    onChange={data => onInputChange(data)}
-                />
+                <LexicalEditor tag={tag} value={initialValue} onChange={onInputChange} />
             </EditorWrapper>
             <Dialog
                 onOpened={onDialogOpenedEvent}
                 open={isDialogOpen}
-                onClose={() => onDialogClose()}
+                onClose={onDialogClose}
                 preventOutsideDismiss={false}
             >
                 <DialogContent>
@@ -111,7 +107,7 @@ export const LexicalVariableInputPlugin: React.FC<LexicalVariableInputPlugin> = 
                         <LexicalEditor
                             tag={tag}
                             value={initialValue}
-                            onChange={data => setDialogEditorValue(data)}
+                            onChange={setDialogEditorValue}
                             focus={dialogInputFocused}
                             height="100%"
                         />

--- a/packages/lexical-editor/src/components/Editor/HeadingEditor.tsx
+++ b/packages/lexical-editor/src/components/Editor/HeadingEditor.tsx
@@ -6,6 +6,8 @@ interface HeadingEditorProps extends RichTextEditorProps {
     tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 }
 
+const styles = { padding: 5 };
+
 export const HeadingEditor: React.FC<HeadingEditorProps> = ({ tag, placeholder, ...rest }) => {
     return (
         <RichTextEditor
@@ -13,7 +15,7 @@ export const HeadingEditor: React.FC<HeadingEditorProps> = ({ tag, placeholder, 
             tag={tag ?? "h1"}
             placeholder={placeholder ?? "Enter your heading text here..."}
             {...rest}
-            styles={{ padding: 5 }}
+            styles={styles}
         >
             {rest?.children}
         </RichTextEditor>

--- a/packages/lexical-editor/src/components/Editor/ParagraphEditor.tsx
+++ b/packages/lexical-editor/src/components/Editor/ParagraphEditor.tsx
@@ -6,6 +6,8 @@ interface ParagraphLexicalEditorProps extends RichTextEditorProps {
     tag?: "p";
 }
 
+const styles = { padding: 5 };
+
 const ParagraphEditor: React.FC<ParagraphLexicalEditorProps> = ({ placeholder, tag, ...rest }) => {
     return (
         <RichTextEditor
@@ -13,7 +15,7 @@ const ParagraphEditor: React.FC<ParagraphLexicalEditorProps> = ({ placeholder, t
             tag={tag ?? "p"}
             placeholder={placeholder ?? "Enter your text here..."}
             {...rest}
-            styles={{ padding: 5 }}
+            styles={styles}
         >
             {rest?.children}
         </RichTextEditor>

--- a/packages/lexical-editor/src/utils/generateInitialLexicalValue.ts
+++ b/packages/lexical-editor/src/utils/generateInitialLexicalValue.ts
@@ -1,27 +1,29 @@
 import { LexicalValue } from "~/types";
 
+const defaultLexicalValue = JSON.stringify({
+    root: {
+        children: [
+            {
+                children: [],
+                direction: null,
+                format: "",
+                indent: 0,
+                styles: [],
+                type: "paragraph-element",
+                version: 1
+            }
+        ],
+        direction: null,
+        format: "",
+        indent: 0,
+        type: "root",
+        version: 1
+    }
+});
+
 /**
  * @description Basic JSON data string that will initialize the editor.
  */
 export const generateInitialLexicalValue = (): LexicalValue => {
-    return JSON.stringify({
-        root: {
-            children: [
-                {
-                    children: [],
-                    direction: null,
-                    format: "",
-                    indent: 0,
-                    styles: [],
-                    type: "paragraph-element",
-                    version: 1
-                }
-            ],
-            direction: null,
-            format: "",
-            indent: 0,
-            type: "root",
-            version: 1
-        }
-    });
+    return defaultLexicalValue;
 };

--- a/packages/lexical-editor/src/utils/isValidLexicalData.ts
+++ b/packages/lexical-editor/src/utils/isValidLexicalData.ts
@@ -1,18 +1,29 @@
-import { isValidJSON } from "~/utils/isValidJSON";
+import { SerializedEditorState } from "lexical";
 import { LexicalValue } from "~/types";
-/*
- * @description Checks for valid lexical data.
- *
- * Check for first level of properties that empty editor state data need to have.
- * @see generateInitialLexicalValue
- */
+
+export const parseLexicalState = (
+    editorStateValue: LexicalValue | null
+): false | SerializedEditorState => {
+    if (!editorStateValue) {
+        return false;
+    }
+    try {
+        const maybeValidState = JSON.parse(editorStateValue);
+        return maybeValidState["root"] ? maybeValidState : false;
+    } catch {
+        return false;
+    }
+};
+
 export const isValidLexicalData = (editorStateValue: LexicalValue | null): boolean => {
     if (!editorStateValue) {
         return false;
     }
-    if (!isValidJSON(editorStateValue)) {
+
+    try {
+        const data = JSON.parse(editorStateValue);
+        return !!data["root"];
+    } catch {
         return false;
     }
-    const data = JSON.parse(editorStateValue);
-    return !!data["root"];
 };


### PR DESCRIPTION
## Changes
This PR fixes an issue in Lexical state updates, when many instances of the editor are present in the view at the same time. 
I also optimized handling of block variables overall, by adding better memoization to reduce callback recreation on variable value updates.

## How Has This Been Tested?
Manually, in a page with content rich blocks, with many instances of Lexical.