### PR TITLE
fix: various datatable / actions

### DIFF
--- a/packages/app-aco/src/components/Table/components/Table/Columns/Column.ts
+++ b/packages/app-aco/src/components/Table/components/Table/Columns/Column.ts
@@ -42,7 +42,7 @@ export class Column {
         this.name = data.name;
         this.header = data.header;
         this.cell = data.cell;
-        this.size = data.size || 200;
+        this.size = data.size || 100;
         this.className = data.className || "";
         this.hideable = data.hideable ?? true;
         this.sortable = data.sortable ?? false;

--- a/packages/app-page-builder/src/PageBuilder.tsx
+++ b/packages/app-page-builder/src/PageBuilder.tsx
@@ -18,7 +18,8 @@ import { PagesModule } from "~/admin/views/Pages/PagesModule";
 
 export type { EditorProps };
 export { EditorRenderer };
-export { PageListConfig, usePageListConfig } from "~/admin/config/pages";
+export * from "~/admin/config/pages";
+export * from "~/admin/views/Pages/hooks";
 
 const PageBuilderProviderPlugin = createProviderPlugin(Component => {
     return function PageBuilderProvider({ children }) {

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/index.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePage";

--- a/packages/ui/src/DataTable/DataTable.tsx
+++ b/packages/ui/src/DataTable/DataTable.tsx
@@ -200,10 +200,11 @@ const defineColumns = <T,>(
                 header,
                 id,
                 meta,
-                size = 200
+                size = 100
             } = column;
 
             return {
+                id,
                 accessorKey: id,
                 header: () => header,
                 cell: info => {


### PR DESCRIPTION
## Changes
With this PR we fixed some minor bugs that emerged while documenting table and actions API feature:

- Column size: set default size to `100` instead of `200`
- Pass `id` to column definition: without it, the DataTable library created it based on the `accessorKey` transforming `.` in `_`. This caused issues while trying to change the column visibility of fields inside an object (i.e. file manager extension fields)
- Export `usePage` hook from `@webiny/app-page-builder` root.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually

