### PR TITLE
fix: add missing css prop to the pb carousel element

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/carousel.tsx
+++ b/packages/app-page-builder-elements/src/renderers/carousel.tsx
@@ -45,6 +45,7 @@ const CarouselWrapper = styled.div`
     }
 
     & .carousel-element-wrapper {
+        width: 100%;
         max-width: calc(95% - 41px);
     }
 `;


### PR DESCRIPTION
PB carousel renderer is missing a single css prop which causes the element not to render properly. The issue is only present in the renderer, while the editor works fine since it already contains the missing css prop. This PR fixes this issue on the renderer.

## How Has This Been Tested?
Manually
