### PR TITLE
fix(app-aco): support undefined table cell renderer

### DIFF
--- a/packages/app-aco/src/components/Table/components/Table/Columns/ColumnMapper.ts
+++ b/packages/app-aco/src/components/Table/components/Table/Columns/ColumnMapper.ts
@@ -31,7 +31,7 @@ export class ColumnMapper {
             enableHiding: column.hideable,
             enableResizing: column.resizable,
             enableSorting: column.sortable,
-            cell: (row: T) => cellRenderer(row, column.cell)
+            cell: column.cell ? (row: T) => cellRenderer(row, column.cell) : undefined
         };
     }
 }


### PR DESCRIPTION
## Changes
Developers can now define a new column without specifying the `cell` property. If not specified, the plain data will be shown in the cell.

## How Has This Been Tested?
Manually.

## Documentation

### Example of definition

```tsx
<Browser.Table.Column
    name={"description"}
    header={"Description"}
    // cell={<DescriptionCell />} -> Cell renderer definition: it accepts a React Element or string
/>
```
