### PR TITLE
feat(lexical-editor): add support for link alt attribute

### DIFF
--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.css
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.css
@@ -40,21 +40,74 @@
   background-color: rgb(223, 232, 250);
 }
 
+.link-editor .link-editor-section {
+  margin: 0 15px;
+  padding: 10px 0;
+  width: calc(100% - 24px);
+}
+
+.link-editor .link-editor-popup-title {
+  margin: 0 15px 10px;;
+  color: #fa5723;
+}
+
+.link-editor .link-editor-section .header {
+  width: auto;
+  margin-bottom: 10px;
+}
+
+.link-editor .link-editor-section .header_icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+}
+
+.link-editor .link-editor-section .header_title {
+  font-size: 16px;
+  font-width: bold;
+  color: #fa5723;
+}
+
+.link-editor .link-editor-section .section-desc {
+  color: #0a0a0a;
+}
+
+.link-editor .link-editor-section.edit-form-bottom-menu {
+  display: flex;
+  justify-content: right;
+  margin-top: 5px;
+  column-gap: 10px;
+}
+
+.link-editor .link-editor-section ul {
+  list-style: initial;
+  padding: 0 20px;
+}
+
+.link-editor .link-editor-section ul li {
+  padding: 3px 0;
+}
+
 .link-editor .link-input {
   display: block;
   width: calc(100% - 24px);
-  height: 32px;
+  height: 42px;
   box-sizing: border-box;
-  margin: 8px 12px;
-  padding: 8px 12px;
-  border-radius: 15px;
+  margin: 12px;
+  padding: 12px;
+  border-radius: 10px;
   background-color: #eee;
-  font-size: 15px;
+  font-size: 16px;
   color: rgb(5, 5, 5);
   border: 0;
   outline: 0;
   position: relative;
   font-family: inherit;
+}
+
+.link-editor .link-input.full-with {
+  width: 100%;
+  margin: 0;
 }
 
 .link-editor .link-input .link-unlink {
@@ -119,4 +172,9 @@
   height: 20px;
   width: 20px;
   vertical-align: -0.25em;
+}
+
+
+.link-preview-form {
+
 }

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/FloatingLinkEditorPlugin.tsx
@@ -1,29 +1,31 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import debounce from "lodash/debounce";
-import "./FloatingLinkEditorPlugin.css";
-import { $findMatchingParent, mergeRegister } from "@lexical/utils";
+import { mergeRegister } from "@lexical/utils";
 import {
     $getSelection,
     $isRangeSelection,
-    COMMAND_PRIORITY_CRITICAL,
+    BLUR_COMMAND,
     COMMAND_PRIORITY_LOW,
     GridSelection,
     LexicalEditor,
     NodeSelection,
     RangeSelection,
-    SELECTION_CHANGE_COMMAND,
-    BLUR_COMMAND
+    SELECTION_CHANGE_COMMAND
 } from "lexical";
-
-import { $isAutoLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND } from "@webiny/lexical-nodes";
-import { LinkPreview } from "~/ui/LinkPreview";
+import { $isLinkNode, TOGGLE_LINK_COMMAND } from "@webiny/lexical-nodes";
 import { getSelectedNode } from "~/utils/getSelectedNode";
-import { sanitizeUrl } from "~/utils/sanitizeUrl";
 import { setFloatingElemPosition } from "~/utils/setFloatingElemPosition";
