### PR TITLE
fix(api-headless-cms): rename `deleted` flag to `wbyDeleted`

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
@@ -93,7 +93,7 @@ export const createEntryEntity = (params: CreateEntryEntityParams): Entity<any> 
             location: {
                 type: "map"
             },
-            deleted: {
+            wbyDeleted: {
                 type: "boolean"
             },
             binOriginalFolderId: {

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fields.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fields.ts
@@ -174,7 +174,7 @@ const createSystemFields = (): ModelFields => {
             }),
             parents: []
         },
-        deleted: {
+        wbyDeleted: {
             type: "boolean",
             unmappedType: undefined,
             keyword: false,
@@ -182,8 +182,8 @@ const createSystemFields = (): ModelFields => {
             searchable: true,
             sortable: false,
             field: createSystemField({
-                storageId: "deleted",
-                fieldId: "deleted",
+                storageId: "wbyDeleted",
+                fieldId: "wbyDeleted",
                 type: "boolean"
             }),
             parents: []

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -760,7 +760,7 @@ export const createEntriesStorageOperations = (
                 entity.putBatch({
                     ...record,
                     ...updatedEntryMetaFields,
-                    deleted: storageEntry.deleted,
+                    wbyDeleted: storageEntry.wbyDeleted,
                     location: storageEntry.location,
                     binOriginalFolderId: storageEntry.binOriginalFolderId
                 })
@@ -856,7 +856,7 @@ export const createEntriesStorageOperations = (
                     data: await compress(plugins, {
                         ...item.data,
                         ...updatedEntryMetaFields,
-                        deleted: entry.deleted,
+                        wbyDeleted: entry.wbyDeleted,
                         location: entry.location,
                         binOriginalFolderId: entry.binOriginalFolderId
                     })
@@ -940,7 +940,7 @@ export const createEntriesStorageOperations = (
                 entity.putBatch({
                     ...record,
                     ...updatedEntryMetaFields,
-                    deleted: storageEntry.deleted,
+                    wbyDeleted: storageEntry.wbyDeleted,
                     location: storageEntry.location,
                     binOriginalFolderId: storageEntry.binOriginalFolderId
                 })
@@ -1033,7 +1033,7 @@ export const createEntriesStorageOperations = (
                     data: await compress(plugins, {
                         ...item.data,
                         ...updatedEntryMetaFields,
-                        deleted: entry.deleted,
+                        wbyDeleted: entry.wbyDeleted,
                         location: entry.location,
                         binOriginalFolderId: entry.binOriginalFolderId
                     })

--- a/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
@@ -455,12 +455,12 @@ const expectedSystemFields: Record<string, Field> = {
         transform: expect.any(Function),
         label: "Status"
     },
-    deleted: {
-        id: "deleted",
+    wbyDeleted: {
+        id: "wbyDeleted",
         parents: [],
         type: "boolean",
-        storageId: "deleted",
-        fieldId: "deleted",
+        storageId: "wbyDeleted",
+        fieldId: "wbyDeleted",
         createPath: expect.any(Function),
         system: true,
         transform: expect.any(Function),

--- a/packages/api-headless-cms-ddb/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/entry.ts
@@ -100,7 +100,7 @@ export const createEntryEntity = (params: Params): Entity<any> => {
             location: {
                 type: "map"
             },
-            deleted: {
+            wbyDeleted: {
                 type: "boolean"
             },
             binOriginalFolderId: {

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
@@ -95,10 +95,10 @@ export const createSystemFields = (): Field[] => {
             label: "Status"
         },
         {
-            id: "deleted",
+            id: "wbyDeleted",
             type: "boolean",
-            storageId: "deleted",
-            fieldId: "deleted",
+            storageId: "wbyDeleted",
+            fieldId: "wbyDeleted",
             label: "Deleted"
         }
     ];

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -526,7 +526,7 @@ export const createEntriesStorageOperations = (
             return entity.putBatch({
                 ...record,
                 ...updatedDeletedMetaFields,
-                deleted: storageEntry.deleted,
+                wbyDeleted: storageEntry.wbyDeleted,
                 location: storageEntry.location,
                 binOriginalFolderId: storageEntry.binOriginalFolderId
             });
@@ -663,7 +663,7 @@ export const createEntriesStorageOperations = (
             return entity.putBatch({
                 ...record,
                 ...updatedRestoredMetaFields,
-                deleted: storageEntry.deleted,
+                wbyDeleted: storageEntry.wbyDeleted,
                 location: storageEntry.location,
                 binOriginalFolderId: storageEntry.binOriginalFolderId
             });

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/DeleteEntry/TransformEntryMoveToBin.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/DeleteEntry/TransformEntryMoveToBin.ts
@@ -41,7 +41,7 @@ export class TransformEntryMoveToBin {
 
         const entry: CmsEntry = {
             ...originalEntry,
-            deleted: true,
+            wbyDeleted: true,
 
             /**
              * Entry location fields. 👇

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetEntriesByIds/GetEntriesByIdsNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetEntriesByIds/GetEntriesByIdsNotDeleted.ts
@@ -10,6 +10,6 @@ export class GetEntriesByIdsNotDeleted implements IGetEntriesByIds {
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetByIdsParams) {
         const entries = await this.getEntriesByIds.execute(model, params);
-        return entries.filter(entry => !entry.deleted);
+        return entries.filter(entry => !entry.wbyDeleted);
     }
 }

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestEntriesByIds/GetLatestEntriesByIdsNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestEntriesByIds/GetLatestEntriesByIdsNotDeleted.ts
@@ -10,6 +10,6 @@ export class GetLatestEntriesByIdsNotDeleted implements IGetLatestEntriesByIds {
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetLatestByIdsParams) {
         const entries = await this.getLatestEntriesByIds.execute(model, params);
-        return entries.filter(entry => !entry.deleted);
+        return entries.filter(entry => !entry.wbyDeleted);
     }
 }

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestRevisionByEntryId/GetLatestRevisionByEntryIdDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestRevisionByEntryId/GetLatestRevisionByEntryIdDeleted.ts
@@ -11,7 +11,7 @@ export class GetLatestRevisionByEntryIdDeleted implements IGetLatestRevisionByEn
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetLatestRevisionParams) {
         const entry = await this.getLatestRevisionByEntryId.execute(model, params);
 
-        if (!entry || !entry.deleted) {
+        if (!entry || !entry.wbyDeleted) {
             return null;
         }
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestRevisionByEntryId/GetLatestRevisionByEntryIdNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetLatestRevisionByEntryId/GetLatestRevisionByEntryIdNotDeleted.ts
@@ -11,7 +11,7 @@ export class GetLatestRevisionByEntryIdNotDeleted implements IGetLatestRevisionB
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetLatestRevisionParams) {
         const entry = await this.getLatestRevisionByEntryId.execute(model, params);
 
-        if (!entry || entry.deleted) {
+        if (!entry || entry.wbyDeleted) {
             return null;
         }
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPreviousRevisionByEntryId/GetPreviousRevisionByEntryIdNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPreviousRevisionByEntryId/GetPreviousRevisionByEntryIdNotDeleted.ts
@@ -11,7 +11,7 @@ export class GetPreviousRevisionByEntryIdNotDeleted implements IGetPreviousRevis
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetPreviousRevisionParams) {
         const entry = await this.getPreviousRevisionByEntryId.execute(model, params);
 
-        if (!entry || entry.deleted) {
+        if (!entry || entry.wbyDeleted) {
             return null;
         }
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPublishedEntriesByIds/GetPublishedEntriesByIdsNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPublishedEntriesByIds/GetPublishedEntriesByIdsNotDeleted.ts
@@ -10,6 +10,6 @@ export class GetPublishedEntriesByIdsNotDeleted implements IGetPublishedEntriesB
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetPublishedByIdsParams) {
         const entries = await this.getPublishedEntriesByIds.execute(model, params);
-        return entries.filter(entry => !entry.deleted);
+        return entries.filter(entry => !entry.wbyDeleted);
     }
 }

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPublishedRevisionByEntryId/GetPublishedRevisionByEntryIdNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetPublishedRevisionByEntryId/GetPublishedRevisionByEntryIdNotDeleted.ts
@@ -11,7 +11,7 @@ export class GetPublishedRevisionByEntryIdNotDeleted implements IGetPublishedRev
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetPublishedRevisionParams) {
         const entry = await this.getPublishedRevisionByEntryId.execute(model, params);
 
-        if (!entry || entry.deleted) {
+        if (!entry || entry.wbyDeleted) {
             return null;
         }
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetRevisionById/GetRevisionByIdNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetRevisionById/GetRevisionByIdNotDeleted.ts
@@ -11,7 +11,7 @@ export class GetRevisionByIdNotDeleted implements IGetRevisionById {
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetRevisionParams) {
         const entry = await this.getRevisionById.execute(model, params);
 
-        if (!entry || entry.deleted) {
+        if (!entry || entry.wbyDeleted) {
             return null;
         }
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/GetRevisionsByEntryId/GetRevisionsByEntryIdNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/GetRevisionsByEntryId/GetRevisionsByEntryIdNotDeleted.ts
@@ -10,6 +10,6 @@ export class GetRevisionsByEntryIdNotDeleted implements IGetRevisionsByEntryId {
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsGetRevisionParams) {
         const entries = await this.getRevisionsByEntryId.execute(model, params);
-        return entries.filter(entry => !entry.deleted);
+        return entries.filter(entry => !entry.wbyDeleted);
     }
 }

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/ListEntries/ListEntriesOperationDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/ListEntries/ListEntriesOperationDeleted.ts
@@ -9,7 +9,7 @@ export class ListEntriesOperationDeleted implements IListEntriesOperation {
     }
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsListParams) {
-        const where = { ...params.where, deleted: true };
+        const where = { ...params.where, wbyDeleted: true };
 
         return await this.listEntries.execute(model, {
             ...params,

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/ListEntries/ListEntriesOperationNotDeleted.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/ListEntries/ListEntriesOperationNotDeleted.ts
@@ -9,7 +9,7 @@ export class ListEntriesOperationNotDeleted implements IListEntriesOperation {
     }
 
     async execute(model: CmsModel, params: CmsEntryStorageOperationsListParams) {
-        const where = { ...params.where, deleted_not: true };
+        const where = { ...params.where, wbyDeleted_not: true };
 
         return await this.listEntries.execute(model, {
             ...params,

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/RestoreEntryFromBin/TransformEntryRestoreFromBin.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/RestoreEntryFromBin/TransformEntryRestoreFromBin.ts
@@ -40,7 +40,7 @@ export class TransformEntryRestoreFromBin {
 
         const entry: CmsEntry = {
             ...originalEntry,
-            deleted: false,
+            wbyDeleted: false,
 
             /**
              * Entry location fields. 👇

--- a/packages/api-headless-cms/src/types/types.ts
+++ b/packages/api-headless-cms/src/types/types.ts
@@ -621,7 +621,7 @@ export interface CmsEntry<T = CmsEntryValues> {
     /**
      * Is the entry in the bin?
      */
-    deleted?: boolean | null;
+    wbyDeleted?: boolean | null;
     /**
      * This field preserves the original folderId value, as the ROOT_FOLDER is set upon deletion.
      * The value is utilized when restoring the entry from the trash bin.


### PR DESCRIPTION
## Changes
With this PR, we rename the newly created `deleted` flag to `wbyDeleted`. This is necessary to avoid conflicting with user-defined 'deleted' fields by treating `wby` as a reserved field.

## How Has This Been Tested?
Jest + manually

## Documentation
We need to highlight the newly created field (`wbyDeleted`) inside the release docs.
