### PR TITLE
Page Templates - Listing Templates - Minor Fixes

### DIFF
--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
@@ -118,7 +118,7 @@ export const createPageTemplateStorageOperations = ({
         return createListResponse({
             items: sortedItems,
             limit: limit || 100000,
-            totalCount: filteredItems.length,
+            totalCount: sortedItems.length,
             after: null
         });
     };

--- a/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pageTemplate/index.ts
@@ -26,6 +26,7 @@ export interface CreatePageTemplateStorageOperationsParams {
     entity: Entity<any>;
     plugins: PluginsContainer;
 }
+
 export const createPageTemplateStorageOperations = ({
     entity,
     plugins
@@ -95,25 +96,27 @@ export const createPageTemplateStorageOperations = ({
             );
         }
 
+        const itemsData = items.map(item => item?.data).filter(Boolean);
+
         const fields = plugins.byType<PageTemplateDynamoDbElasticFieldPlugin>(
             PageTemplateDynamoDbElasticFieldPlugin.type
         );
 
-        const filteredItems = filterItems<DataContainer<PageTemplate>>({
+        const filteredItems = filterItems<PageTemplate>({
             plugins,
             where: restWhere,
-            items,
+            items: itemsData,
             fields
         });
 
-        const sortedItems = sortItems<DataContainer<PageTemplate>>({
+        const sortedItems = sortItems<PageTemplate>({
             items: filteredItems,
             sort,
             fields
         });
 
         return createListResponse({
-            items: sortedItems.map(item => item?.data).filter(Boolean),
+            items: sortedItems,
             limit: limit || 100000,
             totalCount: filteredItems.length,
             after: null

--- a/packages/api-page-builder-so-ddb/src/operations/pageTemplate/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pageTemplate/index.ts
@@ -26,6 +26,7 @@ export interface CreatePageTemplateStorageOperationsParams {
     entity: Entity<any>;
     plugins: PluginsContainer;
 }
+
 export const createPageTemplateStorageOperations = ({
     entity,
     plugins
@@ -95,27 +96,29 @@ export const createPageTemplateStorageOperations = ({
             );
         }
 
+        const itemsData = items.map(item => item?.data).filter(Boolean);
+
         const fields = plugins.byType<PageTemplateDynamoDbFieldPlugin>(
             PageTemplateDynamoDbFieldPlugin.type
         );
 
-        const filteredItems = filterItems<DataContainer<PageTemplate>>({
+        const filteredItems = filterItems<PageTemplate>({
             plugins,
             where: restWhere,
-            items,
+            items: itemsData,
             fields
         });
 
-        const sortedItems = sortItems<DataContainer<PageTemplate>>({
+        const sortedItems = sortItems<PageTemplate>({
             items: filteredItems,
             sort,
             fields
         });
 
         return createListResponse({
-            items: sortedItems.map(item => item?.data).filter(Boolean),
+            items: sortedItems,
             limit: limit || 100000,
-            totalCount: filteredItems.length,
+            totalCount: sortedItems.length,
             after: null
         });
     };

--- a/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pageTemplates.crud.ts
@@ -141,7 +141,7 @@ export const createPageTemplatesCrud = (
                     tenant: getTenantId(),
                     locale: getLocaleCode()
                 },
-                sort: Array.isArray(sort) && sort.length > 0 ? sort : ["createdOn_ASC"]
+                sort: Array.isArray(sort) && sort.length > 0 ? sort : ["createdOn_DESC"]
             };
 
             // If user can only manage own records, let's add that to the listing.


### PR DESCRIPTION
## Changes
This PR addresses two minor issues related to listing of page templates:

1. Fixes sorting (previously, the list would contain unsorted data)
2. Makes the default sort `createdOn_DESC` (instead of `createdOn_ASC`)

The fix was applied within both `ddb` and `ddb-es` packages.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.