### PR TITLE
fix(api-headless-cms-ddb): find breaks on null value

### DIFF
--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/getValue.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/getValue.ts
@@ -16,10 +16,12 @@ const find = (target: Record<string, any>, input: string[]): any[] | undefined =
 
     if (!path) {
         return undefined;
-    } else if (target[path] === undefined) {
+    }
+
+    const value = target[path];
+    if (value === undefined || value === null) {
         return undefined;
     }
-    const value = target[path];
     if (paths.length === 0) {
         return value;
     } else if (Array.isArray(value)) {

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/getValue.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/getValue.ts
@@ -10,7 +10,7 @@ const addArrayResult = (target: any[], result: any[]): void => {
  * A recursive function which goes through given input paths and returns the value in it.
  * In case a path is an array, it goes through the array of those values to get values further down the path line.
  */
-const find = (target: Record<string, any>, input: string[]): any[] | undefined => {
+const find = (target: Record<string, any> | undefined, input: string[]): any[] | undefined => {
     const paths = [...input];
     const path = paths.shift();
 
@@ -18,8 +18,8 @@ const find = (target: Record<string, any>, input: string[]): any[] | undefined =
         return undefined;
     }
 
-    const value = target[path];
-    if (value === undefined || value === null) {
+    const value = target?.[path];
+    if (value === undefined) {
         return undefined;
     }
     if (paths.length === 0) {


### PR DESCRIPTION
## Changes
In DynamoDB systems, when doing a comparison on a null value in the CMS Entry, code broke due to not checking for null value.

## How Has This Been Tested?
Jest and manually.