### PR TITLE
Webiny CLI - Introduce `--data-migration-reporter` Flag

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -59,6 +59,11 @@ module.exports = [
                         describe: `Enable base compilation-related logs`,
                         type: "boolean"
                     });
+                    yargs.option("--data-migration-logs", {
+                        default: true,
+                        describe: `Enable data migration logs`,
+                        type: "boolean"
+                    });
                 },
                 async argv => {
                     await deploy(argv, context);

--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -59,7 +59,7 @@ module.exports = [
                         describe: `Enable base compilation-related logs`,
                         type: "boolean"
                     });
-                    yargs.option("--data-migration-logs", {
+                    yargs.option("data-migration-logs", {
                         default: true,
                         describe: `Enable data migration logs`,
                         type: "boolean"

--- a/packages/cli-plugin-deploy-pulumi/commands/index.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/index.js
@@ -59,9 +59,9 @@ module.exports = [
                         describe: `Enable base compilation-related logs`,
                         type: "boolean"
                     });
-                    yargs.option("data-migration-logs", {
+                    yargs.option("data-migration-reporter", {
                         default: true,
-                        describe: `Enable data migration logs`,
+                        describe: `Enable data migration reporting during the deployment process`,
                         type: "boolean"
                     });
                 },

--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -187,6 +187,10 @@ export const createHandler = (params: CreateHandlerParams) => {
      */
     const app = fastify({
         bodyLimit: 536870912, // 512MB
+
+        // TODO: in the near future, pass own Pino logger instance.
+        logger: false,
+
         ...(params.options || {})
     });
 

--- a/packages/serverless-cms-aws/src/api/plugins/executeDataMigrations.ts
+++ b/packages/serverless-cms-aws/src/api/plugins/executeDataMigrations.ts
@@ -6,7 +6,8 @@ import {
     InteractiveCliStatusReporter,
     NonInteractiveCliStatusReporter,
     MigrationRunner,
-    CliMigrationRunReporter
+    CliMigrationRunReporter,
+    MigrationStatusReporter
 } from "@webiny/data-migration/cli";
 
 /**
@@ -43,10 +44,14 @@ export const executeDataMigrations = {
             const functionName = apiOutput["migrationLambdaArn"];
 
             const logReporter = new LogReporter(functionName);
-            const statusReporter =
-                !process.stdout.isTTY || "CI" in process.env
+
+            let statusReporter: MigrationStatusReporter | undefined;
+            if (inputs.dataMigrationLogs) {
+                const useNonInteractiveReporter = !process.stdout.isTTY || "CI" in process.env;
+                statusReporter = useNonInteractiveReporter
                     ? new NonInteractiveCliStatusReporter(logReporter)
                     : new InteractiveCliStatusReporter(logReporter);
+            }
 
             const runner = MigrationRunner.create({
                 lambdaClient,

--- a/packages/serverless-cms-aws/src/api/plugins/executeDataMigrations.ts
+++ b/packages/serverless-cms-aws/src/api/plugins/executeDataMigrations.ts
@@ -46,7 +46,7 @@ export const executeDataMigrations = {
             const logReporter = new LogReporter(functionName);
 
             let statusReporter: MigrationStatusReporter | undefined;
-            if (inputs.dataMigrationLogs) {
+            if (inputs.dataMigrationReporter) {
                 const useNonInteractiveReporter = !process.stdout.isTTY || "CI" in process.env;
                 statusReporter = useNonInteractiveReporter
                     ? new NonInteractiveCliStatusReporter(logReporter)


### PR DESCRIPTION
## Changes
With the `--data-migration-reporter` flag that can be passed upon running the `webiny deploy` command, users have the ability to skip emitting data migration logs in their terminal (by passing `--no-data-migration-reporter`.

This can be useful for users that are experiencing issues in their CI/CD environments (we've had a case where the data migration was emitting too much logs, ultimately causing the environment to crash).

## Other Changes

Upon instantiating `fastify`, we're now passing [`logger: false`](https://github.com/webiny/webiny-js/pull/4136/files#diff-03c3666e5f2d68531eaa7ab5bd3d5147b59480f1b088a7534beb48d65e52909eR192). This is simply because, at the moment, Fastify dumps a solid amount of useless logs related to HTTP requests, which ultimately do not bring any value to the user. 

In the near future, we'll have our own Pino logger instance which we'll be sending to Fastify, which users will be able to further configure.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.