### PR TITLE
Headless CMS Security - Bring Back Old Permissions Checking-related Utils

### DIFF
--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -12,8 +12,17 @@ import { Topic } from "@webiny/pubsub/types";
 import { CmsModelConverterCallable } from "~/utils/converters/ConverterCollection";
 import { HeadlessCmsExport, HeadlessCmsImport } from "~/export/types";
 import { AccessControl } from "~/crud/AccessControl/AccessControl";
+import { ModelGroupsPermissions } from "~/utils/permissions/ModelGroupsPermissions";
+import { ModelsPermissions } from "~/utils/permissions/ModelsPermissions";
+import { EntriesPermissions } from "~/utils/permissions/EntriesPermissions";
 
 export type ApiEndpoint = "manage" | "preview" | "read";
+
+interface HeadlessCmsPermissions {
+    groups: ModelGroupsPermissions;
+    models: ModelsPermissions;
+    entries: EntriesPermissions;
+}
 
 export interface HeadlessCms
     extends CmsSystemContext,
@@ -48,12 +57,19 @@ export interface HeadlessCms
      * The storage operations loaded for current context.
      */
     storageOperations: HeadlessCmsStorageOperations;
+
     /**
-     * Permissions for groups, models and entries.
-     *
-     * @internal
+     * Use to ensure perform authorization and ensure identities have access to the groups, models and entries.
      */
     accessControl: AccessControl;
+
+    /**
+     * Permissions for groups, models and entries.
+     * @internal
+     * @deprecated Will be removed with the 5.40.0 release.
+     */
+    permissions: HeadlessCmsPermissions;
+
     /**
      * Export operations.
      */

--- a/packages/api-headless-cms/src/types.ts
+++ b/packages/api-headless-cms/src/types.ts
@@ -66,7 +66,7 @@ export interface HeadlessCms
     /**
      * Permissions for groups, models and entries.
      * @internal
-     * @deprecated Will be removed with the 5.40.0 release.
+     * @deprecated Will be removed with the 5.40.0 release. Use `accessControl` instead.
      */
     permissions: HeadlessCmsPermissions;
 

--- a/packages/api-headless-cms/src/utils/permissions/EntriesPermissions.ts
+++ b/packages/api-headless-cms/src/utils/permissions/EntriesPermissions.ts
@@ -1,0 +1,4 @@
+import { CmsEntryPermission } from "~/types";
+import { AppPermissions } from "@webiny/api-security";
+
+export class EntriesPermissions extends AppPermissions<CmsEntryPermission> {}

