### PR TITLE
Ensure extension exists on edited images

### DIFF
--- a/packages/api-file-manager-s3/jest.config.js
+++ b/packages/api-file-manager-s3/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base");
+
+module.exports = {
+    ...base({ path: __dirname })
+};

--- a/packages/api-file-manager-s3/src/plugins/graphqlFileStorageS3.ts
+++ b/packages/api-file-manager-s3/src/plugins/graphqlFileStorageS3.ts
@@ -28,6 +28,8 @@ const plugin: GraphQLSchemaPlugin<FileManagerContext> = {
                 name: String!
                 type: String!
                 size: Long!
+                key: String
+                keyPrefix: String
             }
 
             type GetPreSignedPostPayloadResponseDataFile {

--- a/packages/api-file-manager-s3/src/utils/FileExtension.ts
+++ b/packages/api-file-manager-s3/src/utils/FileExtension.ts
@@ -9,15 +9,12 @@ export class FileExtension {
     }
 
     getValue() {
-        const name = this.data.name.toLowerCase();
-        const maybeHasExtension = name.includes(".");
+        const name = (this.data.key || this.data.name).toLowerCase();
 
-        if (maybeHasExtension) {
-            const maybeExt = name.split(".").pop() as string;
-            const extensions = mimeTypes[this.data.type];
-            if (extensions && !extensions.includes(maybeExt)) {
-                return extensions[0];
-            }
+        const maybeExt = name.split(".").pop() as string;
+        const extensions = mimeTypes[this.data.type];
+        if (extensions && !extensions.includes(maybeExt)) {
+            return extensions[0];
         }
 
         return "";

--- a/packages/api-file-manager-s3/src/utils/FileKey.test.ts
+++ b/packages/api-file-manager-s3/src/utils/FileKey.test.ts
@@ -1,0 +1,68 @@
+import { FileKey } from "./FileKey";
+
+describe("FileKey", () => {
+    it("should generate a file key (extension is included in the name)", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image-14.jpg",
+            type: "image/jpeg"
+        });
+
+        expect(fileKey.toString()).toEqual("image-14.jpg");
+    });
+
+    it("should generate a file key (extension derived from file type)", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image-14",
+            type: "image/jpeg"
+        });
+
+        expect(fileKey.toString()).toEqual("image-14.jpeg");
+    });
+
+    it("should generate a file key containing id", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image-14.jpeg",
+            type: "image/jpeg",
+            id: "12345678"
+        });
+
+        expect(fileKey.toString()).toEqual("12345678/image-14.jpeg");
+    });
+
+    it("should generate a file key containing prefix", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image-14.jpeg",
+            type: "image/jpeg",
+            keyPrefix: "prefix"
+        });
+
+        expect(fileKey.toString()).toEqual("prefix/image-14.jpeg");
+    });
+
+    it("should generate a file key containing id and prefix", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image-14.jpeg",
+            type: "image/jpeg",
+            id: "12345678",
+            keyPrefix: "prefix"
+        });
+
+        expect(fileKey.toString()).toEqual("prefix/12345678/image-14.jpeg");
+    });
+
+    it("should use the key defined in the input", () => {
+        const fileKey = new FileKey({
+            size: 1071690,
+            name: "image",
+            type: "image/jpeg",
+            key: "image-14.jpg"
+        });
+
+        expect(fileKey.toString()).toEqual("image-14.jpg");
+    });
+});

--- a/packages/api-file-manager-s3/src/utils/FileKey.ts
+++ b/packages/api-file-manager-s3/src/utils/FileKey.ts
@@ -27,7 +27,7 @@ export class FileKey {
     }
 
     private getSanitizedKey() {
-        const key = sanitizeFilename(this.data.name).replace(/\s/g, "");
+        const key = sanitizeFilename(this.data.key || this.data.name).replace(/\s/g, "");
 
         return [key, this.getExtension()].filter(Boolean).join(".");
     }

--- a/packages/app-file-manager-s3/src/SimpleUploadStrategy.ts
+++ b/packages/app-file-manager-s3/src/SimpleUploadStrategy.ts
@@ -2,6 +2,13 @@ import { UploadedFile, UploadOptions } from "@webiny/app/types";
 import { GET_PRE_SIGNED_POST_PAYLOAD } from "./graphql";
 import { FileUploadStrategy } from "~/index";
 
+declare global {
+    interface File {
+        key?: string;
+        keyPrefix?: string;
+    }
+}
+
 export class SimpleUploadStrategy implements FileUploadStrategy {
     async upload(file: File, { apolloClient, onProgress }: UploadOptions): Promise<UploadedFile> {
         // 1. GET PreSignedPostPayload
@@ -9,7 +16,13 @@ export class SimpleUploadStrategy implements FileUploadStrategy {
             query: GET_PRE_SIGNED_POST_PAYLOAD,
             fetchPolicy: "no-cache",
             variables: {
-                data: { size: file.size, name: file.name, type: file.type }
+                data: {
+                    size: file.size,
+                    name: file.name,
+                    type: file.type,
+                    key: file.key,
+                    keyPrefix: file.keyPrefix
+                }
             }
         });
 

--- a/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
@@ -56,9 +56,10 @@ const prepareFileData = (data: Record<string, any>, fields: CmsModelField[]) => 
     if (fields.length === 0) {
         return output;
     }
+
     return {
         ...output,
-        extensions: prepareFormData(output.extensions, fields)
+        extensions: prepareFormData(output.extensions || {}, fields)
     };
 };
 

--- a/packages/app-file-manager/src/modules/FileTypes/fileImage/EditAction.tsx
+++ b/packages/app-file-manager/src/modules/FileTypes/fileImage/EditAction.tsx
@@ -94,6 +94,7 @@ export const EditAction: React.FC<EditActionProps> = props => {
                     onAccept={src => {
                         const blob = dataURLtoBlob(src);
                         blob.name = file.name;
+                        blob.key = file.key.split("/").pop();
                         uploadFile(blob);
                         dispatch({ type: "hideImageEditor" });
                     }}


### PR DESCRIPTION
## Changes
This PR fixes a bug where an edited image would lose its extension, if the original image name didn't contain an extension. We're now sending the original file key to the API when requesting a presigned payload. The original file key is used to generate the new file key. File name is kept the same as the original.

## How Has This Been Tested?
Jest tests on the API side, and manually in the Admin app.