### PR TITLE
fix(create-webiny-project): update check for yarn version

### DIFF
--- a/packages/create-webiny-project/bin.js
+++ b/packages/create-webiny-project/bin.js
@@ -4,15 +4,22 @@
 const semver = require("semver");
 const chalk = require("chalk");
 const getYarnVersion = require("./utils/getYarnVersion");
+const getNpmVersion = require("./utils/getNpmVersion");
 const verifyConfig = require("./utils/verifyConfig");
 
 (async () => {
+    const minNodeVersion = "16";
+    const minNpmVersion = "10";
+    const minYarnVersion = "1.22.21";
+    /**
+     * Node
+     */
     const nodeVersion = process.versions.node;
-    if (!semver.satisfies(nodeVersion, ">=14")) {
+    if (!semver.satisfies(nodeVersion, `>=${minNodeVersion}`)) {
         console.error(
             chalk.red(
                 [
-                    `You are running Node.js ${nodeVersion}, but Webiny requires version 14 or higher.`,
+                    `You are running Node.js ${nodeVersion}, but Webiny requires version ${minNodeVersion} or higher.`,
                     `Please switch to one of the required versions and try again.`,
                     "For more information, please visit https://docs.webiny.com/docs/tutorials/install-webiny#prerequisites."
                 ].join(" ")
@@ -20,14 +27,46 @@ const verifyConfig = require("./utils/verifyConfig");
         );
         process.exit(1);
     }
-
+    /**
+     * npm
+     */
     try {
-        const yarnVersion = await getYarnVersion();
-        if (!semver.satisfies(yarnVersion, ">=1.22.0")) {
+        const npmVersion = await getNpmVersion();
+        if (!semver.satisfies(npmVersion, `>=${minNpmVersion}`)) {
             console.error(
                 chalk.red(
                     [
-                        `Webiny requires yarn@^1.22.0 or higher.`,
+                        `Webiny requires npm@^${minNpmVersion} or higher.`,
+                        `Please run ${chalk.green(
+                            "npm install npm@latest -g"
+                        )}, to get the latest version.`
+                    ].join("\n")
+                )
+            );
+            process.exit(1);
+        }
+    } catch (err) {
+        console.error(chalk.red(`Webiny depends on "npm".`));
+
+        console.log(
+            `Please visit https://docs.npmjs.com/try-the-latest-stable-version-of-npm to install ${chalk.green(
+                "npm"
+            )}.`
+        );
+
+        process.exit(1);
+    }
+
+    /**
+     * yarn
+     */
+    try {
+        const yarnVersion = await getYarnVersion();
+        if (!semver.satisfies(yarnVersion, `>=${minYarnVersion}`)) {
+            console.error(
+                chalk.red(
+                    [
+                        `Webiny requires yarn@^${minYarnVersion} or higher.`,
                         `Please visit https://yarnpkg.com/ to install ${chalk.green("yarn")}.`
                     ].join("\n")
                 )

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -272,6 +272,18 @@ module.exports = async function createProject({
         const node = process.versions.node;
         const os = process.platform;
 
+        let npm = NOT_APPLICABLE;
+        try {
+            const subprocess = await execa("npm", ["--version"], { cwd: projectRoot });
+            npm = subprocess.stdout;
+        } catch {}
+
+        let npx = NOT_APPLICABLE;
+        try {
+            const subprocess = await execa("npx", ["--version"], { cwd: projectRoot });
+            npx = subprocess.stdout;
+        } catch {}
+
         let yarn = NOT_APPLICABLE;
         try {
             const subprocess = await execa("yarn", ["--version"], { cwd: projectRoot });
@@ -312,6 +324,8 @@ module.exports = async function createProject({
                 `Operating System: ${os}`,
                 `Node: ${node}`,
                 `Yarn: ${yarn}`,
+                `Npm: ${npm}`,
+                `Npx: ${npx}`,
                 `create-webiny-project: ${cwp}`,
                 `Template: ${cwpTemplate}`,
                 `Template Options: ${templateOptionsJson}`,

--- a/packages/create-webiny-project/utils/getNpmVersion.js
+++ b/packages/create-webiny-project/utils/getNpmVersion.js
@@ -1,0 +1,10 @@
+const execa = require("execa");
+
+module.exports = async () => {
+    try {
+        const { stdout } = await execa("npm", ["--version"]);
+        return stdout;
+    } catch (err) {
+        return "";
+    }
+};


### PR DESCRIPTION
## Changes
This PR updates check for yarn version.
It also includes checks for npm version and, when install fails, outputs npm and npx versions into the console.

## Yarn version error
```bash
npx create-webiny-project@5.38.3-local cwp-testing --tag 5.38.3-local --assign-to-yarnrc '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}' --template-options '{"region":"eu-central-1","vpc":false}'
Need to install the following packages:
create-webiny-project@5.38.3-local
Ok to proceed? (y) y
Webiny requires yarn@^1.22.21 or higher.
Please visit https://yarnpkg.com/ to install yarn.
```