### PR TITLE
fix(api-headless-cms): import models to existing group if matched by id

### DIFF
--- a/packages/api-headless-cms/src/export/crud/imports/importData.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/importData.ts
@@ -20,18 +20,48 @@ interface Response {
     error?: string;
 }
 
+interface GetGroupParams {
+    validated: ValidCmsGroupResult[];
+    imported: CmsGroupImportResult[];
+    target: string;
+}
+
+const getGroup = (params: GetGroupParams) => {
+    const { validated, imported, target } = params;
+    const group = imported.find(group => {
+        return group.group.id === target;
+    });
+    if (group) {
+        return group.group.id;
+    }
+    const validatedGroup = validated.find(group => {
+        return group.group.id === target || group.target === target;
+    });
+    return validatedGroup?.target || validatedGroup?.group.id;
+};
+
 export const importData = async (params: Params): Promise<Response> => {
     const { context } = params;
 
     const groups = await importGroups(params);
 
-    const importModelResults = await importModels({
+    const models = await importModels({
         context,
-        models: params.models
+        models: params.models.map(model => {
+            const group = getGroup({
+                validated: params.groups,
+                imported: groups,
+                target: model.model.group
+            });
+            return {
+                ...model,
+                group: group || model.model.group
+            };
+        })
     });
 
     return {
         groups,
-        models: importModelResults
+        models
     };
 };

--- a/packages/api-headless-cms/src/export/crud/imports/validateGroups.ts
+++ b/packages/api-headless-cms/src/export/crud/imports/validateGroups.ts
@@ -89,15 +89,21 @@ export const validateGroups = async (params: Params): Promise<ValidatedCmsGroupR
                 };
             }
 
-            const groupWithSlugExists = groups.some(g => g.slug === data.slug);
+            const groupWithSlugExists = groups.find(g => g.slug === data.slug);
             if (groupWithSlugExists) {
+                /**
+                 * If group with given slug already exists, we will map the ID to the existing group.
+                 *
+                 * We will also point all models from the imported group to the existing group.
+                 * We will not update the existing group.
+                 */
                 return {
-                    group: data,
-                    action: CmsImportAction.NONE,
-                    error: {
-                        message: `Group with slug "${data.slug}" already exists. Cannot update because the ID is different.`,
-                        code: "GROUP_SLUG_EXISTS"
-                    }
+                    group: {
+                        ...data,
+                        id: groupWithSlugExists.id
+                    },
+                    target: data.id,
+                    action: CmsImportAction.NONE
                 };
             }
 

