### PR TITLE
fix: remove unnecessary ts-expect-error

### DIFF
--- a/apps/admin/src/plugins/scaffolds/index.ts
+++ b/apps/admin/src/plugins/scaffolds/index.ts
@@ -1,4 +1,3 @@
 // This file is automatically updated via various scaffolding utilities.
 
-// @ts-expect-error
 export default () => [];


### PR DESCRIPTION
## Changes
Remove unnecessary `@ts-expect-error` from the dev api/graphql folder.

## How Has This Been Tested?
Manually.