--- a/packages/api-headless-cms/src/utils/permissions/ModelGroupsPermissions.ts
+++ b/packages/api-headless-cms/src/utils/permissions/ModelGroupsPermissions.ts
@@ -1,0 +1,52 @@
+import { AppPermissions, NotAuthorizedError } from "@webiny/api-security";
+import { CmsGroup, CmsGroupPermission } from "~/types";
+
+export interface CanAccessGroupParams {
+    group: Pick<CmsGroup, "id" | "locale">;
+}
+
+export class ModelGroupsPermissions extends AppPermissions<CmsGroupPermission> {
+    async canAccessGroup({ group }: CanAccessGroupParams) {
+        if (await this.hasFullAccess()) {
+            return true;
+        }
+
+        const permissions = await this.getPermissions();
+
+        const locale = group.locale;
+
+        for (const permission of permissions) {
+            const { groups } = permission;
+
+            // When no groups defined on permission it means user has access to everything.
+            if (!groups) {
+                return true;
+            }
+
+            // when there is no locale in groups, it means that no access was given
+            // this happens when access control was set but no models or groups were added
+            if (
+                Array.isArray(groups[locale]) === false ||
+                groups[locale].includes(group.id) === false
+            ) {
+                continue;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    async ensureCanAccessGroup(params: CanAccessGroupParams) {
+        const canAccessModel = await this.canAccessGroup(params);
+        if (canAccessModel) {
+            return;
+        }
+
+        throw new NotAuthorizedError({
+            data: {
+                reason: `Not allowed to access group "${params.group.id}".`
+            }
+        });
+    }
+}

--- a/packages/api-headless-cms/src/utils/permissions/ModelsPermissions.ts
+++ b/packages/api-headless-cms/src/utils/permissions/ModelsPermissions.ts
@@ -1,0 +1,113 @@
+import { AppPermissions, AppPermissionsParams, NotAuthorizedError } from "@webiny/api-security";
+import {
+    CmsGroupPermission,
+    CmsModel as BaseCmsModel,
+    CmsModelGroup as BaseCmsModelGroup,
+    CmsModelPermission
+} from "~/types";
+import { ModelGroupsPermissions } from "~/utils/permissions/ModelGroupsPermissions";
+
+export interface ModelsPermissionsParams extends AppPermissionsParams<CmsGroupPermission> {
+    modelGroupsPermissions: ModelGroupsPermissions;
+}
+
+interface PickedCmsModel extends Pick<BaseCmsModel, "modelId" | "locale"> {
+    group: Pick<BaseCmsModelGroup, "id">;
+}
+
+export interface CanAccessModelParams {
+    model: PickedCmsModel;
+}
+
+export interface EnsureModelAccessParams {
+    model: PickedCmsModel;
+}
+
+export class ModelsPermissions extends AppPermissions<CmsModelPermission> {
+    private readonly modelGroupsPermissions: ModelGroupsPermissions;
+
+    public constructor(params: ModelsPermissionsParams) {
+        super(params);
+        this.modelGroupsPermissions = params.modelGroupsPermissions;
+    }
+
+    public async canAccessModel({ model }: CanAccessModelParams) {
+        if (await this.hasFullAccess()) {
+            return true;
+        }
+
+        const modelGroupsPermissions = this.modelGroupsPermissions;
+
+        // eslint-disable-next-line
+        const modelsPermissions = this;
+
+        const canReadGroups = await modelGroupsPermissions.ensure({ rwd: "r" }, { throw: false });
+        if (!canReadGroups) {
+            return false;
+        }
+
+        const canReadModels = await modelsPermissions.ensure({ rwd: "r" }, { throw: false });
+        if (!canReadModels) {
+            return false;
+        }
+
+        const modelGroupsPermissionsList = await modelGroupsPermissions.getPermissions();
+        const modelsPermissionsList = await this.getPermissions();
+
+        const locale = model.locale;
+
+        for (let i = 0; i < modelGroupsPermissionsList.length; i++) {
+            const modelGroupPermission = modelGroupsPermissionsList[i];
+
+            const { groups } = modelGroupPermission;
+
+            for (let j = 0; j < modelsPermissionsList.length; j++) {
+                const modelPermission = modelsPermissionsList[j];
+
+                const { models } = modelPermission;
+                // when no models or groups defined on permission
+                // it means user has access to everything
+                if (!models && !groups) {
+                    return true;
+                }
+
+                // Does the model belong to a group for which user has permission?
+                if (groups) {
+                    if (
+                        Array.isArray(groups[locale]) === false ||
+                        groups[locale].includes(model.group.id) === false
+                    ) {
+                        continue;
+                    }
+                }
+
+                // Does the user have access to the specific model?
+                if (models) {
+                    if (
+                        Array.isArray(models[locale]) === false ||
+                        models[locale].includes(model.modelId) === false
+                    ) {
+                        continue;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public async ensureCanAccessModel(params: EnsureModelAccessParams) {
+        const canAccessModel = await this.canAccessModel(params);
+        if (canAccessModel) {
+            return;
+        }
+
+        throw new NotAuthorizedError({
+            data: {
+                reason: `Not allowed to access model "${params.model.modelId}".`
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Changes
Despite the fact that, with the https://github.com/webiny/webiny-js/pull/3865 PR, we've introduced the new `AccessControl` class that users can now use to perform authorization in custom CMS-related GraphQL queries/mutations, we still need to leave the old authorization/permissions utils, in order to preserve backwards compatibility.

This PR brings back those utils. We'll remove them again with the 5.40.0 release.
## How Has This Been Tested?
Jest.

## Documentation
N/A