### PR TITLE
Page Builder - Use `object` HTML Tag When Rendering SVGs

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -5,6 +5,16 @@ import { useRenderer } from "~/hooks/useRenderer";
 import { LinkComponent as LinkComponentType } from "~/types";
 import { DefaultLinkComponent } from "~/renderers/components";
 
+declare global {
+    // eslint-disable-next-line
+    namespace JSX {
+        interface IntrinsicElements {
+            // "object" HTML tags cannot be clicked, hence the need for "pb-image-object-wrapper" wrapper.
+            "pb-image-object-wrapper": any;
+        }
+    }
+}
+
 export interface ImageElementData {
     image?: {
         title: string;
@@ -13,6 +23,7 @@ export interface ImageElementData {
         file?: {
             src: string;
         };
+        htmlTag?: string;
     };
     link?: {
         newTab: boolean;
@@ -30,6 +41,17 @@ const PbImg = styled.img`
     height: ${props => props.height};
 `;
 
+const PbImgObject = styled.object`
+    max-width: 100%;
+    width: ${props => props.width};
+    height: ${props => props.height};
+
+    // "object" HTML tags cannot be clicked, hence the need for the wrapper
+    // "pb-image-object-wrapper" tag, which handles click events. For this
+    // to work, we need to set "pointer-events: none" on the object tag.
+    pointer-events: none;
+`;
+
 export const ImageRendererComponent = ({
     onClick,
     renderEmpty,
@@ -44,48 +66,67 @@ export const ImageRendererComponent = ({
     let content;
     if (element.data?.image?.file?.src) {
         const { title, width, height, file } = element.data.image;
+        let { htmlTag } = element.data.image;
         const { src } = value || file;
 
-        // If a fixed image width in pixels was set, let's filter out unneeded
-        // image resize widths. For example, if 155px was set as the fixed image
-        // width, then we want the `srcset` attribute to only contain 100w and 300w.
-        let srcSetWidths: number[] = [];
-
-        if (width && width.endsWith("px")) {
-            const imageWidthInt = parseInt(width);
-            for (let i = 0; i < SUPPORTED_IMAGE_RESIZE_WIDTHS.length; i++) {
-                const supportedResizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
-                if (imageWidthInt > supportedResizeWidth) {
-                    srcSetWidths.push(supportedResizeWidth);
-                } else {
-                    srcSetWidths.push(supportedResizeWidth);
-                    break;
-                }
-            }
-        } else {
-            // If a fixed image width was not provided, we
-            // rely on all the supported image resize widths.
-            srcSetWidths = SUPPORTED_IMAGE_RESIZE_WIDTHS;
+        if (htmlTag === "auto") {
+            htmlTag = src.endsWith(".svg") ? "object" : "img";
         }
 
-        const srcSet = srcSetWidths
-            .map(item => {
-                return `${src}?width=${item} ${item}w`;
-            })
-            .join(", ");
+        if (htmlTag === "object") {
+            content = (
+                <pb-image-object-wrapper onClick={onClick}>
+                    <PbImgObject
+                        // Image has its width / height set from its own settings.
+                        width={width}
+                        height={height}
+                        title={title}
+                        data={src}
+                    />
+                </pb-image-object-wrapper>
+            );
+        } else {
+            // If a fixed image width in pixels was set, let's filter out unneeded
+            // image resize widths. For example, if 155px was set as the fixed image
+            // width, then we want the `srcset` attribute to only contain 100w and 300w.
+            let srcSetWidths: number[] = [];
 
-        content = (
-            <PbImg
-                // Image has its width / height set from its own settings.
-                width={width}
-                height={height}
-                alt={title}
-                title={title}
-                src={src}
-                srcSet={srcSet}
-                onClick={onClick}
-            />
-        );
+            if (width && width.endsWith("px")) {
+                const imageWidthInt = parseInt(width);
+                for (let i = 0; i < SUPPORTED_IMAGE_RESIZE_WIDTHS.length; i++) {
+                    const supportedResizeWidth = SUPPORTED_IMAGE_RESIZE_WIDTHS[i];
+                    if (imageWidthInt > supportedResizeWidth) {
+                        srcSetWidths.push(supportedResizeWidth);
+                    } else {
+                        srcSetWidths.push(supportedResizeWidth);
+                        break;
+                    }
+                }
+            } else {
+                // If a fixed image width was not provided, we
+                // rely on all the supported image resize widths.
+                srcSetWidths = SUPPORTED_IMAGE_RESIZE_WIDTHS;
+            }
+
+            const srcSet = srcSetWidths
+                .map(item => {
+                    return `${src}?width=${item} ${item}w`;
+                })
+                .join(", ");
+
+            content = (
+                <PbImg
+                    // Image has its width / height set from its own settings.
+                    width={width}
+                    height={height}
+                    alt={title}
+                    title={title}
+                    src={src}
+                    srcSet={srcSet}
+                    onClick={onClick}
+                />
+            );
+        }
     } else {
         content = renderEmpty || null;
     }

--- a/packages/app-page-builder-elements/src/renderers/image.tsx
+++ b/packages/app-page-builder-elements/src/renderers/image.tsx
@@ -10,7 +10,7 @@ declare global {
     namespace JSX {
         interface IntrinsicElements {
             // "object" HTML tags cannot be clicked, hence the need for "pb-image-object-wrapper" wrapper.
-            "pb-image-object-wrapper": any;
+            "pb-image-object": any;
         }
     }
 }
@@ -75,7 +75,7 @@ export const ImageRendererComponent = ({
 
         if (htmlTag === "object") {
             content = (
-                <pb-image-object-wrapper onClick={onClick}>
+                <pb-image-object onClick={onClick}>
                     <PbImgObject
                         // Image has its width / height set from its own settings.
                         width={width}
@@ -83,7 +83,7 @@ export const ImageRendererComponent = ({
                         title={title}
                         data={src}
                     />
-                </pb-image-object-wrapper>
+                </pb-image-object>
             );
         } else {
             // If a fixed image width in pixels was set, let's filter out unneeded

--- a/packages/app-page-builder/src/editor/plugins/elements/image/ImageSettings.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/ImageSettings.tsx
@@ -14,6 +14,7 @@ import {
     WIDTH_UNIT_OPTIONS,
     HEIGHT_UNIT_OPTIONS
 } from "~/editor/plugins/elementSettings/elementSettingsUtils";
+import SelectField from "~/editor/plugins/elementSettings/components/SelectField";
 
 const classes = {
     grid: css({
@@ -45,6 +46,7 @@ const ImageSettings = ({
     const updateTitle = useCallback(value => getUpdateValue("title")(value), []);
     const updateWidth = useCallback(value => getUpdateValue("width")(value), []);
     const updateHeight = useCallback(value => getUpdateValue("height")(value), []);
+    const updateHtmlTag = useCallback(value => getUpdateValue("htmlTag")(value), []);
 
     return (
         <Accordion title={"Image"} defaultValue={defaultAccordionValue}>
@@ -77,6 +79,18 @@ const ImageSettings = ({
                         useDefaultStyle={false}
                         className={spacingPickerStyle}
                     />
+                </Wrapper>
+                <Wrapper
+                    label={"HTML Tag"}
+                    containerClassName={classes.grid}
+                    leftCellSpan={4}
+                    rightCellSpan={8}
+                >
+                    <SelectField value={image?.htmlTag || "img"} onChange={updateHtmlTag}>
+                        <option value={"auto"}>{"Auto-detect"}</option>
+                        <option value={"img"}>{"<img>"}</option>
+                        <option value={"object"}>{"<object>"} (for SVGs)</option>
+                    </SelectField>
                 </Wrapper>
             </>
         </Accordion>

--- a/packages/app-page-builder/src/editor/plugins/elements/image/PeImage.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/image/PeImage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
 import { FileManager, SingleImageUploadProps } from "@webiny/app-admin";
 import { UpdateElementActionEvent } from "~/editor/recoil/actions";
-import pick from "lodash/pick";
 import { useEventActionHandler } from "~/editor/hooks/useEventActionHandler";
 import { ImageRendererComponent } from "@webiny/app-page-builder-elements/renderers/image";
 import { AddImageIconWrapper, AddImageWrapper } from "@webiny/ui/ImageUpload/styled";
@@ -33,18 +32,19 @@ const PeImage = createRenderer(() => {
 
     const onChange = useCallback<NonNullable<SingleImageUploadProps["onChange"]>>(
         file => {
+            const elementClone = structuredClone(element);
+            if (file) {
+                const { id, src } = file;
+                elementClone.data.image = {
+                    ...elementClone.data.image,
+                    file: { id, src },
+                    htmlTag: "auto"
+                };
+            }
+
             handler.trigger(
                 new UpdateElementActionEvent({
-                    element: {
-                        ...element,
-                        data: {
-                            ...element.data,
-                            image: {
-                                ...(element.data.image || {}),
-                                file: file ? pick(file, ["id", "src"]) : undefined
-                            }
-                        }
-                    },
+                    element: elementClone,
                     history: true
                 })
             );

--- a/packages/app-page-builder/src/types.ts
+++ b/packages/app-page-builder/src/types.ts
@@ -118,6 +118,7 @@ export interface PbElementDataImageType {
         src?: string;
     };
     title?: string;
+    htmlTag?: string;
 }
 
 export interface PbElementDataIconType {


### PR DESCRIPTION
## Changes
With this PR, we're allowing users to use the [`object`](https://www.w3schools.com/tags/tag_object.asp) HTML tag when rendering SVGs with the **Image** page element. 

The following screenshot shows two images, one rendered the usual way, one rendered with the new `object` HTML tag:

![image](https://github.com/webiny/webiny-js/assets/5121148/46a279b1-31f4-41f0-a6ee-6f256bd22e6f)

Note that, for existing users / backwards compatibility, existing SVG images on pages will still be rendered via the `img` HTML tag. But, if needed, users are able to change this via the new HTML Tag input:

![image](https://github.com/webiny/webiny-js/assets/5121148/9341179e-47ef-4cb7-8d22-1af992b1c1eb)

Also note that, once a user upgrades their Webiny project, all newly selected images will have their HTML tag set to "Auto-detect". In other words, if a user selects a file that ends up with the `.svg` extension, `object` HTML tag will be used. Otherwise, `img` HTML tag will be used.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.