### PR TITLE
fix(api-file-manager-s3): make invalidate cache task private

### DIFF
--- a/packages/api-file-manager-s3/src/flushCdnCache/invalidateCacheTaskDefinition.ts
+++ b/packages/api-file-manager-s3/src/flushCdnCache/invalidateCacheTaskDefinition.ts
@@ -1,9 +1,9 @@
-import { createTaskDefinition } from "@webiny/tasks";
+import { createPrivateTaskDefinition } from "@webiny/tasks";
 import { FileManagerContext } from "@webiny/api-file-manager/types";
 import { InvalidateCloudfrontCacheTask } from "./InvalidateCacheTask";
 
 export const createInvalidateCacheTask = () => {
-    return createTaskDefinition<FileManagerContext>({
+    return createPrivateTaskDefinition<FileManagerContext>({
         id: "cloudfrontInvalidateCache",
         title: "Invalidate Cloudfront Cache",
         description: "A task to invalidate Cloudfront cache by given paths.",

--- a/packages/api-page-builder/__tests__/graphql/pagesListingLatest.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pagesListingLatest.test.ts
@@ -824,7 +824,7 @@ describe("listing latest pages", () => {
             () =>
                 listPages({
                     search: {
-                        query: "title for seo"
+                        query: "page title for seo"
                     }
                 }),
             ([res]: any) => res.data.pageBuilder.listPages.data[0].title === TITLE_SEO,
@@ -867,19 +867,12 @@ describe("listing latest pages", () => {
             { title: "Serverless Side Rendering — The Ultimate Guide" }
         ]);
 
-        const [listPagesSearchServerlessWorthIt] = await until(
-            () =>
-                listPages({
-                    search: {
-                        query: "serverless worth it"
-                    },
-                    sort: ["createdOn_ASC"]
-                }),
-            ([res]: any) => res.data.pageBuilder.listPages.data.length === 3,
-            {
-                name: "list pages serverless worth it"
-            }
-        );
+        const [listPagesSearchServerlessWorthIt] = await listPages({
+            search: {
+                query: "serverless worth it"
+            },
+            sort: ["createdOn_ASC"]
+        });
 
         expect(listPagesSearchServerlessWorthIt.data.pageBuilder.listPages.data).toMatchObject([
             { title: "What is Serverless and is it worth it?" },

--- a/packages/aws-sdk/package.json
+++ b/packages/aws-sdk/package.json
@@ -24,7 +24,8 @@
     "@aws-sdk/lib-storage": "^3.425.0",
     "@aws-sdk/s3-presigned-post": "^3.425.0",
     "@aws-sdk/s3-request-presigner": "^3.425.0",
-    "@aws-sdk/util-dynamodb": "^3.425.0"
+    "@aws-sdk/util-dynamodb": "^3.425.0",
+    "@webiny/utils": "0.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.6",

--- a/packages/aws-sdk/src/client-eventbridge/index.ts
+++ b/packages/aws-sdk/src/client-eventbridge/index.ts
@@ -2,7 +2,8 @@ export {
     EventBridgeClient,
     PutEventsRequestEntry,
     PutEventsCommand,
-    PutEventsCommandInput
+    PutEventsCommandInput,
+    PutEventsCommandOutput
 } from "@aws-sdk/client-eventbridge";
 
 export * from "./types";

--- a/packages/aws-sdk/src/client-s3/index.ts
+++ b/packages/aws-sdk/src/client-s3/index.ts
@@ -1,3 +1,6 @@
+import { S3, S3ClientConfig } from "@aws-sdk/client-s3";
+import { createCacheKey } from "@webiny/utils";
+
 export {
     CompleteMultipartUploadCommandOutput,
     CompleteMultipartUploadOutput,
@@ -25,3 +28,20 @@ export { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 export { PresignedPost, PresignedPostOptions } from "@aws-sdk/s3-presigned-post";
 
 export { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+const clients = new Map<string, S3>();
+
+export const createS3Client = (initial?: S3ClientConfig): S3 => {
+    const options = {
+        region: process.env.AWS_REGION,
+        ...initial
+    };
+    const key = createCacheKey(options);
+    if (clients.has(key)) {
+        return clients.get(key) as S3;
+    }
+
+    const instance = new S3(options);
+    clients.set(key, instance);
+    return instance;
+};

--- a/packages/aws-sdk/tsconfig.build.json
+++ b/packages/aws-sdk/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
-  "references": [],
+  "references": [{ "path": "../utils/tsconfig.build.json" }],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/aws-sdk/tsconfig.json
+++ b/packages/aws-sdk/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__"],
-  "references": [],
+  "references": [{ "path": "../utils" }],
   "compilerOptions": {
     "rootDirs": ["./src", "./__tests__"],
     "outDir": "./dist",
     "declarationDir": "./dist",
-    "paths": { "~/*": ["./src/*"], "~tests/*": ["./__tests__/*"] },
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"],
+      "@webiny/utils/*": ["../utils/src/*"],
+      "@webiny/utils": ["../utils/src"]
+    },
     "baseUrl": "."
   }
 }

--- a/packages/db-dynamodb/package.json
+++ b/packages/db-dynamodb/package.json
@@ -19,7 +19,7 @@
     "date-fns": "^2.22.1",
     "dot-prop": "^6.0.1",
     "dynamodb-toolbox": "^0.9.2",
-    "fuse.js": "^6.4.6",
+    "fuse.js": "7.0.0",
     "is-number": "^7.0.0",
     "lodash": "^4.17.21"
   },

--- a/packages/db-dynamodb/src/plugins/filters/fuzzy.ts
+++ b/packages/db-dynamodb/src/plugins/filters/fuzzy.ts
@@ -1,23 +1,31 @@
 import Fuse from "fuse.js";
 import {
-    ValueFilterPluginParamsMatchesParams,
-    ValueFilterPlugin
+    ValueFilterPlugin,
+    ValueFilterPluginParamsMatchesParams
 } from "../definitions/ValueFilterPlugin";
 
 const plugin = new ValueFilterPlugin({
     operation: "fuzzy",
     matches: ({
-        value,
-        compareValue
-    }: ValueFilterPluginParamsMatchesParams<string | null, string>) => {
-        if (typeof value !== "string") {
+        value: initialValue,
+        compareValue: initialCompareValue
+    }: ValueFilterPluginParamsMatchesParams<
+        string | null | undefined,
+        string | null | undefined
+    >) => {
+        if (typeof initialValue !== "string" || typeof initialCompareValue !== "string") {
             return false;
         }
+        const value = initialValue.replaceAll("/", " ");
+        const compareValue = initialCompareValue.replaceAll("/", " ");
+
         const f = new Fuse([value], {
             includeScore: true,
             minMatchCharLength: 3,
-            threshold: 0.6,
-            isCaseSensitive: false
+            threshold: 0.5,
+            isCaseSensitive: false,
+            findAllMatches: true,
+            ignoreLocation: true
         });
         const result = f.search(compareValue);
 

--- a/packages/db-dynamodb/src/utils/filter.ts
+++ b/packages/db-dynamodb/src/utils/filter.ts
@@ -24,6 +24,7 @@ interface MappedPluginParams<T extends Plugin = Plugin> {
 }
 
 interface Filter {
+    operation: string;
     compareValue: any;
     filterPlugin: ValueFilterPlugin;
     transformValue?: TransformValue;
@@ -121,9 +122,12 @@ const createFilters = (params: Omit<Params, "items">): Filter[] => {
                 }
                 return field;
             });
+
+            const filterPlugin = findFilterPlugin(filterPlugins, key);
             filters.push({
+                operation: filterPlugin.operation,
                 compareValue: data.value,
-                filterPlugin: findFilterPlugin(filterPlugins, key),
+                filterPlugin,
                 transformValue,
                 paths,
                 negate: false
@@ -146,6 +150,7 @@ const createFilters = (params: Omit<Params, "items">): Filter[] => {
         }
 
         filters.push({
+            operation: filterPlugin.operation,
             compareValue,
             filterPlugin,
             transformValue,

--- a/packages/tasks/__tests__/crud/store.test.ts
+++ b/packages/tasks/__tests__/crud/store.test.ts
@@ -1,6 +1,6 @@
 import { useHandler } from "~tests/helpers/useHandler";
 import { createTaskDefinition } from "~/task";
-import { ITaskData, TaskDataStatus } from "~/types";
+import { ITask, TaskDataStatus } from "~/types";
 import { NotFoundError } from "@webiny/handler-graphql";
 import WebinyError from "@webiny/error";
 import { createMockIdentity } from "~tests/mocks/identity";
@@ -91,7 +91,7 @@ describe("store crud", () => {
                 someOtherValue: 123
             }
         });
-        const expectedCreatedTask: ITaskData = {
+        const expectedCreatedTask: ITask = {
             id: expect.any(String),
             createdOn: expect.stringMatching(/^20/),
             savedOn: expect.stringMatching(/^20/),
@@ -131,7 +131,7 @@ describe("store crud", () => {
                 addedNewValue: "yes!"
             }
         });
-        const expectedUpdatedTask: ITaskData = {
+        const expectedUpdatedTask: ITask = {
             id: expect.any(String),
             createdOn: expect.stringMatching(/^20/),
             savedOn: expect.stringMatching(/^20/),

--- a/packages/tasks/__tests__/mocks/context.ts
+++ b/packages/tasks/__tests__/mocks/context.ts
@@ -1,7 +1,7 @@
 import { PluginsContainer } from "@webiny/plugins";
 import {
     Context,
-    ITaskData,
+    ITask,
     ITaskLog,
     ITaskLogUpdateInput,
     ITaskUpdateData,
@@ -12,7 +12,7 @@ import { createMockTask } from "./task";
 import { createMockTaskLog } from "~tests/mocks/taskLog";
 
 export const createMockContext = (params?: PartialDeep<Context>): Context => {
-    const getTask = async (id: string): Promise<ITaskData> => {
+    const getTask = async (id: string): Promise<ITask> => {
         return {
             ...createMockTask(),
             id

--- a/packages/tasks/__tests__/mocks/store.ts
+++ b/packages/tasks/__tests__/mocks/store.ts
@@ -1,12 +1,12 @@
 import { TaskManagerStore, TaskManagerStoreContext } from "~/runner/TaskManagerStore";
-import { ITaskData, ITaskDataInput, ITaskLog } from "~/types";
+import { ITask, ITaskDataInput, ITaskLog } from "~/types";
 import { createMockContext } from "./context";
 import { createMockTask } from "./task";
 import { createMockTaskLog } from "./taskLog";
 
 interface Params {
     context?: TaskManagerStoreContext;
-    task?: ITaskData<ITaskDataInput>;
+    task?: ITask<ITaskDataInput>;
     taskLog?: ITaskLog;
 }
 

--- a/packages/tasks/__tests__/mocks/task.ts
+++ b/packages/tasks/__tests__/mocks/task.ts
@@ -1,4 +1,4 @@
-import { ITaskData, TaskDataStatus } from "~/types";
+import { ITask, TaskDataStatus } from "~/types";
 import { createMockIdentity } from "./identity";
 import { EventBridgeClientSendResponse } from "@webiny/aws-sdk/client-eventbridge";
 import { MOCK_TASK_DEFINITION_ID } from "~tests/mocks/definition";
@@ -20,7 +20,7 @@ export const createMockTaskEventResponse = (): EventBridgeClientSendResponse => 
     };
 };
 
-export const createMockTask = (task?: Partial<ITaskData>): ITaskData => {
+export const createMockTask = (task?: Partial<ITask>): ITask => {
     return {
         id: "myCustomTaskDataId",
         definitionId: MOCK_TASK_DEFINITION_ID,

--- a/packages/tasks/__tests__/mocks/taskLog.ts
+++ b/packages/tasks/__tests__/mocks/taskLog.ts
@@ -1,10 +1,7 @@
-import { ITaskData, ITaskLog } from "~/types";
+import { ITask, ITaskLog } from "~/types";
 import { createMockIdentity } from "~tests/mocks/identity";
 
-export const createMockTaskLog = (
-    task: Pick<ITaskData, "id">,
-    input?: Partial<ITaskLog>
-): ITaskLog => {
+export const createMockTaskLog = (task: Pick<ITask, "id">, input?: Partial<ITaskLog>): ITaskLog => {
     return {
         id: "mock-task-log-id",
         task: task.id,

--- a/packages/tasks/__tests__/task/plugin.test.ts
+++ b/packages/tasks/__tests__/task/plugin.test.ts
@@ -90,7 +90,7 @@ describe("task plugin", () => {
     });
 
     it("should properly create a task - via method", async () => {
-        const task = createTaskDefinition<Context, MyTask>({
+        const task = createTaskDefinition<Context, MyInput>({
             id: "myCustomTask",
             title: "A custom task defined via method",
             run: async ({ response, isCloseToTimeout, input }) => {
@@ -109,6 +109,9 @@ describe("task plugin", () => {
                 return;
             },
             onError: async () => {
+                return;
+            },
+            onAbort: async () => {
                 return;
             },
             config: task => {

--- a/packages/tasks/src/crud/createEventBridgeEvent.ts
+++ b/packages/tasks/src/crud/createEventBridgeEvent.ts
@@ -1,11 +1,17 @@
 import WebinyError from "@webiny/error";
-import { EventBridgeClient, PutEventsCommand } from "@webiny/aws-sdk/client-eventbridge";
-import { ITaskConfig, ITaskData } from "~/types";
+import {
+    EventBridgeClient,
+    PutEventsCommand,
+    PutEventsCommandOutput
+} from "@webiny/aws-sdk/client-eventbridge";
+import { ITaskConfig, ITask } from "~/types";
 import { ITaskEventInput } from "~/handler/types";
+
+export { PutEventsCommandOutput };
 
 interface CreateEventBridgeEventParams {
     client: EventBridgeClient;
-    task: Pick<ITaskData, "id" | "definitionId">;
+    task: Pick<ITask, "id" | "definitionId">;
     tenant: string;
     locale: string;
     eventBusName: string;
@@ -60,7 +66,7 @@ export const createEventBridgeEventFactory = (params: IFactoryParams) => {
         region: process.env.AWS_REGION
     });
     const eventBusName = config.eventBusName;
-    return (task: ITaskData) => {
+    return (task: ITask) => {
         return createEventBridgeEvent({
             client,
             eventBusName,

--- a/packages/tasks/src/crud/model.ts
+++ b/packages/tasks/src/crud/model.ts
@@ -168,6 +168,13 @@ const taskModelPlugin = createCmsModel(
                 ]
             },
             {
+                id: "parentId",
+                fieldId: "parentId",
+                storageId: "text@parentId",
+                type: "text",
+                label: "Parent ID"
+            },
+            {
                 id: "executionName",
                 fieldId: "executionName",
                 storageId: "text@executionName",
@@ -187,6 +194,13 @@ const taskModelPlugin = createCmsModel(
                 storageId: "object@input",
                 type: "json",
                 label: "Input"
+            },
+            {
+                id: "output",
+                fieldId: "output",
+                storageId: "object@output",
+                type: "json",
+                label: "Output"
             },
             {
                 id: "taskStatus",

--- a/packages/tasks/src/graphql/utils.ts
+++ b/packages/tasks/src/graphql/utils.ts
@@ -10,8 +10,8 @@ interface ResolveCallable<T = any> {
 export const resolve = async <T = any>(fn: ResolveCallable<T>) => {
     try {
         return new Response(await fn());
-    } catch (e) {
-        return new ErrorResponse(e);
+    } catch (ex) {
+        return new ErrorResponse(ex);
     }
 };
 
@@ -24,7 +24,7 @@ export const resolveList = async (fn: ResolveCallable) => {
     try {
         const result = (await fn()) as IListResult;
         return new ListResponse(result.items, result.meta);
-    } catch (e) {
-        return new ListErrorResponse(e);
+    } catch (ex) {
+        return new ListErrorResponse(ex);
     }
 };

--- a/packages/tasks/src/response/Response.ts
+++ b/packages/tasks/src/response/Response.ts
@@ -7,7 +7,6 @@ import {
     IResponseContinueResult,
     IResponseDoneParams,
     IResponseDoneResult,
-    IResponseError,
     IResponseErrorParams,
     IResponseErrorResult,
     IResponseFromParams,
@@ -17,15 +16,7 @@ import { ResponseContinueResult } from "~/response/ResponseContinueResult";
 import { ResponseDoneResult } from "~/response/ResponseDoneResult";
 import { ResponseErrorResult } from "~/response/ResponseErrorResult";
 import { ResponseAbortedResult } from "./ResponseAbortedResult";
-
-const transformError = (error: IResponseError): IResponseError => {
-    return {
-        message: error.message,
-        code: error.code,
-        data: error.data,
-        stack: error.stack
-    };
-};
+import { getErrorProperties } from "~/utils/getErrorProperties";
 
 export class Response implements IResponse {
     public readonly event: ITaskEvent;
@@ -81,7 +72,7 @@ export class Response implements IResponse {
             webinyTaskDefinitionId: this.event.webinyTaskDefinitionId,
             tenant: params.tenant || this.event.tenant,
             locale: params.locale || this.event.locale,
-            error: transformError(params.error)
+            error: params.error instanceof Error ? getErrorProperties(params.error) : params.error
         });
     }
 }

--- a/packages/tasks/src/response/abstractions/Response.ts
+++ b/packages/tasks/src/response/abstractions/Response.ts
@@ -3,6 +3,7 @@ import { IResponseContinueParams, IResponseContinueResult } from "./ResponseCont
 import { IResponseDoneParams, IResponseDoneResult } from "./ResponseDoneResult";
 import { IResponseErrorParams, IResponseErrorResult } from "./ResponseErrorResult";
 import { IResponseAbortedResult } from "./ResponseAbortedResult";
+import { ITaskResponseDoneResultOutput } from "~/response/abstractions/TaskResponse";
 
 export type IResponseFromParams =
     | IResponseDoneResult
@@ -18,7 +19,9 @@ export type IResponseResult =
 export interface IResponse {
     readonly event: ITaskEvent;
     from: (params: IResponseFromParams) => IResponseResult;
-    done: (params?: IResponseDoneParams) => IResponseDoneResult;
+    done: <O extends ITaskResponseDoneResultOutput = ITaskResponseDoneResultOutput>(
+        params?: IResponseDoneParams<O>
+    ) => IResponseDoneResult;
     aborted: () => IResponseAbortedResult;
     continue: (params: IResponseContinueParams) => IResponseContinueResult;
     error: (params: IResponseErrorParams) => IResponseErrorResult;

--- a/packages/tasks/src/response/abstractions/ResponseDoneResult.ts
+++ b/packages/tasks/src/response/abstractions/ResponseDoneResult.ts
@@ -1,11 +1,14 @@
-import { TaskResponseStatus } from "~/types";
+import { ITaskResponseDoneResultOutput, TaskResponseStatus } from "~/types";
 import { IResponseBaseResult } from "./ResponseBaseResult";
 
-export interface IResponseDoneParams {
+export interface IResponseDoneParams<
+    O extends ITaskResponseDoneResultOutput = ITaskResponseDoneResultOutput
+> {
     tenant?: string;
     locale?: string;
     webinyTaskId?: string;
     message?: string;
+    output?: O;
 }
 
 export interface IResponseDoneResult extends IResponseBaseResult {

--- a/packages/tasks/src/response/abstractions/ResponseErrorResult.ts
+++ b/packages/tasks/src/response/abstractions/ResponseErrorResult.ts
@@ -3,13 +3,13 @@ import { IResponseBaseResult } from "./ResponseBaseResult";
 
 export interface IResponseError {
     message: string;
-    code: string;
+    code?: string;
     data?: Record<string, any>;
     stack?: string;
 }
 
 export interface IResponseErrorParams {
-    error: IResponseError;
+    error: IResponseError | Error;
     tenant?: string;
     locale?: string;
     webinyTaskId?: string;

--- a/packages/tasks/src/response/abstractions/TaskResponse.ts
+++ b/packages/tasks/src/response/abstractions/TaskResponse.ts
@@ -1,14 +1,23 @@
 import { ITaskDataInput, TaskResponseStatus } from "~/types";
 import { IResponseError } from "./ResponseErrorResult";
 
-export type ITaskResponseResult =
-    | ITaskResponseDoneResult
-    | ITaskResponseContinueResult
+export type ITaskResponseResult<
+    I = ITaskDataInput,
+    O extends ITaskResponseDoneResultOutput = ITaskResponseDoneResultOutput
+> =
+    | ITaskResponseDoneResult<O>
+    | ITaskResponseContinueResult<I>
     | ITaskResponseErrorResult
     | ITaskResponseAbortedResult;
 
-export interface ITaskResponseDoneResult {
+export interface ITaskResponseDoneResultOutput {
+    [key: string]: string | string[] | number | boolean | Record<string, string | number>;
+}
+export interface ITaskResponseDoneResult<
+    O extends ITaskResponseDoneResultOutput = ITaskResponseDoneResultOutput
+> {
     message?: string;
+    output?: O;
     status: TaskResponseStatus.DONE;
 }
 
@@ -38,9 +47,12 @@ export type ITaskResponseContinueOptions =
     | ITaskResponseContinueOptionsUntil
     | ITaskResponseContinueOptionsSeconds;
 
-export interface ITaskResponse<T = ITaskDataInput> {
-    done: (message?: string) => ITaskResponseDoneResult;
+export interface ITaskResponse<
+    T = ITaskDataInput,
+    O extends ITaskResponseDoneResultOutput = ITaskResponseDoneResultOutput
+> {
+    done: (message?: string, output?: O) => ITaskResponseDoneResult<O>;
     continue: (data: T, options?: ITaskResponseContinueOptions) => ITaskResponseContinueResult<T>;
-    error: (error: IResponseError) => ITaskResponseErrorResult;
+    error: (error: IResponseError | Error) => ITaskResponseErrorResult;
     aborted: () => ITaskResponseAbortedResult;
 }

--- a/packages/tasks/src/runner/TaskRunner.ts
+++ b/packages/tasks/src/runner/TaskRunner.ts
@@ -7,7 +7,7 @@ import { Response } from "~/response";
 import { TaskControl } from "./TaskControl";
 import { TaskEventValidation } from "./TaskEventValidation";
 import { IResponseResult } from "~/response/abstractions";
-import { getObjectProperties } from "~/runner/utils/getObjectProperties";
+import { getErrorProperties } from "~/utils/getErrorProperties";
 
 const transformMinutesIntoMilliseconds = (minutes: number) => {
     return minutes * 60000;
@@ -47,11 +47,11 @@ export class TaskRunner<C extends Context = Context> implements ITaskRunner<C> {
         this.validation = validation;
     }
 
-    public isCloseToTimeout() {
-        return (
-            this.lambdaContext.getRemainingTimeInMillis() <
-            transformMinutesIntoMilliseconds(this.getIsCloseToTimeoutMinutes())
-        );
+    public isCloseToTimeout(seconds?: number) {
+        const milliseconds = seconds
+            ? seconds * 1000
+            : transformMinutesIntoMilliseconds(this.getIsCloseToTimeoutMinutes());
+        return this.lambdaContext.getRemainingTimeInMillis() < milliseconds;
     }
 
     public getRemainingTime() {
@@ -66,7 +66,7 @@ export class TaskRunner<C extends Context = Context> implements ITaskRunner<C> {
             event = this.validation.validate(input);
         } catch (ex) {
             return response.error({
-                error: getObjectProperties(ex)
+                error: getErrorProperties(ex)
             });
         }
 
@@ -76,7 +76,7 @@ export class TaskRunner<C extends Context = Context> implements ITaskRunner<C> {
             return await control.run(event);
         } catch (ex) {
             return response.error({
-                error: getObjectProperties(ex)
+                error: getErrorProperties(ex)
             });
         }
     }

--- a/packages/tasks/src/runner/abstractions/TaskManager.ts
+++ b/packages/tasks/src/runner/abstractions/TaskManager.ts
@@ -1,6 +1,6 @@
 import { IResponseResult } from "~/response/abstractions";
-import { ITaskData, ITaskDataInput, ITaskDefinition } from "~/types";
+import { ITask, ITaskDataInput, ITaskDefinition } from "~/types";
 
 export interface ITaskManager<T = ITaskDataInput> {
-    run: (definition: ITaskDefinition, task: ITaskData<T>) => Promise<IResponseResult>;
+    run: (definition: ITaskDefinition, task: ITask<T>) => Promise<IResponseResult>;
 }

--- a/packages/tasks/src/runner/abstractions/TaskManagerStore.ts
+++ b/packages/tasks/src/runner/abstractions/TaskManagerStore.ts
@@ -1,6 +1,6 @@
 import {
     IResponseError,
-    ITaskData,
+    ITask,
     ITaskDataInput,
     ITaskLogItemData,
     ITaskUpdateData,
@@ -18,7 +18,7 @@ export type ITaskManagerStoreUpdateTaskInputParam<T extends ITaskDataInput = ITa
     | Partial<ITaskManagerStoreUpdateTaskValues<T>>;
 
 export interface ITaskManagerStoreUpdateTaskParamCb<T extends ITaskDataInput = ITaskDataInput> {
-    (task: ITaskData<T>): ITaskUpdateData<T>;
+    (task: ITask<T>): ITaskUpdateData<T>;
 }
 
 export type ITaskManagerStoreUpdateTask<T extends ITaskDataInput = ITaskDataInput> =
@@ -36,12 +36,12 @@ export interface ITaskManagerStoreInfoLog {
 export interface ITaskManagerStoreErrorLog {
     message: string;
     data?: ITaskLogItemData;
-    error: IResponseError;
+    error: IResponseError | Error;
 }
 
 export interface ITaskManagerStore<T extends ITaskDataInput = ITaskDataInput> {
-    setTask: (task: ITaskData<T>) => void;
-    getTask: () => ITaskData<T>;
+    setTask: (task: ITask<T>) => void;
+    getTask: () => ITask<T>;
     getStatus: () => TaskDataStatus;
     /**
      * @throws {Error} If task not found or something goes wrong during the database update.
@@ -55,6 +55,14 @@ export interface ITaskManagerStore<T extends ITaskDataInput = ITaskDataInput> {
      */
     updateInput: (params: ITaskManagerStoreUpdateTaskInputParam<T>) => Promise<void>;
     getInput: () => T;
+    /**
+     * @throws {Error} If task not found or something goes wrong during the database update.
+     */
     addInfoLog: (log: ITaskManagerStoreInfoLog) => Promise<void>;
+    /**
+     * @throws {Error} If task not found or something goes wrong during the database update.
+     *
+     *
+     */
     addErrorLog: (log: ITaskManagerStoreErrorLog) => Promise<void>;
 }

--- a/packages/tasks/src/runner/abstractions/TaskRunner.ts
+++ b/packages/tasks/src/runner/abstractions/TaskRunner.ts
@@ -9,7 +9,7 @@ export interface ITaskRunner<C extends Context = Context> {
     reply: Reply;
     context: C;
     lambdaContext: LambdaContext;
-    isCloseToTimeout: () => boolean;
+    isCloseToTimeout: (seconds?: number) => boolean;
     getRemainingTime: () => number;
 
     run(event: ITaskEvent): Promise<IResponseResult>;

--- a/packages/tasks/src/utils/getErrorProperties.ts
+++ b/packages/tasks/src/utils/getErrorProperties.ts
@@ -1,0 +1,6 @@
+import { IResponseError } from "~/response/abstractions";
+import { getObjectProperties } from "~/utils/getObjectProperties";
+
+export const getErrorProperties = (error: Error): IResponseError => {
+    return getObjectProperties<IResponseError>(error);
+};

--- a/packages/tasks/src/utils/getObjectProperties.ts
+++ b/packages/tasks/src/utils/getObjectProperties.ts
@@ -1,0 +1,16 @@
+/**
+ * Unfortunately we need some casting as we do not know which properties are available on the object.
+ */
+interface GenericRecord {
+    [key: string]: any;
+}
+
+export const getObjectProperties = <T = GenericRecord>(input: unknown): T => {
+    if (!input || typeof input !== "object") {
+        return {} as unknown as T;
+    }
+    return Object.getOwnPropertyNames(input).reduce<T>((acc, key) => {
+        acc[key as keyof T] = (input as unknown as T)[key as keyof T];
+        return acc;
+    }, {} as T) as unknown as T;
+};

--- a/packages/utils/src/cacheKey.ts
+++ b/packages/utils/src/cacheKey.ts
@@ -1,0 +1,27 @@
+import crypto, { BinaryToTextEncoding } from "crypto";
+
+export type ICacheKeyKeys = Record<string, any> | string | number;
+
+export interface ICacheKeyOptions {
+    algorithm?: CacheKeyAlgorithmType;
+    encoding?: BinaryToTextEncoding;
+}
+
+export type CacheKeyAlgorithmType = "md5" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
+
+const getCacheKey = (input: ICacheKeyKeys): string => {
+    if (typeof input === "string") {
+        return input;
+    } else if (typeof input === "number") {
+        return `${input}`;
+    }
+    return JSON.stringify(input);
+};
+
+export const createCacheKey = (input: ICacheKeyKeys, options?: ICacheKeyOptions): string => {
+    const key = getCacheKey(input);
+    return crypto
+        .createHash(options?.algorithm || "sha1")
+        .update(key)
+        .digest(options?.encoding || "hex");
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,7 @@ export * from "~/executeWithRetry";
 export * from "~/removeUndefinedValues";
 export * from "~/removeNullValues";
 export * from "~/utcTimezones";
+export * from "./cacheKey";
 import { composeAsync, AsyncProcessor, NextAsyncProcessor } from "~/compose";
 
 export { composeAsync };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17554,6 +17554,7 @@ __metadata:
     "@babel/core": ^7.22.8
     "@webiny/cli": 0.0.0
     "@webiny/project-utils": 0.0.0
+    "@webiny/utils": 0.0.0
     rimraf: ^3.0.2
     typescript: 4.7.4
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -17953,7 +17953,7 @@ __metadata:
     date-fns: ^2.22.1
     dot-prop: ^6.0.1
     dynamodb-toolbox: ^0.9.2
-    fuse.js: ^6.4.6
+    fuse.js: 7.0.0
     is-number: ^7.0.0
     jest: ^29.5.0
     jest-dynalite: ^3.2.0
@@ -28927,17 +28927,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuse.js@npm:7.0.0":
+  version: 7.0.0
+  resolution: "fuse.js@npm:7.0.0"
+  checksum: d15750efec1808370c0cae92ec9473aa7261c59bca1f15f1cf60039ba6f804b8f95340b5cabd83a4ef55839c1034764856e0128e443921f072aa0d8a20e4cacf
+  languageName: node
+  linkType: hard
+
 "fuse.js@npm:^3.4.6":
   version: 3.6.1
   resolution: "fuse.js@npm:3.6.1"
   checksum: 958aa877ace65dc900df776becd39a03df68d7eebc7890b5fd2fc8c5d88e2fff238f60c37f80013ce70e9d9e7ac8efa9f503695fdd23d1eca3cc983797b50191
-  languageName: node
-  linkType: hard
-
-"fuse.js@npm:^6.4.6":
-  version: 6.6.2
-  resolution: "fuse.js@npm:6.6.2"
-  checksum: 17ae758ce205276ebd88bd9c9f088a100be0b4896abac9f6b09847151269d1690f41d7f98ff5813d4a58973162dbd99d0072ce807020fee6f9de60170f6b08eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
Mark the invalidate cloudfront cache task as private so it does not show up in the GraphQL API.

## How Has This Been Tested?
Manually.