### PR TITLE
fix: remove imperative API from Tabs

### DIFF
--- a/packages/app-form-builder/src/admin/components/FormEditor/EditorContent.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/EditorContent.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useState } from "react";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import { SplitView, LeftPanel, RightPanel } from "@webiny/app-admin/components/SplitView";
 import { Typography } from "@webiny/ui/Typography";
-import { Tabs, Tab, TabsImperativeApi } from "@webiny/ui/Tabs";
+import { Tabs, Tab } from "@webiny/ui/Tabs";
 import { Icon } from "@webiny/ui/Icon";
 import { EditTab } from "./Tabs/EditTab";
 import { TriggersTab } from "./Tabs/TriggersTab";
@@ -44,14 +44,11 @@ const formTabs = css({
     }
 });
 const EditorContent = () => {
-    const tabsRef = useRef<TabsImperativeApi>();
+    const [activeTab, setActiveTab] = useState(0);
 
     const onFieldDragStart = useCallback(() => {
-        if (!tabsRef.current) {
-            return;
-        }
-        tabsRef.current.switchTab(0);
-    }, [tabsRef]);
+        setActiveTab(0);
+    }, []);
 
     return (
         <ContentContainer>
@@ -66,7 +63,7 @@ const EditorContent = () => {
                     </LeftBarFieldList>
                 </LeftPanel>
                 <RightPanel span={8}>
-                    <Tabs className={formTabs} ref={tabsRef}>
+                    <Tabs className={formTabs} value={activeTab} onActivate={setActiveTab}>
                         <Tab label={"Edit"}>
                             <EditTab />
                         </Tab>

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorProvider.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditorProvider.tsx
@@ -1,11 +1,4 @@
-import React, {
-    MutableRefObject,
-    useCallback,
-    useEffect,
-    useMemo,
-    useReducer,
-    useRef
-} from "react";
+import React, { useCallback, useEffect, useMemo, useReducer } from "react";
 import get from "lodash/get";
 import pick from "lodash/pick";
 import { ApolloClient } from "apollo-client";
@@ -22,7 +15,6 @@ import {
 import { LIST_MENU_CONTENT_GROUPS_MODELS } from "~/admin/viewsGraphql";
 import { CmsModelField, CmsModel } from "~/types";
 import { FetchResult } from "apollo-link";
-import { TabsImperativeApi } from "@webiny/ui/Tabs";
 import { ModelProvider } from "~/admin/components/ModelProvider";
 
 export interface ContentModelEditorProviderContext {
@@ -35,7 +27,6 @@ export interface ContentModelEditorProviderContext {
         data?: CmsModel
     ) => Promise<UpdateCmsModelMutationResponse["updateContentModel"]>;
     setData: (setter: (model: CmsModel) => void, saveContentModel?: boolean) => Promise<any>;
-    tabsRef: MutableRefObject<TabsImperativeApi | undefined>;
     activeTabIndex: number;
     setActiveTabIndex: (index: number) => void;
 }
@@ -121,8 +112,6 @@ export const ContentModelEditorProvider = ({
         data: null as unknown as CmsModel,
         activeTabIndex: 0
     });
-
-    const tabsRef = useRef<TabsImperativeApi>();
 
     const { history } = useRouter();
     const { showSnackbar } = useSnackbar();
@@ -241,7 +230,6 @@ export const ContentModelEditorProvider = ({
             getContentModel,
             saveContentModel,
             setData,
-            tabsRef,
             activeTabIndex: state.activeTabIndex,
             setActiveTabIndex
         }),

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/Editor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { Prompt } from "@webiny/react-router";
 import styled from "@emotion/styled";
 import { css } from "emotion";
@@ -7,7 +7,7 @@ import { CircularProgress } from "@webiny/ui/Progress";
 import { LeftPanel, RightPanel, SplitView } from "@webiny/app-admin/components/SplitView";
 import { Icon } from "@webiny/ui/Icon";
 import { Typography } from "@webiny/ui/Typography";
-import { Tab, Tabs, TabsImperativeApi } from "@webiny/ui/Tabs";
+import { Tab, Tabs } from "@webiny/ui/Tabs";
 import { ReactComponent as FormIcon } from "./icons/round-assignment-24px.svg";
 import { FieldsSidebar } from "./FieldsSidebar";
 import { FieldEditor } from "../FieldEditor";
@@ -66,8 +66,7 @@ interface OnChangeParams {
 export const Editor = () => {
     const { data, setData, isPristine } = useModelEditor();
 
-    const tabsRef = useRef<TabsImperativeApi>();
-    const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
 
     const onChange = ({ fields, layout }: OnChangeParams) => {
         setData(data => ({ ...data, fields, layout }));
@@ -91,18 +90,15 @@ export const Editor = () => {
                         <LeftBarFieldList>
                             <FieldsSidebar
                                 onFieldDragStart={() => {
-                                    if (!tabsRef.current) {
-                                        return;
-                                    }
-                                    tabsRef.current.switchTab(0);
+                                    setActiveTabIndex(0);
                                 }}
                             />
                         </LeftBarFieldList>
                     </LeftPanel>
                     <RightPanel span={8}>
                         <Tabs
+                            value={activeTabIndex}
                             className={formTabs}
-                            ref={tabsRef}
                             onActivate={e => setActiveTabIndex(e)}
                         >
                             <Tab label={"Edit"} data-testid={"cms.editor.tab.edit"}>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry.tsx
@@ -49,8 +49,16 @@ declare global {
 }
 
 export const ContentEntry = () => {
-    const { loading, entry, showEmptyView, canCreate, createEntry, tabsRef, setFormRef } =
-        useContentEntry();
+    const {
+        loading,
+        entry,
+        showEmptyView,
+        canCreate,
+        createEntry,
+        activeTab,
+        setActiveTab,
+        setFormRef
+    } = useContentEntry();
 
     // Render "No content selected" view.
     if (showEmptyView) {
@@ -73,7 +81,7 @@ export const ContentEntry = () => {
     return (
         <DetailsContainer>
             <test-id data-testid="cms-content-details">
-                <Tabs ref={tabsRef}>
+                <Tabs value={activeTab} onActivate={setActiveTab}>
                     <Tab
                         label={"Content"}
                         disabled={loading}

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -1,7 +1,6 @@
 import React, {
     Dispatch,
     MutableRefObject,
-    RefObject,
     SetStateAction,
     useCallback,
     useEffect,
@@ -17,7 +16,6 @@ import { useQuery } from "~/admin/hooks";
 import { ContentEntriesContext } from "~/admin/views/contentEntries/ContentEntriesContext";
 import { useContentEntries } from "~/admin/views/contentEntries/hooks/useContentEntries";
 import { CmsContentEntry, CmsContentEntryRevision } from "~/types";
-import { TabsImperativeApi } from "@webiny/ui/Tabs";
 import { parseIdentifier } from "@webiny/utils";
 import {
     CmsEntriesListRevisionsQueryResponse,
@@ -46,7 +44,8 @@ export interface ContentEntryContext extends ContentEntriesContext {
     setLoading: Dispatch<SetStateAction<boolean>>;
     revisions: CmsContentEntryRevision[];
     refetchContent: () => void;
-    tabsRef: RefObject<TabsImperativeApi | undefined>;
+    setActiveTab(index: number): void;
+    activeTab: number;
     showEmptyView: boolean;
 }
 
@@ -84,6 +83,7 @@ export const ContentEntryProvider = ({
     isNewEntry,
     getContentId
 }: ContentEntryContextProviderProps) => {
+    const [activeTab, setActiveTab] = useState(0);
     const { contentModel, canCreate } = useContentEntries();
 
     const { search } = useRouter();
@@ -115,8 +115,6 @@ export const ContentEntryProvider = ({
         entryId = result.id;
         version = result.version;
     }
-
-    const tabsRef = useRef<TabsImperativeApi>();
 
     const { READ_CONTENT } = useMemo(() => {
         return {
@@ -211,7 +209,8 @@ export const ContentEntryProvider = ({
         refetchContent: getEntry.refetch,
         setFormRef,
         setLoading,
-        tabsRef,
+        setActiveTab,
+        activeTab,
         showEmptyView: !newEntry && !loading && isEmpty(entry)
     };
 

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
@@ -87,7 +87,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
             </span>
         )
     });
-    const { entry, tabsRef } = useContentEntry();
+    const { entry, setActiveTab } = useContentEntry();
     const { canEdit, canDelete, canPublish, canUnpublish } = usePermission();
     const { icon, text: tooltipText } = getIcon(revision);
 
@@ -130,10 +130,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                         <MenuItem
                             onClick={() => {
                                 editRevision();
-                                if (!tabsRef.current) {
-                                    return;
-                                }
-                                tabsRef.current.switchTab(0);
+                                setActiveTab(0);
                             }}
                         >
                             <ListItemGraphic>

--- a/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
@@ -49,7 +49,7 @@ export const EditorSidebar = React.memo(() => {
     const [element] = useActiveElement();
     const [sidebar, setSidebar] = useElementSidebar();
 
-    const activeTabIndex = element ? store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex) : 0;
+    const activeTabIndex = store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex) ?? 0;
 
     const setActiveTabIndex = useCallback(
         index => {

--- a/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
@@ -49,12 +49,17 @@ export const EditorSidebar = React.memo(() => {
     const [element] = useActiveElement();
     const [sidebar, setSidebar] = useElementSidebar();
 
-    const activeTabIndex = store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex);
+    const activeTabIndex = element ? store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex) : 0;
 
-    const setActiveTabIndex = useCallback(index => {
-        setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, index));
-        store.set(LOCAL_STORAGE_KEY, index);
-    }, []);
+    const setActiveTabIndex = useCallback(
+        index => {
+            setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, index));
+            if (element) {
+                store.set(LOCAL_STORAGE_KEY, index);
+            }
+        },
+        [element]
+    );
 
     const unhighlightElementTab = useCallback(() => {
         setSidebar(prev => highlightSidebarTabMutation(prev, false));

--- a/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
+++ b/packages/app-page-builder/src/editor/components/Editor/EditorSidebar.tsx
@@ -49,9 +49,7 @@ export const EditorSidebar = React.memo(() => {
     const [element] = useActiveElement();
     const [sidebar, setSidebar] = useElementSidebar();
 
-    const getActiveTabIndex = useCallback(() => {
-        return store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex);
-    }, []);
+    const activeTabIndex = store.get(LOCAL_STORAGE_KEY, sidebar.activeTabIndex);
 
     const setActiveTabIndex = useCallback(index => {
         setSidebar(prev => updateSidebarActiveTabIndexMutation(prev, index));
@@ -70,7 +68,7 @@ export const EditorSidebar = React.memo(() => {
 
     return (
         <Elevation z={1} className={rightSideBar}>
-            <Tabs value={getActiveTabIndex()} updateValue={setActiveTabIndex}>
+            <Tabs value={activeTabIndex} onActivate={setActiveTabIndex}>
                 <EditorSidebarTab label={"Style"}>
                     <StyleSettingsTabContent />
                 </EditorSidebarTab>

--- a/packages/ui/src/Tabs/Tabs.tsx
+++ b/packages/ui/src/Tabs/Tabs.tsx
@@ -1,13 +1,4 @@
-import React, {
-    createContext,
-    forwardRef,
-    PropsWithChildren,
-    useCallback,
-    useEffect,
-    useImperativeHandle,
-    useMemo,
-    useState
-} from "react";
+import React, { createContext, PropsWithChildren, useMemo, useState } from "react";
 import classNames from "classnames";
 import { TabBar, Tab as RmwcTab } from "@rmwc/tabs";
 import { TabProps } from "./Tab";
@@ -28,10 +19,6 @@ export type TabsProps = PropsWithChildren<{
      */
     value?: number;
 
-    /**
-     * Function to change active tab.
-     */
-    updateValue?: (index: number) => void;
     /**
      * Tab ID for the testing.
      */
@@ -54,45 +41,14 @@ interface TabsContext {
 
 export const TabsContext = createContext<TabsContext | undefined>(undefined);
 
-export interface TabsImperativeApi {
-    switchTab(index: number): void;
-    getActiveIndex(): number;
-}
 /**
  * Use Tabs component to display a list of choices, once the handler is triggered.
  */
-export const Tabs = forwardRef<TabsImperativeApi | undefined, TabsProps>((props, ref) => {
+export const Tabs = (props: TabsProps) => {
     const [activeTabIndex, setActiveIndex] = useState(0);
     const [tabs, setTabs] = useState<TabItem[]>([]);
 
     const activeIndex = props.value !== undefined ? props.value : activeTabIndex;
-
-    const activateTabIndex = useCallback((index: number) => {
-        if (typeof props.updateValue === "function") {
-            props.updateValue(index);
-            return;
-        }
-
-        setActiveIndex(index);
-    }, []);
-
-    useImperativeHandle(ref, () => ({
-        getActiveIndex() {
-            return activeIndex;
-        },
-        switchTab(tabIndex: number) {
-            activateTabIndex(tabIndex);
-        }
-    }));
-
-    /**
-     * This effect will make sure that disabled tabs automatically switch to the first tab.
-     */
-    useEffect(() => {
-        if (tabs[activeIndex]?.disabled) {
-            activateTabIndex(0);
-        }
-    });
 
     /* We need to generate a key like this to trigger a proper component re-render when child tabs change. */
     const tabBar = (
@@ -101,11 +57,7 @@ export const Tabs = forwardRef<TabsImperativeApi | undefined, TabsProps>((props,
             className="webiny-ui-tabs__tab-bar"
             activeTabIndex={activeIndex}
             onActivate={evt => {
-                if (typeof props.updateValue === "function") {
-                    props.updateValue(evt.detail.index);
-                } else {
-                    setActiveIndex(evt.detail.index);
-                }
+                setActiveIndex(evt.detail.index);
                 props.onActivate && props.onActivate(evt.detail.index);
             }}
         >
@@ -175,6 +127,6 @@ export const Tabs = forwardRef<TabsImperativeApi | undefined, TabsProps>((props,
             <TabsContext.Provider value={context}>{props.children}</TabsContext.Provider>
         </div>
     );
-});
+};
 
 Tabs.displayName = "Tabs";


### PR DESCRIPTION
## Changes
This PR removes the imperative API from the Tabs component. Imperative interaction with components causes various weird scenarios, where state gets updated uncontrollably. This caused bugs in Page Builder sidebar tabs state to go out of sync with the application state.

This imperative API was used in just a handful of places across the system, and I was able to easily replace it with simple `useState` hook to track and update the active tab though props.

## How Has This Been Tested?
Manually.
