### PR TITLE
fix: reset isSearch flag when filters are empty

### DIFF
--- a/packages/app-aco/src/contexts/acoList.tsx
+++ b/packages/app-aco/src/contexts/acoList.tsx
@@ -293,7 +293,15 @@ export const AcoListProvider = ({ children, ...props }: AcoListProviderProps) =>
             setState({ searchQuery: query, after: undefined });
         },
         setFilters(data) {
-            setState({ filters: data, after: undefined });
+            // Create filters object excluding entries with `undefined` values
+            const filters = Object.fromEntries(
+                Object.entries(data).filter(([, value]) => value !== undefined)
+            );
+
+            setState({
+                filters: Object.keys(filters)?.length ? filters : undefined,
+                after: undefined
+            });
         },
         setListSort(sort: ListSearchRecordsSort) {
             setState({ listSort: sort, after: undefined });

--- a/packages/app-aco/src/contexts/acoList.tsx
+++ b/packages/app-aco/src/contexts/acoList.tsx
@@ -299,7 +299,7 @@ export const AcoListProvider = ({ children, ...props }: AcoListProviderProps) =>
             );
 
             setState({
-                filters: Object.keys(filters)?.length ? filters : undefined,
+                filters: Object.keys(filters).length ? filters : undefined,
                 after: undefined
             });
         },

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
@@ -419,7 +419,7 @@ export const FileManagerViewProvider = ({ children, ...props }: FileManagerViewP
             setState(state => ({
                 ...state,
                 selected: [],
-                filters: Object.keys(filters)?.length ? filters : undefined,
+                filters: Object.keys(filters).length ? filters : undefined,
                 selection: {}
             }));
         },

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
@@ -411,10 +411,15 @@ export const FileManagerViewProvider = ({ children, ...props }: FileManagerViewP
             }));
         },
         setFilters(data) {
+            // Create filters object excluding entries with `undefined` values
+            const filters = Object.fromEntries(
+                Object.entries(data).filter(([, value]) => value !== undefined)
+            );
+
             setState(state => ({
                 ...state,
                 selected: [],
-                filters: data,
+                filters: Object.keys(filters)?.length ? filters : undefined,
                 selection: {}
             }));
         },


### PR DESCRIPTION
## Changes
In this PR, we have removed the `isSearch` flag when there are no filters selected by the user. 

Previously, when a user deselected all filters, a network request was made without declaring the `location`. Now, if the `filters` object is empty or contains undefined values, entries will be loaded based on their `location`.

https://github.com/webiny/webiny-js/assets/2866531/ad7e4536-0480-40ee-9b6d-d4ea4f5576be


## How Has This Been Tested?
Manually

## Documentation
Inline
