### PR TITLE
fix: various aco react properties definitions

### DIFF
--- a/packages/app-aco/src/config/table/Column.tsx
+++ b/packages/app-aco/src/config/table/Column.tsx
@@ -40,7 +40,7 @@ const BaseColumn: React.FC<ColumnProps> = ({
     name,
     remove = false,
     resizable = true,
-    size = 200,
+    size = 100,
     sortable = false,
     visible = true
 }) => {
@@ -68,7 +68,7 @@ const BaseColumn: React.FC<ColumnProps> = ({
                 {header ? (
                     <Property id={getId(name, "header")} name={"header"} value={header} />
                 ) : null}
-                {cell ? <Property id={getId(name, "element")} name={"cell"} value={cell} /> : null}
+                {cell ? <Property id={getId(name, "cell")} name={"cell"} value={cell} /> : null}
                 {className ? (
                     <Property id={getId(name, "className")} name={"className"} value={className} />
                 ) : null}

--- a/packages/app-file-manager/src/components/Table/Actions/CopyFile.tsx
+++ b/packages/app-file-manager/src/components/Table/Actions/CopyFile.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Copy } from "@material-design-icons/svg/outlined/content_copy.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig";
 import { useCopyFile } from "~/hooks/useCopyFile";
 import { useFile } from "~/hooks/useFile";
 
 export const CopyFile = () => {
     const { file } = useFile();
     const { copyFileUrl } = useCopyFile({ file });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = FileManagerViewConfig.Browser.FileAction;
 
     return (
         <OptionsMenuItem

--- a/packages/app-file-manager/src/components/Table/Actions/DeleteFile.tsx
+++ b/packages/app-file-manager/src/components/Table/Actions/DeleteFile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ReactComponent as Delete } from "@material-design-icons/svg/outlined/delete.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig";
 import { useFileManagerApi } from "~/modules/FileManagerApiProvider/FileManagerApiContext";
 import { useDeleteFile } from "~/hooks/useDeleteFile";
 import { useFile } from "~/hooks/useFile";
@@ -11,7 +11,7 @@ export const DeleteFile = () => {
     const { openDialogDeleteFile } = useDeleteFile({
         file
     });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = FileManagerViewConfig.Browser.FileAction;
 
     if (!canDelete(file)) {
         return null;

--- a/packages/app-file-manager/src/components/Table/Actions/EditFile.tsx
+++ b/packages/app-file-manager/src/components/Table/Actions/EditFile.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Edit } from "@material-design-icons/svg/outlined/edit.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig";
 import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerViewProvider";
 import { useFile } from "~/hooks/useFile";
 
 export const EditFile = () => {
     const { file } = useFile();
     const { showFileDetails } = useFileManagerView();
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = FileManagerViewConfig.Browser.FileAction;
 
     return (
         <OptionsMenuItem

--- a/packages/app-file-manager/src/components/Table/Actions/MoveFile.tsx
+++ b/packages/app-file-manager/src/components/Table/Actions/MoveFile.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Move } from "@material-design-icons/svg/outlined/drive_file_move.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { FileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig";
 import { useFile } from "~/hooks/useFile";
 import { useMoveFileToFolder } from "~/hooks/useMoveFileToFolder";
 
 export const MoveFile = () => {
     const { file } = useFile();
     const moveFileToFolder = useMoveFileToFolder(file);
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = FileManagerViewConfig.Browser.FileAction;
 
     return (
         <OptionsMenuItem

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FileAction.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FileAction.tsx
@@ -8,7 +8,7 @@ export { RecordActionConfig as FileActionConfig };
 
 type FileActionProps = React.ComponentProps<typeof AcoConfig.Record.Action>;
 
-export const FileAction = (props: FileActionProps) => {
+const BaseFileAction = (props: FileActionProps) => {
     return (
         <CompositionScope name={"fm"}>
             <AcoConfig>
@@ -17,3 +17,8 @@ export const FileAction = (props: FileActionProps) => {
         </CompositionScope>
     );
 };
+
+export const FileAction = Object.assign(BaseFileAction, {
+    OptionsMenuItem: Record.Action.OptionsMenuItem,
+    OptionsMenuLink: Record.Action.OptionsMenuLink
+});

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FolderAction.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FolderAction.tsx
@@ -8,7 +8,7 @@ export { FolderActionConfig };
 
 type FolderActionProps = React.ComponentProps<typeof AcoConfig.Folder.Action>;
 
-export const FolderAction = (props: FolderActionProps) => {
+const BaseFolderAction = (props: FolderActionProps) => {
     return (
         <CompositionScope name={"fm"}>
             <AcoConfig>
@@ -17,3 +17,7 @@ export const FolderAction = (props: FolderActionProps) => {
         </CompositionScope>
     );
 };
+
+export const FolderAction = Object.assign(BaseFolderAction, {
+    OptionsMenuItem: Folder.Action.OptionsMenuItem
+});

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/index.tsx
@@ -45,7 +45,7 @@ export const FileManagerRendererModule = () => {
                     cell={<CellName />}
                     sortable={true}
                     hideable={false}
-                    size={300}
+                    size={200}
                 />
                 <Browser.Table.Column name={"type"} header={"Type"} cell={<CellType />} />
                 <Browser.Table.Column

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/ChangeEntryStatus.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/ChangeEntryStatus.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { ReactComponent as Publish } from "@material-design-icons/svg/outlined/publish.svg";
 import { ReactComponent as Unpublish } from "@material-design-icons/svg/outlined/settings_backup_restore.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { ContentEntryListConfig } from "~/admin/config/contentEntries";
 import { useChangeEntryStatus, useEntry, usePermission } from "~/admin/hooks";
 
 export const ChangeEntryStatus = () => {
     const { entry } = useEntry();
     const { canPublish, canUnpublish } = usePermission();
     const { openDialogPublishEntry, openDialogUnpublishEntry } = useChangeEntryStatus({ entry });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = ContentEntryListConfig.Browser.EntryAction;
 
     if (entry.meta.status === "published" && canUnpublish("cms.contentEntry")) {
         return (

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/DeleteEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/DeleteEntry.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Delete } from "@material-design-icons/svg/outlined/delete.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { ContentEntryListConfig } from "~/admin/config/contentEntries";
 import { useDeleteEntry, useEntry, usePermission } from "~/admin/hooks";
 
 export const DeleteEntry = () => {
     const { entry } = useEntry();
     const { canDelete } = usePermission();
     const { openDialogDeleteEntry } = useDeleteEntry({ entry });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = ContentEntryListConfig.Browser.EntryAction;
 
     if (!canDelete(entry, "cms.contentEntry")) {
         return null;

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/EditEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/EditEntry.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Edit } from "@material-design-icons/svg/outlined/edit.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { ContentEntryListConfig } from "~/admin/config/contentEntries";
 import { useContentEntriesList, useEntry, usePermission } from "~/admin/hooks";
 
 export const EditEntry = () => {
     const { entry } = useEntry();
     const { canEdit } = usePermission();
     const { getEntryEditUrl } = useContentEntriesList();
-    const { OptionsMenuLink } = AcoConfig.Record.Action;
+    const { OptionsMenuLink } = ContentEntryListConfig.Browser.EntryAction;
 
     if (!canEdit(entry, "cms.contentEntry")) {
         return null;

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/MoveEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/MoveEntry.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { ReactComponent as Move } from "@material-design-icons/svg/outlined/drive_file_move.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { ContentEntryListConfig } from "~/admin/config/contentEntries";
 import { useEntry, useMoveContentEntryToFolder } from "~/admin/hooks";
 
 export const MoveEntry = () => {
     const { entry: record } = useEntry();
     const moveContentEntry = useMoveContentEntryToFolder({ record });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = ContentEntryListConfig.Browser.EntryAction;
 
     return (
         <OptionsMenuItem

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/EntryAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/EntryAction.tsx
@@ -11,7 +11,7 @@ export interface EntryActionProps extends React.ComponentProps<typeof AcoConfig.
     modelIds?: string[];
 }
 
-export const EntryAction = ({ modelIds = [], ...props }: EntryActionProps) => {
+const BaseEntryAction = ({ modelIds = [], ...props }: EntryActionProps) => {
     const { model } = useModel();
 
     if (modelIds.length > 0 && !modelIds.includes(model.modelId)) {
@@ -26,3 +26,8 @@ export const EntryAction = ({ modelIds = [], ...props }: EntryActionProps) => {
         </CompositionScope>
     );
 };
+
+export const EntryAction = Object.assign(BaseEntryAction, {
+    OptionsMenuItem: Record.Action.OptionsMenuItem,
+    OptionsMenuLink: Record.Action.OptionsMenuLink
+});

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderAction.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderAction.tsx
@@ -11,7 +11,7 @@ export interface FolderActionProps extends React.ComponentProps<typeof AcoConfig
     modelIds?: string[];
 }
 
-export const FolderAction = ({ modelIds = [], ...props }: FolderActionProps) => {
+const BaseFolderAction = ({ modelIds = [], ...props }: FolderActionProps) => {
     const { model } = useModel();
 
     if (modelIds.length > 0 && !modelIds.includes(model.modelId)) {
@@ -26,3 +26,7 @@ export const FolderAction = ({ modelIds = [], ...props }: FolderActionProps) => 
         </CompositionScope>
     );
 };
+
+export const FolderAction = Object.assign(BaseFolderAction, {
+    OptionsMenuItem: Folder.Action.OptionsMenuItem
+});

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntriesModule.tsx
@@ -54,7 +54,7 @@ export const ContentEntriesModule = () => {
                     cell={<CellName />}
                     sortable={true}
                     hideable={false}
-                    size={300}
+                    size={200}
                     className={"cms-aco-list-title"}
                 />
                 <Browser.Table.Column

--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/ChangePageStatus.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/ChangePageStatus.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ReactComponent as Publish } from "@material-design-icons/svg/outlined/publish.svg";
 import { ReactComponent as Unpublish } from "@material-design-icons/svg/outlined/settings_backup_restore.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { PageListConfig } from "~/admin/config/pages";
 import { usePage } from "~/admin/views/Pages/hooks/usePage";
 import { useChangePageStatus } from "~/admin/views/Pages/hooks/useChangePageStatus";
 import { usePagesPermissions } from "~/hooks/permissions";
@@ -9,7 +9,7 @@ import { usePagesPermissions } from "~/hooks/permissions";
 export const ChangePageStatus = () => {
     const { page } = usePage();
     const { openDialogUnpublishPage, openDialogPublishPage } = useChangePageStatus({ page });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = PageListConfig.Browser.PageAction;
     const { hasPermissions, canPublish, canUnpublish } = usePagesPermissions();
 
     if (!hasPermissions()) {

--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/DeletePage.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/DeletePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ReactComponent as Delete } from "@material-design-icons/svg/outlined/delete.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { PageListConfig } from "~/admin/config/pages";
 import { usePage } from "~/admin/views/Pages/hooks/usePage";
 import { useDeletePage } from "~/admin/views/Pages/hooks/useDeletePage";
 import { usePagesPermissions } from "~/hooks/permissions";
@@ -9,7 +9,7 @@ export const DeletePage = () => {
     const { page } = usePage();
     const { canDelete } = usePagesPermissions();
     const { openDialogDeletePage } = useDeletePage({ page });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = PageListConfig.Browser.PageAction;
 
     if (!canDelete(page.data.createdBy.id)) {
         return null;

--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/EditPage.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/EditPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ReactComponent as Edit } from "@material-design-icons/svg/outlined/edit.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { PageListConfig } from "~/admin/config/pages";
 import { usePage } from "~/admin/views/Pages/hooks/usePage";
 import { useCreatePageFrom } from "~/admin/views/Pages/hooks/useCreatePageFrom";
 import { useNavigatePage } from "~/admin/hooks/useNavigatePage";
@@ -9,7 +9,7 @@ import { usePagesPermissions } from "~/hooks/permissions";
 export const EditPage = () => {
     const { page } = usePage();
     const { canUpdate } = usePagesPermissions();
-    const { OptionsMenuItem, OptionsMenuLink } = AcoConfig.Record.Action;
+    const { OptionsMenuItem, OptionsMenuLink } = PageListConfig.Browser.PageAction;
     const { getPageEditorUrl, navigateToPageEditor } = useNavigatePage();
     const { createPageForm, loading } = useCreatePageFrom({
         page,

--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/MovePage.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/MovePage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Move } from "@material-design-icons/svg/outlined/drive_file_move.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { PageListConfig } from "~/admin/config/pages";
 import { usePage } from "~/admin/views/Pages/hooks/usePage";
 import { useMovePageToFolder } from "~/admin/views/Pages/hooks/useMovePageToFolder";
 
 export const MovePage = () => {
     const { page } = usePage();
     const movePageToFolder = useMovePageToFolder({ record: page });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = PageListConfig.Browser.PageAction;
 
     return (
         <OptionsMenuItem

--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/PreviewPage.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/PreviewPage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ReactComponent as Visibility } from "@material-design-icons/svg/outlined/visibility.svg";
-import { AcoConfig } from "@webiny/app-aco";
+import { PageListConfig } from "~/admin/config/pages";
 import { usePage } from "~/admin/views/Pages/hooks/usePage";
 import { usePreviewPage } from "~/admin/views/Pages/hooks/usePreviewPage";
 
 export const PreviewPage = () => {
     const { page } = usePage();
     const { previewPage } = usePreviewPage({ page });
-    const { OptionsMenuItem } = AcoConfig.Record.Action;
+    const { OptionsMenuItem } = PageListConfig.Browser.PageAction;
 
     const label = page.data.status === "published" ? "View" : "Preview";
 

--- a/packages/app-page-builder/src/admin/config/pages/list/Browser/FolderAction.tsx
+++ b/packages/app-page-builder/src/admin/config/pages/list/Browser/FolderAction.tsx
@@ -8,7 +8,7 @@ export { FolderActionConfig };
 
 type FolderActionProps = React.ComponentProps<typeof AcoConfig.Folder.Action>;
 
-export const FolderAction = (props: FolderActionProps) => {
+const BaseFolderAction = (props: FolderActionProps) => {
     return (
         <CompositionScope name={"pb.page"}>
             <AcoConfig>
@@ -17,3 +17,7 @@ export const FolderAction = (props: FolderActionProps) => {
         </CompositionScope>
     );
 };
+
+export const FolderAction = Object.assign(BaseFolderAction, {
+    OptionsMenuItem: Folder.Action.OptionsMenuItem
+});

--- a/packages/app-page-builder/src/admin/config/pages/list/Browser/PageAction.tsx
+++ b/packages/app-page-builder/src/admin/config/pages/list/Browser/PageAction.tsx
@@ -8,7 +8,7 @@ export { RecordActionConfig as PageActionConfig };
 
 type PageActionProps = React.ComponentProps<typeof AcoConfig.Record.Action>;
 
-export const PageAction = (props: PageActionProps) => {
+const BasePageAction = (props: PageActionProps) => {
     return (
         <CompositionScope name={"pb.page"}>
             <AcoConfig>
@@ -17,3 +17,8 @@ export const PageAction = (props: PageActionProps) => {
         </CompositionScope>
     );
 };
+
+export const PageAction = Object.assign(BasePageAction, {
+    OptionsMenuItem: Record.Action.OptionsMenuItem,
+    OptionsMenuLink: Record.Action.OptionsMenuLink
+});

--- a/packages/app-page-builder/src/admin/views/Pages/PagesModule.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PagesModule.tsx
@@ -46,7 +46,7 @@ export const PagesModule = () => {
                 header={"Name"}
                 cell={<CellName />}
                 hideable={false}
-                size={300}
+                size={200}
                 sortable={true}
             />
             <Browser.Table.Column name={"createdBy"} header={"Author"} cell={<CellAuthor />} />


### PR DESCRIPTION
## Changes
With this PR, we improve the newly created ACO react property definitions:

- `Column`: make default size props `100` instead of `200` -> easier to document and explain
- `FolderAction` and `EntryAction`: assign both `OptionsMenuItem` and  `OptionsMenuLink` directly to the configuration component

## How Has This Been Tested?
Manually
