### PR TITLE
fix(tasks): wrong position of the error in the log items array

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/indexing/objectIndexing.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/plugins/elasticsearch/indexing/objectIndexing.test.ts
@@ -160,6 +160,7 @@ const expectedRawValue = {
         }
     ],
     settingsStorageId: {
+        optionsStorageId: [{}, {}],
         snippetStorageId: [
             {
                 tag: "p",

--- a/packages/api-headless-cms-ddb-es/src/elasticsearch/indexing/objectIndexing.ts
+++ b/packages/api-headless-cms-ddb-es/src/elasticsearch/indexing/objectIndexing.ts
@@ -178,13 +178,9 @@ export default (): CmsModelFieldToElasticsearchPlugin => ({
                     plugins,
                     fields
                 });
-                if (Object.keys(value).length > 0) {
-                    result.value.push(value);
-                }
 
-                if (Object.keys(rawValue).length > 0) {
-                    result.rawValue.push(rawValue);
-                }
+                result.value.push(value);
+                result.rawValue.push(rawValue);
             }
 
             return {

--- a/packages/tasks/__tests__/graphql/logs.test.ts
+++ b/packages/tasks/__tests__/graphql/logs.test.ts
@@ -62,7 +62,7 @@ describe("graphql - logs", () => {
         });
 
         const log2Item = {
-            message: "someMessage",
+            message: "Log 2 item message",
             type: ITaskLogItemType.INFO,
             createdOn: new Date().toISOString()
         };
@@ -71,7 +71,7 @@ describe("graphql - logs", () => {
         });
 
         const log3Item = {
-            message: "someMessage #2",
+            message: "log 3 item message",
             type: ITaskLogItemType.INFO,
             createdOn: new Date().toISOString()
         };
@@ -81,14 +81,14 @@ describe("graphql - logs", () => {
         });
 
         const log4Item = {
-            message: "someMessage",
+            message: "log 4 item message",
             type: ITaskLogItemType.ERROR,
             createdOn: new Date().toISOString(),
             error: {
-                message: "someErrorMessage",
-                code: "SOME_ERROR_CODE",
+                message: "log 4 item error message",
+                code: "log4ItemErrorCode",
                 data: {
-                    someData: "someData"
+                    someData: "log4data"
                 }
             }
         };

--- a/packages/tasks/src/crud/model.ts
+++ b/packages/tasks/src/crud/model.ts
@@ -238,6 +238,10 @@ const taskModelPlugin = createCmsModel({
                     {
                         value: TaskDataStatus.SUCCESS,
                         label: "Success"
+                    },
+                    {
+                        value: TaskDataStatus.ABORTED,
+                        label: "Aborted"
                     }
                 ]
             },


### PR DESCRIPTION
## Changes
When having an error in the log items array, on the array index 2, and not array index 0 or 1, error is pushed to array index 1 due to a bug in object indexing plugin. This only affected Elasticsearch systems.

## How Has This Been Tested?
Jest and manually.