### PR TITLE
Fix `WEBINY_ELASTICSEARCH_INDEX_LOCALE` Environment Variable Check

### DIFF
--- a/packages/cli/utils/loadEnvVariables.js
+++ b/packages/cli/utils/loadEnvVariables.js
@@ -48,6 +48,7 @@ if (project.config.featureFlags) {
 // With 5.38.0, we are hiding the `WEBINY_ELASTICSEARCH_INDEX_LOCALE` env variable and always setting it to `true`.
 // This is because this variable is not something users should be concerned with, nor should they be able to change it.
 // In order to ensure backwards compatibility, we first check if the variable is set, and if it is, we don't override it.
-if (!"WEBINY_ELASTICSEARCH_INDEX_LOCALE" in process.env) {
+const esIndexLocaleEnvVarExists = "WEBINY_ELASTICSEARCH_INDEX_LOCALE" in process.env;
+if (!esIndexLocaleEnvVarExists) {
     process.env.WEBINY_ELASTICSEARCH_INDEX_LOCALE = "true";
 }


### PR DESCRIPTION
## Changes
This PR fixes the `WEBINY_ELASTICSEARCH_INDEX_LOCALE` env var check.

## How Has This Been Tested?
Manually on an existing project.

## Documentation
N/A