### PR TITLE
refactor: prepare react 18 upgrade - batch #19

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Website } from "@webiny/app-website";
 
-export const App: React.FC = () => {
+export const App = () => {
     return <Website />;
 };

--- a/packages/app-aco/README.md
+++ b/packages/app-aco/README.md
@@ -50,7 +50,7 @@ The `@webiny/app-aco` package contains essential aco-related utilities (Advanced
 <p>
 
 ```tsx
-export declare const ACOProvider: React.FC;
+export declare const ACOProvider: React.ComponentType;
 ```
 
 </p>
@@ -91,7 +91,7 @@ interface Props {
     onTitleClick?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
-declare function FolderTree(props: Props): React.FC;
+declare function FolderTree(props: Props): React.ComponentType;
 ```
 </p>
 </details>
@@ -137,7 +137,7 @@ interface Props {
     onClose: DialogOnClose;
 }
 
-declare function EntryDialogMove(props: Props): React.FC;
+declare function EntryDialogMove(props: Props): React.ComponentType;
 ```
 </p>
 </details>
@@ -184,7 +184,7 @@ interface Props {
     currentParentId?: string | null;
 }
 
-declare function FolderDialogCreate(props: Props): React.FC;
+declare function FolderDialogCreate(props: Props): React.ComponentType;
 ```
 </p>
 </details>
@@ -225,7 +225,7 @@ interface Props {
     onClose: DialogOnClose;
 }
 
-declare function FolderDialogDelete(props: Props): React.FC;
+declare function FolderDialogDelete(props: Props): React.ComponentType;
 ```
 </p>
 </details>
@@ -270,7 +270,7 @@ interface Props {
     onClose: DialogOnClose;
 }
 
-declare function FolderDialogUpdate(props: Props): React.FC;
+declare function FolderDialogUpdate(props: Props): React.ComponentType;
 ```
 </p>
 </details>

--- a/packages/app-aco/src/Folders.tsx
+++ b/packages/app-aco/src/Folders.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import { Plugin } from "@webiny/app-admin";
 import { FoldersApiProvider } from "~/contexts/FoldersApi";
 
-const FoldersApiProviderHOC = (Component: React.FC): React.FC => {
-    return function FoldersApiProviderHOC({ children }) {
+interface FoldersApiProviderHOCProps {
+    children: React.ReactNode;
+}
+
+const FoldersApiProviderHOC = (Component: React.ComponentType) => {
+    return function FoldersApiProviderHOC({ children }: FoldersApiProviderHOCProps) {
         return (
             <FoldersApiProvider>
                 <Component>{children}</Component>

--- a/packages/app-admin-auth0/src/Auth0.tsx
+++ b/packages/app-admin-auth0/src/Auth0.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, useEffect, useRef, useState } from "react";
+import React, { Fragment, useEffect, useRef, useState } from "react";
 import get from "lodash/get";
 import { LoginScreenRenderer, useTenancy, createComponentPlugin } from "@webiny/app-serverless-cms";
 import { createAuthentication, Auth0Options } from "./createAuthentication";
@@ -10,6 +10,7 @@ import gql from "graphql-tag";
 interface AppClientIdLoaderProps {
     auth0: Auth0Options;
     rootAppClientId: string;
+    children: React.ReactNode;
 }
 
 const GET_CLIENT_ID = gql`
@@ -20,9 +21,9 @@ const GET_CLIENT_ID = gql`
     }
 `;
 
-const AppClientIdLoader: FC<AppClientIdLoaderProps> = ({ auth0, rootAppClientId, children }) => {
+const AppClientIdLoader = ({ auth0, rootAppClientId, children }: AppClientIdLoaderProps) => {
     const [loaded, setState] = useState<boolean>(false);
-    const authRef = useRef<React.FC | null>(null);
+    const authRef = useRef<React.ComponentType | null>(null);
     const client = useApolloClient();
     const { tenant, setTenant } = useTenancy();
 
@@ -64,7 +65,9 @@ const AppClientIdLoader: FC<AppClientIdLoaderProps> = ({ auth0, rootAppClientId,
         });
     }, []);
 
-    return loaded ? React.createElement(authRef.current as React.FC, {}, children) : null;
+    return loaded
+        ? React.createElement(authRef.current as React.ComponentType, {}, children)
+        : null;
 };
 
 const createLoginScreenPlugin = (params: Auth0Props) => {

--- a/packages/app-admin-auth0/src/createAuthentication.tsx
+++ b/packages/app-admin-auth0/src/createAuthentication.tsx
@@ -35,11 +35,14 @@ interface WithGetIdentityDataProps {
     children: React.ReactNode;
 }
 
-export const createAuthentication = ({
-    auth0,
-    ...config
-}: CreateAuthenticationConfig): React.FC => {
-    const withGetIdentityData = (Component: React.FC<WithGetIdentityDataProps>): React.FC => {
+interface PropsWithChildren {
+    children?: React.ReactNode;
+}
+
+export const createAuthentication = ({ auth0, ...config }: CreateAuthenticationConfig) => {
+    const withGetIdentityData = (
+        Component: React.ComponentType<WithGetIdentityDataProps>
+    ): React.ComponentType<PropsWithChildren> => {
         return function WithGetIdentityData({ children }) {
             const { isMultiTenant } = useTenancy();
             const loginMutation = config.loginMutation || (isMultiTenant ? LOGIN_MT : LOGIN_ST);
@@ -158,7 +161,7 @@ export const createAuthentication = ({
     // Compose Login widget with GQL queries and multi-tenancy features.
     const LoginWidget = withGetIdentityData(withTenant(Authentication));
 
-    return function Authentication({ children }) {
+    return function Authentication({ children }: PropsWithChildren) {
         return (
             <Auth0Provider
                 redirectUri={window.location.origin}

--- a/packages/app-admin-cognito/src/index.tsx
+++ b/packages/app-admin-cognito/src/index.tsx
@@ -75,7 +75,7 @@ export interface AuthenticationFactoryConfig extends AuthOptions {
 }
 
 interface AuthenticationFactory {
-    (params: AuthenticationFactoryConfig): React.FC<AuthenticationProps>;
+    (params: AuthenticationFactoryConfig): React.ComponentType<AuthenticationProps>;
 }
 
 export const createAuthentication: AuthenticationFactory = ({

--- a/packages/app-admin-okta/src/Okta.tsx
+++ b/packages/app-admin-okta/src/Okta.tsx
@@ -28,7 +28,7 @@ const AppClientIdLoader: FC<AppClientIdLoaderProps> = ({
     children
 }) => {
     const [loaded, setState] = useState<boolean>(false);
-    const authRef = useRef<React.FC | null>(null);
+    const authRef = useRef<React.ComponentType | null>(null);
     const client = useApolloClient();
     const { tenant, setTenant } = useTenancy();
 
@@ -63,7 +63,9 @@ const AppClientIdLoader: FC<AppClientIdLoaderProps> = ({
         });
     }, []);
 
-    return loaded ? React.createElement(authRef.current as React.FC, {}, children) : null;
+    return loaded
+        ? React.createElement(authRef.current as React.ComponentType, {}, children)
+        : null;
 };
 
 interface OktaLoginScreenProps {

--- a/packages/app-admin-okta/src/createAuthentication.tsx
+++ b/packages/app-admin-okta/src/createAuthentication.tsx
@@ -53,7 +53,7 @@ interface WithGetIdentityDataFunctionProps {
 }
 
 export const createAuthentication = ({ oktaAuth, oktaSignIn, clientId, ...config }: Config) => {
-    const withGetIdentityData = (Component: React.FC<WithGetIdentityDataProps>) => {
+    const withGetIdentityData = (Component: React.ComponentType<WithGetIdentityDataProps>) => {
         return function WithGetIdentityData({ children }: WithGetIdentityDataFunctionProps) {
             const { isMultiTenant } = useTenancy();
             const loginMutation = config.loginMutation || (isMultiTenant ? LOGIN_MT : LOGIN_ST);

--- a/packages/app-admin-rmwc/src/modules/Navigation/index.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/index.tsx
@@ -60,7 +60,7 @@ interface NavigationProviderProps {
     children?: React.ReactNode;
 }
 
-const NavigationProvider = (Component: React.FC) => {
+const NavigationProvider = (Component: React.ComponentType) => {
     return function NavigationProvider(props: NavigationProviderProps) {
         const [visible, setVisible] = useState(false);
 

--- a/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuElementRenderer.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuElementRenderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useMenuItem } from "@webiny/app-admin";
 
-export const MenuElementRenderer = (PrevMenuItem: React.FC) => {
+export const MenuElementRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuComponent() {
         const { menuItem } = useMenuItem();
         if (!menuItem || !menuItem.element) {

--- a/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuGroupRenderer.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuGroupRenderer.tsx
@@ -68,7 +68,7 @@ function getState(id: string | null): boolean {
     return state.includes(id);
 }
 
-export const MenuGroupRenderer = (PrevMenuItem: React.FC) => {
+export const MenuGroupRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuGroup() {
         const { setVisible } = useNavigation();
         const { menuItem, depth } = useMenuItem();

--- a/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuLinkRenderer.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuLinkRenderer.tsx
@@ -15,7 +15,7 @@ const listItemStyle = css`
     }
 `;
 
-export const MenuLinkRenderer = (PrevMenuItem: React.FC) => {
+export const MenuLinkRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuLink() {
         const { setVisible } = useNavigation();
         const { menuItem, depth } = useMenuItem();

--- a/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuSectionItemRenderer.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuSectionItemRenderer.tsx
@@ -34,7 +34,7 @@ const submenuList = css({
     }
 });
 
-export const MenuSectionItemRenderer = (PrevMenuItem: React.FC) => {
+export const MenuSectionItemRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuSectionItem() {
         const { setVisible } = useNavigation();
         const { menuItem, depth } = useMenuItem();

--- a/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuSectionRenderer.tsx
+++ b/packages/app-admin-rmwc/src/modules/Navigation/renderers/MenuSectionRenderer.tsx
@@ -15,7 +15,7 @@ const iconWrapper = css({
     color: "var(--mdc-theme-on-surface)"
 });
 
-export const MenuSectionRenderer = (PrevMenuItem: React.FC) => {
+export const MenuSectionRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuSection() {
         const { menuItem, depth } = useMenuItem();
 

--- a/packages/app-admin-rmwc/src/modules/Overlays/index.tsx
+++ b/packages/app-admin-rmwc/src/modules/Overlays/index.tsx
@@ -15,7 +15,7 @@ interface OverlaysProps {
  * any other views that are constructed by developers. We need these 2 containers to always be
  * present, even if there is no <Layout> mounted.
  */
-const OverlaysHOC = (Component: React.FC) => {
+const OverlaysHOC = (Component: React.ComponentType) => {
     return function Overlays({ children }: OverlaysProps) {
         return (
             <Component>

--- a/packages/app-admin-users-cognito/src/createAuthentication/createAuthentication.tsx
+++ b/packages/app-admin-users-cognito/src/createAuthentication/createAuthentication.tsx
@@ -25,7 +25,7 @@ interface AuthenticationProps {
 }
 
 export const createAuthentication = (config: CreateAuthenticationConfig = {}) => {
-    const withGetIdentityData = (Component: React.FC<WithGetIdentityDataProps>) => {
+    const withGetIdentityData = (Component: React.ComponentType<WithGetIdentityDataProps>) => {
         const WithGetIdentityData = ({ children }: WithGetIdentityDataProps) => {
             const { isMultiTenant } = useTenancy();
             const loginMutation = config.loginMutation || (isMultiTenant ? LOGIN_MT : LOGIN_ST);

--- a/packages/app-admin/src/base/providers/TelemetryProvider.tsx
+++ b/packages/app-admin/src/base/providers/TelemetryProvider.tsx
@@ -3,19 +3,21 @@ import { sendEvent } from "@webiny/telemetry/react";
 
 let eventSent = false;
 
-export const createTelemetryProvider =
-    () =>
-    (Component: React.FC): React.FC => {
-        return function TelemetryProvider({ children }) {
-            useEffect(() => {
-                if (eventSent) {
-                    return;
-                }
+interface TelemetryProviderProps {
+    children: React.ReactNode;
+}
 
-                eventSent = true;
-                sendEvent("app-start");
-            }, []);
+export const createTelemetryProvider = () => (Component: React.ComponentType) => {
+    return function TelemetryProvider({ children }: TelemetryProviderProps) {
+        useEffect(() => {
+            if (eventSent) {
+                return;
+            }
 
-            return <Component>{children}</Component>;
-        };
+            eventSent = true;
+            sendEvent("app-start");
+        }, []);
+
+        return <Component>{children}</Component>;
     };
+};

--- a/packages/app-admin/src/base/providers/UiStateProvider.tsx
+++ b/packages/app-admin/src/base/providers/UiStateProvider.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { UiProvider } from "@webiny/app/contexts/Ui";
 
-export const createUiStateProvider =
-    () =>
-    (Component: React.ComponentType<unknown>): React.FC => {
-        return function UiStateProvider({ children }) {
-            return (
-                <UiProvider>
-                    <Component>{children}</Component>
-                </UiProvider>
-            );
-        };
+interface UiStateProviderProps {
+    children: React.ReactNode;
+}
+
+export const createUiStateProvider = () => (Component: React.ComponentType<unknown>) => {
+    return function UiStateProvider({ children }: UiStateProviderProps) {
+        return (
+            <UiProvider>
+                <Component>{children}</Component>
+            </UiProvider>
+        );
     };
+};

--- a/packages/app-admin/src/base/ui/Navigation.tsx
+++ b/packages/app-admin/src/base/ui/Navigation.tsx
@@ -52,7 +52,7 @@ const LegacyMenu = (props: LegacyMenuProps & { children: React.ReactNode }) => {
     );
 };
 
-const LegacyMenuPlugins: React.FC = () => {
+const LegacyMenuPlugins = () => {
     // IMPORTANT! The following piece of code is for BACKWARDS COMPATIBILITY purposes only!
     const [menus, setMenus] = useState<JSX.Element | null>(null);
 

--- a/packages/app-admin/src/base/ui/Search.tsx
+++ b/packages/app-admin/src/base/ui/Search.tsx
@@ -27,8 +27,13 @@ export function useSearch() {
     return React.useContext(SearchContext);
 }
 
-export const SearchProvider = (Component: React.FC): React.FC => {
-    return function SearchProvider({ children, ...props }) {
+interface SearchProviderProps {
+    children: React.ReactNode;
+    [key: string]: any;
+}
+
+export const SearchProvider = (Component: React.ComponentType) => {
+    return function SearchProvider({ children, ...props }: SearchProviderProps) {
         const [options, setOptions] = useState<SearchOptionData[]>([]);
 
         const addOption = useCallback<SearchContext["addOption"]>(

--- a/packages/app-admin/src/base/ui/UserMenu.tsx
+++ b/packages/app-admin/src/base/ui/UserMenu.tsx
@@ -26,8 +26,13 @@ export function useUserMenu() {
     return React.useContext(UserMenuContext);
 }
 
-export const UserMenuProvider = (Component: React.FC): React.FC => {
-    return function UserMenuProvider({ children, ...props }) {
+interface UserMenuProviderProps {
+    children: React.ReactNode;
+    [key: string]: any;
+}
+
+export const UserMenuProvider = (Component: React.ComponentType) => {
+    return function UserMenuProvider({ children, ...props }: UserMenuProviderProps) {
         const [menuItems, setItems] = useState<UserMenuItemData[]>([]);
 
         const addMenuItem = useCallback<UserMenuContext["addMenuItem"]>(

--- a/packages/app-admin/src/components/AppInstaller/index.tsx
+++ b/packages/app-admin/src/components/AppInstaller/index.tsx
@@ -3,8 +3,12 @@ import React from "react";
 import { ComponentType } from "react";
 import { AppInstaller as Installer } from "./AppInstaller";
 
-const AppInstallerHOC = (Component: ComponentType<unknown>): React.FC => {
-    return function AppInstallerProvider({ children }) {
+interface AppInstallerProviderProps {
+    children: React.ReactNode;
+}
+
+const AppInstallerHOC = (Component: ComponentType<unknown>) => {
+    return function AppInstallerProvider({ children }: AppInstallerProviderProps) {
         return (
             <Installer>
                 <Component>{children}</Component>

--- a/packages/app-admin/src/types.ts
+++ b/packages/app-admin/src/types.ts
@@ -49,7 +49,7 @@ export type AdminFileManagerFileTypePlugin = Plugin & {
     types: string[];
     render(params: AdminFileManagerFileTypePluginRenderParams): React.ReactNode;
     fileDetails?: {
-        actions: Array<React.FC | React.Component>;
+        actions: Array<React.ComponentType | React.Component>;
     };
 };
 

--- a/packages/app-apw/src/plugins/cms/MenuGroupRenderer.tsx
+++ b/packages/app-apw/src/plugins/cms/MenuGroupRenderer.tsx
@@ -1,7 +1,7 @@
 import { useMenuItem } from "@webiny/app-admin";
 import React from "react";
 
-export const MenuGroupRenderer = (PrevMenuItem: React.FC) => {
+export const MenuGroupRenderer = (PrevMenuItem: React.ComponentType) => {
     return function MenuGroup() {
         const { menuItem } = useMenuItem();
 

--- a/packages/app-apw/src/views/publishingWorkflows/components/WorkflowTitle.tsx
+++ b/packages/app-apw/src/views/publishingWorkflows/components/WorkflowTitle.tsx
@@ -51,7 +51,7 @@ interface TitleProps {
     value: string;
     onChange: (value: string) => void;
 }
-const Title: React.FunctionComponent<TitleProps> = ({ value, onChange }) => {
+const Title: React.ComponentType<TitleProps> = ({ value, onChange }) => {
     const [editTitle, setEdit] = useState<boolean>(false);
     const [stateTitle, setTitle] = useState<string | null>(null);
     let title = stateTitle === null ? value : stateTitle;

--- a/packages/app-file-manager/src/components/FileDetails/components/Actions.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/components/Actions.tsx
@@ -14,12 +14,16 @@ const ActionsContainer = styled.div`
     border-bottom: 1px solid var(--mdc-theme-on-background);
 `;
 
+interface ActionsProps {
+    file: FileItem;
+}
+
 export const Actions = () => {
     const { file } = useFile();
     const filePlugin = getFileTypePlugin(file);
 
     // TODO: implement actions using component composition
-    const actions: React.FC[] =
+    const actions: React.ComponentType<ActionsProps>[] =
         get(filePlugin, "fileDetails.actions") || get(filePlugin, "actions") || [];
 
     return (
@@ -27,7 +31,7 @@ export const Actions = () => {
             <Download />
             <MoveTo />
             <CopyUrl />
-            {actions.map((Component: React.FC<{ file: FileItem }>, index: number) => (
+            {actions.map((Component: React.ComponentType<ActionsProps>, index: number) => (
                 <Component key={index} file={file} />
             ))}
             <DeleteImage />

--- a/packages/app-form-builder/src/admin/components/FormEditor/Droppable.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/Droppable.tsx
@@ -84,4 +84,4 @@ const DroppableComponent = (props: DroppableProps) => {
     return children({ isDragging: Boolean(item), isOver, item, drop });
 };
 
-export const Droppable: React.FC<DroppableProps> = React.memo(DroppableComponent);
+export const Droppable: React.ComponentType<DroppableProps> = React.memo(DroppableComponent);

--- a/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/editor/formFields/components/OptionsList.tsx
@@ -76,11 +76,9 @@ interface SortableContainerProps {
     transitionDuration: number;
     onSortEnd: OnSortEndCallable;
 }
-const SortableContainer: React.FC<SortableContainerProps> = sortableContainer(
-    ({ children }: SortableContainerProps) => {
-        return <OptionList>{children}</OptionList>;
-    }
-);
+const SortableContainer = sortableContainer(({ children }: SortableContainerProps) => {
+    return <OptionList>{children}</OptionList>;
+});
 
 interface SetEditOptionParams {
     index: number | null;
@@ -96,7 +94,7 @@ interface SortableItemProps {
     Bind: BindComponent;
     index: number;
 }
-const SortableItem: React.FC<SortableItemProps> = sortableElement(
+const SortableItem = sortableElement(
     ({
         setOptionsValue,
         setEditOption,

--- a/packages/app-form-builder/src/components/Form/components/createReCaptchaComponent.tsx
+++ b/packages/app-form-builder/src/components/Form/components/createReCaptchaComponent.tsx
@@ -20,7 +20,7 @@ export type ReCaptchaProps = {
     onExpired?: (...args: any) => void;
 };
 
-export type ReCaptchaComponent = React.FC<ReCaptchaProps>;
+export type ReCaptchaComponent = React.ComponentType<ReCaptchaProps>;
 
 const createReCaptchaComponent = ({
     formData,

--- a/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-form-builder/src/components/Form/components/createTermsOfServiceComponent.tsx
@@ -22,7 +22,7 @@ export interface TermsOfServiceProps {
     onExpired?: (...args: any) => void;
 }
 
-export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;
+export type TermsOfServiceComponent = React.ComponentType<TermsOfServiceProps>;
 
 const createTermsOfServiceComponent = ({
     formData,

--- a/packages/app-headless-cms-common/src/types/index.ts
+++ b/packages/app-headless-cms-common/src/types/index.ts
@@ -225,7 +225,7 @@ export interface CmsModelFieldTypePlugin extends Plugin {
 
 export interface CmsModelFieldRendererProps {
     field: CmsModelField;
-    Label: React.FC;
+    Label: React.ComponentType;
     getBind: <T = any, F = any>(index?: number, key?: string) => BindComponent<T, F>;
     contentModel: CmsModel;
 }
@@ -374,7 +374,7 @@ export interface CmsContentEntryRevision {
     };
 }
 
-export type CmsEditorContentTab = React.FC<{ activeTab: boolean }>;
+export type CmsEditorContentTab = React.ComponentType<{ activeTab: boolean }>;
 
 // ------------------------------------------------------------------------------------------------------------
 export interface CmsEditorFieldOptionPlugin extends Plugin {
@@ -533,7 +533,7 @@ interface BindComponentProps<T = any, F = any>
     children?: ((props: BindComponentRenderProp<T, F>) => React.ReactElement) | React.ReactElement;
 }
 
-export type BindComponent<T = any, F = any> = React.FC<BindComponentProps<T, F>> & {
+export type BindComponent<T = any, F = any> = React.ComponentType<BindComponentProps<T, F>> & {
     parentName?: string;
 };
 

--- a/packages/app-headless-cms/src/HeadlessCMS.tsx
+++ b/packages/app-headless-cms/src/HeadlessCMS.tsx
@@ -18,7 +18,7 @@ interface HeadlessCMSProvider {
 }
 
 const createHeadlessCMSProvider =
-    (createApolloClient: CreateApolloClient) => (Component: React.FC) => {
+    (createApolloClient: CreateApolloClient) => (Component: React.ComponentType) => {
         return function HeadlessCMSProvider({ children }: HeadlessCMSProvider) {
             return (
                 <CmsProvider createApolloClient={createApolloClient}>

--- a/packages/app-headless-cms/src/admin/components/Draggable.tsx
+++ b/packages/app-headless-cms/src/admin/components/Draggable.tsx
@@ -48,5 +48,5 @@ const Draggable = (props: DraggableProps) => {
     );
 };
 
-const MemoizedDraggable: React.FC<DraggableProps> = React.memo(Draggable);
+const MemoizedDraggable: React.ComponentType<DraggableProps> = React.memo(Draggable);
 export default MemoizedDraggable;

--- a/packages/app-headless-cms/src/admin/components/Droppable.tsx
+++ b/packages/app-headless-cms/src/admin/components/Droppable.tsx
@@ -65,4 +65,4 @@ const DroppableComponent = (props: DroppableProps) => {
     return children({ isDragging: Boolean(item), isOver, isDroppable, item, drop });
 };
 
-export const Droppable: React.FC<DroppableProps> = React.memo(DroppableComponent);
+export const Droppable: React.ComponentType<DroppableProps> = React.memo(DroppableComponent);

--- a/packages/app-headless-cms/src/admin/menus/CmsMenuLoader.tsx
+++ b/packages/app-headless-cms/src/admin/menus/CmsMenuLoader.tsx
@@ -67,6 +67,6 @@ const CmsMenuLoaderComponent = () => {
     );
 };
 
-export const CmsMenuLoader: React.FC = React.memo(CmsMenuLoaderComponent);
+export const CmsMenuLoader: React.ComponentType = React.memo(CmsMenuLoaderComponent);
 
 CmsMenuLoader.displayName = "CmsMenuLoader";

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/Accordion.tsx
@@ -120,5 +120,5 @@ const Accordion = ({ title, children, action, icon, defaultValue = false }: Acco
         </div>
     );
 };
-const MemoizedAccordion: React.FC<AccordionProps> = React.memo(Accordion);
+const MemoizedAccordion: React.ComponentType<AccordionProps> = React.memo(Accordion);
 export default MemoizedAccordion;

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/file/fileFields.tsx
@@ -45,7 +45,7 @@ const InnerImageFieldWrapper = styled("div")({
 
 interface FieldRendererProps {
     getBind: GetBindCallable;
-    Label: React.FC;
+    Label: React.ComponentType;
     field: CmsModelField;
 }
 const FieldRenderer = ({ getBind, Label, field }: FieldRendererProps) => {

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionSelector.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/PermissionSelector.tsx
@@ -26,7 +26,7 @@ export interface PermissionSelectorProps {
     locales: string[];
     entity: string;
     getItems: (code: string) => PermissionSelectorCmsModel[] | PermissionSelectorCmsGroup[];
-    RenderItems?: React.FC<RenderItemsProps>;
+    RenderItems?: React.ComponentType<RenderItemsProps>;
     disabled?: boolean;
 }
 

--- a/packages/app-i18n-content/src/index.tsx
+++ b/packages/app-i18n-content/src/index.tsx
@@ -16,4 +16,4 @@ const I18NContentExtension = () => {
     return <Compose component={LocaleSelectorSpec} with={LocaleSelectorHOC} />;
 };
 
-export const I18NContent: React.FC = memo(I18NContentExtension);
+export const I18NContent: React.ComponentType = memo(I18NContentExtension);

--- a/packages/app-i18n/src/I18N.tsx
+++ b/packages/app-i18n/src/I18N.tsx
@@ -12,7 +12,7 @@ interface I18NProviderProps {
     children: React.ReactNode;
 }
 
-const I18NProviderHOC = (Component: React.FC) => {
+const I18NProviderHOC = (Component: React.ComponentType) => {
     return function I18NProvider({ children }: I18NProviderProps) {
         return (
             <ContextProvider>

--- a/packages/app-i18n/src/contexts/I18N/I18NContext.tsx
+++ b/packages/app-i18n/src/contexts/I18N/I18NContext.tsx
@@ -122,4 +122,4 @@ const I18NProviderComponent = (props: I18NProviderProps) => {
     return <I18NContext.Provider value={value}>{children}</I18NContext.Provider>;
 };
 
-export const I18NProvider: React.FC<I18NProviderProps> = memo(I18NProviderComponent);
+export const I18NProvider: React.ComponentType<I18NProviderProps> = memo(I18NProviderComponent);

--- a/packages/app-page-builder-elements/README.md
+++ b/packages/app-page-builder-elements/README.md
@@ -55,7 +55,7 @@ cell, grid, ...), but also the necessary utilities to create new ones.
 <p>
 
 ```ts
-export declare const PageElementsProvider: React.FC<PageElementsProviderProps>;
+export declare const PageElementsProvider: React.ComponentType<PageElementsProviderProps>;
 ```
 
 </p>

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createReCaptchaComponent.tsx
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createReCaptchaComponent.tsx
@@ -20,7 +20,7 @@ export type ReCaptchaProps = {
     onExpired?: (...args: any[]) => void;
 };
 
-export type ReCaptchaComponent = React.FC<ReCaptchaProps>;
+export type ReCaptchaComponent = React.ComponentType<ReCaptchaProps>;
 
 const createReCaptchaComponent = ({
     formData,

--- a/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
+++ b/packages/app-page-builder-elements/src/renderers/form/FormRender/components/createTermsOfServiceComponent.tsx
@@ -22,7 +22,7 @@ export interface TermsOfServiceProps {
     onExpired?: (...args: any[]) => void;
 }
 
-export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;
+export type TermsOfServiceComponent = React.ComponentType<TermsOfServiceProps>;
 
 const createTermsOfServiceComponent = ({
     formData,

--- a/packages/app-page-builder-elements/src/renderers/form/types.ts
+++ b/packages/app-page-builder-elements/src/renderers/form/types.ts
@@ -113,7 +113,7 @@ export type ReCaptchaProps = {
     onExpired?: (...args: any[]) => void;
 };
 
-export type ReCaptchaComponent = React.FC<ReCaptchaProps>;
+export type ReCaptchaComponent = React.ComponentType<ReCaptchaProps>;
 
 export type TermsOfServiceChildrenFunction = (params: {
     onChange: (value: boolean) => void;
@@ -129,7 +129,7 @@ export interface TermsOfServiceProps {
     onExpired?: (...args: any[]) => void;
 }
 
-export type TermsOfServiceComponent = React.FC<TermsOfServiceProps>;
+export type TermsOfServiceComponent = React.ComponentType<TermsOfServiceProps>;
 
 export type FormSubmissionFieldValues = Record<string, any>;
 
@@ -189,7 +189,7 @@ export interface CreateFormParams {
         | (() => CreateFormParamsFormLayoutComponent[]);
     fieldValidators?: CreateFormParamsValidator[] | (() => CreateFormParamsValidator[]);
     triggers?: CreateFormParamsTrigger[] | (() => CreateFormParamsTrigger[]);
-    renderFormNotSelected?: React.VFC;
-    renderFormLoading?: React.VFC;
-    renderFormNotFound?: React.VFC;
+    renderFormNotSelected?: React.FC;
+    renderFormLoading?: React.FC;
+    renderFormNotFound?: React.FC;
 }

--- a/packages/app-page-builder-elements/src/types.ts
+++ b/packages/app-page-builder-elements/src/types.ts
@@ -28,8 +28,8 @@ export interface PageElementsProviderProps {
         styles: Record<string, ElementStylesModifier>;
         attributes: Record<string, ElementAttributesModifier>;
     };
-    beforeRenderer?: React.VFC | null;
-    afterRenderer?: React.VFC | null;
+    beforeRenderer?: React.ComponentType | null;
+    afterRenderer?: React.ComponentType | null;
     children?: React.ReactNode;
 }
 
@@ -95,8 +95,8 @@ type GetAttributes = () => HTMLAttributes<HTMLElement>;
 export interface RendererContextValue extends PageElementsContextValue {
     getElement: GetElement;
     getAttributes: GetAttributes;
-    beforeRenderer: React.VFC | null;
-    afterRenderer: React.VFC | null;
+    beforeRenderer: React.ComponentType | null;
+    afterRenderer: React.ComponentType | null;
     meta: RendererProviderMeta;
 }
 

--- a/packages/app-page-builder/src/editor/components/Element.tsx
+++ b/packages/app-page-builder/src/editor/components/Element.tsx
@@ -155,7 +155,7 @@ const ElementComponent = ({ id: elementId, className = "", isActive }: ElementPr
     );
 };
 
-const withHighlightElement = (Component: React.FC<ElementPropsType>) => {
+const withHighlightElement = (Component: React.ComponentType<ElementPropsType>) => {
     return function withHighlightElementComponent(props: ElementPropsType) {
         const [activeElementId] = useActiveElementId();
 

--- a/packages/app-page-builder/src/editor/components/withActiveElement.tsx
+++ b/packages/app-page-builder/src/editor/components/withActiveElement.tsx
@@ -3,7 +3,7 @@ import { activeElementAtom, elementByIdSelector } from "../recoil/modules";
 import { useRecoilValue } from "recoil";
 
 export function withActiveElement() {
-    return function decorator(Component: React.ComponentType<any>): React.FC {
+    return function decorator(Component: React.ComponentType<any>): React.ComponentType {
         return function ActiveElementComponent(props) {
             const activeElementId = useRecoilValue(activeElementAtom);
             const element = useRecoilValue(elementByIdSelector(activeElementId));

--- a/packages/app-page-builder/src/modules/WebsiteSettings/AddPbWebsiteSettings.tsx
+++ b/packages/app-page-builder/src/modules/WebsiteSettings/AddPbWebsiteSettings.tsx
@@ -38,7 +38,7 @@ const GenerateElementsComponent = ({ name }: GenerateElementsProps) => {
 
     tracker[name] = true;
 
-    const ElementsHOC = (Fields: React.FC) => {
+    const ElementsHOC = (Fields: React.ComponentType) => {
         return function Elements() {
             const { getViewElement } = useViewComposition();
             const element = getViewElement(VIEW_NAME, name);
@@ -67,7 +67,8 @@ const GenerateElementsComponent = ({ name }: GenerateElementsProps) => {
     return <Compose component={SettingsFields} with={ElementsHOC} />;
 };
 
-const GenerateElements: React.FC<GenerateElementsProps> = memo(GenerateElementsComponent);
+const GenerateElements: React.ComponentType<GenerateElementsProps> =
+    memo(GenerateElementsComponent);
 
 GenerateElements.displayName = "GenerateElements";
 

--- a/packages/app-page-builder/src/render/plugins/elements/imagesList/components/Mosaic.tsx
+++ b/packages/app-page-builder/src/render/plugins/elements/imagesList/components/Mosaic.tsx
@@ -84,4 +84,4 @@ const MosaicComponent = (props: MosaicProps) => {
     return <span>No images to display.</span>;
 };
 
-export const Mosaic: React.FC<MosaicProps> = React.memo(MosaicComponent);
+export const Mosaic: React.ComponentType<MosaicProps> = React.memo(MosaicComponent);

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -691,7 +691,7 @@ export type PbEditorGridPresetPluginType = Plugin & {
     name: string;
     type: "pb-editor-grid-preset";
     cellsType: string;
-    icon: React.FC;
+    icon: React.ComponentType;
 };
 // this will run when saving the element for later use
 export type PbEditorPageElementSaveActionPlugin = Plugin & {

--- a/packages/app-page-builder/src/utils/createConfigPortal.tsx
+++ b/packages/app-page-builder/src/utils/createConfigPortal.tsx
@@ -26,7 +26,7 @@ export function createConfigPortal(name: string) {
      * This component is used to configure the view (it can be mounted many times, and it will accumulate all configs).
      * These configs are not executed until they're actually mounted using the `ConfigApply` component.
      */
-    const Config: React.FC = ({ children }) => {
+    const Config: React.ComponentType = ({ children }) => {
         return <Compose component={ConfigApply} with={createHOC(children)} />;
     };
 

--- a/packages/app-security-access-management/README.md
+++ b/packages/app-security-access-management/README.md
@@ -66,9 +66,11 @@ Auth.configure({
         responseType: "token"
     }
 });
-
+interface AuthenticatorProps {
+    children: React.ReactNode;
+}
 // The `Authenticator` component.
-const Authenticator: React.FC = props => {
+const Authenticator = (props: AuthenticatorProps) => {
     const { setIdentity } = useSecurity();
 
     useEffect(() => {
@@ -101,7 +103,7 @@ Finally, use the `useSecurity` React hook in any of your components:
 import React from "react";
 import { useSecurity } from "@webiny/app-security";
 
-const MyComponent: React.FC = () => {
+const MyComponent = () => {
   const { identity } = useSecurity();
 
   if (identity) {

--- a/packages/app-security/README.md
+++ b/packages/app-security/README.md
@@ -67,8 +67,11 @@ Auth.configure({
     }
 });
 
+interface AuthenticatorProps {
+    children: React.ReactNode;
+}
 // The `Authenticator` component.
-const Authenticator: React.FC = props => {
+const Authenticator = (props: AuthenticatorProps) => {
     const { setIdentity } = useSecurity();
 
     useEffect(() => {
@@ -101,7 +104,7 @@ Finally, use the `useSecurity` React hook in any of your components:
 import React from "react";
 import { useSecurity } from "@webiny/app-security";
 
-const MyComponent: React.FC = () => {
+const MyComponent = () => {
   const { identity } = useSecurity();
 
   if (identity) {

--- a/packages/app-theme-manager/src/components/AddTheme.tsx
+++ b/packages/app-theme-manager/src/components/AddTheme.tsx
@@ -4,7 +4,7 @@ import { ThemeSource } from "~/types";
 
 export type AddThemeProps = ThemeSource;
 
-export const AddTheme: React.FC<AddThemeProps> = props => {
+export const AddTheme: React.ComponentType<AddThemeProps> = props => {
     const { addTheme } = useThemeManager();
 
     useEffect(() => {

--- a/packages/app-theme-manager/src/components/ThemeCheckboxGroup.tsx
+++ b/packages/app-theme-manager/src/components/ThemeCheckboxGroup.tsx
@@ -12,7 +12,7 @@ const WideOptions = styled.div(`
   }  
 `);
 
-export const ThemeCheckboxGroup: React.FC = () => {
+export const ThemeCheckboxGroup = () => {
     const { themes } = useThemeManager();
 
     return (

--- a/packages/app-theme-manager/src/modules/themes/index.tsx
+++ b/packages/app-theme-manager/src/modules/themes/index.tsx
@@ -49,7 +49,7 @@ interface ThemeSelectProps {
     themes: ThemeSource[];
 }
 
-const ThemeSelect: React.FC<ThemeSelectProps> = ({ themes }) => {
+const ThemeSelect: React.ComponentType<ThemeSelectProps> = ({ themes }) => {
     const bind = useBind({
         name: "theme",
         validators: validation.create("required")
@@ -75,7 +75,7 @@ const WebsiteSettingsSelection = gql`
     }
 `;
 
-const WebsiteSettings: React.FC = () => {
+const WebsiteSettings = () => {
     return (
         <Fragment>
             <Group name={"theme"} label={"Theme"} querySelection={WebsiteSettingsSelection}>
@@ -92,7 +92,7 @@ const WebsiteSettings: React.FC = () => {
     );
 };
 
-const AppReloader: React.FC = () => {
+const AppReloader = () => {
     const theme = useCurrentTheme();
     const themeRef = useRef<string | null>(null);
 
@@ -125,7 +125,7 @@ interface ThemesModuleProps {
     themes?: ThemeSource[];
 }
 
-export const ThemesModule: React.FC<ThemesModuleProps> = ({ themes = [] }) => {
+export const ThemesModule: React.ComponentType<ThemesModuleProps> = ({ themes = [] }) => {
     return (
         <Fragment>
             <Provider hoc={ThemeManagerProviderHOC} />

--- a/packages/app-wcp/README.md
+++ b/packages/app-wcp/README.md
@@ -55,7 +55,7 @@ The `@webiny/app-wcp` package contains essential Webiny Control Panel (WCP)-rela
 <p>
 
 ```ts
-export declare const Wcp: React.FC;
+export declare const Wcp: React.ComponentType;
 ```
 
 </p>

--- a/packages/app-wcp/src/WcpProvider.tsx
+++ b/packages/app-wcp/src/WcpProvider.tsx
@@ -44,9 +44,10 @@ export const GET_WCP_PROJECT = gql`
 
 interface WcpProviderProps {
     loader?: React.ReactElement;
+    children: React.ReactNode;
 }
 
-export const WcpProvider: React.FC<WcpProviderProps> = ({ children, loader }) => {
+export const WcpProvider = ({ children, loader }: WcpProviderProps) => {
     // If `REACT_APP_WCP_PROJECT_ID` environment variable is missing, we can immediately exit.
     if (!process.env.REACT_APP_WCP_PROJECT_ID) {
         return <WcpProviderComponent project={null}>{children}</WcpProviderComponent>;

--- a/packages/app-wcp/src/contexts/WcpContext.tsx
+++ b/packages/app-wcp/src/contexts/WcpContext.tsx
@@ -7,13 +7,14 @@ export interface WcpContextValue {
 
 export interface WcpProviderProps {
     project: any;
+    children: React.ReactNode;
 }
 
 export const WcpContext = React.createContext<WcpContextValue>({
     project: null
 });
 
-export const WcpProviderComponent: React.FC<WcpProviderProps> = props => {
+export const WcpProviderComponent = (props: WcpProviderProps) => {
     const { children, project } = props;
     const value: WcpContextValue = { project };
     return <WcpContext.Provider value={value}>{children}</WcpContext.Provider>;

--- a/packages/app-website/src/Menu.tsx
+++ b/packages/app-website/src/Menu.tsx
@@ -60,7 +60,7 @@ interface Props {
     component: React.ComponentType<{ data?: PublishedMenuData }>;
 }
 
-export const Menu: React.FC<Props> = ({ slug, component: Component }) => {
+export const Menu = ({ slug, component: Component }: Props) => {
     const { data } = useQuery(GET_PUBLIC_MENU, { variables: { slug } });
     return (
         <>

--- a/packages/app-website/src/Page/index.tsx
+++ b/packages/app-website/src/Page/index.tsx
@@ -34,7 +34,7 @@ const notFoundInitialPath = trimPath(location.pathname);
  * `preview` query parameter is present, we're getting the page directly by its ID, instead of the URL.
  * The `preview` search parameter is set, for example, when previewing pages from Page Builder's editor / Admin app.
  */
-export const Page: React.FC = () => {
+export const Page = () => {
     const { pathname } = useLocation();
     const [search] = useSearchParams();
 

--- a/packages/app-website/src/Website.tsx
+++ b/packages/app-website/src/Website.tsx
@@ -21,12 +21,7 @@ const PageBuilderProviderHOC: HigherOrderComponent = PreviousProvider => {
     };
 };
 
-export const Website: React.FC<WebsiteProps> = ({
-    children,
-    routes = [],
-    providers = [],
-    ...props
-}) => {
+export const Website = ({ children, routes = [], providers = [], ...props }: WebsiteProps) => {
     const apolloClient = props.apolloClient || createApolloClient();
     const emotionCache = createEmotionCache();
 

--- a/packages/app/src/core/createProviderPlugin.tsx
+++ b/packages/app/src/core/createProviderPlugin.tsx
@@ -7,7 +7,7 @@ import { Provider } from "./Provider";
  * This is particularly useful for wrapping the entire app with custom React Context providers.
  * For more information, visit https://www.webiny.com/docs/admin-area/basics/framework.
  */
-export function createProviderPlugin(hoc: HigherOrderComponent): React.FC {
+export function createProviderPlugin(hoc: HigherOrderComponent) {
     return function ProviderPlugin() {
         return <Provider hoc={hoc} />;
     };

--- a/packages/cli-plugin-scaffold-admin-app-module/template/routes.tsx
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/routes.tsx
@@ -5,11 +5,16 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import { AdminLayout } from "@webiny/app-admin/components/AdminLayout";
 import { RoutePlugin } from "@webiny/app/plugins/RoutePlugin";
 
+interface LoaderProps {
+    children: React.ReactNode;
+    [key: string]: any;
+}
+
 /**
  * Registers new "/target-data-models" route.
  */
 
-const Loader: React.FC = ({ children, ...props }) => (
+const Loader = ({ children, ...props }: LoaderProps) => (
     <Suspense fallback={<CircularProgress />}>
         {React.cloneElement(children as unknown as React.ReactElement, props)}
     </Suspense>

--- a/packages/cli-plugin-scaffold-admin-app-module/template/views/TargetDataModelsDataList.tsx
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/views/TargetDataModelsDataList.tsx
@@ -30,7 +30,7 @@ const sorters = [
     }
 ];
 
-const TargetDataModelsDataList: React.FC = () => {
+const TargetDataModelsDataList = () => {
     const {
         targetDataModels,
         loading,

--- a/packages/cli-plugin-scaffold-admin-app-module/template/views/TargetDataModelsForm.tsx
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/views/TargetDataModelsForm.tsx
@@ -20,7 +20,7 @@ import { useTargetDataModelsForm } from "./hooks/useTargetDataModelsForm";
  * Includes two basic fields - title (required) and description.
  * The form submission-related functionality is located in the `useTargetDataModelsForm` React hook.
  */
-const TargetDataModelsForm: React.FC = () => {
+const TargetDataModelsForm = () => {
     const {
         loading,
         emptyViewIsShown,

--- a/packages/cli-plugin-scaffold-admin-app-module/template/views/index.tsx
+++ b/packages/cli-plugin-scaffold-admin-app-module/template/views/index.tsx
@@ -7,7 +7,7 @@ import TargetDataModelsForm from "./TargetDataModelsForm";
  * Main view component - renders data list and form.
  */
 
-const TargetDataModelsView: React.FC = () => {
+const TargetDataModelsView = () => {
     return (
         <SplitView>
             <LeftPanel>

--- a/packages/cli-plugin-scaffold-react-app/template/code/src/App.tsx
+++ b/packages/cli-plugin-scaffold-react-app/template/code/src/App.tsx
@@ -9,7 +9,7 @@ import "./App.scss";
 
 // The beginning of our React application, where we mount a couple of useful providers.
 // If needed, feel free to add new or modify existing providers.
-export const App: React.FC = () => (
+export const App = () => (
     <>
         {/* Sets up a new Apollo GraphQL client, pointed to an existing GraphQL API. */}
         <ApolloProvider client={createApolloClient({ uri: process.env.REACT_APP_GRAPHQL_API_URL })}>

--- a/packages/cli-plugin-scaffold-react-component/template/src/Target.tsx
+++ b/packages/cli-plugin-scaffold-react-component/template/src/Target.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 interface Props {
     id?: number;
 }
-const Target: React.FC<Props> = ({ id }) => {
+const Target = ({ id }: Props) => {
     const [randomNumber, setRandomNumber] = useState<number>();
 
     return (

--- a/packages/cwp-template-aws/template/common/apps/admin/src/App.tsx
+++ b/packages/cwp-template-aws/template/common/apps/admin/src/App.tsx
@@ -3,7 +3,7 @@ import { Admin } from "@webiny/app-serverless-cms";
 import { Cognito } from "@webiny/app-admin-users-cognito";
 import "./App.scss";
 
-export const App: React.FC = () => {
+export const App = () => {
     return (
         <Admin>
             <Cognito />

--- a/packages/cwp-template-aws/template/common/apps/website/src/App.tsx
+++ b/packages/cwp-template-aws/template/common/apps/website/src/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Website } from "@webiny/app-website";
 
-export const App: React.FC = () => {
+export const App = () => {
     return <Website />;
 };

--- a/packages/form/__tests__/form.test.tsx
+++ b/packages/form/__tests__/form.test.tsx
@@ -12,7 +12,7 @@ type FormProps = Omit<BaseFormProps, "children" | "onSubmit"> & {
     children?: React.ReactNode;
 };
 
-const FormViewWithBind: React.FC<FormProps> = ({ children, data, onSubmit, ...props }) => {
+const FormViewWithBind = ({ children, data, onSubmit, ...props }: FormProps) => {
     const [formData] = useState(data || { name: "empty name" });
 
     return (
@@ -66,7 +66,7 @@ const Input = (bindProps: BindComponentProps & { "data-testid"?: string }) => {
     );
 };
 
-const FormViewWithHooks: React.FC<FormProps> = ({ children = null, data, onSubmit, ...props }) => {
+const FormViewWithHooks = ({ children = null, data, onSubmit, ...props }: FormProps) => {
     const [formData] = useState(data || { name: "empty name" });
 
     return (

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -48,7 +48,7 @@ export interface BindComponentProps<T = any> {
     validate?: Validator;
 }
 
-export type BindComponent = React.FC<BindComponentProps>;
+export type BindComponent = React.ComponentType<BindComponentProps>;
 
 export interface FormRenderPropParamsSubmit {
     (event?: React.SyntheticEvent<any, any>): Promise<void>;

--- a/packages/lexical-editor-actions/src/components/LexicalColorPicker/LexicalColorPicker.tsx
+++ b/packages/lexical-editor-actions/src/components/LexicalColorPicker/LexicalColorPicker.tsx
@@ -112,11 +112,11 @@ interface LexicalColorPickerProps {
     handlerClassName?: string;
 }
 
-export const LexicalColorPicker: React.FC<LexicalColorPickerProps> = ({
+export const LexicalColorPicker = ({
     value,
     onChange,
     onChangeComplete
-}) => {
+}: LexicalColorPickerProps) => {
     const [showPicker, setShowPicker] = useState(false);
     // Either a custom color or a color coming from the theme object.
     const [actualSelectedColor, setActualSelectedColor] = useState(value || "#fff");

--- a/packages/lexical-editor-pb-element/src/LexicalEditor.tsx
+++ b/packages/lexical-editor-pb-element/src/LexicalEditor.tsx
@@ -15,7 +15,7 @@ interface LexicalEditorProps {
     width?: number | string;
 }
 
-export const LexicalEditor: React.FC<LexicalEditorProps> = ({ tag, value, onChange, ...rest }) => {
+export const LexicalEditor = ({ tag, value, onChange, ...rest }: LexicalEditorProps) => {
     const { theme } = usePageElements();
 
     const isHeading = useMemo(() => isHeadingTag(tag), [tag]);

--- a/packages/lexical-editor-pb-element/src/components/LexicalText.tsx
+++ b/packages/lexical-editor-pb-element/src/components/LexicalText.tsx
@@ -17,7 +17,7 @@ interface TextElementProps {
 }
 
 const DATA_NAMESPACE = "data.text";
-export const LexicalText: React.FC<TextElementProps> = ({ elementId, tag: customTag }) => {
+export const LexicalText = ({ elementId, tag: customTag }: TextElementProps) => {
     const [element] = useElementById(elementId);
     const { displayMode } = useDisplayMode();
     const [activeElement, setActiveElement] = useActiveElement();

--- a/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/LexicalVariableInputPlugin.tsx
+++ b/packages/lexical-editor-pb-element/src/plugins/elementSettings/variables/LexicalVariableInputPlugin.tsx
@@ -44,14 +44,14 @@ const ButtonPrimaryStyled = styled(ButtonPrimary)`
     margin-left: 8px;
 `;
 
-interface LexicalVariableInputPlugin {
+interface LexicalVariableInputPluginProps {
     tag: string;
     variableId: string;
 }
-export const LexicalVariableInputPlugin: React.FC<LexicalVariableInputPlugin> = ({
+export const LexicalVariableInputPlugin = ({
     tag,
     variableId
-}): JSX.Element => {
+}: LexicalVariableInputPluginProps): JSX.Element => {
     const { value, onChange } = useVariable<LexicalValue>(variableId);
     const [initialValue, setInitialValue] = useState(value);
     // We need a separate piece of state for dialog input, to support "cancel edit" functionality

--- a/packages/lexical-editor/src/components/Editor/HeadingEditor.tsx
+++ b/packages/lexical-editor/src/components/Editor/HeadingEditor.tsx
@@ -8,7 +8,7 @@ interface HeadingEditorProps extends RichTextEditorProps {
 
 const styles = { padding: 5 };
 
-export const HeadingEditor: React.FC<HeadingEditorProps> = ({ tag, placeholder, ...rest }) => {
+export const HeadingEditor = ({ tag, placeholder, ...rest }: HeadingEditorProps) => {
     return (
         <RichTextEditor
             toolbar={<Toolbar />}

--- a/packages/lexical-editor/src/components/Editor/ParagraphEditor.tsx
+++ b/packages/lexical-editor/src/components/Editor/ParagraphEditor.tsx
@@ -8,7 +8,7 @@ interface ParagraphLexicalEditorProps extends RichTextEditorProps {
 
 const styles = { padding: 5 };
 
-const ParagraphEditor: React.FC<ParagraphLexicalEditorProps> = ({ placeholder, tag, ...rest }) => {
+const ParagraphEditor = ({ placeholder, tag, ...rest }: ParagraphLexicalEditorProps) => {
     return (
         <RichTextEditor
             toolbar={<Toolbar />}

--- a/packages/lexical-editor/src/components/Editor/RichTextEditor.tsx
+++ b/packages/lexical-editor/src/components/Editor/RichTextEditor.tsx
@@ -55,7 +55,7 @@ export interface RichTextEditorProps {
     width?: number | string;
 }
 
-const BaseRichTextEditor: React.FC<RichTextEditorProps> = ({
+const BaseRichTextEditor = ({
     toolbar,
     staticToolbar,
     onChange,

--- a/packages/lexical-editor/src/components/LexicalEditorConfig/components/Node.tsx
+++ b/packages/lexical-editor/src/components/LexicalEditorConfig/components/Node.tsx
@@ -15,13 +15,13 @@ export interface NodeProps {
     after?: string;
 }
 
-export const Node: React.FC<NodeProps> = ({
+export const Node = ({
     name,
     node,
     after = undefined,
     before = undefined,
     remove = false
-}) => {
+}: NodeProps) => {
     const placeBefore = before !== undefined ? `node:${before}` : undefined;
     const placeAfter = after !== undefined ? `node:${after}` : undefined;
 

--- a/packages/lexical-editor/src/components/LexicalEditorConfig/components/Plugin.tsx
+++ b/packages/lexical-editor/src/components/LexicalEditorConfig/components/Plugin.tsx
@@ -14,13 +14,13 @@ export interface PluginProps {
     after?: string;
 }
 
-export const Plugin: React.FC<PluginProps> = ({
+export const Plugin = ({
     name,
     element,
     after = undefined,
     before = undefined,
     remove = false
-}) => {
+}: PluginProps) => {
     const placeBefore = before !== undefined ? `plugin:${before}` : undefined;
     const placeAfter = after !== undefined ? `plugin:${after}` : undefined;
 

--- a/packages/lexical-editor/src/components/LexicalEditorConfig/components/ToolbarElement.tsx
+++ b/packages/lexical-editor/src/components/LexicalEditorConfig/components/ToolbarElement.tsx
@@ -14,13 +14,13 @@ export interface ToolbarElementProps {
     after?: string;
 }
 
-export const ToolbarElement: React.FC<ToolbarElementProps> = ({
+export const ToolbarElement = ({
     name,
     element,
     after = undefined,
     before = undefined,
     remove = false
-}) => {
+}: ToolbarElementProps) => {
     const placeBefore = before !== undefined ? `element:${before}` : undefined;
     const placeAfter = after !== undefined ? `element:${after}` : undefined;
 

--- a/packages/lexical-editor/src/components/LexicalHtmlRenderer.tsx
+++ b/packages/lexical-editor/src/components/LexicalHtmlRenderer.tsx
@@ -25,12 +25,12 @@ interface LexicalHtmlRendererProps {
     themeStylesTransformer?: (cssObject: Record<string, any>) => CSSObject;
 }
 
-export const BaseLexicalHtmlRenderer: React.FC<LexicalHtmlRendererProps> = ({
+export const BaseLexicalHtmlRenderer = ({
     nodes,
     value,
     theme,
     themeEmotionMap
-}) => {
+}: LexicalHtmlRendererProps) => {
     const editorTheme = useRef(createTheme());
     const editorValue = isValidLexicalData(value) ? value : generateInitialLexicalValue();
 
@@ -66,7 +66,7 @@ export const BaseLexicalHtmlRenderer: React.FC<LexicalHtmlRendererProps> = ({
 /**
  * @description Main editor container
  */
-export const LexicalHtmlRenderer: React.FC<LexicalHtmlRendererProps> = props => {
+export const LexicalHtmlRenderer = (props: LexicalHtmlRendererProps) => {
     return (
         <ClassNames>
             {({ css }) => {

--- a/packages/lexical-editor/src/components/ToolbarActions/FontColorAction.tsx
+++ b/packages/lexical-editor/src/components/ToolbarActions/FontColorAction.tsx
@@ -18,13 +18,13 @@ interface FontActionColorPicker {
     element: JSX.Element;
 }
 
-const FontActionColorPicker: React.FC<FontActionColorPicker> = ({ element }): JSX.Element => {
+const FontActionColorPicker = ({ element }: FontActionColorPicker): JSX.Element => {
     return <Compose component={FontColorPicker} with={() => () => element} />;
 };
 
-export interface FontColorAction extends React.FC<unknown> {
+export type FontColorAction = React.ComponentType<unknown> & {
     ColorPicker: typeof FontActionColorPicker;
-}
+};
 
 export const FontColorAction: FontColorAction = () => {
     const [editor] = useLexicalComposerContext();

--- a/packages/lexical-editor/src/components/ToolbarActions/TextAlignmentAction.tsx
+++ b/packages/lexical-editor/src/components/ToolbarActions/TextAlignmentAction.tsx
@@ -29,15 +29,15 @@ interface TextAlignmentActionDropdownProps {
     element: JSX.Element;
 }
 
-const TextAlignmentActionDropDown: React.FC<TextAlignmentActionDropdownProps> = ({
+const TextAlignmentActionDropDown = ({
     element
-}): JSX.Element => {
+}: TextAlignmentActionDropdownProps): JSX.Element => {
     return <Compose component={BaseTextAlignmentDropDown} with={() => () => element} />;
 };
 
-export interface TextAlignmentAction extends React.FC<unknown> {
+export type TextAlignmentAction = React.ComponentType<unknown> & {
     TextAlignmentDropDown: typeof TextAlignmentActionDropDown;
-}
+};
 
 export const TextAlignmentAction: TextAlignmentAction = () => {
     const [editor] = useLexicalComposerContext();

--- a/packages/lexical-editor/src/components/ToolbarActions/TypographyAction.tsx
+++ b/packages/lexical-editor/src/components/ToolbarActions/TypographyAction.tsx
@@ -41,15 +41,13 @@ interface TypographyActionDropdownProps {
     element: JSX.Element;
 }
 
-const TypographyActionDropDown: React.FC<TypographyActionDropdownProps> = ({
-    element
-}): JSX.Element => {
+const TypographyActionDropDown = ({ element }: TypographyActionDropdownProps): JSX.Element => {
     return <Compose component={BaseTypographyActionDropDown} with={() => () => element} />;
 };
 
-export interface TypographyAction extends React.FC<unknown> {
+export type TypographyAction = React.ComponentType<unknown> & {
     TypographyDropDown: typeof TypographyActionDropDown;
-}
+};
 
 export const TypographyAction: TypographyAction = () => {
     const [editor] = useLexicalComposerContext();

--- a/packages/lexical-editor/src/context/RichTextEditorContext.tsx
+++ b/packages/lexical-editor/src/context/RichTextEditorContext.tsx
@@ -24,7 +24,7 @@ interface RichTextEditorProviderProps {
     children?: React.ReactNode | React.ReactNode[];
 }
 
-export const RichTextEditorProvider: React.FC<RichTextEditorProviderProps> = ({ children }) => {
+export const RichTextEditorProvider = ({ children }: RichTextEditorProviderProps) => {
     const [toolbarType, setToolbarType] = useState<ToolbarType | undefined>();
     const [theme, setTheme] = useState<WebinyTheme | undefined>(undefined);
     const [themeEmotionMap, setThemeEmotionMap] = useState<ThemeEmotionMap | undefined>(undefined);

--- a/packages/lexical-editor/src/plugins/FontColorPlugin/FontColorPlugin.tsx
+++ b/packages/lexical-editor/src/plugins/FontColorPlugin/FontColorPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
     $applyStylesToNode,
@@ -16,7 +16,7 @@ import {
 } from "lexical";
 import { $wrapNodeInElement } from "@lexical/utils";
 
-export const FontColorPlugin: React.FC = () => {
+export const FontColorPlugin = () => {
     const [editor] = useLexicalComposerContext();
 
     useEffect(() => {

--- a/packages/lexical-editor/src/plugins/TypographyPlugin/TypographyPlugin.tsx
+++ b/packages/lexical-editor/src/plugins/TypographyPlugin/TypographyPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_EDITOR } from "lexical";
 import {
@@ -9,7 +9,7 @@ import {
 } from "@webiny/lexical-nodes";
 import { HeadingTagType } from "@lexical/rich-text";
 
-export const TypographyPlugin: React.FC = () => {
+export const TypographyPlugin = () => {
     const [editor] = useLexicalComposerContext();
 
     useEffect(() => {

--- a/packages/lexical-editor/src/ui/ToolbarActionDialog.tsx
+++ b/packages/lexical-editor/src/ui/ToolbarActionDialog.tsx
@@ -56,7 +56,7 @@ interface ToolbarActionDialogProps {
     stopCloseOnClickSelf?: boolean;
 }
 
-export const ToolbarActionDialog: React.FC<ToolbarActionDialogProps> = ({
+export const ToolbarActionDialog = ({
     disabled,
     buttonAriaLabel,
     buttonClassName,
@@ -64,7 +64,7 @@ export const ToolbarActionDialog: React.FC<ToolbarActionDialogProps> = ({
     buttonLabel,
     children,
     stopCloseOnClickSelf
-}): JSX.Element => {
+}: ToolbarActionDialogProps): JSX.Element => {
     const menuWindowRef = useRef<HTMLDivElement>(null);
     const [showDropDown, setShowDropDown] = useState(false);
 

--- a/packages/react-composition/src/Compose.tsx
+++ b/packages/react-composition/src/Compose.tsx
@@ -2,10 +2,10 @@ import React, { useEffect } from "react";
 import { HigherOrderComponent, useComposition } from "./Context";
 import { useCompositionScope } from "~/CompositionScope";
 
-export interface ComposableFC<TProps = unknown> extends React.FC<TProps> {
-    original: React.FC<TProps>;
+export type ComposableFC<TProps = unknown> = React.ComponentType<TProps> & {
+    original: React.ComponentType<TProps>;
     originalName: string;
-}
+};
 
 export interface ComposeProps {
     /**
@@ -16,7 +16,7 @@ export interface ComposeProps {
     with: HigherOrderComponent | HigherOrderComponent[];
 }
 
-export const Compose: React.FC<ComposeProps> = props => {
+export const Compose = (props: ComposeProps) => {
     const { composeComponent } = useComposition();
     const scope = useCompositionScope();
 

--- a/packages/react-composition/src/Context.tsx
+++ b/packages/react-composition/src/Context.tsx
@@ -1,5 +1,4 @@
 import React, {
-    FC,
     ComponentType,
     useState,
     useCallback,
@@ -10,7 +9,7 @@ import React, {
 import { useCompositionScope } from "~/CompositionScope";
 
 export function compose(...fns: Decorator[]) {
-    return function ComposedComponent(Base: FC<unknown>): FC<unknown> {
+    return function ComposedComponent(Base: ComponentType<unknown>): ComponentType<unknown> {
         return fns.reduceRight((Component, hoc) => hoc(Component), Base);
     };
 }
@@ -36,14 +35,14 @@ interface ComposedComponent {
  * to let it be `any` in this interface.
  */
 export interface Decorator<TProps = any> {
-    (Component: FC<TProps>): FC<TProps>;
+    (Component: ComponentType<TProps>): ComponentType<TProps>;
 }
 
 /**
  * @deprecated Use `Decorator` instead.
  */
 export interface HigherOrderComponent<TProps = any, TOutput = TProps> {
-    (Component: FC<TProps>): FC<TOutput>;
+    (Component: ComponentType<TProps>): ComponentType<TOutput>;
 }
 
 type ComposedComponents = Map<ComponentType<unknown>, ComposedComponent>;
@@ -64,7 +63,11 @@ interface CompositionContext {
 
 const CompositionContext = createContext<CompositionContext | undefined>(undefined);
 
-export const CompositionProvider: React.FC = ({ children }) => {
+interface CompositionProviderProps {
+    children: React.ReactNode;
+}
+
+export const CompositionProvider = ({ children }: CompositionProviderProps) => {
     const [components, setComponents] = useState<ComponentScopes>(new Map());
 
     const composeComponent = useCallback(

--- a/packages/react-composition/src/createComponentPlugin.tsx
+++ b/packages/react-composition/src/createComponentPlugin.tsx
@@ -9,7 +9,7 @@ import { ComposableFC, Compose, HigherOrderComponent } from "./index";
 export function createComponentPlugin<T extends ComposableFC<ComponentProps<T>>>(
     Base: T,
     hoc: HigherOrderComponent<ComponentProps<T>>
-): React.FC {
+) {
     const ComponentPlugin = () => <Compose component={Base} with={hoc} />;
     ComponentPlugin.displayName = Base.displayName;
     return ComponentPlugin;

--- a/packages/react-composition/src/decorators.tsx
+++ b/packages/react-composition/src/decorators.tsx
@@ -11,7 +11,7 @@ export function createConditionalDecorator(
     decorator: Decorator,
     decoratorProps: unknown
 ): Decorator {
-    return (Original: React.FC) => {
+    return (Original: React.ComponentType) => {
         return function ShouldDecorate(props) {
             if (shouldDecorate(decoratorProps, props)) {
                 const Component = decorator(Original);

--- a/packages/react-composition/src/makeComposable.tsx
+++ b/packages/react-composition/src/makeComposable.tsx
@@ -15,7 +15,7 @@ function useComposableParents() {
     return context;
 }
 
-const createEmptyRenderer = (name: string): React.FC => {
+const createEmptyRenderer = (name: string) => {
     return {
         [name]: function () {
             useEffect(() => {
@@ -37,14 +37,14 @@ const createEmptyRenderer = (name: string): React.FC => {
     }[name];
 };
 
-export function makeComposable<TProps>(name: string, Component?: React.FC<TProps>) {
+export function makeComposable<TProps>(name: string, Component?: React.ComponentType<TProps>) {
     if (!Component) {
         Component = createEmptyRenderer(name);
     }
 
     const Composable: ComposableFC<TProps> = props => {
         const parents = useComposableParents();
-        const ComposedComponent = useComponent(Component as React.FC<TProps>);
+        const ComposedComponent = useComponent(Component as React.ComponentType<TProps>);
 
         const context = useMemo(() => [...parents, name], [parents, name]);
 

--- a/packages/react-properties/__tests__/Filter.tsx
+++ b/packages/react-properties/__tests__/Filter.tsx
@@ -8,12 +8,12 @@ export interface FilterProps {
     after?: string;
 }
 
-export const Filter: React.FC<FilterProps> = ({
+export const Filter = ({
     name,
     after = undefined,
     before = undefined,
     remove = false
-}) => {
+}: FilterProps) => {
     const getId = useIdGenerator("filter");
 
     const placeAfter = after !== undefined ? getId(after) : undefined;

--- a/packages/react-properties/__tests__/cases/dashboard/App.tsx
+++ b/packages/react-properties/__tests__/cases/dashboard/App.tsx
@@ -25,6 +25,7 @@ export interface CardWidget extends Record<string, unknown> {
 
 interface DashboardViewProps {
     onProperties(properties: Property[]): void;
+    children: React.ReactNode;
 }
 
 interface DashboardConfigData {
@@ -38,7 +39,7 @@ export const DashboardConfig = Object.assign(Config, { AddWidget });
 
 export const useDashboardConfig = useConfig;
 
-export const App: React.FC<DashboardViewProps> = ({ onProperties, children }) => {
+export const App = ({ onProperties, children }: DashboardViewProps) => {
     return (
         <CompositionProvider>
             <DashboardConfig>

--- a/packages/react-properties/__tests__/cases/dashboard/dashboard.test.tsx
+++ b/packages/react-properties/__tests__/cases/dashboard/dashboard.test.tsx
@@ -112,7 +112,7 @@ describe("Dashboard", () => {
             title: string;
         }
 
-        const Link: React.FC<LinkProps> = ({ url, title }) => {
+        const Link = ({ url, title }: LinkProps) => {
             return (
                 <Property id={title} name={"link"} array>
                     <Property name={"url"} value={url} />

--- a/packages/react-properties/__tests__/cases/pbEditorSettings/PbEditorSettingsView.tsx
+++ b/packages/react-properties/__tests__/cases/pbEditorSettings/PbEditorSettingsView.tsx
@@ -8,18 +8,14 @@ interface SettingsGroupProps {
     icon?: string;
     remove?: boolean;
     replace?: string;
+    children: React.ReactNode;
 }
 
 type DynamicProps<T> = T & {
     [key: string]: any;
 };
 
-const SettingsGroup: React.FC<SettingsGroupProps> = ({
-    children,
-    replace,
-    remove = false,
-    ...rest
-}) => {
+const SettingsGroup = ({ children, replace, remove = false, ...rest }: SettingsGroupProps) => {
     const props: DynamicProps<typeof rest> = rest;
     const id = `group:${props.name}`;
     const toReplace = replace !== undefined ? `group:${replace}` : undefined;
@@ -47,14 +43,14 @@ interface FormFieldProps extends Record<string, unknown> {
     replace?: string;
 }
 
-const FormField: React.FC<FormFieldProps> = ({
+const FormField = ({
     children,
     after,
     before,
     replace,
     remove = false,
     ...props
-}) => {
+}: FormFieldProps) => {
     const parent = useParentProperty();
     if (!parent) {
         throw Error(`<FormField> must be a child of a <SettingsGroup> element.`);

--- a/packages/react-properties/__tests__/cases/pbEditorSettings/createConfigurableView.tsx
+++ b/packages/react-properties/__tests__/cases/pbEditorSettings/createConfigurableView.tsx
@@ -16,6 +16,10 @@ const createHOC =
         };
     };
 
+export interface ConfigPropss {
+    children: React.ReactNode;
+}
+
 export interface ViewProps {
     onProperties?(properties: Property[]): void;
 }
@@ -31,7 +35,7 @@ export function createConfigurableView(name: string) {
     /**
      * This component is used to configure the view (it can be mounted many times).
      */
-    const Config: React.FC = ({ children }) => {
+    const Config = ({ children }: ConfigPropss) => {
         return <Compose component={ConfigApply} with={createHOC(children)} />;
     };
 
@@ -47,7 +51,7 @@ export function createConfigurableView(name: string) {
 
     const ViewContext = React.createContext<ViewContext>(defaultContext);
 
-    const View: React.FC<ViewProps> = ({ onProperties }) => {
+    const View = ({ onProperties }: ViewProps) => {
         const [properties, setProperties] = useState<Property[]>([]);
         const context = { properties };
 

--- a/packages/react-properties/__tests__/properties.test.tsx
+++ b/packages/react-properties/__tests__/properties.test.tsx
@@ -10,9 +10,10 @@ import { Filter } from "./Filter";
 interface GroupProps {
     name: string;
     label?: string;
+    children: React.ReactNode;
 }
 
-const Group: React.FC<GroupProps> = ({ name, label, children }) => {
+const Group = ({ name, label, children }: GroupProps) => {
     return (
         <Property id={`group:${name}`} name={"settingsGroup"} array={true}>
             <Property id={`group:${name}:name`} name={"name"} value={name} />
@@ -31,7 +32,7 @@ interface FieldProps {
     replace?: string;
 }
 
-const Field: React.FC<FieldProps> = ({ name, label, replace, after, before, remove = false }) => {
+const Field = ({ name, label, replace, after, before, remove = false }: FieldProps) => {
     const parentProperty = useParentProperty();
 
     const id = parentProperty ? parentProperty.id : undefined;
@@ -218,9 +219,10 @@ describe("Test Properties", () => {
         interface GroupProps {
             name: string;
             label?: string;
+            children?: React.ReactNode;
         }
 
-        const Group: React.FC<GroupProps> = ({ name, label, children }) => {
+        const Group = ({ name, label, children }: GroupProps) => {
             return (
                 <Property name={"group"}>
                     <Property name={"name"} value={name} />
@@ -234,7 +236,7 @@ describe("Test Properties", () => {
             name: string;
         }
 
-        const Toolbar: React.FC<ToolbarProps> = ({ name }) => {
+        const Toolbar = ({ name }: ToolbarProps) => {
             return (
                 <Property name={"toolbar"}>
                     <Property name={"name"} value={name} />
@@ -335,7 +337,11 @@ describe("Test Properties", () => {
     it("should allow addition of custom properties to predefined components", async () => {
         const onChange = jest.fn();
 
-        const Tutorial: React.FC<{ label: string }> = ({ label }) => {
+        interface TutorialProps {
+            label: string;
+        }
+
+        const Tutorial = ({ label }: TutorialProps) => {
             return <Property name={"tutorial"} value={label} />;
         };
 

--- a/packages/react-properties/src/Properties.tsx
+++ b/packages/react-properties/src/Properties.tsx
@@ -89,9 +89,10 @@ const PropertiesContext = createContext<PropertiesContext | undefined>(undefined
 
 interface PropertiesProps {
     onChange?(properties: Property[]): void;
+    children: React.ReactNode;
 }
 
-export const Properties: React.FC<PropertiesProps> = ({ onChange, children }) => {
+export const Properties = ({ onChange, children }: PropertiesProps) => {
     const [properties, setProperties] = useState<Property[]>([]);
 
     useEffect(() => {
@@ -183,6 +184,7 @@ interface PropertyProps {
     remove?: boolean;
     parent?: string;
     root?: boolean;
+    children?: React.ReactNode;
 }
 
 const PropertyContext = createContext<Property | undefined>(undefined);
@@ -221,7 +223,7 @@ export function useAncestor(params: AncestorMatch) {
     return property ? matchOrGetAncestor(property, params) : undefined;
 }
 
-export const Property: React.FC<PropertyProps> = ({
+export const Property = ({
     id,
     name,
     value,
@@ -233,7 +235,7 @@ export const Property: React.FC<PropertyProps> = ({
     array = false,
     root = false,
     parent = undefined
-}) => {
+}: PropertyProps) => {
     const uniqueId = useMemo(() => id || getUniqueId(), []);
     const parentProperty = useParentProperty();
     const properties = useProperties();

--- a/packages/react-rich-text-lexical-renderer/src/index.tsx
+++ b/packages/react-rich-text-lexical-renderer/src/index.tsx
@@ -11,7 +11,7 @@ interface RichTextLexicalRenderer {
     nodes?: Klass<LexicalNode>[];
 }
 
-const LexicalRenderer: React.FC<RichTextLexicalRenderer> = props => {
+const LexicalRenderer = (props: RichTextLexicalRenderer) => {
     const { theme } = useTheme();
 
     const getValue = (value: RendererLexicalValue): string | null => {
@@ -30,7 +30,7 @@ const LexicalRenderer: React.FC<RichTextLexicalRenderer> = props => {
     );
 };
 
-export const RichTextLexicalRenderer: React.FC<RichTextLexicalRenderer> = props => {
+export const RichTextLexicalRenderer = (props: RichTextLexicalRenderer) => {
     return (
         <ThemeProvider>
             <LexicalRenderer {...props} />

--- a/packages/react-rich-text-renderer/src/index.tsx
+++ b/packages/react-rich-text-renderer/src/index.tsx
@@ -253,7 +253,7 @@ interface RichTextRendererProps {
     sanitizationConfig?: sanitize.IOptions;
 }
 
-export const RichTextRenderer: React.FC<RichTextRendererProps> = props => {
+export const RichTextRenderer = (props: RichTextRendererProps) => {
     // Combine default renderers with custom renderers
     const renderers = Object.assign({}, defaultRenderers, props.renderers);
 

--- a/packages/react-router/src/Prompt.tsx
+++ b/packages/react-router/src/Prompt.tsx
@@ -1,14 +1,13 @@
 /**
  * https://github.com/remix-run/react-router/blob/v5/packages/react-router/modules/Prompt.js
  */
-import React from "react";
 import { usePrompt } from "~/usePrompt";
 
 export interface PromptProps {
     when: boolean;
     message: string;
 }
-export const Prompt: React.FC<PromptProps> = ({ when, message }) => {
+export const Prompt = ({ when, message }: PromptProps) => {
     usePrompt(message, when);
     return null;
 };

--- a/packages/react-router/src/Route.tsx
+++ b/packages/react-router/src/Route.tsx
@@ -25,7 +25,7 @@ export type RouteProps = BaseRouteProps & {
     component?: React.ComponentType;
 };
 
-export const Route: React.FC<RouteProps> = props => {
+export const Route = (props: RouteProps) => {
     const newProps = {
         ...props
     };

--- a/packages/react-router/src/Routes.tsx
+++ b/packages/react-router/src/Routes.tsx
@@ -35,7 +35,7 @@ const createNativeRoute = (props: RouteProps, index: number, location: Location)
 
 export type RoutesProps = BaseRoutesProps;
 
-export const Routes: React.FC<RoutesProps> = props => {
+export const Routes = (props: RoutesProps) => {
     const location = useLocation();
 
     const children = React.Children.map(props.children, (route: any, index) => {

--- a/packages/react-router/src/context/RouterContext.tsx
+++ b/packages/react-router/src/context/RouterContext.tsx
@@ -14,7 +14,11 @@ export const RouterContext = React.createContext<ReactRouterContext>({
     }
 });
 
-export const RouterProvider: React.FC = ({ children }) => {
+interface RouterProviderProps {
+    children: React.ReactNode;
+}
+
+export const RouterProvider = ({ children }: RouterProviderProps) => {
     let apolloClient: ApolloClient<any>;
     try {
         apolloClient = useApolloClient();
@@ -44,7 +48,11 @@ export const RouterProvider: React.FC = ({ children }) => {
     return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
 };
 
-export const RouterConsumer: React.FC = ({ children }) => (
+interface RouterConsumerProps {
+    children: React.ReactNode;
+}
+
+export const RouterConsumer = ({ children }: RouterConsumerProps) => (
     <RouterContext.Consumer>
         {props => {
             /**

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -93,7 +93,7 @@ export function useRouter(): UseRouter {
  * For Webiny, we only need a BrowserRouter, and we also export a StaticRouter, if we ever
  * need to do SSR. Right now, StaticRouter is not being used at all.
  */
-export const BrowserRouter: React.FC<BrowserRouterProps> = enhancer(RBrowserRouter);
+export const BrowserRouter: React.ComponentType<BrowserRouterProps> = enhancer(RBrowserRouter);
 export type { BrowserRouterProps };
 
-export const StaticRouter: React.FC<StaticRouterProps> = enhancer(RStaticRouter);
+export const StaticRouter: React.ComponentType<StaticRouterProps> = enhancer(RStaticRouter);

--- a/packages/react-router/src/routerEnhancer.tsx
+++ b/packages/react-router/src/routerEnhancer.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { RouterProvider } from "./context/RouterContext";
 
+interface EnhancedComponentProps {
+    children?: React.ReactNode;
+}
+
 /**
  * @internal
  */
 const routerEnhancer = (BaseComponent: any) => {
-    const EnhancedComponent: React.FC = props => {
+    const EnhancedComponent = (props: EnhancedComponentProps) => {
         return (
             <RouterProvider>
                 <BaseComponent {...props} />

--- a/packages/storybook-utils/src/Story/index.tsx
+++ b/packages/storybook-utils/src/Story/index.tsx
@@ -14,9 +14,10 @@ export class Story extends React.Component<{ children: React.ReactNode }> {
 
 interface StorySandboxProps {
     title?: React.ReactNode;
+    children: React.ReactNode;
 }
 
-export const StorySandbox: React.FC<StorySandboxProps> = props => {
+export const StorySandbox = (props: StorySandboxProps) => {
     const children = React.Children.toArray(props.children);
     if (children.length === 2) {
         return <div style={{ display: "flex" }}>{props.children}</div>;
@@ -30,13 +31,18 @@ export const StorySandbox: React.FC<StorySandboxProps> = props => {
     );
 };
 
-export const StoryReadme: React.FC = ({ children }) => <Markdown source={children} />;
+interface StoryReadmeProps {
+    children: React.ReactNode;
+}
+
+export const StoryReadme = ({ children }: StoryReadmeProps) => <Markdown source={children} />;
 
 interface StoryPropsProps {
     title?: React.ReactNode;
+    children: React.ReactNode;
 }
 
-export const StoryProps: React.FC<StoryPropsProps> = ({ title, children }) => (
+export const StoryProps = ({ title, children }: StoryPropsProps) => (
     <React.Fragment>
         <h3>{title || "Props"}</h3>
         <CodeBlock lang={"js"}>{children}</CodeBlock>
@@ -45,16 +51,21 @@ export const StoryProps: React.FC<StoryPropsProps> = ({ title, children }) => (
 
 interface StorySandboxExampleProps {
     title?: React.ReactNode;
+    children: React.ReactNode;
 }
 
-export const StorySandboxExample: React.FC<StorySandboxExampleProps> = ({ children, title }) => (
+export const StorySandboxExample = ({ children, title }: StorySandboxExampleProps) => (
     <div style={{ width: "50%", marginRight: 15 }}>
         <h2>{title || "Example"}</h2>
         {children}
     </div>
 );
 
-export const StorySandboxCode: React.FC = ({ children }) => (
+interface StorySandboxCodeProps {
+    children: React.ReactNode;
+}
+
+export const StorySandboxCode = ({ children }: StorySandboxCodeProps) => (
     <div style={{ width: "50%" }}>
         <h2>Code</h2>
         <CodeBlock copy={true}>{children}</CodeBlock>

--- a/packages/ui-composer/src/UIView.tsx
+++ b/packages/ui-composer/src/UIView.tsx
@@ -3,7 +3,11 @@ import pWaitFor from "p-wait-for";
 import { Plugin, plugins } from "@webiny/plugins";
 import { UIElement, UIElementConfig } from "./UIElement";
 
-const UIViewID: React.FC = ({ children }) => {
+interface UIViewIDProps {
+    children: React.ReactNode;
+}
+
+const UIViewID = ({ children }: UIViewIDProps) => {
     return <>{children}</>;
 };
 
@@ -161,7 +165,7 @@ interface UIViewHooksProps {
     render: any;
 }
 
-const UIViewHooks: React.FC<UIViewHooksProps> = ({ view, props, render }) => {
+const UIViewHooks = ({ view, props, render }: UIViewHooksProps) => {
     const hooks = view.getHookDefinitions();
     if (hooks) {
         view.setHookValues(


### PR DESCRIPTION
## Changes
Nineteens batch of changes to React component definitions before upgrading to React 18.
https://www.notion.so/webiny/Upgrade-to-React-18-ceacd9bbfcf74b39a7ceb70943c3afa7

Packages: apps/website, app-aco, app-admin-auth0, app-admin-cognito, app-admin-okta, app-admin-rmwc,
app-admin-user-cognito, app-admin, app-apw, app-file-manager, app-form-builder, app-headless-cms,
app-i18n-content, app-i18n, app-page-builder, app-page-builder-elements, app-security-access-managment,
app-security, app-theme, app-website, app, cli-plugin-scaffold-admin-app, cli-plugin-scaffold-react-app,
cli-plugin-scaffold-react-component, cwp-template-aws, form, lexical-editor-actions, lexical-editor-pb-element, lexical-editor, react-composition, react-properties, reach-rich-text-lexical-renderer,  reach-rich-text-renderer, react-router, storybook-utils, ui-composer.

## How Has This Been Tested?
Manually.

## Documentation
None.
