### PR TITLE
refactor: replace function types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
                 "ts-expect-error": false
             }
         ],
-        "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/ban-types": "error",
         "@typescript-eslint/no-use-before-define": 0,
         "@typescript-eslint/no-unused-vars": getNoUnusedVars(),
         "@typescript-eslint/no-var-requires": 0,

--- a/cypress-tests/cypress/support/pageBuilder/pbCreateCategoryAndBlocks.ts
+++ b/cypress-tests/cypress/support/pageBuilder/pbCreateCategoryAndBlocks.ts
@@ -9,7 +9,9 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
         interface Chainable {
-            pbCreateCategoryAndBlocks(params: CreateCategoryAndBlocksParams): Promise<Array<{}>>;
+            pbCreateCategoryAndBlocks(
+                params: CreateCategoryAndBlocksParams
+            ): Promise<Array<Record<string, any>>>;
         }
     }
 }

--- a/packages/api-aco/src/apps/AcoApp.ts
+++ b/packages/api-aco/src/apps/AcoApp.ts
@@ -78,7 +78,7 @@ export class AcoApp implements IAcoApp {
                 const items = await onEntryList(entries);
                 return [items, meta];
             },
-            delete: async (id: string): Promise<Boolean> => {
+            delete: async (id: string): Promise<boolean> => {
                 await this.execOnAnyRequest("delete");
                 return this.context.aco.search.delete(this.getModel(), id);
             },

--- a/packages/api-aco/src/filter/filter.types.ts
+++ b/packages/api-aco/src/filter/filter.types.ts
@@ -102,7 +102,7 @@ export interface AcoFilterCrud {
     list(params: ListFiltersParams): Promise<[Filter[], ListMeta]>;
     create(data: CreateFilterParams): Promise<Filter>;
     update(id: string, data: UpdateFilterParams): Promise<Filter>;
-    delete(id: string): Promise<Boolean>;
+    delete(id: string): Promise<boolean>;
     onFilterBeforeCreate: Topic<OnFilterBeforeCreateTopicParams>;
     onFilterAfterCreate: Topic<OnFilterAfterCreateTopicParams>;
     onFilterBeforeUpdate: Topic<OnFilterBeforeUpdateTopicParams>;

--- a/packages/api-aco/src/folder/folder.types.ts
+++ b/packages/api-aco/src/folder/folder.types.ts
@@ -116,7 +116,7 @@ export interface AcoFolderCrud {
 
     update(id: string, data: UpdateFolderParams): Promise<Folder>;
 
-    delete(id: string): Promise<Boolean>;
+    delete(id: string): Promise<boolean>;
 
     getAncestors(folder: Folder): Promise<Folder[]>;
 

--- a/packages/api-aco/src/record/record.types.ts
+++ b/packages/api-aco/src/record/record.types.ts
@@ -173,7 +173,7 @@ export interface AcoSearchRecordCrudBase {
         data: UpdateSearchRecordParams<TData>
     ): Promise<SearchRecord<TData>>;
     move(id: string, folderId?: string | null): Promise<boolean>;
-    delete(id: string): Promise<Boolean>;
+    delete(id: string): Promise<boolean>;
 }
 
 export interface AcoSearchRecordCrud
@@ -200,7 +200,7 @@ export interface AcoSearchRecordCrud
         data: UpdateSearchRecordParams<TData>
     ): Promise<SearchRecord<TData>>;
     move(model: CmsModel, id: string, folderId?: string | null): Promise<boolean>;
-    delete(model: CmsModel, id: string): Promise<Boolean>;
+    delete(model: CmsModel, id: string): Promise<boolean>;
     onSearchRecordBeforeCreate: Topic<OnSearchRecordBeforeCreateTopicParams>;
     onSearchRecordAfterCreate: Topic<OnSearchRecordAfterCreateTopicParams>;
     onSearchRecordBeforeUpdate: Topic<OnSearchRecordBeforeUpdateTopicParams>;

--- a/packages/api-apw-scheduler-so-ddb/src/index.ts
+++ b/packages/api-apw-scheduler-so-ddb/src/index.ts
@@ -214,7 +214,7 @@ export const createStorageOperations = (
             }
         },
 
