### PR TITLE
fix: use IntrospectionFragmentMatcher in Apollo Client

### DIFF
--- a/packages/app-serverless-cms/src/apolloClientFactory.ts
+++ b/packages/app-serverless-cms/src/apolloClientFactory.ts
@@ -5,12 +5,22 @@ import { InMemoryCache } from "@webiny/app/apollo-client/InMemoryCache";
 import { plugins } from "@webiny/plugins";
 import { ApolloDynamicLink } from "@webiny/app/plugins/ApolloDynamicLink";
 import { ApolloCacheObjectIdPlugin } from "@webiny/app/plugins/ApolloCacheObjectIdPlugin";
+import { IntrospectionFragmentMatcher } from "@webiny/app/apollo-client/IntrospectionFragmentMatcher";
 
 export interface CreateApolloClientParams {
     uri: string;
     batching?: Pick<BatchHttpLink.Options, "batchMax" | "batchInterval" | "batchKey">;
 }
+
 export const createApolloClient = ({ uri, batching }: CreateApolloClientParams) => {
+    const fragmentMatcher = new IntrospectionFragmentMatcher({
+        introspectionQueryResultData: {
+            __schema: {
+                types: []
+            }
+        }
+    });
+
     return new ApolloClient({
         link: ApolloLink.from([
             /**
@@ -25,6 +35,7 @@ export const createApolloClient = ({ uri, batching }: CreateApolloClientParams) 
         ]),
         cache: new InMemoryCache({
             addTypename: true,
+            fragmentMatcher,
             dataIdFromObject: obj => {
                 /**
                  * Since every data type coming from API can have a different data structure,

--- a/packages/app-website/src/utils/createApolloClient.ts
+++ b/packages/app-website/src/utils/createApolloClient.ts
@@ -2,6 +2,7 @@ import ApolloClient from "apollo-client";
 import { ApolloLink } from "apollo-link";
 import { BatchHttpLink } from "apollo-link-batch-http";
 import { InMemoryCache } from "@webiny/app/apollo-client/InMemoryCache";
+import { IntrospectionFragmentMatcher } from "@webiny/app/apollo-client/IntrospectionFragmentMatcher";
 import { ApolloDynamicLink } from "@webiny/app/plugins/ApolloDynamicLink";
 import { plugins } from "@webiny/plugins";
 import { ApolloCacheObjectIdPlugin } from "@webiny/app/plugins/ApolloCacheObjectIdPlugin";
@@ -13,8 +14,17 @@ declare global {
 }
 
 export const createApolloClient = () => {
+    const fragmentMatcher = new IntrospectionFragmentMatcher({
+        introspectionQueryResultData: {
+            __schema: {
+                types: []
+            }
+        }
+    });
+
     const cache = new InMemoryCache({
         addTypename: true,
+        fragmentMatcher,
         dataIdFromObject: obj => {
             /**
              * Since every data type coming from API can have a different data structure,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,6 +39,7 @@
     "nanoid": "^3.1.30",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "ts-invariant": "^0.10.3",
     "warning": "^4.0.2"
   },
   "devDependencies": {

--- a/packages/app/src/apollo-client/IntrospectionFragmentMatcher.ts
+++ b/packages/app/src/apollo-client/IntrospectionFragmentMatcher.ts
@@ -1,0 +1,71 @@
+import { IdValue } from "apollo-utilities";
+import { invariant } from "ts-invariant";
+
+import {
+    ReadStoreContext,
+    FragmentMatcherInterface,
+    PossibleTypesMap,
+    IntrospectionResultData
+} from "apollo-cache-inmemory";
+
+export class IntrospectionFragmentMatcher implements FragmentMatcherInterface {
+    private readonly isReady: boolean;
+    private readonly possibleTypesMap: PossibleTypesMap = {};
+
+    constructor(options?: { introspectionQueryResultData?: IntrospectionResultData }) {
+        if (options && options.introspectionQueryResultData) {
+            this.possibleTypesMap = this.parseIntrospectionResult(
+                options.introspectionQueryResultData
+            );
+            this.isReady = true;
+        } else {
+            this.isReady = false;
+        }
+
+        this.match = this.match.bind(this);
+    }
+
+    public match(idValue: IdValue, typeCondition: string, context: ReadStoreContext) {
+        invariant(this.isReady, "FragmentMatcher.match() was called before FragmentMatcher.init()");
+
+        const obj = context.store.get(idValue.id);
+        const isRootQuery = idValue.id === "ROOT_QUERY";
+
+        if (!obj) {
+            // https://github.com/apollographql/apollo-client/pull/4620
+            return isRootQuery;
+        }
+
+        const { __typename = isRootQuery && "Query" } = obj;
+
+        invariant(
+            __typename,
+            `Cannot match fragment because __typename property is missing: ${JSON.stringify(obj)}`
+        );
+
+        if (__typename === typeCondition) {
+            return true;
+        }
+
+        const implementingTypes = this.possibleTypesMap[typeCondition];
+        if (__typename && implementingTypes && implementingTypes.indexOf(__typename) > -1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private parseIntrospectionResult(
+        introspectionResultData: IntrospectionResultData
+    ): PossibleTypesMap {
+        const typeMap: PossibleTypesMap = {};
+        introspectionResultData.__schema.types.forEach(type => {
+            if (type.kind === "UNION" || type.kind === "INTERFACE") {
+                typeMap[type.name] = type.possibleTypes.map(
+                    implementingType => implementingType.name
+                );
+            }
+        });
+        return typeMap;
+    }
+}

--- a/packages/lexical-editor/src/components/ToolbarActions/FontSizeAction.tsx
+++ b/packages/lexical-editor/src/components/ToolbarActions/FontSizeAction.tsx
@@ -76,14 +76,20 @@ function FontSizeDropDown(props: FontSizeDropDownProps): JSX.Element {
     );
 }
 
+const defaultSize = "15px";
+
 export const FontSizeAction = () => {
     const [editor] = useLexicalComposerContext();
     const [isEditable, setIsEditable] = useState(() => editor.isEditable());
     const fontSize = useDeriveValueFromSelection(({ rangeSelection }) => {
         if (!rangeSelection) {
-            return "15px";
+            return defaultSize;
         }
-        return $getSelectionStyleValueForProperty(rangeSelection, "font-size", "15px");
+        try {
+            return $getSelectionStyleValueForProperty(rangeSelection, "font-size", "15px");
+        } catch {
+            return defaultSize;
+        }
     });
 
     useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17478,6 +17478,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     rimraf: ^3.0.2
+    ts-invariant: ^0.10.3
     typescript: 4.7.4
     warning: ^4.0.2
   languageName: unknown
@@ -44871,6 +44872,15 @@ __metadata:
   version: 1.3.0
   resolution: "ts-expect@npm:1.3.0"
   checksum: c007702906354ada640392c26373660a8a034506859b5c084de74376ca2c6fe092c5909235d1bad8ed67423e7ab023dae4dc3032dcdcce70852c0211c5238013
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "ts-invariant@npm:0.10.3"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: bb07d56fe4aae69d8860e0301dfdee2d375281159054bc24bf1e49e513fb0835bf7f70a11351344d213a79199c5e695f37ebbf5a447188a377ce0cd81d91ddb5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR replaces the default Apollo Client `HeuristicFragmentMatcher` with an explicit `IntrospectionFragmentMatcher`. this matcher has the ability to be expanded using GraphQL schema introspection in the future. Right now, this matcher essentially behaves the same as the Heuristic one, but doesn't throw unnecessary errors.

In the future, we plan to remove Apollo Client as the driver of our GraphQL queries and cache, so this interim solution is acceptable.

Along the way, I had to fix a bug in the `@webiny/lexical-editor` package, as it was breaking the Content Entry form.

## How Has This Been Tested?
Manually, by creating a complex content model with repeatable objects and dynamic zones, and creating several entries. All data was resolved correctly, without errors in the UI.