### PR TITLE
fix(api-file-manager-s3): add cache-control header to asset reply

### DIFF
--- a/packages/api-file-manager-s3/src/assetDelivery/s3/S3StreamAssetReply.ts
+++ b/packages/api-file-manager-s3/src/assetDelivery/s3/S3StreamAssetReply.ts
@@ -6,6 +6,7 @@ export class S3StreamAssetReply extends AssetReply {
         super({
             code: 200,
             headers: ResponseHeaders.create({
+                "cache-control": `public, max-age=${86400 * 365}`,
                 "content-type": asset.getContentType()
             }),
             body: () => asset.getContents()


### PR DESCRIPTION
## Changes
This PR fixes an issue with asset caching in the browser and CDN, by setting the appropriate `cache-control` header.

## How Has This Been Tested?
Manually.