### PR TITLE
feat(plugins): async plugins container

### DIFF
--- a/packages/api/src/Context.ts
+++ b/packages/api/src/Context.ts
@@ -10,9 +10,19 @@ interface Waiter {
 }
 
 export interface ContextParams {
-    plugins?: PluginCollection;
+    plugins?: PluginCollection | PluginsContainer;
     WEBINY_VERSION: string;
 }
+
+const getPluginsContainer = (plugins?: PluginCollection | PluginsContainer): PluginsContainer => {
+    if (!plugins) {
+        return new PluginsContainer();
+    }
+    if (plugins instanceof PluginsContainer) {
+        return plugins;
+    }
+    return new PluginsContainer(plugins);
+};
 
 export class Context implements ContextInterface {
     public _result: any;
@@ -25,7 +35,7 @@ export class Context implements ContextInterface {
 
     public constructor(params: ContextParams) {
         const { plugins, WEBINY_VERSION } = params;
-        this.plugins = new PluginsContainer(plugins || []);
+        this.plugins = getPluginsContainer(plugins);
         this.WEBINY_VERSION = WEBINY_VERSION;
         /**
          * At the moment let's have benchmark as part of the context.

--- a/packages/handler-aws/src/createHandler.ts
+++ b/packages/handler-aws/src/createHandler.ts
@@ -1,11 +1,18 @@
+import { AsyncPluginsContainer } from "@webiny/plugins";
 import { HandlerFactory } from "~/types";
 import { registry } from "./registry";
 
-export const createHandler: HandlerFactory = params => {
+export const createHandler: HandlerFactory = ({ plugins, ...params }) => {
+    const pluginsContainer = new AsyncPluginsContainer(plugins);
+
     return async (event, context) => {
+        const plugins = await pluginsContainer.init();
         const handler = registry.getHandler(event, context);
         return handler.handle({
-            params,
+            params: {
+                ...params,
+                plugins
+            },
             event,
             context
         });

--- a/packages/handler/src/Context.ts
+++ b/packages/handler/src/Context.ts
@@ -8,12 +8,10 @@ import {
 import { Context as ContextInterface } from "~/types";
 
 export interface ContextParams extends BaseContextParams {
-    server: ContextInterface["server"];
     routes: ContextInterface["routes"];
 }
 
 export class Context extends BaseContext implements ContextInterface {
-    public readonly server: ContextInterface["server"];
     public readonly routes: ContextInterface["routes"];
     // @ts-expect-error
     public handlerClient: ContextInterface["handlerClient"];
@@ -24,7 +22,6 @@ export class Context extends BaseContext implements ContextInterface {
 
     public constructor(params: ContextParams) {
         super(params);
-        this.server = params.server;
         this.routes = params.routes;
     }
 }

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -250,7 +250,6 @@ export const createHandler = (params: CreateHandlerParams) => {
              * Inserted via webpack on build time.
              */
             WEBINY_VERSION: process.env.WEBINY_VERSION as string,
-            server: app,
             routes
         });
     } catch (ex) {

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -1,4 +1,4 @@
-import { PluginCollection } from "@webiny/plugins/types";
+import { PluginCollection, PluginsContainer } from "@webiny/plugins/types";
 import fastify, {
     FastifyServerOptions as ServerOptions,
     preSerializationAsyncHookHandler
@@ -78,7 +78,7 @@ const OPTIONS_HEADERS: Record<string, string> = {
 };
 
 export interface CreateHandlerParams {
-    plugins: PluginCollection;
+    plugins: PluginCollection | PluginsContainer;
     options?: ServerOptions;
     debug?: boolean;
 }
@@ -236,18 +236,21 @@ export const createHandler = (params: CreateHandlerParams) => {
         }
     };
     let context: Context;
+
+    const plugins = new PluginsContainer([
+        /**
+         * We must have handlerClient by default.
+         * And it must be one of the first context plugins applied.
+         */
+        createHandlerClient()
+    ]);
+    plugins.merge(params.plugins || []);
+
     try {
         context = new Context({
-            plugins: [
-                /**
-                 * We must have handlerClient by default.
-                 * And it must be one of the first context plugins applied.
-                 */
-                createHandlerClient(),
-                ...(params.plugins || [])
-            ],
+            plugins,
             /**
-             * Inserted via webpack on build time.
+             * Inserted via webpack at build time.
              */
             WEBINY_VERSION: process.env.WEBINY_VERSION as string,
             routes

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -1,9 +1,4 @@
-import {
-    FastifyRequest,
-    FastifyReply,
-    HTTPMethods,
-    RouteHandlerMethod
-} from "fastify";
+import { FastifyRequest, FastifyReply, HTTPMethods, RouteHandlerMethod } from "fastify";
 
 export { FastifyInstance, HTTPMethods } from "fastify";
 import { ClientContext } from "@webiny/handler-client/types";

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -1,5 +1,4 @@
 import {
-    FastifyInstance,
     FastifyRequest,
     FastifyReply,
     HTTPMethods,
@@ -35,12 +34,6 @@ export interface ContextRoutes {
 }
 
 export interface Context extends ClientContext {
-    /**
-     * An instance of fastify server.
-     * Use at your own risk.
-     * @instance
-     */
-    server: FastifyInstance;
     /**
      * Current request. Must be set only once!
      */

--- a/packages/plugins/__tests__/AsyncPluginsContainer.test.ts
+++ b/packages/plugins/__tests__/AsyncPluginsContainer.test.ts
@@ -1,0 +1,36 @@
+import { AsyncPluginsContainer } from "~/AsyncPluginsContainer";
+import { PluginCollection } from "~/types";
+
+describe("AsyncPluginsContainer", () => {
+    it("should flatten plugins and run plugin loaders", async () => {
+        const pluginsCollection: PluginCollection = [
+            { name: "1", type: "type-1" },
+            () => Promise.resolve({ name: "2", type: "lazy-type-1" }),
+            () =>
+                Promise.resolve([
+                    { name: "3", type: "lazy-type-2" },
+                    { name: "4", type: "lazy-type-3" }
+                ]),
+            { name: "5", type: "type-2" },
+            [
+                { name: "6", type: "type-3" },
+                [{ name: "7", type: "type-4" }, [{ name: "8", type: "type-5" }]]
+            ]
+        ];
+
+        const asyncContainer = new AsyncPluginsContainer(pluginsCollection);
+        const pluginsContainer = await asyncContainer.init();
+        const allPlugins = pluginsContainer.all();
+        expect(allPlugins.length).toBe(8);
+        expect(allPlugins).toEqual([
+            { name: "1", type: "type-1" },
+            { name: "2", type: "lazy-type-1" },
+            { name: "3", type: "lazy-type-2" },
+            { name: "4", type: "lazy-type-3" },
+            { name: "5", type: "type-2" },
+            { name: "6", type: "type-3" },
+            { name: "7", type: "type-4" },
+            { name: "8", type: "type-5" }
+        ]);
+    });
+});

--- a/packages/plugins/src/AsyncPluginsContainer.ts
+++ b/packages/plugins/src/AsyncPluginsContainer.ts
@@ -1,0 +1,42 @@
+import { Plugin, PluginCollection, PluginFactory, PluginsContainer } from "~/types";
+
+const isPluginLoader = (value: unknown): value is PluginFactory => {
+    return typeof value === "function";
+};
+
+export class AsyncPluginsContainer {
+    private readonly plugins: PluginCollection;
+    private pluginsContainer: PluginsContainer | undefined;
+
+    constructor(plugins: PluginCollection | PluginsContainer) {
+        this.plugins = plugins instanceof PluginsContainer ? plugins.all() : plugins;
+    }
+
+    async init() {
+        if (this.pluginsContainer) {
+            return this.pluginsContainer;
+        }
+
+        const plugins = await this.traverseAndLoadPlugins(this.plugins);
+        this.pluginsContainer = new PluginsContainer(plugins);
+
+        return this.pluginsContainer;
+    }
+
+    private async traverseAndLoadPlugins(plugins: Plugin | PluginCollection): Promise<Plugin[]> {
+        if (!Array.isArray(plugins)) {
+            return [plugins];
+        }
+
+        return plugins.reduce<Promise<Plugin[]>>((acc, item) => {
+            return acc.then(async plugins => {
+                if (isPluginLoader(item)) {
+                    const lazyPlugins = await item();
+                    return [...plugins, ...(await this.traverseAndLoadPlugins(lazyPlugins))];
+                }
+
+                return [...plugins, ...(await this.traverseAndLoadPlugins(item))];
+            });
+        }, Promise.resolve([]));
+    }
+}

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -1,6 +1,7 @@
 import { PluginsContainer } from "./PluginsContainer";
+import { AsyncPluginsContainer } from "./AsyncPluginsContainer";
 import { Plugin } from "./Plugin";
 
 const plugins = new PluginsContainer();
 
-export { Plugin, PluginsContainer, plugins };
+export { Plugin, PluginsContainer, plugins, AsyncPluginsContainer };

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -7,4 +7,6 @@ export type Plugin<T = Record<string, any>> = {
     [key: string]: any;
 } & T;
 
-export type PluginCollection = (Plugin | PluginCollection)[];
+export type PluginCollection = (Plugin | PluginFactory | PluginCollection)[];
+
+export type PluginFactory = () => Promise<Plugin | PluginCollection>;


### PR DESCRIPTION
## Changes
This PR adds a new class to the `@webiny/plugins` package, called `AsyncPluginsContainer`. This class has an ability to process registered plugins, detect async plugin factories, and create a sync `PluginsContainer`.

## Why is this useful?
This is most useful in our `graphql` Lambda bundle, which we deploy into various Lambda functions, and we want to apply sets of plugins dynamically, which means, some Lambda functions will have certain plugins loaded, while other Lambda functions won't. A good example of this is our new `Asset Delivery` set of plugins. We want to load transformation plugins only when the bundle is loaded in the `download` Lambda function, but not in the `graphql` Lambda.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
This class is for internal use.

```ts
const asyncContainer = new AsyncPluginsContainer(pluginsCollection);
// Process plugins and create a `PluginsContainer` instance.
const pluginsContainer = await asyncContainer.init();
```