### PR TITLE
feat(project-utils): automatically refresh index on bulk operations in tests

### DIFF
--- a/packages/api-aco-so-ddb-es/__tests__/handler/index.ts
+++ b/packages/api-aco-so-ddb-es/__tests__/handler/index.ts
@@ -103,13 +103,6 @@ export const useGraphQlHandler = (params: UseGQLHandlerParams = {}) => {
         return index;
     };
 
-    const refreshIndex = (model: Pick<CmsModel, "tenant" | "locale" | "modelId">) => {
-        const index = createIndexName(model);
-        return elasticsearch.indices.refresh({
-            index
-        });
-    };
-
     const handler = createHandler({
         plugins: [
             createGzipCompression(),
@@ -133,10 +126,9 @@ export const useGraphQlHandler = (params: UseGQLHandlerParams = {}) => {
             }),
             new ContextPlugin<CmsContext>(async context => {
                 context.cms.onEntryBeforeCreate.subscribe(async ({ model }) => {
-                    elasticsearch.indices.registerIndex(createIndexName(model));
-                });
-                context.cms.onEntryAfterCreate.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
+                    elasticsearch.indices.create({
+                        index: createIndexName(model)
+                    });
                 });
             }),
             createHeadlessCmsGraphQL(),

--- a/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
+++ b/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
@@ -36,12 +36,6 @@ module.exports = () => {
             return index;
         };
 
-        const refreshIndex = model => {
-            const index = createIndexName(model);
-            return elasticsearchClient.indices.refresh({
-                index
-            });
-        };
         /**
          * We need to create model index before entry create because of the direct storage operations tests.
          * When running direct storage ops tests, index is created on the fly otherwise and then it is not cleaned up afterwards.
@@ -65,40 +59,7 @@ module.exports = () => {
                                 ...baseIndexConfigurationPlugin.body
                             }
                         });
-                        await refreshIndex(model);
-                    } catch (ex) {
-                        // This is commented out to prevent noise in the console.
-                        // process.stdout.write(
-                        //     `\nCould not create index "${index}" on before entry create: ${ex.message}\n`
-                        // );
-                    }
-                });
-                context.cms.onEntryAfterCreate.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterUpdate.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterMove.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryRevisionAfterCreate.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterPublish.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterRepublish.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterUnpublish.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryRevisionAfterDelete.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
-                });
-                context.cms.onEntryAfterDelete.subscribe(async ({ model }) => {
-                    await refreshIndex(model);
+                    } catch (ex) {}
                 });
             });
         });

--- a/packages/api-page-builder-aco/__tests__/utils/useGraphQlHandler.ts
+++ b/packages/api-page-builder-aco/__tests__/utils/useGraphQlHandler.ts
@@ -10,11 +10,11 @@ import { createTenancyAndSecurity } from "./tenancySecurity";
 import {
     CREATE_PAGE,
     DELETE_PAGE,
+    GET_PAGE,
+    LIST_PAGES,
     PUBLISH_PAGE,
     UNPUBLISH_PAGE,
-    UPDATE_PAGE,
-    GET_PAGE,
-    LIST_PAGES
+    UPDATE_PAGE
 } from "~tests/graphql/page.gql";
 import { CREATE_CATEGORY } from "~tests/graphql/categories.gql";
 
@@ -42,6 +42,7 @@ import { DecryptedWcpProjectLicense } from "@webiny/wcp/types";
 import createAdminUsersApp from "@webiny/api-admin-users";
 import { createTestWcpLicense } from "~tests/utils/createTestWcpLicense";
 import { createWcpContext } from "@webiny/api-wcp";
+import { AdminUsersStorageOperations } from "@webiny/api-admin-users/types";
 
 export interface UseGQLHandlerParams {
     permissions?: SecurityPermission[];
@@ -72,7 +73,7 @@ export const useGraphQlHandler = (params: UseGQLHandlerParams = {}) => {
     const i18nStorage = getStorageOps<any[]>("i18n");
     const pageBuilderStorage = getStorageOps<PageBuilderStorageOperations>("pageBuilder");
     const cmsStorage = getStorageOps<HeadlessCmsStorageOperations>("cms");
-    const adminUsersStorage = getStorageOps<HeadlessCmsStorageOperations>("adminUsers");
+    const adminUsersStorage = getStorageOps<AdminUsersStorageOperations>("adminUsers");
 
     const testProjectLicense = params.testProjectLicense || createTestWcpLicense();
 

--- a/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
+++ b/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
@@ -38,8 +38,6 @@ import elasticsearchClientContextPlugin, {
 // @ts-ignore
 import { simulateStream } from "@webiny/project-utils/testing/dynamodb";
 import { configurations } from "~/configurations";
-import { createContextPlugin } from "@webiny/handler";
-import { PbContext } from "@webiny/api-page-builder/graphql/types";
 import { createAco } from "@webiny/api-aco";
 import { createAcoPageBuilderContext } from "@webiny/api-page-builder-aco";
 import { createHeadlessCmsContext, createHeadlessCmsGraphQL } from "@webiny/api-headless-cms";
@@ -99,18 +97,6 @@ export const useHandler = (params: Params) => {
         return index;
     };
 
-    const refreshIndex = async (): Promise<void> => {
-        const index = getPageBuilderIndexName();
-
-        try {
-            await elasticsearch.indices.refresh({ index });
-        } catch (ex) {
-            console.log(`Could not reindex elasticsearch index: ${index}`);
-            console.log(ex.message);
-            console.log(JSON.stringify(ex));
-        }
-    };
-
     /**
      *
      * Intercept DocumentClient operations and trigger dynamoToElastic function (almost like a DynamoDB Stream trigger)
@@ -167,26 +153,6 @@ export const useHandler = (params: Params) => {
                         process: "process"
                     }
                 }
-            }),
-            createContextPlugin<PbContext>(async context => {
-                context.pageBuilder.onPageAfterCreate.subscribe(async () => {
-                    return refreshIndex();
-                });
-                context.pageBuilder.onPageAfterCreateFrom.subscribe(async () => {
-                    return refreshIndex();
-                });
-                context.pageBuilder.onPageAfterUpdate.subscribe(async () => {
-                    return refreshIndex();
-                });
-                context.pageBuilder.onPageAfterDelete.subscribe(async () => {
-                    return refreshIndex();
-                });
-                context.pageBuilder.onPageAfterPublish.subscribe(async () => {
-                    return refreshIndex();
-                });
-                context.pageBuilder.onPageAfterUnpublish.subscribe(async () => {
-                    return refreshIndex();
-                });
             }),
             ...(params.plugins || [])
         ]

--- a/packages/project-utils/testing/elasticsearch/createClient.js
+++ b/packages/project-utils/testing/elasticsearch/createClient.js
@@ -179,6 +179,13 @@ const attachCustomEvents = client => {
 
     client.indices.registerIndex = registerIndex;
 
+    const bulk = client.bulk;
+    client.bulk = async (...params) => {
+        const result = await bulk.apply(client, params);
+        await client.indices.refreshAll();
+        return result;
+    };
+
     return client;
 };
 


### PR DESCRIPTION
## Changes
Remove refreshIndex in ddb-es package tests and add logic to support indexing just before searching in some index or when deleting records from index.

## How Has This Been Tested?
Jest.