### PR TITLE
E-mail Validators - Allow `+` Character

### DIFF
--- a/packages/api-form-builder/src/plugins/validators/patternPlugins/email.ts
+++ b/packages/api-form-builder/src/plugins/validators/patternPlugins/email.ts
@@ -5,7 +5,7 @@ const plugin: FbFormFieldPatternValidatorPlugin = {
     name: "form-field-validator-pattern-email",
     pattern: {
         name: "email",
-        regex: `^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
+        regex: `^\\w[\\+\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
         flags: "i"
     }
 };

--- a/packages/api-headless-cms/src/validators/patternPlugins/email.ts
+++ b/packages/api-headless-cms/src/validators/patternPlugins/email.ts
@@ -6,7 +6,7 @@ export const createEmailPatternValidator = (): CmsModelFieldPatternValidatorPlug
         name: "cms-model-field-validator-pattern-email",
         pattern: {
             name: "email",
-            regex: `^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
+            regex: `^\\w[\\+\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
             flags: "i"
         }
     };

--- a/packages/app-form-builder/src/render/plugins/validators/patternPlugins/email.ts
+++ b/packages/app-form-builder/src/render/plugins/validators/patternPlugins/email.ts
@@ -5,7 +5,7 @@ const plugin: FbFormFieldPatternValidatorPlugin = {
     name: "form-field-validator-pattern-email",
     pattern: {
         name: "email",
-        regex: `^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
+        regex: `^\\w[\\+\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
         flags: "i"
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldValidators/patternPlugins/email.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldValidators/patternPlugins/email.ts
@@ -7,7 +7,7 @@ const plugin: CmsModelFieldRegexValidatorExpressionPlugin = {
         name: "email",
         label: "E-mail",
         message: "Please enter a valid e-mail.",
-        regex: `^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
+        regex: `^\\w[\\+\\w.-]*@([\\w-]+\\.)+[\\w-]+$`,
         flags: "i"
     }
 };


### PR DESCRIPTION
## Changes
This PR improves the regex we use when validating an email address. Prior to this PR, if an email address included a plus (+) sign before "@," the regex would not match, thus the validator throwing an error.

## How Has This Been Tested?
Manual, relying on existing Jest tests.

## Documentation
Changelog.