### PR TITLE
fix(app-file-manager): append data to not defined field values

### DIFF
--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.test.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.test.ts
@@ -67,4 +67,146 @@ describe("GraphQLInputMapper", () => {
             field2: "old-field2"
         });
     });
+
+    it("should not OVERRIDE data in case of nullish value", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field-1"
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.OVERRIDE,
+                    value: {
+                        field1: null
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "old-field-1"
+        });
+    });
+
+    it("should not APPEND data in case of nullish value", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field-1"
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.APPEND,
+                    value: {
+                        field1: null
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "old-field-1"
+        });
+    });
+
+    it("should not APPEND data in case of non-array value", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field-1"
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.APPEND,
+                    value: {
+                        field1: "any-string"
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "old-field-1"
+        });
+    });
+
+    it("should APPEND new data to non existing envelope", () => {
+        const data: FileItem["extensions"] = {};
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.APPEND,
+                    value: {
+                        field1: ["new-field1-1", "new-field1-2"]
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: ["new-field1-1", "new-field1-2"]
+        });
+    });
+
+    it("should APPEND new data for fields with nullish value", () => {
+        const data: FileItem["extensions"] = {
+            field1: null
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: OperatorType.APPEND,
+                    value: {
+                        field1: ["new-field1-1", "new-field1-2"]
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: ["new-field1-1", "new-field1-2"]
+        });
+    });
+
+    it("should return existing data in case of invalid operation", () => {
+        const data: FileItem["extensions"] = {
+            field1: "old-field1"
+        };
+
+        const batch: BatchDTO = {
+            operations: [
+                {
+                    field: "field1",
+                    operator: "ANY-OPERATION",
+                    value: {
+                        field1: "new-field1"
+                    }
+                }
+            ]
+        };
+
+        const output = GraphQLInputMapper.toGraphQLExtensions(data, batch);
+
+        expect(output).toEqual({
+            field1: "old-field1"
+        });
+    });
 });

--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/GraphQLInputMapper.ts
@@ -24,9 +24,8 @@ export class GraphQLInputMapper {
                         return;
                     }
 
-                    if (data && data[field]) {
-                        update[field] = [...data[field], ...value[field]];
-                    }
+                    const oldData = (data && data[field]) ?? [];
+                    update[field] = [...oldData, ...value[field]];
 
                     break;
                 default:


### PR DESCRIPTION
## Changes
With this PR we fix a bug found when trying to `APPEND` new values to a field without data via the File Manager -> Bulk Edit.

## How Has This Been Tested?
Jest

## Documentation

### How to replicate the bug: 
- Select one or more files from the File Manager list: the files should not have previously saved data for the field we are trying to update
- Click on the "Edit" action
- Select the field  ->  "Append to existing values" -> Add some values
- Submit the operation


https://github.com/webiny/webiny-js/assets/2866531/e0d985bc-330b-4b6f-9214-ec99e11bba56