-import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
-import { isChildOfLinkEditor } from "./isChildOfLinkEditor";
-import { useRichTextEditor } from "~/hooks";
+import { useFloatingLinkEditor } from "./useFloatingLinkEditor";
+import { LinkEditForm } from "./LinkEditForm";
+import { LinkPreviewForm } from "./LinkPreviewForm";
+import "./FloatingLinkEditorPlugin.css";
+import { sanitizeUrl } from "~/utils/sanitizeUrl";
+import { isChildOfLinkEditor } from "~/plugins/FloatingLinkEditorPlugin/isChildOfLinkEditor";
+
+export interface LinkData {
+    url: string;
+    target: string | null;
+    alt: string | null;
+}
 
 interface FloatingLinkEditorProps {
     editor: LexicalEditor;
@@ -31,13 +33,14 @@ interface FloatingLinkEditorProps {
     anchorElem: HTMLElement;
 }
 
-function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEditorProps) {
+export function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEditorProps) {
     const editorRef = useRef<HTMLDivElement | null>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
-    const [linkUrl, setLinkUrl] = useState<{ url: string; target: string | null }>({
+    const [linkData, setLinkData] = useState<LinkData>({
         url: "",
-        target: null
+        target: null,
+        alt: null
     });
+
     const [isEditMode, setEditMode] = useState(false);
     const [lastSelection, setLastSelection] = useState<
         RangeSelection | GridSelection | NodeSelection | null
@@ -45,15 +48,27 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
 
     const updateLinkEditor = useCallback(() => {
         const selection = $getSelection();
+        const emptyLinkData = { url: "", target: null, alt: null };
         if ($isRangeSelection(selection)) {
             const node = getSelectedNode(selection);
             const parent = node.getParent();
+
             if ($isLinkNode(parent)) {
-                setLinkUrl({ url: parent.getURL(), target: parent.getTarget() });
+                const linkData = {
+                    url: parent.getURL(),
+                    target: parent.getTarget(),
+                    alt: $isLinkNode(parent) ? parent.getAlt() : null
+                };
+                setLinkData(linkData);
             } else if ($isLinkNode(node)) {
-                setLinkUrl({ url: node.getURL(), target: node.getTarget() });
+                const linkData = {
+                    url: node.getURL(),
+                    target: node.getTarget(),
+                    alt: $isLinkNode(node) ? node.getAlt() : null
+                };
+                setLinkData(linkData);
             } else {
-                setLinkUrl({ url: "", target: null });
+                setLinkData(emptyLinkData);
             }
         }
         const editorElem = editorRef.current;
@@ -92,7 +107,7 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
             }
             setLastSelection(null);
             setEditMode(false);
-            setLinkUrl({ url: "", target: null });
+            setLinkData(emptyLinkData);
         }
 
         return true;
@@ -101,6 +116,19 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
     const removeLink = () => {
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
         setEditMode(false);
+    };
+
+    const applyChanges = (linkData: LinkData) => {
+        const confirmedLinkData = {
+            url: sanitizeUrl(linkData.url),
+            target: linkData.target,
+            alt: linkData.alt
+        };
+
+        if (lastSelection !== null) {
+            editor.dispatchCommand(TOGGLE_LINK_COMMAND, confirmedLinkData);
+            setEditMode(false);
+        }
     };
 
     useEffect(() => {
@@ -139,7 +167,18 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
                 SELECTION_CHANGE_COMMAND,
                 () => {
                     updateLinkEditor();
-                    return true;
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+
+            editor.registerCommand(
+                BLUR_COMMAND,
+                payload => {
+                    if (!isChildOfLinkEditor(payload.relatedTarget as HTMLElement)) {
+                        setEditMode(false);
+                    }
+                    return false;
                 },
                 COMMAND_PRIORITY_LOW
             )
@@ -152,12 +191,6 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
         });
     }, [editor, updateLinkEditor]);
 
-    useEffect(() => {
-        if (isEditMode && inputRef.current) {
-            inputRef.current.focus();
-        }
-    }, [isEditMode]);
-
     return (
         <div
             ref={editorRef}
@@ -165,148 +198,21 @@ function FloatingLinkEditor({ editor, isVisible, anchorElem }: FloatingLinkEdito
             style={{ display: isVisible ? "block" : "none" }}
         >
             {isEditMode ? (
-                <>
-                    <div className={"link-editor-target-checkbox"}>
-                        <input
-                            type={"checkbox"}
-                            checked={linkUrl.target === "_blank"}
-                            disabled={isUrlLinkReference(linkUrl.url)}
-                            onChange={() =>
-                                setLinkUrl({ ...linkUrl, target: linkUrl.target ? null : "_blank" })
-                            }
-                        />{" "}
-                        <span>New tab</span>
-                    </div>
-                    <input
-                        ref={inputRef}
-                        className="link-input"
-                        value={linkUrl.url}
-                        onChange={event => {
-                            setLinkUrl({ url: event.target.value, target: null });
-                        }}
-                        onKeyDown={event => {
-                            if (event.key === "Enter") {
-                                event.preventDefault();
-                                if (lastSelection !== null) {
-                                    if (linkUrl.url !== "") {
-                                        editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
-                                            url: sanitizeUrl(linkUrl.url),
-                                            target: linkUrl.target
-                                        });
-                                    }
-                                    setEditMode(false);
-                                }
-                            } else if (event.key === "Escape") {
-                                event.preventDefault();
-                                setEditMode(false);
-                            }
-                        }}
-                    />
-                </>
+                <LinkEditForm
+                    linkData={linkData}
+                    onSave={applyChanges}
+                    onCancel={() => setEditMode(false)}
+                />
             ) : (
-                <>
-                    <div className={"link-editor-target-checkbox"}>
-                        <input type={"checkbox"} checked={linkUrl.target === "_blank"} readOnly />{" "}
-                        <span>New tab</span>
-                    </div>
-                    <div className="link-input">
-                        <a href={linkUrl.url} target="_blank" rel="noopener noreferrer">
-                            {linkUrl.url}
-                        </a>
-                        <div
-                            className="link-edit"
-                            role="button"
-                            tabIndex={0}
-                            onMouseDown={event => event.preventDefault()}
-                            onClick={() => {
-                                setEditMode(true);
-                            }}
-                        />
-                        <div
-                            className="link-unlink"
-                            role="button"
-                            tabIndex={0}
-                            onMouseDown={event => event.preventDefault()}
-                            onClick={() => {
-                                removeLink();
-                            }}
-                        />
-                    </div>
-                    <LinkPreview url={linkUrl.url} />
-                </>
+                <LinkPreviewForm
+                    linkData={linkData}
+                    removeLink={removeLink}
+                    onEdit={() => {
+                        setEditMode(true);
+                    }}
+                />
             )}
         </div>
-    );
-}
-
-function useFloatingLinkEditorToolbar(anchorElem: HTMLElement): JSX.Element | null {
-    const { editor } = useRichTextEditor();
-    const [isLink, setIsLink] = useState(false);
-
-    const debounceSetIsLink = useCallback(debounce(setIsLink, 50), []);
-
-    const updateToolbar = useCallback(() => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) {
-            return;
-        }
-
-        const node = getSelectedNode(selection);
-        const linkParent = $findMatchingParent(node, $isLinkNode);
-        const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
-        const isLinkOrChildOfLink = Boolean($isLinkNode(node) || linkParent);
-
-        if (!isLinkOrChildOfLink) {
-            // When hiding the toolbar, we want to hide immediately.
-            setIsLink(false);
-        }
-
-        if (selection.dirty) {
-            // We don't want this menu to open for auto links.
-            if (linkParent != null && autoLinkParent == null) {
-                // When showing the toolbar, we want to debounce it, because sometimes selection gets updated
-                // multiple times, and the `selection.dirty` flag goes from true to false multiple times,
-                // eventually settling on `false`, which we want to set once it has settled.
-                debounceSetIsLink(true);
-            }
-        }
-    }, []);
-
-    useEffect(() => {
-        return mergeRegister(
-            editor.registerCommand(
-                SELECTION_CHANGE_COMMAND,
-                () => {
-                    updateToolbar();
-                    return false;
-                },
-                COMMAND_PRIORITY_CRITICAL
-            ),
-            editor.registerCommand(
-                BLUR_COMMAND,
-                payload => {
-                    if (!isChildOfLinkEditor(payload.relatedTarget as HTMLElement)) {
-                        setIsLink(false);
-                    }
-
-                    return false;
-                },
-                COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
-                TOGGLE_LINK_COMMAND,
-                payload => {
-                    setIsLink(!!payload);
-                    return false;
-                },
-                COMMAND_PRIORITY_CRITICAL
-            )
-        );
-    }, [editor, updateToolbar]);
-
-    return createPortal(
-        <FloatingLinkEditor isVisible={isLink} editor={editor} anchorElem={anchorElem} />,
-        anchorElem
     );
 }
 
