### PR TITLE
FLP - Take `withoutAuthorization` Into Consideration When Checking For FLP

### DIFF
--- a/apps/api/pageBuilder/import/process/src/index.ts
+++ b/apps/api/pageBuilder/import/process/src/index.ts
@@ -54,7 +54,7 @@ export const handler = createHandler({
                 locale
             };
         }),
-        createAco(),
+        createAco({ useFolderLevelPermissions: false }),
         createFileManagerContext({
             storageOperations: createFileManagerStorageOperations({ documentClient })
         }),

--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -97,7 +97,8 @@ const setupAcoContext = async (context: AcoContext): Promise<void> => {
             });
         },
         canUseTeams: () => context.wcp.canUseTeams(),
-        canUseFolderLevelPermissions: () => context.wcp.canUseFolderLevelPermissions()
+        canUseFolderLevelPermissions: () => context.wcp.canUseFolderLevelPermissions(),
+        isAuthorizationEnabled: () => context.security.isAuthorizationEnabled()
     });
 
     const params: CreateAcoParams = {

--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -180,7 +180,7 @@ const setupAcoContext = async (
     }
 };
 
-export const createAcoContext = (params: CreateAcoContextParams) => {
+export const createAcoContext = (params: CreateAcoContextParams = {}) => {
     const plugin = new ContextPlugin<AcoContext>(async context => {
         /**
          * We can skip the ACO initialization if the installation is pending.

--- a/packages/api-aco/src/index.ts
+++ b/packages/api-aco/src/index.ts
@@ -12,6 +12,6 @@ export interface CreateAcoParams {
     useFolderLevelPermissions?: boolean;
 }
 
-export const createAco = (params: CreateAcoParams = {}) => {
+export const createAco = (params: CreateAcoParams) => {
     return [...createFields(), createAcoContext(params), ...createAcoGraphQL()];
 };

--- a/packages/api-aco/src/index.ts
+++ b/packages/api-aco/src/index.ts
@@ -8,6 +8,10 @@ export { FILTER_MODEL_ID } from "./filter/filter.model";
 export * from "./apps";
 export * from "./plugins";
 
-export const createAco = () => {
-    return [...createFields(), createAcoContext(), ...createAcoGraphQL()];
+export interface CreateAcoParams {
+    useFolderLevelPermissions?: boolean;
+}
+
+export const createAco = (params: CreateAcoParams = {}) => {
+    return [...createFields(), createAcoContext(params), ...createAcoGraphQL()];
 };

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -71,7 +71,16 @@ export class FolderLevelPermissions {
         this.listAllFoldersCallback = params.listAllFolders;
         this.canUseTeams = params.canUseTeams;
         this.canUseFolderLevelPermissions = params.canUseFolderLevelPermissions;
+
         this.isAuthorizationEnabled = params.isAuthorizationEnabled;
+
+        // TODO: resolve this issue.
+        // We immediately enable authorization, because, at the moment, the rest of the system
+        // requires us to have FLP always enabled. We must now disable it, even if the security's
+        // `isAuthorizationEnabled` is set to false. To resolve this, we'll need to refactor CMS-based
+        // CRUD files and have them use CMS storage operations instead of CMS CRUD methods.
+        // We'll be handling this in the near future.
+        this.isAuthorizationEnabled = () => true;
     }
 
     async listAllFolders(folderType: string): Promise<Folder[]> {

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -351,8 +351,12 @@ export class FolderLevelPermissions {
     }
 
     canManageFolderPermissions(folder: Folder) {
-        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
+        if (!this.canUseFolderLevelPermissions()) {
             return false;
+        }
+
+        if (!this.isAuthorizationEnabled()) {
+            return true;
         }
 
         return this.canAccessFolder({ folder, rwd: "w", managePermissions: true });

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -51,6 +51,7 @@ export interface FolderLevelPermissionsParams {
     listAllFolders: (folderType: string) => Promise<Folder[]>;
     canUseTeams: () => boolean;
     canUseFolderLevelPermissions: () => boolean;
+    isAuthorizationEnabled: () => boolean;
 }
 
 export class FolderLevelPermissions {
@@ -60,6 +61,7 @@ export class FolderLevelPermissions {
     private readonly listAllFoldersCallback: (folderType: string) => Promise<Folder[]>;
     private readonly canUseTeams: () => boolean;
     private readonly canUseFolderLevelPermissions: () => boolean;
+    private readonly isAuthorizationEnabled: () => boolean;
     private allFolders: Record<string, Folder[]> = {};
 
     constructor(params: FolderLevelPermissionsParams) {
@@ -69,6 +71,7 @@ export class FolderLevelPermissions {
         this.listAllFoldersCallback = params.listAllFolders;
         this.canUseTeams = params.canUseTeams;
         this.canUseFolderLevelPermissions = params.canUseFolderLevelPermissions;
+        this.isAuthorizationEnabled = params.isAuthorizationEnabled;
     }
 
     async listAllFolders(folderType: string): Promise<Folder[]> {
@@ -107,7 +110,7 @@ export class FolderLevelPermissions {
     async listFoldersPermissions(
         params: ListFolderPermissionsParams
     ): Promise<FolderPermissionsList> {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return [];
         }
 
@@ -275,7 +278,7 @@ export class FolderLevelPermissions {
     }
 
     async canAccessFolder(params: CanAccessFolderParams) {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return true;
         }
 
@@ -339,7 +342,7 @@ export class FolderLevelPermissions {
     }
 
     canManageFolderPermissions(folder: Folder) {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return false;
         }
 
@@ -347,7 +350,7 @@ export class FolderLevelPermissions {
     }
 
     canManageFolderStructure(folder: Folder) {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return true;
         }
 
@@ -355,7 +358,7 @@ export class FolderLevelPermissions {
     }
 
     canManageFolderContent(folder: Folder) {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return true;
         }
 
@@ -363,7 +366,7 @@ export class FolderLevelPermissions {
     }
 
     async canAccessFolderContent(params: CanAccessFolderContentParams) {
-        if (!this.canUseFolderLevelPermissions()) {
+        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
             return true;
         }
 

--- a/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/uploadAssets.ts
@@ -74,6 +74,9 @@ export const uploadAssets = async (params: UploadAssetsParams) => {
         const newFile: FileInput = {
             ...toImport,
             id,
+            location: {
+                folderId: "root"
+            },
             key: newKey,
             meta: { ...toImport.meta, originalKey: toImport.key }
         };


### PR DESCRIPTION
## Changes
This PR initially started by having the main FLP be aware of the Security's `isAuthorizationEnabled` flag. But that revealed some other problems with FM/CMS, and then we decided not to do this change. But we'll want to tackle this ASAP.

With this, in order to tackle the issue with the PB/Import Lambda function being blocked by FLP, we've added a way to disable FLP within that Lambda function. Once we resolve the discovered issue, we'll remove this functionality as it'll no longer be needed.

## How Has This Been Tested?
Manually.

## Documentation
N/A
