### PR TITLE
Multitenancy - Unset Locale when Exiting Tenant

### DIFF
--- a/packages/app-admin-auth0/src/modules/userMenu/exitTenant.tsx
+++ b/packages/app-admin-auth0/src/modules/userMenu/exitTenant.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { makeComposable } from "@webiny/app-serverless-cms";
 import { ListItem, ListItemGraphic } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
 import { ReactComponent as LogoutIcon } from "~/assets/icons/logout_black_24dp.svg";
 import { useSecurity } from "@webiny/app-security";
 import { useTenancy } from "@webiny/app-tenancy";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 export const ExitTenant = makeComposable("ExitTenant", () => {
     const security = useSecurity();
     const tenancy = useTenancy();
+    const i18n = useI18N();
 
     if (!security || !security.identity) {
         return null;
@@ -17,9 +19,14 @@ export const ExitTenant = makeComposable("ExitTenant", () => {
     // This is only applicable in multi-tenant environments
     const { currentTenant, defaultTenant } = security.identity;
 
+    const exitTenant = useCallback(() => {
+        tenancy.setTenant(defaultTenant.id);
+        i18n.setCurrentLocale("", "content");
+    }, [defaultTenant]);
+
     if (tenancy && currentTenant && defaultTenant && currentTenant.id !== defaultTenant.id) {
         return (
-            <ListItem onClick={() => tenancy.setTenant(defaultTenant.id)}>
+            <ListItem onClick={exitTenant}>
                 <ListItemGraphic>
                     <Icon icon={<LogoutIcon />} />
                 </ListItemGraphic>

--- a/packages/app-admin-okta/src/modules/userMenu/exitTenant.tsx
+++ b/packages/app-admin-okta/src/modules/userMenu/exitTenant.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { makeComposable } from "@webiny/app-serverless-cms";
 import { ListItem, ListItemGraphic } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
 import { ReactComponent as LogoutIcon } from "~/assets/icons/logout_black_24dp.svg";
 import { useSecurity } from "@webiny/app-security";
 import { useTenancy } from "@webiny/app-tenancy";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 export const ExitTenant = makeComposable("ExitTenant", () => {
     const security = useSecurity();
     const tenancy = useTenancy();
+    const i18n = useI18N();
 
     if (!security || !security.identity) {
         return null;
@@ -17,9 +19,14 @@ export const ExitTenant = makeComposable("ExitTenant", () => {
     // This is only applicable in multi-tenant environments
     const { currentTenant, defaultTenant } = security.identity;
 
+    const exitTenant = useCallback(() => {
+        tenancy.setTenant(defaultTenant.id);
+        i18n.setCurrentLocale("", "content");
+    }, [defaultTenant]);
+
     if (tenancy && currentTenant && defaultTenant && currentTenant.id !== defaultTenant.id) {
         return (
-            <ListItem onClick={() => tenancy.setTenant(defaultTenant.id)}>
+            <ListItem onClick={exitTenant}>
                 <ListItemGraphic>
                     <Icon icon={<LogoutIcon />} />
                 </ListItemGraphic>

--- a/packages/app-admin-users-cognito/src/plugins/userMenu/accountDetails.tsx
+++ b/packages/app-admin-users-cognito/src/plugins/userMenu/accountDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { css } from "emotion";
 import { ListItem, ListItemGraphic } from "@webiny/ui/List";
 import { Icon } from "@webiny/ui/Icon";
@@ -7,6 +7,7 @@ import { ReactComponent as AccountIcon } from "~/assets/icons/round-account_circ
 import { ReactComponent as LogoutIcon } from "~/assets/icons/logout_black_24dp.svg";
 import { useSecurity } from "@webiny/app-security";
 import { useTenancy } from "@webiny/app-tenancy";
+import { useI18N } from "@webiny/app-i18n/hooks/useI18N";
 
 const linkStyles = css({
     "&:hover": {
@@ -17,6 +18,7 @@ const linkStyles = css({
 export const AccountDetails: React.FC = () => {
     const security = useSecurity();
     const tenancy = useTenancy();
+    const i18n = useI18N();
 
     if (!security || !security.identity) {
         return null;
@@ -25,9 +27,14 @@ export const AccountDetails: React.FC = () => {
     // This is only applicable in multi-tenant environments
     const { currentTenant, defaultTenant } = security.identity;
 
+    const exitTenant = useCallback(() => {
+        tenancy.setTenant(defaultTenant.id);
+        i18n.setCurrentLocale("", "content");
+    }, [defaultTenant]);
+
     if (tenancy && currentTenant && defaultTenant && currentTenant.id !== defaultTenant.id) {
         return (
-            <ListItem onClick={() => tenancy.setTenant(defaultTenant.id)}>
+            <ListItem onClick={exitTenant}>
                 <ListItemGraphic>
                     <Icon icon={<LogoutIcon />} />
                 </ListItemGraphic>


### PR DESCRIPTION
## Changes
When exiting tenant, apart from setting the tenant to user's default tenant, we're now also unsetting the locale. This ensures the locale is reset when returning to the default tenant.

## How Has This Been Tested?
Manual.

## Documentation
Changelog.