### PR TITLE
feat(migrations): add block element ids migration

### DIFF
--- a/packages/migrations/__tests__/migrations/5.40.0/001/ddb/001.data.ts
+++ b/packages/migrations/__tests__/migrations/5.40.0/001/ddb/001.data.ts
@@ -1,0 +1,399 @@
+import { compress } from "~/migrations/5.40.0/001/ddb/compression";
+
+export const rawContent = {
+    path: ["vYyuUH3RPN"],
+    type: "block",
+    data: {
+        settings: {
+            width: {
+                desktop: {
+                    value: "100%"
+                }
+            },
+            padding: {
+                "mobile-portrait": {
+                    top: "20px",
+                    advanced: true,
+                    bottom: "20px"
+                },
+                desktop: {
+                    all: "10px",
+                    right: "10px",
+                    top: "40px",
+                    advanced: true,
+                    left: "10px",
+                    bottom: "20px"
+                }
+            },
+            horizontalAlignFlex: {
+                desktop: "center"
+            },
+            verticalAlign: {
+                desktop: "flex-start"
+            },
+            margin: {
+                desktop: {
+                    right: "0px",
+                    top: "0px",
+                    left: "0px",
+                    advanced: true,
+                    bottom: "0px"
+                }
+            },
+            background: {
+                desktop: {
+                    color: null
+                }
+            }
+        },
+        variables: [
+            {
+                id: "e0LV1SGW8E",
+                label: "Title",
+                type: "heading",
+                value: '{"root":{"children":[{"children":[{"detail":0,"format":1,"mode":"normal","style":"font-size: 18px;","text":"LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT","type":"font-color-node","version":1,"themeColor":"color4","color":"#616161"}],"direction":"ltr","format":"","indent":0,"type":"heading-element","version":1,"tag":"h3","styles":[{"styleId":"heading3","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+            },
+            {
+                id: "RN9CtkSL0b",
+                label: "Logo Image",
+                type: "image",
+                value: {
+                    src: "https://d2b8of00q5koup.cloudfront.net/files/648c2584fc82b0000881f865/LogoCloudV1.svg",
+                    id: "648c2584fc82b0000881f865"
+                }
+            }
+        ]
+    },
+    elements: [
+        {
+            path: ["vYyuUH3RPN", "6JBEyzzdUY"],
+            type: "grid",
+            data: {
+                settings: {
+                    gridSettings: {
+                        tablet: {
+                            flexDirection: "column"
+                        },
+                        "mobile-landscape": {
+                            flexDirection: "column"
+                        },
+                        desktop: {
+                            flexDirection: "column"
+                        }
+                    },
+                    padding: {
+                        desktop: {
+                            all: "10px"
+                        }
+                    },
+                    horizontalAlignFlex: {
+                        desktop: "flex-start"
+                    },
+                    verticalAlign: {
+                        tablet: "stretch",
+                        desktop: "stretch",
+                        "mobile-landscape": "flex-start",
+                        "mobile-portrait": "flex-start"
+                    },
+                    margin: {
+                        desktop: {
+                            right: "0px",
+                            top: "0px",
+                            left: "0px",
+                            advanced: true,
+                            bottom: "0px"
+                        }
+                    },
+                    grid: {
+                        cellsType: "12",
+                        rowCount: 2
+                    },
+                    width: {
+                        desktop: {
+                            value: "1100px"
+                        }
+                    }
+                }
+            },
+            elements: [
+                {
+                    path: ["vYyuUH3RPN", "6JBEyzzdUY", "j3XI0MiQ3M"],
+                    type: "cell",
+                    data: {
+                        settings: {
+                            padding: {
+                                desktop: {
+                                    all: "0px"
+                                }
+                            },
+                            horizontalAlignFlex: {
+                                desktop: "flex-start"
+                            },
+                            verticalAlign: {
+                                desktop: "center"
+                            },
+                            margin: {
+                                desktop: {
+                                    right: "0px",
+                                    top: "0px",
+                                    left: "0px",
+                                    advanced: true,
+                                    bottom: "0px"
+                                }
+                            },
+                            grid: {
+                                size: 12
+                            }
+                        }
+                    },
+                    elements: [
+                        {
+                            path: ["vYyuUH3RPN", "6JBEyzzdUY", "j3XI0MiQ3M", "h8QcsWnLnp"],
+                            type: "heading",
+                            data: {
+                                settings: {
+                                    padding: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    },
+                                    margin: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    }
+                                },
+                                variableId: "e0LV1SGW8E",
+                                text: {
+                                    data: {
+                                        text: '{"root":{"children":[{"children":[{"detail":0,"format":1,"mode":"normal","style":"font-size: 18px;","text":"LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT","type":"font-color-node","version":1,"themeColor":"color4","color":"#616161"}],"direction":"ltr","format":"","indent":0,"type":"heading-element","version":1,"tag":"h3","styles":[{"styleId":"heading3","type":"typography"}]}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}'
+                                    },
+                                    desktop: {
+                                        type: "heading",
+                                        alignment: "center",
+                                        tag: "h1"
+                                    }
+                                }
+                            },
+                            elements: []
+                        }
+                    ]
+                },
+                {
+                    path: ["vYyuUH3RPN", "6JBEyzzdUY", "j3XI0MiQ3M"],
+                    type: "cell",
+                    data: {
+                        settings: {
+                            padding: {
+                                desktop: {
+                                    all: "0px"
+                                }
+                            },
+                            horizontalAlignFlex: {
+                                desktop: "flex-start"
+                            },
+                            margin: {
+                                desktop: {
+                                    right: "0px",
+                                    top: "0px",
+                                    left: "0px",
+                                    advanced: true,
+                                    bottom: "0px"
+                                }
+                            },
+                            grid: {
+                                size: 12
+                            }
+                        }
+                    },
+                    elements: [
+                        {
+                            path: ["vYyuUH3RPN", "6JBEyzzdUY", "j3XI0MiQ3M", "XUrIerQSDG"],
+                            type: "image",
+                            data: {
+                                link: {
+                                    href: null
+                                },
+                                settings: {
+                                    horizontalAlignFlex: {
+                                        desktop: "center"
+                                    },
+                                    padding: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    },
+                                    margin: {
+                                        desktop: {
+                                            all: "0px"
+                                        }
+                                    }
+                                },
+                                image: {
+                                    file: {
+                                        name: "Logo Cloud V1.svg",
+                                        id: "65415260b431680008ad4596",
+                                        src: "https://d26watk6chcr2b.cloudfront.net/files/65415260b431680008ad4596/LogoCloudV1.svg",
+                                        key: "65415260b431680008ad4596/LogoCloudV1.svg"
+                                    }
+                                },
+                                variableId: "RN9CtkSL0b"
+                            },
+                            elements: []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+export const createBlocksData = async (amount = 100) => {
+    return Promise.all([
+        ...Array.from({ length: amount }).map(async (_, index) => {
+            const id = `65415260b431680008ad4598${index.toString().padStart(4, "0")}`;
+
+            return {
+                content: await compress(rawContent),
+                locale: "en-US",
+                entity: "PbPageBlocks",
+                createdBy: {
+                    type: "admin",
+                    displayName: "Pavel Denisjuk",
+                    id: "6496fbd7d6062300081e4727"
+                },
+                name: `Logo Cloud ${index}`,
+                created: "2023-10-31T19:15:44.897Z",
+                TYPE: "pb.pageBlock",
+                tenant: "root",
+                modified: "2023-10-31T19:15:44.897Z",
+                blockCategory: "logo-cloud",
+                createdOn: "2023-10-31T19:15:44.896Z",
+                id,
+                SK: `A`,
+                PK: `T#root#L#en-US#PB#BLOCK#${id}`,
+                GSI1_PK: `T#root#L#en-US#PB#BLOCKS`,
+                GSI1_SK: `logo-cloud#${id}`
+            };
+        }),
+        {
+            PK: "T#root",
+            SK: "A",
+            createdOn: "2023-01-25T09:37:58.183Z",
+            description: "The top-level Webiny tenant.",
+            GSI1_PK: "TENANTS",
+            GSI1_SK: "T#null#2023-01-25T09:37:58.183Z",
+            data: {
+                id: "root",
+                name: "Root",
+                savedOn: "2023-01-25T09:37:58.183Z",
+                settings: {
+                    domains: []
+                },
+                status: "active",
+                TYPE: "tenancy.tenant",
+                webinyVersion: "0.0.0",
+                createdBy: {
+                    type: "admin",
+                    displayName: "ad min",
+                    id: "6540185ca0f1c30008594e34"
+                }
+            }
+        },
+        {
+            PK: "T#otherTenant",
+            SK: "A",
+            createdOn: "2023-03-11T09:59:17.327Z",
+            description: "Tenant #1",
+            GSI1_PK: "TENANTS",
+            GSI1_SK: "T#root#2023-03-11T09:59:17.327Z",
+            data: {
+                id: "otherTenant",
+                name: "Other Tenant",
+                parent: "root",
+                savedOn: "2023-03-11T09:59:17.327Z",
+                settings: {
+                    domains: []
+                },
+                status: "active",
+                TYPE: "tenancy.tenant",
+                webinyVersion: "0.0.0",
+                createdBy: {
+                    type: "admin",
+                    displayName: "ad min",
+                    id: "6540185ca0f1c30008594e34"
+                }
+            }
+        },
+        {
+            PK: `T#root#I18N#L`,
+            SK: "en-US",
+            code: "en-US",
+            default: true,
+            createdOn: "2023-01-25T09:37:58.220Z",
+            createdBy: {
+                type: "admin",
+                displayName: "ad min",
+                id: "6540185ca0f1c30008594e34"
+            },
+            tenant: "root",
+            webinyVersion: "0.0.0"
+        },
+        {
+            PK: `T#root#I18N#L`,
+            SK: "de-DE",
+            code: "de-DE",
+            default: false,
+            createdOn: "2023-01-25T09:37:58.220Z",
+            createdBy: {
+                type: "admin",
+                displayName: "ad min",
+                id: "6540185ca0f1c30008594e34"
+            },
+            tenant: "root",
+            webinyVersion: "0.0.0"
+        },
+        {
+            PK: `T#root#I18N#L`,
+            SK: "fr-FR",
+            code: "fr-FR",
+            default: false,
+            createdOn: "2023-01-25T09:37:58.220Z",
+            createdBy: {
+                type: "admin",
+                displayName: "ad min",
+                id: "6540185ca0f1c30008594e34"
+            },
+            tenant: "root",
+            webinyVersion: "0.0.0"
+        },
+        {
+            PK: `T#otherTenant#I18N#L`,
+            SK: "fr-FR",
+            code: "fr-FR",
+            default: false,
+            createdOn: "2023-01-25T09:37:58.220Z",
+            createdBy: {
+                type: "admin",
+                displayName: "ad min",
+                id: "6540185ca0f1c30008594e34"
+            },
+            tenant: "otherTenant",
+            webinyVersion: "0.0.0"
+        },
+        {
+            PK: `T#otherTenant#I18N#L`,
+            SK: "de-DE",
+            code: "de-DE",
+            default: true,
+            createdOn: "2023-01-25T09:37:58.220Z",
+            createdBy: {
+                type: "admin",
+                displayName: "ad min",
+                id: "6540185ca0f1c30008594e34"
+            },
+            tenant: "otherTenant",
+            webinyVersion: "0.0.0"
+        }
+    ]);
+};

--- a/packages/migrations/__tests__/migrations/5.40.0/001/ddb/001.test.ts
+++ b/packages/migrations/__tests__/migrations/5.40.0/001/ddb/001.test.ts
@@ -1,0 +1,76 @@
+import {
+    assertNotError,
+    createDdbMigrationHandler,
+    getPrimaryDynamoDbTable,
+    groupMigrations,
+    insertDynamoDbTestData as insertTestData,
+    logTestNameBeforeEachTest,
+    scanTable
+} from "~tests/utils";
+import { createBlocksData } from "./001.data";
+import { decompress } from "~/migrations/5.40.0/001/ddb/compression";
+import { PbUniqueBlockElementIds_5_40_0_001 } from "~/migrations/5.40.0/001/ddb";
+
+jest.retryTimes(0);
+jest.setTimeout(900000);
+
+const NUMBER_OF_RECORDS = 1000;
+
+describe("5.40.0-001", () => {
+    const table = getPrimaryDynamoDbTable();
+
+    logTestNameBeforeEachTest();
+
+    it("should not run if no blocks exist in the system", async () => {
+        const handler = createDdbMigrationHandler({
+            table,
+            migrations: [PbUniqueBlockElementIds_5_40_0_001]
+        });
+
+        const { data, error } = await handler();
+
+        assertNotError(error);
+        const grouped = groupMigrations(data.migrations);
+
+        expect(grouped.executed.length).toBe(0);
+        expect(grouped.skipped.length).toBe(1);
+        expect(grouped.notApplicable.length).toBe(0);
+    });
+
+    it("should execute migration", async () => {
+        await insertTestData(table, await createBlocksData(NUMBER_OF_RECORDS));
+
+        const handler = createDdbMigrationHandler({
+            table,
+            migrations: [PbUniqueBlockElementIds_5_40_0_001]
+        });
+        const { data, error } = await handler();
+
+        assertNotError(error);
+        const grouped = groupMigrations(data.migrations);
+
+        expect(grouped.executed.length).toBe(1);
+        expect(grouped.skipped.length).toBe(0);
+        expect(grouped.notApplicable.length).toBe(0);
+
+        const newData = await scanTable(table, {
+            execute: true,
+            parse: true,
+            filters: [
+                {
+                    attr: "TYPE",
+                    eq: "pb.pageBlock"
+                }
+            ]
+        });
+
+        const firstBlock = await decompress(newData[0]);
+        const lastBlock = await decompress(newData[newData.length - 1]);
+
+        expect(firstBlock.content.id).toBeString();
+        expect(firstBlock.content.id).toHaveLength(10);
+
+        expect(lastBlock.content.id).toBeString();
+        expect(lastBlock.content.id).toHaveLength(10);
+    });
+});

--- a/packages/migrations/src/ddb-es.ts
+++ b/packages/migrations/src/ddb-es.ts
@@ -23,6 +23,8 @@ import { CmsEntriesInitNewMetaFields_5_39_0_001 } from "~/migrations/5.39.0/001/
 import { FileManager_5_39_0_002 } from "~/migrations/5.39.0/002/ddb-es";
 // 5.39.2
 import { CmsEntriesInitNewMetaFields_5_39_2_001 } from "~/migrations/5.39.2/001/ddb-es";
+// Page Blocks storage is the same for both DDB abd DDB-ES projects.
+import { PbUniqueBlockElementIds_5_40_0_001 } from "~/migrations/5.40.0/001/ddb";
 
 export const migrations = () => {
     return [
@@ -49,6 +51,8 @@ export const migrations = () => {
         CmsEntriesInitNewMetaFields_5_39_0_001,
         FileManager_5_39_0_002,
         // 5.39.2
-        CmsEntriesInitNewMetaFields_5_39_2_001
+        CmsEntriesInitNewMetaFields_5_39_2_001,
+        // 5.40.0
+        PbUniqueBlockElementIds_5_40_0_001
     ];
 };

--- a/packages/migrations/src/ddb.ts
+++ b/packages/migrations/src/ddb.ts
@@ -20,6 +20,8 @@ import { PageBlocks_5_38_0_003 } from "~/migrations/5.38.0/003/ddb";
 // 5.39.0
 import { CmsEntriesInitNewMetaFields_5_39_0_001 } from "~/migrations/5.39.0/001/ddb";
 import { FileManager_5_39_0_002 } from "~/migrations/5.39.0/002/ddb";
+// Page Blocks storage is the same for both DDB abd DDB-ES projects.
+import { PbUniqueBlockElementIds_5_40_0_001 } from "~/migrations/5.40.0/001/ddb";
 
 export const migrations = () => {
     return [
@@ -44,6 +46,8 @@ export const migrations = () => {
         PageBlocks_5_38_0_003,
         // 5.39.0
         CmsEntriesInitNewMetaFields_5_39_0_001,
-        FileManager_5_39_0_002
+        FileManager_5_39_0_002,
+        // 5.40.0
+        PbUniqueBlockElementIds_5_40_0_001
     ];
 };

--- a/packages/migrations/src/migrations/5.40.0/001/ddb/compression.ts
+++ b/packages/migrations/src/migrations/5.40.0/001/ddb/compression.ts
@@ -1,0 +1,35 @@
+import { compress as gzip, decompress as ungzip } from "@webiny/utils/compression/gzip";
+import { PageBlock } from "./types";
+
+const GZIP = "gzip";
+const TO_STORAGE_ENCODING = "base64";
+const FROM_STORAGE_ENCODING = "utf8";
+
+const convertToBuffer = (value: string | Buffer) => {
+    if (typeof value === "string") {
+        return Buffer.from(value, TO_STORAGE_ENCODING);
+    }
+    return value;
+};
+
+export const compress = async (data: any) => {
+    const value = await gzip(JSON.stringify(data));
+
+    return {
+        compression: GZIP,
+        value: value.toString(TO_STORAGE_ENCODING)
+    };
+};
+
+export const decompress = async (pageBlock: PageBlock) => {
+    try {
+        const buf = await ungzip(convertToBuffer(pageBlock.content.value));
+        const value = buf.toString(FROM_STORAGE_ENCODING);
+        return {
+            ...pageBlock,
+            content: JSON.parse(value)
+        };
+    } catch (ex) {
+        return { ...pageBlock, content: null };
+    }
+};

--- a/packages/migrations/src/migrations/5.40.0/001/ddb/createBlockEntity.ts
+++ b/packages/migrations/src/migrations/5.40.0/001/ddb/createBlockEntity.ts
@@ -1,0 +1,48 @@
+import { Table, AttributeDefinitions } from "@webiny/db-dynamodb/toolbox";
+import { createLegacyEntity } from "~/utils";
+
+const attributes: AttributeDefinitions = {
+    PK: {
+        partitionKey: true
+    },
+    SK: {
+        sortKey: true
+    },
+    TYPE: {
+        type: "string"
+    },
+    id: {
+        type: "string"
+    },
+    name: {
+        type: "string"
+    },
+    blockCategory: {
+        type: "string"
+    },
+    content: {
+        type: "map"
+    },
+    createdOn: {
+        type: "string"
+    },
+    createdBy: {
+        type: "map"
+    },
+    tenant: {
+        type: "string"
+    },
+    locale: {
+        type: "string"
+    },
+    GSI1_PK: {
+        type: "string"
+    },
+    GSI1_SK: {
+        type: "string"
+    }
+};
+
+export const createBlockEntity = (table: Table<string, string, string>) => {
+    return createLegacyEntity(table, "PbPageBlocks", attributes);
+};

--- a/packages/migrations/src/migrations/5.40.0/001/ddb/index.ts
+++ b/packages/migrations/src/migrations/5.40.0/001/ddb/index.ts
@@ -1,0 +1,178 @@
+import { Table } from "@webiny/db-dynamodb/toolbox";
+import {
+    DataMigration,
+    DataMigrationContext,
+    PrimaryDynamoTableSymbol
+} from "@webiny/data-migration";
+import {
+    batchWriteAll,
+    BatchWriteItem,
+    count,
+    ddbQueryAllWithCallback,
+    forEachTenantLocale
+} from "~/utils";
+import { inject, makeInjectable } from "@webiny/ioc";
+import { executeWithRetry, generateAlphaNumericId } from "@webiny/utils";
+import { createBlockEntity } from "~/migrations/5.40.0/001/ddb/createBlockEntity";
+import { ContentElement, PageBlock } from "./types";
+import { compress, decompress } from "./compression";
+
+const isGroupMigrationCompleted = (status: boolean | undefined): status is boolean => {
+    return typeof status === "boolean";
+};
+
+export class PbUniqueBlockElementIds_5_40_0_001 implements DataMigration {
+    private readonly table: Table<string, string, string>;
+    private readonly blockEntity: ReturnType<typeof createBlockEntity>;
+
+    constructor(table: Table<string, string, string>) {
+        this.table = table;
+        this.blockEntity = createBlockEntity(table);
+    }
+
+    getId() {
+        return "5.40.0-001";
+    }
+
+    getDescription() {
+        return "Generate unique element IDs in existing PB blocks.";
+    }
+
+    async shouldExecute({ logger }: DataMigrationContext): Promise<boolean> {
+        let shouldExecute = false;
+
+        await forEachTenantLocale({
+            table: this.table,
+            logger,
+            callback: async ({ tenantId, localeCode }) => {
+                // We simply need to find out if there are any blocks stored in the system.
+                const blocksCount = await count({
+                    entity: this.blockEntity,
+                    partitionKey: `T#${tenantId}#L#${localeCode}#PB#BLOCKS`,
+                    options: {
+                        index: "GSI1"
+                    }
+                });
+
+                if (blocksCount > 0) {
+                    shouldExecute = true;
+                    return false;
+                }
+
+                // Continue to the next locale.
+                return true;
+            }
+        });
+
+        return shouldExecute;
+    }
+
+    async execute({ logger, ...context }: DataMigrationContext): Promise<void> {
+        const migrationStatus = context.checkpoint || {};
+
+        let batch = 0;
+
+        await forEachTenantLocale({
+            table: this.table,
+            logger,
+            callback: async ({ tenantId, localeCode }) => {
+                const groupId = `${tenantId}:${localeCode}`;
+                const status = migrationStatus[groupId];
+
+                if (isGroupMigrationCompleted(status)) {
+                    return true;
+                }
+
+                await ddbQueryAllWithCallback<PageBlock>(
+                    {
+                        entity: this.blockEntity,
+                        partitionKey: `T#${tenantId}#L#${localeCode}#PB#BLOCKS`,
+                        options: {
+                            index: "GSI1",
+                            gt: status || " "
+                        }
+                    },
+                    async blocks => {
+                        batch++;
+
+                        logger.info(
+                            `Processing batch #${batch} in group ${groupId} (${blocks.length} blocks).`
+                        );
+
+                        const items = await Promise.all(
+                            blocks
+                                .map(async block => {
+                                    const newContent = await this.generateElementIds(block);
+                                    if (!newContent) {
+                                        return null;
+                                    }
+
+                                    return this.blockEntity.putBatch({
+                                        ...block,
+                                        content: newContent
+                                    });
+                                })
+                                .filter(Boolean) as Promise<BatchWriteItem>[]
+                        );
+
+                        const execute = () => {
+                            return batchWriteAll({ table: this.blockEntity.table, items });
+                        };
+
+                        await executeWithRetry(execute, {
+                            onFailedAttempt: error => {
+                                logger.error(
+                                    `"batchWriteAll" attempt #${error.attemptNumber} failed.`
+                                );
+                                logger.error(error.message);
+                            }
+                        });
+
+                        // Update checkpoint after every batch
+                        migrationStatus[groupId] = blocks[blocks.length - 1]?.id;
+
+                        // Check if we should store checkpoint and exit.
+                        if (context.runningOutOfTime()) {
+                            await context.createCheckpointAndExit(migrationStatus);
+                        } else {
+                            await context.createCheckpoint(migrationStatus);
+                        }
+                    }
+                );
+
+                // Mark group as completed.
+                migrationStatus[groupId] = true;
+
+                // Store checkpoint.
+                await context.createCheckpoint(migrationStatus);
+
+                // Continue processing.
+                return true;
+            }
+        });
+    }
+
+    private async generateElementIds(block: PageBlock) {
+        const { content } = await decompress(block);
+
+        // If block content already has an `id`, it means the block was already migrated.
+        if (content.id) {
+            return null;
+        }
+
+        const contentWithIds = this.ensureElementId(content);
+        return compress(contentWithIds);
+    }
+
+    private ensureElementId(element: ContentElement): ContentElement {
+        const id = element.id || element.data.variableId || generateAlphaNumericId(10);
+
+        return {
+            ...element,
+            id,
+            elements: element.elements.map(element => this.ensureElementId(element))
+        };
+    }
+}
+
+makeInjectable(PbUniqueBlockElementIds_5_40_0_001, [inject(PrimaryDynamoTableSymbol)]);

--- a/packages/migrations/src/migrations/5.40.0/001/ddb/types.ts
+++ b/packages/migrations/src/migrations/5.40.0/001/ddb/types.ts
@@ -1,0 +1,22 @@
+export interface CreatedBy {
+    id: string;
+    displayName: string | null;
+    type: string;
+}
+
+export interface PageBlock {
+    id: string;
+    name: string;
+    blockCategory: string;
+    content: any;
+    createdOn: string;
+    createdBy: CreatedBy;
+    tenant: string;
+    locale: string;
+}
+
+export interface ContentElement {
+    id: string;
+    data: Record<string, any>;
+    elements: ContentElement[];
+}


### PR DESCRIPTION
## Changes
This PR adds a migration for existing PB Blocks, to generate stable element IDs. With 5.40.0, blocks and pages created in PB have unique, stable, element IDs. But in previous versions, these IDs were not stored as part of the Block content. This migration ensures that all existing blocks in the system follow the same data structure, and have fixed element IDs (recursively).

## How Has This Been Tested?
Jest tests.