### PR TITLE
Amazon OpenSearch Service - Add IAM Service Role Check 

### DIFF
--- a/packages/serverless-cms-aws/src/core/plugins/checkEsServiceRole.ts
+++ b/packages/serverless-cms-aws/src/core/plugins/checkEsServiceRole.ts
@@ -10,30 +10,30 @@ export const checkEsServiceRole = {
     name: "hook-before-deploy-es-service-role",
     async hook(params: Record<string, any>, context: CliContext) {
         const spinner = ora();
-        spinner.start(`Checking Elastic Search service role...`);
+        spinner.start(`Checking Amazon Elasticsearch service role...`);
         const iam = new IAM();
         try {
             await iam.getRole({ RoleName: "AWSServiceRoleForAmazonElasticsearchService" });
 
             spinner.stopAndPersist({
                 symbol: green("✔"),
-                text: `Found Elastic Search service role!`
+                text: `Found Amazon Elasticsearch service role!`
             });
-            context.success(`Found Elastic Search service role!`);
+            context.success(`Found Amazon Elasticsearch service role!`);
         } catch (err) {
             // We've seen cases where the `iam.getRole` call fails because of an issue
             // other than not being able to retrieve the service role. Let's print
             // additional info if that's the case. Will make debugging a bit easier.
             if (err.code !== NO_SUCH_ENTITY_IAM_ERROR) {
                 spinner.fail(
-                    "Tried retrieving Elastic Search service role but failed with the following error: " +
+                    "Tried retrieving Amazon Elasticsearch service role but failed with the following error: " +
                         err.message
                 );
                 context.debug(err);
                 process.exit(1);
             }
 
-            spinner.text = "Creating Elastic Search service role...";
+            spinner.text = "Creating Amazon Elasticsearch service role...";
 
             try {
                 await iam.createServiceLinkedRole({ AWSServiceName: "es.amazonaws.com" });

--- a/packages/serverless-cms-aws/src/core/plugins/checkOsServiceRole.ts
+++ b/packages/serverless-cms-aws/src/core/plugins/checkOsServiceRole.ts
@@ -1,0 +1,49 @@
+import { IAM } from "@webiny/aws-sdk/client-iam";
+import ora from "ora";
+import { green } from "chalk";
+import { CliContext } from "@webiny/cli/types";
+
+const NO_SUCH_ENTITY_IAM_ERROR = "NoSuchEntity";
+
+export const checkOsServiceRole = {
+    type: "hook-before-deploy",
+    name: "hook-before-deploy-es-service-role",
+    async hook(params: Record<string, any>, context: CliContext) {
+        const spinner = ora();
+        spinner.start(`Checking Amazon OpenSearch service role...`);
+        const iam = new IAM();
+        try {
+            await iam.getRole({ RoleName: "AWSServiceRoleForAmazonOpenSearchService" });
+
+            spinner.stopAndPersist({
+                symbol: green("✔"),
+                text: `Found Amazon OpenSearch service role!`
+            });
+            context.success(`Found Amazon OpenSearch service role!`);
+        } catch (err) {
+            // We've seen cases where the `iam.getRole` call fails because of an issue
+            // other than not being able to retrieve the service role. Let's print
+            // additional info if that's the case. Will make debugging a bit easier.
+            if (err.code !== NO_SUCH_ENTITY_IAM_ERROR) {
+                spinner.fail(
+                    "Tried retrieving Amazon OpenSearch service role but failed with the following error: " +
+                    err.message
+                );
+                context.debug(err);
+                process.exit(1);
+            }
+
+            spinner.text = "Creating Amazon OpenSearch service role...";
+
+            try {
+                await iam.createServiceLinkedRole({ AWSServiceName: "es.amazonaws.com" });
+
+                spinner.stop();
+            } catch (err) {
+                spinner.fail(err.message);
+                context.debug(err);
+                process.exit(1);
+            }
+        }
+    }
+};

--- a/packages/serverless-cms-aws/src/core/plugins/checkOsServiceRole.ts
+++ b/packages/serverless-cms-aws/src/core/plugins/checkOsServiceRole.ts
@@ -27,7 +27,7 @@ export const checkOsServiceRole = {
             if (err.code !== NO_SUCH_ENTITY_IAM_ERROR) {
                 spinner.fail(
                     "Tried retrieving Amazon OpenSearch service role but failed with the following error: " +
-                    err.message
+                        err.message
                 );
                 context.debug(err);
                 process.exit(1);

--- a/packages/serverless-cms-aws/src/core/plugins/index.ts
+++ b/packages/serverless-cms-aws/src/core/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from "./generateDdbToEsHandler";
 export * from "./checkEsServiceRole";
+export * from "./checkOsServiceRole";

--- a/packages/serverless-cms-aws/src/createCoreApp.ts
+++ b/packages/serverless-cms-aws/src/createCoreApp.ts
@@ -1,6 +1,6 @@
 import { createCorePulumiApp, CreateCorePulumiAppParams } from "@webiny/pulumi-aws";
 import { PluginCollection } from "@webiny/plugins/types";
-import { generateDdbToEsHandler, checkEsServiceRole } from "./core/plugins";
+import { generateDdbToEsHandler, checkEsServiceRole, checkOsServiceRole } from "./core/plugins";
 
 export { CoreOutput, configureAdminCognitoFederation } from "@webiny/pulumi-aws";
 
@@ -11,7 +11,12 @@ export interface CreateCoreAppParams extends CreateCorePulumiAppParams {
 export function createCoreApp(projectAppParams: CreateCoreAppParams = {}) {
     const builtInPlugins = [];
     if (projectAppParams.elasticSearch || projectAppParams.openSearch) {
-        builtInPlugins.push(generateDdbToEsHandler, checkEsServiceRole);
+        builtInPlugins.push(generateDdbToEsHandler);
+        if (projectAppParams.elasticSearch) {
+            builtInPlugins.push(checkEsServiceRole);
+        } else {
+            builtInPlugins.push(checkOsServiceRole);
+        }
     }
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];

--- a/packages/serverless-cms-aws/src/enterprise/createCoreApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createCoreApp.ts
@@ -1,8 +1,8 @@
 import { createCorePulumiApp, CreateCorePulumiAppParams } from "@webiny/pulumi-aws/enterprise";
 import { PluginCollection } from "@webiny/plugins/types";
-import { generateDdbToEsHandler, checkEsServiceRole } from "~/core/plugins";
+import { generateDdbToEsHandler, checkEsServiceRole, checkOsServiceRole } from "~/core/plugins";
 
-export { CoreOutput } from "@webiny/pulumi-aws";
+export { CoreOutput, configureAdminCognitoFederation } from "@webiny/pulumi-aws";
 
 export interface CreateCoreAppParams extends CreateCorePulumiAppParams {
     plugins?: PluginCollection;
@@ -11,7 +11,12 @@ export interface CreateCoreAppParams extends CreateCorePulumiAppParams {
 export function createCoreApp(projectAppParams: CreateCoreAppParams = {}) {
     const builtInPlugins = [];
     if (projectAppParams.elasticSearch || projectAppParams.openSearch) {
-        builtInPlugins.push(generateDdbToEsHandler, checkEsServiceRole);
+        builtInPlugins.push(generateDdbToEsHandler);
+        if (projectAppParams.elasticSearch) {
+            builtInPlugins.push(checkEsServiceRole);
+        } else {
+            builtInPlugins.push(checkOsServiceRole);
+        }
     }
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];


### PR DESCRIPTION
## Changes
This PR adds the Amazon OpenSearch Service-related IAM service role check (works in the same way we had it with ES).

## How Has This Been Tested?
Manual.

## Documentation
Changelog.