### PR TITLE
fix(api-file-manager-s3): create metadata on batch file creation

### DIFF
--- a/packages/api-file-manager-s3/src/plugins/addFileMetadata.ts
+++ b/packages/api-file-manager-s3/src/plugins/addFileMetadata.ts
@@ -1,27 +1,63 @@
 import { S3 } from "@webiny/aws-sdk/client-s3";
 import { ContextPlugin } from "@webiny/api";
-import { FileManagerContext } from "@webiny/api-file-manager/types";
+import { FileManagerContext, File } from "@webiny/api-file-manager/types";
+import { executeWithRetry } from "@webiny/utils";
+
+export class MetadataWriter {
+    private readonly bucket: string;
+
+    constructor(bucket: string) {
+        this.bucket = bucket;
+    }
+
+    async write(files: File[]) {
+        const s3 = this.getS3();
+
+        /**
+         * We need to write each file with retry.
+         */
+        const writers = files.map(file => {
+            const writer = () => {
+                return s3.putObject({
+                    Bucket: this.bucket,
+                    Key: `${file.key}.metadata`,
+                    Body: JSON.stringify(this.getMetadata(file)),
+                    ContentType: "application/json",
+                    CacheControl: "max-age=31536000"
+                });
+            };
+
+            return executeWithRetry(writer);
+        });
+
+        await Promise.all(writers);
+    }
+
+    private getS3() {
+        return new S3({ region: process.env.AWS_REGION });
+    }
+
+    private getMetadata(file: File) {
+        return {
+            id: file.id,
+            tenant: file.tenant,
+            locale: file.locale,
+            size: file.size,
+            contentType: file.type
+        };
+    }
+}
 
 export const addFileMetadata = () => {
     return new ContextPlugin<FileManagerContext>(context => {
-        context.fileManager.onFileAfterCreate.subscribe(async ({ file }) => {
-            const metadata = {
-                id: file.id,
-                tenant: file.tenant,
-                locale: file.locale,
-                size: file.size,
-                contentType: file.type
-            };
+        const metadataWriter = new MetadataWriter(String(process.env.S3_BUCKET));
 
-            const s3 = new S3({ region: process.env.AWS_REGION });
+        context.fileManager.onFileAfterCreate.subscribe(({ file }) => {
+            return metadataWriter.write([file]);
+        });
 
-            await s3.putObject({
-                Bucket: String(process.env.S3_BUCKET),
-                Key: `${file.key}.metadata`,
-                Body: JSON.stringify(metadata),
-                ContentType: "application/json",
-                CacheControl: "max-age=31536000"
-            });
+        context.fileManager.onFileAfterBatchCreate.subscribe(({ files }) => {
+            return metadataWriter.write(files);
         });
     });
 };


### PR DESCRIPTION
## Changes
This PR adds metadata creation to bulk file creation. The original implementation only subscribed to `onFileAfterCreate`, which worked fine for files created one by one, via the FM UI. But on import/export of pages/blocks, the metadata was not created for imported files. We now also subscribe to `onFileAfterBatchCreate`.

## How Has This Been Tested?
Manually.