### PR TITLE
fix(app-aco): possibility to remove field from list query

### DIFF
--- a/packages/api-audit-logs/src/app/app.ts
+++ b/packages/api-audit-logs/src/app/app.ts
@@ -80,7 +80,12 @@ export const createApp = (): IAcoAppRegisterParams => {
                 fieldId: "data",
                 type: "text",
                 storageId: "text@data",
-                label: "Data"
+                label: "Data",
+                settings: {
+                    aco: {
+                        list: false
+                    }
+                }
             },
             {
                 id: "timestamp",

--- a/packages/app-aco/src/graphql/records/common.ts
+++ b/packages/app-aco/src/graphql/records/common.ts
@@ -55,7 +55,36 @@ const createFieldsList = ({ model, fields }: CreateFieldsListParams): string => 
         .join("\n");
 };
 
-export const createAppFields = (model: AcoModel) => {
+export const createAppFields = (model: AcoModel, filterOutUnnecessaryFields?: boolean) => {
+    if (filterOutUnnecessaryFields) {
+        return createFieldsList({
+            model,
+            fields: model.fields.filter(field => {
+                /**
+                 * Filter out by field type for start.
+                 */
+                const filtered = [
+                    "text",
+                    "number",
+                    "boolean",
+                    "file",
+                    "long-text",
+                    "ref",
+                    "datetime"
+                ].includes(field.type);
+                if (!filtered) {
+                    return false;
+                }
+                /**
+                 * Then we need to check the field settings.
+                 */
+                if (field.settings?.aco?.list === false) {
+                    return false;
+                }
+                return true;
+            })
+        });
+    }
     return createFieldsList({
         model,
         fields: model.fields

--- a/packages/app-aco/src/graphql/records/listRecords.ts
+++ b/packages/app-aco/src/graphql/records/listRecords.ts
@@ -13,7 +13,10 @@ export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
              * We could do that if we fetched the information from the API side - we do not have that information in the UI.
              */
             model.fields.filter(field => {
-                return [
+                /**
+                 * Filter out by field type for start.
+                 */
+                const filtered = [
                     "text",
                     "number",
                     "boolean",
@@ -22,6 +25,16 @@ export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
                     "ref",
                     "datetime"
                 ].includes(field.type);
+                if (!filtered) {
+                    return false;
+                }
+                /**
+                 * Then we need to check the field settings.
+                 */
+                if (field.settings?.aco?.list === false) {
+                    return false;
+                }
+                return true;
             })
         );
     }
@@ -31,7 +44,7 @@ export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
             search {
                 content: list${pluralApiName}(where: $where, limit: $limit, after: $after, sort: $sort, search: $search) {
                     data {
-                        ${createAppFields(model)}
+                        ${createAppFields(model, true)}
                     }
                     ${LIST_META_FIELD}
                     ${ERROR_FIELD}

--- a/packages/app-aco/src/graphql/records/listRecords.ts
+++ b/packages/app-aco/src/graphql/records/listRecords.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import { AcoAppMode, AcoModel } from "~/types";
-import { createAppFields, ERROR_FIELD, LIST_META_FIELD } from "./common";
+import { createAppFields, ERROR_FIELD, filterFields, LIST_META_FIELD } from "./common";
 import { createListQuery } from "@webiny/app-headless-cms-common";
 
 export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
@@ -12,11 +12,8 @@ export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
              * TODO: possibly have only searchable / sortable fields here?
              * We could do that if we fetched the information from the API side - we do not have that information in the UI.
              */
-            model.fields.filter(field => {
-                /**
-                 * Filter out by field type for start.
-                 */
-                const filtered = [
+            filterFields(model.fields, field => {
+                return [
                     "text",
                     "number",
                     "boolean",
@@ -25,16 +22,6 @@ export const createListRecords = (model: AcoModel, mode: AcoAppMode) => {
                     "ref",
                     "datetime"
                 ].includes(field.type);
-                if (!filtered) {
-                    return false;
-                }
-                /**
-                 * Then we need to check the field settings.
-                 */
-                if (field.settings?.aco?.list === false) {
-                    return false;
-                }
-                return true;
             })
         );
     }

--- a/packages/app-aco/src/types.ts
+++ b/packages/app-aco/src/types.ts
@@ -179,6 +179,7 @@ export interface AcoModel extends CmsModel {
 export interface AcoModelFieldSettingsAco {
     enabled?: boolean;
     header?: boolean;
+    list?: boolean;
 }
 
 export interface AcoModelFieldSettings {

--- a/packages/app-audit-logs/src/views/Logs/Preview/Preview.tsx
+++ b/packages/app-audit-logs/src/views/Logs/Preview/Preview.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { format, addMinutes } from "date-fns";
+import React, { useEffect, useState } from "react";
+import { addMinutes, format } from "date-fns";
 
-import { Grid, Cell } from "@webiny/ui/Grid";
-import { Dialog, DialogContent, DialogTitle, DialogCancel, DialogActions } from "@webiny/ui/Dialog";
+import { Cell, Grid } from "@webiny/ui/Grid";
+import { Dialog, DialogActions, DialogCancel, DialogContent, DialogTitle } from "@webiny/ui/Dialog";
 import { CodeEditor } from "@webiny/ui/CodeEditor";
 import { Tooltip } from "@webiny/ui/Tooltip";
 
@@ -10,6 +10,7 @@ import { Action } from "~/views/Logs/Table";
 import { Text } from "~/components/Text";
 import { Entry } from "~/utils/transformCmsContentEntriesToRecordEntries";
 import { PayloadWrapper, previewDialog } from "./styled";
+import { useRecords } from "@webiny/app-aco";
 
 type HeaderProps = {
     auditLog: Entry | null;
@@ -18,7 +19,20 @@ type HeaderProps = {
 };
 
 export const Preview = ({ auditLog, onClose, hasAccessToUsers }: HeaderProps) => {
-    if (!auditLog) {
+    const { getRecord } = useRecords();
+
+    const [auditLogData, setAuditLogData] = useState(null);
+
+    useEffect(() => {
+        if (auditLogData || !auditLog?.id) {
+            return;
+        }
+        getRecord(auditLog.id).then(data => {
+            setAuditLogData(data as any);
+        });
+    }, [auditLog?.id, auditLogData, setAuditLogData]);
+
+    if (!auditLog || !auditLogData) {
         return null;
     }
 
@@ -88,7 +102,7 @@ export const Preview = ({ auditLog, onClose, hasAccessToUsers }: HeaderProps) =>
                             <CodeEditor
                                 mode="json"
                                 theme="chrome"
-                                value={JSON.stringify(JSON.parse(auditLog.data), null, 2)}
+                                value={JSON.stringify(auditLogData, null, 2)}
                                 readOnly
                             />
                         </PayloadWrapper>


### PR DESCRIPTION
## Changes
When creating an ACO App, developer can now choose not to list some field when fetching a list of ACO Records.
When loading a single record, all fields are loaded.

## How Has This Been Tested?
Manually.