### PR TITLE
FLP - Optimize Calculating of Permissions of Folders

### DIFF
--- a/packages/api-aco/src/folder/folder.crud.ts
+++ b/packages/api-aco/src/folder/folder.crud.ts
@@ -137,6 +137,7 @@ export const createFolderCrudMethods = ({
             const folder = await storageOperations.createFolder({ data });
 
             // We need to add the newly created folder to FLP's internal cache.
+            folderLevelPermissions.invalidateFoldersPermissionsListCache(folder.type);
             folderLevelPermissions.updateFoldersCache(folder.type, cachedFolders => {
                 return [...cachedFolders, folder];
             });
@@ -207,6 +208,8 @@ export const createFolderCrudMethods = ({
                     });
                 });
 
+            folderLevelPermissions.invalidateFoldersPermissionsListCache(original.type);
+
             const stillHasAccess = await folderLevelPermissions.canAccessFolder({
                 folder: { id, type: original.type },
                 rwd: "w",
@@ -225,6 +228,7 @@ export const createFolderCrudMethods = ({
             await onFolderAfterUpdate.publish({ original, input: { id, data }, folder });
 
             // We need to update the folder in FLP's internal cache.
+            folderLevelPermissions.invalidateFoldersPermissionsListCache(folder.type);
             folderLevelPermissions.updateFoldersCache(folder.type, cachedFolders => {
                 return cachedFolders.map(currentFolder => {
                     if (currentFolder.id === folder.id) {
@@ -233,8 +237,6 @@ export const createFolderCrudMethods = ({
                     return currentFolder;
                 });
             });
-
-            folderLevelPermissions.invalidateFoldersPermissionsListCache(folder.type);
 
             await folderLevelPermissions.assignFolderPermissions(folder);
             return folder;

--- a/packages/api-aco/src/folder/folder.crud.ts
+++ b/packages/api-aco/src/folder/folder.crud.ts
@@ -137,7 +137,7 @@ export const createFolderCrudMethods = ({
             const folder = await storageOperations.createFolder({ data });
 
             // We need to add the newly created folder to FLP's internal cache.
-            folderLevelPermissions.updateCache(folder.type, cachedFolders => {
+            folderLevelPermissions.updateFoldersCache(folder.type, cachedFolders => {
                 return [...cachedFolders, folder];
             });
 
@@ -225,7 +225,7 @@ export const createFolderCrudMethods = ({
             await onFolderAfterUpdate.publish({ original, input: { id, data }, folder });
 
             // We need to update the folder in FLP's internal cache.
-            folderLevelPermissions.updateCache(folder.type, cachedFolders => {
+            folderLevelPermissions.updateFoldersCache(folder.type, cachedFolders => {
                 return cachedFolders.map(currentFolder => {
                     if (currentFolder.id === folder.id) {
                         return folder;
@@ -233,6 +233,8 @@ export const createFolderCrudMethods = ({
                     return currentFolder;
                 });
             });
+
+            folderLevelPermissions.invalidateFoldersPermissionsListCache(folder.type);
 
             await folderLevelPermissions.assignFolderPermissions(folder);
             return folder;

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -98,7 +98,7 @@ export class FolderLevelPermissions {
         return filteredFoldersWithPermissions;
     }
 
-    invalidateCache(folderType?: string) {
+    invalidateFoldersCache(folderType?: string) {
         if (folderType) {
             if (folderType in this.allFolders) {
                 delete this.allFolders[folderType];
@@ -108,7 +108,17 @@ export class FolderLevelPermissions {
         }
     }
 
-    updateCache(folderType: string, modifier: (folders: Folder[]) => Folder[]) {
+    invalidateFoldersPermissionsListCache(folderType?: string) {
+        if (folderType) {
+            if (folderType in this.foldersPermissionsLists) {
+                delete this.foldersPermissionsLists[folderType];
+            }
+        } else {
+            this.allFolders = {};
+        }
+    }
+
+    updateFoldersCache(folderType: string, modifier: (folders: Folder[]) => Folder[]) {
         const foldersClone = structuredClone(this.allFolders[folderType]) || [];
         this.allFolders[folderType] = modifier(foldersClone);
     }

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -62,8 +62,7 @@ export class FolderLevelPermissions {
     private readonly canUseFolderLevelPermissions: () => boolean;
     private readonly isAuthorizationEnabled: () => boolean;
     private allFolders: Record<string, Folder[]> = {};
-    private listFoldersPermissionsPromises: Record<string, Promise<FolderPermissionsList> | null> =
-        {};
+    private foldersPermissionsLists: Record<string, Promise<FolderPermissionsList> | null> = {};
 
     constructor(params: FolderLevelPermissionsParams) {
         this.getIdentity = params.getIdentity;
@@ -117,12 +116,12 @@ export class FolderLevelPermissions {
     async listFoldersPermissions(
         params: ListFolderPermissionsParams
     ): Promise<FolderPermissionsList> {
-        const existingPromise = this.listFoldersPermissionsPromises[params.folderType];
-        if (existingPromise) {
-            return existingPromise;
+        const existingFoldersPermissionsList = this.foldersPermissionsLists[params.folderType];
+        if (existingFoldersPermissionsList) {
+            return existingFoldersPermissionsList;
         }
 
-        this.listFoldersPermissionsPromises[params.folderType] = new Promise(async resolve => {
+        this.foldersPermissionsLists[params.folderType] = new Promise(async resolve => {
             if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
                 resolve([]);
                 return;
@@ -285,7 +284,7 @@ export class FolderLevelPermissions {
             //return processedFolderPermissions;
         });
 
-        return this.listFoldersPermissionsPromises[params.folderType]!;
+        return this.foldersPermissionsLists[params.folderType]!;
     }
 
     async getFolderPermissions(

--- a/packages/api-aco/src/utils/FolderLevelPermissions.ts
+++ b/packages/api-aco/src/utils/FolderLevelPermissions.ts
@@ -62,6 +62,8 @@ export class FolderLevelPermissions {
     private readonly canUseFolderLevelPermissions: () => boolean;
     private readonly isAuthorizationEnabled: () => boolean;
     private allFolders: Record<string, Folder[]> = {};
+    private listFoldersPermissionsPromises: Record<string, Promise<FolderPermissionsList> | null> =
+        {};
 
     constructor(params: FolderLevelPermissionsParams) {
         this.getIdentity = params.getIdentity;
@@ -115,159 +117,175 @@ export class FolderLevelPermissions {
     async listFoldersPermissions(
         params: ListFolderPermissionsParams
     ): Promise<FolderPermissionsList> {
-        if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
-            return [];
+        const existingPromise = this.listFoldersPermissionsPromises[params.folderType];
+        if (existingPromise) {
+            return existingPromise;
         }
 
-        const { folderType, foldersList } = params;
-
-        const allFolders = foldersList || (await this.listAllFolders(folderType));
-        const identity = this.getIdentity();
-        const permissions = await this.listPermissions();
-
-        let identityTeam: Team | null;
-        if (this.canUseTeams()) {
-            identityTeam = await this.getIdentityTeam();
-        }
-
-        const processedFolderPermissions: FolderPermissionsListItem[] = [];
-
-        const processFolderPermissions = (folder: Folder) => {
-            if (processedFolderPermissions.some(fp => fp.folderId === folder.id)) {
+        this.listFoldersPermissionsPromises[params.folderType] = new Promise(async resolve => {
+            if (!this.canUseFolderLevelPermissions() || !this.isAuthorizationEnabled()) {
+                resolve([]);
                 return;
+                // return [];
             }
 
-            // Copy permissions, so we don't modify the original object.
-            const currentFolderPermissions: FolderPermissionsListItem = {
-                folderId: folder.id,
-                // On new folders, permissions can be `null`. Guard against that.
-                permissions: folder.permissions?.map(permission => ({ ...permission })) || []
-            };
+            const { folderType, foldersList } = params;
 
-            // Check for permissions inherited from parent folder.
-            if (folder.parentId) {
-                const parentFolder = allFolders!.find(f => f.id === folder.parentId)!;
-                if (parentFolder) {
-                    // First check if the parent folder has already been processed.
-                    let processedParentFolderPermissions = processedFolderPermissions.find(
-                        fp => fp.folderId === parentFolder.id
-                    );
+            const allFolders = foldersList || (await this.listAllFolders(folderType));
+            const identity = this.getIdentity();
+            const permissions = await this.listPermissions();
 
-                    // If not, process the parent folder.
-                    if (!processedParentFolderPermissions) {
-                        processFolderPermissions(parentFolder);
-                        processedParentFolderPermissions = processedFolderPermissions.find(
-                            fp => fp.folderId === folder.parentId
+            let identityTeam: Team | null;
+            if (this.canUseTeams()) {
+                identityTeam = await this.getIdentityTeam();
+            }
+
+            const processedFolderPermissions: FolderPermissionsListItem[] = [];
+
+            const processFolderPermissions = (folder: Folder) => {
+                if (processedFolderPermissions.some(fp => fp.folderId === folder.id)) {
+                    return;
+                }
+
+                // Copy permissions, so we don't modify the original object.
+                const currentFolderPermissions: FolderPermissionsListItem = {
+                    folderId: folder.id,
+                    // On new folders, permissions can be `null`. Guard against that.
+                    permissions: folder.permissions?.map(permission => ({ ...permission })) || []
+                };
+
+                // Check for permissions inherited from parent folder.
+                if (folder.parentId) {
+                    const parentFolder = allFolders!.find(f => f.id === folder.parentId)!;
+                    if (parentFolder) {
+                        // First check if the parent folder has already been processed.
+                        let processedParentFolderPermissions = processedFolderPermissions.find(
+                            fp => fp.folderId === parentFolder.id
                         );
-                    }
 
-                    // If the parent folder has permissions, let's add them to the current folder.
-                    if (processedParentFolderPermissions) {
-                        const isPublicParentFolder =
-                            processedParentFolderPermissions.permissions.some(
-                                p => p.level === "public"
+                        // If not, process the parent folder.
+                        if (!processedParentFolderPermissions) {
+                            processFolderPermissions(parentFolder);
+                            processedParentFolderPermissions = processedFolderPermissions.find(
+                                fp => fp.folderId === folder.parentId
                             );
+                        }
 
-                        // We inherit parent permissions if:
-                        // 1. the parent folder is not public or...
-                        // 2. ...the parent folder is public, but the current folder doesn't have any permissions set
-                        const mustInherit =
-                            !isPublicParentFolder ||
-                            currentFolderPermissions.permissions.length === 0;
+                        // If the parent folder has permissions, let's add them to the current folder.
+                        if (processedParentFolderPermissions) {
+                            const isPublicParentFolder =
+                                processedParentFolderPermissions.permissions.some(
+                                    p => p.level === "public"
+                                );
 
-                        if (mustInherit) {
-                            const inheritedPermissions =
-                                processedParentFolderPermissions.permissions.map(p => {
-                                    return {
-                                        ...p,
-                                        inheritedFrom:
-                                            "parent:" + processedParentFolderPermissions!.folderId
-                                    };
-                                });
+                            // We inherit parent permissions if:
+                            // 1. the parent folder is not public or...
+                            // 2. ...the parent folder is public, but the current folder doesn't have any permissions set
+                            const mustInherit =
+                                !isPublicParentFolder ||
+                                currentFolderPermissions.permissions.length === 0;
 
-                            currentFolderPermissions.permissions.push(...inheritedPermissions);
+                            if (mustInherit) {
+                                const inheritedPermissions =
+                                    processedParentFolderPermissions.permissions.map(p => {
+                                        return {
+                                            ...p,
+                                            inheritedFrom:
+                                                "parent:" +
+                                                processedParentFolderPermissions!.folderId
+                                        };
+                                    });
+
+                                currentFolderPermissions.permissions.push(...inheritedPermissions);
+                            }
                         }
                     }
                 }
-            }
 
-            // Let's ensure current identity's permission is included in the permissions array.
-            // We first check if the current identity is already included in the permissions array.
-            // If not, we check if the user has full access or if the team user belongs to has access.
-            const currentIdentityIncludedInPermissions = currentFolderPermissions.permissions.some(
-                p => p.target === `admin:${identity.id}`
-            );
-
-            if (currentIdentityIncludedInPermissions) {
-                // Ensure existing identity permission is always the first one in the array.
-                const currentIdentityPermissionIndex =
-                    currentFolderPermissions.permissions.findIndex(
+                // Let's ensure current identity's permission is included in the permissions array.
+                // We first check if the current identity is already included in the permissions array.
+                // If not, we check if the user has full access or if the team user belongs to has access.
+                const currentIdentityIncludedInPermissions =
+                    currentFolderPermissions.permissions.some(
                         p => p.target === `admin:${identity.id}`
                     );
 
-                if (currentIdentityPermissionIndex > 0) {
-                    const [currentIdentityPermission] = currentFolderPermissions.permissions.splice(
-                        currentIdentityPermissionIndex,
-                        1
-                    );
-                    currentFolderPermissions.permissions.unshift(currentIdentityPermission);
-                }
-            } else {
-                // Current identity not included in permissions? Let's add it.
-                let currentIdentityPermission: FolderPermission | null = null;
+                if (currentIdentityIncludedInPermissions) {
+                    // Ensure existing identity permission is always the first one in the array.
+                    const currentIdentityPermissionIndex =
+                        currentFolderPermissions.permissions.findIndex(
+                            p => p.target === `admin:${identity.id}`
+                        );
 
-                // 1. Check if the user has full access.
-                const hasFullAccess = permissions.some(p => p.name === "*");
-                if (hasFullAccess) {
-                    currentIdentityPermission = {
-                        target: `admin:${identity.id}`,
-                        level: "owner",
-                        inheritedFrom: "role:full-access"
-                    };
-                } else if (identityTeam) {
-                    // 2. Check the team user belongs to grants access to the folder.
-                    const teamPermission = currentFolderPermissions.permissions.find(
-                        p => p.target === `team:${identityTeam!.id}`
-                    );
+                    if (currentIdentityPermissionIndex > 0) {
+                        const [currentIdentityPermission] =
+                            currentFolderPermissions.permissions.splice(
+                                currentIdentityPermissionIndex,
+                                1
+                            );
+                        currentFolderPermissions.permissions.unshift(currentIdentityPermission);
+                    }
+                } else {
+                    // Current identity not included in permissions? Let's add it.
+                    let currentIdentityPermission: FolderPermission | null = null;
 
-                    if (teamPermission) {
+                    // 1. Check if the user has full access.
+                    const hasFullAccess = permissions.some(p => p.name === "*");
+                    if (hasFullAccess) {
                         currentIdentityPermission = {
                             target: `admin:${identity.id}`,
-                            level: teamPermission.level,
-                            inheritedFrom: "team:" + identityTeam!.id
+                            level: "owner",
+                            inheritedFrom: "role:full-access"
                         };
+                    } else if (identityTeam) {
+                        // 2. Check the team user belongs to grants access to the folder.
+                        const teamPermission = currentFolderPermissions.permissions.find(
+                            p => p.target === `team:${identityTeam!.id}`
+                        );
+
+                        if (teamPermission) {
+                            currentIdentityPermission = {
+                                target: `admin:${identity.id}`,
+                                level: teamPermission.level,
+                                inheritedFrom: "team:" + identityTeam!.id
+                            };
+                        }
+                    }
+
+                    if (currentIdentityPermission) {
+                        // If permission is found, let's add it to the beginning of the array.
+                        // We're doing this just because it looks nicer in the UI.
+                        currentFolderPermissions.permissions.unshift(currentIdentityPermission);
                     }
                 }
 
-                if (currentIdentityPermission) {
-                    // If permission is found, let's add it to the beginning of the array.
-                    // We're doing this just because it looks nicer in the UI.
-                    currentFolderPermissions.permissions.unshift(currentIdentityPermission);
+                // Note that this can only happen with root folders. All other (child) folders will
+                // always have at least one permission (inherited from parent).
+                const mustAddPublicPermission = currentFolderPermissions.permissions.length === 0;
+                if (mustAddPublicPermission) {
+                    currentFolderPermissions.permissions = [
+                        {
+                            target: `admin:${identity.id}`,
+                            level: "public",
+                            inheritedFrom: "public"
+                        }
+                    ];
                 }
+
+                processedFolderPermissions.push(currentFolderPermissions);
+            };
+
+            for (let i = 0; i < allFolders!.length; i++) {
+                const folder = allFolders![i];
+                processFolderPermissions(folder);
             }
 
-            // Note that this can only happen with root folders. All other (child) folders will
-            // always have at least one permission (inherited from parent).
-            const mustAddPublicPermission = currentFolderPermissions.permissions.length === 0;
-            if (mustAddPublicPermission) {
-                currentFolderPermissions.permissions = [
-                    {
-                        target: `admin:${identity.id}`,
-                        level: "public",
-                        inheritedFrom: "public"
-                    }
-                ];
-            }
+            resolve(processedFolderPermissions);
+            return;
+            //return processedFolderPermissions;
+        });
 
-            processedFolderPermissions.push(currentFolderPermissions);
-        };
-
-        for (let i = 0; i < allFolders!.length; i++) {
-            const folder = allFolders![i];
-            processFolderPermissions(folder);
-        }
-
-        return processedFolderPermissions;
+        return this.listFoldersPermissionsPromises[params.folderType]!;
     }
 
     async getFolderPermissions(
@@ -288,27 +306,6 @@ export class FolderLevelPermissions {
         }
 
         const { folder } = params;
-
-        // We check for parent folder access first because the passed folder should be
-        // inaccessible if the parent folder is inaccessible.
-        if (folder.parentId) {
-            let foldersList = params.foldersList;
-            if (!foldersList) {
-                foldersList = await this.listAllFolders(folder.type);
-            }
-
-            const parentFolder = foldersList.find(f => f.id === folder.parentId);
-            if (parentFolder) {
-                const canAccessParentFolder = await this.canAccessFolder({
-                    ...params,
-                    folder: parentFolder
-                });
-
-                if (!canAccessParentFolder) {
-                    return false;
-                }
-            }
-        }
 
         const folderPermissions = await this.getFolderPermissions({
             folder,


### PR DESCRIPTION
## Changes
This PR optimizes the calculation of permissions of folders, which is happening when Folder Level Permissions (FLP) feature is enabled. Basically, the optimization was to simply ensure that the calculation of permissions of folders is not done from scratch every time a FLP-related check is triggered. With this PR, even if multiple FLP-related checks are requested, the calculation will be done only once, because, when triggered, the calculation (a promise) is immediately cached [via a private property](https://github.com/webiny/webiny-js/pull/3902/files#diff-1230b4c7be4315ec606c9b259d1cbba5bb76c07b098e1851be582781a398bee6R65).

## Additional Changes

### 1. Additional Cache Invalidation
Since the mentioned calculation is now being cached, I also had to introduce additional cache invalidation in `createFolder` / `updateFolder` CRUD methods. Instead of just dealing with folders cache, now we also need to deal with cache related to folders permissions.

### 2. Minor Simplification In the `updateFolder` Method
Minor code simplification was done in the `updateFolder` method, related to how we check if the user is about to lose access if the requested folder update was about to be processed. Basically, updating of FLP cache is now updated/invalidated only before the update is about to be done, and not twice: before and after it.

### 3. Ensured the Order Of `folderLevelPermissions.assignFolderPermissions` Calls Are Consistent Within `createFolder` and `updateFolder` CRUD Methods
While working on this PR, in the `updateFolder` CRUD method, I noticed the `await folderLevelPermissions.assignFolderPermissions(folder);` call was done after the publishing of `onFolderAfterUpdate` lifecycle event. But, in the `createFolder` method, this is done before the `onFolderAfterCreate` lifecycle event is published.

So, I synced the two, and, in the `updateFolder` CRUD method, moved the `await folderLevelPermissions.assignFolderPermissions(folder);` call before the publishing of `onFolderAfterUpdate` lifecycle event. 

## How Has This Been Tested?
Tested manually. 

I first programatically created 320 folders, and then continued by issuing `listFolders` GraphQL queries. In those tests, I was able to see sub-second responses from the GraphQL API.

![image](https://github.com/webiny/webiny-js/assets/5121148/3d04c212-57a2-47c1-aebb-a12b724d0a96)

## Documentation
Changelog.