### PR TITLE
fix(app-record-locking): use context to control prompt

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryForm.tsx
@@ -81,6 +81,7 @@ export const ContentEntryForm = makeDecoratable(
                 onAfterCreate={onAfterCreate || defaultOnAfterCreate}
                 setSaveEntry={setSaveEntry}
                 addItemToListCache={addEntryToListCache}
+                confirmNavigationIfDirty={true}
             >
                 <ModelProvider model={model}>
                     {header ? <Header /> : null}

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormPreview.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormPreview.tsx
@@ -25,7 +25,11 @@ export const ContentEntryFormPreview = makeDecoratable(
         const formRenderer = useFormRenderer(contentModel);
 
         return (
-            <ContentEntryFormProvider entry={{}} model={contentModel}>
+            <ContentEntryFormProvider
+                entry={{}}
+                model={contentModel}
+                confirmNavigationIfDirty={false}
+            >
                 <ModelProvider model={contentModel}>
                     <FormWrapper data-testid={"cms-content-form"}>
                         {formRenderer ? (

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormProvider.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormProvider.tsx
@@ -4,10 +4,13 @@ import debounce from "lodash/debounce";
 import { Prompt } from "@webiny/react-router";
 import { Form, FormAPI, FormOnSubmit, FormValidation } from "@webiny/form";
 import { CmsContentEntry, CmsModel } from "@webiny/app-headless-cms-common/types";
-import { useSnackbar } from "@webiny/app-admin";
+import { CompositionScope, useSnackbar } from "@webiny/app-admin";
 import { prepareFormData } from "@webiny/app-headless-cms-common";
 import { useContentEntry } from "~/index";
 import { PartialCmsContentEntryWithId } from "~/admin/contexts/Cms";
+
+const promptMessage =
+    "There are some unsaved changes! Are you sure you want to navigate away and discard all changes?";
 
 function omitTypename(key: string, value: string): string | undefined {
     return key === "__typename" ? undefined : value;
@@ -56,6 +59,7 @@ export interface SetSaveEntry {
 interface ContentEntryFormProviderProps {
     entry: Partial<CmsContentEntry>;
     model: CmsModel;
+    confirmNavigationIfDirty: boolean;
     onAfterCreate?: (entry: CmsContentEntry) => void;
     setSaveEntry?: SetSaveEntry;
     addItemToListCache?: boolean;
@@ -75,7 +79,8 @@ export const ContentEntryFormProvider = ({
     children,
     onAfterCreate,
     setSaveEntry,
-    addItemToListCache
+    addItemToListCache,
+    confirmNavigationIfDirty
 }: ContentEntryFormProviderProps) => {
     const ref = useRef<FormAPI<CmsContentEntry> | null>(null);
     const [invalidFields, setInvalidFields] = useState({});
@@ -199,12 +204,11 @@ export const ContentEntryFormProvider = ({
                 };
                 return (
                     <ContentEntryFormContext.Provider value={context}>
-                        <Prompt
-                            when={isDirty}
-                            message={
-                                "There are some unsaved changes! Are you sure you want to navigate away and discard all changes?"
-                            }
-                        />
+                        {confirmNavigationIfDirty ? (
+                            <CompositionScope name={"cms.contentEntryForm"}>
+                                <Prompt when={isDirty} message={promptMessage} />
+                            </CompositionScope>
+                        ) : null}
                         {children}
                     </ContentEntryFormContext.Provider>
                 );

--- a/packages/app-record-locking/src/components/HeadlessCmsContentEntry/HeadlessCmsContentEntry.tsx
+++ b/packages/app-record-locking/src/components/HeadlessCmsContentEntry/HeadlessCmsContentEntry.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
+import { CompositionScope, createGenericContext } from "@webiny/app-admin";
 import { ContentEntryEditorConfig } from "@webiny/app-headless-cms";
+import { Prompt } from "@webiny/react-router";
 import { ContentEntryGuard } from "./ContentEntryGuard";
 import { ContentEntryLocker } from "./ContentEntryLocker";
-import { Prompt } from "@webiny/react-router";
-import { createGenericContext } from "@webiny/app-admin";
 
 const { ContentEntry } = ContentEntryEditorConfig;
 
@@ -50,7 +50,9 @@ export const HeadlessCmsContentEntry = () => {
     return (
         <>
             <ContentEntryDecorator />
-            <PromptDecorator />
+            <CompositionScope name={"cms.contentEntryForm"}>
+                <PromptDecorator />
+            </CompositionScope>
         </>
     );
 };

--- a/packages/app-record-locking/src/components/HeadlessCmsContentEntry/HeadlessCmsContentEntry.tsx
+++ b/packages/app-record-locking/src/components/HeadlessCmsContentEntry/HeadlessCmsContentEntry.tsx
@@ -1,28 +1,56 @@
-import React from "react";
+import React, { useState } from "react";
 import { ContentEntryEditorConfig } from "@webiny/app-headless-cms";
 import { ContentEntryGuard } from "./ContentEntryGuard";
 import { ContentEntryLocker } from "./ContentEntryLocker";
+import { Prompt } from "@webiny/react-router";
+import { createGenericContext } from "@webiny/app-admin";
 
 const { ContentEntry } = ContentEntryEditorConfig;
 
-export const HeadlessCmsContentEntry = ContentEntry.createDecorator(Original => {
+const DisablePrompt = createGenericContext<{ disablePrompt: boolean }>("DisablePrompt");
+
+const PromptDecorator = Prompt.createDecorator(Original => {
+    return function Prompt(props) {
+        const { disablePrompt } = DisablePrompt.useHook();
+        const when = disablePrompt === true ? false : props.when;
+        return <Original message={props.message} when={when} />;
+    };
+});
+
+const ContentEntryDecorator = ContentEntry.createDecorator(Original => {
     return function RecordLockingContentEntry(props) {
+        const [disablePrompt, setDisablePrompt] = useState(false);
         const { entry } = ContentEntry.useContentEntry();
         /**
          * New entry does not have ID yet.
          */
         if (!entry?.id) {
-            return <Original {...props} />;
+            return (
+                <DisablePrompt.Provider disablePrompt={disablePrompt}>
+                    <Original {...props} />
+                </DisablePrompt.Provider>
+            );
         }
         /**
          * Continue with existing entry.
          */
         return (
             <ContentEntryGuard>
-                <ContentEntryLocker>
-                    <Original {...props} />
+                <ContentEntryLocker onDisablePrompt={flag => setDisablePrompt(flag)}>
+                    <DisablePrompt.Provider disablePrompt={disablePrompt}>
+                        <Original {...props} />
+                    </DisablePrompt.Provider>
                 </ContentEntryLocker>
             </ContentEntryGuard>
         );
     };
 });
+
+export const HeadlessCmsContentEntry = () => {
+    return (
+        <>
+            <ContentEntryDecorator />
+            <PromptDecorator />
+        </>
+    );
+};

--- a/packages/app-record-locking/src/components/LockedRecord/LockedRecord.tsx
+++ b/packages/app-record-locking/src/components/LockedRecord/LockedRecord.tsx
@@ -111,7 +111,9 @@ export const LockedRecord = ({ record: lockRecordEntry }: ILockedRecordProps) =>
                     This record is locked, but the system cannot find the user that created the
                     record lock.
                 </Text>
-                <Text>A force-unlock is required to regain edit capabilities for this record.</Text>
+                <Text>
+                    A force-unlock is required to regain editing capabilities for this record.
+                </Text>
                 <LockedRecordForceUnlock
                     id={lockRecordEntry.id}
                     type={record.$lockingType}


### PR DESCRIPTION
## Changes
This PR fixes a problem with infinite render loop caused by a decorator being mounted within a decorator. I refactored the components to make decorators be siblings which register only once, but share data via a local context.

## How Has This Been Tested?
Manually.