--- a/packages/api-headless-cms/src/export/types.ts
+++ b/packages/api-headless-cms/src/export/types.ts
@@ -99,12 +99,14 @@ export interface HeadlessCmsImportStructure {
 export interface ValidCmsGroupResult {
     group: CmsGroup;
     action: CmsImportAction;
+    target?: string;
     error?: never;
 }
 
 export interface InvalidCmsGroupResult {
     group: CmsGroup;
     action: CmsImportAction;
+    target?: never;
     error: CmsImportError;
 }
 

--- a/packages/app-headless-cms-common/src/types/model.ts
+++ b/packages/app-headless-cms-common/src/types/model.ts
@@ -65,7 +65,7 @@ export interface CmsGroup {
     id: string;
     name: string;
     slug: string;
-    icon?: string;
+    icon: string;
     description?: string;
     contentModels: CmsModel[];
     createdBy: CmsIdentity;

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
@@ -3,6 +3,9 @@ import { useApolloClient } from "~/admin/hooks";
 import {
     IMPORT_STRUCTURE,
     ImportStructureResponse,
+    ImportStructureVariables,
+    ImportStructureVariablesGroup,
+    ImportStructureVariablesModel,
     VALIDATE_IMPORT_STRUCTURE,
     ValidateImportStructureResponse
 } from "~/admin/views/contentModels/importing/graphql";
@@ -140,11 +143,16 @@ const createSelected = (params: CreateSelectedParams): Selected => {
     return selected;
 };
 
-const getDataToImport = (state: State) => {
+interface DataToImportResult {
+    groups: ImportStructureVariablesGroup[];
+    models: ImportStructureVariablesModel[];
+}
+
+const getDataToImport = (state: State): DataToImportResult => {
     const selected = Array.from(state.selected.keys());
 
-    const groups: Map<string, CmsGroup> = new Map();
-    const models: Map<string, CmsModel> = new Map();
+    const groups: Map<string, ImportStructureVariablesGroup> = new Map();
+    const models: Map<string, ImportStructureVariablesModel> = new Map();
     const noAction = [ImportAction.CODE, ImportAction.NONE];
 
     for (const id of selected) {
@@ -156,21 +164,28 @@ const getDataToImport = (state: State) => {
         ) {
             continue;
         }
+        const validatedGroup = state.groups?.find(group => group.id === validatedModel.group);
+        if (!validatedGroup?.action || validatedGroup.error) {
+            continue;
+        }
 
         const model = state.data?.models?.find(model => model.modelId === id);
         if (!model) {
             continue;
         }
-        models.set(id, model);
+        models.set(id, {
+            ...model,
+            layout: model.layout || [],
+            titleFieldId: model.titleFieldId || "id",
+            descriptionFieldId: model.descriptionFieldId || "",
+            imageFieldId: model.imageFieldId || "",
+            group: validatedModel.group
+        });
 
-        const validatedGroup = state.groups?.find(group => group.id === validatedModel.group);
-        if (
-            !validatedGroup?.action ||
-            validatedGroup.error ||
-            noAction.includes(validatedGroup.action)
-        ) {
+        if (noAction.includes(validatedGroup.action)) {
             continue;
         }
+
         const group = state.data?.groups?.find(group => group.id === validatedModel.group);
         if (!group) {
             continue;
@@ -259,7 +274,7 @@ export const ImportContextProvider = ({ children }: ImportContextProviderProps) 
             return;
         }
         setState(prev => {
-            return {
+            const next = {
                 ...prev,
                 loading: false,
                 groups: data.groups.map(group => {
@@ -282,6 +297,8 @@ export const ImportContextProvider = ({ children }: ImportContextProviderProps) 
                 }),
                 validated: true
             };
+            console.log(JSON.parse(JSON.stringify({ prev, next })));
+            return next;
         });
     }, [state.data, setState]);
 
@@ -310,7 +327,7 @@ export const ImportContextProvider = ({ children }: ImportContextProviderProps) 
 
         let result: FetchResult<ImportStructureResponse> | undefined;
         try {
-            result = await client.mutate<ImportStructureResponse>({
+            result = await client.mutate<ImportStructureResponse, ImportStructureVariables>({
                 mutation: IMPORT_STRUCTURE,
                 variables: {
                     data: dataToImport

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/ImportContext.tsx
@@ -297,7 +297,6 @@ export const ImportContextProvider = ({ children }: ImportContextProviderProps) 
                 }),
                 validated: true
             };
-            console.log(JSON.parse(JSON.stringify({ prev, next })));
             return next;
         });
     }, [state.data, setState]);

--- a/packages/app-headless-cms/src/admin/views/contentModels/importing/graphql.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/importing/graphql.ts
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { CmsErrorResponse } from "@webiny/app-headless-cms-common/types";
+import { CmsErrorResponse, CmsModelField } from "@webiny/app-headless-cms-common/types";
 import { ImportAction, ValidatedCmsGroup, ValidatedCmsModel } from "./types";
 
 const ERROR = /* GraphQL */ `
@@ -52,6 +52,37 @@ export const VALIDATE_IMPORT_STRUCTURE = gql`
     }
 `;
 
+export interface ImportStructureVariablesGroup {
+    id: string;
+    name: string;
+    slug?: string;
+    description?: string;
+    icon: string;
+}
+
+export interface ImportStructureVariablesModel {
+    name: string;
+    singularApiName: string;
+    pluralApiName: string;
+    modelId: string;
+    group: string;
+    icon?: string;
+    description?: string;
+    layout: string[][];
+    fields: CmsModelField[];
+    titleFieldId: string;
+    descriptionFieldId?: string;
+    imageFieldId?: string;
+    tags?: string[];
+}
+
+export interface ImportStructureVariables {
+    data: {
+        groups: ImportStructureVariablesGroup[];
+        models: ImportStructureVariablesModel[];
+    };
+}
+
 export interface ImportStructureResponseDataGroup {
     group: {
         id: string;
@@ -79,6 +110,7 @@ export interface ImportStructureResponseData {
     models: ImportStructureResponseDataModel[];
     message: string;
 }
+
 export interface ImportStructureResponse {
     importStructure: {
         data: ImportStructureResponseData | null;


### PR DESCRIPTION
## Changes
When importing a model, which has a group with existing slug, put that model into the existing group.

## How Has This Been Tested?
Manually.