### PR TITLE
fix(api-elasticsearch-tasks): possibility to pass the limit through task input

### DIFF
--- a/packages/api-elasticsearch-tasks/src/tasks/reindexing/ReindexingTaskRunner.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/reindexing/ReindexingTaskRunner.ts
@@ -39,7 +39,7 @@ export class ReindexingTaskRunner {
      */
     public async exec(
         keys: IElasticsearchIndexingTaskValuesKeys | undefined = undefined,
-        limit = 200
+        limit: number
     ): Promise<ITaskResponseResult> {
         this.keys = keys;
 

--- a/packages/api-elasticsearch-tasks/src/tasks/reindexing/reindexingTaskDefinition.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/reindexing/reindexingTaskDefinition.ts
@@ -33,7 +33,7 @@ export const createElasticsearchReindexingTask = (params?: IElasticsearchTaskCon
             const reindexing = new ReindexingTaskRunner(manager, indexManager);
 
             const keys = input.keys || undefined;
-            return reindexing.exec(keys, 200);
+            return reindexing.exec(keys, input.limit || 100);
         }
     });
 };

--- a/packages/api-elasticsearch-tasks/src/types.ts
+++ b/packages/api-elasticsearch-tasks/src/types.ts
@@ -31,6 +31,7 @@ export interface IElasticsearchIndexingTaskValuesSettings {
 
 export interface IElasticsearchIndexingTaskValues {
     matching?: string;
+    limit?: number;
     keys?: IElasticsearchIndexingTaskValuesKeys;
     settings?: IElasticsearchIndexingTaskValuesSettings;
 }

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -9,8 +9,8 @@ import {
     ContextRoutes,
     DefinedContextRoutes,
     HTTPMethods,
-    Request,
     Reply,
+    Request,
     RouteMethodOptions
 } from "~/types";
 import { Context } from "~/Context";
@@ -186,7 +186,7 @@ export const createHandler = (params: CreateHandlerParams) => {
      * We must attach the server to our internal context if we want to have it accessible.
      */
     const app = fastify({
-        bodyLimit: 10485760, // 10MB
+        bodyLimit: 536870912, // 512MB
         ...(params.options || {})
     });
 

--- a/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
+++ b/packages/serverless-cms-aws/handlers/ddb-es/core/dynamoToElastic/src/index.ts
@@ -11,6 +11,6 @@ export const handler = createHandler({
         createEventHandler()
     ],
     options: {
-        bodyLimit: 536870912
+        bodyLimit: 536870912 // 512MB
     }
 });

--- a/packages/tasks/__tests__/graphql/tasks.test.ts
+++ b/packages/tasks/__tests__/graphql/tasks.test.ts
@@ -15,7 +15,7 @@ describe("graphql - tasks", () => {
     it("should list tasks", async () => {
         const context = await contextHandler.handle();
 
-        await context.tasks.createTask({
+        const task = await context.tasks.createTask({
             name: "My Custom Task #1",
             definitionId: "myCustomTaskNumber1",
             input: {
@@ -40,6 +40,11 @@ describe("graphql - tasks", () => {
                 someValue: "yes!",
                 someOtherValue: 12345678
             }
+        });
+
+        await context.tasks.createLog(task, {
+            executionName: task.executionName || "mock execution name",
+            iteration: 1
         });
 
         const response = await handler.listTasks();
@@ -98,7 +103,20 @@ describe("graphql - tasks", () => {
                                 createdOn: expect.any(String),
                                 savedOn: expect.any(String),
                                 eventResponse: null,
-                                logs: []
+                                logs: [
+                                    {
+                                        createdBy: {
+                                            displayName: "John Doe",
+                                            id: "id-12345678",
+                                            type: "admin"
+                                        },
+                                        createdOn: expect.toBeDateString(),
+                                        executionName: "mock execution name",
+                                        id: expect.any(String),
+                                        items: [],
+                                        iteration: 1
+                                    }
+                                ]
                             }
                         ],
                         meta: {


### PR DESCRIPTION
## Changes
Sometimes there are really large records in the database and users might want to limit the amount of records the Reindexing task goes through in one loop iteration.
Also, we increased the default bodyLimit on the base handler.

## How Has This Been Tested?
Jest and manually.