### PR TITLE
fix(api-security): use AsyncLocalStorage in withoutAuthorization

### DIFF
--- a/.adiorc.js
+++ b/.adiorc.js
@@ -1,4 +1,4 @@
-const get = require("lodash.get");
+const get = require("lodash/get");
 const getWorkspaces = require("get-yarn-workspaces");
 const path = require("path");
 
@@ -22,23 +22,24 @@ module.exports = {
     },
     ignore: {
         src: [
-            "http",
-            "path",
-            "https",
-            "follow-redirects",
-            "child_process",
-            "os",
+            "~tests",
+            "~",
+            "async_hooks",
+            "aws-sdk",
             "buffer",
+            "child_process",
+            "crypto",
+            "events",
+            "follow-redirects",
             "fs",
+            "http",
+            "https",
+            "os",
+            "path",
             "readline",
             "util",
-            "events",
-            "crypto",
-            "aws-sdk",
             "url",
-            "worker_threads",
-            "~tests",
-            "~"
+            "worker_threads"
         ],
         dependencies: [
             "@babel/runtime",

--- a/packages/api-security/__tests__/graphql/parallelQueries.ts
+++ b/packages/api-security/__tests__/graphql/parallelQueries.ts
@@ -1,0 +1,49 @@
+import { GraphQLSchemaPlugin } from "@webiny/handler-graphql";
+import { SecurityContext } from "~/types";
+
+export const PARALLEL_QUERY = /* GraphQL */ `
+    query ParallelQueries {
+        withoutAuthorization
+        withAuthorization
+        security {
+            listApiKeys {
+                data {
+                    id
+                    token
+                }
+                error {
+                    code
+                }
+            }
+        }
+    }
+`;
+
+export const withoutAuthorizationPlugin = new GraphQLSchemaPlugin<SecurityContext>({
+    typeDefs: /* GraphQL*/ `
+        extend type Query {
+            withoutAuthorization: String!
+            withAuthorization: String!
+        }
+    `,
+    resolvers: {
+        Query: {
+            withoutAuthorization(_, args, context) {
+                return context.security.withoutAuthorization(async () => {
+                    const permissions = await context.security.getPermissions("security.apiKey");
+                    if (!permissions.length) {
+                        return "NOT_AUTHORIZED";
+                    }
+                    return "YOUR DATA!";
+                });
+            },
+            async withAuthorization(_, args, context) {
+                const permissions = await context.security.getPermissions("security.apiKey");
+                if (!permissions.length) {
+                    return "NOT_AUTHORIZED";
+                }
+                return "AUTHORIZED";
+            }
+        }
+    }
+});

--- a/packages/api-security/__tests__/parallelQueries.test.ts
+++ b/packages/api-security/__tests__/parallelQueries.test.ts
@@ -1,0 +1,31 @@
+import useGqlHandler from "./useGqlHandler";
+import { PARALLEL_QUERY, withoutAuthorizationPlugin } from "./graphql/parallelQueries";
+
+describe("Security Parallel Queries", () => {
+    const { install, invoke } = useGqlHandler({ plugins: [withoutAuthorizationPlugin] });
+
+    beforeEach(async () => {
+        await install.install();
+    });
+
+    test("should not disable authorization in parallel queries", async () => {
+        const [response] = await invoke({
+            body: { query: PARALLEL_QUERY },
+            // We want to simulate an anonymous user.
+            headers: { authorization: "anonymous" }
+        });
+
+        expect(response.data).toEqual({
+            withoutAuthorization: "YOUR DATA!",
+            withAuthorization: "NOT_AUTHORIZED",
+            security: {
+                listApiKeys: {
+                    data: null,
+                    error: {
+                        code: "SECURITY_NOT_AUTHORIZED"
+                    }
+                }
+            }
+        });
+    });
+});

--- a/packages/api-security/__tests__/withoutAuthorization.test.ts
+++ b/packages/api-security/__tests__/withoutAuthorization.test.ts
@@ -11,7 +11,9 @@ describe("without authorization", function () {
         advancedAccessControlLayer: {
             enabled: true,
             options: {
-                teams: false
+                teams: false,
+                folderLevelPermissions: false,
+                privateFiles: false
             }
         },
         storageOperations: {} as any,
@@ -24,7 +26,7 @@ describe("without authorization", function () {
         security = await createSecurity(config);
     });
 
-    it("should disable authorization inside the withoutAuthorization method", async () => {
+    it(`should disable authorization inside "withoutAuthorization" execution scope`, async () => {
         /**
          * Should not return permission as user does not have it (not defined in this case)
          */
@@ -47,74 +49,29 @@ describe("without authorization", function () {
         expect(noPermissionCheckAfterWithoutAuthorization).toEqual(null);
     });
 
-    it("should not enable authorization if it was disabled before the withoutAuthorization method", async () => {
-        security.disableAuthorization();
-        /**
-         * Should have full permission as we are disabling authorization.
-         */
-        const noPermissionCheck = await security.getPermission("some-unknown-permission");
-        expect(noPermissionCheck).toEqual(fullPermissions);
-        /**
-         * Should return full permission as we are disabling authorization.
-         */
-        const result = await security.withoutAuthorization(async () => {
-            return security.getPermission("some-unknown-permission");
-        });
-
-        expect(result).toEqual(fullPermissions);
-        /**
-         * Should have full permission as the authorization is not still enabled.
-         */
-        const hasPermissionsCheckAfterWithoutAuthorization = await security.getPermission(
-            "some-unknown-permission"
-        );
-        expect(hasPermissionsCheckAfterWithoutAuthorization).toEqual(fullPermissions);
-        security.enableAuthorization();
-        /**
-         * Should not have permission again.
-         */
-        const noPermissionCheckAfterEnabling = await security.getPermission(
-            "some-unknown-permission"
-        );
-        expect(noPermissionCheckAfterEnabling).toEqual(null);
-    });
-
-    it("should enable authorization if there is an exception in the function - previously enabled authorization", async () => {
+    it("should re-enable authorization if callback throws an error", async () => {
         let error: Error | null = null;
         let result: any = null;
+        let authorizationWithinCallback = null;
+
         const noPermissionCheck = await security.getPermission("some-unknown-permission");
         expect(noPermissionCheck).toEqual(null);
+
         try {
             result = await security.withoutAuthorization(async () => {
+                authorizationWithinCallback = security.isAuthorizationEnabled();
                 throw new Error("Some error");
             });
         } catch (ex) {
             error = ex;
         }
+
         expect(result).toBeNull();
         expect(error?.message).toEqual("Some error");
+        expect(authorizationWithinCallback).toBe(false);
+        expect(security.isAuthorizationEnabled()).toBe(true);
 
         const stillNoPermissionCheck = await security.getPermission("some-unknown-permission");
         expect(stillNoPermissionCheck).toEqual(null);
-    });
-
-    it("should not enable authorization if there is an exception in the function - previously disabled authorization", async () => {
-        let error: Error | null = null;
-        let result: any = null;
-        security.disableAuthorization();
-        const hasPermissionCheck = await security.getPermission("some-unknown-permission");
-        expect(hasPermissionCheck).toEqual(fullPermissions);
-        try {
-            result = await security.withoutAuthorization(async () => {
-                throw new Error("Some error");
-            });
-        } catch (ex) {
-            error = ex;
-        }
-        expect(result).toBeNull();
-        expect(error?.message).toEqual("Some error");
-
-        const stillHasPermissionCheck = await security.getPermission("some-unknown-permission");
-        expect(stillHasPermissionCheck).toEqual(fullPermissions);
     });
 });

--- a/packages/api-security/src/types.ts
+++ b/packages/api-security/src/types.ts
@@ -90,22 +90,6 @@ export interface Security<TIdentity = SecurityIdentity> extends Authentication<T
 
     withoutAuthorization<T = any>(cb: () => Promise<T>): Promise<T>;
 
-    /**
-     * Replace in favor of withoutAuthorization.
-     *
-     * If really required, should be used carefully.
-     * @deprecated
-     */
-    enableAuthorization(): void;
-
-    /**
-     * Replace in favor of withoutAuthorization.
-     *
-     * If really required, should be used carefully.
-     * @deprecated
-     */
-    disableAuthorization(): void;
-
     addAuthorizer(authorizer: Authorizer): void;
 
     getAuthorizers(): Authorizer[];

--- a/packages/project-utils/testing/presets/index.js
+++ b/packages/project-utils/testing/presets/index.js
@@ -5,7 +5,7 @@ const loadJsonFile = require("load-json-file");
 
 const getAllPackages = targetKeywords => {
     const yargs = require("yargs");
-    const { storage } = yargs.argv;
+    const { storage = "ddb" } = yargs.argv;
 
     if (!storage) {
         throw Error(`Missing required --storage parameter!`);


### PR DESCRIPTION
## Changes
This PR fixes a security issue with parallel graphql selection processing, where one selection would disable authorization checks for all parallel GraphQL selection paths, if it ran a `security.withoutAuthorization(...)` call.

## Details
One of our community members discovered an interesting issue when running GraphQL queries which contain multiple selections. When GraphQL is executing a query, multiple selection paths are executed in parallel, and if one of those resolvers runs into a `security.withoutAuthorization()` method call, the authorization will also be disabled for all parallel executions, for the duration of the provided callback. This means that the data fetching logic is affected, and the resolver might return data which should otherwise not be returned.

## The Solution
The solution uses the async context tracking feature of Nodejs: https://nodejs.org/api/async_context.html#class-asynclocalstorage. This makes it possible for us to track the state of authorization on the execution context level, and not the entire request. So now, even if one part of the code execution temporarily disables authorization, all parallel execution paths would still have the authorization enabled.

## Does this affect me? Should I worry?
This issue has a limited impact. You still need to be logged into the system to be able to run such a query. This behavior CANNOT be exploited by anonymous API calls. 

## How Has This Been Tested?
Jest tests and manually.
