### PR TITLE
fix(api-headless-cms-ddb-es): unpublish latest record [skip ci]

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -1454,7 +1454,7 @@ export const createEntriesStorageOperations = (
             })
         ];
         /**
-         * If we are unpublishing the latest revision, let's also update the latest revision entry's status in ES.
+         * If we are unpublishing the latest revision, let's also update the latest revision entry's status in both DynamoDB tables.
          */
         if (latestStorageEntry?.id === entry.id) {
             const { index } = configurations.es({
@@ -1466,7 +1466,7 @@ export const createEntriesStorageOperations = (
                     ...storageEntry,
                     PK: partitionKey,
                     SK: createLatestSortKey(),
-                    TYPE: createRecordType()
+                    TYPE: createLatestRecordType()
                 })
             );
 

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -1461,6 +1461,15 @@ export const createEntriesStorageOperations = (
                 model
             });
 
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    PK: partitionKey,
+                    SK: createLatestSortKey(),
+                    TYPE: createRecordType()
+                })
+            );
+
             const esLatestData = await transformer.getElasticsearchLatestEntryData();
             esItems.push(
                 esEntity.putBatch({


### PR DESCRIPTION
## Changes
In DynamoDB + Elasticsearch systems not all records were properly marked as unpublished.

## How Has This Been Tested?
Jest and manual inspection of the database table.