### PR TITLE
fix(app-aco): minor ACO table fixes

### DIFF
--- a/packages/app-aco/src/components/Table/components/Table/Columns/ColumnsRepository.ts
+++ b/packages/app-aco/src/components/Table/components/Table/Columns/ColumnsRepository.ts
@@ -11,10 +11,16 @@ export class ColumnsRepository implements IColumnsRepository {
     }
 
     getColumns(): ColumnDTO[] {
-        return this.columns;
+        return this.sortColumns(this.columns);
     }
 
     init(): Promise<void> {
         return Promise.resolve();
+    }
+
+    private sortColumns(columns: ColumnDTO[]) {
+        return columns
+            .slice()
+            .sort((a, b) => (a.name === "actions" ? 1 : b.name === "actions" ? -1 : 0));
     }
 }

--- a/packages/app-aco/src/components/Table/components/Table/TableInner.tsx
+++ b/packages/app-aco/src/components/Table/components/Table/TableInner.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { Columns, DataTable, DefaultData, OnSortingChange, Sorting } from "@webiny/ui/DataTable";
-import { ColumnsPresenter, ColumnMapper } from "./Columns";
+import { ColumnMapper, ColumnsPresenter } from "./Columns";
 import { ColumnsVisibilityPresenter, ColumnsVisibilityUpdater } from "./ColumnVisibility";
 import { TablePresenter } from "./TablePresenter";
 import { TableRowProvider } from "~/components";
@@ -36,9 +36,11 @@ export const TableInner = observer(
 
         const columns = useMemo(() => {
             return props.columnsPresenter.vm.columns.reduce((result, column) => {
+                const { nameColumnId = "name" } = props;
                 const { name: defaultName } = column;
 
-                const name = defaultName === "name" ? props.nameColumnId : defaultName;
+                // Determine the column name, using the provided `nameColumnId` if the default is 'name'
+                const name = defaultName === "name" ? nameColumnId : defaultName;
 
                 result[name as keyof Columns<T>] = ColumnMapper.toDataTable(column, cellRenderer);
 


### PR DESCRIPTION
## Changes
With this PR, we fix a couple of minor issues found on the ACO table:

- making sure the `actions` column is always the last in the table
- sorting entries in the file manager by `name` throws an error; this has been fixed.

## How Has This Been Tested?
Manually
