### PR TITLE
refactor(project-utils): user project ts checks by default

### DIFF
--- a/packages/project-utils/bundling/function/buildFunctionWithDll/webpack.config.js
+++ b/packages/project-utils/bundling/function/buildFunctionWithDll/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = options => {
     const sourceMaps = options.sourceMaps !== false;
 
     const definitions = overrides.define ? JSON.parse(overrides.define) : {};
-    const tsChecksEnabled = process.env.WEBINY_ENABLE_TS_CHECKS === "true";
+    const tsChecksEnabled = process.env.WEBINY_DISABLE_TS_CHECKS !== "true";
 
     return {
         entry: [

--- a/packages/project-utils/bundling/function/webpack.config.js
+++ b/packages/project-utils/bundling/function/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = options => {
     const sourceMaps = options.sourceMaps !== false;
 
     const definitions = overrides.define ? JSON.parse(overrides.define) : {};
-    const tsChecksEnabled = process.env.WEBINY_ENABLE_TS_CHECKS === "true";
+    const tsChecksEnabled = process.env.WEBINY_DISABLE_TS_CHECKS !== "true";
 
     return {
         entry: [

--- a/packages/serverless-cms-aws/package.json
+++ b/packages/serverless-cms-aws/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "build": "yarn webiny run build",
     "watch": "yarn webiny run watch",
-    "prepublishOnly": "yarn webiny run buildHandlers"
+    "prepublishOnly": "WEBINY_DISABLE_TS_CHECKS=true yarn webiny run buildHandlers"
   },
   "adio": {
     "ignoreDirs": [


### PR DESCRIPTION
## Changes
Enable TS checks in user projects by default.
Users can disable it via env var `WEBINY_DISABLE_TS_CHECKS=true`, although it is not recommended.

## How Has This Been Tested?
Manually.
