### PR TITLE
fix(app-headless-cms): allow sending empty arrays from form

### DIFF
--- a/packages/app-headless-cms-common/src/prepareFormData.ts
+++ b/packages/app-headless-cms-common/src/prepareFormData.ts
@@ -65,7 +65,7 @@ export const prepareFormData = (
 
         if (field.multipleValues) {
             const values = Array.isArray(inputValue) ? inputValue : undefined;
-            if (!values?.length) {
+            if (!values) {
                 return output;
             }
             /**


### PR DESCRIPTION
## Changes
Fix for a Headless CMS multiple references field where last related entry could not be removed from the list.

## How Has This Been Tested?
Manually.