### PR TITLE
Headless CMS / `createModelField` Function - Add Missing Fields

### DIFF
--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -83,7 +83,9 @@ const fieldSchema = zod.object({
         .object({
             name: shortString
         })
-        .optional(),
+        .optional()
+        .nullable()
+        .default(null),
     validation: zod
         .array(
             zod.object({

--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -72,7 +72,7 @@ export interface CmsModelField {
     /**
      * Field renderer. Blank if determined automatically.
      */
-    renderer?: CmsModelFieldRenderer;
+    renderer?: CmsModelFieldRenderer | null;
     /**
      * List of validations for the field
      *

--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -154,7 +154,7 @@ export interface CmsModelFieldInput {
     /**
      * Renderer options for the field. Check the reference for more information.
      */
-    renderer?: CmsModelFieldRenderer;
+    renderer?: CmsModelFieldRenderer | null;
     /**
      * List of validations for the field.
      */

--- a/packages/api-headless-cms/src/utils/createModelField.ts
+++ b/packages/api-headless-cms/src/utils/createModelField.ts
@@ -9,42 +9,16 @@ export interface CreateModelFieldParams
 }
 
 export const createModelField = (params: CreateModelFieldParams): CmsModelField => {
-    const {
-        id,
-        label,
-        fieldId: initialFieldId,
-        storageId,
-        type,
-        tags,
-        settings = {},
-        listValidation = [],
-        validation = [],
-        multipleValues = false,
-        predefinedValues = {
-            values: [],
-            enabled: false
-        },
-        helpText,
-        placeholderText,
-        renderer
-    } = params;
+    const { id, label, fieldId: initialFieldId, storageId, type } = params;
 
     const fieldId = initialFieldId ? camelCase(initialFieldId) : camelCase(label);
 
     return {
+        ...params,
         id: id ?? fieldId,
         storageId: storageId ?? `${type}@${fieldId}`,
         fieldId,
         label,
-        type,
-        settings,
-        tags,
-        listValidation,
-        validation,
-        multipleValues,
-        predefinedValues,
-        helpText,
-        placeholderText,
-        renderer
+        type
     };
 };

--- a/packages/api-headless-cms/src/utils/createModelField.ts
+++ b/packages/api-headless-cms/src/utils/createModelField.ts
@@ -9,16 +9,44 @@ export interface CreateModelFieldParams
 }
 
 export const createModelField = (params: CreateModelFieldParams): CmsModelField => {
-    const { id, label, fieldId: initialFieldId, storageId, type } = params;
+    // We are not just spreading `params` because we want to ensure
+    // a default value is set for every property of the model field.
+    const {
+        id,
+        label,
+        fieldId: initialFieldId,
+        storageId,
+        type,
+        tags,
+        settings = {},
+        listValidation = [],
+        validation = [],
+        multipleValues = false,
+        predefinedValues = {
+            values: [],
+            enabled: false
+        },
+        helpText = null,
+        placeholderText = null,
+        renderer = null
+    } = params;
 
     const fieldId = initialFieldId ? camelCase(initialFieldId) : camelCase(label);
 
     return {
-        ...params,
         id: id ?? fieldId,
         storageId: storageId ?? `${type}@${fieldId}`,
         fieldId,
         label,
-        type
+        type,
+        settings,
+        tags,
+        listValidation,
+        validation,
+        multipleValues,
+        predefinedValues,
+        helpText,
+        placeholderText,
+        renderer
     };
 };

--- a/packages/api-headless-cms/src/utils/createModelField.ts
+++ b/packages/api-headless-cms/src/utils/createModelField.ts
@@ -23,7 +23,10 @@ export const createModelField = (params: CreateModelFieldParams): CmsModelField 
         predefinedValues = {
             values: [],
             enabled: false
-        }
+        },
+        helpText,
+        placeholderText,
+        renderer
     } = params;
 
     const fieldId = initialFieldId ? camelCase(initialFieldId) : camelCase(label);
@@ -39,6 +42,9 @@ export const createModelField = (params: CreateModelFieldParams): CmsModelField 
         listValidation,
         validation,
         multipleValues,
-        predefinedValues
+        predefinedValues,
+        helpText,
+        placeholderText,
+        renderer
     };
 };


### PR DESCRIPTION
## Changes
This PR ensures that `helpText`, `placeholderText`, and `renderer` fields are taken into consideration upon defining a model field via the `createModelField` function. Prior to this PR, these fields would get ignored.

## How Has This Been Tested?
Manually / relying on existing Jest tests.

## Documentation
N/A