### PR TITLE
fix(app-file-manager): render extensions next to the basic fields

### DIFF
--- a/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/FileDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-// @ts-ignore
+// @ts-expect-error
 import { useHotkeys } from "react-hotkeyz";
 import omit from "lodash/omit";
 import styled from "@emotion/styled";
@@ -70,6 +70,8 @@ const FileDetailsInner: React.FC<FileDetailsInnerProps> = ({ file }) => {
     const { close } = useFileDetails();
     const { fileDetails } = useFileManagerViewConfig();
 
+    const [, leftPanel = "1", rightPanel = "1"] = fileDetails.width.split(",");
+
     const extensionFields = useMemo(() => {
         const fields = fileModel.fields.find(field => field.fieldId === "extensions");
         if (!fields?.settings?.fields) {
@@ -87,6 +89,19 @@ const FileDetailsInner: React.FC<FileDetailsInnerProps> = ({ file }) => {
         close();
     };
 
+    const basicFieldsElement = (
+        <Grid>
+            {fileDetails.fields.map(field => (
+                <Cell span={12} key={field.name}>
+                    {field.element}
+                </Cell>
+            ))}
+        </Grid>
+    );
+
+    const extensionFieldsElement =
+        extensionFields.length > 0 ? <Extensions model={fileModel} /> : null;
+
     return (
         <Form data={file} onSubmit={onSubmit}>
             {() => (
@@ -95,30 +110,27 @@ const FileDetailsInner: React.FC<FileDetailsInnerProps> = ({ file }) => {
                     <FormContainer>
                         <Header />
                         <Content>
-                            <Content.Panel>
+                            <Content.Panel flex={parseFloat(leftPanel)}>
                                 <Elevation z={2} style={{ margin: 20 }}>
                                     <Actions />
                                     <Preview />
                                     <PreviewMeta />
                                 </Elevation>
                             </Content.Panel>
-                            <Content.Panel>
-                                <Tabs>
-                                    <Tab label={"Basic Details"}>
-                                        <Grid>
-                                            {fileDetails.fields.map(field => (
-                                                <Cell span={12} key={field.name}>
-                                                    {field.element}
-                                                </Cell>
-                                            ))}
-                                        </Grid>
-                                    </Tab>
-                                    {extensionFields.length > 0 ? (
+                            <Content.Panel flex={parseFloat(rightPanel)}>
+                                {fileDetails.groupFields ? (
+                                    <Tabs>
+                                        <Tab label={"Basic Details"}>{basicFieldsElement}</Tab>
                                         <Tab label={"Advanced Details"}>
-                                            <Extensions model={fileModel} />
+                                            {extensionFieldsElement}
                                         </Tab>
-                                    ) : null}
-                                </Tabs>
+                                    </Tabs>
+                                ) : (
+                                    <>
+                                        {basicFieldsElement}
+                                        {extensionFieldsElement}
+                                    </>
+                                )}
                             </Content.Panel>
                         </Content>
                         <Footer />
@@ -147,9 +159,11 @@ export const FileDetails: React.FC<FileDetailsProps> = ({ open, onClose, loading
 
     const { fileDetails } = useFileManagerViewConfig();
 
+    const drawerWidth = fileDetails.width.split(",")[0];
+
     return (
         <FileDetailsDrawer
-            width={fileDetails.width}
+            width={drawerWidth}
             dir="rtl"
             modal
             open={open}

--- a/packages/app-file-manager/src/components/FileDetails/components/Content.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/components/Content.tsx
@@ -6,8 +6,8 @@ const Horizontal = styled.div`
     height: calc(100vh - 160px);
 `;
 
-const Grow = styled.div`
-    flex: 1;
+const Grow = styled.div<{ flex: number }>`
+    flex: ${({ flex }) => flex};
     :last-of-type {
         border-left: 1px solid var(--mdc-theme-on-background);
     }
@@ -22,11 +22,16 @@ export const Content = ({ children }: ContentProps) => {
 };
 
 interface PanelProps {
+    flex?: number;
     children: React.ReactNode;
 }
 
-const Panel = ({ children }: PanelProps) => {
-    return <Grow data-role={"panel"}>{children}</Grow>;
+const Panel = ({ flex, children }: PanelProps) => {
+    return (
+        <Grow data-role={"panel"} flex={flex ?? 1}>
+            {children}
+        </Grow>
+    );
 };
 
 Content.Panel = Panel;

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.tsx
@@ -28,6 +28,7 @@ export function useFileManagerViewConfig() {
                 filtersToWhere: [...(browser.filtersToWhere || [])]
             },
             fileDetails: {
+                groupFields: config.fileDetails?.groupFields ?? false,
                 width: config.fileDetails?.width ?? "1000px",
                 fields: config.fileDetails?.fields ?? []
             }

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/GroupFields.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/GroupFields.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Property } from "@webiny/react-properties";
+
+export interface GroupFieldsProps {
+    value: boolean;
+}
+
+export const GroupFields: React.FC<GroupFieldsProps> = ({ value }) => {
+    return (
+        <Property id="fileDetails" name={"fileDetails"}>
+            <Property id={`drawer:groupFields`} name={"groupFields"} value={value} />
+        </Property>
+    );
+};

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/index.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/FileDetails/index.ts
@@ -1,14 +1,17 @@
 import { Field, FieldConfig } from "./Field";
 import { createScopedFieldDecorator } from "./FieldDecorator";
 import { Width } from "./Width";
+import { GroupFields } from "./GroupFields";
 
 export interface FileDetailsConfig {
     width: string;
+    groupFields: boolean;
     fields: FieldConfig[];
 }
 
 export const FileDetails = {
     Width,
+    GroupFields,
     Field,
     ExtensionField: {
         createDecorator: createScopedFieldDecorator("fm.fileDetails.extensionFields")

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
@@ -22,6 +22,8 @@ export const FileManagerRendererModule = () => {
                 <FileDetails.Field name={"name"} element={<Name />} />
                 <FileDetails.Field name={"tags"} element={<Tags />} />
                 <FileDetails.Field name={"aliases"} element={<Aliases />} />
+                <FileDetails.GroupFields value={false} />
+                <FileDetails.Width value={"1000px"} />
             </FileManagerConfig>
         </>
     );


### PR DESCRIPTION
## Changes
With this PR we change the way how File field are laid out; we combine Basic Details and Advanced Details tabs into one, making all fields immediately visible to the user. The old layout can be turned on via a config, if you find it more appropriate for your use case.

We also added the ability to control left and right drawer panel width ratio.

```tsx
// Turn grouping in tabs on
<FileDetails.GroupFields value={true} />

// Control the width of the file details drawer
<FileDetails.Width value={"1000px"} />

// Use comma to add left and right panel "flex"value (default is 1)
<FileDetails.Width value={"1000px,1,0.5"} />
```


## How Has This Been Tested?
Manually.