### PR TITLE
fix(app-page-builder): separate state observers for better performance

### DIFF
--- a/packages/api-page-builder-import-export/src/import/process/blocks/blocksHandler.ts
+++ b/packages/api-page-builder-import-export/src/import/process/blocks/blocksHandler.ts
@@ -97,7 +97,7 @@ export const blocksHandler = async (
         });
         prevStatusOfSubTask = subTask.status;
     } catch (e) {
-        log("[IMPORT_BLOCKS_PROCESS] Error => ", e.message);
+        log("[IMPORT_BLOCKS_PROCESS] Error => ", e.message, e.data);
 
         if (subTask && subTask.id) {
             /**

--- a/packages/api-page-builder-import-export/src/import/process/blocks/blocksHandler.ts
+++ b/packages/api-page-builder-import-export/src/import/process/blocks/blocksHandler.ts
@@ -97,7 +97,11 @@ export const blocksHandler = async (
         });
         prevStatusOfSubTask = subTask.status;
     } catch (e) {
-        log("[IMPORT_BLOCKS_PROCESS] Error => ", e.message, e.data);
+        console.error(
+            "[IMPORT_BLOCKS_PROCESS] Error => ",
+            e.message,
+            JSON.stringify(e.data, null, 2)
+        );
 
         if (subTask && subTask.id) {
             /**

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/BlocksRepository.ts
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/BlocksRepository.ts
@@ -106,7 +106,7 @@ export class BlocksRepository {
         const decompressed = this.decompressPageBlock(pageBlock);
 
         runInAction(() => {
-            this.pageBlocks.push(decompressed);
+            this.pageBlocks = [...this.pageBlocks, decompressed];
         });
 
         this.createBlockPlugin(decompressed);

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/usePageBlocks.ts
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/usePageBlocks.ts
@@ -20,17 +20,25 @@ export function usePageBlocks() {
 
     useEffect(() => {
         blocksRepository.listPageBlocks();
+    }, [blocksRepository]);
 
-        autorun(() => {
+    useEffect(() => {
+        return autorun(() => {
             const loading = blocksRepository.getLoading();
 
-            setVm({
-                pageBlocks: blocksRepository.getPageBlocks().map(pageBlock => {
-                    return structuredClone(pageBlock);
-                }),
+            setVm(vm => ({
+                ...vm,
                 loading: loading.isLoading,
                 loadingLabel: loading.loadingLabel
-            });
+            }));
+        });
+    }, [blocksRepository]);
+
+    useEffect(() => {
+        return autorun(() => {
+            const pageBlocks = blocksRepository.getPageBlocks();
+
+            setVm(vm => ({ ...vm, pageBlocks }));
         });
     }, [blocksRepository]);
 

--- a/packages/app-page-builder/src/admin/views/PageBlocks/PageBlocksDataList.tsx
+++ b/packages/app-page-builder/src/admin/views/PageBlocks/PageBlocksDataList.tsx
@@ -34,16 +34,16 @@ const List = styled("div")`
 `;
 
 const ListItem = styled.div`
-  position: relative;
-  border: 1px solid rgba(212, 212, 212, 0.5);
-  box-shadow: 0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%),
-  0px 1px 3px 0px rgb(0 0 0 / 12%);
-  min-height: 70px;
-  padding: 15px;
-  margin-bottom: 10px;
-  :last-of-type {
-    margin-bottom: 0;
-  }
+    position: relative;
+    border: 1px solid rgba(212, 212, 212, 0.5);
+    box-shadow: 0px 2px 1px -1px rgb(0 0 0 / 20%), 0px 1px 1px 0px rgb(0 0 0 / 14%),
+        0px 1px 3px 0px rgb(0 0 0 / 12%);
+    min-height: 70px;
+    padding: 15px;
+    margin-bottom: 10px;
+    :last-of-type {
+        margin-bottom: 0;
+    }
 `;
 
 const ListItemText = styled("div")({


### PR DESCRIPTION
## Changes
This PR separates observers into 2 `useEffect` hooks, to optimize switches between loading states. We don't want to update state with page blocks if they didn't change, and this makes a major impact on performance. Loading transitions are now instant, and page blocks only update when they've actually changed.

## How Has This Been Tested?
Manually.
