### PR TITLE
Pavel/fix/pb blocks editor

### DIFF
--- a/packages/app-admin/src/hooks/index.ts
+++ b/packages/app-admin/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from "./useSnackbar";
 export * from "./useKeyHandler";
 export * from "./useShiftKey";
 export * from "./useModKey";
+export * from "./useIsMounted";

--- a/packages/app-admin/src/hooks/useIsMounted.ts
+++ b/packages/app-admin/src/hooks/useIsMounted.ts
@@ -1,0 +1,17 @@
+import { useRef, useEffect } from "react";
+
+export const useIsMounted = () => {
+    const isMountedRef = useRef(false);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
+
+    return {
+        isMounted: () => isMountedRef.current
+    };
+};

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/BlocksRepository.ts
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/BlocksRepository.ts
@@ -3,7 +3,6 @@ import { plugins } from "@webiny/plugins";
 import { Loading } from "./Loading";
 import { BlockGatewayInterface } from "./BlockGatewayInterface";
 import { PbEditorBlockPlugin, PbPageBlock } from "~/types";
-import { decompress } from "~/admin/components/useDecompress";
 import { getDefaultBlockContent } from "./defaultBlockContent";
 import { addElementId } from "~/editor/helpers";
 import { createBlockPlugin } from "./createBlockPlugin";
