### PR TITLE
fix: file details drawer overlay

### DIFF
--- a/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
@@ -34,6 +34,9 @@ const FileDetailsDrawer = styled(Drawer)<FileDetailsDrawerProps>`
     &.mdc-drawer {
         width: ${props => props.width};
     }
+    & + .mdc-drawer-scrim {
+        z-index: 65;
+    }
 `;
 
 const FormContainer = styled(SimpleForm)`


### PR DESCRIPTION
## Changes
With this PR, we fix a bug found while opening the file details drawer: 
![CleanShot 2023-12-07 at 21 22 09](https://github.com/webiny/webiny-js/assets/2866531/332da5eb-00e7-409c-a20d-4f919ef79264)



## How Has This Been Tested?
Manually.