### PR TITLE
refactor: prepare react 18 upgrade - batch #12

### DIFF
--- a/packages/app-graphql-playground/src/index.tsx
+++ b/packages/app-graphql-playground/src/index.tsx
@@ -13,7 +13,7 @@ interface GraphQLPlaygroundProps {
     createApolloClient(params: CreateApolloClientParams): ApolloClient<any>;
 }
 
-const GraphQLPlaygroundExtension: React.FC<GraphQLPlaygroundProps> = ({ createApolloClient }) => {
+const GraphQLPlaygroundExtension = ({ createApolloClient }: GraphQLPlaygroundProps) => {
     plugins.register(playgroundPlugins);
 
     return (

--- a/packages/app-graphql-playground/src/plugins/Playground.tsx
+++ b/packages/app-graphql-playground/src/plugins/Playground.tsx
@@ -52,7 +52,7 @@ interface CreateApolloClientParams {
 interface PlaygroundProps {
     createApolloClient: (params: CreateApolloClientParams) => ApolloClient<any>;
 }
-const Playground: React.FC<PlaygroundProps> = ({ createApolloClient }) => {
+const Playground = ({ createApolloClient }: PlaygroundProps) => {
     const [loading, setLoading] = useState(true);
     const { getCurrentLocale } = useI18N();
     const { identity } = useSecurity();

--- a/packages/app-headless-cms/src/HeadlessCMS.tsx
+++ b/packages/app-headless-cms/src/HeadlessCMS.tsx
@@ -13,10 +13,13 @@ import { DefaultOnEntryUnpublish } from "~/admin/plugins/entry/DefaultOnEntryUnp
 import allPlugins from "./allPlugins";
 import { LexicalEditorCmsPlugin } from "~/admin/components/LexicalCmsEditor/LexicalEditorCmsPlugin";
 
+interface HeadlessCMSProvider {
+    children: React.ReactNode;
+}
+
 const createHeadlessCMSProvider =
-    (createApolloClient: CreateApolloClient) =>
-    (Component: React.FC): React.FC => {
-        return function HeadlessCMSProvider({ children }) {
+    (createApolloClient: CreateApolloClient) => (Component: React.FC) => {
+        return function HeadlessCMSProvider({ children }: HeadlessCMSProvider) {
             return (
                 <CmsProvider createApolloClient={createApolloClient}>
                     <Component>{children}</Component>

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Empty/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Empty/index.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from "@webiny/ui/Tooltip";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/empty");
 
-interface Props {
+interface EmptyProps {
     isSearch: boolean;
     onCreateEntry: (event: React.SyntheticEvent) => void;
     onCreateFolder: (event: React.SyntheticEvent) => void;
@@ -16,13 +16,13 @@ interface Props {
     canCreateFolder: boolean;
 }
 
-export const Empty: React.VFC<Props> = ({
+export const Empty = ({
     isSearch,
     onCreateEntry,
     onCreateFolder,
     canCreateContent,
     canCreateFolder
-}) => {
+}: EmptyProps) => {
     if (isSearch) {
         return <EmptyView icon={<SearchIcon />} title={t`No results found.`} action={null} />;
     }

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Filters/FilterByStatus.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Filters/FilterByStatus.tsx
@@ -13,7 +13,7 @@ const getValidFilterValue = (value: string): string | undefined => {
     return value;
 };
 
-export const FilterByStatus: React.FC = () => {
+export const FilterByStatus = () => {
     const bind = useBind({
         name: "status",
         beforeChange(value, cb) {

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Header/ButtonFilters/ButtonFilters.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Header/ButtonFilters/ButtonFilters.tsx
@@ -13,12 +13,12 @@ interface IconProps {
     showingFilters?: boolean;
 }
 
-const Icon: React.VFC<IconProps> = ({ showingFilters }) => {
+const Icon = ({ showingFilters }: IconProps) => {
     return showingFilters ? <CloseFilterIcon /> : <FilterIcon />;
 };
 const IconComponent = React.memo(Icon);
 
-export const ButtonFilters: React.VFC = () => {
+export const ButtonFilters = () => {
     const list = useContentEntriesList();
 
     const toggleFilters = useCallback(() => {

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Header/ButtonsCreate/ButtonsCreate.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Header/ButtonsCreate/ButtonsCreate.tsx
@@ -7,19 +7,19 @@ import { Tooltip } from "@webiny/ui/Tooltip";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/header/buttons/create");
 
-interface Props {
+interface ButtonsCreateProps {
     onCreateEntry: (event: React.SyntheticEvent) => void;
     onCreateFolder: (event: React.SyntheticEvent) => void;
     canCreateFolder: boolean;
     canCreateContent: boolean;
 }
 
-export const ButtonsCreate: React.VFC<Props> = ({
+export const ButtonsCreate = ({
     onCreateFolder,
     onCreateEntry,
     canCreateContent,
     canCreateFolder
-}) => {
+}: ButtonsCreateProps) => {
     let newFolderButton = (
         <ButtonSecondary
             data-testid="new-folder-button"

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Header/Header.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Header/Header.tsx
@@ -8,7 +8,7 @@ import { Title } from "./Title";
 
 import { Container, WrapperActions } from "./styled";
 
-interface Props {
+interface HeaderProps {
     title?: string;
     canCreateFolder: boolean;
     canCreateContent: boolean;
@@ -18,7 +18,7 @@ interface Props {
     onSearchChange: (value: string) => void;
 }
 
-export const Header: React.VFC<Props> = props => {
+export const Header = (props: HeaderProps) => {
     const {
         canCreateFolder,
         canCreateContent,

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Header/Title/Title.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Header/Title/Title.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { Skeleton } from "@webiny/ui/Skeleton";
 import { Name } from "./styled";
 
-interface Props {
+interface TitleProps {
     title?: string;
 }
 
-export const Title: React.VFC<Props> = ({ title }) => {
+export const Title = ({ title }: TitleProps) => {
     return (
         <Name use={"headline6"} tag={"h1"}>
             {title || <Skeleton theme={"dark"} />}

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/LoadMoreButton/LoadMoreButton.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/LoadMoreButton/LoadMoreButton.tsx
@@ -5,7 +5,7 @@ import { Container } from "./styled";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/load-more-button");
 
-interface Props {
+interface LoadMoreButtonProps {
     windowHeight: number;
     tableHeight: number;
     onClick: () => void;
@@ -13,13 +13,13 @@ interface Props {
     show: boolean;
 }
 
-export const LoadMoreButton: React.VFC<Props> = ({
+export const LoadMoreButton = ({
     disabled,
     windowHeight,
     tableHeight,
     show,
     onClick
-}) => {
+}: LoadMoreButtonProps) => {
     if (!show || windowHeight <= tableHeight) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/LoadingMore/index.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/LoadingMore/index.tsx
@@ -10,7 +10,7 @@ interface LoadingMoreProps {
     show: boolean;
 }
 
-export const LoadingMore: React.VFC<LoadingMoreProps> = ({ show }) => {
+export const LoadingMore = ({ show }: LoadingMoreProps) => {
     if (!show) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Name.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Name.tsx
@@ -28,7 +28,7 @@ interface FolderNameProps {
     record: FolderEntry;
 }
 
-export const FolderName: React.VFC<FolderNameProps> = ({ record }) => {
+export const FolderName = ({ record }: FolderNameProps) => {
     const { navigateToFolder } = useNavigateFolder();
 
     const { hasNonInheritedPermissions, canManagePermissions } = record.original;
@@ -50,7 +50,7 @@ interface EntryNameProps {
     onClick?: () => void;
 }
 
-export const EntryName: React.VFC<EntryNameProps> = ({ record, onClick }) => {
+export const EntryName = ({ record, onClick }: EntryNameProps) => {
     return (
         <Title onClick={onClick} className="cms-data-list-record-title">
             <Icon>

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionDelete.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionDelete.tsx
@@ -12,11 +12,11 @@ import { useNavigateFolder, useRecords } from "@webiny/app-aco";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/table");
 
-interface Props {
+interface RecordActionDeleteProps {
     record: RecordEntry;
 }
 
-export const RecordActionDelete: React.VFC<Props> = ({ record }) => {
+export const RecordActionDelete = ({ record }: RecordActionDeleteProps) => {
     const { deleteEntry } = useCms();
     const { canDelete } = usePermission();
     const { model } = useModel();

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionEdit.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionEdit.tsx
@@ -8,7 +8,7 @@ import { CreatableItem, EditableItem } from "~/admin/hooks/usePermission";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/table");
 
-interface Props {
+interface RecordActionEditProps {
     canEdit: (params: CreatableItem) => boolean;
     onClick?: () => void;
     record: {
@@ -16,7 +16,7 @@ interface Props {
     };
 }
 
-export const RecordActionEdit: React.VFC<Props> = ({ record, onClick, canEdit }) => {
+export const RecordActionEdit = ({ record, onClick, canEdit }: RecordActionEditProps) => {
     if (!canEdit(record.original)) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionMove.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionMove.tsx
@@ -9,10 +9,10 @@ import { RecordEntry } from "~/admin/components/ContentEntries/Table/types";
 
 const t = i18n.ns("app-headless-cms/admin/components/content-entries/table");
 
-interface Props {
+interface RecordActionMoveProps {
     record: RecordEntry;
 }
-export const RecordActionMove: React.VFC<Props> = ({ record }) => {
+export const RecordActionMove = ({ record }: RecordActionMoveProps) => {
     const moveContentEntry = useMoveContentEntryToFolder({ record });
 
     return (

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionPublish.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Row/Record/RecordActionPublish.tsx
@@ -12,7 +12,7 @@ import { CmsContentEntryStatusType } from "@webiny/app-headless-cms-common/types
 
 const t = i18n.ns("app-headless-cms/pages-table/actions/page/publish");
 
-interface Props {
+interface RecordActionPublishProps {
     record: {
         id: string;
         title: string;
@@ -26,7 +26,7 @@ interface Props {
     };
 }
 
-export const RecordActionPublish: React.VFC<Props> = ({ record }) => {
+export const RecordActionPublish = ({ record }: RecordActionPublishProps) => {
     const { canPublish, canUnpublish } = usePermission();
 
     const { unpublishRevision, publishRevision } = useRevision({

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
@@ -36,7 +36,7 @@ const isDifferent = (value: any, compare: any): boolean => {
     return stringify(value) !== stringify(compare);
 };
 
-export const ContentEntryForm: React.FC<ContentEntryFormProps> = ({ onForm, ...props }) => {
+export const ContentEntryForm = ({ onForm, ...props }: ContentEntryFormProps) => {
     const formElementRef = useRef<HTMLDivElement>(null);
     const { model } = useModel();
     const {

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormPreview.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormPreview.tsx
@@ -11,11 +11,11 @@ const FormWrapper = styled("div")({
     overflow: "auto"
 });
 
-interface Props {
+interface ContentEntryFormPreviewProps {
     contentModel: CmsEditorContentModel;
 }
 
-export const ContentEntryFormPreview: React.FC<Props> = props => {
+export const ContentEntryFormPreview = (props: ContentEntryFormPreviewProps) => {
     const { contentModel } = props;
 
     const formRenderer = plugins

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Fields.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Fields.tsx
@@ -20,13 +20,7 @@ const getFieldById = (fields: CmsModelField[], id: string): CmsModelField | null
     return fields.find(field => field.id === id) || null;
 };
 
-export const Fields: React.FC<FieldsProps> = ({
-    Bind,
-    fields,
-    layout,
-    contentModel,
-    gridClassName
-}) => {
+export const Fields = ({ Bind, fields, layout, contentModel, gridClassName }: FieldsProps) => {
     return (
         <Grid className={gridClassName}>
             {layout.map((row, rowIndex) => (

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/ContentFormOptionsMenu/ContentFormOptionsMenu.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/ContentFormOptionsMenu/ContentFormOptionsMenu.tsx
@@ -4,7 +4,7 @@ import { OptionsMenu } from "@webiny/app-admin";
 import { useContentEntryEditorConfig } from "~/admin/config/contentEntries";
 import { OptionMenuContainer } from "./ContentFormOptionsMenu.styles";
 
-export const ContentFormOptionsMenu: React.VFC = () => {
+export const ContentFormOptionsMenu = () => {
     const { menuItemActions } = useContentEntryEditorConfig();
 
     return (

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/DeleteEntry/DeleteEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/DeleteEntry/DeleteEntry.tsx
@@ -7,7 +7,7 @@ import { ContentEntryEditorConfig } from "~/admin/config/contentEntries";
 import { useContentEntry } from "~/admin/views/contentEntries/hooks/useContentEntry";
 import { useDeleteEntry } from "./useDeleteEntry";
 
-export const DeleteEntry: React.FC = () => {
+export const DeleteEntry = () => {
     const { history } = useRouter();
     const { entry, contentModel, loading } = useContentEntry();
     const { canDelete } = usePermission();

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/Header.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/Header.tsx
@@ -26,7 +26,7 @@ const headerActionsRight = css({
     justifyContent: "flex-start"
 });
 
-export const Header: React.FC = () => {
+export const Header = () => {
     const { buttonActions } = useContentEntryEditorConfig();
 
     return (

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/RevisionSelector/RevisionSelector.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/RevisionSelector/RevisionSelector.tsx
@@ -25,7 +25,7 @@ const defaultRevisions: CmsEntryRevision[] = [
     }
 ];
 
-export const RevisionSelector: React.FC = () => {
+export const RevisionSelector = () => {
     const { entry, revisions, loading } = useContentEntry();
     const { location, history } = useRouter();
     const query = new URLSearchParams(location.search);

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/SaveAndPublishContent/SaveAndPublishContent.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/SaveAndPublishContent/SaveAndPublishContent.tsx
@@ -6,7 +6,7 @@ import { useContentEntry } from "~/admin/views/contentEntries/hooks/useContentEn
 import usePermission from "~/admin/hooks/usePermission";
 import { useSaveAndPublish } from "./useSaveAndPublish";
 
-const SaveAndPublishButtonComponent: React.FC = () => {
+const SaveAndPublishButtonComponent = () => {
     const { loading, entry } = useContentEntry();
     const { showConfirmationDialog } = useSaveAndPublish();
     const { ButtonPrimary } = ContentEntryEditorConfig.Actions.ButtonAction.useButtons();

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/SaveContent/SaveContent.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/SaveContent/SaveContent.tsx
@@ -3,7 +3,7 @@ import { ContentEntryEditorConfig } from "~/admin/config/contentEntries";
 import usePermission from "~/admin/hooks/usePermission";
 import { useContentEntry } from "~/admin/views/contentEntries/hooks/useContentEntry";
 
-export const SaveContentButton: React.FC = () => {
+export const SaveContentButton = () => {
     const { form, entry } = useContentEntry();
     const { canEdit } = usePermission();
     const { useButtons } = ContentEntryEditorConfig.Actions.ButtonAction;

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Label.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Label.tsx
@@ -9,7 +9,11 @@ const style = {
     })
 };
 
-const Label: React.FC = ({ children }) => (
+interface LabelProps {
+    children?: React.ReactNode;
+}
+
+const Label = ({ children }: LabelProps) => (
     <div
         className={classNames(
             "mdc-text-field-helper-text mdc-text-field-helper-text--persistent",

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorProvider.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorProvider.tsx
@@ -110,11 +110,11 @@ interface ContentModelEditorProviderProps {
     children: React.ReactElement;
 }
 
-export const ContentModelEditorProvider: React.FC<ContentModelEditorProviderProps> = ({
+export const ContentModelEditorProvider = ({
     children,
     apolloClient,
     modelId
-}) => {
+}: ContentModelEditorProviderProps) => {
     const [state, dispatch] = useReducer<Reducer>(contentModelEditorReducer, {
         modelId: modelId || null,
         isPristine: true,

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Editor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Editor.tsx
@@ -63,7 +63,7 @@ interface OnChangeParams {
     layout: CmsEditorFieldsLayout;
 }
 
-export const Editor: React.FC = () => {
+export const Editor = () => {
     const { data, setData, isPristine } = useModelEditor();
 
     const tabsRef = useRef<TabsImperativeApi>();

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/FieldsSidebar.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/FieldsSidebar.tsx
@@ -46,7 +46,7 @@ interface FieldProps {
     onFieldDragStart: DragEventHandler;
     fieldType: CmsModelFieldTypePlugin["field"];
 }
-const Field: React.FC<FieldProps> = props => {
+const Field = (props: FieldProps) => {
     const {
         onFieldDragStart,
         fieldType: { type, label, icon, description }
@@ -78,7 +78,7 @@ const Field: React.FC<FieldProps> = props => {
 interface FieldsSidebarProps {
     onFieldDragStart: DragEventHandler;
 }
-export const FieldsSidebar: React.FC<FieldsSidebarProps> = ({ onFieldDragStart }) => {
+export const FieldsSidebar = ({ onFieldDragStart }: FieldsSidebarProps) => {
     const fieldTypePlugin = plugins.byType<CmsModelFieldTypePlugin>("cms-editor-field-type");
 
     return (

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Header.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Header.tsx
@@ -8,7 +8,7 @@ const topBar = css({
     boxShadow: "1px 0px 5px 0px rgba(128,128,128,1)"
 });
 
-const EditorBar: React.FC = () => {
+const EditorBar = () => {
     return (
         <TopAppBar className={topBar} fixed data-testid={"cms-editor-top-bar"}>
             <TopAppBarSection style={{ width: "50%" }} alignEnd>

--- a/packages/app-headless-cms/src/admin/components/DragPreview.tsx
+++ b/packages/app-headless-cms/src/admin/components/DragPreview.tsx
@@ -24,7 +24,7 @@ const onOffsetChange = (monitor: DragSourceMonitor) => () => {
     dragPreviewRef.style["-webkit-transform"] = transform;
 };
 
-const DragPreview: React.FC = () => {
+const DragPreview = () => {
     const [dragHelperOpacity, setDragHelperOpacity] = useState(0);
     const { isDragging } = useDragLayer(initialMonitor => {
         /**

--- a/packages/app-headless-cms/src/admin/components/Draggable.tsx
+++ b/packages/app-headless-cms/src/admin/components/Draggable.tsx
@@ -18,7 +18,7 @@ export interface DraggableProps {
     target?: string[];
 }
 
-const Draggable: React.FC<DraggableProps> = props => {
+const Draggable = (props: DraggableProps) => {
     const { children, beginDrag, endDrag, target } = props;
 
     const [{ isDragging }, drag, preview] = useDrag({

--- a/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
@@ -53,7 +53,7 @@ const getInert = (isDroppable: boolean) => {
     return isDroppable ? {} : { inert: "" };
 };
 
-const Center: React.FC<CenterProps> = ({ onDrop, children, style, isDroppable }) => {
+const Center = ({ onDrop, children, style, isDroppable }: CenterProps) => {
     return (
         <Droppable onDrop={onDrop} isDroppable={isDroppable}>
             {({ isOver, drop, isDroppable }) => (

--- a/packages/app-headless-cms/src/admin/components/DropZone/Horizontal.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Horizontal.tsx
@@ -60,7 +60,7 @@ interface HorizontalProps {
     ["data-testid"]?: string;
 }
 
-const Horizontal: React.FC<HorizontalProps> = ({ last, onDrop, isVisible, ...rest }) => {
+const Horizontal = ({ last, onDrop, isVisible, ...rest }: HorizontalProps) => {
     return (
         <Droppable onDrop={onDrop} isVisible={isVisible}>
             {({ isOver, isDragging, drop }) => (

--- a/packages/app-headless-cms/src/admin/components/DropZone/Vertical.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Vertical.tsx
@@ -62,7 +62,7 @@ interface VerticalProps {
     isVisible?: any;
 }
 
-const Vertical: React.FC<VerticalProps> = ({ depth, last, onDrop, isVisible }) => {
+const Vertical = ({ depth, last, onDrop, isVisible }: VerticalProps) => {
     return (
         <Droppable onDrop={onDrop} isVisible={isVisible}>
             {({ isOver, isDragging, drop }) => (

--- a/packages/app-headless-cms/src/admin/components/Droppable.tsx
+++ b/packages/app-headless-cms/src/admin/components/Droppable.tsx
@@ -33,7 +33,7 @@ export interface DroppableProps {
     onDrop?: OnDropCallable;
 }
 
-const DroppableComponent: React.FC<DroppableProps> = props => {
+const DroppableComponent = (props: DroppableProps) => {
     const { children, onDrop, isVisible = () => true } = props;
 
     const [{ item, isOver }, drop] = useDrop({

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog.tsx
@@ -75,7 +75,7 @@ interface EditFieldDialogProps {
     onSubmit: FormOnSubmit<CmsModelField>;
 }
 
-const EditFieldDialog: React.FC<EditFieldDialogProps> = props => {
+const EditFieldDialog = (props: EditFieldDialogProps) => {
     const { field, fieldPlugin } = useModelField();
     const { data: contentModel, setData: setContentModelData } = useModelEditor();
     const [{ shadowField, isTitleField }] = useState<EditFieldState>(

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/ValidatorsList.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/ValidatorsList.tsx
@@ -213,7 +213,7 @@ const ValidatorItem = ({ validator, value, onChange }: ValidatorItemProps) => {
     );
 };
 
-export const ValidatorsList: React.FC<ValidatorsTabProps> = props => {
+export const ValidatorsList = (props: ValidatorsTabProps) => {
     const { name, validators } = props;
 
     return (

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
@@ -144,7 +144,7 @@ export interface FieldProps {
     parent?: CmsModelField;
 }
 
-const Field: React.FC<FieldProps> = props => {
+const Field = (props: FieldProps) => {
     const { field, onEdit, parent } = props;
     const { showSnackbar } = useSnackbar();
     const { setData: setModel, data: model } = useModelEditor();

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditor.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditor.tsx
@@ -17,7 +17,7 @@ const t = i18n.namespace("app-headless-cms/admin/components/editor");
 
 const fieldTypes: string[] = ["field", "newField"];
 
-const Editor: React.FC = () => {
+const Editor = () => {
     const {
         parent,
         depth,
@@ -246,7 +246,7 @@ export interface FieldEditorProps {
     onChange: (params: { fields: CmsModelField[]; layout: CmsEditorFieldsLayout }) => void;
 }
 
-export const FieldEditor: React.FC<FieldEditorProps> = props => {
+export const FieldEditor = (props: FieldEditorProps) => {
     return (
         <FieldEditorProvider {...props}>
             <Editor />

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/FieldEditorContext.tsx
@@ -131,13 +131,13 @@ interface State {
     field: CmsModelField | null;
     dropTarget: DropTarget;
 }
-export const FieldEditorProvider: React.FC<FieldEditorProviderProps> = ({
+export const FieldEditorProvider = ({
     parent,
     fields,
     layout,
     onChange,
     children
-}) => {
+}: FieldEditorProviderProps) => {
     // We need to determine depth of this provider so we can render drop zones with correct z-indexes.
     let depth = 0;
     try {

--- a/packages/app-headless-cms/src/admin/components/IconPicker.tsx
+++ b/packages/app-headless-cms/src/admin/components/IconPicker.tsx
@@ -103,13 +103,13 @@ export interface IconPickerProps extends FormComponentProps {
     description?: React.ReactNode;
 }
 
-export const IconPicker: React.FC<IconPickerProps> = ({
+export const IconPicker = ({
     value,
     onChange,
     label,
     description,
     validation
-}) => {
+}: IconPickerProps) => {
     const [filter, setFilter] = useState("");
     const [mustRenderGrid, setMustRenderGrid] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/BaseAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/BaseAction.tsx
@@ -18,7 +18,7 @@ export interface BaseActionProps {
     $type: string;
 }
 
-export const BaseAction: React.FC<BaseActionProps> = ({
+export const BaseAction = ({
     name,
     after = undefined,
     before = undefined,
@@ -26,7 +26,7 @@ export const BaseAction: React.FC<BaseActionProps> = ({
     modelIds = [],
     element,
     $type
-}) => {
+}: BaseActionProps) => {
     const { model } = useModel();
     const getId = useIdGenerator("action");
 

--- a/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/ButtonAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/ButtonAction.tsx
@@ -5,7 +5,7 @@ import { BaseAction, BaseActionProps } from "./BaseAction";
 export type ButtonActionType = "button-action";
 export type ButtonActionProps = Omit<BaseActionProps, "$type">;
 
-export const BaseButtonAction: React.FC<ButtonActionProps> = props => {
+export const BaseButtonAction = (props: ButtonActionProps) => {
     return <BaseAction {...props} $type={"button-action"} />;
 };
 

--- a/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/MenuItemAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/editor/Actions/MenuItemAction.tsx
@@ -5,7 +5,7 @@ import { BaseAction, BaseActionProps } from "./BaseAction";
 export type MenuItemActionType = "menu-item-action";
 export type MenuItemActionProps = Omit<BaseActionProps, "$type">;
 
-export const BaseMenuItemAction: React.FC<MenuItemActionProps> = props => {
+export const BaseMenuItemAction = (props: MenuItemActionProps) => {
     return <BaseAction {...props} $type={"menu-item-action"} />;
 };
 

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/BulkAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/BulkAction.tsx
@@ -18,14 +18,14 @@ export interface BulkActionProps {
     element?: React.ReactElement;
 }
 
-export const BaseBulkAction: React.FC<BulkActionProps> = ({
+export const BaseBulkAction = ({
     name,
     after = undefined,
     before = undefined,
     remove = false,
     modelIds = [],
     element
-}) => {
+}: BulkActionProps) => {
     const { model } = useModel();
     const getId = useIdGenerator("bulkAction");
 

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderAction.tsx
@@ -11,7 +11,7 @@ export interface FolderActionProps extends React.ComponentProps<typeof AcoConfig
     modelIds?: string[];
 }
 
-export const FolderAction: React.FC<FolderActionProps> = ({ modelIds = [], ...props }) => {
+export const FolderAction = ({ modelIds = [], ...props }: FolderActionProps) => {
     const { model } = useModel();
 
     if (modelIds.length > 0 && !modelIds.includes(model.modelId)) {

--- a/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
+++ b/packages/app-headless-cms/src/admin/contexts/Cms/index.tsx
@@ -134,7 +134,7 @@ export interface CmsProviderProps {
     children: React.ReactNode;
 }
 
-export const CmsProvider: React.FC<CmsProviderProps> = props => {
+export const CmsProvider = (props: CmsProviderProps) => {
     const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL);
     const { getCurrentLocale } = useI18N();
 

--- a/packages/app-headless-cms/src/admin/menus/CmsMenuLoader.tsx
+++ b/packages/app-headless-cms/src/admin/menus/CmsMenuLoader.tsx
@@ -9,7 +9,7 @@ interface ChildMenuProps {
     canAccess: boolean;
 }
 
-const CmsContentModelsMenu: React.VFC<ChildMenuProps> = ({ canAccess }) => {
+const CmsContentModelsMenu = ({ canAccess }: ChildMenuProps) => {
     if (!canAccess) {
         return null;
     }
@@ -22,7 +22,7 @@ const CmsContentModelsMenu: React.VFC<ChildMenuProps> = ({ canAccess }) => {
     );
 };
 
-const CmsContentGroupsMenu: React.VFC<ChildMenuProps> = ({ canAccess }) => {
+const CmsContentGroupsMenu = ({ canAccess }: ChildMenuProps) => {
     if (!canAccess) {
         return null;
     }
@@ -35,7 +35,7 @@ const CmsContentGroupsMenu: React.VFC<ChildMenuProps> = ({ canAccess }) => {
     );
 };
 
-const CmsMenuLoaderComponent: React.FC = () => {
+const CmsMenuLoaderComponent = () => {
     const {
         canAccessManageEndpoint,
         canReadContentModels,

--- a/packages/app-headless-cms/src/admin/menus/ContentGroupsMenuItems.tsx
+++ b/packages/app-headless-cms/src/admin/menus/ContentGroupsMenuItems.tsx
@@ -18,11 +18,11 @@ interface HasContentEntryPermissionsProps {
     children: JSX.Element;
 }
 
-const HasContentEntryPermissions: React.FC<HasContentEntryPermissionsProps> = ({
+const HasContentEntryPermissions = ({
     group,
     contentModel,
     children
-}) => {
+}: HasContentEntryPermissionsProps) => {
     const { canReadEntries } = usePermission();
 
     if (contentModel) {
@@ -48,7 +48,7 @@ const HasContentEntryPermissions: React.FC<HasContentEntryPermissionsProps> = ({
 interface IconProps {
     group: CmsGroup;
 }
-const Icon: React.FC<IconProps> = ({ group }) => {
+const Icon = ({ group }: IconProps) => {
     return (
         <FontAwesomeIcon
             style={{ color: "var(--mdc-theme-text-secondary-on-background)" }}
@@ -57,7 +57,7 @@ const Icon: React.FC<IconProps> = ({ group }) => {
     );
 };
 
-export const ContentGroupsMenuItems: React.FC = () => {
+export const ContentGroupsMenuItems = () => {
     const response = useQuery<ListMenuCmsGroupsQueryResponse>(LIST_MENU_CONTENT_GROUPS_MODELS);
     const groups: CmsGroup[] = get(response, "data.listContentModelGroups.data") || [];
 

--- a/packages/app-headless-cms/src/admin/menus/GlobalSearchPlugins.tsx
+++ b/packages/app-headless-cms/src/admin/menus/GlobalSearchPlugins.tsx
@@ -16,7 +16,7 @@ import { CmsGroup } from "~/types";
  * Even if we keep a dedicated `AdminGlobalSearchPlugin`, it needs to be converted to a proper class.
  * This can be a "good first issue" for community to solve.
  */
-const GlobalSearchPlugins: React.FC = () => {
+const GlobalSearchPlugins = () => {
     const { getCurrentLocale } = useI18N();
     const response = useQuery<ListMenuCmsGroupsQueryResponse>(LIST_MENU_CONTENT_GROUPS_MODELS);
 

--- a/packages/app-headless-cms/src/admin/menus/NothingToShowElement.tsx
+++ b/packages/app-headless-cms/src/admin/menus/NothingToShowElement.tsx
@@ -31,7 +31,7 @@ const submenuList = css({
     }
 });
 
-export const NothingToShow: React.FC = () => {
+export const NothingToShow = () => {
     return (
         <List className={submenuList} style={{ opacity: 0.4 }}>
             <ListItem className={submenuItems} ripple={false} disabled>

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/BackButton.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/BackButton.tsx
@@ -8,7 +8,7 @@ const backStyles = css({
     marginLeft: -10
 });
 
-const BackButton: React.FC = React.memo(() => {
+const BackButton = React.memo(() => {
     const { history } = useRouter();
 
     return (

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/CreateContentButton.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/CreateContentButton.tsx
@@ -14,7 +14,7 @@ import { useModelEditor } from "~/admin/hooks";
 
 const t = i18n.namespace("app-headless-cms/admin/editor/top-bar/save-button");
 
-const CreateContentButton: React.FC = () => {
+const CreateContentButton = () => {
     const router = useRouter();
     const { data, apolloClient } = useModelEditor();
 

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/FormSettings/FormSettings.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/FormSettings/FormSettings.tsx
@@ -20,7 +20,7 @@ interface FormSettingsProps {
     onExited: () => void;
 }
 
-const FormSettings: React.FC<FormSettingsProps> = ({ onExited }) => {
+const FormSettings = ({ onExited }: FormSettingsProps) => {
     const cmsEditorFormSettingsPlugins = plugins.byType<CmsEditorFormSettingsPlugin>(
         "cms-editor-form-settings"
     );

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/FormSettings/FormSettingsButton.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/FormSettings/FormSettingsButton.tsx
@@ -4,7 +4,7 @@ import FormSettings from "./FormSettings";
 
 import { ReactComponent as SettingsIcon } from "./../icons/settings.svg";
 
-const FormSettingsButton: React.FC = () => {
+const FormSettingsButton = () => {
     const [opened, setOpened] = useState(false);
     const open = useCallback(() => setOpened(true), []);
     const close = useCallback(() => setOpened(false), []);

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/Name/Name.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/Name/Name.tsx
@@ -18,7 +18,7 @@ declare global {
     }
 }
 
-export const Name: React.FC = () => {
+export const Name = () => {
     const { data, setData } = useModelEditor();
     const [localName, setLocalName] = useState<string>("");
     const [editingEnabled, setEditing] = useState<boolean>(false);

--- a/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/SaveContentModelButton.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/defaultBar/SaveContentModelButton.tsx
@@ -6,7 +6,7 @@ import { useModelEditor } from "~/admin/hooks";
 
 const t = i18n.namespace("app-headless-cms/admin/editor/top-bar/save-button");
 
-const SaveContentModelButton: React.FC = () => {
+const SaveContentModelButton = () => {
     const { saveContentModel } = useModelEditor();
     const [loading, setLoading] = useState<boolean>(false);
     const { showSnackbar } = useSnackbar();

--- a/packages/app-headless-cms/src/admin/plugins/editor/formSettings/components/GeneralSettings.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/editor/formSettings/components/GeneralSettings.tsx
@@ -11,7 +11,7 @@ interface GeneralSettingsProps {
     Bind: BindComponent;
 }
 
-const GeneralSettings: React.VFC<GeneralSettingsProps> = ({ Bind }) => {
+const GeneralSettings = ({ Bind }: GeneralSettingsProps) => {
     return (
         <React.Fragment>
             <Grid>

--- a/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryDelete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryDelete.tsx
@@ -24,7 +24,7 @@ const createMutationKey = (params: CreateMutationKeyParams): string => {
     return `${model.modelId}_${locale}_${model.savedOn}`;
 };
 
-const OnEntryDelete: React.FC = () => {
+const OnEntryDelete = () => {
     const { onEntryDelete } = useCms();
 
     const mutations = useRef<Mutations>({});

--- a/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryPublish.ts
+++ b/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryPublish.ts
@@ -23,7 +23,7 @@ const createMutationKey = (params: CreateMutationKeyParams): string => {
     return `${model.modelId}_${locale}_${model.savedOn}`;
 };
 
-const OnEntryPublish: React.FC = () => {
+const OnEntryPublish = () => {
     const { onEntryRevisionPublish } = useCms();
 
     const mutations = useRef<Mutations>({});

--- a/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryUnpublish.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/entry/DefaultOnEntryUnpublish.tsx
@@ -23,7 +23,7 @@ const createMutationKey = (params: CreateMutationKeyParams): string => {
     return `${model.modelId}_${locale}_${model.savedOn}`;
 };
 
-const OnEntryUnpublish: React.FC = () => {
+const OnEntryUnpublish = () => {
     const { onEntryRevisionUnpublish } = useCms();
 
     const mutations = useRef<Mutations>({});

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
@@ -91,15 +91,10 @@ interface AccordionProps {
     action?: ReactElement | null;
     icon?: ReactElement;
     defaultValue?: boolean;
+    children: React.ReactNode;
 }
 
-const Accordion: React.FC<AccordionProps> = ({
-    title,
-    children,
-    action,
-    icon,
-    defaultValue = false
-}) => {
+const Accordion = ({ title, children, action, icon, defaultValue = false }: AccordionProps) => {
     const [isOpen, setOpen] = useState(defaultValue);
     const toggleOpen = useCallback(() => setOpen(!isOpen), [isOpen]);
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
@@ -39,7 +39,7 @@ export interface DynamicSectionProps {
     gridClassName?: string;
 }
 
-const DynamicSection: React.FC<DynamicSectionProps> = ({
+const DynamicSection = ({
     field,
     getBind,
     Label,
@@ -48,7 +48,7 @@ const DynamicSection: React.FC<DynamicSectionProps> = ({
     emptyValue = "",
     renderTitle,
     gridClassName
-}) => {
+}: DynamicSectionProps) => {
     const Bind = getBind();
     const FirstFieldBind = getBind(0);
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateOnly.tsx
@@ -7,13 +7,13 @@ import {
 } from "~/admin/plugins/fieldRenderers/dateTime/utils";
 import { BindComponentRenderProp } from "@webiny/form";
 
-export interface Props {
+export interface DateOnlyProps {
     field: CmsModelField;
     bind: BindComponentRenderProp;
     trailingIcon?: TrailingIcon;
 }
 
-export const DateOnly: React.FC<Props> = props => {
+export const DateOnly = (props: DateOnlyProps) => {
     const { field, bind, trailingIcon } = props;
     const date = getDefaultFieldValue(field, bind, () => {
         return getCurrentDate(new Date());

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithTimezone.tsx
@@ -58,11 +58,7 @@ export interface DateTimeWithTimezoneProps {
     trailingIcon?: any;
     field: CmsModelField;
 }
-export const DateTimeWithTimezone: React.FC<DateTimeWithTimezoneProps> = ({
-    bind,
-    trailingIcon,
-    field
-}) => {
+export const DateTimeWithTimezone = ({ bind, trailingIcon, field }: DateTimeWithTimezoneProps) => {
     const defaultTimeZone = getCurrentTimeZone() || DEFAULT_TIMEZONE;
 
     // "2020-05-18T09:00+10:00"

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -49,11 +49,11 @@ export interface DateTimeWithoutTimezoneProps {
     trailingIcon?: any;
     field: CmsModelField;
 }
-export const DateTimeWithoutTimezone: React.FC<DateTimeWithoutTimezoneProps> = ({
+export const DateTimeWithoutTimezone = ({
     field,
     bind,
     trailingIcon
-}) => {
+}: DateTimeWithoutTimezoneProps) => {
     // "2020-05-18 09:00:00"
     const initialValue = getDefaultFieldValue(field, bind, () => {
         const date = new Date();

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -16,7 +16,7 @@ export interface InputProps {
     trailingIcon?: TrailingIcon;
 }
 
-export const Input: React.FC<InputProps> = ({ bind, ...props }) => {
+export const Input = ({ bind, ...props }: InputProps) => {
     return (
         <UiInput
             {...props}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Select.tsx
@@ -9,7 +9,7 @@ export interface Option {
 export interface SelectProps extends BaseSelectProps {
     options: Option[];
 }
-export const Select: React.FC<SelectProps> = props => {
+export const Select = (props: SelectProps) => {
     return (
         <UiSelect {...props}>
             {props.options.map(t => {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Time.tsx
@@ -5,7 +5,7 @@ import {
     getDefaultFieldValue
 } from "~/admin/plugins/fieldRenderers/dateTime/utils";
 
-export const Time: React.FC<InputProps> = props => {
+export const Time = (props: InputProps) => {
     const { field, bind } = props;
     const time = getDefaultFieldValue(field, bind, () => {
         return getCurrentLocalTime(new Date());

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -67,7 +67,7 @@ const deleteIconStyles = css({
 interface RemoveFieldButtonProps {
     trailingIcon: any;
 }
-export const RemoveFieldButton: React.FC<RemoveFieldButtonProps> = ({ trailingIcon }) => {
+export const RemoveFieldButton = ({ trailingIcon }: RemoveFieldButtonProps) => {
     if (!trailingIcon) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/AddTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/AddTemplate.tsx
@@ -66,7 +66,7 @@ interface AddTemplateProps {
     onTemplate: UseAddTemplateParams["onTemplate"];
 }
 
-export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
+export const AddTemplateButton = (props: AddTemplateProps) => {
     const { showGallery, onTemplate, browseTemplates, onGalleryClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });
@@ -90,7 +90,7 @@ export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
     );
 };
 
-export const AddTemplateIcon: React.VFC<AddTemplateProps> = props => {
+export const AddTemplateIcon = (props: AddTemplateProps) => {
     const { showGallery, onTemplate, browseTemplates, onGalleryClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/MultiValueDynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/MultiValueDynamicZone.tsx
@@ -42,7 +42,7 @@ interface TemplateValueFormProps {
     onClone: () => void;
 }
 
-const TemplateValueForm: React.VFC<TemplateValueFormProps> = ({
+const TemplateValueForm = ({
     value,
     contentModel,
     Bind,
@@ -52,7 +52,7 @@ const TemplateValueForm: React.VFC<TemplateValueFormProps> = ({
     onMoveDown,
     onDelete,
     onClone
-}) => {
+}: TemplateValueFormProps) => {
     const { field } = useModelField();
     const templates = field.settings?.templates || [];
 
@@ -104,11 +104,11 @@ interface MultiValueDynamicZoneProps {
     getBind: GetBind;
 }
 
-export const MultiValueDynamicZone: React.VFC<MultiValueDynamicZoneProps> = ({
+export const MultiValueDynamicZone = ({
     bind,
     getBind,
     contentModel
-}) => {
+}: MultiValueDynamicZoneProps) => {
     const onTemplate = (template: CmsDynamicZoneTemplate) => {
         bind.appendValue({ _templateId: template.id });
     };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/SingleValueDynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/SingleValueDynamicZone.tsx
@@ -21,12 +21,12 @@ interface SingleValueDynamicZoneProps {
     getBind: GetBind;
 }
 
-export const SingleValueDynamicZone: React.VFC<SingleValueDynamicZoneProps> = ({
+export const SingleValueDynamicZone = ({
     field,
     bind,
     contentModel,
     getBind
-}) => {
+}: SingleValueDynamicZoneProps) => {
     const onTemplate = (template: CmsDynamicZoneTemplate) => {
         bind.onChange({ _templateId: template.id });
     };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateCard.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateCard.tsx
@@ -52,7 +52,7 @@ interface TemplateCardProps {
     onTemplate: (template: CmsDynamicZoneTemplate) => void;
 }
 
-export const TemplateCard: React.VFC<TemplateCardProps> = ({ template, onTemplate }) => {
+export const TemplateCard = ({ template, onTemplate }: TemplateCardProps) => {
     return (
         <CardContainer>
             <CardIcon>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
@@ -20,7 +20,7 @@ interface TemplateGalleryProps {
     onClose: () => void;
 }
 
-export const TemplateGallery: React.VFC<TemplateGalleryProps> = ({ onTemplate, onClose }) => {
+export const TemplateGallery = ({ onTemplate, onClose }: TemplateGalleryProps) => {
     const { field } = useModelField();
     const templates = field.settings?.templates || [];
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateIcon.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateIcon.tsx
@@ -5,7 +5,7 @@ interface TemplateIconProps {
     icon: string;
 }
 
-export const TemplateIcon: React.VFC<TemplateIconProps> = ({ icon }) => {
+export const TemplateIcon = ({ icon }: TemplateIconProps) => {
     const faIcon = icon ? (icon.split("/") as FontAwesomeIconProps["icon"]) : undefined;
 
     return faIcon ? <FontAwesomeIcon icon={faIcon} /> : null;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
@@ -12,11 +12,7 @@ const noBottomPadding = css`
     }
 `;
 
-const DynamicZoneContent: React.VFC<CmsModelFieldRendererProps> = ({
-    field,
-    getBind,
-    contentModel
-}) => {
+const DynamicZoneContent = ({ field, getBind, contentModel }: CmsModelFieldRendererProps) => {
     const templates = field.settings?.templates || [];
     if (!templates.length) {
         console.info(

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/File.tsx
@@ -45,7 +45,7 @@ export interface FileProps {
     };
     description?: string;
 }
-const File: React.FC<FileProps> = props => {
+const File = (props: FileProps) => {
     const { url, onRemove, placeholder, showFileManager, description } = props;
 
     const styles = props.styles || defaultStyles;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -48,7 +48,7 @@ interface FieldRendererProps {
     Label: React.FC;
     field: CmsModelField;
 }
-const FieldRenderer: React.FC<FieldRendererProps> = ({ getBind, Label, field }) => {
+const FieldRenderer = ({ getBind, Label, field }: FieldRendererProps) => {
     const Bind = getBind();
 
     const imagesOnly = field.settings && field.settings.imagesOnly;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -37,7 +37,7 @@ interface ActionsProps {
     };
 }
 
-const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => {
+const Actions = ({ setHighlightIndex, bind, index }: ActionsProps) => {
     const { moveValueDown, moveValueUp } = bind.field;
 
     const onDown = useCallback(
@@ -73,7 +73,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
     ) : null;
 };
 
-const ObjectsRenderer: React.FC<CmsModelFieldRendererProps> = props => {
+const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     const [highlightMap, setHighlightIndex] = useState<{ [key: number]: string }>({});
     const { field, contentModel } = props;
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
@@ -35,7 +35,7 @@ interface ActionsProps {
     };
 }
 
-const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => {
+const Actions = ({ setHighlightIndex, bind, index }: ActionsProps) => {
     const { moveValueDown, moveValueUp } = bind.field;
 
     const onDown = useCallback(
@@ -71,7 +71,7 @@ const Actions: React.FC<ActionsProps> = ({ setHighlightIndex, bind, index }) => 
     ) : null;
 };
 
-const ObjectsRenderer: React.FC<CmsModelFieldRendererProps> = props => {
+const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     const [highlightMap, setHighlightIndex] = useState<{ [key: number]: string }>({});
     const { field, contentModel } = props;
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
@@ -91,11 +91,11 @@ const getRecordCountMessage = (count: number) => {
     }
 };
 
-interface Props extends CmsModelFieldRendererProps {
+interface AdvancedMultipleReferenceFieldProps extends CmsModelFieldRendererProps {
     bind: BindComponentRenderProp<CmsReferenceValue[] | undefined | null>;
 }
 
-export const AdvancedMultipleReferenceField: React.VFC<Props> = props => {
+export const AdvancedMultipleReferenceField = (props: AdvancedMultipleReferenceFieldProps) => {
     const { bind, field } = props;
     const { showSnackbar } = useSnackbar();
     const requestContext = useModelFieldGraphqlContext();

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
@@ -29,11 +29,11 @@ const FieldLabel = styled("h3")({
     paddingBottom: "5px"
 });
 
-interface Props extends CmsModelFieldRendererProps {
+interface AdvancedSingleReferenceFieldProps extends CmsModelFieldRendererProps {
     bind: BindComponentRenderProp<CmsReferenceValue | null>;
 }
 
-export const AdvancedSingleReferenceField: React.VFC<Props> = props => {
+export const AdvancedSingleReferenceField = (props: AdvancedSingleReferenceFieldProps) => {
     const { bind, field } = props;
     const { showSnackbar } = useSnackbar();
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entries.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entries.tsx
@@ -27,13 +27,13 @@ const ContainerChild = styled("div")({
     margin: "0 2px 25px 2px"
 });
 
-interface Props {
+interface EntriesProps {
     entries: CmsReferenceContentEntry[];
     children: (entry: CmsReferenceContentEntry, index: number) => React.ReactNode;
     loadMore: () => void;
 }
 
-export const Entries: React.VFC<Props> = props => {
+export const Entries = (props: EntriesProps) => {
     const { entries, children, loadMore } = props;
 
     const loadMoreOnScroll = useCallback(

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entry.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entry.tsx
@@ -78,7 +78,7 @@ const RightContainer = styled("div")({
     }
 });
 
-interface Props {
+interface EntryProps {
     model: CmsModel;
     entry: CmsReferenceContentEntry;
     onChange: (value: CmsReferenceValue) => void;
@@ -90,7 +90,7 @@ interface Props {
     placement?: string;
 }
 
-interface PropsWithRemove {
+interface EntryPropsWithRemove {
     onRemove: (entryId: string) => void;
     model: CmsModel;
     entry: CmsReferenceContentEntry;
@@ -102,7 +102,7 @@ interface PropsWithRemove {
     placement?: string;
 }
 
-export const Entry: React.VFC<PropsWithRemove | Props> = ({
+export const Entry = ({
     model,
     entry,
     onChange,
@@ -112,7 +112,7 @@ export const Entry: React.VFC<PropsWithRemove | Props> = ({
     onMoveUp: onMoveUpClick,
     onMoveDown: onMoveDownClick,
     placement
-}) => {
+}: EntryPropsWithRemove | EntryProps) => {
     const onMoveUp = useCallback(
         (ev: React.MouseEvent) => {
             if (!onMoveUpClick) {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Loader.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Loader.tsx
@@ -15,14 +15,14 @@ const AbsoluteLoaderContainer = styled("div")({
     top: 0,
     left: 0
 });
-export const Loader: React.VFC = () => {
+export const Loader = () => {
     return (
         <LoaderContainer>
             <CircularProgress />
         </LoaderContainer>
     );
 };
-export const AbsoluteLoader: React.VFC = () => {
+export const AbsoluteLoader = () => {
     return (
         <AbsoluteLoaderContainer>
             <CircularProgress />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Options.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Options.tsx
@@ -66,12 +66,12 @@ const LinkExistingRecordButton = styled("button")({
     }
 });
 
-interface Props {
+interface OptionsProps {
     models: CmsModel[];
     onNewRecord: (modelId: string) => void;
     onLinkExistingRecord: (modelId: string) => void;
 }
-export const Options: React.VFC<Props> = ({ models, onNewRecord, onLinkExistingRecord }) => {
+export const Options = ({ models, onNewRecord, onLinkExistingRecord }: OptionsProps) => {
     const hasMultipleModels = models.length > 1;
     const onSingleNewRecord = useCallback(() => {
         if (models.length === 0 || hasMultipleModels) {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/ReferencesDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/ReferencesDialog.tsx
@@ -48,14 +48,14 @@ const isSelected = (entryId: string, values: CmsReferenceValue[]) => {
     });
 };
 
-interface Props extends CmsModelFieldRendererProps {
+interface ReferencesDialogProps extends CmsModelFieldRendererProps {
     values?: CmsReferenceValue[] | null;
     onDialogClose: () => void;
     storeValues: (values: CmsReferenceValue[]) => void;
     multiple: boolean;
 }
 
-export const ReferencesDialog: React.VFC<Props> = props => {
+export const ReferencesDialog = (props: ReferencesDialogProps) => {
     const { contentModel, onDialogClose, storeValues, values: initialValues, multiple } = props;
     const { showSnackbar } = useSnackbar();
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Search.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Search.tsx
@@ -36,11 +36,11 @@ const Input = styled("input")({
     }
 });
 
-interface Props {
+interface SearchProps {
     onInput: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-export const Search: React.VFC<Props> = ({ onInput }) => {
+export const Search = ({ onInput }: SearchProps) => {
     return (
         <Container>
             <Icon src={searchIcon} />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Box.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Box.tsx
@@ -33,13 +33,13 @@ const Text = styled("h5")({
     color: "#49454F"
 });
 
-interface Props {
+interface BoxProps {
     icon: React.ReactElement | null;
     name: string;
     children?: React.ReactNode;
 }
 
-export const Box: React.VFC<Props> = ({ icon, name, children }) => {
+export const Box = ({ icon, name, children }: BoxProps) => {
     if (!children) {
         return <Container />;
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/CreatedBy.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/CreatedBy.tsx
@@ -3,11 +3,11 @@ import { CmsIdentity } from "~/types";
 import { Box } from "./Box";
 import { TimeAgo } from "@webiny/ui/TimeAgo";
 
-interface Props {
+interface CreatedByProps {
     createdBy: CmsIdentity;
     createdOn: Date;
 }
-export const CreatedBy: React.VFC<Props> = ({ createdBy, createdOn }) => {
+export const CreatedBy = ({ createdBy, createdOn }: CreatedByProps) => {
     return (
         <Box icon={null} name={"Created By"}>
             {createdBy.displayName} <br />

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Description.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Description.tsx
@@ -11,11 +11,11 @@ const Content = styled("p")({
     paddingRight: 20,
     paddingBottom: 10
 });
-interface Props {
+interface DescriptionProps {
     description?: string | null;
 }
 
-export const Description: React.VFC<Props> = ({ description }) => {
+export const Description = ({ description }: DescriptionProps) => {
     const MAX_LENGTH = 320;
     if (!description) {
         return <Content />;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Image.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Image.tsx
@@ -36,21 +36,21 @@ interface IconProps {
     icon: string | undefined;
 }
 
-interface Props {
+interface ImageProps {
     title: string;
     src?: string | null;
     width?: number;
     icon: string | undefined;
 }
 
-const DisplayIcon: React.VFC<IconProps> = ({ icon }) => {
+const DisplayIcon = ({ icon }: IconProps) => {
     if (!icon) {
         return null;
     }
     return <FontAwesomeIcon icon={(icon || "").split("/") as IconProp} />;
 };
 
-export const Image: React.VFC<Props> = ({ src, icon, width = 166 }) => {
+export const Image = ({ src, icon, width = 166 }: ImageProps) => {
     if (!src) {
         return (
             <Container>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModelName.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModelName.tsx
@@ -10,9 +10,9 @@ const Content = styled("h4")({
     textTransform: "uppercase"
 });
 
-interface Props {
+interface ModelNameProps {
     name: string;
 }
-export const ModelName: React.VFC<Props> = ({ name }) => {
+export const ModelName = ({ name }: ModelNameProps) => {
     return <Content>{name}</Content>;
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModifiedBy.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/ModifiedBy.tsx
@@ -3,12 +3,12 @@ import { CmsIdentity } from "~/types";
 import { Box } from "./Box";
 import { TimeAgo } from "@webiny/ui/TimeAgo";
 
-interface Props {
+interface ModifiedByProps {
     modifiedBy?: CmsIdentity | null;
     savedOn: Date;
 }
 
-export const ModifiedBy: React.VFC<Props> = ({ modifiedBy, savedOn }) => {
+export const ModifiedBy = ({ modifiedBy, savedOn }: ModifiedByProps) => {
     const showInformation = !!(modifiedBy?.displayName && savedOn);
 
     if (!showInformation) {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/MoveDown.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/MoveDown.tsx
@@ -3,12 +3,12 @@ import { ButtonLink } from "./elements/ButtonLink";
 import { ReactComponent as MoveDownIcon } from "./assets/move-down.svg";
 import { Tooltip } from "@webiny/ui/Tooltip";
 
-interface Props {
+interface MoveDownProps {
     onClick: (ev: React.MouseEvent) => void;
     className?: string;
 }
 
-export const MoveDown: React.VFC<Props> = ({ onClick, className }) => {
+export const MoveDown = ({ onClick, className }: MoveDownProps) => {
     return (
         <ButtonLink className={"has-tooltip " + className} onClick={onClick} maxWidth={"100px"}>
             <Tooltip content={"Shift+Click to move to bottom"} placement={"top"}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/MoveUp.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/MoveUp.tsx
@@ -3,12 +3,12 @@ import { ButtonLink } from "./elements/ButtonLink";
 import { ReactComponent as MoveUpIcon } from "./assets/move-up.svg";
 import { Tooltip } from "@webiny/ui/Tooltip";
 
-interface Props {
+interface MoveUpProps {
     onClick: (ev: React.MouseEvent) => void;
     className?: string;
 }
 
-export const MoveUp: React.VFC<Props> = ({ onClick, className }) => {
+export const MoveUp = ({ onClick, className }: MoveUpProps) => {
     return (
         <ButtonLink className={"has-tooltip " + className} onClick={onClick} maxWidth={"100px"}>
             <Tooltip content={"Shift+Click to move to top"} placement={"top"}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Remove.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Remove.tsx
@@ -14,12 +14,12 @@ const Text = styled("span")({
     textTransform: "uppercase"
 });
 
-interface Props {
+interface RemoveProps {
     entry: CmsReferenceContentEntry;
     onRemove: (entryId: string) => void;
 }
 
-export const Remove: React.VFC<Props> = ({ entry, onRemove }) => {
+export const Remove = ({ entry, onRemove }: RemoveProps) => {
     const { showConfirmation } = useConfirmationDialog({
         title: "Remove referenced entry",
         message: `Are you sure you want to remove the referenced entry "${entry.title}"?`,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Select.tsx
@@ -54,12 +54,12 @@ const Text = styled("span")({
     marginLeft: "10px"
 });
 
-interface Props {
+interface SelectProps {
     entry: CmsReferenceContentEntry;
     selected?: boolean;
     onChange: (value: CmsReferenceValue) => void;
 }
-export const Select: React.VFC<Props> = ({ entry, selected, onChange }) => {
+export const Select = ({ entry, selected, onChange }: SelectProps) => {
     const onIconClick = useCallback(() => {
         onChange({
             id: entry.id,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Status.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Status.tsx
@@ -18,10 +18,10 @@ const getIcon = (status: CmsContentEntryStatusType) => {
     }
 };
 
-interface Props {
+interface StatusProps {
     status: CmsContentEntryStatusType;
 }
-export const Status: React.VFC<Props> = ({ status }) => {
+export const Status = ({ status }: StatusProps) => {
     return (
         <Box icon={getIcon(status)} name={"Status"}>
             {status.toUpperCase()}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Title.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/Title.tsx
@@ -9,9 +9,9 @@ const Content = styled("h3")({
     marginBottom: "5px"
 });
 
-interface Props {
+interface TitleProps {
     title: string;
 }
-export const Title: React.VFC<Props> = ({ title }) => {
+export const Title = ({ title }: TitleProps) => {
     return <Content>{title}</Content>;
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/View.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/View.tsx
@@ -10,10 +10,10 @@ const createEntryUrl = (entry: CmsReferenceContentEntry) => {
     }&folderId=${encodeURIComponent(folderId)}`;
 };
 
-interface Props {
+interface ViewProps {
     entry: CmsReferenceContentEntry;
 }
-export const View: React.VFC<Props> = ({ entry }) => {
+export const View = ({ entry }: ViewProps) => {
     return (
         <ButtonLink href={createEntryUrl(entry)} target="_blank" maxWidth={"95px"}>
             <ViewIcon /> <span>View</span>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/elements/ButtonLink.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/entry/elements/ButtonLink.tsx
@@ -73,7 +73,7 @@ interface PropsWithHref extends Props {
     onClick?: never;
 }
 
-export const ButtonLink: React.VFC<PropsWithClick | PropsWithHref> = props => {
+export const ButtonLink = (props: PropsWithClick | PropsWithHref) => {
     const { children, href, target, onClick, className, ...styles } = props;
     return (
         <Container className={className} {...styles}>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelList.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelList.tsx
@@ -26,11 +26,11 @@ const ModelsContainer = styled(Elevation)({
     flexDirection: "column"
 });
 
-interface Props {
+interface OptionsModelListProps {
     models: CmsModel[];
     onClick: (modelId: string) => void;
 }
-export const OptionsModelList: React.VFC<Props> = ({ models, onClick }) => {
+export const OptionsModelList = ({ models, onClick }: OptionsModelListProps) => {
     if (models.length <= 1) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelListItem.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/options/OptionsModelListItem.tsx
@@ -61,19 +61,22 @@ interface IconProps {
     model: Pick<CmsModel, "icon">;
 }
 
-const DisplayIcon: React.VFC<IconProps> = ({ model }) => {
+const DisplayIcon = ({ model }: IconProps) => {
     if (!model.icon) {
         return null;
     }
     return <FontAwesomeIcon icon={(model.icon || "").split("/") as IconProp} />;
 };
 
-interface Props {
+interface OptionsModelListItemProps {
     model: Pick<CmsModel, "modelId" | "name" | "description" | "icon">;
     onClick: (modelId: string) => void;
 }
 
-export const OptionsModelListItem: React.VFC<Props> = ({ model, onClick: originalOnClick }) => {
+export const OptionsModelListItem = ({
+    model,
+    onClick: originalOnClick
+}: OptionsModelListItemProps) => {
     const onClick = useCallback(() => {
         originalOnClick(model.modelId);
     }, [originalOnClick]);

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesAutocomplete.tsx
@@ -33,7 +33,7 @@ interface ContentEntriesAutocompleteProps {
     bind: BindComponentRenderProp;
     field: CmsModelField;
 }
-const ContentEntriesAutocomplete: React.FC<ContentEntriesAutocompleteProps> = ({ bind, field }) => {
+const ContentEntriesAutocomplete = ({ bind, field }: ContentEntriesAutocompleteProps) => {
     const { models } = useModels();
     const [showNewEntryModal, setShowNewEntryModal] = useState(false);
     const { options, setSearch, value, loading, onChange } = useReference({

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesMultiAutoComplete.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/ContentEntriesMultiAutoComplete.tsx
@@ -21,10 +21,7 @@ interface ContentEntriesMultiAutocompleteProps {
     bind: BindComponentRenderProp;
     field: CmsModelField;
 }
-const ContentEntriesMultiAutocomplete: React.FC<ContentEntriesMultiAutocompleteProps> = ({
-    bind,
-    field
-}) => {
+const ContentEntriesMultiAutocomplete = ({ bind, field }: ContentEntriesMultiAutocompleteProps) => {
     const { models } = useModels();
     const [showNewEntryModal, setShowNewEntryModal] = useState(false);
     const { options, setSearch, entries, loading, onChange } = useReferences({ bind, field });

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/EntryStatus.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/EntryStatus.tsx
@@ -28,8 +28,9 @@ interface EntryStatusProps {
     item: OptionItem | null;
     placement?: TooltipProps["placement"];
     className?: string;
+    children?: React.ReactNode;
 }
-export const EntryStatus: React.FC<EntryStatusProps> = props => {
+export const EntryStatus = (props: EntryStatusProps) => {
     const { item, children, placement = "bottom", className } = props;
     if (!item) {
         return <>{children}</>;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/MissingEntryHelpText.tsx
@@ -28,7 +28,7 @@ export const ReferenceMultipleModelsHelpText = () => {
 interface MissingEntryHelpTextProps {
     refModelId: string;
 }
-const MissingEntryHelpText: React.FC<MissingEntryHelpTextProps> = ({ refModelId }) => {
+const MissingEntryHelpText = ({ refModelId }: MissingEntryHelpTextProps) => {
     return (
         <HelpTextTypography use={"caption"}>
             {missingEntryLabel({

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/NewReferencedEntryDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/NewReferencedEntryDialog.tsx
@@ -69,7 +69,7 @@ interface EntryFormProps {
     onCreate: (entry: CmsContentEntry) => void;
 }
 
-const EntryForm: React.VFC<EntryFormProps> = ({ onCreate }) => {
+const EntryForm = ({ onCreate }: EntryFormProps) => {
     const { setFormRef, contentModel } = useContentEntry();
     const { currentFolderId, navigateToFolder } = useNavigateFolder();
 
@@ -101,7 +101,7 @@ const EntryForm: React.VFC<EntryFormProps> = ({ onCreate }) => {
     );
 };
 
-const DialogSaveButton: React.VFC = () => {
+const DialogSaveButton = () => {
     const { form } = useContentEntry();
 
     const onClick = useCallback(
@@ -116,17 +116,17 @@ const DialogSaveButton: React.VFC = () => {
     return <ButtonPrimary onClick={onClick}>{t`Create Entry`}</ButtonPrimary>;
 };
 
-interface Props {
+interface NewReferencedEntryDialogProps {
     model: Pick<CmsModel, "modelId">;
     onClose: () => void;
     onChange: (entry: any) => void;
 }
 
-export const NewReferencedEntryDialog: React.VFC<Props> = ({
+export const NewReferencedEntryDialog = ({
     model: baseModel,
     onClose,
     onChange
-}) => {
+}: NewReferencedEntryDialogProps) => {
     const { apolloClient } = useCms();
     const [model, setModel] = useState<CmsModel | undefined>(undefined);
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/dialog/DialogHeader.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/dialog/DialogHeader.tsx
@@ -61,7 +61,7 @@ interface CloseProps {
     onClick: () => void;
 }
 
-const Close: React.VFC<CloseProps> = ({ onClick }) => {
+const Close = ({ onClick }: CloseProps) => {
     return (
         <CloseContainer>
             <CloseButton onClick={onClick}>
@@ -71,12 +71,12 @@ const Close: React.VFC<CloseProps> = ({ onClick }) => {
     );
 };
 
-interface Props {
+interface DialogHeaderProps {
     model: CmsModel;
     onClose: () => void;
 }
 
-export const DialogHeader: React.VFC<Props> = ({ model, onClose }) => {
+export const DialogHeader = ({ model, onClose }: DialogHeaderProps) => {
     return (
         <Container>
             <Content>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/renderItem.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/renderItem.tsx
@@ -22,7 +22,7 @@ export interface RenderItemProps {
     modelId: string;
     id: string;
 }
-export const renderItem: React.FC<RenderItemProps> = props => {
+export const renderItem = (props: RenderItemProps) => {
     return (
         <Typography use={"body2"}>
             <Link to={createEntryUrl(props)}>{props.name}</Link>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleItems.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleItems.tsx
@@ -33,7 +33,7 @@ interface ItemProps {
     onChange: (checked?: boolean) => void;
 }
 
-const Item: React.VFC<ItemProps> = props => {
+const Item = (props: ItemProps) => {
     const { multiple, value, item, onChange } = props;
     if (!multiple) {
         return <Radio value={value} onChange={onChange} label={item.title} />;
@@ -41,7 +41,7 @@ const Item: React.VFC<ItemProps> = props => {
     return <Checkbox value={value} onChange={onChange} label={item.title} />;
 };
 
-interface Props {
+interface SimpleItemsProps {
     multiple?: boolean;
     field: CmsModelField;
     items?: CmsReferenceContentEntry[];
@@ -50,7 +50,7 @@ interface Props {
     removeItem: (params: RemoveItemParams) => void;
 }
 
-export const SimpleItems: React.VFC<Props> = props => {
+export const SimpleItems = (props: SimpleItemsProps) => {
     const { field, items, values, addItem, removeItem, multiple } = props;
 
     const onChange = useCallback(

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleMultipleRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleMultipleRenderer.tsx
@@ -5,12 +5,12 @@ import { useContentModels } from "./useContentModels";
 import { useReferences } from "./useReferences";
 import { AddItemParams, RemoveItemParams, SimpleItems } from "./SimpleItems";
 
-interface Props {
+interface SimpleMultipleRendererProps {
     bind: BindComponentRenderProp<CmsReferenceValue[] | undefined | null>;
     field: CmsModelField;
 }
 
-export const SimpleMultipleRenderer: React.VFC<Props> = props => {
+export const SimpleMultipleRenderer = (props: SimpleMultipleRendererProps) => {
     const { field, bind } = props;
 
     const values = useMemo(() => {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleSingleRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/simple/components/SimpleSingleRenderer.tsx
@@ -5,12 +5,12 @@ import { useContentModels } from "./useContentModels";
 import { useReferences } from "./useReferences";
 import { AddItemParams, SimpleItems } from "./SimpleItems";
 
-interface Props {
+interface SimpleSingleRendererProps {
     bind: BindComponentRenderProp<CmsReferenceValue | undefined | null>;
     field: CmsModelField;
 }
 
-export const SimpleSingleRenderer: React.VFC<Props> = props => {
+export const SimpleSingleRenderer = (props: SimpleSingleRendererProps) => {
     const { field, bind } = props;
 
     const value = useMemo(() => {

--- a/packages/app-headless-cms/src/admin/plugins/fields/PredefinedValuesDynamicFieldset.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/PredefinedValuesDynamicFieldset.tsx
@@ -69,11 +69,14 @@ const onSelectedChange = (params: OnSelectedParams) => {
     );
 };
 
-export interface Props {
+export interface PredefinedValuesDynamicFieldsetProps {
     getBind: (value?: any) => BindComponent;
-    renderValueInput?: (Bind: BindComponent) => React.ReactNode;
+    renderValueInput?: ((Bind: BindComponent) => React.ReactNode) | null;
 }
-const PredefinedValuesDynamicFieldset: React.FC<Props> = ({ getBind, renderValueInput = null }) => {
+const PredefinedValuesDynamicFieldset = ({
+    getBind,
+    renderValueInput = null
+}: PredefinedValuesDynamicFieldsetProps) => {
     const Bind = getBind();
     const { field } = useModelField();
 

--- a/packages/app-headless-cms/src/admin/plugins/fields/boolean.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/boolean.tsx
@@ -13,7 +13,7 @@ interface OptionsProps {
     value?: boolean | "true" | "false";
 }
 
-const Options: React.VFC<OptionsProps> = ({ onChange, value: initialValue }) => {
+const Options = ({ onChange, value: initialValue }: OptionsProps) => {
     const value = initialValue === true || initialValue === "true";
 
     return (

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/AddTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/AddTemplate.tsx
@@ -69,7 +69,7 @@ function useAddTemplate(params: UseAddTemplateParams) {
     };
 }
 
-export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
+export const AddTemplateButton = (props: AddTemplateProps) => {
     const { addTemplate, onTemplate, showTemplateDialog, onDialogClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });
@@ -90,7 +90,7 @@ export const AddTemplateButton: React.VFC<AddTemplateProps> = props => {
     );
 };
 
-export const AddTemplateIcon: React.VFC<AddTemplateProps> = props => {
+export const AddTemplateIcon = (props: AddTemplateProps) => {
     const { addTemplate, onTemplate, showTemplateDialog, onDialogClose } = useAddTemplate({
         onTemplate: props.onTemplate
     });

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
@@ -22,7 +22,7 @@ function updateOrCreateTemplate(
     return [...templates, template];
 }
 
-export const DynamicZone: React.VFC = () => {
+export const DynamicZone = () => {
     const { field } = useModelField();
     const { updateField } = useModelFieldEditor();
     const newTemplateId = useRef<string | undefined>(undefined);

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
@@ -31,13 +31,13 @@ interface UpdateFieldsAndLayout {
 
 const TEMPLATES_PATH = "settings.templates";
 
-export const DynamicZoneTemplate: React.VFC<DynamicZoneTemplateProps> = ({
+export const DynamicZoneTemplate = ({
     index,
     field,
     template,
     onChange,
     open
-}) => {
+}: DynamicZoneTemplateProps) => {
     const { showConfirmation } = useConfirmationDialog({
         title: "Delete content template",
         message: "Are you sure you want to delete this content template?",

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/TemplateDialog.tsx
@@ -32,7 +32,7 @@ interface TemplateDialogProps {
     onTemplate: (template: CmsDynamicZoneTemplate) => void;
 }
 
-export const TemplateDialog: React.VFC<TemplateDialogProps> = props => {
+export const TemplateDialog = (props: TemplateDialogProps) => {
     const [showWarning, setWarning] = useState(false);
     const newTemplate = !Boolean(props.template);
     const dialogTitle = newTemplate ? "Add Template" : "Edit Template";

--- a/packages/app-headless-cms/src/admin/plugins/fields/object/ObjectFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/object/ObjectFields.tsx
@@ -6,7 +6,7 @@ import { CmsModelField, CmsModel } from "~/types";
 interface ObjectFieldsProps {
     field: CmsModelField;
 }
-export const ObjectFields: React.FC<ObjectFieldsProps> = ({ field }) => {
+export const ObjectFields = ({ field }: ObjectFieldsProps) => {
     const { getField, updateField } = useModelFieldEditor();
 
     const onChange = useCallback(

--- a/packages/app-headless-cms/src/admin/plugins/fields/ref/renderInfo.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/ref/renderInfo.tsx
@@ -45,22 +45,23 @@ const Extras = styled("div")({
 interface BadgeProps {
     model: CmsModel;
 }
-const Badge: React.FC<BadgeProps> = ({ model }) => {
+
+const Badge = ({ model }: BadgeProps) => {
     return <BadgeItem>{model.name}</BadgeItem>;
 };
 
-interface Params {
+interface RenderInfoParams {
     field: CmsModelField;
     model: CmsModel;
 }
 
 const takeBadges = 1;
 
-export const renderInfo = ({ model, field }: Params) => {
+export const renderInfo = ({ model, field }: RenderInfoParams) => {
     return <RenderInfo model={model} field={field} />;
 };
 
-const RenderInfo: React.FC<Params> = ({ field }) => {
+const RenderInfo = ({ field }: RenderInfoParams) => {
     const hasAnyModels = (field.settings?.models || []).length > 0;
     const { data, loading, error } = useQuery<ListReferencedModelsQueryResult>(
         LIST_REFERENCED_MODELS,

--- a/packages/app-headless-cms/src/admin/plugins/install.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/install.tsx
@@ -60,7 +60,7 @@ const INSTALL = gql`
 interface CMSInstallerProps {
     onInstalled: () => void;
 }
-const CMSInstaller: React.FC<CMSInstallerProps> = ({ onInstalled }) => {
+const CMSInstaller = ({ onInstalled }: CMSInstallerProps) => {
     const client = useApolloClient();
     const [error, setError] = useState<string | null>(null);
 

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
@@ -43,7 +43,7 @@ export interface CMSPermissionsProps {
     value: CmsSecurityPermission[];
     onChange: (value: CmsSecurityPermission[]) => void;
 }
-export const CMSPermissions: React.FC<CMSPermissionsProps> = ({ value, onChange }) => {
+export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
     const { getPermission } = useSecurity();
 
     // We disable form elements for custom permissions if AACL cannot be used.

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentEntryPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentEntryPermission.tsx
@@ -29,14 +29,14 @@ interface ContentEntryPermissionProps {
     title: string;
     disabled?: boolean;
 }
-export const ContentEntryPermission: React.FC<ContentEntryPermissionProps> = ({
+export const ContentEntryPermission = ({
     Bind,
     data,
     entity,
     setValue,
     title,
     disabled
-}) => {
+}: ContentEntryPermissionProps) => {
     // Set "cms.contentEntry" access scope to "own" if "cms.contentModel" === "own".
     useEffect(() => {
         if (

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelGroupPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelGroupPermission.tsx
@@ -19,14 +19,14 @@ interface ContentModelGroupPermissionProps {
     locales: string[];
     disabled?: boolean;
 }
-const ContentModelGroupPermission: React.FC<ContentModelGroupPermissionProps> = ({
+const ContentModelGroupPermission = ({
     Bind,
     data,
     entity,
     title,
     locales,
     disabled
-}) => {
+}: ContentModelGroupPermissionProps) => {
     const modelsGroups = useCmsData(locales);
 
     const getItems = useCallback(

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelList.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelList.tsx
@@ -25,7 +25,7 @@ interface ContentModelListProps {
     onChange: OnChangeCallable;
     getValue: GetValueCallable;
 }
-const ContentModelList: React.FC<ContentModelListProps> = ({ items, onChange, getValue }) => {
+const ContentModelList = ({ items, onChange, getValue }: ContentModelListProps) => {
     const list: [string, GroupItem[]][] = Object.entries(
         groupBy(
             items.map((item): GroupItem => {

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelPermission.tsx
@@ -24,7 +24,7 @@ interface ContentModelPermissionProps {
     selectedContentModelGroups?: Record<string, string[]>;
     disabled?: boolean;
 }
-export const ContentModelPermission: React.FC<ContentModelPermissionProps> = ({
+export const ContentModelPermission = ({
     Bind,
     data,
     setValue,
@@ -33,7 +33,7 @@ export const ContentModelPermission: React.FC<ContentModelPermissionProps> = ({
     locales,
     selectedContentModelGroups = {},
     disabled
-}) => {
+}: ContentModelPermissionProps) => {
     const modelsGroups = useCmsData(locales);
     // Set "cms.contentModel" access scope to "own" if "cms.contentModelGroup" === "own".
     useEffect(() => {

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionRendererWrapper.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionRendererWrapper.tsx
@@ -9,11 +9,9 @@ import { Typography } from "@webiny/ui/Typography";
 
 interface PermissionRendererWrapperProps {
     label: string;
+    children: React.ReactNode;
 }
-export const PermissionRendererWrapper: React.FC<PermissionRendererWrapperProps> = ({
-    label,
-    children
-}) => (
+export const PermissionRendererWrapper = ({ label, children }: PermissionRendererWrapperProps) => (
     <Elevation z={1} className={""}>
         <Grid className={""} style={{ marginTop: 36 }}>
             <Cell span={12}>

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionSelector.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionSelector.tsx
@@ -30,12 +30,7 @@ export interface PermissionSelectorProps {
     disabled?: boolean;
 }
 
-const DefaultRenderItems: React.FC<RenderItemsProps> = ({
-    items,
-    getValue,
-    onChange,
-    disabled
-}) => {
+const DefaultRenderItems = ({ items, getValue, onChange, disabled }: RenderItemsProps) => {
     return (
         <React.Fragment>
             {items.map(({ id, label }) => (
@@ -53,7 +48,7 @@ const DefaultRenderItems: React.FC<RenderItemsProps> = ({
     );
 };
 
-export const PermissionSelector: React.FC<PermissionSelectorProps> = ({
+export const PermissionSelector = ({
     Bind,
     entity,
     locales,
@@ -61,7 +56,7 @@ export const PermissionSelector: React.FC<PermissionSelectorProps> = ({
     getItems,
     RenderItems = DefaultRenderItems,
     disabled
-}) => {
+}: PermissionSelectorProps) => {
     const description = t`Select the {selectorKey} user will be allowed to access.`({
         selectorKey
     });
@@ -104,7 +99,11 @@ export const PermissionSelector: React.FC<PermissionSelectorProps> = ({
     );
 };
 
-export const PermissionSelectorWrapper: React.FC = ({ children }) => (
+interface PermissionSelectorWrapperProps {
+    children: React.ReactNode;
+}
+
+export const PermissionSelectorWrapper = ({ children }: PermissionSelectorWrapperProps) => (
     <Fragment>
         <Cell span={1} />
         <Cell span={11}>{children}</Cell>

--- a/packages/app-headless-cms/src/admin/plugins/routes.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/routes.tsx
@@ -12,7 +12,11 @@ import { CompositionScope } from "@webiny/react-composition";
 
 const t = i18n.ns("app-headless-cms/admin/routes");
 
-const Loader: React.FC = ({ children, ...props }) => (
+interface LoaderProps {
+    children: React.ReactNode;
+}
+
+const Loader = ({ children, ...props }: LoaderProps) => (
     <Suspense fallback={<CircularProgress />}>
         {React.cloneElement(children as unknown as React.ReactElement, props)}
     </Suspense>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntries.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntries.tsx
@@ -8,7 +8,7 @@ import {
 import { ContentEntriesProvider } from "~/admin/views/contentEntries/ContentEntriesContext";
 import { AcoWithConfig } from "@webiny/app-aco";
 
-export const ContentEntries: React.FC = () => {
+export const ContentEntries = () => {
     const { model } = useModel();
 
     return (

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContainer.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContainer.tsx
@@ -15,10 +15,11 @@ import { ModelProvider } from "~/admin/components/ModelProvider";
 
 const t = i18n.ns("app-headless-cms/admin/content-entries");
 
-interface Props {
+interface ContentEntriesContainerProps {
     children: React.ReactNode;
 }
-export const ContentEntriesContainer: React.VFC<Props> = ({ children }) => {
+
+export const ContentEntriesContainer = ({ children }: ContentEntriesContainerProps) => {
     const { params } = useRouter();
     const modelId = params?.modelId;
     const [contentModel, setContentModel] = useState<CmsModel | null>(null);

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesContext.tsx
@@ -16,11 +16,11 @@ export interface ContentEntriesContextProviderProps {
     insideDialog?: boolean;
 }
 
-export const ContentEntriesProvider: React.FC<ContentEntriesContextProviderProps> = ({
+export const ContentEntriesProvider = ({
     contentModel,
     children,
     insideDialog
-}) => {
+}: ContentEntriesContextProviderProps) => {
     const { identity, getPermission } = useSecurity();
 
     const canCreate = useMemo((): boolean => {

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesModule.tsx
@@ -18,7 +18,7 @@ import { DeleteFolder, EditFolder, SetFolderPermissions } from "@webiny/app-aco"
 const { Browser } = ContentEntryListConfig;
 const { Actions } = ContentEntryEditorConfig;
 
-export const ContentEntriesModule: React.FC = () => {
+export const ContentEntriesModule = () => {
     return (
         <>
             <ContentEntryListConfig>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
@@ -48,7 +48,7 @@ declare global {
     }
 }
 
-export const ContentEntry: React.FC = () => {
+export const ContentEntry = () => {
     const { loading, entry, showEmptyView, canCreate, createEntry, tabsRef, setFormRef } =
         useContentEntry();
 

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -79,11 +79,11 @@ export const useContentEntryProviderProps = (): UseContentEntryProviderProps => 
     };
 };
 
-export const ContentEntryProvider: React.FC<ContentEntryContextProviderProps> = ({
+export const ContentEntryProvider = ({
     children,
     isNewEntry,
     getContentId
-}) => {
+}: ContentEntryContextProviderProps) => {
     const { contentModel, canCreate } = useContentEntries();
 
     const { search } = useRouter();

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/PublishEntryRevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/PublishEntryRevisionListItem.tsx
@@ -7,7 +7,7 @@ import { i18n } from "@webiny/app/i18n";
 
 const t = i18n.ns("app-headless-cms/admin/plugins/content-details/content-revisions");
 
-const PublishEntryRevisionListItemComponent: React.FC = () => {
+const PublishEntryRevisionListItemComponent = () => {
     return (
         <>
             <ListItemGraphic>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
@@ -69,7 +69,7 @@ interface RevisionListItemProps {
     revision: CmsContentEntry;
 }
 
-const RevisionListItem: React.FC<RevisionListItemProps> = ({ revision }) => {
+const RevisionListItem = ({ revision }: RevisionListItemProps) => {
     const { createRevision, deleteRevision, publishRevision, unpublishRevision, editRevision } =
         useRevision({
             revision

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList.tsx
@@ -31,7 +31,7 @@ const style = {
     })
 };
 
-const RevisionsList: React.FC = () => {
+const RevisionsList = () => {
     const { entry, revisions, loading } = useContentEntry();
 
     return (

--- a/packages/app-headless-cms/src/admin/views/contentEntries/Table/Main.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/Table/Main.tsx
@@ -15,11 +15,11 @@ import { useRouter } from "@webiny/react-router";
 import { ROOT_FOLDER } from "~/admin/constants";
 import { BulkActions } from "~/admin/components/ContentEntries/BulkActions";
 
-interface Props {
+interface MainProps {
     folderId?: string;
 }
 
-export const Main: React.VFC<Props> = ({ folderId: initialFolderId }) => {
+export const Main = ({ folderId: initialFolderId }: MainProps) => {
     const folderId = initialFolderId === undefined ? ROOT_FOLDER : initialFolderId;
     const list = useContentEntriesList();
     const { showDialog: showCreateFolderDialog } = useCreateDialog();

--- a/packages/app-headless-cms/src/admin/views/contentEntries/Table/Sidebar.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/Table/Sidebar.tsx
@@ -25,11 +25,11 @@ const disabled = css({
     cursor: "default"
 });
 
-interface Props {
+interface SidebarProps {
     folderId?: string;
 }
 
-export const Sidebar: React.VFC<Props> = ({ folderId }) => {
+export const Sidebar = ({ folderId }: SidebarProps) => {
     const { navigateToFolder } = useNavigateFolder();
 
     const { model } = useModel();

--- a/packages/app-headless-cms/src/admin/views/contentEntries/Table/index.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/Table/index.tsx
@@ -8,7 +8,7 @@ import { useApolloClient, useModel } from "~/admin/hooks";
 import { ContentEntriesListProvider } from "~/admin/views/contentEntries/hooks";
 import { CMS_ENTRY_LIST_LINK, LOCAL_STORAGE_LATEST_VISITED_FOLDER } from "~/admin/constants";
 
-const View: React.VFC = () => {
+const View = () => {
     const { currentFolderId } = useNavigateFolder();
 
     return (
@@ -25,7 +25,7 @@ const View: React.VFC = () => {
     );
 };
 
-export const Table: React.VFC = () => {
+export const Table = () => {
     const { model } = useModel();
     const client = useApolloClient();
 

--- a/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroups.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroups.tsx
@@ -5,7 +5,7 @@ import ContentModelGroupsDataList from "./ContentModelGroupsDataList";
 import ContentModelGroupsForm from "./ContentModelGroupsForm";
 import { CmsSecurityPermission } from "~/types";
 
-const ContentModelGroups: React.FC = () => {
+const ContentModelGroups = () => {
     const { identity, getPermission } = useSecurity();
 
     const canCreate = useMemo((): boolean => {

--- a/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroupsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroupsDataList.tsx
@@ -59,7 +59,7 @@ const SORTERS: Sort[] = [
 interface ContentModelGroupsDataListProps {
     canCreate: boolean;
 }
-const ContentModelGroupsDataList: React.FC<ContentModelGroupsDataListProps> = ({ canCreate }) => {
+const ContentModelGroupsDataList = ({ canCreate }: ContentModelGroupsDataListProps) => {
     const [filter, setFilter] = useState<string>("");
     const [sort, setSort] = useState<string>(SORTERS[0].sorters);
     const { history } = useRouter();

--- a/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroupsForm.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModelGroups/ContentModelGroupsForm.tsx
@@ -45,7 +45,7 @@ const ButtonWrapper = styled("div")({
 interface ContentModelGroupsFormProps {
     canCreate: boolean;
 }
-const ContentModelGroupsForm: React.FC<ContentModelGroupsFormProps> = ({ canCreate }) => {
+const ContentModelGroupsForm = ({ canCreate }: ContentModelGroupsFormProps) => {
     const { location, history } = useRouter();
     const { showSnackbar } = useSnackbar();
     const { canEdit } = usePermission();

--- a/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/CloneContentModelDialog.tsx
@@ -29,12 +29,6 @@ import { IconPicker } from "~/admin/components/IconPicker";
 
 const t = i18n.ns("app-headless-cms/admin/views/content-models/clone-content-model-dialog");
 
-interface Props {
-    onClose: UID.DialogOnClose;
-    contentModel: CmsModel;
-    closeModal: () => void;
-}
-
 const getSelectedGroup = (groups: CmsGroupOption[] | null, model: CmsModel): string | null => {
     if (!groups || groups.length === 0 || !model) {
         return "";
@@ -48,7 +42,17 @@ const getSelectedGroup = (groups: CmsGroupOption[] | null, model: CmsModel): str
     return defaultSelected ? defaultSelected.value : null;
 };
 
-export const CloneContentModelDialog: React.FC<Props> = ({ onClose, contentModel, closeModal }) => {
+interface CloneContentModelDialogProps {
+    onClose: UID.DialogOnClose;
+    contentModel: CmsModel;
+    closeModal: () => void;
+}
+
+export const CloneContentModelDialog = ({
+    onClose,
+    contentModel,
+    closeModal
+}: CloneContentModelDialogProps) => {
     const [loading, setLoading] = useState<boolean>(false);
     const { showSnackbar } = useSnackbar();
     const { history } = useRouter();

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelEditor.tsx
@@ -9,7 +9,7 @@ import { CmsModel } from "~/types";
 
 type QueryMatch = Pick<Partial<CmsModel>, "modelId">;
 
-const ContentModelEditorView: React.FC = () => {
+const ContentModelEditorView = () => {
     const { params } = useRouter();
     const { apolloClient } = useCms();
 

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
@@ -36,7 +36,7 @@ const centeredContent = css({
     }
 });
 
-const ContentModels: React.FC = () => {
+const ContentModels = () => {
     const [newContentModelDialogOpened, openNewContentModelDialog] = React.useState(false);
 
     const [cloneContentModel, setCloneContentModel] = React.useState<CmsModel | null>(null);

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -101,19 +101,19 @@ interface IconProps {
     model: Pick<CmsModel, "icon">;
 }
 
-const DisplayIcon: React.VFC<IconProps> = ({ model }) => {
+const DisplayIcon = ({ model }: IconProps) => {
     if (!model.icon) {
         return null;
     }
     return <FontAwesomeIcon icon={(model.icon || "").split("/") as IconProp} />;
 };
 
-const ContentModelsDataList: React.FC<ContentModelsDataListProps> = ({
+const ContentModelsDataList = ({
     canCreate,
     onCreate,
     onClone,
     showImportModelModal
-}) => {
+}: ContentModelsDataListProps) => {
     const [filter, setFilter] = useState<string>("");
     const [sort, setSort] = useState<string>(SORTERS[0].sorters);
     const { history } = useRouter();

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -39,7 +39,7 @@ interface CmsModelData {
     group: string;
 }
 
-const NewContentModelDialog: React.FC<NewContentModelDialogProps> = ({ open, onClose }) => {
+const NewContentModelDialog = ({ open, onClose }: NewContentModelDialogProps) => {
     const [loading, setLoading] = React.useState(false);
     const { showSnackbar } = useSnackbar();
     const { history } = useRouter();

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContentModelsDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContentModelsDialog.tsx
@@ -16,7 +16,7 @@ export interface ImportContentModelsDialogProps {
     onClose: () => void;
 }
 
-export const ImportContentModelsDialog: React.VFC<ImportContentModelsDialogProps> = props => {
+export const ImportContentModelsDialog = (props: ImportContentModelsDialogProps) => {
     const { onClose } = props;
 
     const onCloseClick = useCallback(() => {

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
@@ -190,7 +190,7 @@ export interface ImportContextProviderProps {
     children: (props: ImportContextProperties) => React.ReactNode;
 }
 
-export const ImportContextProvider: React.VFC<ImportContextProviderProps> = ({ children }) => {
+export const ImportContextProvider = ({ children }: ImportContextProviderProps) => {
     const client = useApolloClient();
 
     const { showSnackbar } = useSnackbar();

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/DataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/DataList.tsx
@@ -10,7 +10,7 @@ const getGroupModels = (group: ImportGroupData, models?: ImportModelData[] | nul
     return models.filter(model => model.group === group.id);
 };
 
-export const DataList: React.VFC = () => {
+export const DataList = () => {
     const { groups, models } = useImport();
     if (!groups) {
         return null;

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/DataListGroup.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/DataListGroup.tsx
@@ -19,7 +19,7 @@ interface GroupProps {
     group: Pick<ImportGroupData, "id" | "name">;
 }
 
-const Group: React.VFC<GroupProps> = ({ group }) => {
+const Group = ({ group }: GroupProps) => {
     return <GroupName>{group.name || group.id}</GroupName>;
 };
 
@@ -28,7 +28,7 @@ interface DataListGroupProps {
     models: ImportModelData[];
 }
 
-export const DataListGroup: React.VFC<DataListGroupProps> = ({ group, models }) => {
+export const DataListGroup = ({ group, models }: DataListGroupProps) => {
     return (
         <Container>
             <Group group={group} />

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Errors.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Errors.tsx
@@ -30,7 +30,7 @@ interface ErrorsProps {
     errors?: string[] | null;
 }
 
-export const Errors: React.VFC<ErrorsProps> = ({ errors }) => {
+export const Errors = ({ errors }: ErrorsProps) => {
     if (!errors?.length) {
         return null;
     }

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/FileUpload.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/FileUpload.tsx
@@ -19,7 +19,7 @@ const Text = styled("p")({
     display: "block"
 });
 
-export const FileUpload: React.VFC = () => {
+export const FileUpload = () => {
     const { onFile, onFileError, file } = useImport();
     const fileName = file?.name;
 

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/ImportButton.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/ImportButton.tsx
@@ -10,7 +10,7 @@ interface ImportButtonProps {
     disabled: boolean;
 }
 
-export const ImportButton: React.VFC<ImportButtonProps> = ({ onClick, validated, disabled }) => {
+export const ImportButton = ({ onClick, validated, disabled }: ImportButtonProps) => {
     const text = validated ? t`Import` : t`Validate file`;
     return (
         <ButtonPrimary onClick={onClick} disabled={disabled}>

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListInstructions.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListInstructions.tsx
@@ -6,7 +6,7 @@ const Instructions = styled("div")({
     margin: "10px 0"
 });
 
-export const DataListInstructions: React.VFC = () => {
+export const DataListInstructions = () => {
     return (
         <Instructions>
             <h4>Instructions</h4>

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItem.tsx
@@ -76,7 +76,7 @@ const ImportedText = styled("div")({
     color: "#FFF"
 });
 
-const Imported: React.VFC = () => {
+const Imported = () => {
     return (
         <CheckboxContainer>
             <ImportedText>Imported.</ImportedText>
@@ -90,7 +90,7 @@ interface CheckboxProps {
     selected: boolean;
 }
 
-const Checkbox: React.VFC<CheckboxProps> = ({ model, toggle, selected }) => {
+const Checkbox = ({ model, toggle, selected }: CheckboxProps) => {
     const onClick = useCallback(() => {
         toggle(model);
     }, [toggle]);
@@ -108,9 +108,10 @@ const Checkbox: React.VFC<CheckboxProps> = ({ model, toggle, selected }) => {
 
 interface ContainerProps {
     model: Pick<ImportModelData, "action" | "error" | "imported">;
+    children: React.ReactNode;
 }
 
-const Container: React.VFC<React.PropsWithChildren<ContainerProps>> = ({ model, children }) => {
+const Container = ({ model, children }: ContainerProps) => {
     if (model.imported) {
         return <ContainerImported>{children}</ContainerImported>;
     } else if (model.action === "create") {
@@ -123,13 +124,13 @@ const Container: React.VFC<React.PropsWithChildren<ContainerProps>> = ({ model, 
     return <ContainerBase>{children}</ContainerBase>;
 };
 
-interface Props {
+interface DataListModelItemProps {
     model: ImportModelData;
     toggle: ToggleModelCb;
     selected: boolean;
 }
 
-export const DataListModelItem: React.VFC<Props> = ({ model, toggle, selected }) => {
+export const DataListModelItem = ({ model, toggle, selected }: DataListModelItemProps) => {
     return (
         <Container model={model}>
             <ModelContainer>

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItemError.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItemError.tsx
@@ -26,7 +26,7 @@ interface InvalidFieldsProps {
     expanded: boolean;
 }
 
-const InvalidFields: React.VFC<InvalidFieldsProps> = ({ invalidFields, expanded }) => {
+const InvalidFields = ({ invalidFields, expanded }: InvalidFieldsProps) => {
     if (!expanded) {
         return null;
     }
@@ -40,11 +40,11 @@ const InvalidFields: React.VFC<InvalidFieldsProps> = ({ invalidFields, expanded 
     );
 };
 
-interface Props {
+interface DataListModelItemErrorProps {
     error: CmsErrorResponse;
 }
 
-export const DataListModelItemError: React.VFC<Props> = ({ error }) => {
+export const DataListModelItemError = ({ error }: DataListModelItemErrorProps) => {
     const [expanded, setExpanded] = useState(false);
 
     const toggleContainer = useCallback(() => {

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItemInfo.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModelItemInfo.tsx
@@ -10,10 +10,6 @@ const Text = styled("p")({
     margin: "0"
 });
 
-interface Props {
-    model: ImportModelData;
-}
-
 const getText = (action?: string | null) => {
     if (action === "create") {
         return `Model will be created.`;
@@ -24,7 +20,12 @@ const getText = (action?: string | null) => {
     }
     return `Unknown action: ${action}`;
 };
-export const DataListModelItemInfo: React.VFC<Props> = ({ model }) => {
+
+interface DataListModelItemInfoProps {
+    model: ImportModelData;
+}
+
+export const DataListModelItemInfo = ({ model }: DataListModelItemInfoProps) => {
     const { action } = model;
 
     return <Text>{getText(action)}</Text>;

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModels.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/components/Model/DataListModels.tsx
@@ -11,11 +11,11 @@ const Container = styled("div")({
     borderBox: "box-sizing"
 });
 
-interface Props {
+interface DataListModelsProps {
     models: ImportModelData[];
 }
 
-export const DataListModels: React.VFC<Props> = ({ models }) => {
+export const DataListModels = ({ models }: DataListModelsProps) => {
     const { toggleModel, isModelSelected } = useImport();
     return (
         <Container>

--- a/packages/app-headless-cms/src/index.tsx
+++ b/packages/app-headless-cms/src/index.tsx
@@ -8,6 +8,10 @@ export { ModelProvider } from "~/admin/components/ModelProvider";
 import { ContentEntryEditorConfig, ContentEntryListConfig } from "./admin/config/contentEntries";
 export { ContentEntryEditorConfig, ContentEntryListConfig };
 
+interface LegacyContentEntriesViewConfigProps {
+    children: React.ReactNode;
+}
+
 /**
  * DANGER!
  * The following components are created to support the old experimental API:
@@ -16,7 +20,7 @@ export { ContentEntryEditorConfig, ContentEntryListConfig };
  *
  * Check out 5.37.0 changelog and discover the new `ContentEntryListConfig` API.
  */
-const LegacyContentEntriesViewConfig: React.FC = ({ children }) => {
+const LegacyContentEntriesViewConfig = ({ children }: LegacyContentEntriesViewConfigProps) => {
     return <ContentEntryListConfig>{children}</ContentEntryListConfig>;
 };
 


### PR DESCRIPTION
## Changes
Twelfth batch of changes to React component definitions before upgrading to React 18.
https://www.notion.so/webiny/Upgrade-to-React-18-ceacd9bbfcf74b39a7ceb70943c3afa7

Packages: app-graphql-playground, app-headless-cms.

## How Has This Been Tested?
Manually.

## Documentation
None.
