### PR TITLE
Headless CMS - New Meta Fields: Move `CmsPublishEntryOptionsInput` Fields Deprecation Warnings Into a Regular Comment

### DIFF
--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -106,12 +106,17 @@ const createSchema = (plugins: PluginsContainer): GraphQLSchemaPlugin<CmsContext
             }
 
             input CmsPublishEntryOptionsInput {
-                # By default, updatePublishedOn is true. User can set it to false to skip the publishedOn field update.
+                """
+                By default, updatePublishedOn is true. User can set it to false to skip the publishedOn field update.
+                Note that this input field is deprecated and will be removed in one of future releases.
+                """
                 updatePublishedOn: Boolean
-                    @deprecated(reason: "Will be removed in one of future releases.")
-                # By default, updateSavedOn is true. User can set it to false to skip the publishedOn field update.
+
+                """
+                By default, updateSavedOn is true. User can set it to false to skip the savedOn field update.
+                Note that this input field is deprecated and will be removed in one of future releases.
+                """
                 updateSavedOn: Boolean
-                    @deprecated(reason: "Will be removed in one of future releases.")
             }
 
             input CmsIdentityInput {


### PR DESCRIPTION
## Changes
With the intro of new meta fields, via the built-in `@deprecated` directive, we've marked two `CmsPublishEntryOptionsInput` input fields as deprecated. And although this works, when sending a schema introspection query in the API Playground, the backend responds with a response that basically says that the two fields don't exist (check sshot below).

And despite the fact that backend doesn't have issues with this, API Playground doesn't like this, and throws an error.

![image](https://github.com/webiny/webiny-js/assets/5121148/8f161b3f-8685-4006-8a09-2bc67c56e8a6)

In order to quickly fix this, instead of using the `@deprecated` directive with the input fields, I've just added a deprecation message into already existing field comments. It's not the same as if we used the directive, but it works.

![Snipaste_2023-12-28_16-28-14](https://github.com/webiny/webiny-js/assets/5121148/88cc0868-e208-405f-b6f9-bdd9b016e7e6)

We'll additionally highlight this deprecation via release notes, so the deprecation should be prominent enough.

## How Has This Been Tested?
Manual, relying on existing tests.

## Documentation
Changelog/upgrade guide.