### PR TITLE
WCP - Add Record Locking Feature To WCP License

### DIFF
--- a/packages/api-aco/__tests__/utils/createTestWcpLicense.ts
+++ b/packages/api-aco/__tests__/utils/createTestWcpLicense.ts
@@ -32,6 +32,9 @@ export const createTestWcpLicense = (): DecryptedWcpProjectLicense => {
                 [PROJECT_PACKAGE_FEATURE_NAME.AUDIT_LOGS]: {
                     enabled: false
                 },
+                [PROJECT_PACKAGE_FEATURE_NAME.RECORD_LOCKING]: {
+                    enabled: false
+                },
                 [PROJECT_PACKAGE_FEATURE_NAME.SEATS]: {
                     enabled: true,
                     options: {

--- a/packages/api-page-builder-aco/__tests__/utils/createTestWcpLicense.ts
+++ b/packages/api-page-builder-aco/__tests__/utils/createTestWcpLicense.ts
@@ -32,6 +32,9 @@ export const createTestWcpLicense = (): DecryptedWcpProjectLicense => {
                 [PROJECT_PACKAGE_FEATURE_NAME.AUDIT_LOGS]: {
                     enabled: false
                 },
+                [PROJECT_PACKAGE_FEATURE_NAME.RECORD_LOCKING]: {
+                    enabled: false
+                },
                 [PROJECT_PACKAGE_FEATURE_NAME.SEATS]: {
                     enabled: true,
                     options: {

--- a/packages/api-wcp/__tests__/context.test.ts
+++ b/packages/api-wcp/__tests__/context.test.ts
@@ -25,6 +25,8 @@ describe("context", () => {
             canUseFolderLevelPermissions: expect.any(Function),
             canUsePrivateFiles: expect.any(Function),
             canUseTeams: expect.any(Function),
+            canUseAuditLogs: expect.any(Function),
+            canUseRecordLocking: expect.any(Function),
             decrementSeats: expect.any(Function),
             incrementTenants: expect.any(Function),
             decrementTenants: expect.any(Function)

--- a/packages/api-wcp/src/createWcp.ts
+++ b/packages/api-wcp/src/createWcp.ts
@@ -147,6 +147,14 @@ export const createWcp = async (params: CreateWcpParams = {}): Promise<WcpContex
             return license!.package.features.advancedAccessControlLayer.options.privateFiles;
         },
 
+        canUseAuditLogs() {
+            return this.canUseFeature("auditLogs");
+        },
+
+        canUseRecordLocking() {
+            return this.canUseFeature("recordLocking");
+        },
+
         ensureCanUseFeature(wcpFeatureId: keyof typeof WCP_FEATURE_LABEL) {
             if (this.canUseFeature(wcpFeatureId)) {
                 return;

--- a/packages/app-wcp/src/hooks/useWcp.ts
+++ b/packages/app-wcp/src/hooks/useWcp.ts
@@ -9,6 +9,8 @@ interface UseWcpHook {
     canUseTeams: () => boolean;
     canUsePrivateFiles: () => boolean;
     canUseFolderLevelPermissions: () => boolean;
+    canUseAuditLogs: () => boolean;
+    canUseRecordLocking: () => boolean;
 }
 
 export function useWcp(): UseWcpHook {
@@ -65,12 +67,22 @@ export function useWcp(): UseWcpHook {
         return advancedAccessControlLayer.options.privateFiles;
     };
 
+    const canUseAuditLogs = () => {
+        return canUseFeature("auditLogs");
+    };
+
+    const canUseRecordLocking = () => {
+        return canUseFeature("recordLocking");
+    };
+
     return {
         getProject,
         canUseFeature,
         canUseAacl,
         canUseTeams,
         canUseFolderLevelPermissions,
-        canUsePrivateFiles
+        canUsePrivateFiles,
+        canUseAuditLogs,
+        canUseRecordLocking
     };
 }

--- a/packages/app-wcp/src/types.ts
+++ b/packages/app-wcp/src/types.ts
@@ -25,6 +25,9 @@ export type WcpProjectPackage = {
         auditLogs: {
             enabled: boolean;
         };
+        recordLocking: {
+            enabled: boolean;
+        };
     };
 };
 

--- a/packages/wcp/src/index.ts
+++ b/packages/wcp/src/index.ts
@@ -7,5 +7,6 @@ export const WCP_FEATURE_LABEL = {
     multiTenancy: "Multi-tenancy",
     advancedPublishingWorkflow: "Advanced Publishing Workflow (APW)",
     advancedAccessControlLayer: "Advanced Access Control Layer (ACL)",
-    auditLogs: "Audit Logs"
+    auditLogs: "Audit Logs",
+    recordLocking: "Record Locking"
 };

--- a/packages/wcp/src/types.ts
+++ b/packages/wcp/src/types.ts
@@ -17,7 +17,8 @@ export enum PROJECT_PACKAGE_FEATURE_NAME {
     APW = "advancedPublishingWorkflow",
     AACL = "advancedAccessControlLayer",
     AL = "auditLogs",
-    AUDIT_LOGS = "auditLogs"
+    AUDIT_LOGS = "auditLogs",
+    RECORD_LOCKING = "recordLocking"
 }
 
 export enum MT_OPTIONS_MAX_COUNT_TYPE {
@@ -47,6 +48,9 @@ export interface ProjectPackageFeatures {
         enabled: boolean;
     };
     [PROJECT_PACKAGE_FEATURE_NAME.AUDIT_LOGS]: {
+        enabled: boolean;
+    };
+    [PROJECT_PACKAGE_FEATURE_NAME.RECORD_LOCKING]: {
         enabled: boolean;
     };
     [PROJECT_PACKAGE_FEATURE_NAME.AACL]: {


### PR DESCRIPTION
## Changes
This PR adds `recordLocking` property to WCP license.

## How Has This Been Tested?
Manually.

## Documentation
None.