### PR TITLE
refactor(app-trash-bin): assign API env variable to ADMIN env variable

### DIFF
--- a/packages/serverless-cms-aws/src/createAdminAppConfig.ts
+++ b/packages/serverless-cms-aws/src/createAdminAppConfig.ts
@@ -5,7 +5,12 @@ export const createAdminAppConfig = (modifier?: ReactAppConfigModifier) => {
     return createReactAppConfig(baseParams => {
         const { config } = baseParams;
 
-        config.customEnv(env => ({ ...env, PORT: 3001 }));
+        config.customEnv(env => ({
+            ...env,
+            WEBINY_ADMIN_TRASH_BIN_RETENTION_PERIOD_DAYS: process.env
+                .WEBINY_TRASH_BIN_RETENTION_PERIOD_DAYS as string,
+            PORT: 3001
+        }));
 
         config.pulumiOutputToEnv<ApiOutput>("apps/api", ({ output, env }) => {
             return {

--- a/typings/env/index.d.ts
+++ b/typings/env/index.d.ts
@@ -17,6 +17,8 @@ declare namespace NodeJS {
         WEBINY_LOGS_FORWARD_URL?: string;
         WEBINY_FILE_UPLOAD_CHUNK_SIZE?: string;
         WEBINY_FILE_UPLOAD_PARALLEL_CHUNKS?: string;
+        WEBINY_TRASH_BIN_RETENTION_PERIOD_DAYS?: string;
+        WEBINY_ADMIN_TRASH_BIN_RETENTION_PERIOD_DAYS?: string;
         AWS_LAMBDA_FUNCTION_NAME?: string;
         PATH?: string;
         DEBUG?: "true" | "false" | string;


### PR DESCRIPTION
## Changes
With this PR, we are assigning the `WEBINY_TRASH_BIN_RETENTION_PERIOD_DAYS` value to `WEBINY_ADMIN_TRASH_BIN_RETENTION_PERIOD_DAYS` so developers can set one `env` variable  and be used for both background task and admin.

## How Has This Been Tested?
Manually

## Documentation
I need to update both release notes and docs.