### PR TITLE
fix(api-headless-cms): always assign api name to plugin models

### DIFF
--- a/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
@@ -144,13 +144,17 @@ export class CmsModelPlugin extends Plugin {
 
             return {
                 ...modelPlugin,
-                ...input
+                ...input,
+                pluralApiName,
+                singularApiName
             };
         }
 
         const model: CmsModelPluginModel = {
             ...modelPlugin,
             ...input,
+            pluralApiName,
+            singularApiName,
             fields: this.buildFields(input, input.fields)
         };
         this.validateLayout(model);


### PR DESCRIPTION
## Changes
Fix an issue where `singularApiName` and `pluralApiName` were not assigned properly when creating a model via plugin.

## How Has This Been Tested?
Manually.
