### PR TITLE
Folder Level Permissions - Ensuring Folder Permissions Are Immediately Set When Performing Create/Update Folder Mutations

### DIFF
--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -115,6 +115,11 @@ export class FolderLevelPermissions {
         }
     }
 
+    updateCache(folderType: string, modifier: (folders: Folder[]) => Folder[]) {
+        const foldersClone = structuredClone(this.allFolders[folderType]) || [];
+        this.allFolders[folderType] = modifier(foldersClone);
+    }
+
     async listFoldersPermissions(
         params: ListFolderPermissionsParams
     ): Promise<FolderPermissionsList> {


### PR DESCRIPTION
## Changes
Essentially, this PR ensures that when a user issues a `createFolder` or `updateFolder` mutation, that the returned folder has its permissions set correctly, which was not the case for DDB+ES/DDB+OS projects. In these systems, if a user created a new folder via the UI, only after refreshing the screen, the user would see its permissions as expected. 

This was happening just because of the nature of ES/OS and the existing application code that didn't take this into account. 

With this PR, when creating/updating folders, we're no longer invalidating FLP's internal cache and by doing that, forcing FLP to reload its list of folders when required. Instead, we're updating its cache. For example, when creating a new folder, instead of invalidating the cache, we're simply appending the newly created folder to it. 

## How Has This Been Tested?
Jest. Manually.

## Documentation
Changelog.