### PR TITLE
`dynamo-to-elastic` Lambda Function: Do Not Exit if `newImage` Does Not Exist

### DIFF
--- a/packages/api-dynamodb-to-elasticsearch/src/index.ts
+++ b/packages/api-dynamodb-to-elasticsearch/src/index.ts
@@ -110,6 +110,9 @@ export const createEventHandler = () => {
                 // @ts-expect-error
                 const newImage = unmarshall<RecordDynamoDbImage>(dynamodb.NewImage);
 
+                // Note that with the `REMOVE` event, there is no `NewImage` property. Which means,
+                // if the `newImage` is `undefined`, we are dealing with a `REMOVE` event and we still
+                // need to process it.
                 if (newImage && newImage.ignore === true) {
                     continue;
                 }

--- a/packages/api-dynamodb-to-elasticsearch/src/index.ts
+++ b/packages/api-dynamodb-to-elasticsearch/src/index.ts
@@ -110,7 +110,7 @@ export const createEventHandler = () => {
                 // @ts-expect-error
                 const newImage = unmarshall<RecordDynamoDbImage>(dynamodb.NewImage);
 
-                if (!newImage || newImage.ignore === true) {
+                if (newImage && newImage.ignore === true) {
                     continue;
                 }
                 /**
@@ -134,7 +134,7 @@ export const createEventHandler = () => {
                  * No need to try to decompress if operation is REMOVE since there is no data sent into that operation.
                  */
                 let data: any = undefined;
-                if (operation !== Operations.REMOVE) {
+                if (newImage && operation !== Operations.REMOVE) {
                     /**
                      * We must decompress the data that is going into the Elasticsearch.
                      */
@@ -157,15 +157,17 @@ export const createEventHandler = () => {
                 switch (record.eventName) {
                     case Operations.INSERT:
                     case Operations.MODIFY:
-                        operations.push(
-                            {
-                                index: {
-                                    _id,
-                                    _index: newImage.index
-                                }
-                            },
-                            data
-                        );
+                        if (newImage) {
+                            operations.push(
+                                {
+                                    index: {
+                                        _id,
+                                        _index: newImage.index
+                                    }
+                                },
+                                data
+                            );
+                        }
                         break;
                     case Operations.REMOVE:
                         operations.push({


### PR DESCRIPTION
## Changes
A regression on the `dynamo-to-elastic` Lambda fn was introduced with Node18 PR.

Deletions of ES records would not happen because of an incorrect if statement. 

## How Has This Been Tested?
Manual. Cypress.

## Documentation
N/A