### PR TITLE
fix(api-page-builder): increase page size limit by implementing gzip compression

### DIFF
--- a/packages/api-page-builder/__tests__/graphql/mocks/pageContent.ts
+++ b/packages/api-page-builder/__tests__/graphql/mocks/pageContent.ts
@@ -1,0 +1,236 @@
+import { mdbid } from "@webiny/utils";
+import bytes from "bytes";
+
+export const calculateSize = (value: any) => {
+    return new Blob([JSON.stringify(value)]).size;
+};
+
+/**
+ * 1992 bytes
+ */
+const buildMockContent = () => {
+    return {
+        id: mdbid(),
+        type: "document",
+        data: {
+            settings: {}
+        },
+        elements: [
+            {
+                id: mdbid(),
+                type: "block",
+                data: {
+                    settings: {
+                        width: {
+                            desktop: {
+                                value: "100%" + mdbid()
+                            }
+                        },
+                        margin: {
+                            desktop: {
+                                top: "0px" + mdbid(),
+                                right: "0px" + mdbid(),
+                                bottom: "0px" + mdbid(),
+                                left: "0px" + mdbid(),
+                                advanced: true + mdbid()
+                            }
+                        },
+                        padding: {
+                            desktop: {
+                                all: "10px" + mdbid()
+                            }
+                        },
+                        horizontalAlignFlex: {
+                            desktop: "center" + mdbid()
+                        },
+                        verticalAlign: {
+                            desktop: "flex-start" + mdbid()
+                        }
+                    }
+                },
+                elements: [
+                    {
+                        id: mdbid(),
+                        type: "grid" + mdbid(),
+                        data: {
+                            settings: {
+                                width: {
+                                    desktop: {
+                                        value: "1100px" + mdbid()
+                                    }
+                                },
+                                margin: {
+                                    desktop: {
+                                        top: "0px" + mdbid(),
+                                        right: "0px" + mdbid(),
+                                        bottom: "0px" + mdbid(),
+                                        left: "0px" + mdbid(),
+                                        advanced: true + mdbid()
+                                    }
+                                },
+                                padding: {
+                                    desktop: {
+                                        all: "10px" + mdbid()
+                                    }
+                                },
+                                grid: {
+                                    cellsType: "12" + mdbid()
+                                },
+                                gridSettings: {
+                                    desktop: {
+                                        flexDirection: "row" + mdbid()
+                                    },
+                                    "mobile-landscape": {
+                                        flexDirection: "column" + mdbid()
+                                    }
+                                },
+                                horizontalAlignFlex: {
+                                    desktop: "flex-start" + mdbid()
+                                },
+                                verticalAlign: {
+                                    desktop: "flex-start" + mdbid()
+                                }
+                            }
+                        },
+                        elements: [
+                            {
+                                id: mdbid(),
+                                type: "cell" + mdbid(),
+                                data: {
+                                    settings: {
+                                        margin: {
+                                            desktop: {
+                                                top: "0px" + mdbid(),
+                                                right: "0px" + mdbid(),
+                                                bottom: "0px" + mdbid(),
+                                                left: "0px" + mdbid(),
+                                                advanced: true + mdbid()
+                                            }
+                                        },
+                                        padding: {
+                                            desktop: {
+                                                all: "0px" + mdbid(),
+                                                advanced: true + mdbid(),
+                                                top: "80px" + mdbid()
+                                            }
+                                        },
+                                        grid: {
+                                            size: 12 + mdbid()
+                                        }
+                                    }
+                                },
+                                elements: [
+                                    {
+                                        id: mdbid(),
+                                        type: "heading" + mdbid(),
+                                        data: {
+                                            text: {
+                                                desktop: {
+                                                    type: "heading" + mdbid(),
+                                                    typography: "heading1" + mdbid(),
+                                                    alignment: "center" + mdbid(),
+                                                    tag: "h1" + mdbid(),
+                                                    color: "color3" + mdbid()
+                                                },
+                                                data: {
+                                                    text: "Page not found!" + mdbid()
+                                                }
+                                            },
+                                            settings: {
+                                                margin: {
+                                                    desktop: {
+                                                        all: "0px" + mdbid()
+                                                    }
+                                                },
+                                                padding: {
+                                                    desktop: {
+                                                        all: "0px" + mdbid()
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        elements: []
+                                    },
+                                    {
+                                        id: mdbid(),
+                                        type: "paragraph" + mdbid(),
+                                        data: {
+                                            text: {
+                                                desktop: {
+                                                    type: "paragraph" + mdbid(),
+                                                    typography: "paragraph1" + mdbid(),
+                                                    alignment: "center" + mdbid(),
+                                                    tag: "div" + mdbid(),
+                                                    color: "color3" + mdbid()
+                                                },
+                                                data: {
+                                                    text:
+                                                        "Sorry, but the page you were looking for could not be found." +
+                                                        mdbid()
+                                                }
+                                            },
+                                            settings: {
+                                                margin: {
+                                                    desktop: {
+                                                        all: "0px" + mdbid(),
+                                                        advanced: true + mdbid(),
+                                                        top: "10px" + mdbid()
+                                                    }
+                                                },
+                                                padding: {
+                                                    desktop: {
+                                                        all: "0px" + mdbid()
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        elements: []
+                                    },
+                                    {
+                                        id: mdbid(),
+                                        type: "button" + mdbid(),
+                                        data: {
+                                            buttonText: "TAKE ME HOme" + mdbid(),
+                                            settings: {
+                                                margin: {
+                                                    desktop: {
+                                                        all: "0px" + mdbid(),
+                                                        advanced: true + mdbid(),
+                                                        top: "30px" + mdbid()
+                                                    }
+                                                },
+                                                horizontalAlignFlex: {
+                                                    desktop: "center" + mdbid()
+                                                }
+                                            },
+                                            link: {
+                                                href: "/" + mdbid()
+                                            },
+                                            type: "primary" + mdbid()
+                                        },
+                                        elements: []
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+};
+export const createPageContent = (input?: `${number}KB` | `${number}MB`) => {
+    if (!input) {
+        return structuredClone(buildMockContent());
+    }
+
+    const maxSize = bytes(input);
+    const content = structuredClone(buildMockContent());
+    let currentSize = calculateSize(content);
+
+    while (currentSize < maxSize) {
+        content.elements = content.elements.concat(buildMockContent().elements);
+        currentSize = calculateSize(content);
+    }
+    return content;
+};

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -560,5 +560,20 @@ describe("CRUD Test", () => {
             }
         });
         expect(updatePageResponse.data.pageBuilder.updatePage.data.content).toEqual(content);
+
+        const [getPageResponse] = await getPage({ id });
+        expect(getPageResponse).toMatchObject({
+            data: {
+                pageBuilder: {
+                    getPage: {
+                        data: {
+                            id
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+        expect(getPageResponse.data.pageBuilder.getPage.data.content).toEqual(content);
     });
 });

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -591,12 +591,12 @@ describe("CRUD Test", () => {
         const id = createPageResponse.data.pageBuilder.createPage.data.id;
         expect(id).toMatch("#0001");
 
-        const content = createPageContent("3.4MB");
+        const content = createPageContent("3.6MB");
         const size = calculateSize(content);
         /**
          * Validate that we really did generate more than 5MB of data.
          */
-        expect(size).toBeGreaterThan(bytes("3.39MB"));
+        expect(size).toBeGreaterThan(bytes("3.59MB"));
 
         const [updatePageResponse] = await updatePage({
             id,

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -594,7 +594,7 @@ describe("CRUD Test", () => {
         const content = createPageContent("4MB");
         const size = calculateSize(content);
 
-        expect(size).toBeGreaterThan(bytes("4.99MB"));
+        expect(size).toBeGreaterThan(bytes("3.99MB"));
 
         const [updatePageResponse] = await updatePage({
             id,

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -120,7 +120,7 @@ describe("CRUD Test", () => {
                     }
                 },
                 /**
-                 * This basically creates a page content of 1.2MB in size
+                 * This basically creates a page content of 1MB in size
                  */
                 content: createPageContent("1MB")
             };

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -591,12 +591,10 @@ describe("CRUD Test", () => {
         const id = createPageResponse.data.pageBuilder.createPage.data.id;
         expect(id).toMatch("#0001");
 
-        const content = createPageContent("3.6MB");
+        const content = createPageContent("4MB");
         const size = calculateSize(content);
-        /**
-         * Validate that we really did generate more than 5MB of data.
-         */
-        expect(size).toBeGreaterThan(bytes("3.59MB"));
+
+        expect(size).toBeGreaterThan(bytes("4.99MB"));
 
         const [updatePageResponse] = await updatePage({
             id,
@@ -605,17 +603,9 @@ describe("CRUD Test", () => {
             }
         });
 
-        expect(updatePageResponse).toMatchObject({
-            data: {
-                pageBuilder: {
-                    updatePage: {
-                        data: null,
-                        error: {
-                            message: "Item size has exceeded the maximum allowed size"
-                        }
-                    }
-                }
-            }
-        });
+        expect(updatePageResponse.data.pageBuilder.updatePage.error?.message).toEqual(
+            "Item size has exceeded the maximum allowed size"
+        );
+        expect(updatePageResponse.data.pageBuilder.updatePage.data).toBeNull();
     });
 });

--- a/packages/api-page-builder/package.json
+++ b/packages/api-page-builder/package.json
@@ -56,6 +56,7 @@
     "@webiny/cli": "0.0.0",
     "@webiny/project-utils": "0.0.0",
     "aws-sdk": "^2.971.0",
+    "bytes": "^3.1.0",
     "jest": "^29.5.0",
     "rimraf": "^3.0.2",
     "ttypescript": "^1.5.12",

--- a/packages/api-page-builder/src/graphql/crud.ts
+++ b/packages/api-page-builder/src/graphql/crud.ts
@@ -10,7 +10,6 @@ import { createSettingsCrud } from "./crud/settings.crud";
 import { createSystemCrud } from "./crud/system.crud";
 import { ContextPlugin } from "@webiny/api";
 import { PbContext, PrerenderingHandlers } from "~/graphql/types";
-import { JsonpackContentCompressionPlugin } from "~/plugins/JsonpackContentCompressionPlugin";
 import { createTopic } from "@webiny/pubsub";
 import { PageBuilderStorageOperations } from "~/types";
 import WebinyError from "@webiny/error";
@@ -20,6 +19,7 @@ import { CategoriesPermissions } from "./crud/permissions/CategoriesPermissions"
 import { BlockCategoriesPermissions } from "./crud/permissions/BlockCategoriesPermissions";
 import { PageTemplatesPermissions } from "~/graphql/crud/permissions/PageTemplatesPermissions";
 import { PageBlocksPermissions } from "~/graphql/crud/permissions/PageBlocksPermissions";
+import { GzipContentCompressionPlugin, JsonpackContentCompressionPlugin } from "~/plugins";
 
 export interface CreateCrudParams {
     storageOperations: PageBuilderStorageOperations;
@@ -227,6 +227,7 @@ const setup = (params: CreateCrudParams) => {
 export const createCrud = (params: CreateCrudParams) => {
     return [
         new JsonpackContentCompressionPlugin(),
+        new GzipContentCompressionPlugin(),
         setup(params),
         /**
          * We must have default compression in the page builder.

--- a/packages/api-page-builder/src/graphql/crud/pages.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages.crud.ts
@@ -640,10 +640,11 @@ export const createPageCrud = (params: CreatePageCrudParams): PagesCrud => {
                     input
                 });
 
+                const compressedPage = await compressPage(page);
                 await storageOperations.pages.update({
                     input,
                     original: rawOriginal,
-                    page: await compressPage(page)
+                    page: compressedPage
                 });
 
                 await onPageAfterUpdate.publish({

--- a/packages/api-page-builder/src/graphql/crud/pages/compression.ts
+++ b/packages/api-page-builder/src/graphql/crud/pages/compression.ts
@@ -21,14 +21,24 @@ export interface CreateCompressionResult {
 }
 
 const createCompressContent = (plugins: ContentCompressionPlugin[]): CompressContentCallable => {
-    const [plugin] = plugins;
-
     return async (page: Page) => {
         const value = page.content;
 
         if (value && (value as any).compression) {
             return value as CompressedValue;
         }
+
+        const plugin = plugins.find(pl => pl.canCompress(value));
+        if (!plugin) {
+            throw new WebinyError(
+                "There is no compression plugin to compress the page content.",
+                "MISSING_COMPRESSION_PLUGIN",
+                {
+                    id: page.id
+                }
+            );
+        }
+
         try {
             return await plugin.compress(value);
         } catch (ex) {

--- a/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/ContentCompressionPlugin.ts
@@ -29,6 +29,10 @@ export abstract class ContentCompressionPlugin extends Plugin {
         this.identifier = identifier;
     }
     /**
+     * Must return true if it is possible to compress the content with given implementation.
+     */
+    public abstract canCompress(value: any): boolean;
+    /**
      * Must return if it is possible to decompress the content with given implementation.
      * This step makes sure no invalid data is passed into decompress method.
      */

--- a/packages/api-page-builder/src/plugins/GzipContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/GzipContentCompressionPlugin.ts
@@ -1,0 +1,76 @@
+import { CompressedValue, ContentCompressionPlugin } from "./ContentCompressionPlugin";
+import { compress as gzip, decompress as ungzip } from "@webiny/utils/compression/gzip";
+
+const GZIP_COMPRESSION = "gzip";
+const TO_STORAGE_ENCODING = "base64";
+const FROM_STORAGE_ENCODING = "utf8";
+
+const convertToBuffer = (value: string | Buffer): Buffer => {
+    if (typeof value === "string") {
+        return Buffer.from(value, TO_STORAGE_ENCODING);
+    }
+    return value;
+};
+
+/**
+ * The GZIP compression for content field.
+ */
+export class GzipContentCompressionPlugin extends ContentCompressionPlugin {
+    public constructor() {
+        super(GZIP_COMPRESSION);
+    }
+
+    public canCompress(): boolean {
+        return true;
+    }
+
+    public canDecompress(value: CompressedValue): boolean {
+        if (!value || !value.compression) {
+            return false;
+        }
+        return value.compression === GZIP_COMPRESSION;
+    }
+
+    public async compress(initialValue: any): Promise<CompressedValue> {
+        if (!initialValue) {
+            return {
+                compression: GZIP_COMPRESSION,
+                content: null
+            };
+        }
+        try {
+            const value = JSON.stringify(initialValue);
+            const compressed = await gzip(value);
+
+            const content = compressed.toString(TO_STORAGE_ENCODING);
+
+            return {
+                compression: GZIP_COMPRESSION,
+                content
+            };
+        } catch (ex) {
+            console.log(`Error while compressing page content: ${ex.message}`);
+        }
+
+        return {
+            compression: GZIP_COMPRESSION,
+            content: null
+        };
+    }
+
+    public async decompress(value: CompressedValue): Promise<any> {
+        if (!value?.content) {
+            return null;
+        }
+
+        try {
+            const buf = await ungzip(convertToBuffer(value.content));
+            const result = buf.toString(FROM_STORAGE_ENCODING);
+            return JSON.parse(result);
+        } catch (ex) {
+            console.log("Error while transforming long-text.");
+            console.log(ex.message);
+            return "";
+        }
+    }
+}

--- a/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
+++ b/packages/api-page-builder/src/plugins/JsonpackContentCompressionPlugin.ts
@@ -1,5 +1,5 @@
 import jsonpack from "jsonpack";
-import { ContentCompressionPlugin, CompressedValue } from "./ContentCompressionPlugin";
+import { CompressedValue, ContentCompressionPlugin } from "./ContentCompressionPlugin";
 
 const JSONPACK_COMPRESSION = "jsonpack";
 
@@ -9,6 +9,10 @@ const JSONPACK_COMPRESSION = "jsonpack";
 export class JsonpackContentCompressionPlugin extends ContentCompressionPlugin {
     public constructor() {
         super(JSONPACK_COMPRESSION);
+    }
+
+    public override canCompress(): boolean {
+        return false;
     }
 
     public canDecompress(value: CompressedValue): boolean {

--- a/packages/api-page-builder/src/plugins/index.ts
+++ b/packages/api-page-builder/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from "./ContentCompressionPlugin";
 export * from "./JsonpackContentCompressionPlugin";
 export * from "./PageBuilderPageValidationModifierPlugin";
+export * from "./GzipContentCompressionPlugin";

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -4,7 +4,7 @@ import fastify, {
     preSerializationAsyncHookHandler
 } from "fastify";
 import { getWebinyVersionHeaders } from "@webiny/utils";
-import { ContextRoutes, DefinedContextRoutes, RouteMethodOptions, HTTPMethods } from "~/types";
+import { ContextRoutes, DefinedContextRoutes, HTTPMethods, RouteMethodOptions } from "~/types";
 import { Context } from "~/Context";
 import WebinyError from "@webiny/error";
 import { RoutePlugin } from "./plugins/RoutePlugin";
@@ -150,6 +150,7 @@ export const createHandler = (params: CreateHandlerParams) => {
      * We must attach the server to our internal context if we want to have it accessible.
      */
     const app = fastify({
+        bodyLimit: 10485760, // 10MB
         ...(params.options || {})
     });
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -13918,6 +13918,7 @@ __metadata:
     "@webiny/pubsub": 0.0.0
     "@webiny/utils": 0.0.0
     aws-sdk: ^2.971.0
+    bytes: ^3.1.0
     dataloader: ^2.0.0
     extract-zip: ^1.6.7
     fs-extra: ^9.1.0


### PR DESCRIPTION
## Changes
This PR increases the page content limit to 3MB by using GZIP compression of the content. This is only for the JSON data of the page, images and videos are not in this limit.
We also increased request body max size to 10MB by default. Of course, users can increase the body limit even higher if necessary.

## How Has This Been Tested?
Jest tests which create 3.2MB of page content.