### PR TITLE
fix(app-headless-cms): select the first available plugin render on field change

### DIFF
--- a/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/EditFieldDialog/AppearanceTab.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import { i18n } from "@webiny/app/i18n";
 import { Radio, RadioGroup } from "@webiny/ui/Radio";
@@ -10,6 +10,7 @@ import { Typography } from "@webiny/ui/Typography";
 import { RendererOptions } from "./AppearanceTab/RendererOptions";
 import { LegacyRichTextInput } from "./AppearanceTab/LegacyRichTextInput";
 import { useRendererPlugins } from "./useRendererPlugins";
+import { useModelField } from "~/admin/components/ModelFieldProvider";
 
 const t = i18n.ns("app-headless-cms/admin/content-model-editor/tabs/appearance-tab");
 
@@ -26,6 +27,7 @@ const style = {
 
 const AppearanceTab = () => {
     const renderers = useRendererPlugins();
+    const { field } = useModelField();
 
     const rendererName = useBind({
         name: "renderer.name",
@@ -46,6 +48,20 @@ const AppearanceTab = () => {
             </Grid>
         );
     }
+
+    useEffect(() => {
+        // If the currently selected render plugin is no longer available, select the first available one.
+        if (selectedPlugin) {
+            return;
+        }
+
+        if (renderers[0]) {
+            rendererName.onChange(renderers[0].renderer.rendererName);
+            return;
+        }
+
+        console.info(`No renderers for field ${field.fieldId} found.`, field);
+    }, [field.id, field.multipleValues, field.predefinedValues?.enabled, selectedPlugin]);
 
     return (
         <>


### PR DESCRIPTION
## Changes
We are reinstating the logic to verify the availability of the currently selected renderer. If the chosen renderer is unavailable, it will automatically switch to the first available renderer.

RELATED: https://github.com/webiny/webiny-js/commit/3cc545e532c8b6fb757097ec76a67f797f424575

## How Has This Been Tested?
Manually