### PR TITLE
Lexical RTE - Break Toolbar Items Into Multiple Lines When Needed

### DIFF
--- a/packages/lexical-editor/src/components/Toolbar/StaticToolbar.css
+++ b/packages/lexical-editor/src/components/Toolbar/StaticToolbar.css
@@ -4,9 +4,9 @@
   padding: 4px;
   vertical-align: middle;
   border: 1px solid #eee;
-  height: 35px;
   will-change: transform;
   background: #fff;
+  flex-wrap: wrap;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Changes
This PR ensures Lexical's toolbar items are broken into multiple lines when needed (when there's not enough space for them to be shown in a single line).

![image](https://github.com/webiny/webiny-js/assets/5121148/374b521e-05aa-46f1-88aa-e49549818bbd)


## How Has This Been Tested?
Manually.

## Documentation
None.