### PR TITLE
fix: new reference record z-index

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/dialog/Dialog.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/components/dialog/Dialog.tsx
@@ -13,6 +13,7 @@ export const Dialog = styled(BaseDialog)({
 export const FullWidthDialog = styled(BaseDialog)({
     maxWidth: "100%",
     minWidth: "90%",
+    zIndex: "20",
     ".mdc-dialog__surface": {
         width: "auto",
         maxWidth: "100%",


### PR DESCRIPTION
## Changes
With this PR, we fixed an odd behaviour when trying to interact with the file manager opened from the new reference entry dialog.

**How to reproduce the bug:**

1. Open an entry with a reference field (the target model must have a file field)
2. Click on "Create a new record" button
3. The dialog should open
4. Click on the file field
5. The file manager opens in the background, user cannot interact with it

 
![CleanShot 2023-12-11 at 10 21 46](https://github.com/webiny/webiny-js/assets/2866531/abd954ba-1112-4649-999a-3bec6c579813)
![CleanShot 2023-12-11 at 10 10 31](https://github.com/webiny/webiny-js/assets/2866531/89b181bd-4012-428b-bcd5-0e0810eafc24)


## How Has This Been Tested?
Manually

