### PR TITLE
fix(api-aco): meta fields update inside the ACO table

### DIFF
--- a/packages/api-aco/src/filter/filter.so.ts
+++ b/packages/api-aco/src/filter/filter.so.ts
@@ -59,6 +59,10 @@ export const createFilterOperations = (
                 const original = await cms.getEntryById(model, id);
 
                 const input = {
+                    /**
+                     *  We are omitting the standard entry meta fields:
+                     *  we don't want to override them with the ones coming from the `original` entry.
+                     */
                     ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };

--- a/packages/api-aco/src/filter/filter.so.ts
+++ b/packages/api-aco/src/filter/filter.so.ts
@@ -1,3 +1,4 @@
+import omit from "lodash/omit";
 import WebinyError from "@webiny/error";
 import { FILTER_MODEL_ID } from "./filter.model";
 import { CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
@@ -5,6 +6,7 @@ import { createListSort } from "~/utils/createListSort";
 import { createOperationsWrapper } from "~/utils/createOperationsWrapper";
 import { pickEntryFieldValues } from "~/utils/pickEntryFieldValues";
 import { AcoFilterStorageOperations, Filter } from "./filter.types";
+import { ENTRY_META_FIELDS } from "@webiny/api-headless-cms/constants";
 
 export const createFilterOperations = (
     params: CreateAcoStorageOperationsParams
@@ -57,7 +59,7 @@ export const createFilterOperations = (
                 const original = await cms.getEntryById(model, id);
 
                 const input = {
-                    ...original,
+                    ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };
 

--- a/packages/api-aco/src/folder/folder.so.ts
+++ b/packages/api-aco/src/folder/folder.so.ts
@@ -137,6 +137,10 @@ export const createFolderOperations = (
                 });
 
                 const input = {
+                    /**
+                     *  We are omitting the standard entry meta fields:
+                     *  we don't want to override them with the ones coming from the `original` entry.
+                     */
                     ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };

--- a/packages/api-aco/src/folder/folder.so.ts
+++ b/packages/api-aco/src/folder/folder.so.ts
@@ -1,3 +1,4 @@
+import omit from "lodash/omit";
 import WebinyError from "@webiny/error";
 import { FOLDER_MODEL_ID } from "./folder.model";
 import { CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
@@ -5,6 +6,7 @@ import { createListSort } from "~/utils/createListSort";
 import { createOperationsWrapper } from "~/utils/createOperationsWrapper";
 import { pickEntryFieldValues } from "~/utils/pickEntryFieldValues";
 import { AcoFolderStorageOperations, Folder } from "./folder.types";
+import { ENTRY_META_FIELDS } from "@webiny/api-headless-cms/constants";
 
 interface AcoCheckExistingFolderParams {
     params: {
@@ -135,7 +137,7 @@ export const createFolderOperations = (
                 });
 
                 const input = {
-                    ...original,
+                    ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };
 

--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -1,3 +1,4 @@
+import omit from "lodash/omit";
 import WebinyError from "@webiny/error";
 import { CreateAcoStorageOperationsParams } from "~/createAcoStorageOperations";
 import { pickEntryFieldValues } from "~/utils/pickEntryFieldValues";
@@ -5,6 +6,7 @@ import { AcoSearchRecordStorageOperations, SearchRecord } from "./record.types";
 import { CmsModel, UpdateCmsEntryInput } from "@webiny/api-headless-cms/types";
 import { attachAcoRecordPrefix } from "~/utils/acoRecordId";
 import { SEARCH_RECORD_MODEL_ID } from "~/record/record.model";
+import { ENTRY_META_FIELDS } from "@webiny/api-headless-cms/constants";
 
 export const createSearchRecordOperations = (
     params: CreateAcoStorageOperationsParams
@@ -97,7 +99,7 @@ export const createSearchRecordOperations = (
                 const original = await this.getRecord(model, { id });
 
                 const input = {
-                    ...original,
+                    ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };
 

--- a/packages/api-aco/src/record/record.so.ts
+++ b/packages/api-aco/src/record/record.so.ts
@@ -99,6 +99,10 @@ export const createSearchRecordOperations = (
                 const original = await this.getRecord(model, { id });
 
                 const input = {
+                    /**
+                     *  We are omitting the standard entry meta fields:
+                     *  we don't want to override them with the ones coming from the `original` entry.
+                     */
                     ...omit(original, ENTRY_META_FIELDS),
                     ...data
                 };

--- a/packages/app-headless-cms-common/src/entries.graphql.ts
+++ b/packages/app-headless-cms-common/src/entries.graphql.ts
@@ -399,8 +399,8 @@ export const createPublishMutation = (model: CmsEditorContentModel) => {
         mutation CmsPublish${model.singularApiName}($revision: ID!) {
             content: publish${model.singularApiName}(revision: $revision) {
                 data {
-                    id
-                    ${CONTENT_META_FIELDS}
+                    ${CONTENT_ENTRY_SYSTEM_FIELDS}
+                    ${createFieldsList({ model, fields: model.fields })}
                 }
                 error ${ERROR_FIELD}
             }
@@ -426,9 +426,9 @@ export const createUnpublishMutation = (model: CmsEditorContentModel) => {
     return gql`
         mutation CmsUnpublish${model.singularApiName}($revision: ID!) {
             content: unpublish${model.singularApiName}(revision: $revision) {
-                data {
-                    id
-                    ${CONTENT_META_FIELDS}
+                 data {
+                    ${CONTENT_ENTRY_SYSTEM_FIELDS}
+                    ${createFieldsList({ model, fields: model.fields })}
                 }
                 error ${ERROR_FIELD}
             }


### PR DESCRIPTION
## Changes
With this PR, we fixed two bugs that occurred on the ACO table:

- when an ACO entry is updated, the `savedOn` field (as well as other meta fields) is overwritten
- when an HCMS entry is published/unpublished, the `Modified` column value is not updated

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Jest