@@ -34,7 +33,7 @@ export class BlocksRepository {
     }
 
     private async runWithLoading<T>(
-        action: Promise<T>,
+        action: () => Promise<T>,
         loadingLabel?: string,
         successMessage?: string,
         failureMessage?: string
@@ -58,7 +57,7 @@ export class BlocksRepository {
 
         return (this.listOperation = (async () => {
             const pageBlocks = await this.runWithLoading<PbPageBlock[]>(
-                this.gateway.list(),
+                () => this.gateway.list(),
                 "Loading page blocks"
             );
 
@@ -66,15 +65,13 @@ export class BlocksRepository {
                 return [];
             }
 
-            const decompressedPageBlocks = await Promise.all(
-                pageBlocks.map(pageBlock => this.decompressPageBlock(pageBlock))
+            const processedBlocks = await Promise.all(
+                pageBlocks.map(pageBlock => this.processBlockFromApi(pageBlock))
             );
 
             runInAction(() => {
-                this.pageBlocks = decompressedPageBlocks;
+                this.pageBlocks = processedBlocks;
             });
-
-            this.pageBlocks.map(pageBlock => this.createBlockPlugin(pageBlock));
 
             return this.pageBlocks;
         })());
@@ -87,31 +84,56 @@ export class BlocksRepository {
             return structuredClone(blockInCache);
         }
 
-        const pageBlock = await this.runWithLoading<PbPageBlock>(this.gateway.getById(id));
+        const pageBlock = await this.runWithLoading<PbPageBlock>(async () => {
+            const block = await this.gateway.getById(id);
+            return this.processBlockFromApi(block);
+        });
+
+        runInAction(() => {
+            this.pageBlocks = [...this.pageBlocks, pageBlock];
+        });
+
+        return structuredClone(pageBlock);
+    }
+
+    async refetchById(id: string): Promise<PbPageBlock> {
+        const pageBlock = await this.runWithLoading<PbPageBlock>(async () => {
+            const block = await this.gateway.getById(id);
+            return this.processBlockFromApi(block);
+        });
+
+        runInAction(() => {
+            const blockIndex = this.pageBlocks.findIndex(pb => pb.id === id);
+            if (blockIndex > -1) {
+                this.pageBlocks = this.pageBlocks.splice(blockIndex, 1, pageBlock);
+            } else {
+                this.pageBlocks = [...this.pageBlocks, pageBlock];
+            }
+        });
 
         return structuredClone(pageBlock);
     }
 
     async createPageBlock(input: { name: string; category: string; content?: unknown }) {
         const pageBlock = await this.runWithLoading(
-            this.gateway.create({
-                name: input.name,
-                blockCategory: input.category,
-                content: input.content ?? getDefaultBlockContent()
-            }),
+            () => {
+                return this.gateway.create({
+                    name: input.name,
+                    blockCategory: input.category,
+                    content: input.content ?? getDefaultBlockContent()
+                });
+            },
             "Creating page block",
             `Page block "${input.name}" was created successfully.`
         );
 
-        const decompressed = this.decompressPageBlock(pageBlock);
+        const processedBlock = this.processBlockFromApi(pageBlock);
 
         runInAction(() => {
-            this.pageBlocks = [...this.pageBlocks, decompressed];
+            this.pageBlocks = [...this.pageBlocks, processedBlock];
         });
 
-        this.createBlockPlugin(decompressed);
-
-        return decompressed;
+        return processedBlock;
     }
 
     async updatePageBlock(pageBlock: {
@@ -130,16 +152,18 @@ export class BlocksRepository {
             ...block,
             name: pageBlock.name ?? block.name,
             blockCategory: pageBlock.category ?? block.blockCategory,
-            content: pageBlock.content ?? block.content
+            content: addElementId(pageBlock.content ?? block.content)
         };
 
         await this.runWithLoading(
-            this.gateway.update({
-                id: updatePageBlock.id,
-                name: updatePageBlock.name,
-                content: updatePageBlock.content,
-                blockCategory: updatePageBlock.blockCategory
-            }),
+            () => {
+                return this.gateway.update({
+                    id: updatePageBlock.id,
+                    name: updatePageBlock.name,
+                    content: updatePageBlock.content,
+                    blockCategory: updatePageBlock.blockCategory
+                });
+            },
             "Updating page block",
             `Filter "${updatePageBlock.name}" was updated successfully.`
         );
@@ -167,7 +191,7 @@ export class BlocksRepository {
         }
 
         await this.runWithLoading(
-            this.gateway.delete(id),
+            () => this.gateway.delete(id),
             "Deleting page block",
             `Filter "${block.name}" was deleted successfully.`
         );
@@ -179,11 +203,10 @@ export class BlocksRepository {
         this.removeBlockPlugin(block);
     }
 
-    private decompressPageBlock(pageBlock: PbPageBlock) {
-        return {
-            ...pageBlock,
-            content: addElementId(decompress(pageBlock.content))
-        };
+    private processBlockFromApi(pageBlock: PbPageBlock) {
+        const withElementIds = { ...pageBlock, content: addElementId(pageBlock.content) };
+        this.createBlockPlugin(withElementIds);
+        return withElementIds;
     }
 
     /**

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/Loading.ts
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/Loading.ts
@@ -48,14 +48,14 @@ export class Loading {
     }
 
     async runCallbackWithLoading<T>(
-        callback: Promise<T>,
+        callback: () => Promise<T>,
         loadingLabel?: string,
         successMessage?: string,
         failureMessage?: string
     ): Promise<T> {
         try {
             this.startLoading(loadingLabel);
-            const result = await callback;
+            const result = await callback();
             this.stopLoadingWithSuccess(successMessage);
             return result;
         } catch (e) {

--- a/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/usePageBlocks.ts
+++ b/packages/app-page-builder/src/admin/contexts/AdminPageBuilder/PageBlocks/usePageBlocks.ts
@@ -79,5 +79,10 @@ export function usePageBlocks() {
         [blocksRepository]
     );
 
-    return { ...vm, listBlocks, getBlockById, createBlock, updateBlock, deleteBlock };
+    const refetchBlock = useCallback(
+        (id: string) => blocksRepository.refetchById(id),
+        [blocksRepository]
+    );
+
+    return { ...vm, listBlocks, getBlockById, createBlock, updateBlock, deleteBlock, refetchBlock };
 }

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/Action.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/Action.tsx
@@ -17,6 +17,7 @@ const activeStyle = css({
 });
 
 interface ActionProps {
+    disabled?: boolean;
     plugin?: string;
     icon?: ReactElement;
     tooltip?: string;
@@ -32,6 +33,7 @@ const Action: React.FC<ActionProps> = ({
     tooltip,
     onClick,
     shortcut = [],
+    disabled = false,
     ...props
 }) => {
     const eventActionHandler = useEventActionHandler();
@@ -82,6 +84,7 @@ const Action: React.FC<ActionProps> = ({
             {...(isPluginActive ? { visible: false } : {})}
         >
             <IconButton
+                disabled={disabled}
                 icon={icon}
                 onClick={clickHandler}
                 className={isPluginActive ? activeStyle : ""}

--- a/packages/app-page-builder/src/pageEditor/config/ElementSettingsTabContentPlugin.tsx
+++ b/packages/app-page-builder/src/pageEditor/config/ElementSettingsTabContentPlugin.tsx
@@ -18,7 +18,7 @@ export const ElementSettingsTabContentPlugin = createComponentPlugin(
             const [element] = useActiveElement();
             const elementSettings = useElementSettings();
             const [isTemplateMode] = useTemplateMode();
-            const refreshBlock = useRefreshBlock(element as PbEditorElement);
+            const { refreshBlock, loading } = useRefreshBlock(element as PbEditorElement);
 
             if (isTemplateMode) {
                 return <VariableSettings />;
@@ -53,7 +53,8 @@ export const ElementSettingsTabContentPlugin = createComponentPlugin(
                                     }
                                 />
                                 <Action
-                                    tooltip={"Refresh block"}
+                                    disabled={loading}
+                                    tooltip={loading ? "Refreshing..." : "Refresh block"}
                                     onClick={refreshBlock}
                                     icon={<RefreshIcon />}
                                 />

--- a/packages/app-page-builder/src/templateEditor/config/ElementSettingsTabContentPlugin.tsx
+++ b/packages/app-page-builder/src/templateEditor/config/ElementSettingsTabContentPlugin.tsx
@@ -23,7 +23,7 @@ export const ElementSettingsTabContentPlugin = createComponentPlugin(
         return function SettingsTabContent({ children, ...props }) {
             const [element] = useActiveElement();
             const elementSettings = useElementSettings();
-            const refreshBlock = useRefreshBlock(element as PbEditorElement);
+            const { refreshBlock, loading } = useRefreshBlock(element as PbEditorElement);
             const canHaveVariable =
                 element &&
                 variablePlugins.some(variablePlugin => variablePlugin.elementType === element.type);
@@ -58,7 +58,8 @@ export const ElementSettingsTabContentPlugin = createComponentPlugin(
                                     }
                                 />
                                 <Action
-                                    tooltip={"Refresh block"}
+                                    disabled={loading}
+                                    tooltip={loading ? "Refreshing..." : "Refresh block"}
                                     onClick={refreshBlock}
                                     icon={<RefreshIcon />}
                                 />


### PR DESCRIPTION
## Changes
This PR fixes inconsistent loading of blocks when opening a block editor. 
- All queries are now routed through the `usePageBlocks()` hook, which communicates with the central BlocksRepository. 
- Block content decompression was moved to the BlocksGateway, because it's a data layer concern, so Repository shouldn't know about it.
- `getById` GraphQL query was fixed to use the `network-only` fetch policy. 
- `Refresh Block` element action now works as expected.

## How Has This Been Tested?
Manually.