### PR TITLE
fix(api-page-builder): set page elements list limit to 1000

### DIFF
--- a/packages/api-page-builder/src/graphql/crud/pageElements.crud.ts
+++ b/packages/api-page-builder/src/graphql/crud/pageElements.crud.ts
@@ -108,6 +108,7 @@ export const createPageElementsCrud = (params: CreatePageElementsCrudParams): Pa
                     tenant: getTenantId(),
                     locale: getLocaleCode()
                 },
+                limit: 1000,
                 sort: Array.isArray(sort) && sort.length > 0 ? sort : ["createdOn_ASC"]
             };
 


### PR DESCRIPTION
## Changes
This PR fixes an issue with saved page elements. Currently, if you call the `context.pageBuilder.listPageElements` method, it simply forwards the call to the storage layer, which has a default limit set to `10`. With this PR we pass an explicit limit value of 1000, which should be more than enough, as these elements are only used in the page editor sidebar.

## How Has This Been Tested?
Manually.
