### PR TITLE
fix(app-file-manager): prevent bulk edit dialog dismiss

### DIFF
--- a/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
+++ b/packages/app-file-manager/src/components/BulkActions/ActionEdit/BatchEditorDialog/BatchEditorDialog.tsx
@@ -42,7 +42,11 @@ export const BatchEditorDialog = observer((props: BatchEditorDialogProps) => {
     const ref = useRef<FormAPI | null>(null);
 
     return (
-        <DialogContainer open={props.vm.isOpen} onClose={props.onClose}>
+        <DialogContainer
+            open={props.vm.isOpen}
+            onClose={props.onClose}
+            preventOutsideDismiss={true}
+        >
             {props.vm.isOpen ? (
                 <>
                     <DialogTitle>{"Edit items"}</DialogTitle>


### PR DESCRIPTION
## Changes
With this PR, clicking outside the "Bulk edit - dialog" no longer dismisses it.

## How Has This Been Tested?
Manually

## Documentation
### How to replicate the bug:
Register a new extension field that renders a new custom dialog.

- Select one or more files from the File Manager list
- Click on the "Edit" action
- Select the field -> "Override existing values" -> Click to open the new dialog
- Click outside the custom dialog: both the custom dialog and the "Bulk Edit" dialog close.

https://github.com/webiny/webiny-js/assets/2866531/372929c7-89aa-4d25-861d-83a6f6279b7e