-        async delete(params: StorageOperationsDeleteScheduleActionParams): Promise<Boolean> {
+        async delete(params: StorageOperationsDeleteScheduleActionParams): Promise<boolean> {
             const { tenant, locale, id } = params;
             const keys = {
                 PK: createPartitionKey({

--- a/packages/api-apw/src/plugins/cms/utils.ts
+++ b/packages/api-apw/src/plugins/cms/utils.ts
@@ -172,7 +172,7 @@ export const assignWorkflowToEntry = async (params: AssignWorkflowToEntryParams)
     }
 };
 
-export const hasEntries = (workflow: ApwWorkflow): Boolean => {
+export const hasEntries = (workflow: ApwWorkflow): boolean => {
     const { app, scope } = workflow;
     return (
         app === ApwWorkflowApplications.CMS &&

--- a/packages/api-apw/src/plugins/pageBuilder/utils.ts
+++ b/packages/api-apw/src/plugins/pageBuilder/utils.ts
@@ -85,7 +85,7 @@ export const assignWorkflowToPage = async ({ listWorkflow, page }: AssignWorkflo
     }
 };
 
-export const hasPages = (workflow: ApwWorkflow): Boolean => {
+export const hasPages = (workflow: ApwWorkflow): boolean => {
     const { app, scope } = workflow;
     return (
         app === ApwWorkflowApplications.PB &&
@@ -98,7 +98,7 @@ export const hasPages = (workflow: ApwWorkflow): Boolean => {
 export const shouldUpdatePages = (
     scope: ApwWorkflowScope,
     prevScope: ApwWorkflowScope
-): Boolean => {
+): boolean => {
     /**
      * Bail out early if the scope is not "CUSTOM" - at that point all pages should be updated.
      */

--- a/packages/api-apw/src/plugins/utils.ts
+++ b/packages/api-apw/src/plugins/utils.ts
@@ -27,7 +27,7 @@ export interface HasReviewersParams {
     getReviewer: ApwReviewerCrud["get"];
 }
 
-export const hasReviewer = async (params: HasReviewersParams): Promise<Boolean> => {
+export const hasReviewer = async (params: HasReviewersParams): Promise<boolean> => {
     const { getReviewer, identity, step } = params;
     for (const stepReviewer of step.reviewers) {
         const entry = await getReviewer(stepReviewer.id);

--- a/packages/api-apw/src/scheduler/types.ts
+++ b/packages/api-apw/src/scheduler/types.ts
@@ -93,7 +93,7 @@ interface BaseApwCrud<TEntry, TCreateEntryParams, TUpdateEntryParams> {
 
     update(id: string, data: TUpdateEntryParams): Promise<TEntry>;
 
-    delete(id: string): Promise<Boolean>;
+    delete(id: string): Promise<boolean>;
 }
 
 export interface ApwScheduleActionCrud
@@ -104,7 +104,7 @@ export interface ApwScheduleActionCrud
 
     updateCurrentTask(item: ApwScheduleAction): Promise<ApwScheduleAction>;
 
-    deleteCurrentTask(): Promise<Boolean>;
+    deleteCurrentTask(): Promise<boolean>;
 }
 
 export interface ScheduleActionContext extends Context, I18NContext, TenancyContext {
@@ -183,7 +183,7 @@ export interface ApwScheduleActionStorageOperations {
 
     update(params: StorageOperationsUpdateScheduleActionParams): Promise<ApwScheduleAction>;
 
-    delete(params: StorageOperationsDeleteScheduleActionParams): Promise<Boolean>;
+    delete(params: StorageOperationsDeleteScheduleActionParams): Promise<boolean>;
 
     getCurrentTask(
         params: StorageOperationsGetCurrentTaskParams
@@ -191,7 +191,7 @@ export interface ApwScheduleActionStorageOperations {
 
     updateCurrentTask(params: StorageOperationsUpdateCurrentTaskParams): Promise<ApwScheduleAction>;
 
-    deleteCurrentTask(params: StorageOperationsDeleteCurrentTaskParams): Promise<Boolean>;
+    deleteCurrentTask(params: StorageOperationsDeleteCurrentTaskParams): Promise<boolean>;
 }
 
 export interface CreateApwContextParams {

--- a/packages/api-apw/src/types.ts
+++ b/packages/api-apw/src/types.ts
@@ -341,7 +341,7 @@ interface BaseApwCrud<TEntry, TCreateEntryParams, TUpdateEntryParams> {
 
     update(id: string, data: TUpdateEntryParams): Promise<TEntry>;
 
-    delete(id: string): Promise<Boolean>;
+    delete(id: string): Promise<boolean>;
 }
 
 export interface ApwWorkflowCrud
@@ -436,18 +436,18 @@ export interface ApwContentReviewCrud
     > {
     list(params: ApwContentReviewListParams): Promise<[ApwContentReview[], ListMeta]>;
 
-    provideSignOff(id: string, step: string): Promise<Boolean>;
+    provideSignOff(id: string, step: string): Promise<boolean>;
 
-    retractSignOff(id: string, step: string): Promise<Boolean>;
+    retractSignOff(id: string, step: string): Promise<boolean>;
 
     isReviewRequired(data: ApwContentReviewContent): Promise<{
         isReviewRequired: boolean;
         contentReviewId?: string | null;
     }>;
 
-    publishContent(id: string, datetime?: string): Promise<Boolean>;
+    publishContent(id: string, datetime?: string): Promise<boolean>;
 
-    unpublishContent(id: string, datetime?: string): Promise<Boolean>;
+    unpublishContent(id: string, datetime?: string): Promise<boolean>;
 
     scheduleAction(data: ApwScheduleActionData): Promise<string>;
 
@@ -473,12 +473,12 @@ export type ContentGetter = (
 export type ContentPublisher = (
     id: string,
     settings: { modelId?: string }
-) => Promise<Boolean | null>;
+) => Promise<boolean | null>;
 
 export type ContentUnPublisher = (
     id: string,
     settings: { modelId?: string }
-) => Promise<Boolean | null>;
+) => Promise<boolean | null>;
 
 export interface AdvancedPublishingWorkflow {
     addContentGetter: (type: ApwContentTypes, func: ContentGetter) => void;
@@ -639,7 +639,7 @@ export interface ApwReviewerStorageOperations {
 
     updateReviewer(params: StorageOperationsUpdateReviewerParams): Promise<ApwReviewer>;
 
-    deleteReviewer(params: StorageOperationsDeleteReviewerParams): Promise<Boolean>;
+    deleteReviewer(params: StorageOperationsDeleteReviewerParams): Promise<boolean>;
 }
 
 export interface ApwWorkflowStorageOperations {
@@ -654,7 +654,7 @@ export interface ApwWorkflowStorageOperations {
 
     updateWorkflow(params: StorageOperationsUpdateWorkflowParams): Promise<ApwWorkflow>;
 
-    deleteWorkflow(params: StorageOperationsDeleteWorkflowParams): Promise<Boolean>;
+    deleteWorkflow(params: StorageOperationsDeleteWorkflowParams): Promise<boolean>;
 }
 
 export interface ApwContentReviewStorageOperations {
@@ -675,7 +675,7 @@ export interface ApwContentReviewStorageOperations {
         params: StorageOperationsUpdateContentReviewParams
     ): Promise<ApwContentReview>;
 
-    deleteContentReview(params: StorageOperationsDeleteContentReviewParams): Promise<Boolean>;
+    deleteContentReview(params: StorageOperationsDeleteContentReviewParams): Promise<boolean>;
 }
 
 export interface ApwChangeRequestStorageOperations {
@@ -696,7 +696,7 @@ export interface ApwChangeRequestStorageOperations {
         params: StorageOperationsUpdateChangeRequestParams
     ): Promise<ApwChangeRequest>;
 
-    deleteChangeRequest(params: StorageOperationsDeleteChangeRequestParams): Promise<Boolean>;
+    deleteChangeRequest(params: StorageOperationsDeleteChangeRequestParams): Promise<boolean>;
 }
 
 export interface ApwCommentStorageOperations {
@@ -711,7 +711,7 @@ export interface ApwCommentStorageOperations {
 
     updateComment(params: StorageOperationsUpdateCommentParams): Promise<ApwComment>;
 
-    deleteComment(params: StorageOperationsDeleteCommentParams): Promise<Boolean>;
+    deleteComment(params: StorageOperationsDeleteCommentParams): Promise<boolean>;
 }
 
 export interface ApwStorageOperations

--- a/packages/app-aco/src/dialogs/dialogs.tsx
+++ b/packages/app-aco/src/dialogs/dialogs.tsx
@@ -14,8 +14,8 @@ interface ShowDialogParams {
     acceptLabel: ReactNode;
     cancelLabel: ReactNode;
     loadingLabel: ReactNode;
-    onAccept?: Function;
-    onClose?: Function;
+    onAccept?: (data: GenericFormData) => void;
+    onClose?: () => void;
 }
 
 export interface DialogsContext {
@@ -32,8 +32,8 @@ interface State {
     acceptLabel: ReactNode;
     cancelLabel: ReactNode;
     loadingLabel: ReactNode;
-    onAccept?: Function;
-    onClose?: Function;
+    onAccept?: (data: GenericFormData) => void;
+    onClose?: () => void;
     open: boolean;
     loading: boolean;
 }

--- a/packages/app-admin/src/base/ui/FileManager.tsx
+++ b/packages/app-admin/src/base/ui/FileManager.tsx
@@ -58,7 +58,7 @@ export type MultipleProps =
       };
 
 export type FileManagerProps = {
-    accept?: Array<string>;
+    accept?: string[];
     images?: boolean;
     maxSize?: number | string;
     /**
@@ -69,7 +69,7 @@ export type FileManagerProps = {
     onUploadCompletion?: (files: FileManagerFileItem[]) => void;
     own?: boolean;
     scope?: string;
-    tags?: Array<string>;
+    tags?: string[];
     show?: boolean;
     /**
      * @deprecated This prop is no longer used. Use the `render` prop to get better TS autocomplete.

--- a/packages/app-admin/src/ui/elements/NavigationMenuElement.tsx
+++ b/packages/app-admin/src/ui/elements/NavigationMenuElement.tsx
@@ -7,7 +7,7 @@ export interface NavigationMenuElementConfig extends UIElementConfig {
     label: React.ReactNode;
     icon?: React.ReactElement;
     path?: string;
-    onClick?: Function;
+    onClick?: (value: any) => void;
     testId?: string;
     rel?: string;
     target?: string;

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ApwFile.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ApwFile.tsx
@@ -3,6 +3,7 @@ import * as Ui from "@webiny/ui/ImageUpload";
 import { Image } from "@webiny/app/components";
 import { ApwMediaFile } from "~/types";
 import { createRenderImagePreview, imagePlugins } from "./utils";
+import { FileManagerFileItem } from "@webiny/app-admin";
 
 const imageContainerStyle = { width: 184, height: 187 };
 
@@ -23,7 +24,7 @@ const defaultStyles = {
 
 interface ApwFileProps {
     value: ApwMediaFile;
-    onChange: Function;
+    onChange: (file: FileManagerFileItem | null) => void;
     showFileManager: () => void;
 }
 

--- a/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequestDialog.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/ChangeRequest/ChangeRequestDialog.tsx
@@ -161,7 +161,7 @@ export const ChangeRequestDialog: React.FC = () => {
          */
         if (isValidId(changeRequestId)) {
             await update({
-                variables: { id: changeRequestId, data: pick(data, fields) }
+                variables: { id: changeRequestId as string, data: pick(data, fields) }
             });
         } else {
             await create({ variables: { data } });

--- a/packages/app-apw/src/components/ContentReviewEditor/Comment/CommentBox.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/Comment/CommentBox.tsx
@@ -14,6 +14,7 @@ import { Box, Columns } from "~/components/Layout";
 import Spinner from "react-spinner-material";
 import { FileManager } from "@webiny/app-admin/components";
 import { richTextWrapperStyles } from "../Styled";
+import { ApwComment } from "~/types";
 
 const richTextStyles = css`
     /**
@@ -77,7 +78,7 @@ const InputBox = styled(Box)`
 `;
 
 interface CommentBoxProps {
-    scrollToLatestComment: Function;
+    scrollToLatestComment: () => void;
 }
 
 export const CommentBox: React.FC<CommentBoxProps> = ({ scrollToLatestComment }) => {
@@ -89,13 +90,17 @@ export const CommentBox: React.FC<CommentBoxProps> = ({ scrollToLatestComment })
     return (
         <Form
             key={commentBoxKey}
-            onSubmit={async formData => {
-                const data = {
+            onSubmit={async (formData: ApwComment) => {
+                const data: ApwComment = {
                     ...formData,
-                    changeRequest: changeRequestId
+                    changeRequest: changeRequestId as string
                 };
                 setLoading(true);
-                const response = await createComment({ variables: { data } });
+                const response = await createComment({
+                    variables: {
+                        data
+                    }
+                });
                 /*
                  * After submitting comment we're using the "id" state to re-mount entire Form component,
                  * so that we have a clean slate for "RichTextEditor" for new comment.
@@ -107,7 +112,7 @@ export const CommentBox: React.FC<CommentBoxProps> = ({ scrollToLatestComment })
         >
             {({ Bind, submit, data }) => (
                 <CommentBoxColumns space={2} alignItems={"center"} paddingX={6}>
-                    <AttachmentBox active={data.media}>
+                    <AttachmentBox active={!!data.media}>
                         <Bind name={"media"}>
                             {props => (
                                 <FileManager

--- a/packages/app-apw/src/components/ContentReviewEditor/RightPanel.tsx
+++ b/packages/app-apw/src/components/ContentReviewEditor/RightPanel.tsx
@@ -25,7 +25,7 @@ export const RightPanel: React.FC = () => {
      * After adding a comment we scroll the comments list to the bottom,
      * so that the latest comment is always visible.
      */
-    const scrollToLatestComment = () => {
+    const scrollToLatestComment = (): void => {
         if (!ref.current || typeof ref.current.scrollIntoView !== "function") {
             return;
         }

--- a/packages/app-apw/src/hooks/useChangeRequest.ts
+++ b/packages/app-apw/src/hooks/useChangeRequest.ts
@@ -1,5 +1,5 @@
 import dotPropImmutable from "dot-prop-immutable";
-import { useQuery, useMutation } from "@apollo/react-hooks";
+import { useQuery, useMutation, MutationTuple } from "@apollo/react-hooks";
 import cloneDeep from "lodash/cloneDeep";
 import {
     CREATE_CHANGE_REQUEST_MUTATION,
@@ -27,8 +27,14 @@ interface UseChangeRequestParams {
 }
 
 interface UseChangeRequestResult {
-    create: Function;
-    update: Function;
+    create: MutationTuple<
+        CreateChangeRequestMutationResponse,
+        CreateChangeRequestMutationVariables
+    >[0];
+    update: MutationTuple<
+        UpdateChangeRequestMutationResponse,
+        UpdateChangeRequestMutationVariables
+    >[0];
     deleteChangeRequest: (id: string) => Promise<any>;
     changeRequest: ApwChangeRequest;
     markResolved: (resolved: boolean) => Promise<void>;

--- a/packages/app-apw/src/hooks/useComment.ts
+++ b/packages/app-apw/src/hooks/useComment.ts
@@ -1,5 +1,5 @@
 import dotPropImmutable from "dot-prop-immutable";
-import { useQuery, useMutation } from "@apollo/react-hooks";
+import { useQuery, useMutation, MutationTuple } from "@apollo/react-hooks";
 import { useSnackbar } from "@webiny/app-admin";
 import { ApwComment } from "~/types";
 import { useListCommentsVariables } from "~/hooks/useCommentsList";
@@ -14,7 +14,7 @@ import {
 } from "~/graphql/comment.gql";
 
 interface UseCommentResult {
-    createComment: Function;
+    createComment: MutationTuple<CreateCommentMutationResponse, CreateCommentMutationVariables>[0];
     comment: ApwComment;
     loading: boolean;
 }

--- a/packages/app-apw/src/hooks/usePublishContent.ts
+++ b/packages/app-apw/src/hooks/usePublishContent.ts
@@ -2,23 +2,23 @@ import { useState } from "react";
 import { useMutation } from "@apollo/react-hooks";
 import dotPropImmutable from "dot-prop-immutable";
 import {
-    PUBLISH_CONTENT_MUTATION,
-    UNPUBLISH_CONTENT_MUTATION,
     DELETE_SCHEDULED_ACTION_MUTATION,
+    DeleteApwContentReviewMutationResponse,
+    DeleteApwContentReviewMutationVariables,
+    GET_CONTENT_REVIEW_QUERY,
+    PUBLISH_CONTENT_MUTATION,
     PublishContentMutationResponse,
     PublishContentMutationVariables,
+    UNPUBLISH_CONTENT_MUTATION,
     UnPublishContentMutationResponse,
-    UnPublishContentMutationVariables,
-    DeleteApwContentReviewMutationResponse,
-    DeleteApwContentReviewMutationVariables
+    UnPublishContentMutationVariables
 } from "~/graphql/contentReview.gql";
 import { useContentReviewId } from "~/hooks/useContentReviewId";
 import { useSnackbar } from "@webiny/app-admin";
-import { GET_CONTENT_REVIEW_QUERY } from "~/graphql/contentReview.gql";
 
 interface UsePublishContentResult {
-    publishContent: Function;
-    unpublishContent: Function;
+    publishContent: (datetime?: string) => Promise<void>;
+    unpublishContent: (datetime?: string) => Promise<void>;
     deleteScheduledAction: () => void;
     loading: boolean;
 }

--- a/packages/app-apw/src/hooks/useStepSignoff.ts
+++ b/packages/app-apw/src/hooks/useStepSignoff.ts
@@ -16,8 +16,8 @@ import {
 } from "~/graphql/contentReview.gql";
 
 interface UseStepSignOffResult {
-    provideSignOff: Function;
-    retractSignOff: Function;
+    provideSignOff: () => Promise<void>;
+    retractSignOff: () => Promise<void>;
     loading: boolean;
 }
 

--- a/packages/app-apw/src/views/publishingWorkflows/components/WorkflowTitle.tsx
+++ b/packages/app-apw/src/views/publishingWorkflows/components/WorkflowTitle.tsx
@@ -47,10 +47,11 @@ export const pageTitleWrapper = css({
     maxWidth: "calc(100% - 50px)"
 });
 
-const Title: React.FunctionComponent<{ value: string; onChange: Function }> = ({
-    value,
-    onChange
-}) => {
+interface TitleProps {
+    value: string;
+    onChange: (value: string) => void;
+}
+const Title: React.FunctionComponent<TitleProps> = ({ value, onChange }) => {
     const [editTitle, setEdit] = useState<boolean>(false);
     const [stateTitle, setTitle] = useState<string | null>(null);
     let title = stateTitle === null ? value : stateTitle;

--- a/packages/app-apw/src/views/publishingWorkflows/components/cms/CmsScopeSettings.tsx
+++ b/packages/app-apw/src/views/publishingWorkflows/components/cms/CmsScopeSettings.tsx
@@ -98,7 +98,7 @@ const CmsEntriesList: React.FC<CmsEntriesListProps> = ({ bind, models }) => {
         models
     });
 
-    const render = useCallback((item: CmsEntryOption) => {
+    const render = useCallback((item: CmsEntryOption): React.ReactNode => {
         return (
             <div>
                 <div className={entryNameStyle}>{item.name}</div>

--- a/packages/app-file-manager/src/components/Grid/File.tsx
+++ b/packages/app-file-manager/src/components/Grid/File.tsx
@@ -26,12 +26,17 @@ import {
 } from "./styled";
 import { useMoveFileToFolder } from "~/hooks/useMoveFileToFolder";
 
+export interface FileOptions {
+    label: string;
+    // TODO fix the type!
+    onClick: (file: boolean) => void;
+}
 export interface FileProps {
     file: FileItem;
     selected: boolean;
     onSelect?: (event?: React.MouseEvent) => void;
     onClick?: (event?: React.MouseEvent) => void;
-    options?: Array<{ label: string; onClick: (file: Object) => void }>;
+    options?: FileOptions[];
     multiple?: boolean;
     children: React.ReactNode;
     showFileDetails: (id: string) => void;

--- a/packages/app-file-manager/src/components/Grid/Grid.tsx
+++ b/packages/app-file-manager/src/components/Grid/Grid.tsx
@@ -21,8 +21,8 @@ interface GridProps {
     multiple?: boolean;
     toggleSelected: (file: FileItem) => void;
     deselectAll: () => void;
-    onChange?: Function;
-    onClose?: Function;
+    onChange?: (file: FileItem) => void;
+    onClose?: () => void;
     hasOnSelectCallback: boolean;
 }
 

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
@@ -7,7 +7,7 @@ export interface BrowserConfig {
     bulkActions: BulkActionConfig[];
     filters: FilterConfig[];
     filtersToWhere: FiltersToWhereConverter[];
-    filterByTags: Boolean;
+    filterByTags: boolean;
 }
 
 export const Browser = {

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/index.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/index.tsx
@@ -55,7 +55,7 @@ export const FileManagerRenderer = createComponentPlugin(BaseFileManagerRenderer
             }
 
             if (Array.isArray(value)) {
-                const finalValue: FileManagerFileItem[] = value.map(formatFileItem);
+                const finalValue = value.map(formatFileItem);
                 (onChange as FileManagerOnChange<FileManagerFileItem[]>)(finalValue);
                 return;
             }
@@ -65,6 +65,11 @@ export const FileManagerRenderer = createComponentPlugin(BaseFileManagerRenderer
 
         const viewProps: FileManagerViewProviderProps = {
             ...forwardProps,
+            /**
+             * TODO @pavel - verify that this is correct
+             */
+            onUploadCompletion:
+                forwardProps.onUploadCompletion as FileManagerViewProviderProps["onUploadCompletion"],
             onChange: typeof onChange === "function" ? handleFileOnChange : undefined,
             accept: images ? accept || imagesAccept : accept || []
         };

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
@@ -36,7 +36,7 @@ export interface FileManagerViewContext<TFileItem extends FileItem = FileItem> e
     moveFileToFolder: (fileId: string, folderId: string) => Promise<void>;
     multiple: boolean;
     onClose: () => void;
-    onChange: Function;
+    onChange: (value: FileItem[] | FileItem) => void;
     onUploadCompletion: (files: FileItem[]) => void;
     own: boolean;
     scope?: string;
@@ -83,14 +83,14 @@ const getCurrentFolderList = (
 };
 
 export interface FileManagerViewProviderProps {
-    onChange?: Function;
+    onChange?: (value: FileItem[] | FileItem) => void;
     onClose?: () => void;
     multiple?: boolean;
     accept: string[];
     maxSize?: number | string;
     multipleMaxCount?: number;
     multipleMaxSize?: number | string;
-    onUploadCompletion?: Function;
+    onUploadCompletion?: (files: FileItem[]) => void;
     tags?: string[];
     scope?: string;
     own?: boolean;
@@ -392,7 +392,7 @@ export const FileManagerViewProvider: React.VFC<FileManagerViewProviderProps> = 
         meta,
         moveFileToFolder,
         multiple: Boolean(props.multiple),
-        onChange(value: any[]) {
+        onChange(value: FileItem[] | FileItem) {
             if (typeof props.onChange === "function") {
                 props.onChange(value);
             }

--- a/packages/app-form-builder/src/components/Form/components/createReCaptchaComponent.tsx
+++ b/packages/app-form-builder/src/components/Form/components/createReCaptchaComponent.tsx
@@ -16,8 +16,8 @@ interface ChildrenFunction {
 export type ReCaptchaProps = {
     children?: React.ReactNode | ChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any) => void;
+    onExpired?: (...args: any) => void;
 };
 
 export type ReCaptchaComponent = React.FC<ReCaptchaProps>;

--- a/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
@@ -18,8 +18,8 @@ type ChildrenFunction = (params: {
 export interface TermsOfServiceProps {
     children: ChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any) => void;
+    onExpired?: (...args: any) => void;
 }
 
 export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;

--- a/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
@@ -11,7 +11,7 @@ interface CreateTermsOfServiceComponentArgs {
 
 type ChildrenFunction = (params: {
     onChange: (value: boolean) => void;
-    errorMessage: String;
+    errorMessage: string;
     message: OutputBlockData[];
 }) => React.ReactNode;
 

--- a/packages/app-form-builder/src/types.ts
+++ b/packages/app-form-builder/src/types.ts
@@ -294,8 +294,8 @@ export type FormRenderFbFormModelField = FbFormModelField & {
 };
 
 export type FormRenderPropsType<T = Record<string, any>> = {
-    getFieldById: Function;
-    getFieldByFieldId: Function;
+    getFieldById: (id: string) => FbFormModelField | null;
+    getFieldByFieldId: (id: string) => FbFormModelField | null;
     getFields: (stepIndex?: number) => FormRenderFbFormModelField[][];
     getDefaultValues: () => { [key: string]: any };
     goToNextStep: () => void;

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -28,7 +28,7 @@ import {
     createRevisionsQuery
 } from "@webiny/app-headless-cms-common";
 import { getFetchPolicy } from "~/utils/getFetchPolicy";
-import { FormSubmitOptions } from "@webiny/form";
+import { FormAPI, FormSubmitOptions } from "@webiny/form";
 
 interface ContentEntryContextForm {
     submit: (
@@ -41,7 +41,7 @@ export interface ContentEntryContext extends ContentEntriesContext {
     createEntry: () => void;
     entry: CmsContentEntry;
     form: ContentEntryContextFormRef;
-    setFormRef: (form: { submit: Function }) => void;
+    setFormRef: (form: Pick<FormAPI, "submit">) => void;
     loading: boolean;
     setLoading: Dispatch<SetStateAction<boolean>>;
     revisions: CmsContentEntryRevision[];

--- a/packages/app-page-builder-editor/src/contexts/compose.ts
+++ b/packages/app-page-builder-editor/src/contexts/compose.ts
@@ -1,4 +1,7 @@
-export const composeAsync = (functions: Array<Function> = []): Function => {
+export interface ComposeAsyncCallable {
+    (...args: any[]): Promise<any>;
+}
+export const composeAsync = (functions: ComposeAsyncCallable[] = []) => {
     return (input: unknown): Promise<any> => {
         if (!functions.length) {
             return Promise.resolve();
@@ -28,7 +31,10 @@ export const composeAsync = (functions: Array<Function> = []): Function => {
     };
 };
 
-export const composeSync = (functions: Array<Function> = []): Function => {
+export interface ComposeSyncCallable {
+    (...args: any[]): any;
+}
+export const composeSync = (functions: ComposeSyncCallable[] = []) => {
     return (input: unknown) => {
         if (!functions.length) {
             return input;

--- a/packages/app-page-builder-elements/src/createRenderer.tsx
+++ b/packages/app-page-builder-elements/src/createRenderer.tsx
@@ -23,7 +23,7 @@ const DEFAULT_RENDERER_STYLES: StylesObject = {
     boxSizing: "border-box"
 };
 
-export function createRenderer<TRenderComponentProps = {}>(
+export function createRenderer<TRenderComponentProps = Record<string, any>>(
     RendererComponent: React.ComponentType<TRenderComponentProps>,
     options: CreateRendererOptions<TRenderComponentProps> = {}
 ): Renderer<TRenderComponentProps> {

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createReCaptchaComponent.tsx
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createReCaptchaComponent.tsx
@@ -16,8 +16,8 @@ interface ChildrenFunction {
 export type ReCaptchaProps = {
     children?: React.ReactNode | ChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any[]) => void;
+    onExpired?: (...args: any[]) => void;
 };
 
 export type ReCaptchaComponent = React.FC<ReCaptchaProps>;

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
@@ -11,7 +11,7 @@ interface CreateTermsOfServiceComponentArgs {
 
 type ChildrenFunction = (params: {
     onChange: (value: boolean) => void;
-    errorMessage: String;
+    errorMessage: string;
     message: OutputBlockData[];
 }) => React.ReactNode;
 

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
@@ -18,8 +18,8 @@ type ChildrenFunction = (params: {
 export interface TermsOfServiceProps {
     children: ChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any[]) => void;
+    onExpired?: (...args: any[]) => void;
 }
 
 export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;

--- a/packages/app-page-builder-elements/src/renderers/form/types.ts
+++ b/packages/app-page-builder-elements/src/renderers/form/types.ts
@@ -81,8 +81,8 @@ export interface ErrorResponse {
 }
 
 export type FormLayoutComponentProps<T = any> = {
-    getFieldById: Function;
-    getFieldByFieldId: Function;
+    getFieldById: (id: string) => FormDataField | null;
+    getFieldByFieldId: (id: string) => FormDataField | null;
     getFields: (stepIndex?: number) => FormRenderComponentDataField[][];
     getDefaultValues: () => { [key: string]: any };
     goToNextStep: () => void;
@@ -109,8 +109,8 @@ export interface ReCaptchaChildrenFunction {
 export type ReCaptchaProps = {
     children?: React.ReactNode | ReCaptchaChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any[]) => void;
+    onExpired?: (...args: any[]) => void;
 };
 
 export type ReCaptchaComponent = React.FC<ReCaptchaProps>;
@@ -125,8 +125,8 @@ export type TermsOfServiceChildrenFunction = (params: {
 export interface TermsOfServiceProps {
     children: TermsOfServiceChildrenFunction;
     onChange?: (value: string) => void;
-    onErrored?: Function;
-    onExpired?: Function;
+    onErrored?: (...args: any[]) => void;
+    onExpired?: (...args: any[]) => void;
 }
 
 export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;

--- a/packages/app-page-builder-elements/src/renderers/form/types.ts
+++ b/packages/app-page-builder-elements/src/renderers/form/types.ts
@@ -117,7 +117,7 @@ export type ReCaptchaComponent = React.FC<ReCaptchaProps>;
 
 export type TermsOfServiceChildrenFunction = (params: {
     onChange: (value: boolean) => void;
-    errorMessage: String;
+    errorMessage: string;
     // Should be `OutputBlockData` from `@editorjs/editorjs`, but didn't want to introduce an extra dependency.
     message: any;
 }) => React.ReactNode;

--- a/packages/app-page-builder-elements/src/types.ts
+++ b/packages/app-page-builder-elements/src/types.ts
@@ -122,9 +122,10 @@ export interface PageProviderProps {
     layoutProps?: Record<string, any>;
 }
 
-export type Renderer<T = {}, TElementData = Record<string, any>> = React.ComponentType<
-    RendererProps<TElementData> & T
->;
+export type Renderer<
+    T = Record<string, any>,
+    TElementData = Record<string, any>
+> = React.ComponentType<RendererProps<TElementData> & T>;
 
 export type ElementAttributesModifier = (args: {
     element: Element;

--- a/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/PagePreview.tsx
+++ b/packages/app-page-builder/src/admin/plugins/pageDetails/previewContent/PagePreview.tsx
@@ -6,6 +6,7 @@ import { Select } from "@webiny/ui/Select";
 import { Page } from "@webiny/app-page-builder-elements/components/Page";
 import { Zoom } from "./Zoom";
 import { PbPageData, PbPageTemplate } from "~/types";
+import { QueryResult } from "@apollo/react-common";
 
 const webinyZoomStyles = css`
     &.mdc-select--no-label:not(.mdc-select--outlined)
@@ -81,7 +82,7 @@ const SelectPageZoom: React.ComponentType<PagePreviewInnerProps> = ({ zoom, setZ
 
 interface PagePreviewProps {
     page: PbPageData | PbPageTemplate;
-    getPageQuery?: Function;
+    getPageQuery?: QueryResult;
 }
 
 const PagePreview: React.FC<PagePreviewProps> = ({ page }) => {

--- a/packages/app-page-builder/src/admin/views/Categories/CategoriesDialog.tsx
+++ b/packages/app-page-builder/src/admin/views/Categories/CategoriesDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from "@webiny/ui/List";
 import { ButtonDefault } from "@webiny/ui/Button";
 import { LIST_CATEGORIES } from "./graphql";
-import { PageBuilderListCategoriesResponse } from "~/types";
+import { PageBuilderListCategoriesResponse, PbCategory } from "~/types";
 
 const narrowDialog = css({
     ".mdc-dialog__surface": {
@@ -30,7 +30,7 @@ const narrowDialog = css({
 export type CategoriesDialogProps = {
     open: boolean;
     onClose: DialogOnClose;
-    onSelect: Function;
+    onSelect: (item: PbCategory) => void;
     children: any;
 };
 interface ListCategoriesQueryResponse {

--- a/packages/app-page-builder/src/admin/views/Menus/MenusDialog.tsx
+++ b/packages/app-page-builder/src/admin/views/Menus/MenusDialog.tsx
@@ -41,7 +41,7 @@ interface ListMenusResponse {
 export interface MenusDialogProps {
     open: boolean;
     onClose: DialogOnClose;
-    onSelect: Function;
+    onSelect: (item: PbMenu) => void;
     children: any;
 }
 

--- a/packages/app-page-builder/src/contexts/PageBuilder/PageBuilderContext.tsx
+++ b/packages/app-page-builder/src/contexts/PageBuilder/PageBuilderContext.tsx
@@ -7,12 +7,12 @@ import { PageElementsProvider } from "./PageElementsProvider";
 
 export interface ResponsiveDisplayMode {
     displayMode: DisplayMode;
-    setDisplayMode: Function;
+    setDisplayMode: (value: DisplayMode) => void;
 }
 
 export interface ExportPageData {
     revisionType: string;
-    setRevisionType: Function;
+    setRevisionType: (value: string) => void;
 }
 
 export interface PageBuilderContext {
@@ -37,7 +37,7 @@ export const PageBuilderContext = React.createContext<PageBuilderContext | undef
 
 export const PageBuilderProvider: React.FC<PageBuilderProviderProps> = ({ children }) => {
     const [displayMode, setDisplayMode] = React.useState(DisplayMode.DESKTOP);
-    const [revisionType, setRevisionType] = React.useState("published");
+    const [revisionType, setRevisionType] = React.useState<string>("published");
     const { theme, loadThemeFromPlugins } = useTheme();
 
     return (

--- a/packages/app-page-builder/src/editor/components/ColorPicker/ColorPicker.tsx
+++ b/packages/app-page-builder/src/editor/components/ColorPicker/ColorPicker.tsx
@@ -171,8 +171,8 @@ const styles = {
 
 interface ColorPickerProps {
     value: string;
-    onChange: Function;
-    onChangeComplete: Function;
+    onChange: (value: string) => void;
+    onChangeComplete: (value: string) => void;
     compact?: boolean;
     handlerClassName?: string;
 }

--- a/packages/app-page-builder/src/editor/components/ColorPicker/index.tsx
+++ b/packages/app-page-builder/src/editor/components/ColorPicker/index.tsx
@@ -112,8 +112,8 @@ const styles = {
 
 type ColorPickerProps = {
     value: string;
-    onChange: Function;
-    onChangeComplete: Function;
+    onChange: (value: string) => void;
+    onChangeComplete: (value: string) => void;
     compact?: boolean;
     handlerClassName?: string;
 };

--- a/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControlsOverlay.tsx
+++ b/packages/app-page-builder/src/editor/contexts/EditorPageElementsProvider/ElementControlsOverlay.tsx
@@ -30,7 +30,7 @@ const ACTIVE_COLOR = "var(--mdc-theme-primary)";
 const HOVER_COLOR = "var(--mdc-theme-secondary)";
 
 type PbElementControlsOverlayProps = React.HTMLProps<HTMLDivElement> & {
-    className?: String;
+    className?: string;
     element: Element;
     elementRendererMeta: RendererMeta;
     isActive: boolean;

--- a/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/useExportPageRevisionSelectorDialog.tsx
+++ b/packages/app-page-builder/src/editor/plugins/defaultBar/components/ExportPageButton/useExportPageRevisionSelectorDialog.tsx
@@ -42,7 +42,10 @@ const ExportPageDialogMessage: React.FC<ExportPageDialogMessageProps> = ({ selec
                         data={{ revision: value }}
                         onChange={data => {
                             const { revision } = data as unknown as PbElementDataSettingsFormType;
-                            return setValue(revision);
+                            /**
+                             * We expect revision to be string.
+                             */
+                            return setValue(revision as string);
                         }}
                     >
                         {({ Bind }) => (

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/background/BackgroundPositionSelector.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/background/BackgroundPositionSelector.tsx
@@ -47,7 +47,7 @@ const PositionWrapper = styled("div")({
 interface BackgroundPositionSelectorProps {
     disabled?: boolean;
     value?: string;
-    onChange: Function;
+    onChange: (value: string) => void;
 }
 
 const BackgroundPositionSelector: React.FC<BackgroundPositionSelectorProps> = props => {

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/background/BackgroundSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/background/BackgroundSettings.tsx
@@ -93,15 +93,15 @@ const BackgroundSettings: React.FC<SettingsPropsType> = ({ options, defaultAccor
         [getUpdateValue, displayMode]
     );
     const setPosition = useCallback(
-        value => getUpdateValue(`${displayMode}.image.position`)(value),
+        (value: string) => getUpdateValue(`${displayMode}.image.position`)(value),
         [getUpdateValue, displayMode]
     );
     const setColor = useCallback(
-        value => getUpdateValue(`${displayMode}.color`)(value),
+        (value: string) => getUpdateValue(`${displayMode}.color`)(value),
         [getUpdateValue, displayMode]
     );
     const onColorChange = useCallback(
-        value => getUpdatePreview(`${displayMode}.color`)(value),
+        (value: string) => getUpdatePreview(`${displayMode}.color`)(value),
         [getUpdatePreview, displayMode]
     );
 

--- a/packages/app-page-builder/src/editor/plugins/elementSettings/components/ColorPicker.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elementSettings/components/ColorPicker.tsx
@@ -27,8 +27,8 @@ interface ColorPickerProps {
     value?: string;
     valueKey?: string;
     defaultValue?: string;
-    updatePreview: Function;
-    updateValue: Function;
+    updatePreview: (value: string) => void;
+    updateValue: (value: string) => void;
     className?: string;
     handlerClassName?: string;
 }

--- a/packages/app-page-builder/src/editor/plugins/elements/embeds/soundcloud/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/embeds/soundcloud/index.tsx
@@ -53,6 +53,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             // @ts-expect-error
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
+            // @ts-expect-error
             settings: args.settings,
             create: args.create,
             render

--- a/packages/app-page-builder/src/editor/plugins/elements/embeds/vimeo/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/embeds/vimeo/index.tsx
@@ -55,6 +55,10 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
             create: args.create,
+            /**
+             * TODO Figure out types.
+             */
+            // @ts-expect-error
             settings: args.settings,
             oembed: {
                 renderEmbed(props) {

--- a/packages/app-page-builder/src/editor/plugins/elements/embeds/youtube/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/embeds/youtube/index.tsx
@@ -57,6 +57,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
             create: args.create,
+            // @ts-expect-error
             settings: args.settings,
             onCreate: OnCreateActions.OPEN_SETTINGS,
             oembed: {

--- a/packages/app-page-builder/src/editor/plugins/elements/imagesList/File.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/imagesList/File.tsx
@@ -77,7 +77,7 @@ const imageStyles = css({
 interface FileProps {
     file: ImagesListFile;
     selected?: boolean;
-    uploadFile?: Function;
+    uploadFile?: () => void;
     onSelect?: (e: SyntheticEvent) => void;
     onClick?: (e: SyntheticEvent) => void;
     onRemove?: (e: SyntheticEvent) => void;

--- a/packages/app-page-builder/src/editor/plugins/elements/social/pinterest/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/social/pinterest/index.tsx
@@ -52,6 +52,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
             create: args.create,
+            // @ts-expect-error
             settings: args.settings,
             render(props) {
                 // @ts-expect-error No need to worry about different `element.elements` type.

--- a/packages/app-page-builder/src/editor/plugins/elements/social/twitter/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/social/twitter/index.tsx
@@ -55,6 +55,7 @@ export default (args: PbEditorElementPluginArgs = {}) => {
             toolbar:
                 typeof args.toolbar === "function" ? args.toolbar(defaultToolbar) : defaultToolbar,
             create: args.create,
+            // @ts-expect-error
             settings: args.settings,
             oembed: {
                 global: "twttr",

--- a/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/createEmbedPlugin.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/utils/oembed/createEmbedPlugin.tsx
@@ -44,8 +44,8 @@ export interface EmbedPluginConfig {
         renderEmbed?: (props: OEmbedProps) => React.ReactElement;
         init?: (params: { node: HTMLElement }) => void;
     };
-    settings?: Array<string | Array<string | any>> | Function;
-    create?: Function;
+    settings?: Array<string | Array<string | any>> | ((values: string[]) => string[]);
+    create?: (element: Partial<PbEditorElement>) => Partial<PbEditorElement>;
     target?: Array<string>;
     onCreate?: OnCreateActions;
     renderElementPreview?: EmbedPluginConfigRenderElementPreviewCallable;

--- a/packages/app-page-builder/src/editor/plugins/toolbar/navigator/navigatorHooks.ts
+++ b/packages/app-page-builder/src/editor/plugins/toolbar/navigator/navigatorHooks.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
-import { useDrag, useDrop, DropTargetMonitor } from "react-dnd";
+import { useDrag, useDrop, DropTargetMonitor, DragSourceMonitor } from "react-dnd";
 import { elementByIdSelector, rootElementAtom } from "~/editor/recoil/modules";
 import { MoveBlockActionArgsType } from "~/editor/recoil/actions/moveBlock/types";
 import { MoveBlockActionEvent } from "~/editor/recoil/actions";
@@ -58,8 +58,8 @@ interface UseSortableListArgs {
     id: string;
     type: string;
     move: (current: number, next: number) => void;
-    beginDrag?: Function;
-    endDrag?: Function;
+    beginDrag?: (monitor: DragSourceMonitor) => void;
+    endDrag?: (item: DraggableItem | undefined, monitor: DragSourceMonitor) => void;
 }
 
 export const useSortableList = ({

--- a/packages/app-page-builder/src/editor/recoil/actions/drag/types.ts
+++ b/packages/app-page-builder/src/editor/recoil/actions/drag/types.ts
@@ -1,2 +1,2 @@
-export type DragStartActionArgsType = {};
-export type DragEndActionArgsType = {};
+export type DragStartActionArgsType = Record<string, any>;
+export type DragEndActionArgsType = Record<string, any>;

--- a/packages/app-page-builder/src/hooks/useResponsiveClassName.ts
+++ b/packages/app-page-builder/src/hooks/useResponsiveClassName.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { plugins } from "@webiny/plugins";
 import kebabCase from "lodash/kebabCase";
-import { PbRenderResponsiveModePlugin } from "~/types";
+import { DisplayMode, PbRenderResponsiveModePlugin } from "~/types";
 import { usePageBuilder } from "~/hooks/usePageBuilder";
 
 interface UseResponsiveClassName {
@@ -55,8 +55,10 @@ const useResponsiveClassName = (): UseResponsiveClassName => {
                     mode = config.displayMode;
                 }
             });
-
-            setDisplayMode(mode);
+            /**
+             * We can safely cast.
+             */
+            setDisplayMode(mode as DisplayMode);
         },
         [responsiveModeConfigs]
     );

--- a/packages/app-page-builder/src/hooks/useSortableList.ts
+++ b/packages/app-page-builder/src/hooks/useSortableList.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { useDrag, useDrop, DropTargetMonitor } from "react-dnd";
+import { useDrag, useDrop, DropTargetMonitor, DragSourceMonitor } from "react-dnd";
 import { DraggableItem } from "~/editor/components/Draggable";
 
 export const moveInPlace = (arr: any[], from: number, to: number): any[] => {
@@ -24,8 +24,8 @@ interface UseSortableListArgs {
     id: string;
     type: string;
     move: (current: number, next: number) => void;
-    beginDrag?: Function;
-    endDrag?: Function;
+    beginDrag?: (monitor: DragSourceMonitor) => void;
+    endDrag?: (item: DraggableItem | undefined, monitor: DragSourceMonitor) => void;
 }
 
 export const useSortableList = ({

--- a/packages/app/src/contexts/Ui/index.tsx
+++ b/packages/app/src/contexts/Ui/index.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { UiStatePlugin } from "~/types";
 import { plugins } from "@webiny/plugins";
 
-export const UiContext = React.createContext({});
+export const UiContext = React.createContext<Record<string, any>>({});
 
-type Props = {};
+type Props = Record<string, any>;
 
 type State = {
     ui: { [key: string]: any };
@@ -28,7 +28,7 @@ export class UiProvider extends React.Component<Props, State> {
         ui: {}
     };
 
-    private readonly setData = (setter: Function): void => {
+    private readonly setData = (setter: UiDataSetter): void => {
         return this.setState((state: State) => {
             return { ui: { ...state.ui, ...setter(state.ui) } };
         });

--- a/packages/app/src/hooks/useDataList/utils/types.ts
+++ b/packages/app/src/hooks/useDataList/utils/types.ts
@@ -4,9 +4,15 @@ export type UseDataListParams = {
     type: string;
     fields: string;
     limit?: number;
-    sort?: Object;
-    where?: Object;
-    search?: Object;
+    sort?: {
+        [key: string]: string;
+    };
+    where?: {
+        [key: string]: any;
+    };
+    search?: {
+        [key: string]: any;
+    };
 };
 
 export type SearchParams = {
@@ -16,22 +22,22 @@ export type SearchParams = {
 };
 
 export type UseDataListProps = {
-    data: Array<Object>;
-    meta: Object;
+    data: Record<string, any>[];
+    meta: Record<string, any>;
     init: () => void;
-    refresh: (params?: Object) => void;
-    delete: (id: string, options: Object) => void;
+    refresh: (params?: Record<string, any>) => void;
+    delete: (id: string, options: Record<string, any>) => void;
     setPerPage: (perPage: number) => void;
     setPage: (page: number) => void;
     setSearch: (search: SearchParams | any) => void;
-    setWhere: (where: Object) => void;
-    setSorters: (sort: Object) => void;
-    multiSelect: (item: Object, value: boolean) => void;
+    setWhere: (where: Record<string, any>) => void;
+    setSorters: (sort: Record<string, any>) => void;
+    multiSelect: (item: Record<string, any>, value: boolean) => void;
     multiSelectAll: (value: boolean) => void;
 
-    isMultiSelected: (item: Object) => boolean;
+    isMultiSelected: (item: Record<string, any>) => boolean;
     isAllMultiSelected: () => boolean;
     isNoneMultiSelected: () => boolean;
-    getMultiSelected: () => Array<Object>;
+    getMultiSelected: () => Record<string, any>[];
     __loadParams: UseDataListParams;
 };

--- a/packages/aws-helpers/src/cloudfrontFunctions/utils.ts
+++ b/packages/aws-helpers/src/cloudfrontFunctions/utils.ts
@@ -2,6 +2,10 @@ import { CloudFrontRequestHandler, CloudFrontResponseHandler } from "./types";
 
 declare const global: typeof globalThis & {
     // CloudFront Functions use global handler value, not exports.
+    /**
+     * We will leave the Function for now.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-types
     handler: Function;
 };
 

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -1,4 +1,4 @@
-export type FeatureFlags<TFeatureFlags = {}> = {
+export type FeatureFlags<TFeatureFlags = Record<string, any>> = {
     copyPermissionsButton?: boolean;
     experimentalAdminOmniSearch?: boolean;
     pbLegacyRenderingEngine?: boolean;

--- a/packages/form/src/Form.tsx
+++ b/packages/form/src/Form.tsx
@@ -151,7 +151,7 @@ function FormInner<T extends GenericFormData = GenericFormData>(
         if (!onChangeFns.current[name]) {
             const linkStateChange = (
                 value: unknown,
-                inlineCallback: Function = lodashNoop
+                inlineCallback: (value?: any) => void = lodashNoop
             ): Promise<unknown> => {
                 return new Promise(resolve => {
                     afterChange.current[name] = true;

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -45,7 +45,7 @@ export interface BindComponentProps<T = any> {
     defaultValue?: any;
     validators?: Validator | Validator[];
     children?: ((props: BindComponentRenderProp<T>) => React.ReactElement) | React.ReactElement;
-    validate?: () => void;
+    validate?: Validator;
 }
 
 export type BindComponent = React.FC<BindComponentProps>;

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -45,7 +45,7 @@ export interface BindComponentProps<T = any> {
     defaultValue?: any;
     validators?: Validator | Validator[];
     children?: ((props: BindComponentRenderProp<T>) => React.ReactElement) | React.ReactElement;
-    validate?: Function;
+    validate?: () => void;
 }
 
 export type BindComponent = React.FC<BindComponentProps>;
@@ -81,10 +81,13 @@ export interface FormOnSubmit<T = GenericFormData> {
     (data: T, form: FormAPI<T>): void;
 }
 
+export interface FormPropsState<T extends GenericFormData = GenericFormData> {
+    data: T;
+}
 export interface FormProps<T extends GenericFormData = GenericFormData> {
     invalidFields?: { [key: string]: any };
     data?: Partial<T>;
-    disabled?: boolean | Function;
+    disabled?: boolean | ((state: FormPropsState<T>) => boolean);
     validateOnFirstSubmit?: boolean;
     submitOnEnter?: boolean;
     onSubmit?: FormOnSubmit<T>;

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -11,7 +11,7 @@ import { RoutePlugin } from "./plugins/RoutePlugin";
 import { createHandlerClient } from "@webiny/handler-client";
 import fastifyCookie from "@fastify/cookie";
 import fastifyCompress from "@fastify/compress";
-import { middleware } from "~/middleware";
+import { middleware, MiddlewareCallable } from "~/middleware";
 import { ContextPlugin } from "@webiny/api";
 import { BeforeHandlerPlugin } from "./plugins/BeforeHandlerPlugin";
 import { HandlerResultPlugin } from "./plugins/HandlerResultPlugin";
@@ -471,7 +471,7 @@ export const createHandler = (params: CreateHandlerParams) => {
 
         const handler = middleware(
             plugins.map(pl => {
-                return (context: Context, error: Error, next: Function) => {
+                return (context: Context, error: Error, next: MiddlewareCallable) => {
                     return pl.handle(context, error, next);
                 };
             })

--- a/packages/handler/src/middleware.ts
+++ b/packages/handler/src/middleware.ts
@@ -1,8 +1,11 @@
+export interface MiddlewareCallable {
+    (...args: any[]): Promise<any>;
+}
 /**
  * Compose a single middleware from the array of middleware functions
  */
-export const middleware = (functions: Function[] = []): Function => {
-    return (...args: string[]): Promise<any> => {
+export const middleware = (functions: MiddlewareCallable[] = []) => {
+    return (...args: any[]): Promise<any> => {
         if (!functions.length) {
             return Promise.resolve();
         }

--- a/packages/handler/src/plugins/HandlerErrorPlugin.ts
+++ b/packages/handler/src/plugins/HandlerErrorPlugin.ts
@@ -1,8 +1,12 @@
 import { Plugin } from "@webiny/plugins";
 import { Context } from "~/types";
 
+export interface NextCallable {
+    (): Promise<any>;
+}
+
 export interface HandlerErrorCallable<T extends Context = Context> {
-    (context: T, error: Error, next: Function): Promise<any>;
+    (context: T, error: Error, next: NextCallable): Promise<any>;
 }
 
 export class HandlerErrorPlugin<T extends Context = Context> extends Plugin {
@@ -15,7 +19,7 @@ export class HandlerErrorPlugin<T extends Context = Context> extends Plugin {
         this._callable = callable;
     }
 
-    public async handle(context: T, error: Error, next: Function): Promise<any> {
+    public async handle(context: T, error: Error, next: NextCallable): Promise<any> {
         return this._callable(context, error, next);
     }
 }

--- a/packages/lexical-editor-actions/src/components/LexicalColorPicker/LexicalColorPicker.tsx
+++ b/packages/lexical-editor-actions/src/components/LexicalColorPicker/LexicalColorPicker.tsx
@@ -107,8 +107,8 @@ const styles = {
 
 interface LexicalColorPickerProps {
     value: string;
-    onChange?: Function;
-    onChangeComplete: Function;
+    onChange?: (color: string) => void;
+    onChangeComplete: (color: string, name?: string) => void;
     handlerClassName?: string;
 }
 

--- a/packages/lexical-editor/src/components/ToolbarActions/ImageAction.tsx
+++ b/packages/lexical-editor/src/components/ToolbarActions/ImageAction.tsx
@@ -22,7 +22,7 @@ export const ImageAction = () => {
 
     const handleClick = () => {
         if (typeof imageActionPlugin?.plugin === "function") {
-            imageActionPlugin?.plugin((data: FileManagerFileItem) => {
+            const cb = (data: FileManagerFileItem) => {
                 const imagePayload = fileToImagePayload(data);
                 if (imagePayload) {
                     editor.dispatchCommand<LexicalCommand<ImagePayload>>(
@@ -30,7 +30,8 @@ export const ImageAction = () => {
                         imagePayload
                     );
                 }
-            });
+            };
+            imageActionPlugin.plugin(cb);
         }
     };
 

--- a/packages/lexical-editor/src/types.ts
+++ b/packages/lexical-editor/src/types.ts
@@ -6,7 +6,7 @@ export type ImageActionType = "image-action";
 export type ToolbarActionType = ImageActionType | string;
 export interface ToolbarActionPlugin {
     targetAction: ToolbarActionType;
-    plugin: Record<string, any> | Function | undefined;
+    plugin: Record<string, any> | ((cb: (value: any) => void) => any) | undefined;
 }
 
 /* Commands payload types */

--- a/packages/lexical-theme/src/utils/toTypographyEmotionMap.ts
+++ b/packages/lexical-theme/src/utils/toTypographyEmotionMap.ts
@@ -9,7 +9,7 @@ export const toTypographyEmotionMap = (
     css: (cssStyle: Record<string, any>) => string,
     theme: WebinyTheme,
     themeStylesTransformer?: any
-): ThemeEmotionMap | {} => {
+): ThemeEmotionMap => {
     const map: ThemeEmotionMap = {};
     const typographyStyles = theme.styles?.typography;
     if (!typographyStyles) {

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -33,7 +33,7 @@ export interface CognitoIdentityProviderConfig {
     attributeMapping?: IdentityAttributeMapping;
 }
 
-const isString = (value?: any): value is String => {
+const isString = (value?: any): value is string => {
     return typeof value === "string";
 };
 

--- a/packages/serverless-cms-aws/src/createReactAppConfig.ts
+++ b/packages/serverless-cms-aws/src/createReactAppConfig.ts
@@ -27,7 +27,7 @@ export interface ReactAppFactoryParams {
 }
 
 export interface ReactAppCommands {
-    [key: string]: Function;
+    [key: string]: () => Promise<any>;
 }
 
 export interface ReactAppCommandsModifier {

--- a/packages/ui-composer/src/UIElement.ts
+++ b/packages/ui-composer/src/UIElement.ts
@@ -8,7 +8,7 @@ import { UIRenderer } from "./UIRenderer";
 type Class<T> = new (...args: any[]) => T;
 
 export interface ShouldRender<TProps = any> {
-    (params: { props: TProps; next: Function }): boolean;
+    (params: { props: TProps; next: () => any }): boolean;
 }
 
 export interface UIElementConfig<TProps = any> {
@@ -349,7 +349,7 @@ export class UIElement<TConfig extends UIElementConfig = UIElementConfig> {
 
     public shouldRender(props: Record<string, any>): boolean {
         const shouldRender = [...this._shouldRender];
-        const next = (nextProps: Record<string, any>) => {
+        const next = (nextProps: Record<string, any>): any => {
             const shouldRenderCallable = shouldRender.pop();
             if (!shouldRenderCallable) {
                 return false;

--- a/packages/ui-composer/src/UIView.tsx
+++ b/packages/ui-composer/src/UIView.tsx
@@ -23,7 +23,7 @@ export interface UIViewProps {
 
 export class UIView<TConfig = UIElementConfig> extends UIElement<TConfig> {
     private _events = new Map();
-    private _hookDefinitions: Record<string, Function> = {};
+    private _hookDefinitions: Record<string, () => any> = {};
     private _hookValues: Record<string, any> = {};
     private _props?: UIViewProps;
     private _isRendered = false;
@@ -43,7 +43,7 @@ export class UIView<TConfig = UIElementConfig> extends UIElement<TConfig> {
         this._props = value;
     }
 
-    public addHookDefinition(key: string, hook: Function): void {
+    public addHookDefinition<T = any>(key: string, hook: () => T): void {
         this._hookDefinitions[key] = hook;
     }
 
@@ -65,7 +65,7 @@ export class UIView<TConfig = UIElementConfig> extends UIElement<TConfig> {
         return this.getElement<TElement>(id) as TElement;
     }
 
-    public getHookDefinitions(): Record<string, Function> {
+    public getHookDefinitions<T>(): Record<string, () => T> {
         return this._hookDefinitions;
     }
 

--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -105,7 +105,7 @@ export interface MultiAutoCompleteProps extends Omit<AutoCompleteBaseProps, "val
     /**
      * Render list item when `useMultipleSelectionList` is used.
      */
-    renderListItemLabel?: Function;
+    renderListItemLabel?: (item: any) => React.ReactNode;
     /**
      * Render in meta wrapper
      */

--- a/packages/ui/src/AutoComplete/types.ts
+++ b/packages/ui/src/AutoComplete/types.ts
@@ -55,12 +55,12 @@ export interface AutoCompleteBaseProps extends FormComponentProps {
     /**
      * Callback that gets executed on change of input value.
      */
-    onInput?: Function;
+    onInput?: (value: any) => void;
 
     /**
      * Callback that gets executed when the input is focused.
      */
-    onFocus?: Function;
+    onFocus?: (ev: React.FocusEvent<any>) => void;
 
     /**
      * Set if you are saving plain strings as values.
@@ -70,5 +70,5 @@ export interface AutoCompleteBaseProps extends FormComponentProps {
     /**
      * Renders a single suggestion item.
      */
-    renderItem: Function;
+    renderItem: (item: any, index?: number) => React.ReactNode;
 }

--- a/packages/ui/src/ConfirmationDialog/withConfirmation.tsx
+++ b/packages/ui/src/ConfirmationDialog/withConfirmation.tsx
@@ -9,10 +9,10 @@ type ConfirmationProps = {
 type WithConfirmationParams = (props: Record<string, any>) => ConfirmationProps;
 
 export type WithConfirmationProps = {
-    showConfirmation: (confirm: Function, cancel: Function) => void;
+    showConfirmation: (confirm: () => void, cancel: () => void) => void;
 };
 
-export const withConfirmation = (dialogProps: WithConfirmationParams): Function => {
+export const withConfirmation = (dialogProps: WithConfirmationParams) => {
     return (Component: typeof React.Component) => {
         return function withConfirmationRender(ownProps: Record<string, any>) {
             const props = typeof dialogProps === "function" ? dialogProps(ownProps) : dialogProps;

--- a/packages/ui/src/DataTable/DataTable.tsx
+++ b/packages/ui/src/DataTable/DataTable.tsx
@@ -307,7 +307,7 @@ const TableRow = <T,>({ row, selected }: TableRowProps<T>) => {
 
 const MemoTableRow = typedMemo(TableRow);
 
-export const DataTable = <T extends Object & DefaultData>({
+export const DataTable = <T extends Record<string, any> & DefaultData>({
     data,
     columns,
     onSelectRow,

--- a/packages/ui/src/DynamicFieldset/Fieldset.tsx
+++ b/packages/ui/src/DynamicFieldset/Fieldset.tsx
@@ -19,8 +19,8 @@ interface ChildrenRenderPropEmptyCallable {
 }
 interface ChildrenRenderProp {
     actions: {
-        add: Function;
-        remove: Function;
+        add: (index?: number) => () => void;
+        remove: (index: number) => () => void;
     };
     header: (cb: ChildrenRenderPropHeaderCallable) => React.ReactNode;
     row: (cb: ChildrenRenderPropRowCallable) => React.ReactNode;
@@ -31,7 +31,7 @@ interface FieldsetProps {
     value?: any[];
     description?: string;
     validation?: { isValid: null | boolean; message?: string };
-    onChange: Function;
+    onChange: (value: any) => void;
     children: (props: ChildrenRenderProp) => React.ReactNode;
 }
 

--- a/packages/ui/src/Icon/Icon.tsx
+++ b/packages/ui/src/Icon/Icon.tsx
@@ -11,7 +11,7 @@ export type IconProps = {
     /**
      * Optional onclick handler
      */
-    onClick?: Function;
+    onClick?: (value: any) => void;
 
     /**
      * CSS class to be added to the icon

--- a/packages/ui/src/ImageEditor/ImageEditor.tsx
+++ b/packages/ui/src/ImageEditor/ImageEditor.tsx
@@ -60,7 +60,7 @@ const initScripts = (): Promise<string> => {
 };
 
 interface RenderPropArgs {
-    render: Function;
+    render: () => React.ReactNode;
     getCanvasDataUrl: () => string;
     activeTool: ImageEditorTool | null;
     applyActiveTool: () => Promise<void>;
@@ -80,8 +80,8 @@ interface ImageEditorProps {
         crop: ImageEditorPropsPropsOptions;
         rotate: ImageEditorPropsPropsOptions;
     };
-    onToolActivate?: Function;
-    onToolDeactivate?: Function;
+    onToolActivate?: () => void;
+    onToolDeactivate?: () => void;
     children?: (props: RenderPropArgs) => React.ReactNode;
 }
 

--- a/packages/ui/src/ImageEditor/toolbar/filter.tsx
+++ b/packages/ui/src/ImageEditor/toolbar/filter.tsx
@@ -18,7 +18,7 @@ interface RenderFormState {
 
 interface RenderFormProps {
     canvas: any;
-    renderApplyCancel?: Function;
+    renderApplyCancel?: () => void;
 }
 
 const Wrapper = styled("div")({

--- a/packages/ui/src/ImageEditor/toolbar/types.ts
+++ b/packages/ui/src/ImageEditor/toolbar/types.ts
@@ -5,7 +5,7 @@ export type ToolbarTool = "crop" | "flip" | "rotate" | "filter";
 interface RenderFormParams {
     canvas: React.RefObject<HTMLCanvasElement>;
     image: HTMLImageElement;
-    renderApplyCancel?: Function;
+    renderApplyCancel?: () => void;
     options?: { [key: string]: any };
 }
 

--- a/packages/ui/src/ImageUpload/Image.tsx
+++ b/packages/ui/src/ImageUpload/Image.tsx
@@ -13,11 +13,12 @@ import {
     ImagePreviewWrapper,
     RemoveImage
 } from "./styled";
+import { BrowseFilesParams } from "react-butterfiles";
 
 interface ImageProps {
     uploadImage: () => void;
     removeImage?: (value: string | null) => void;
-    editImage?: Function;
+    editImage?: (value: BrowseFilesParams | undefined) => void;
     value?: any;
     disabled?: boolean;
     loading?: boolean;

--- a/packages/ui/src/ImageUpload/MultiImageUpload.tsx
+++ b/packages/ui/src/ImageUpload/MultiImageUpload.tsx
@@ -46,7 +46,7 @@ interface MultiImageUploadProps extends FormComponentProps {
     className?: string;
 
     // Define a list of accepted image types.
-    accept?: Array<string>;
+    accept?: string[];
 
     // Define file's max allowed size (default is "5mb").
     // Uses "bytes" (https://www.npmjs.com/package/bytes) library to convert string notation to actual number.
@@ -54,7 +54,9 @@ interface MultiImageUploadProps extends FormComponentProps {
 
     // Image editor options.
     // Please check the docs of ImageEditor component for the list of all available options.
-    imageEditor?: Object;
+    imageEditor?: {
+        [key: string]: any;
+    };
 
     // Use these to customize error messages (eg. if i18n supported is needed).
     errorMessages: {

--- a/packages/ui/src/ImageUpload/SingleImageUpload.tsx
+++ b/packages/ui/src/ImageUpload/SingleImageUpload.tsx
@@ -38,7 +38,7 @@ interface SingleImageUploadProps extends FormComponentProps {
     className?: string;
 
     // Define a list of accepted image types.
-    accept?: Array<string>;
+    accept?: string[];
 
     // Define file's max allowed size (default is "10mb").
     // Uses "bytes" (https://www.npmjs.com/package/bytes) library to convert string notation to actual number.
@@ -46,7 +46,9 @@ interface SingleImageUploadProps extends FormComponentProps {
 
     // Image editor options.
     // Please check the docs of ImageEditor component for the list of all available options.
-    imageEditor?: Object;
+    imageEditor?: {
+        [key: string]: any;
+    };
 
     // Custom image preview renderer. By default images are rendered via simple <img> element.
     renderImagePreview?: () => React.ReactElement<any>;

--- a/packages/ui/src/Input/__tests__/Input.test.tsx
+++ b/packages/ui/src/Input/__tests__/Input.test.tsx
@@ -57,7 +57,7 @@ function setup(props: SetupProps = {}) {
  * @param {...Function} fns the functions to call
  * @return {Function} the function that calls all the functions
  */
-function callAll(...fns: Function[]) {
+function callAll(...fns: ((...params: any) => void)[]) {
     return (...args: any) => {
         fns.forEach(fn => {
             fn && fn(...args);

--- a/packages/ui/src/List/DataList/DataList.tsx
+++ b/packages/ui/src/List/DataList/DataList.tsx
@@ -150,7 +150,7 @@ interface DataListProps {
     pagination?: PaginationProp;
 
     // Triggered once a sorter has been selected.
-    setSorters?: Function | null;
+    setSorters?: ((sorter: any) => void) | null;
 
     // Provide all sorters options and callbacks here.
     sorters?: SortersProp | null;

--- a/packages/ui/src/List/DataList/DataListWithSections.tsx
+++ b/packages/ui/src/List/DataList/DataListWithSections.tsx
@@ -10,15 +10,15 @@ import isEmpty from "lodash/isEmpty";
 
 import { Checkbox } from "../../Checkbox";
 import { Menu, MenuItem } from "../../Menu";
-import { Grid, Cell } from "../../Grid";
+import { Cell, Grid } from "../../Grid";
 
 import {
-    RefreshIcon,
-    SortIcon,
     FilterIcon,
-    PreviousPageIcon,
     NextPageIcon,
-    OptionsIcon
+    OptionsIcon,
+    PreviousPageIcon,
+    RefreshIcon,
+    SortIcon
 } from "./icons";
 import { List, ListItem, ListProps } from "..";
 import { DataListModalOverlayProvider } from "./DataListModalOverlay";
@@ -161,7 +161,7 @@ interface DataListWithSectionsProps {
     pagination?: PaginationProp;
 
     // Triggered once a sorter has been selected.
-    setSorters?: Function | null;
+    setSorters?: ((sorter: any) => void) | null;
 
     // Provide all sorters options and callbacks here.
     sorters?: SortersProp | null;

--- a/packages/ui/src/List/DataList/types.ts
+++ b/packages/ui/src/List/DataList/types.ts
@@ -27,16 +27,16 @@ export type SortersProp = Array<{ label: string; value: any }>;
 
 export type Props = {
     // Pass a function to take full control of list render.
-    children?: Function;
+    children?: <T = Record<string, any>>(props: T) => React.ReactNode;
 
     // A title of paginated list.
     title?: React.ReactNode;
 
     // FormData that needs to be shown in the list.
-    data?: Object[];
+    data?: Record<string, any>[];
 
     // A callback that must refresh current view by repeating the previous query.
-    refresh?: Function;
+    refresh?: () => void;
 
     // If true, Loader component will be shown, disallowing any interaction.
     loading?: boolean;
@@ -48,13 +48,13 @@ export type Props = {
     pagination?: PaginationProp;
 
     // Triggered once the page has been selected.
-    setPage?: Function;
+    setPage?: (page: string) => void;
 
     // Triggered once a sorter has been selected.
-    setSorters?: Function;
+    setSorters?: (sorter: any) => void;
 
     // Triggered once selected filters are submitted.
-    setFilters?: Function;
+    setFilters?: (filters: any) => void;
 
     // Provide all sorters options and callbacks here.
     sorters?: SortersProp;

--- a/packages/ui/src/Section/index.tsx
+++ b/packages/ui/src/Section/index.tsx
@@ -28,7 +28,7 @@ const ElevationContent = styled("div")({
 });
 
 interface SectionProps {
-    title?: String;
+    title?: string;
 }
 
 const Section: React.FC<SectionProps> = ({ children, title, ...props }) => {

--- a/packages/ui/src/Select/Select.tsx
+++ b/packages/ui/src/Select/Select.tsx
@@ -27,10 +27,12 @@ export type SelectProps = FormComponentProps &
         box?: string;
 
         // One or more <option> or <optgroup> elements.
-        children?: Array<React.ReactElement<"option"> | React.ReactElement<"optgroup">>;
+        children?: (React.ReactElement<"option"> | React.ReactElement<"optgroup">)[];
 
         // IconProps for the root element. By default, additional props spread to the native select element.
-        rootProps?: Object;
+        rootProps?: {
+            [key: string]: any;
+        };
 
         // A className for the root element.
         className?: string;

--- a/packages/ui/src/Slider/Slider.tsx
+++ b/packages/ui/src/Slider/Slider.tsx
@@ -30,7 +30,7 @@ type Props = FormComponentProps & {
     displayMarkers?: boolean;
 
     // Function that gets triggered on each input.
-    onInput?: Function;
+    onInput?: (value: any) => void;
 };
 
 // wrapper fixes a bug in slider where the slider handle is rendered outside the bounds of the slider box

--- a/packages/ui/src/Tags/Tags.tsx
+++ b/packages/ui/src/Tags/Tags.tsx
@@ -42,12 +42,12 @@ interface TagsProps extends FormComponentProps {
     /**
      * Callback that gets executed on change of input value.
      */
-    onInput?: Function;
+    onInput?: <T = unknown>(value: T) => void;
 
     /**
      * Callback that gets executed when the input is focused.
      */
-    onFocus?: Function;
+    onFocus?: (ev: Event) => void;
 
     /**
      * Automatically focus on the tags input.


### PR DESCRIPTION
## Changes
This PR replaces `Function`, `Object` and `{}` types with correct ones.

There are some `any` added due to heavy refactoring required to make everything work properly - that will come in some other PR.

## How Has This Been Tested?
Jest.
