### PR TITLE
Skip Authorization When Loading `profile` GraphQL Field

### DIFF
--- a/packages/api-admin-users/src/graphql/user.gql.ts
+++ b/packages/api-admin-users/src/graphql/user.gql.ts
@@ -66,8 +66,10 @@ export default (params: CreateUserGraphQlPluginsParams) => {
             resolvers: {
                 AdminUserIdentity: {
                     async profile(identity, _, context) {
-                        const adminUser = await context.adminUsers.getUser({
-                            where: { id: identity.id }
+                        const adminUser = await context.security.withoutAuthorization(async () => {
+                            return context.adminUsers.getUser({
+                                where: { id: identity.id }
+                            });
                         });
 
                         if (adminUser) {
@@ -78,17 +80,19 @@ export default (params: CreateUserGraphQlPluginsParams) => {
                         // a "parent" tenant user, so naturally, his user profile lives in his original tenant.
                         const tenant = context.tenancy.getCurrentTenant();
 
-                        return await context.adminUsers.getUser({
-                            where: {
-                                id: identity.id,
-                                /**
-                                 * TODO @ts-refactor @pavel
-                                 * What happens if tenant has no parent?
-                                 * Or is the getUser.where.tenant optional parameter? In that case, remove comments and make tenant param optional
-                                 */
-                                // @ts-expect-error
-                                tenant: tenant.parent
-                            }
+                        return context.security.withoutAuthorization(async () => {
+                            return context.adminUsers.getUser({
+                                where: {
+                                    id: identity.id,
+                                    /**
+                                     * TODO @ts-refactor @pavel
+                                     * What happens if tenant has no parent?
+                                     * Or is the getUser.where.tenant optional parameter? In that case, remove comments and make tenant param optional
+                                     */
+                                    // @ts-expect-error
+                                    tenant: tenant.parent
+                                }
+                            });
                         });
                     },
                     __isTypeOf(obj: SecurityIdentity) {


### PR DESCRIPTION
## Changes
If a user did not have access to the Admin Users module, the loading of the currently logged-in admin user within the `profile` GraphQL resolver / within the initial `Login` GraphQL query would fail. 

More specifically, the `Not Authorized` error would be thrown, simply because within the resolver, a `context.adminUsers.getUser` is being made, which requires the user to have access to the mention Admin Users module.

In order to resolve this, we are calling the method within the `withoutAuthorization` callback. No need to perform authorization, because we want to be able to load the profile, no matter if the user has access to Admin Users module or not.

## How Has This Been Tested?
Manual. Relying on existing tests.

## Documentation
Changelog.