@@ -315,5 +221,5 @@ export function FloatingLinkEditorPlugin({
 }: {
     anchorElem?: HTMLElement;
 }): JSX.Element | null {
-    return useFloatingLinkEditorToolbar(anchorElem);
+    return useFloatingLinkEditor(anchorElem);
 }

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/LinkEditForm.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/LinkEditForm.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+import { sanitizeUrl } from "~/utils/sanitizeUrl";
+import { isAnchorLink } from "~/utils/isAnchorLink";
+import { LinkData } from "./FloatingLinkEditorPlugin";
+
+interface LinkFormProps {
+    linkData: LinkData;
+    onSave: (linkData: LinkData) => void;
+    onCancel: () => void;
+}
+
+export const LinkEditForm = ({ linkData, onSave, onCancel }: LinkFormProps) => {
+    const [linkState, setLinkState] = useState(linkData);
+
+    const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit();
+        } else if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+        }
+    };
+
+    const onSubmit = () => {
+        onSave({
+            ...linkState,
+            target: isAnchorLink(linkState.url) ? null : linkState.target,
+            url: sanitizeUrl(linkState.url)
+        });
+    };
+
+    return (
+        <div>
+            <h5 className={"link-editor-popup-title"}>Edit Link</h5>
+
+            <div className={"link-editor-section"}>
+                <div className={"header"}>
+                    <div className={"header_title"}>URL</div>
+                </div>
+                <div className={"section-desc"}>
+                    <input
+                        autoFocus
+                        placeholder={"URL: https://example.com"}
+                        className="link-input full-with"
+                        value={linkState.url}
+                        onKeyDown={onInputKeyDown}
+                        onChange={e => {
+                            return setLinkState(state => ({
+                                ...state,
+                                url: e.target.value
+                            }));
+                        }}
+                    />
+                </div>
+            </div>
+            <div className={"link-editor-section"}>
+                <div className={"header"}>
+                    <div className={"header_title"}>Alt text</div>
+                </div>
+                <div className={"section-desc"}>
+                    <input
+                        placeholder={"Enter alt text"}
+                        className={"link-input full-with"}
+                        type={"text"}
+                        value={linkState.alt || ""}
+                        onKeyDown={onInputKeyDown}
+                        onChange={e => {
+                            return setLinkState(state => ({
+                                ...state,
+                                alt: e.target.value
+                            }));
+                        }}
+                    />
+                </div>
+            </div>
+            <div className={"link-editor-section"}>
+                <div className={"section-desc"}>
+                    <input
+                        id={"link-editor-new-tab"}
+                        type={"checkbox"}
+                        checked={linkState.target === "_blank"}
+                        disabled={isAnchorLink(linkState.url)}
+                        onChange={e => {
+                            return setLinkState(state => ({
+                                ...state,
+                                target: e.target.checked ? "_blank" : null
+                            }));
+                        }}
+                    />
+                    <label htmlFor={"link-editor-new-tab"}>Open link in a new tab</label>
+                </div>
+            </div>
+
+            <div className={"link-editor-section full-with edit-form-bottom-menu"}>
+                <button className="webiny-ui-button mdc-button" onClick={onCancel}>
+                    <div className="mdc-button__ripple"></div>
+                    <span className="mdc-button__label">Cancel</span>
+                </button>
+                <button
+                    className="webiny-ui-button webiny-ui-button--primary mdc-button mdc-button--raised"
+                    onClick={onSubmit}
+                >
+                    <div className="mdc-button__ripple"></div>
+                    <span className="mdc-button__label">Confirm</span>
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/LinkPreviewForm.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/LinkPreviewForm.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { LinkData } from "./FloatingLinkEditorPlugin";
+
+interface LinkFormProps {
+    linkData: LinkData;
+    onEdit: () => void;
+    removeLink: () => void;
+}
+
+export const LinkPreviewForm = ({ linkData, onEdit, removeLink }: LinkFormProps) => {
+    return (
+        <div className={"link-preview-form"}>
+            <h5 className={"link-editor-popup-title"}>Preview Link</h5>
+            <div className="link-input">
+                <a href={linkData.url} target="_blank" rel="noopener noreferrer">
+                    {linkData.url}
+                </a>
+                <div
+                    className="link-edit"
+                    role="button"
+                    tabIndex={0}
+                    onMouseDown={event => event.preventDefault()}
+                    onClick={onEdit}
+                />
+                <div
+                    className="link-unlink"
+                    role="button"
+                    tabIndex={0}
+                    onMouseDown={event => event.preventDefault()}
+                    onClick={removeLink}
+                />
+            </div>
+            <div className={"link-editor-section"}>
+                <ul>
+                    <li>
+                        {linkData.target === "_blank" ? (
+                            <span>Open link in a new tab</span>
+                        ) : (
+                            <span>Open link in the same tab</span>
+                        )}
+                    </li>
+                    {linkData.alt && (
+                        <li>
+                            <span>
+                                Alt text: <span>{linkData.alt}</span>
+                            </span>
+                        </li>
+                    )}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/useFloatingLinkEditor.tsx
+++ b/packages/lexical-editor/src/plugins/FloatingLinkEditorPlugin/useFloatingLinkEditor.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useRichTextEditor } from "~/hooks";
+import { getSelectedNode } from "~/utils/getSelectedNode";
+import { $isAutoLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND } from "@webiny/lexical-nodes";
+import { isChildOfLinkEditor } from "~/plugins/FloatingLinkEditorPlugin/isChildOfLinkEditor";
+import debounce from "lodash/debounce";
+import {
+    $getSelection,
+    $isRangeSelection,
+    BLUR_COMMAND,
+    COMMAND_PRIORITY_CRITICAL,
+    COMMAND_PRIORITY_LOW,
+    SELECTION_CHANGE_COMMAND
+} from "lexical";
+import { $findMatchingParent, mergeRegister } from "@lexical/utils";
+import { FloatingLinkEditor } from "./FloatingLinkEditorPlugin";
+
+export function useFloatingLinkEditor(anchorElem: HTMLElement): JSX.Element | null {
+    const { editor } = useRichTextEditor();
+    const [isLink, setIsLink] = useState(false);
+
+    const debounceSetIsLink = useCallback(debounce(setIsLink, 50), []);
+
+    const updateToolbar = useCallback(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+            return;
+        }
+
+        const node = getSelectedNode(selection);
+        const linkParent = $findMatchingParent(node, $isLinkNode);
+        const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
+        const isLinkOrChildOfLink = Boolean($isLinkNode(node) || linkParent);
+
+        if (!isLinkOrChildOfLink) {
+            // When hiding the toolbar, we want to hide immediately.
+            setIsLink(false);
+        }
+
+        if (selection.dirty) {
+            // We don't want this menu to open for auto links.
+            if (linkParent != null && autoLinkParent == null) {
+                // When showing the toolbar, we want to debounce it, because sometimes selection gets updated
+                // multiple times, and the `selection.dirty` flag goes from true to false multiple times,
+                // eventually settling on `false`, which we want to set once it has settled.
+                debounceSetIsLink(true);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        return mergeRegister(
+            editor.registerCommand(
+                SELECTION_CHANGE_COMMAND,
+                () => {
+                    updateToolbar();
+                    return false;
+                },
+                COMMAND_PRIORITY_CRITICAL
+            ),
+            editor.registerCommand(
+                BLUR_COMMAND,
+                payload => {
+                    if (!isChildOfLinkEditor(payload.relatedTarget as HTMLElement)) {
+                        setIsLink(false);
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                TOGGLE_LINK_COMMAND,
+                payload => {
+                    setIsLink(!!payload);
+                    return false;
+                },
+                COMMAND_PRIORITY_CRITICAL
+            )
+        );
+    }, [editor, updateToolbar]);
+
+    return createPortal(
+        <FloatingLinkEditor isVisible={isLink} editor={editor} anchorElem={anchorElem} />,
+        anchorElem
+    );
+}

--- a/packages/lexical-editor/src/utils/isAnchorLink.ts
+++ b/packages/lexical-editor/src/utils/isAnchorLink.ts
@@ -1,0 +1,3 @@
+export const isAnchorLink = (url: string) => {
+    return url.startsWith("#");
+};

--- a/packages/lexical-editor/src/utils/isUrlLinkReference.ts
+++ b/packages/lexical-editor/src/utils/isUrlLinkReference.ts
@@ -1,3 +1,0 @@
-export const isUrlLinkReference = (url: string) => {
-    return url.startsWith("#");
-};

--- a/packages/lexical-editor/src/utils/sanitizeUrl.ts
+++ b/packages/lexical-editor/src/utils/sanitizeUrl.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import { isUrlLinkReference } from "~/utils/isUrlLinkReference";
+import { isAnchorLink } from "~/utils/isAnchorLink";
 
 export const sanitizeUrl = (url: string): string => {
     /** A pattern that matches safe  URLs. */
@@ -17,7 +17,7 @@ export const sanitizeUrl = (url: string): string => {
 
     url = String(url).trim();
 
-    if (isUrlLinkReference(url)) {
+    if (isAnchorLink(url)) {
         return url;
     }
 

--- a/packages/lexical-nodes/src/LinkNode.ts
+++ b/packages/lexical-nodes/src/LinkNode.ts
@@ -23,7 +23,6 @@ import type {
 import { addClassNamesToElement, isHTMLAnchorElement } from "@lexical/utils";
 import {
     $applyNodeReplacement,
-    $getSelection,
     $isElementNode,
     $isRangeSelection,
     createCommand,
@@ -100,8 +99,8 @@ export class LinkNode extends ElementNode {
         if (this.__title !== null) {
             element.title = this.__title;
         }
-        if (this.__alt !== null) {
-            element.alt = this.__alt;
+        if (this.__alt) {
+            element.setAttribute("alt", this.__alt);
         }
         addClassNamesToElement(element, config.theme.link);
         return element;
@@ -144,7 +143,7 @@ export class LinkNode extends ElementNode {
 
         if (alt !== prevNode.__alt) {
             if (alt) {
-                anchor.alt = alt;
+                anchor.setAttribute("alt", alt);
             } else {
                 anchor.removeAttribute("alt");
             }
@@ -168,7 +167,8 @@ export class LinkNode extends ElementNode {
         const node = $createLinkNode(serializedNode.url, {
             rel: serializedNode.rel,
             target: serializedNode.target,
-            title: serializedNode.title
+            title: serializedNode.title,
+            alt: serializedNode.alt
         });
         node.setFormat(serializedNode.format);
         node.setIndent(serializedNode.indent);
@@ -195,6 +195,7 @@ export class LinkNode extends ElementNode {
             rel: this.getRel(),
             target: this.getTarget(),
             title: this.getTitle(),
+            alt: this.getAlt(),
             type: "link",
             url: this.getURL(),
             version: 1
@@ -237,6 +238,15 @@ export class LinkNode extends ElementNode {
         writable.__title = title;
     }
 
+    getAlt(): string | null {
+        return this.__alt;
+    }
+
+    setAlt(text: string | null): void {
+        const writable = super.getWritable();
+        writable.__alt = text;
+    }
+
     override insertNewAfter(
         selection: RangeSelection,
         restoreSelection = true
@@ -246,7 +256,8 @@ export class LinkNode extends ElementNode {
             const linkNode = $createLinkNode(this.__url, {
                 rel: this.__rel,
                 target: this.__target,
-                title: this.__title
+                title: this.__title,
+                alt: this.__alt
             });
             element.append(linkNode);
             return linkNode;
@@ -407,136 +418,3 @@ export function $isAutoLinkNode(node: LexicalNode | null | undefined): node is A
 export const TOGGLE_LINK_COMMAND: LexicalCommand<
     string | ({ url: string } & LinkAttributes) | null
 > = createCommand("TOGGLE_LINK_COMMAND");
-
-/**
- * Generates or updates a LinkNode. It can also delete a LinkNode if the URL is null,
- * but saves any children and brings them up to the parent node.
- * @param url - The URL the link directs to.
- * @param attributes - Optional HTML a tag attributes. { target, rel, title }
- */
-export function toggleLink(url: null | string, attributes: LinkAttributes = {}): void {
-    const { target, title } = attributes;
-    const rel = attributes.rel === undefined ? "noreferrer" : attributes.rel;
-    const selection = $getSelection();
-
-    if (!$isRangeSelection(selection)) {
-        return;
-    }
-    const nodes = selection.extract();
-
-    if (url === null) {
-        // Remove LinkNodes
-        nodes.forEach(node => {
-            const parent = node.getParent();
-
-            if ($isLinkNode(parent)) {
-                const children = parent.getChildren();
-
-                for (let i = 0; i < children.length; i++) {
-                    parent.insertBefore(children[i]);
-                }
-
-                parent.remove();
-            }
-        });
-    } else {
-        // Add or merge LinkNodes
-        if (nodes.length === 1) {
-            const firstNode = nodes[0];
-            // if the first node is a LinkNode or if its
-            // parent is a LinkNode, we update the URL, target and rel.
-            const linkNode = $isLinkNode(firstNode) ? firstNode : $getLinkAncestor(firstNode);
-            if (linkNode !== null) {
-                linkNode.setURL(url);
-                if (target !== undefined) {
-                    linkNode.setTarget(target);
-                }
-                if (rel !== null) {
-                    linkNode.setRel(rel);
-                }
-                if (title !== undefined) {
-                    linkNode.setTitle(title);
-                }
-                return;
-            }
-        }
-
-        let prevParent: ElementNode | LinkNode | null = null;
-        let linkNode: LinkNode | null = null;
-
-        nodes.forEach(node => {
-            const parent = node.getParent();
-
-            if (
-                parent === linkNode ||
-                parent === null ||
-                ($isElementNode(node) && !node.isInline())
-            ) {
-                return;
-            }
-
-            if ($isLinkNode(parent)) {
-                linkNode = parent;
-                parent.setURL(url);
-                if (target !== undefined) {
-                    parent.setTarget(target);
-                }
-                if (rel !== null) {
-                    linkNode.setRel(rel);
-                }
-                if (title !== undefined) {
-                    linkNode.setTitle(title);
-                }
-                return;
-            }
-
-            if (!parent.is(prevParent)) {
-                prevParent = parent;
-                linkNode = $createLinkNode(url, { rel, target });
-
-                if ($isLinkNode(parent)) {
-                    if (node.getPreviousSibling() === null) {
-                        parent.insertBefore(linkNode);
-                    } else {
-                        parent.insertAfter(linkNode);
-                    }
-                } else {
-                    node.insertBefore(linkNode);
-                }
-            }
-
-            if ($isLinkNode(node)) {
-                if (node.is(linkNode)) {
-                    return;
-                }
-                if (linkNode !== null) {
-                    const children = node.getChildren();
-
-                    for (let i = 0; i < children.length; i++) {
-                        linkNode.append(children[i]);
-                    }
-                }
-
-                node.remove();
-                return;
-            }
-
-            if (linkNode !== null) {
-                linkNode.append(node);
-            }
-        });
-    }
-}
-
-function $getLinkAncestor(node: LexicalNode): null | LexicalNode {
-    return $getAncestor(node, $isLinkNode);
-}
-
-function $getAncestor<NodeType extends LexicalNode = LexicalNode>(
-    node: LexicalNode,
-    predicate: (ancestor: LexicalNode) => ancestor is NodeType
-): null | LexicalNode {
-    let parent: null | LexicalNode = node;
-    while (parent !== null && (parent = parent.getParent()) !== null && !predicate(parent)) {}
-    return parent;
-}

--- a/packages/lexical-nodes/src/index.ts
+++ b/packages/lexical-nodes/src/index.ts
@@ -32,6 +32,7 @@ export * from "./utils/formatToQuote";
 export * from "./utils/formatToHeading";
 export * from "./utils/formatToParagraph";
 export * from "./utils/clearNodeFormating";
+export * from "./utils/toggleLink";
 
 // This is a list of all the nodes that our Lexical implementation supports OOTB.
 export const allNodes: ReadonlyArray<

--- a/packages/lexical-nodes/src/utils/toggleLink.ts
+++ b/packages/lexical-nodes/src/utils/toggleLink.ts
@@ -1,0 +1,153 @@
+import {
+    $getSelection,
+    $isElementNode,
+    $isRangeSelection,
+    ElementNode,
+    LexicalNode
+} from "lexical";
+import { $createLinkNode, $isLinkNode, LinkAttributes, LinkNode } from "~/LinkNode";
+
+/**
+ * Generates or updates a LinkNode. It can also delete a LinkNode if the URL is null,
+ * but saves any children and brings them up to the parent node.
+ * @param url - The URL the link directs to.
+ * @param attributes - Optional HTML a tag attributes. { target, rel, title }
+ */
+export function toggleLink(url: null | string, attributes: LinkAttributes = {}): void {
+    const { target, title, alt } = attributes;
+    const rel = attributes.rel === undefined ? "noreferrer" : attributes.rel;
+    const selection = $getSelection();
+
+    if (!$isRangeSelection(selection)) {
+        return;
+    }
+    const nodes = selection.extract();
+
+    if (url === null) {
+        // Remove LinkNodes
+        nodes.forEach(node => {
+            const parent = node.getParent();
+
+            if ($isLinkNode(parent)) {
+                const children = parent.getChildren();
+
+                for (let i = 0; i < children.length; i++) {
+                    parent.insertBefore(children[i]);
+                }
+
+                parent.remove();
+            }
+        });
+    } else {
+        // Add or merge LinkNodes
+        if (nodes.length === 1) {
+            const firstNode = nodes[0];
+            // if the first node is a LinkNode or if its
+            // parent is a LinkNode, we update the URL, target and rel.
+            const linkNode = $isLinkNode(firstNode) ? firstNode : $getLinkAncestor(firstNode);
+            if (linkNode !== null) {
+                linkNode.setURL(url);
+                if (target !== undefined) {
+                    linkNode.setTarget(target);
+                }
+                if (rel !== null) {
+                    linkNode.setRel(rel);
+                }
+                if (title !== undefined) {
+                    linkNode.setTitle(title);
+                }
+
+                if (alt !== undefined) {
+                    linkNode.setAlt(alt);
+                }
+                return;
+            }
+        }
+
+        let prevParent: ElementNode | LinkNode | null = null;
+        let linkNode: LinkNode | null = null;
+
+        nodes.forEach(node => {
+            const parent = node.getParent();
+
+            if (
+                parent === linkNode ||
+                parent === null ||
+                ($isElementNode(node) && !node.isInline())
+            ) {
+                return;
+            }
+
+            if ($isLinkNode(parent)) {
+                linkNode = parent;
+                parent.setURL(url);
+                if (target !== undefined) {
+                    parent.setTarget(target);
+                }
+                if (rel !== null) {
+                    linkNode.setRel(rel);
+                }
+                if (title !== undefined) {
+                    linkNode.setTitle(title);
+                }
+                if (alt !== undefined) {
+                    linkNode.setAlt(alt);
+                }
+                return;
+            }
+
+            if (!parent.is(prevParent)) {
+                prevParent = parent;
+                linkNode = $createLinkNode(url, { rel, target, alt });
+
+                if ($isLinkNode(parent)) {
+                    if (node.getPreviousSibling() === null) {
+                        parent.insertBefore(linkNode);
+                    } else {
+                        parent.insertAfter(linkNode);
+                    }
+                } else {
+                    node.insertBefore(linkNode);
+                }
+            }
+
+            if ($isLinkNode(node)) {
+                if (node.is(linkNode)) {
+                    return;
+                }
+                if (linkNode !== null) {
+                    const children = node.getChildren();
+
+                    for (let i = 0; i < children.length; i++) {
+                        linkNode.append(children[i]);
+                    }
+                }
+
+                node.remove();
+                return;
+            }
+
+            if (linkNode !== null) {
+                linkNode.append(node);
+            }
+        });
+    }
+}
+
+function $getLinkAncestor(node: LexicalNode): LinkNode | null {
+    const ancestor = $getAncestor(node, $isLinkNode);
+    if (!ancestor) {
+        return null;
+    }
+
+    return ancestor as LinkNode;
+}
+
+function $getAncestor<NodeType extends LexicalNode = LexicalNode>(
+    node: LexicalNode,
+    predicate: (ancestor: LexicalNode) => ancestor is NodeType
+): null | LexicalNode {
+    let parent: null | LexicalNode = node;
+    while (parent !== null && (parent = parent.getParent()) !== null && !predicate(parent)) {}
+    return parent;
+}


### PR DESCRIPTION
## Changes
This PR adds support for an "alt" attribute to Lexical links, and improves the overall link editing experience.

![image](https://github.com/webiny/webiny-js/assets/3920893/ed3c820a-ccf5-4160-b5d3-2b8df2d8cd90)

![image](https://github.com/webiny/webiny-js/assets/3920893/277a0680-4f60-4dd7-9aa2-994c918bce93)


## How Has This Been Tested?
Manually, in Page Builder and HCMS.
