### PR TITLE
feat(app-page-builder): store active tab index into localStorage

### DIFF
--- a/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from "react";
 import styled from "@emotion/styled";
 import { css } from "emotion";
+import store from "store";
 import { makeComposable } from "@webiny/app-admin";
 import { Elevation } from "@webiny/ui/Elevation";
 import { Tabs, Tab, TabProps } from "@webiny/ui/Tabs";
@@ -12,6 +13,8 @@ import StyleSettingsTabContent from "./Sidebar/StyleSettingsTabContent";
 import ElementSettingsTabContent from "./Sidebar/ElementSettingsTabContent";
 import { useActiveElement } from "~/editor/hooks/useActiveElement";
 import { useElementSidebar } from "~/editor/hooks/useElementSidebar";
+
+const LOCAL_STORAGE_KEY = "webiny_pb_editor_active_tab";
 
 const rightSideBar = css({
     boxShadow: "1px 0px 5px 0px rgba(128,128,128,1)",
@@ -46,8 +49,13 @@ export const EditorSidebar = React.memo(() => {
     const [element] = useActiveElement();
     const [sidebar, setSidebar] = useElementSidebar();
 
+    const getActiveTabIndex = useCallback(() => {
+        return store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex);
+    }, []);
+
     const setActiveTabIndex = useCallback(index => {
         setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, index));
+        store.set(LOCAL_STORAGE_KEY, index);
     }, []);
 
     const unhighlightElementTab = useCallback(() => {
@@ -62,7 +70,7 @@ export const EditorSidebar = React.memo(() => {
 
     return (
         <Elevation z={1} className={rightSideBar}>
-            <Tabs value={sidebar.activeTabIndex} updateValue={setActiveTabIndex}>
+            <Tabs value={getActiveTabIndex()} updateValue={setActiveTabIndex}>
                 <EditorSidebarTab label={"Style"}>
                     <StyleSettingsTabContent />
                 </EditorSidebarTab>


### PR DESCRIPTION
## Changes
With the following PR, we save the active element tab index into `localStorage`, so the last visited tab will remain active even after clicking on the different page elements.

CLOSE [WEB-3479](https://webiny.atlassian.net/browse/WEB-3479)


https://github.com/webiny/webiny-js/assets/2866531/1a714eb9-57f9-45cd-a8ae-5c123ea0c131



## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually

