### PR TITLE
Pulumi CLI - Fixed Setting of Pulumi Path in `PATH` Environment Variable 

### DIFF
--- a/packages/pulumi-sdk/src/Pulumi.ts
+++ b/packages/pulumi-sdk/src/Pulumi.ts
@@ -17,6 +17,7 @@ export interface ExecaArgs {
     env?: {
         [key: string]: string | undefined;
     };
+
     [key: string]: any;
 }
 
@@ -53,6 +54,7 @@ export class Pulumi {
     pulumiFolder: string;
     pulumiDownloadFolder: string;
     pulumiBinaryPath: string;
+
     constructor(options: Options = {}) {
         this.options = options;
 
@@ -127,7 +129,7 @@ export class Pulumi {
                  * we need to specify the exact location of our Pulumi binaries, using the PATH environment variable, so it can correctly resolve
                  * plugins necessary for custom resources and dynamic providers to work.
                  */
-                PATH: process.env.PATH + PATH_SEPARATOR + this.pulumiFolder
+                PATH: this.pulumiFolder + PATH_SEPARATOR + process.env.PATH
             }
         };
 


### PR DESCRIPTION
## Changes
With this PR, we're addressing how our custom Pulumi path is added to the `PATH` environment variable. 

Prior to this PR, our custom Pulumi path was appended as the last item in the list. With this PR, we're now prepending it - making it first item in the list.

That way, we're ensuring our custom Pulumi path is read by Pulumi CLI BEFORE any other potential Pulumi-related paths. 

### Why is this important?

When installed globally, Pulumi CLI injects its own paths into the `PATH` env var. And then, when a command is run, Pulumi CLI scans `PATH` for potential locations of Pulumi-related things, for example plugins.

It does this one by one, and, from what I've concluded, it'll take the first one that offers something and stop there.

With our custom Pulumi path being appended instead of prepended, our custom path would not get taken into consideration when Pulumi CLI is also installed globally on user's machine. The ones injected by the Pulumi CLI would.

So, ultimately, be prepending our custom path instead of appending it, we ensure it's always examined before any other potential Pulumi-related paths.



## How Has This Been Tested?
Manual.

## Documentation
Changelog.