### PR TITLE
Normalize Data In Publishing-related Entry Data Factories

### DIFF
--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
@@ -2,6 +2,7 @@ import { CmsContext, CmsEntry, CmsModel } from "~/types";
 import { STATUS_PUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
 import { validateModelEntryDataOrThrow } from "~/crud/contentEntry/entryDataValidation";
+import { getIdentity } from "~/utils/identity";
 
 type CreatePublishEntryDataParams = {
     model: CmsModel;
@@ -43,11 +44,11 @@ export const createPublishEntryData = async ({
         savedOn: currentDateTime,
         firstPublishedOn: latestEntry.firstPublishedOn || currentDateTime,
         lastPublishedOn: currentDateTime,
-        createdBy: latestEntry.createdBy,
-        modifiedBy: currentIdentity,
-        savedBy: currentIdentity,
-        firstPublishedBy: latestEntry.firstPublishedBy || currentIdentity,
-        lastPublishedBy: currentIdentity,
+        createdBy: getIdentity(latestEntry.createdBy),
+        modifiedBy: getIdentity(currentIdentity),
+        savedBy: getIdentity(currentIdentity),
+        firstPublishedBy: getIdentity(latestEntry.firstPublishedBy, currentIdentity),
+        lastPublishedBy: getIdentity(currentIdentity),
 
         /**
          * Revision-level meta fields. 👇
@@ -57,11 +58,14 @@ export const createPublishEntryData = async ({
         revisionModifiedOn: currentDateTime,
         revisionFirstPublishedOn: originalEntry.revisionFirstPublishedOn || currentDateTime,
         revisionLastPublishedOn: currentDateTime,
-        revisionCreatedBy: originalEntry.revisionCreatedBy,
-        revisionSavedBy: currentIdentity,
-        revisionModifiedBy: currentIdentity,
-        revisionFirstPublishedBy: originalEntry.revisionFirstPublishedBy || currentIdentity,
-        revisionLastPublishedBy: currentIdentity
+        revisionCreatedBy: getIdentity(originalEntry.revisionCreatedBy),
+        revisionSavedBy: getIdentity(currentIdentity),
+        revisionModifiedBy: getIdentity(currentIdentity),
+        revisionFirstPublishedBy: getIdentity(
+            originalEntry.revisionFirstPublishedBy,
+            currentIdentity
+        ),
+        revisionLastPublishedBy: getIdentity(currentIdentity)
     };
 
     return { entry };

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
@@ -3,6 +3,7 @@ import { STATUS_PUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
 import { validateModelEntryDataOrThrow } from "~/crud/contentEntry/entryDataValidation";
 import { getIdentity } from "~/utils/identity";
+import { getDate } from "~/utils/date";
 
 type CreatePublishEntryDataParams = {
     model: CmsModel;
@@ -39,11 +40,11 @@ export const createPublishEntryData = async ({
         /**
          * Entry-level meta fields. 👇
          */
-        createdOn: latestEntry.createdOn,
-        modifiedOn: currentDateTime,
-        savedOn: currentDateTime,
-        firstPublishedOn: latestEntry.firstPublishedOn || currentDateTime,
-        lastPublishedOn: currentDateTime,
+        createdOn: getDate(latestEntry.createdOn),
+        modifiedOn: getDate(currentDateTime),
+        savedOn: getDate(currentDateTime),
+        firstPublishedOn: getDate(latestEntry.firstPublishedOn, currentDateTime),
+        lastPublishedOn: getDate(currentDateTime),
         createdBy: getIdentity(latestEntry.createdBy),
         modifiedBy: getIdentity(currentIdentity),
         savedBy: getIdentity(currentIdentity),
@@ -53,11 +54,11 @@ export const createPublishEntryData = async ({
         /**
          * Revision-level meta fields. 👇
          */
-        revisionCreatedOn: originalEntry.revisionCreatedOn,
-        revisionSavedOn: currentDateTime,
-        revisionModifiedOn: currentDateTime,
-        revisionFirstPublishedOn: originalEntry.revisionFirstPublishedOn || currentDateTime,
-        revisionLastPublishedOn: currentDateTime,
+        revisionCreatedOn: getDate(originalEntry.revisionCreatedOn),
+        revisionSavedOn: getDate(currentDateTime),
+        revisionModifiedOn: getDate(currentDateTime),
+        revisionFirstPublishedOn: getDate(originalEntry.revisionFirstPublishedOn, currentDateTime),
+        revisionLastPublishedOn: getDate(currentDateTime),
         revisionCreatedBy: getIdentity(originalEntry.revisionCreatedBy),
         revisionSavedBy: getIdentity(currentIdentity),
         revisionModifiedBy: getIdentity(currentIdentity),

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
@@ -2,6 +2,7 @@ import { CmsContext, CmsEntry, CmsModel } from "~/types";
 import { referenceFieldsMapping } from "~/crud/contentEntry/referenceFieldsMapping";
 import { STATUS_PUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
+import { getIdentity } from "~/utils/identity";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -37,24 +38,27 @@ export const createRepublishEntryData = async ({
          */
         savedOn: currentDateTime,
         modifiedOn: currentDateTime,
-        savedBy: currentIdentity,
-        modifiedBy: currentIdentity,
+        savedBy: getIdentity(currentIdentity),
+        modifiedBy: getIdentity(currentIdentity),
         firstPublishedOn: originalEntry.firstPublishedOn || currentDateTime,
-        firstPublishedBy: originalEntry.firstPublishedBy || currentIdentity,
+        firstPublishedBy: getIdentity(originalEntry.firstPublishedBy, currentIdentity),
         lastPublishedOn: currentDateTime,
-        lastPublishedBy: currentIdentity,
+        lastPublishedBy: getIdentity(currentIdentity),
 
         /**
          * Revision-level meta fields. 👇
          */
         revisionSavedOn: currentDateTime,
         revisionModifiedOn: currentDateTime,
-        revisionSavedBy: currentIdentity,
-        revisionModifiedBy: currentIdentity,
+        revisionSavedBy: getIdentity(currentIdentity),
+        revisionModifiedBy: getIdentity(currentIdentity),
         revisionFirstPublishedOn: originalEntry.revisionFirstPublishedOn || currentDateTime,
-        revisionFirstPublishedBy: originalEntry.revisionFirstPublishedBy || currentIdentity,
+        revisionFirstPublishedBy: getIdentity(
+            originalEntry.revisionFirstPublishedBy,
+            currentIdentity
+        ),
         revisionLastPublishedOn: currentDateTime,
-        revisionLastPublishedBy: currentIdentity,
+        revisionLastPublishedBy: getIdentity(currentIdentity),
 
         webinyVersion: context.WEBINY_VERSION,
         values

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
@@ -3,6 +3,7 @@ import { referenceFieldsMapping } from "~/crud/contentEntry/referenceFieldsMappi
 import { STATUS_PUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
 import { getIdentity } from "~/utils/identity";
+import { getDate } from "~/utils/date";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -36,28 +37,28 @@ export const createRepublishEntryData = async ({
         /**
          * Entry-level meta fields. 👇
          */
-        savedOn: currentDateTime,
-        modifiedOn: currentDateTime,
+        savedOn: getDate(currentDateTime),
+        modifiedOn: getDate(currentDateTime),
         savedBy: getIdentity(currentIdentity),
         modifiedBy: getIdentity(currentIdentity),
-        firstPublishedOn: originalEntry.firstPublishedOn || currentDateTime,
+        firstPublishedOn: getDate(originalEntry.firstPublishedOn, currentDateTime),
         firstPublishedBy: getIdentity(originalEntry.firstPublishedBy, currentIdentity),
-        lastPublishedOn: currentDateTime,
+        lastPublishedOn: getDate(currentDateTime),
         lastPublishedBy: getIdentity(currentIdentity),
 
         /**
          * Revision-level meta fields. 👇
          */
-        revisionSavedOn: currentDateTime,
-        revisionModifiedOn: currentDateTime,
+        revisionSavedOn: getDate(currentDateTime),
+        revisionModifiedOn: getDate(currentDateTime),
         revisionSavedBy: getIdentity(currentIdentity),
         revisionModifiedBy: getIdentity(currentIdentity),
-        revisionFirstPublishedOn: originalEntry.revisionFirstPublishedOn || currentDateTime,
+        revisionFirstPublishedOn: getDate(originalEntry.revisionFirstPublishedOn, currentDateTime),
         revisionFirstPublishedBy: getIdentity(
             originalEntry.revisionFirstPublishedBy,
             currentIdentity
         ),
-        revisionLastPublishedOn: currentDateTime,
+        revisionLastPublishedOn: getDate(currentDateTime),
         revisionLastPublishedBy: getIdentity(currentIdentity),
 
         webinyVersion: context.WEBINY_VERSION,

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
@@ -2,6 +2,7 @@ import { CmsContext, CmsEntry, CmsModel } from "~/types";
 import { STATUS_UNPUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
 import { getIdentity } from "~/utils/identity";
+import { getDate } from "~/utils/date";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -26,16 +27,16 @@ export const createUnpublishEntryData = async ({
         /**
          * Entry-level meta fields. 👇
          */
-        savedOn: currentDateTime,
-        modifiedOn: currentDateTime,
+        savedOn: getDate(currentDateTime),
+        modifiedOn: getDate(currentDateTime),
         savedBy: getIdentity(currentIdentity),
         modifiedBy: getIdentity(currentIdentity),
 
         /**
          * Revision-level meta fields. 👇
          */
-        revisionSavedOn: currentDateTime,
-        revisionModifiedOn: currentDateTime,
+        revisionSavedOn: getDate(currentDateTime),
+        revisionModifiedOn: getDate(currentDateTime),
         revisionSavedBy: getIdentity(currentIdentity),
         revisionModifiedBy: getIdentity(currentIdentity)
     };

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
@@ -1,6 +1,7 @@
 import { CmsContext, CmsEntry, CmsModel } from "~/types";
 import { STATUS_UNPUBLISHED } from "./statuses";
 import { SecurityIdentity } from "@webiny/api-security/types";
+import { getIdentity } from "~/utils/identity";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -27,16 +28,16 @@ export const createUnpublishEntryData = async ({
          */
         savedOn: currentDateTime,
         modifiedOn: currentDateTime,
-        savedBy: currentIdentity,
-        modifiedBy: currentIdentity,
+        savedBy: getIdentity(currentIdentity),
+        modifiedBy: getIdentity(currentIdentity),
 
         /**
          * Revision-level meta fields. 👇
          */
         revisionSavedOn: currentDateTime,
         revisionModifiedOn: currentDateTime,
-        revisionSavedBy: currentIdentity,
-        revisionModifiedBy: currentIdentity
+        revisionSavedBy: getIdentity(currentIdentity),
+        revisionModifiedBy: getIdentity(currentIdentity)
     };
 
     return { entry };


### PR DESCRIPTION
## Changes
Prior to this PR, date/time and identity-related data wasn't normalized in publishing-related content entry data factories (publish, republish, unpublish).

This would cause identity-based meta fields to hold more properties than intended, for example:

```ts
"lastPublishedBy": {
  "displayName": "ad min",
  "email": "admin@webiny.com",
  "firstName": "ad",
  "id": "65b7ac2202decd00092691c4",
  "lastName": "min",
  "type": "admin"
 },
```

As we can see, apart from `id`, `type`, and `displayName` fields, we also have `firstName`, `lastName`, and `email`. This should not happen. The correct data would be:

```ts
"lastPublishedBy": {
  "displayName": "ad min",
  "id": "65b7ac2202decd00092691c4",
  "type": "admin"
 },
```

## How Has This Been Tested?
Manually.

## Documentation
Not needed.