### PR TITLE
feat: add bulk edit to File Manager

### DIFF
--- a/apps/api/graphql/src/index.ts
+++ b/apps/api/graphql/src/index.ts
@@ -113,55 +113,6 @@ export const handler = createHandler({
             });
 
             modifier.addField({
-                id: "customLabel",
-                fieldId: "customLabel",
-                label: "Custom Label",
-                type: "text",
-                renderer: {
-                    name: "text-input"
-                },
-                bulkEdit: true
-            });
-
-            modifier.addField({
-                id: "article",
-                fieldId: "article",
-                label: "Article",
-                type: "ref",
-                renderer: {
-                    name: "ref-inputs"
-                },
-                multipleValues: true,
-                settings: {
-                    models: [
-                        {
-                            modelId: "article"
-                        }
-                    ]
-                },
-                bulkEdit: true
-            });
-
-            modifier.addField({
-                id: "demo",
-                fieldId: "demo",
-                label: "Demo content model",
-                type: "ref",
-                renderer: {
-                    name: "ref-simple-multiple"
-                },
-                multipleValues: true,
-                settings: {
-                    models: [
-                        {
-                            modelId: "demo"
-                        }
-                    ]
-                },
-                bulkEdit: true
-            });
-
-            modifier.addField({
                 id: "year",
                 fieldId: "year",
                 label: "Year of manufacturing",

--- a/apps/api/graphql/src/index.ts
+++ b/apps/api/graphql/src/index.ts
@@ -108,7 +108,27 @@ export const handler = createHandler({
                 type: "text",
                 renderer: {
                     name: "text-input"
-                }
+                },
+                bulkEdit: true
+            });
+
+            modifier.addField({
+                id: "article",
+                fieldId: "article",
+                label: "Article",
+                type: "ref",
+                renderer: {
+                    name: "ref-inputs"
+                },
+                multipleValues: true,
+                settings: {
+                    models: [
+                        {
+                            modelId: "article"
+                        }
+                    ]
+                },
+                bulkEdit: true
             });
 
             modifier.addField({

--- a/apps/api/graphql/src/index.ts
+++ b/apps/api/graphql/src/index.ts
@@ -113,6 +113,17 @@ export const handler = createHandler({
             });
 
             modifier.addField({
+                id: "customLabel",
+                fieldId: "customLabel",
+                label: "Custom Label",
+                type: "text",
+                renderer: {
+                    name: "text-input"
+                },
+                bulkEdit: true
+            });
+
+            modifier.addField({
                 id: "article",
                 fieldId: "article",
                 label: "Article",
@@ -125,6 +136,25 @@ export const handler = createHandler({
                     models: [
                         {
                             modelId: "article"
+                        }
+                    ]
+                },
+                bulkEdit: true
+            });
+
+            modifier.addField({
+                id: "demo",
+                fieldId: "demo",
+                label: "Demo content model",
+                type: "ref",
+                renderer: {
+                    name: "ref-simple-multiple"
+                },
+                multipleValues: true,
+                settings: {
+                    models: [
+                        {
+                            modelId: "demo"
                         }
                     ]
                 },

--- a/packages/api-file-manager/src/modelModifier/CmsModelModifier.ts
+++ b/packages/api-file-manager/src/modelModifier/CmsModelModifier.ts
@@ -4,7 +4,7 @@ import { FILE_MODEL_ID } from "~/cmsFileStorage/file.model";
 import { createModelField } from "~/cmsFileStorage/createModelField";
 import { CmsPrivateModelFull } from "@webiny/api-headless-cms";
 
-type CmsModelField = Omit<BaseModelField, "storageId">;
+type CmsModelField = Omit<BaseModelField, "storageId"> & { bulkEdit?: boolean };
 
 class CmsModelFieldsModifier {
     private fields: BaseModelField[];
@@ -14,8 +14,11 @@ class CmsModelFieldsModifier {
     }
 
     addField(field: CmsModelField) {
+        const { bulkEdit, tags, ...rest } = field;
+
         this.fields.push({
-            ...field,
+            ...rest,
+            tags: (tags ?? []).concat(bulkEdit ? ["field:bulk-edit"] : []),
             storageId: `${field.type}@${field.id}`
         });
     }

--- a/packages/api-file-manager/src/modelModifier/CmsModelModifier.ts
+++ b/packages/api-file-manager/src/modelModifier/CmsModelModifier.ts
@@ -18,7 +18,7 @@ class CmsModelFieldsModifier {
 
         this.fields.push({
             ...rest,
-            tags: (tags ?? []).concat(bulkEdit ? ["field:bulk-edit"] : []),
+            tags: (tags ?? []).concat(bulkEdit ? ["$bulk-edit"] : []),
             storageId: `${field.type}@${field.id}`
         });
     }

--- a/packages/app-file-manager/jest.config.js
+++ b/packages/app-file-manager/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/app-file-manager/package.json
+++ b/packages/app-file-manager/package.json
@@ -52,7 +52,8 @@
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "17.0.2",
     "react-hotkeyz": "^1.0.4",
-    "react-lazy-load": "^3.1.14"
+    "react-lazy-load": "^3.1.14",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
@@ -15,8 +15,12 @@ export const DialogContainer = styled(Dialog)`
     }
 `;
 
+export const BatchEditorContainer = styled.div`
+    padding: 24px;
+`;
+
 export const AddOperationInner = styled.div`
-    padding: 0 0 24px;
+    padding: 24px 0 0;
     text-align: center;
 `;
 

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { ReactComponent as AddIcon } from "@material-design-icons/svg/round/add.svg";
 import { Dialog } from "@webiny/ui/Dialog";
 
-export const ActionEditFormContainer = styled("div")`
+export const ActionEditFormContainer = styled.div`
     margin: -24px !important;
 `;
 
@@ -15,21 +15,18 @@ export const DialogContainer = styled(Dialog)`
     }
 `;
 
-export const BatchEditorContainer = styled.div`
-    padding: 24px;
-`;
-
 export const AddOperationInner = styled.div`
-    padding: 24px 0 0;
+    padding: 0 0 24px;
     text-align: center;
 `;
 
-export const ButtonIcon = styled(AddIcon)`
-    fill: var(--mdc-theme-primary);
+interface ButtonIconProps {
+    disabled?: boolean;
+}
+
+export const ButtonIcon = styled(AddIcon)<ButtonIconProps>`
+    fill: ${props =>
+        props.disabled ? "var(--mdc-theme-text-hint-on-light)" : "var(--mdc-theme-primary)"};
     width: 18px;
     margin-right: 8px;
-`;
-
-export const AccordionItemInner = styled.div`
-    position: relative;
 `;

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.styled.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+import { ReactComponent as AddIcon } from "@material-design-icons/svg/round/add.svg";
+import { Dialog } from "@webiny/ui/Dialog";
+
+export const ActionEditFormContainer = styled("div")`
+    margin: -24px !important;
+`;
+
+export const DialogContainer = styled(Dialog)`
+    z-index: 22;
+
+    .mdc-dialog__surface {
+        width: 800px;
+        min-width: 800px;
+    }
+`;
+
+export const BatchEditorContainer = styled.div`
+    padding: 24px;
+`;
+
+export const AddOperationInner = styled.div`
+    padding: 24px 0 0;
+    text-align: center;
+`;
+
+export const ButtonIcon = styled(AddIcon)`
+    fill: var(--mdc-theme-primary);
+    width: 18px;
+    margin-right: 8px;
+`;
+
+export const AccordionItemInner = styled.div`
+    position: relative;
+`;

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import { ReactComponent as EditIcon } from "@material-design-icons/svg/outlined/edit.svg";
+import { prepareFormData } from "@webiny/app-headless-cms-common";
 import { observer } from "mobx-react-lite";
 import omit from "lodash/omit";
 
@@ -7,14 +8,13 @@ import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManager
 import { useFileManagerApi } from "~/modules/FileManagerApiProvider/FileManagerApiContext";
 import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerViewProvider";
 
-import { BatchEditorDialog } from "./BatchEditorDialog";
-import { ActionEditPresenter } from "./ActionEditPresenter";
-
 import { useFileModel } from "~/hooks/useFileModel";
 import { getFilesLabel } from "~/components/BulkActions";
 import { GraphQLInputMapper } from "~/components/BulkActions/ActionEdit/GraphQLInputMapper";
 import { BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
-import { prepareFormData } from "@webiny/app-headless-cms-common";
+
+import { BatchEditorDialog } from "./BatchEditorDialog";
+import { ActionEditPresenter } from "./ActionEditPresenter";
 
 export const ActionEdit = observer(() => {
     const { fields: defaultFields } = useFileModel();
@@ -53,6 +53,8 @@ export const ActionEdit = observer(() => {
         );
     }, [defaultFields]);
 
+    console.log("fields", fields);
+
     const canEditAll = useMemo(() => {
         return worker.items.every(item => canEdit(item));
     }, [worker.items]);
@@ -73,8 +75,6 @@ export const ActionEdit = observer(() => {
                             item.extensions,
                             batch
                         );
-
-                        console.log("extensionsData", extensionsData);
 
                         const output = omit(item, ["id", "createdBy", "createdOn", "src"]);
 

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.tsx
@@ -1,0 +1,144 @@
+import React, { useCallback, useMemo } from "react";
+import { ReactComponent as EditIcon } from "@material-design-icons/svg/outlined/edit.svg";
+import { observer } from "mobx-react-lite";
+import omit from "lodash/omit";
+
+import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig";
+import { useFileManagerApi } from "~/modules/FileManagerApiProvider/FileManagerApiContext";
+import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerViewProvider";
+
+import { BatchEditorDialog } from "./BatchEditorDialog";
+import { ActionEditPresenter } from "./ActionEditPresenter";
+
+import { useFileModel } from "~/hooks/useFileModel";
+import { getFilesLabel } from "~/components/BulkActions";
+import { GraphQLInputMapper } from "~/components/BulkActions/ActionEdit/GraphQLInputMapper";
+import { BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { prepareFormData } from "@webiny/app-headless-cms-common";
+
+export const ActionEdit = observer(() => {
+    const { fields: defaultFields } = useFileModel();
+    const {
+        useWorker,
+        useButtons,
+        useDialog: useBulkActionDialog
+    } = FileManagerViewConfig.Browser.BulkAction;
+
+    const worker = useWorker();
+
+    const presenter = useMemo<ActionEditPresenter>(() => {
+        return new ActionEditPresenter();
+    }, []);
+
+    const { updateFile } = useFileManagerView();
+    const { canEdit } = useFileManagerApi();
+    const { IconButton } = useButtons();
+    const { showConfirmationDialog, showResultsDialog } = useBulkActionDialog();
+
+    const filesLabel = useMemo(() => {
+        return getFilesLabel(worker.items.length);
+    }, [worker.items.length]);
+
+    const fields = useMemo(() => {
+        const extensions = defaultFields.find(field => field.fieldId === "extensions");
+
+        if (!extensions?.settings?.fields) {
+            return [];
+        }
+
+        return (
+            extensions.settings.fields.filter(
+                field => field.tags && field.tags.includes("field:bulk-edit")
+            ) || []
+        );
+    }, [defaultFields]);
+
+    const canEditAll = useMemo(() => {
+        return worker.items.every(item => canEdit(item));
+    }, [worker.items]);
+
+    const openWorkerDialog = (batch: BatchDTO) => {
+        showConfirmationDialog({
+            title: "Edit files",
+            message: `You are about to edit ${filesLabel}. Are you sure you want to continue?`,
+            loadingLabel: `Processing ${filesLabel}`,
+            execute: async () => {
+                await worker.processInSeries(async ({ item, report }) => {
+                    try {
+                        const extensions = defaultFields.find(
+                            field => field.fieldId === "extensions"
+                        );
+
+                        const extensionsData = GraphQLInputMapper.toGraphQLExtensions(
+                            item.extensions,
+                            batch
+                        );
+
+                        console.log("extensionsData", extensionsData);
+
+                        const output = omit(item, ["id", "createdBy", "createdOn", "src"]);
+
+                        const fileData = {
+                            ...output,
+                            extensions: prepareFormData(
+                                extensionsData,
+                                extensions?.settings?.fields || []
+                            )
+                        };
+
+                        await updateFile(item.id, fileData);
+
+                        report.success({
+                            title: `${item.name}`,
+                            message: "File successfully edited."
+                        });
+                    } catch (e) {
+                        report.error({
+                            title: `${item.name}`,
+                            message: e.message
+                        });
+                    }
+                });
+
+                worker.resetItems();
+
+                showResultsDialog({
+                    results: worker.results,
+                    title: "Edit files",
+                    message: "Finished editing files! See full report below:"
+                });
+            }
+        });
+    };
+
+    const onBatchEditorSubmit = useCallback(
+        (batch: BatchDTO) => {
+            presenter.closeEditor();
+            openWorkerDialog(batch);
+        },
+        [openWorkerDialog]
+    );
+
+    if (!canEditAll) {
+        console.log("You don't have permissions to edit files.");
+        return null;
+    }
+
+    return (
+        <>
+            <IconButton
+                icon={<EditIcon />}
+                onAction={() => presenter.openEditor()}
+                label={`Edit ${filesLabel}`}
+                tooltipPlacement={"bottom"}
+            />
+            <BatchEditorDialog
+                onClose={() => presenter.closeEditor()}
+                fields={fields}
+                batch={presenter.vm.currentBatch}
+                vm={presenter.vm.editorVm}
+                onApply={onBatchEditorSubmit}
+            />
+        </>
+    );
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.types.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEdit.types.ts
@@ -1,0 +1,3 @@
+import { FileItem } from "@webiny/app-admin/types";
+
+export type ActionFormData = Partial<Omit<FileItem, "id">>;

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.test.ts
@@ -1,0 +1,187 @@
+import { ActionEditPresenter } from "./ActionEditPresenter";
+import { FieldRaw } from "~/components/BulkActions/ActionEdit/domain";
+
+describe("ActionEditPresenter", () => {
+    const extensionFields = [
+        {
+            id: "field1",
+            fieldId: "field1",
+            label: "Field 1",
+            type: "text",
+            renderer: {
+                name: "text-input"
+            },
+            tags: ["field:bulk-edit"],
+            storageId: "text@field1"
+        },
+        {
+            id: "field2",
+            fieldId: "field2",
+            label: "Field 2",
+            type: "ref",
+            renderer: {
+                name: "ref-inputs"
+            },
+            multipleValues: true,
+            settings: {
+                models: [
+                    {
+                        modelId: "any-model"
+                    }
+                ]
+            },
+            tags: ["field:bulk-edit"],
+            storageId: "ref@field2"
+        },
+        {
+            id: "field3",
+            fieldId: "field3",
+            label: "Field 3",
+            type: "number",
+            renderer: {
+                name: "number-input"
+            },
+            tags: [],
+            storageId: "number@field3"
+        }
+    ];
+
+    const createFields = (extensionFields: FieldRaw[]) => {
+        return [
+            {
+                id: "name",
+                storageId: "text@name",
+                fieldId: "name",
+                label: "Name",
+                type: "text",
+                settings: {},
+                listValidation: [],
+                validation: [
+                    {
+                        name: "required",
+                        message: "Value is required."
+                    }
+                ],
+                multipleValues: false,
+                predefinedValues: {
+                    values: [],
+                    enabled: false
+                },
+                renderer: {
+                    name: "text-input"
+                }
+            },
+            {
+                id: "extensions",
+                storageId: "object@extensions",
+                fieldId: "extensions",
+                label: "Extensions",
+                type: "object",
+                settings: {
+                    layout: extensionFields.map(field => [field.id]),
+                    fields: extensionFields
+                },
+                listValidation: [],
+                validation: [],
+                multipleValues: false,
+                predefinedValues: {
+                    values: [],
+                    enabled: false
+                },
+                renderer: {
+                    name: "any"
+                }
+            }
+        ];
+    };
+
+    let presenter: ActionEditPresenter;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        presenter = new ActionEditPresenter();
+    });
+
+    it("should create a presenter and load extensions fields", () => {
+        presenter.load(createFields(extensionFields));
+
+        // I should see the bulk edit action
+        expect(presenter.vm.show).toEqual(true);
+
+        // I should receive a `currentBatch`
+        expect(presenter.vm.currentBatch).toEqual({
+            operations: [
+                {
+                    field: "",
+                    operator: "",
+                    value: {}
+                }
+            ]
+        });
+
+        // I should receive the `fields` available for bulk edit
+        expect(presenter.vm.fields).toEqual([
+            {
+                label: "Field 1",
+                value: "field1",
+                operators: [
+                    {
+                        label: "Override existing values",
+                        value: "OVERRIDE"
+                    },
+                    {
+                        label: "Clear all existing values",
+                        value: "REMOVE"
+                    }
+                ],
+                raw: extensionFields[0]
+            },
+            {
+                label: "Field 2",
+                value: "field2",
+                operators: [
+                    {
+                        label: "Override existing values",
+                        value: "OVERRIDE"
+                    },
+                    {
+                        label: "Clear all existing values",
+                        value: "REMOVE"
+                    },
+                    {
+                        label: "Append to existing values",
+                        value: "APPEND"
+                    }
+                ],
+                raw: extensionFields[1]
+            }
+        ]);
+
+        // I should receive the editor.vm
+        expect(presenter.vm.editorVm).toEqual({
+            isOpen: false
+        });
+    });
+
+    it("should not show the bulk action if no `extensions` fields are defined", () => {
+        presenter.load(createFields([]));
+
+        // The editor action should not be rendered
+        expect(presenter.vm.show).toBe(false);
+    });
+
+    it("should open / close the editor", () => {
+        presenter.load(createFields(extensionFields));
+
+        // The editor should be closed by default
+        expect(presenter.vm.editorVm.isOpen).toBe(false);
+
+        // Let's open the editor
+        presenter.openEditor();
+        expect(presenter.vm.editorVm.isOpen).toBe(true);
+
+        // Let's open the editor
+        presenter.closeEditor();
+        expect(presenter.vm.editorVm.isOpen).toBe(false);
+    });
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.test.ts
@@ -11,7 +11,7 @@ describe("ActionEditPresenter", () => {
             renderer: {
                 name: "text-input"
             },
-            tags: ["field:bulk-edit"],
+            tags: ["$bulk-edit"],
             storageId: "text@field1"
         },
         {
@@ -30,7 +30,7 @@ describe("ActionEditPresenter", () => {
                     }
                 ]
             },
-            tags: ["field:bulk-edit"],
+            tags: ["$bulk-edit"],
             storageId: "ref@field2"
         },
         {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
@@ -1,0 +1,34 @@
+import { makeAutoObservable } from "mobx";
+
+import { Batch, BatchDTO, BatchMapper } from "~/components/BulkActions/ActionEdit/domain";
+
+export class ActionEditPresenter {
+    private showEditor = false;
+    private currentBatch: BatchDTO;
+
+    constructor() {
+        this.currentBatch = BatchMapper.toDTO(Batch.createEmpty());
+        makeAutoObservable(this);
+    }
+
+    private get editorVm() {
+        return {
+            isOpen: this.showEditor
+        };
+    }
+
+    get vm() {
+        return {
+            currentBatch: this.currentBatch,
+            editorVm: this.editorVm
+        };
+    }
+
+    openEditor() {
+        this.showEditor = true;
+    }
+
+    closeEditor() {
+        this.showEditor = false;
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
@@ -48,7 +48,7 @@ export class ActionEditPresenter implements IActionEditPresenter {
 
         const extensionFields =
             extensions.settings.fields.filter(
-                field => field.tags && field.tags.includes("field:bulk-edit")
+                field => field.tags && field.tags.includes("$bulk-edit")
             ) || [];
 
         return FieldMapper.toDTO(extensionFields.map(field => Field.createFromRaw(field)));

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/ActionEditPresenter.ts
@@ -10,7 +10,21 @@ import {
     FieldRaw
 } from "~/components/BulkActions/ActionEdit/domain";
 
-export class ActionEditPresenter {
+interface IActionEditPresenter {
+    load: (fields: FieldRaw[]) => void;
+    openEditor: () => void;
+    closeEditor: () => void;
+    get vm(): {
+        show: boolean;
+        currentBatch: BatchDTO;
+        fields: FieldDTO[];
+        editorVm: {
+            isOpen: boolean;
+        };
+    };
+}
+
+export class ActionEditPresenter implements IActionEditPresenter {
     private showEditor = false;
     private readonly currentBatch: BatchDTO;
     private extensionFields: FieldDTO[];

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
@@ -2,18 +2,21 @@ import React from "react";
 
 import { ButtonDefault } from "@webiny/ui/Button";
 
-import { AddOperationInner } from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
-import { ButtonIcon } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/Querybuilder.styled";
+import {
+    AddOperationInner,
+    ButtonIcon
+} from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
 
 interface AddOperationProps {
+    disabled: boolean;
     onClick: () => void;
 }
 
-export const AddOperation = ({ onClick }: AddOperationProps) => {
+export const AddOperation = ({ disabled, onClick }: AddOperationProps) => {
     return (
         <AddOperationInner>
-            <ButtonDefault onClick={onClick}>
-                <ButtonIcon /> {"Add new operation"}
+            <ButtonDefault disabled={disabled} onClick={onClick}>
+                <ButtonIcon disabled={disabled} /> {"Add new operation"}
             </ButtonDefault>
         </AddOperationInner>
     );

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
@@ -13,7 +13,7 @@ export const AddOperation = ({ onClick }: AddOperationProps) => {
     return (
         <AddOperationInner>
             <ButtonDefault onClick={onClick}>
-                <ButtonIcon /> {"Add new filter group"}
+                <ButtonIcon /> {"Add new operation"}
             </ButtonDefault>
         </AddOperationInner>
     );

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { ButtonDefault } from "@webiny/ui/Button";
+
+import { AddOperationInner } from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
+import { ButtonIcon } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/Querybuilder.styled";
+
+interface AddOperationProps {
+    onClick: () => void;
+}
+
+export const AddOperation = ({ onClick }: AddOperationProps) => {
+    return (
+        <AddOperationInner>
+            <ButtonDefault onClick={onClick}>
+                <ButtonIcon /> {"Add new filter group"}
+            </ButtonDefault>
+        </AddOperationInner>
+    );
+};

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect } from "react";
+import { observer } from "mobx-react-lite";
+
+import { AddOperation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation";
+import { ReactComponent as DeleteIcon } from "@material-design-icons/svg/outlined/delete_outline.svg";
+
+import { Operation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/Operation";
+import { Form, FormAPI, FormOnSubmit } from "@webiny/form";
+import {
+    BatchEditorDialogViewModel,
+    BatchEditorFormData
+} from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter";
+import { Accordion, AccordionItem } from "@webiny/ui/Accordion";
+import {
+    AccordionItemInner,
+    BatchEditorContainer
+} from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
+import { FilterOperationContainer } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/Querybuilder.styled";
+import { OperationSelector } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/components";
+
+export interface BatchEditorProps {
+    onForm: (form: FormAPI) => void;
+    onAdd: () => void;
+    onDelete: (operationIndex: number) => void;
+    onChange: (data: BatchEditorFormData) => void;
+    onSetOperationFieldData: (operationIndex: number, data: string) => void;
+    onSubmit: FormOnSubmit<BatchEditorFormData>;
+    vm: BatchEditorDialogViewModel;
+}
+
+export const BatchEditor = observer((props: BatchEditorProps) => {
+    const formRef = React.createRef<FormAPI>();
+
+    useEffect(() => {
+        if (formRef.current) {
+            props.onForm(formRef.current);
+        }
+    }, []);
+
+    return (
+        <Form
+            ref={formRef}
+            data={props.vm.data}
+            onChange={props.onChange}
+            onSubmit={props.onSubmit}
+        >
+            {() => (
+                <BatchEditorContainer>
+                    <Accordion elevation={1}>
+                        {props.vm.data.operations.map((operation, operationIndex) => (
+                            <AccordionItem
+                                key={`group-${operationIndex}`}
+                                title={"title"}
+                                actions={
+                                    <AccordionItem.Actions>
+                                        <AccordionItem.Action
+                                            icon={<DeleteIcon />}
+                                            onClick={() => props.onDelete(operationIndex)}
+                                            disabled={!operation.canDelete}
+                                        />
+                                    </AccordionItem.Actions>
+                                }
+                            >
+                                <Operation
+                                    key={`operation-${operationIndex}`}
+                                    name={`operations.${operationIndex}`}
+                                    operation={operation}
+                                    fields={props.vm.fields}
+                                    onSetOperationFieldData={data =>
+                                        props.onSetOperationFieldData(operationIndex, data)
+                                    }
+                                />
+                            </AccordionItem>
+                        ))}
+                    </Accordion>
+                    <AddOperation onClick={() => props.onAdd()} />
+                </BatchEditorContainer>
+            )}
+        </Form>
+    );
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from "react";
 
 import { observer } from "mobx-react-lite";
+import { ReactComponent as DeleteIcon } from "@material-design-icons/svg/outlined/delete_outline.svg";
 import { Form, FormAPI, FormOnSubmit } from "@webiny/form";
+import { Accordion, AccordionItem } from "@webiny/ui/Accordion";
 
 import { AddOperation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation";
 import { Operation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/Operation";
@@ -9,6 +11,7 @@ import {
     BatchEditorDialogViewModel,
     BatchEditorFormData
 } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter";
+import { BatchEditorContainer } from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
 
 export interface BatchEditorProps {
     onForm: (form: FormAPI) => void;
@@ -38,23 +41,39 @@ export const BatchEditor = observer((props: BatchEditorProps) => {
             invalidFields={props.vm.invalidFields}
         >
             {() => (
-                <>
-                    {props.vm.data.operations.map((operation, operationIndex) => (
-                        <Operation
-                            key={`operation-${operationIndex}`}
-                            name={`operations.${operationIndex}`}
-                            operation={operation}
-                            onDelete={() => props.onDelete(operationIndex)}
-                            onSetOperationFieldData={data =>
-                                props.onSetOperationFieldData(operationIndex, data)
-                            }
-                        />
-                    ))}
+                <BatchEditorContainer>
+                    <Accordion elevation={1}>
+                        {props.vm.data.operations.map((operation, operationIndex) => (
+                            <AccordionItem
+                                key={`operation-${operationIndex}`}
+                                title={operation.title}
+                                open={operation.open}
+                                actions={
+                                    <AccordionItem.Actions>
+                                        <AccordionItem.Action
+                                            icon={<DeleteIcon />}
+                                            onClick={() => props.onDelete(operationIndex)}
+                                            disabled={!operation.canDelete}
+                                        />
+                                    </AccordionItem.Actions>
+                                }
+                            >
+                                <Operation
+                                    name={`operations.${operationIndex}`}
+                                    operation={operation}
+                                    onDelete={() => props.onDelete(operationIndex)}
+                                    onSetOperationFieldData={data =>
+                                        props.onSetOperationFieldData(operationIndex, data)
+                                    }
+                                />
+                            </AccordionItem>
+                        ))}
+                    </Accordion>
                     <AddOperation
                         disabled={!props.vm.canAddOperation}
                         onClick={() => props.onAdd()}
                     />
-                </>
+                </BatchEditorContainer>
             )}
         </Form>
     );

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
@@ -44,14 +44,16 @@ export const BatchEditor = observer((props: BatchEditorProps) => {
                             key={`operation-${operationIndex}`}
                             name={`operations.${operationIndex}`}
                             operation={operation}
-                            fields={props.vm.fields}
                             onDelete={() => props.onDelete(operationIndex)}
                             onSetOperationFieldData={data =>
                                 props.onSetOperationFieldData(operationIndex, data)
                             }
                         />
                     ))}
-                    <AddOperation onClick={() => props.onAdd()} />
+                    <AddOperation
+                        disabled={!props.vm.canAddOperation}
+                        onClick={() => props.onAdd()}
+                    />
                 </>
             )}
         </Form>

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor.tsx
@@ -1,22 +1,14 @@
 import React, { useEffect } from "react";
+
 import { observer } from "mobx-react-lite";
+import { Form, FormAPI, FormOnSubmit } from "@webiny/form";
 
 import { AddOperation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/AddOperation";
-import { ReactComponent as DeleteIcon } from "@material-design-icons/svg/outlined/delete_outline.svg";
-
 import { Operation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/Operation";
-import { Form, FormAPI, FormOnSubmit } from "@webiny/form";
 import {
     BatchEditorDialogViewModel,
     BatchEditorFormData
 } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter";
-import { Accordion, AccordionItem } from "@webiny/ui/Accordion";
-import {
-    AccordionItemInner,
-    BatchEditorContainer
-} from "~/components/BulkActions/ActionEdit/ActionEdit.styled";
-import { FilterOperationContainer } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/Querybuilder.styled";
-import { OperationSelector } from "@webiny/app-aco/components/AdvancedSearch/QueryBuilderDrawer/QueryBuilder/components";
 
 export interface BatchEditorProps {
     onForm: (form: FormAPI) => void;
@@ -43,38 +35,24 @@ export const BatchEditor = observer((props: BatchEditorProps) => {
             data={props.vm.data}
             onChange={props.onChange}
             onSubmit={props.onSubmit}
+            invalidFields={props.vm.invalidFields}
         >
             {() => (
-                <BatchEditorContainer>
-                    <Accordion elevation={1}>
-                        {props.vm.data.operations.map((operation, operationIndex) => (
-                            <AccordionItem
-                                key={`group-${operationIndex}`}
-                                title={"title"}
-                                actions={
-                                    <AccordionItem.Actions>
-                                        <AccordionItem.Action
-                                            icon={<DeleteIcon />}
-                                            onClick={() => props.onDelete(operationIndex)}
-                                            disabled={!operation.canDelete}
-                                        />
-                                    </AccordionItem.Actions>
-                                }
-                            >
-                                <Operation
-                                    key={`operation-${operationIndex}`}
-                                    name={`operations.${operationIndex}`}
-                                    operation={operation}
-                                    fields={props.vm.fields}
-                                    onSetOperationFieldData={data =>
-                                        props.onSetOperationFieldData(operationIndex, data)
-                                    }
-                                />
-                            </AccordionItem>
-                        ))}
-                    </Accordion>
+                <>
+                    {props.vm.data.operations.map((operation, operationIndex) => (
+                        <Operation
+                            key={`operation-${operationIndex}`}
+                            name={`operations.${operationIndex}`}
+                            operation={operation}
+                            fields={props.vm.fields}
+                            onDelete={() => props.onDelete(operationIndex)}
+                            onSetOperationFieldData={data =>
+                                props.onSetOperationFieldData(operationIndex, data)
+                            }
+                        />
+                    ))}
                     <AddOperation onClick={() => props.onAdd()} />
-                </BatchEditorContainer>
+                </>
             )}
         </Form>
     );

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo, useEffect, useRef } from "react";
+import { observer } from "mobx-react-lite";
+
+import { ActionEditFormContainer, DialogContainer } from "../ActionEdit.styled";
+import { DialogActions, DialogCancel, DialogContent, DialogTitle } from "@webiny/ui/Dialog";
+import { ButtonPrimary } from "@webiny/ui/Button";
+import { FieldRaw, BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { BatchEditorDialogPresenter, BatchEditorFormData } from "./BatchEditorDialogPresenter";
+import { BatchEditor } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor";
+import { FormAPI } from "@webiny/form";
+
+interface BatchEditorDialogProps {
+    fields: FieldRaw[];
+    batch: BatchDTO;
+    vm: {
+        isOpen: boolean;
+    };
+    onApply: (batch: BatchDTO) => void;
+    onClose: () => void;
+}
+
+export const BatchEditorDialog = observer((props: BatchEditorDialogProps) => {
+    const presenter = useMemo<BatchEditorDialogPresenter>(() => {
+        return new BatchEditorDialogPresenter(props.fields);
+    }, [props.fields]);
+
+    useEffect(() => {
+        presenter.load(props.batch);
+    }, [props.batch]);
+
+    const onChange = (data: BatchEditorFormData) => {
+        presenter.setBatch(data);
+    };
+
+    const onApply = () => {
+        presenter.onApply(batch => {
+            props.onApply(batch);
+        });
+    };
+
+    const ref = useRef<FormAPI | null>(null);
+
+    return (
+        <DialogContainer open={props.vm.isOpen} onClose={props.onClose}>
+            {props.vm.isOpen ? (
+                <>
+                    <DialogTitle>{"Edit items"}</DialogTitle>
+                    <DialogContent>
+                        <ActionEditFormContainer>
+                            <BatchEditor
+                                onForm={form => (ref.current = form)}
+                                onChange={data => onChange(data)}
+                                onSubmit={onApply}
+                                onDelete={operationIndex =>
+                                    presenter.deleteOperation(operationIndex)
+                                }
+                                onAdd={() => presenter.addOperation()}
+                                onSetOperationFieldData={(operationIndex, data) =>
+                                    presenter.setOperationFieldData(operationIndex, data)
+                                }
+                                vm={presenter.vm}
+                            />
+                        </ActionEditFormContainer>
+                    </DialogContent>
+                    <DialogActions>
+                        <DialogCancel onClick={props.onClose}>{"Cancel"}</DialogCancel>
+                        <ButtonPrimary onClick={onApply}>{"Continue"}</ButtonPrimary>
+                    </DialogActions>
+                </>
+            ) : null}
+        </DialogContainer>
+    );
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
@@ -8,10 +8,10 @@ import { DialogActions, DialogCancel, DialogContent, DialogTitle } from "@webiny
 import { BatchEditorDialogPresenter, BatchEditorFormData } from "./BatchEditorDialogPresenter";
 import { BatchEditor } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor";
 import { ActionEditFormContainer, DialogContainer } from "../ActionEdit.styled";
-import { FieldRaw, BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { BatchDTO, FieldDTO } from "~/components/BulkActions/ActionEdit/domain";
 
 interface BatchEditorDialogProps {
-    fields: FieldRaw[];
+    fields: FieldDTO[];
     batch: BatchDTO;
     vm: {
         isOpen: boolean;
@@ -22,12 +22,12 @@ interface BatchEditorDialogProps {
 
 export const BatchEditorDialog = observer((props: BatchEditorDialogProps) => {
     const presenter = useMemo<BatchEditorDialogPresenter>(() => {
-        return new BatchEditorDialogPresenter(props.fields);
-    }, [props.fields]);
+        return new BatchEditorDialogPresenter();
+    }, []);
 
     useEffect(() => {
-        presenter.load(props.batch);
-    }, [props.batch]);
+        presenter.load(props.batch, props.fields);
+    }, [props.batch, props.fields]);
 
     const onChange = (data: BatchEditorFormData) => {
         presenter.setBatch(data);

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
@@ -1,13 +1,14 @@
 import React, { useMemo, useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
 
-import { ActionEditFormContainer, DialogContainer } from "../ActionEdit.styled";
-import { DialogActions, DialogCancel, DialogContent, DialogTitle } from "@webiny/ui/Dialog";
+import { observer } from "mobx-react-lite";
+import { FormAPI } from "@webiny/form";
 import { ButtonPrimary } from "@webiny/ui/Button";
-import { FieldRaw, BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { DialogActions, DialogCancel, DialogContent, DialogTitle } from "@webiny/ui/Dialog";
+
 import { BatchEditorDialogPresenter, BatchEditorFormData } from "./BatchEditorDialogPresenter";
 import { BatchEditor } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditor";
-import { FormAPI } from "@webiny/form";
+import { ActionEditFormContainer, DialogContainer } from "../ActionEdit.styled";
+import { FieldRaw, BatchDTO } from "~/components/BulkActions/ActionEdit/domain";
 
 interface BatchEditorDialogProps {
     fields: FieldRaw[];
@@ -64,7 +65,7 @@ export const BatchEditorDialog = observer((props: BatchEditorDialogProps) => {
                     </DialogContent>
                     <DialogActions>
                         <DialogCancel onClick={props.onClose}>{"Cancel"}</DialogCancel>
-                        <ButtonPrimary onClick={onApply}>{"Continue"}</ButtonPrimary>
+                        <ButtonPrimary onClick={onApply}>{"Submit"}</ButtonPrimary>
                     </DialogActions>
                 </>
             ) : null}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
@@ -34,7 +34,7 @@ describe("BatchEditorDialogPresenter", () => {
                 renderer: {
                     name: "text-input"
                 },
-                tags: ["field:bulk-edit"],
+                tags: ["$bulk-edit"],
                 storageId: "text@field1"
             }
         },
@@ -59,7 +59,7 @@ describe("BatchEditorDialogPresenter", () => {
                 renderer: {
                     name: "text-input"
                 },
-                tags: ["field:bulk-edit"],
+                tags: ["$bulk-edit"],
                 storageId: "text@field2"
             }
         }

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
@@ -79,6 +79,8 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data).toEqual({
             operations: [
                 {
+                    title: "Operation #1",
+                    open: true,
                     canDelete: false,
                     field: "",
                     operator: "",
@@ -102,6 +104,8 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations.length).toBe(1);
         expect(presenter.vm.data.operations).toEqual([
             {
+                title: "Operation #1",
+                open: true,
                 field: "",
                 operator: "",
                 value: {},
@@ -116,6 +120,8 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations.length).toBe(2);
         expect(presenter.vm.data.operations).toEqual([
             {
+                title: "Operation #1",
+                open: true,
                 field: "",
                 operator: "",
                 value: {},
@@ -123,6 +129,8 @@ describe("BatchEditorDialogPresenter", () => {
                 availableFields: fields
             },
             {
+                title: "Operation #2",
+                open: true,
                 field: "",
                 operator: "",
                 value: {},
@@ -137,6 +145,8 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations.length).toBe(1);
         expect(presenter.vm.data.operations).toEqual([
             {
+                title: "Operation #1",
+                open: true,
                 field: "",
                 operator: "",
                 value: {},
@@ -152,6 +162,8 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations.length).toBe(1);
         expect(presenter.vm.data.operations).toEqual([
             {
+                title: "Operation #1",
+                open: true,
                 field: "",
                 operator: "",
                 value: {},
@@ -168,6 +180,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Override existing values for field "${fields[0].label}"`,
+                    open: true,
                     field: fields[0].value,
                     operator: OperatorType.OVERRIDE,
                     value: {
@@ -186,6 +200,8 @@ describe("BatchEditorDialogPresenter", () => {
 
         // Only the not-set field should be available
         expect(presenter.vm.data.operations[1]).toEqual({
+            title: "Operation #2",
+            open: true,
             field: "",
             operator: "",
             value: {},
@@ -197,6 +213,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Override existing values for field "${fields[0].label}"`,
+                    open: true,
                     field: fields[0].value,
                     operator: OperatorType.OVERRIDE,
                     value: {
@@ -206,6 +224,8 @@ describe("BatchEditorDialogPresenter", () => {
                     availableFields: fields
                 },
                 {
+                    title: `Remove all values for field "${fields[1].label}"`,
+                    open: false,
                     field: fields[1].value,
                     operator: OperatorType.REMOVE,
                     value: {},
@@ -226,6 +246,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Remove all values for field "${fields[0].label}"`,
+                    open: false,
                     field: fields[0].value,
                     operator: OperatorType.OVERRIDE,
                     value: {
@@ -251,6 +273,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Override existing values for field "${fields[0].label}"`,
+                    open: true,
                     field: fields[0].value,
                     operator: OperatorType.OVERRIDE,
                     value: {
@@ -267,6 +291,8 @@ describe("BatchEditorDialogPresenter", () => {
 
         // should have an operation with default definition and new field value
         expect(presenter.vm.data.operations[0]).toEqual({
+            title: "Operation #1",
+            open: true,
             field: "new-field",
             operator: "",
             value: {},
@@ -284,6 +310,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Override existing values for field "${fields[0].label}"`,
+                    open: true,
                     field: fields[0].value,
                     operator: "", // empty value -> this should trigger the error
                     value: {},
@@ -301,6 +329,8 @@ describe("BatchEditorDialogPresenter", () => {
         presenter.setBatch({
             operations: [
                 {
+                    title: `Override existing values for field "${fields[0].label}"`,
+                    open: true,
                     field: fields[0].value,
                     operator: OperatorType.OVERRIDE,
                     value: {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
@@ -37,6 +37,31 @@ describe("BatchEditorDialogPresenter", () => {
                 tags: ["field:bulk-edit"],
                 storageId: "text@field1"
             }
+        },
+        {
+            label: "Field 2",
+            value: "field2",
+            operators: [
+                {
+                    label: "Override existing values",
+                    value: OperatorType.OVERRIDE
+                },
+                {
+                    label: "Clear all existing values",
+                    value: OperatorType.REMOVE
+                }
+            ],
+            raw: {
+                id: "field2",
+                fieldId: "field2",
+                label: "Field 1",
+                type: "text",
+                renderer: {
+                    name: "text-input"
+                },
+                tags: ["field:bulk-edit"],
+                storageId: "text@field2"
+            }
         }
     ];
 
@@ -50,9 +75,6 @@ describe("BatchEditorDialogPresenter", () => {
     it("should load data", () => {
         presenter.load(batch, fields);
 
-        // `vm` should have the expected `fields` definition
-        expect(presenter.vm.fields).toEqual(fields);
-
         // `vm` should have the expected `data` definition
         expect(presenter.vm.data).toEqual({
             operations: [
@@ -60,13 +82,17 @@ describe("BatchEditorDialogPresenter", () => {
                     canDelete: false,
                     field: "",
                     operator: "",
-                    value: {}
+                    value: {},
+                    availableFields: fields
                 }
             ]
         });
 
         // `vm` should have the expected `invalidFields` definition
         expect(presenter.vm.invalidFields).toEqual({});
+
+        // `vm` should have the expected `canAddOperation` definition
+        expect(presenter.vm.canAddOperation).toEqual(true);
     });
 
     it("should be able to add and delete operations", () => {
@@ -79,7 +105,8 @@ describe("BatchEditorDialogPresenter", () => {
                 field: "",
                 operator: "",
                 value: {},
-                canDelete: false
+                canDelete: false,
+                availableFields: fields
             }
         ]);
 
@@ -92,13 +119,15 @@ describe("BatchEditorDialogPresenter", () => {
                 field: "",
                 operator: "",
                 value: {},
-                canDelete: false
+                canDelete: false,
+                availableFields: fields
             },
             {
                 field: "",
                 operator: "",
                 value: {},
-                canDelete: true
+                canDelete: true,
+                availableFields: fields
             }
         ]);
 
@@ -111,7 +140,8 @@ describe("BatchEditorDialogPresenter", () => {
                 field: "",
                 operator: "",
                 value: {},
-                canDelete: false
+                canDelete: false,
+                availableFields: fields
             }
         ]);
 
@@ -125,9 +155,68 @@ describe("BatchEditorDialogPresenter", () => {
                 field: "",
                 operator: "",
                 value: {},
-                canDelete: false
+                canDelete: false,
+                availableFields: fields
             }
         ]);
+    });
+
+    it("should be able to handle the `availableFields` based operations set in the batch", () => {
+        presenter.load(batch, fields);
+
+        // let's set some `data` back to the operation
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        [fields[0].value]: "newValue"
+                    },
+                    canDelete: false,
+                    availableFields: fields
+                }
+            ]
+        });
+
+        // I should be able to add a new operation
+        expect(presenter.vm.canAddOperation).toBeTruthy();
+
+        presenter.addOperation();
+
+        // Only the not-set field should be available
+        expect(presenter.vm.data.operations[1]).toEqual({
+            field: "",
+            operator: "",
+            value: {},
+            canDelete: true,
+            availableFields: [fields[1]]
+        });
+
+        // let's set some `data` back to the operations
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        [fields[0].value]: "newValue"
+                    },
+                    canDelete: false,
+                    availableFields: fields
+                },
+                {
+                    field: fields[1].value,
+                    operator: OperatorType.REMOVE,
+                    value: {},
+                    canDelete: true,
+                    availableFields: [fields[1]]
+                }
+            ]
+        });
+
+        // I should NOT be able to add a new operation
+        expect(presenter.vm.canAddOperation).toBeFalsy();
     });
 
     it("should be able to set data back to the operation", () => {
@@ -142,7 +231,8 @@ describe("BatchEditorDialogPresenter", () => {
                     value: {
                         [fields[0].value]: "newValue"
                     },
-                    canDelete: false
+                    canDelete: false,
+                    availableFields: fields
                 }
             ]
         });
@@ -152,6 +242,7 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations[0].value).toEqual({
             [fields[0].value]: "newValue"
         });
+        expect(presenter.vm.data.operations[0].availableFields).toEqual(fields);
     });
 
     it("should able to set the operation `field` data", () => {
@@ -165,7 +256,8 @@ describe("BatchEditorDialogPresenter", () => {
                     value: {
                         [fields[0].value]: "newValue"
                     },
-                    canDelete: false
+                    canDelete: false,
+                    availableFields: fields
                 }
             ]
         });
@@ -178,7 +270,8 @@ describe("BatchEditorDialogPresenter", () => {
             field: "new-field",
             operator: "",
             value: {},
-            canDelete: false
+            canDelete: false,
+            availableFields: fields
         });
     });
 
@@ -194,7 +287,8 @@ describe("BatchEditorDialogPresenter", () => {
                     field: fields[0].value,
                     operator: "", // empty value -> this should trigger the error
                     value: {},
-                    canDelete: false
+                    canDelete: false,
+                    availableFields: fields
                 }
             ]
         });
@@ -212,7 +306,8 @@ describe("BatchEditorDialogPresenter", () => {
                     value: {
                         [fields[0].value]: "newValue"
                     },
-                    canDelete: false
+                    canDelete: false,
+                    availableFields: fields
                 }
             ]
         });

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
@@ -1,0 +1,225 @@
+import { BatchEditorDialogPresenter } from "./BatchEditorDialogPresenter";
+import { BatchDTO, FieldDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+
+describe("BatchEditorDialogPresenter", () => {
+    const batch: BatchDTO = {
+        operations: [
+            {
+                field: "",
+                operator: "",
+                value: {}
+            }
+        ]
+    };
+
+    const fields: FieldDTO[] = [
+        {
+            label: "Field 1",
+            value: "field1",
+            operators: [
+                {
+                    label: "Override existing values",
+                    value: OperatorType.OVERRIDE
+                },
+                {
+                    label: "Clear all existing values",
+                    value: OperatorType.REMOVE
+                }
+            ],
+            raw: {
+                id: "field1",
+                fieldId: "field1",
+                label: "Field 1",
+                type: "text",
+                renderer: {
+                    name: "text-input"
+                },
+                tags: ["field:bulk-edit"],
+                storageId: "text@field1"
+            }
+        }
+    ];
+
+    let presenter: BatchEditorDialogPresenter;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        presenter = new BatchEditorDialogPresenter();
+    });
+
+    it("should load data", () => {
+        presenter.load(batch, fields);
+
+        // `vm` should have the expected `fields` definition
+        expect(presenter.vm.fields).toEqual(fields);
+
+        // `vm` should have the expected `data` definition
+        expect(presenter.vm.data).toEqual({
+            operations: [
+                {
+                    canDelete: false,
+                    field: "",
+                    operator: "",
+                    value: {}
+                }
+            ]
+        });
+
+        // `vm` should have the expected `invalidFields` definition
+        expect(presenter.vm.invalidFields).toEqual({});
+    });
+
+    it("should be able to add and delete operations", () => {
+        presenter.load(batch, fields);
+
+        // should only have 1 operator, created by default
+        expect(presenter.vm.data.operations.length).toBe(1);
+        expect(presenter.vm.data.operations).toEqual([
+            {
+                field: "",
+                operator: "",
+                value: {},
+                canDelete: false
+            }
+        ]);
+
+        presenter.addOperation();
+
+        // should only have 2 operators
+        expect(presenter.vm.data.operations.length).toBe(2);
+        expect(presenter.vm.data.operations).toEqual([
+            {
+                field: "",
+                operator: "",
+                value: {},
+                canDelete: false
+            },
+            {
+                field: "",
+                operator: "",
+                value: {},
+                canDelete: true
+            }
+        ]);
+
+        // let's delete the first operation
+        presenter.deleteOperation(0);
+
+        expect(presenter.vm.data.operations.length).toBe(1);
+        expect(presenter.vm.data.operations).toEqual([
+            {
+                field: "",
+                operator: "",
+                value: {},
+                canDelete: false
+            }
+        ]);
+
+        // let's delete the remaining operation
+        presenter.deleteOperation(0);
+
+        // should still have 1 default operation
+        expect(presenter.vm.data.operations.length).toBe(1);
+        expect(presenter.vm.data.operations).toEqual([
+            {
+                field: "",
+                operator: "",
+                value: {},
+                canDelete: false
+            }
+        ]);
+    });
+
+    it("should be able to set data back to the operation", () => {
+        presenter.load(batch, fields);
+
+        // should be able to set the `data` operation
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        [fields[0].value]: "newValue"
+                    },
+                    canDelete: false
+                }
+            ]
+        });
+
+        expect(presenter.vm.data.operations[0].field).toEqual(fields[0].value);
+        expect(presenter.vm.data.operations[0].operator).toEqual(OperatorType.OVERRIDE);
+        expect(presenter.vm.data.operations[0].value).toEqual({
+            [fields[0].value]: "newValue"
+        });
+    });
+
+    it("should able to set the operation `field` data", () => {
+        presenter.load(batch, fields);
+
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        [fields[0].value]: "newValue"
+                    },
+                    canDelete: false
+                }
+            ]
+        });
+
+        // let's empty the operation
+        presenter.setOperationFieldData(0, "new-field");
+
+        // should have an operation with default definition and new field value
+        expect(presenter.vm.data.operations[0]).toEqual({
+            field: "new-field",
+            operator: "",
+            value: {},
+            canDelete: false
+        });
+    });
+
+    it("should perform validation and call provided callbacks `onApply`", () => {
+        presenter.load(batch, fields);
+
+        const onSuccess = jest.fn();
+        const onError = jest.fn();
+
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: "", // empty value -> this should trigger the error
+                    value: {},
+                    canDelete: false
+                }
+            ]
+        });
+
+        presenter.onApply(onSuccess, onError);
+
+        expect(onError).toBeCalledTimes(1);
+        expect(Object.keys(presenter.vm.invalidFields).length).toBe(1);
+
+        presenter.setBatch({
+            operations: [
+                {
+                    field: fields[0].value,
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        [fields[0].value]: "newValue"
+                    },
+                    canDelete: false
+                }
+            ]
+        });
+
+        presenter.onApply(onSuccess, onError);
+
+        expect(onSuccess).toBeCalledTimes(1);
+        expect(presenter.vm.invalidFields).toEqual({});
+    });
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.test.ts
@@ -1,5 +1,10 @@
 import { BatchEditorDialogPresenter } from "./BatchEditorDialogPresenter";
-import { BatchDTO, FieldDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+import {
+    BatchDTO,
+    FieldDTO,
+    OperatorDTO,
+    OperatorType
+} from "~/components/BulkActions/ActionEdit/domain";
 
 describe("BatchEditorDialogPresenter", () => {
     const batch: BatchDTO = {
@@ -65,6 +70,21 @@ describe("BatchEditorDialogPresenter", () => {
         }
     ];
 
+    const operators: OperatorDTO[] = [
+        {
+            value: OperatorType.OVERRIDE,
+            label: "Override existing values"
+        },
+        {
+            value: OperatorType.REMOVE,
+            label: "Clear all existing values"
+        },
+        {
+            value: OperatorType.APPEND,
+            label: "Append to existing values"
+        }
+    ];
+
     let presenter: BatchEditorDialogPresenter;
 
     beforeEach(() => {
@@ -85,7 +105,9 @@ describe("BatchEditorDialogPresenter", () => {
                     field: "",
                     operator: "",
                     value: {},
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [],
+                    selectedField: undefined
                 }
             ]
         });
@@ -110,7 +132,9 @@ describe("BatchEditorDialogPresenter", () => {
                 operator: "",
                 value: {},
                 canDelete: false,
-                availableFields: fields
+                fieldOptions: fields,
+                operatorOptions: [],
+                selectedField: undefined
             }
         ]);
 
@@ -126,7 +150,9 @@ describe("BatchEditorDialogPresenter", () => {
                 operator: "",
                 value: {},
                 canDelete: false,
-                availableFields: fields
+                fieldOptions: fields,
+                operatorOptions: [],
+                selectedField: undefined
             },
             {
                 title: "Operation #2",
@@ -135,7 +161,9 @@ describe("BatchEditorDialogPresenter", () => {
                 operator: "",
                 value: {},
                 canDelete: true,
-                availableFields: fields
+                fieldOptions: fields,
+                operatorOptions: [],
+                selectedField: undefined
             }
         ]);
 
@@ -151,7 +179,9 @@ describe("BatchEditorDialogPresenter", () => {
                 operator: "",
                 value: {},
                 canDelete: false,
-                availableFields: fields
+                fieldOptions: fields,
+                operatorOptions: [],
+                selectedField: undefined
             }
         ]);
 
@@ -168,12 +198,14 @@ describe("BatchEditorDialogPresenter", () => {
                 operator: "",
                 value: {},
                 canDelete: false,
-                availableFields: fields
+                fieldOptions: fields,
+                operatorOptions: [],
+                selectedField: undefined
             }
         ]);
     });
 
-    it("should be able to handle the `availableFields` based operations set in the batch", () => {
+    it("should be able to handle the `fieldOptions` based operations set in the batch", () => {
         presenter.load(batch, fields);
 
         // let's set some `data` back to the operation
@@ -188,7 +220,9 @@ describe("BatchEditorDialogPresenter", () => {
                         [fields[0].value]: "newValue"
                     },
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 }
             ]
         });
@@ -206,7 +240,9 @@ describe("BatchEditorDialogPresenter", () => {
             operator: "",
             value: {},
             canDelete: true,
-            availableFields: [fields[1]]
+            fieldOptions: [fields[1]],
+            operatorOptions: [],
+            selectedField: undefined
         });
 
         // let's set some `data` back to the operations
@@ -221,7 +257,9 @@ describe("BatchEditorDialogPresenter", () => {
                         [fields[0].value]: "newValue"
                     },
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 },
                 {
                     title: `Remove all values for field "${fields[1].label}"`,
@@ -230,7 +268,9 @@ describe("BatchEditorDialogPresenter", () => {
                     operator: OperatorType.REMOVE,
                     value: {},
                     canDelete: true,
-                    availableFields: [fields[1]]
+                    fieldOptions: [fields[1]],
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[1]
                 }
             ]
         });
@@ -254,7 +294,9 @@ describe("BatchEditorDialogPresenter", () => {
                         [fields[0].value]: "newValue"
                     },
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 }
             ]
         });
@@ -264,7 +306,7 @@ describe("BatchEditorDialogPresenter", () => {
         expect(presenter.vm.data.operations[0].value).toEqual({
             [fields[0].value]: "newValue"
         });
-        expect(presenter.vm.data.operations[0].availableFields).toEqual(fields);
+        expect(presenter.vm.data.operations[0].fieldOptions).toEqual(fields);
     });
 
     it("should able to set the operation `field` data", () => {
@@ -281,7 +323,9 @@ describe("BatchEditorDialogPresenter", () => {
                         [fields[0].value]: "newValue"
                     },
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 }
             ]
         });
@@ -297,7 +341,9 @@ describe("BatchEditorDialogPresenter", () => {
             operator: "",
             value: {},
             canDelete: false,
-            availableFields: fields
+            fieldOptions: fields,
+            operatorOptions: [],
+            selectedField: undefined
         });
     });
 
@@ -316,7 +362,9 @@ describe("BatchEditorDialogPresenter", () => {
                     operator: "", // empty value -> this should trigger the error
                     value: {},
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 }
             ]
         });
@@ -337,7 +385,9 @@ describe("BatchEditorDialogPresenter", () => {
                         [fields[0].value]: "newValue"
                     },
                     canDelete: false,
-                    availableFields: fields
+                    fieldOptions: fields,
+                    operatorOptions: [operators[0], operators[1]],
+                    selectedField: fields[0]
                 }
             ]
         });

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
@@ -1,0 +1,121 @@
+import { makeAutoObservable } from "mobx";
+
+import {
+    BatchDTO,
+    Field,
+    FieldDTO,
+    FieldMapper,
+    FieldRaw,
+    OperationDTO
+} from "~/components/BulkActions/ActionEdit/domain";
+
+export interface IBatchEditorDialogPresenter {
+    load(batch: BatchDTO): void;
+    addOperation(): void;
+    deleteOperation(operationIndex: number): void;
+    setOperationFieldData(operationIndex: number, data: string): void;
+    setBatch(data: any): void;
+    onApply(onSuccess?: (batch: BatchDTO) => void, onError?: (batch: BatchDTO) => void): void;
+}
+
+export interface BatchEditorDialogViewModel {
+    fields: FieldDTO[];
+    data: BatchEditorFormData;
+}
+
+export interface BatchEditorFormData {
+    operations: (OperationDTO & { canDelete: boolean })[];
+}
+
+export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
+    private batch: BatchDTO | undefined;
+    private readonly fields: FieldDTO[];
+
+    constructor(fields: FieldRaw[]) {
+        this.batch = undefined;
+        this.fields = FieldMapper.toDTO(fields.map(field => Field.createFromRaw(field)));
+        makeAutoObservable(this);
+    }
+
+    load(batch: BatchDTO) {
+        this.batch = batch;
+    }
+
+    get vm() {
+        return {
+            fields: this.fields,
+            data: {
+                operations:
+                    this.batch?.operations.map((operation: OperationDTO, operationIndex) => {
+                        return {
+                            field: operation.field,
+                            operator: operation.operator,
+                            value: operation.value,
+                            canDelete: operationIndex !== 0
+                        };
+                    }) || []
+            }
+        };
+    }
+
+    addOperation(): void {
+        if (!this.batch) {
+            return;
+        }
+
+        this.batch.operations.push({
+            field: "",
+            operator: "",
+            value: {}
+        });
+    }
+
+    deleteOperation(operationIndex: number): void {
+        if (!this.batch) {
+            return;
+        }
+
+        this.batch.operations = this.batch.operations.filter(
+            (_, index) => index !== operationIndex
+        );
+    }
+
+    setOperationFieldData(batchIndex: number, data: string) {
+        if (!this.batch) {
+            return;
+        }
+
+        this.batch.operations = [
+            ...this.batch.operations.slice(0, batchIndex),
+            {
+                field: data,
+                operator: "",
+                value: {}
+            },
+            ...this.batch.operations.slice(batchIndex + 1)
+        ];
+    }
+
+    setBatch(data: BatchEditorFormData): void {
+        if (!this.batch) {
+            return;
+        }
+
+        this.batch = {
+            ...this.batch,
+            operations: data.operations.map(operation => ({
+                field: operation.field,
+                operator: operation.operator,
+                value: operation.value
+            }))
+        };
+    }
+
+    onApply(onSuccess?: (batch: BatchDTO) => void, onError?: (batch: BatchDTO) => void) {
+        if (!this.batch) {
+            return;
+        }
+
+        onSuccess && onSuccess(this.batch);
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
@@ -3,15 +3,12 @@ import { makeAutoObservable } from "mobx";
 import {
     Batch,
     BatchDTO,
-    Field,
     FieldDTO,
-    FieldMapper,
-    FieldRaw,
     OperationDTO
 } from "~/components/BulkActions/ActionEdit/domain";
 
 export interface IBatchEditorDialogPresenter {
-    load(batch: BatchDTO): void;
+    load(batch: BatchDTO, fields: FieldDTO[]): void;
     addOperation(): void;
     deleteOperation(operationIndex: number): void;
     setOperationFieldData(operationIndex: number, data: string): void;
@@ -32,18 +29,19 @@ export interface BatchEditorFormData {
 
 export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
     private batch: BatchDTO | undefined;
-    private readonly fields: FieldDTO[];
+    private fields: FieldDTO[];
     private invalidFields: BatchEditorDialogViewModel["invalidFields"] = {};
     private formWasSubmitted = false;
 
-    constructor(fields: FieldRaw[]) {
+    constructor() {
         this.batch = undefined;
-        this.fields = FieldMapper.toDTO(fields.map(field => Field.createFromRaw(field)));
+        this.fields = [];
         makeAutoObservable(this);
     }
 
-    load(batch: BatchDTO) {
+    load(batch: BatchDTO, fields: FieldDTO[]) {
         this.batch = batch;
+        this.fields = fields;
     }
 
     get vm() {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
@@ -24,7 +24,12 @@ export interface BatchEditorDialogViewModel {
 }
 
 export interface BatchEditorFormData {
-    operations: (OperationDTO & { canDelete: boolean; availableFields: FieldDTO[] })[];
+    operations: (OperationDTO & {
+        canDelete: boolean;
+        availableFields: FieldDTO[];
+        title: string;
+        open: boolean;
+    })[];
 }
 
 export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
@@ -62,6 +67,10 @@ export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
         return (
             this.batch?.operations.map((operation: OperationDTO, operationIndex) => {
                 return {
+                    title:
+                        this.getOperationTitle(operation.field, operation.operator) ??
+                        `Operation #${operationIndex + 1}`,
+                    open: true,
                     field: operation.field,
                     operator: operation.operator,
                     value: operation.value,
@@ -71,6 +80,26 @@ export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
             }) || []
         );
     };
+
+    private getOperationTitle(inputField?: string, inputOperation?: string) {
+        if (!inputField || !inputOperation) {
+            return undefined;
+        }
+
+        const field = this.fields.find(field => field.value === inputField);
+
+        if (!field) {
+            return undefined;
+        }
+
+        const operator = field.operators.find(operator => operator.value === inputOperation);
+
+        if (!operator) {
+            return undefined;
+        }
+
+        return `${operator.label} for field "${field.label}"`;
+    }
 
     private getAvailableFields(currentFieldId = "") {
         if (!this.batch) {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter.tsx
@@ -82,6 +82,11 @@ export class BatchEditorDialogPresenter implements IBatchEditorDialogPresenter {
         this.batch.operations = this.batch.operations.filter(
             (_, index) => index !== operationIndex
         );
+
+        // Make sure we always have at least 1 operation!
+        if (this.batch.operations.length === 0) {
+            this.addOperation();
+        }
     }
 
     setOperationFieldData(batchIndex: number, data: string) {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { RenderFieldElement, ModelProvider } from "@webiny/app-headless-cms";
+import { Bind, Form, useBind } from "@webiny/form";
+
+import { FieldDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+import { useFileModel } from "~/hooks/useFileModel";
+
+export interface FieldRendererProps {
+    name: string;
+    operator: string;
+    field?: FieldDTO;
+}
+
+export const FieldRenderer = (props: FieldRendererProps) => {
+    const fileModel = useFileModel();
+
+    const { onChange } = useBind({
+        name: props.name
+    });
+
+    if (!props.field) {
+        return null;
+    }
+
+    if (!props.operator || props.operator === OperatorType.REMOVE) {
+        return null;
+    }
+
+    return (
+        <ModelProvider model={fileModel}>
+            <Form onChange={onChange}>
+                {() => {
+                    return (
+                        <RenderFieldElement
+                            field={props.field!.raw}
+                            Bind={Bind as any}
+                            contentModel={fileModel}
+                        />
+                    );
+                }}
+            </Form>
+        </ModelProvider>
+    );
+};

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
@@ -6,6 +6,7 @@ import { Bind, Form, useBind } from "@webiny/form";
 import { FieldDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
 
 import { useFileModel } from "~/hooks/useFileModel";
+import { Cell } from "@webiny/ui/Grid";
 
 export interface FieldRendererProps {
     name: string;
@@ -30,17 +31,19 @@ export const FieldRenderer = (props: FieldRendererProps) => {
 
     return (
         <ModelProvider model={fileModel}>
-            <Form onChange={onChange}>
-                {() => {
-                    return (
-                        <RenderFieldElement
-                            field={props.field!.raw}
-                            Bind={Bind as any}
-                            contentModel={fileModel}
-                        />
-                    );
-                }}
-            </Form>
+            <Cell span={11}>
+                <Form onChange={onChange}>
+                    {() => {
+                        return (
+                            <RenderFieldElement
+                                field={props.field!.raw}
+                                Bind={Bind as any}
+                                contentModel={fileModel}
+                            />
+                        );
+                    }}
+                </Form>
+            </Cell>
         </ModelProvider>
     );
 };

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
@@ -31,7 +31,7 @@ export const FieldRenderer = (props: FieldRendererProps) => {
 
     return (
         <ModelProvider model={fileModel}>
-            <Cell span={11}>
+            <Cell span={12}>
                 <Form onChange={onChange}>
                     {() => {
                         return (

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer.tsx
@@ -4,6 +4,7 @@ import { RenderFieldElement, ModelProvider } from "@webiny/app-headless-cms";
 import { Bind, Form, useBind } from "@webiny/form";
 
 import { FieldDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+
 import { useFileModel } from "~/hooks/useFileModel";
 
 export interface FieldRendererProps {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -5,11 +5,11 @@ import { Bind } from "@webiny/form";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Select } from "@webiny/ui/Select";
 
-import { FieldDTO, OperationDTO } from "~/components/BulkActions/ActionEdit/domain";
 import { FieldRenderer } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer";
+import { OperationFormData } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialogPresenter";
 
 export interface OperationProps {
-    operation: OperationDTO & { canDelete: boolean; availableFields: FieldDTO[] };
+    operation: OperationFormData;
     name: string;
     onDelete: () => void;
     onSetOperationFieldData: (data: string) => void;
@@ -23,7 +23,7 @@ export const Operation = observer((props: OperationProps) => {
                     {({ value, validation }) => (
                         <Select
                             label={"Field"}
-                            options={props.operation.availableFields}
+                            options={props.operation.fieldOptions}
                             value={value}
                             onChange={data => props.onSetOperationFieldData(data)}
                             validation={validation}
@@ -37,11 +37,7 @@ export const Operation = observer((props: OperationProps) => {
                         {({ value, onChange, validation }) => (
                             <Select
                                 label={"Operation"}
-                                options={
-                                    props.operation.availableFields.find(
-                                        field => field.value === props.operation.field
-                                    )?.operators || []
-                                }
+                                options={props.operation.operatorOptions}
                                 value={value}
                                 onChange={onChange}
                                 validation={validation}
@@ -52,9 +48,7 @@ export const Operation = observer((props: OperationProps) => {
             </Cell>
             <FieldRenderer
                 operator={props.operation.operator}
-                field={props.operation.availableFields.find(
-                    field => field.value === props.operation.field
-                )}
+                field={props.operation.selectedField}
                 name={`${props.name}.value`}
             />
         </Grid>

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -7,12 +7,14 @@ import { Cell, Grid } from "@webiny/ui/Grid";
 import { Select } from "@webiny/ui/Select";
 
 import { FieldDTO, OperationDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { RemoveOperation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/RemoveOperation";
 import { FieldRenderer } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer";
 
 export interface OperationProps {
     fields: FieldDTO[];
     operation: OperationDTO & { canDelete: boolean };
     name: string;
+    onDelete: () => void;
     onSetOperationFieldData: (data: string) => void;
 }
 
@@ -32,7 +34,7 @@ export const Operation = observer((props: OperationProps) => {
                     )}
                 </Bind>
             </Cell>
-            <Cell span={6}>
+            <Cell span={5}>
                 {props.operation.field && (
                     <Bind name={`${props.name}.operator`}>
                         {({ value, onChange, validation }) => (
@@ -51,7 +53,10 @@ export const Operation = observer((props: OperationProps) => {
                     </Bind>
                 )}
             </Cell>
-            <Cell span={12}>
+            <Cell span={1} align={"middle"}>
+                <RemoveOperation onClick={props.onDelete} disabled={!props.operation.canDelete} />
+            </Cell>
+            <Cell span={11}>
                 <FieldRenderer
                     operator={props.operation.operator}
                     field={props.fields.find(field => field.value === props.operation.field)}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { observer } from "mobx-react-lite";
+
+import { Bind } from "@webiny/form";
+import { Cell, Grid } from "@webiny/ui/Grid";
+import { Select } from "@webiny/ui/Select";
+
+import { FieldDTO, OperationDTO } from "~/components/BulkActions/ActionEdit/domain";
+import { FieldRenderer } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer";
+
+export interface OperationProps {
+    fields: FieldDTO[];
+    operation: OperationDTO & { canDelete: boolean };
+    name: string;
+    onSetOperationFieldData: (data: string) => void;
+}
+
+export const Operation = observer((props: OperationProps) => {
+    return (
+        <Grid>
+            <Cell span={6}>
+                <Bind name={`${props.name}.field`}>
+                    {({ value, validation }) => (
+                        <Select
+                            label={"Field"}
+                            options={props.fields}
+                            value={value}
+                            onChange={data => props.onSetOperationFieldData(data)}
+                            validation={validation}
+                        />
+                    )}
+                </Bind>
+            </Cell>
+            <Cell span={6}>
+                {props.operation.field && (
+                    <Bind name={`${props.name}.operator`}>
+                        {({ value, onChange, validation }) => (
+                            <Select
+                                label={"Operation"}
+                                options={
+                                    props.fields.find(
+                                        field => field.value === props.operation.field
+                                    )?.operators || []
+                                }
+                                value={value}
+                                onChange={onChange}
+                                validation={validation}
+                            />
+                        )}
+                    </Bind>
+                )}
+            </Cell>
+            <Cell span={12}>
+                <FieldRenderer
+                    operator={props.operation.operator}
+                    field={props.fields.find(field => field.value === props.operation.field)}
+                    name={`${props.name}.value`}
+                />
+            </Cell>
+        </Grid>
+    );
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 
 import { observer } from "mobx-react-lite";
-
 import { Bind } from "@webiny/form";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Select } from "@webiny/ui/Select";
 
 import { FieldDTO, OperationDTO } from "~/components/BulkActions/ActionEdit/domain";
-import { RemoveOperation } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/RemoveOperation";
 import { FieldRenderer } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer";
 
 export interface OperationProps {
@@ -33,7 +31,7 @@ export const Operation = observer((props: OperationProps) => {
                     )}
                 </Bind>
             </Cell>
-            <Cell span={5}>
+            <Cell span={6}>
                 {props.operation.field && (
                     <Bind name={`${props.name}.operator`}>
                         {({ value, onChange, validation }) => (
@@ -52,10 +50,6 @@ export const Operation = observer((props: OperationProps) => {
                     </Bind>
                 )}
             </Cell>
-            <Cell span={1} align={"middle"}>
-                <RemoveOperation onClick={props.onDelete} disabled={!props.operation.canDelete} />
-            </Cell>
-
             <FieldRenderer
                 operator={props.operation.operator}
                 field={props.operation.availableFields.find(

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -55,15 +55,14 @@ export const Operation = observer((props: OperationProps) => {
             <Cell span={1} align={"middle"}>
                 <RemoveOperation onClick={props.onDelete} disabled={!props.operation.canDelete} />
             </Cell>
-            <Cell span={11}>
-                <FieldRenderer
-                    operator={props.operation.operator}
-                    field={props.operation.availableFields.find(
-                        field => field.value === props.operation.field
-                    )}
-                    name={`${props.name}.value`}
-                />
-            </Cell>
+
+            <FieldRenderer
+                operator={props.operation.operator}
+                field={props.operation.availableFields.find(
+                    field => field.value === props.operation.field
+                )}
+                name={`${props.name}.value`}
+            />
         </Grid>
     );
 });

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/Operation.tsx
@@ -11,8 +11,7 @@ import { RemoveOperation } from "~/components/BulkActions/ActionEdit/BatchEditor
 import { FieldRenderer } from "~/components/BulkActions/ActionEdit/BatchEditorDialog/FieldRenderer";
 
 export interface OperationProps {
-    fields: FieldDTO[];
-    operation: OperationDTO & { canDelete: boolean };
+    operation: OperationDTO & { canDelete: boolean; availableFields: FieldDTO[] };
     name: string;
     onDelete: () => void;
     onSetOperationFieldData: (data: string) => void;
@@ -26,7 +25,7 @@ export const Operation = observer((props: OperationProps) => {
                     {({ value, validation }) => (
                         <Select
                             label={"Field"}
-                            options={props.fields}
+                            options={props.operation.availableFields}
                             value={value}
                             onChange={data => props.onSetOperationFieldData(data)}
                             validation={validation}
@@ -41,7 +40,7 @@ export const Operation = observer((props: OperationProps) => {
                             <Select
                                 label={"Operation"}
                                 options={
-                                    props.fields.find(
+                                    props.operation.availableFields.find(
                                         field => field.value === props.operation.field
                                     )?.operators || []
                                 }
@@ -59,7 +58,9 @@ export const Operation = observer((props: OperationProps) => {
             <Cell span={11}>
                 <FieldRenderer
                     operator={props.operation.operator}
-                    field={props.fields.find(field => field.value === props.operation.field)}
+                    field={props.operation.availableFields.find(
+                        field => field.value === props.operation.field
+                    )}
                     name={`${props.name}.value`}
                 />
             </Cell>

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/RemoveOperation.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/RemoveOperation.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { ReactComponent as DeleteIcon } from "@material-design-icons/svg/outlined/delete.svg";
+import { IconButton } from "@webiny/ui/Button";
+import { Tooltip } from "@webiny/ui/Tooltip";
+
+interface RemoveOperationProps {
+    onClick: () => void;
+    disabled: boolean;
+}
+
+export const RemoveOperation = ({ onClick, disabled }: RemoveOperationProps) => {
+    return (
+        <Tooltip content={"Remove operation"} placement={"bottom"}>
+            <IconButton
+                label={"Remove operation"}
+                icon={<DeleteIcon />}
+                onClick={onClick}
+                disabled={disabled}
+            />
+        </Tooltip>
+    );
+};

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/index.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/index.tsx
@@ -1,0 +1,1 @@
+export * from "./BatchEditorDialog";

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.test.ts
@@ -1,0 +1,70 @@
+import { GraphQLInputMapper } from "./GraphQLInputMapper";
+import { BatchDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+import { FileItem } from "@webiny/app-admin/types";
+
+describe("GraphQLInputMapper", () => {
+    it("should return a GraphQL formatted output based on the received BatchDTO and previous data", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field1",
+            field2: "old-field2",
+            field3: ["old-field3"]
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        field1: "new-field1"
+                    }
+                },
+                {
+                    field: "field2",
+                    operator: OperatorType.REMOVE
+                },
+                {
+                    field: "field3",
+                    operator: OperatorType.APPEND,
+                    value: {
+                        field3: ["new-field3-1", "new-field3-2"]
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "new-field1",
+            field2: null,
+            field3: ["old-field3", "new-field3-1", "new-field3-2"]
+        });
+    });
+
+    it("should not override data for fields not defined in the batch", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field1",
+            field2: "old-field2"
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        field1: "new-field1"
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "new-field1",
+            field2: "old-field2"
+        });
+    });
+});

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
@@ -1,5 +1,5 @@
-import { BatchDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
 import { FileItem } from "@webiny/app-admin/types";
+import { BatchDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
 
 export class GraphQLInputMapper {
     static toGraphQLExtensions(data: FileItem["extensions"], batch: BatchDTO) {

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
@@ -3,17 +3,18 @@ import { BatchDTO, OperatorType } from "~/components/BulkActions/ActionEdit/doma
 
 export class GraphQLInputMapper {
     static toGraphQLExtensions(data: FileItem["extensions"], batch: BatchDTO) {
-        let update = { ...data };
+        const update = { ...data };
 
         batch.operations.forEach(operation => {
             const { field, operator, value } = operation;
 
             switch (operator) {
                 case OperatorType.OVERRIDE:
-                    update = {
-                        ...update,
-                        ...value
-                    };
+                    if (!value || !value[field]) {
+                        return;
+                    }
+
+                    update[field] = value[field];
                     break;
                 case OperatorType.REMOVE:
                     update[field] = null;

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
@@ -1,0 +1,41 @@
+import { BatchDTO, OperatorType } from "~/components/BulkActions/ActionEdit/domain";
+import { FileItem } from "@webiny/app-admin/types";
+
+export class GraphQLInputMapper {
+    static toGraphQLExtensions(data: FileItem["extensions"], batch: BatchDTO) {
+        let update = { ...data };
+
+        batch.operations.forEach(operation => {
+            const { field, operator, value } = operation;
+
+            switch (operator) {
+                case OperatorType.OVERRIDE:
+                    update = {
+                        ...update,
+                        ...value
+                    };
+                    break;
+                case OperatorType.REMOVE:
+                    update[field] = null;
+                    break;
+                case OperatorType.APPEND:
+                    if (!value || !value[field] || !Array.isArray(value[field])) {
+                        return;
+                    }
+
+                    if (data && data[field]) {
+                        update[field] = [...data[field], ...value[field]];
+                    }
+
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        return {
+            ...data,
+            ...update
+        };
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
@@ -5,8 +5,8 @@ export interface BatchDTO {
 }
 
 const operationValidationSchema = zod.object({
-    field: zod.string().trim().nonempty("Field is required."),
-    operator: zod.string().nonempty("Condition is required.")
+    field: zod.string().trim().min(1, "Field is required."),
+    operator: zod.string().min(1, "Operator is required.")
 });
 
 export const batchValidationSchema = zod.object({

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
@@ -1,12 +1,27 @@
+import zod from "zod";
+
 export interface BatchDTO {
     operations: OperationDTO[];
 }
+
+const operationValidationSchema = zod.object({
+    field: zod.string().trim().nonempty("Field is required."),
+    operator: zod.string().nonempty("Condition is required.")
+});
+
+export const batchValidationSchema = zod.object({
+    operations: zod.array(operationValidationSchema).min(1)
+});
 
 export class Batch {
     operations: Operation[];
 
     static createEmpty() {
         return new Batch([new Operation()]);
+    }
+
+    static validate(data: BatchDTO) {
+        return batchValidationSchema.safeParse(data);
     }
 
     protected constructor(operations: Operation[]) {
@@ -23,7 +38,7 @@ export interface OperationDTO {
 export class Operation {
     public readonly field?: string;
     public readonly operator?: string;
-    public readonly value?: any = undefined;
+    public readonly value?: Record<string, any> = undefined;
 
     constructor(field?: string, operator?: string, value?: any) {
         this.field = field;

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Batch.ts
@@ -1,0 +1,33 @@
+export interface BatchDTO {
+    operations: OperationDTO[];
+}
+
+export class Batch {
+    operations: Operation[];
+
+    static createEmpty() {
+        return new Batch([new Operation()]);
+    }
+
+    protected constructor(operations: Operation[]) {
+        this.operations = operations;
+    }
+}
+
+export interface OperationDTO {
+    field: string;
+    operator: string;
+    value?: Record<string, any>;
+}
+
+export class Operation {
+    public readonly field?: string;
+    public readonly operator?: string;
+    public readonly value?: any = undefined;
+
+    constructor(field?: string, operator?: string, value?: any) {
+        this.field = field;
+        this.operator = operator;
+        this.value = value;
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/BatchMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/BatchMapper.ts
@@ -6,7 +6,7 @@ export class BatchMapper {
             operations: input.operations.map(operation => ({
                 operator: operation.operator || "",
                 field: operation.field || "",
-                value: operation.value
+                value: operation.value || {}
             }))
         };
     }

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/BatchMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/BatchMapper.ts
@@ -1,0 +1,13 @@
+import { Batch, BatchDTO } from "./Batch";
+
+export class BatchMapper {
+    static toDTO(input: Batch): BatchDTO {
+        return {
+            operations: input.operations.map(operation => ({
+                operator: operation.operator || "",
+                field: operation.field || "",
+                value: operation.value
+            }))
+        };
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Field.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/Field.ts
@@ -1,0 +1,78 @@
+import { CmsModelField } from "@webiny/app-headless-cms-common/types/model";
+
+export type FieldRaw = CmsModelField;
+
+export enum OperatorType {
+    OVERRIDE = "OVERRIDE",
+    APPEND = "APPEND",
+    REMOVE = "REMOVE"
+}
+
+export interface FieldDTO {
+    label: string;
+    value: string;
+    operators: OperatorDTO[];
+    raw: FieldRaw;
+}
+
+export class Field {
+    public readonly label: string;
+    public readonly value: string;
+    public readonly operators: Operator[];
+    public readonly raw: FieldRaw;
+
+    static createFromRaw(field: FieldRaw) {
+        const label = field.label;
+        const value = field.id;
+        const operators = Operator.createFromField(field);
+        return new Field(label, value, operators, field);
+    }
+
+    private constructor(label: string, value: string, operators: Operator[], renderer: FieldRaw) {
+        this.label = label;
+        this.value = value;
+        this.operators = operators;
+        this.raw = renderer;
+    }
+}
+
+export interface OperatorDTO {
+    label: string;
+    value: string;
+}
+
+export class Operator {
+    public readonly label: string;
+    public readonly value: string;
+
+    static createFrom(rawData: OperatorDTO) {
+        return new Operator(rawData.label, rawData.value);
+    }
+
+    static createFromField(field: CmsModelField) {
+        const operators = [
+            {
+                label: "Override existing values",
+                value: OperatorType.OVERRIDE
+            },
+            {
+                label: "Clear all existing values",
+                value: OperatorType.REMOVE
+            }
+        ];
+
+        if (field.multipleValues) {
+            operators.push({
+                label: "Append to existing values",
+                value: OperatorType.APPEND
+            });
+        }
+
+        return operators.map(operator => this.createFrom(operator));
+    }
+
+    private constructor(label: string, value: string) {
+        this.label = label;
+        this.value = value;
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/FieldMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/FieldMapper.ts
@@ -1,0 +1,23 @@
+import { Field, FieldDTO, Operator, OperatorDTO } from "./Field";
+
+export class FieldMapper {
+    static toDTO(configuration: Field[]): FieldDTO[] {
+        return configuration.map(field => {
+            return {
+                label: field.label,
+                value: field.value,
+                operators: OperatorMapper.toDTO(field.operators),
+                raw: field.raw
+            };
+        });
+    }
+}
+
+export class OperatorMapper {
+    static toDTO(operators: Operator[]): OperatorDTO[] {
+        return operators.map(operator => ({
+            value: operator.value || "",
+            label: operator.label || ""
+        }));
+    }
+}

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/index.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/domain/index.ts
@@ -1,0 +1,4 @@
+export * from "./Batch";
+export * from "./BatchMapper";
+export * from "./Field";
+export * from "./FieldMapper";

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/index.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/index.tsx
@@ -1,0 +1,1 @@
+export * from "./ActionEdit";

--- a/packages/app-file-manager/src/components/BulkActions/index.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/index.tsx
@@ -1,3 +1,4 @@
+export { ActionEdit } from "./ActionEdit";
 export { ActionDelete } from "./ActionDelete";
 export { ActionMove } from "./ActionMove";
 export * from "./BulkActions";

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FileManagerViewConfig as FileManagerConfig } from "~/index";
 import { FileManagerRenderer } from "./FileManagerView";
 import { FilterByType } from "./filters/FilterByType";
-import { ActionDelete, ActionMove } from "~/components/BulkActions";
+import { ActionDelete, ActionEdit, ActionMove } from "~/components/BulkActions";
 import { Name } from "~/components/FileDetails/components/Name";
 import { Tags } from "~/components/FileDetails/components/Tags";
 import { Aliases } from "~/components/FileDetails/components/Aliases";
@@ -16,6 +16,7 @@ export const FileManagerRendererModule = () => {
             <FileManagerConfig>
                 <Browser.FilterByTags />
                 <Browser.Filter name={"type"} element={<FilterByType />} />
+                <Browser.BulkAction name={"edit"} element={<ActionEdit />} />
                 <Browser.BulkAction name={"move"} element={<ActionMove />} />
                 <Browser.BulkAction name={"delete"} element={<ActionDelete />} />
                 <FileDetails.Field name={"name"} element={<Name />} />

--- a/scripts/listPackagesWithTests.js
+++ b/scripts/listPackagesWithTests.js
@@ -111,6 +111,9 @@ const CUSTOM_HANDLERS = {
     },
     "app-aco": () => {
         return ["packages/app-aco"];
+    },
+    "app-file-manager": () => {
+        return ["packages/app-file-manager"];
     }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14800,6 +14800,7 @@ __metadata:
     rimraf: ^3.0.2
     ttypescript: ^1.5.13
     typescript: 4.7.4
+    zod: ^3.22.4
   languageName: unknown
   linkType: soft
 
@@ -44730,5 +44731,12 @@ __metadata:
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Changes
With this PR, we can bulk edit file custom registered fields.

To work, the field should be registered as  `bulkEdit: true` as follows:

```ts
modifier.addField({
  id: "customLabel",
  fieldId: "customLabel",
  label: "Custom Label",
  type: "text",
  renderer: {
    name: "text-input"
  },
  bulkEdit: true <-- Available for bulk edit actions
});
```

By clicking on the action, the user will have the possibility to select the fields to edit and:

- Override existing data
- Remove existing data
- Append new data (available for fields that accept `multipleValues`)

The file data is updated using the default bulk actions worker. 
![CleanShot 2023-11-21 at 14 32 57](https://github.com/webiny/webiny-js/assets/2866531/7af83c22-d30b-4943-bc20-1358044cd408)



## How Has This Been Tested?
Jest + Manually