### PR TITLE
fix(cli-plugin-deploy-pulumi): update config resolution logic

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/watch/WebinyConfigFile.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch/WebinyConfigFile.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+const path = require("path");
+
+class LocalFile {
+    constructor(filePath) {
+        this.filePath = filePath;
+    }
+
+    exists() {
+        return fs.existsSync(this.filePath);
+    }
+
+    getAbsolutePath() {
+        return this.filePath;
+    }
+}
+
+class WebinyConfigFile {
+    constructor(root) {
+        this.potentialConfigs = [
+            new LocalFile(path.join(root, "webiny.config.ts")),
+            new LocalFile(path.join(root, "webiny.config.js"))
+        ];
+    }
+
+    static forWorkspace(workspace) {
+        return new WebinyConfigFile(path.resolve(workspace));
+    }
+
+    getAbsolutePath() {
+        const file = this.potentialConfigs.find(file => file.exists());
+        if (!file) {
+            return undefined;
+        }
+
+        return file.getAbsolutePath();
+    }
+}
+
+module.exports = { WebinyConfigFile };

--- a/packages/cli-plugin-deploy-pulumi/commands/watch/listPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch/listPackages.js
@@ -1,6 +1,5 @@
 const execa = require("execa");
-const fs = require("fs");
-const path = require("path");
+const { WebinyConfigFile } = require("./WebinyConfigFile");
 
 const listPackages = async ({ inputs }) => {
     let packagesList = [];
@@ -41,9 +40,11 @@ const listPackages = async ({ inputs }) => {
         const packages = [];
         for (const packageName in result) {
             const root = result[packageName];
-            const configPath = fs.existsSync(path.join(root, "webiny.config.ts"))
-                ? path.join(root, "webiny.config.ts")
-                : path.join(root, "webiny.config.js");
+            const configPath = WebinyConfigFile.forWorkspace(root).getAbsolutePath();
+
+            if (!configPath) {
+                continue;
+            }
 
             packages.push({
                 name: packageName,

--- a/packages/cli-plugin-deploy-pulumi/commands/watch/watchPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch/watchPackages.js
@@ -1,9 +1,9 @@
 const path = require("path");
-const fs = require("fs");
 const { Worker } = require("worker_threads");
 const chalk = require("chalk");
 const execa = require("execa");
 const { getRandomColorForString } = require("../../utils");
+const { WebinyConfigFile } = require("./WebinyConfigFile");
 
 const parseMessage = message => {
     try {
@@ -135,9 +135,11 @@ const getPackages = async ({ inputs, context, output }) => {
         const packages = [];
         for (const packageName in result) {
             const root = result[packageName];
-            const configPath = fs.existsSync(path.join(root, "webiny.config.ts"))
-                ? path.join(root, "webiny.config.ts")
-                : path.join(root, "webiny.config.js");
+            const configPath = WebinyConfigFile.forWorkspace(root).getAbsolutePath();
+
+            if (!configPath) {
+                continue;
+            }
 
             try {
                 packages.push({


### PR DESCRIPTION
## Changes
This PR fixes a bug in the `watch` command, related to `webiny.config.js/ts` file detection. Currently, if you run a `watch` command in a user project, without specifying explicit packages with a `-p` parameter, the script will simply collect all workspaces and assume that they're all an app (which means they need to have a `webiny.config.*` file).

This PR ensures that workspaces without a config file are ignored.

## How Has This Been Tested?
Manually.
