### PR TITLE
fix(api-elasticsearch): health and node checks

### DIFF
--- a/packages/api-elasticsearch/__tests__/operations/catHealth.test.ts
+++ b/packages/api-elasticsearch/__tests__/operations/catHealth.test.ts
@@ -1,0 +1,30 @@
+import { ElasticsearchCatHealth } from "~/operations/ElasticsearchCatHealth";
+import { createElasticsearchClient } from "../helpers";
+import { IElasticsearchCatHealthResponse } from "~/operations/types";
+
+describe("cat health", () => {
+    it("should fetch health information", async () => {
+        const client = createElasticsearchClient();
+        const catHealth = new ElasticsearchCatHealth(client);
+
+        const expected: IElasticsearchCatHealthResponse = {
+            status: expect.stringMatching(/^green|yellow|red$/),
+            "node.data": expect.stringMatching(/^\d+$/),
+            "node.total": expect.stringMatching(/^\d+$/),
+            shards: expect.stringMatching(/^\d+$/),
+            active_shards_percent: expect.stringMatching(/^([0-9]*[.])?[0-9]%$/),
+            init: expect.stringMatching(/^\d+$/),
+            epoch: expect.stringMatching(/^\d+$/),
+            timestamp: expect.stringMatching(/^\d+:\d+:\d+$/),
+            cluster: expect.any(String),
+            pri: expect.stringMatching(/^\d+$/),
+            relo: expect.stringMatching(/^\d+$/),
+            unassign: expect.stringMatching(/^\d+$/),
+            pending_tasks: expect.stringMatching(/^\d+$/),
+            max_task_wait_time: expect.any(String)
+        };
+
+        const response = await catHealth.getHealth();
+        expect(response).toEqual(expected);
+    });
+});

--- a/packages/api-elasticsearch/__tests__/operations/catHealth.test.ts
+++ b/packages/api-elasticsearch/__tests__/operations/catHealth.test.ts
@@ -25,6 +25,6 @@ describe("cat health", () => {
         };
 
         const response = await catHealth.getHealth();
-        expect(response).toEqual(expected);
+        expect(response).toMatchObject(expected);
     });
 });

--- a/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
+++ b/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
@@ -1,0 +1,27 @@
+import { createElasticsearchClient } from "@webiny/project-utils/testing/elasticsearch/createClient";
+import { ElasticsearchCatHealth, ElasticsearchCatNodes } from "~/operations";
+import { IElasticsearchCatNodeResponse, IElasticsearchCatNodesResponse } from "~/operations/types";
+
+describe("cat nodes", () => {
+    it("should fetch nodes information", async () => {
+        const client = createElasticsearchClient();
+        const catNodes = new ElasticsearchCatNodes(client);
+
+        const expected: Partial<IElasticsearchCatNodeResponse>[] = [
+            {
+                "heap.percent": expect.any(String),
+                "ram.percent": expect.any(String),
+                cpu: expect.any(String),
+                load_1m: expect.any(String),
+                "node.role": expect.any(String),
+                ip: expect.any(String),
+                master: expect.any(String),
+                name: expect.any(String)
+            }
+        ];
+
+        const result = await catNodes.getNodes();
+
+        expect(result).toMatchObject(expected);
+    });
+});

--- a/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
+++ b/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
@@ -1,6 +1,6 @@
 import { createElasticsearchClient } from "@webiny/project-utils/testing/elasticsearch/createClient";
-import { ElasticsearchCatHealth, ElasticsearchCatNodes } from "~/operations";
-import { IElasticsearchCatNodeResponse, IElasticsearchCatNodesResponse } from "~/operations/types";
+import { ElasticsearchCatNodes } from "~/operations";
+import { IElasticsearchCatNodeResponse } from "~/operations/types";
 
 describe("cat nodes", () => {
     it("should fetch nodes information", async () => {

--- a/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
+++ b/packages/api-elasticsearch/__tests__/operations/catNodes.test.ts
@@ -15,7 +15,6 @@ describe("cat nodes", () => {
                 load_1m: expect.any(String),
                 "node.role": expect.any(String),
                 ip: expect.any(String),
-                master: expect.any(String),
                 name: expect.any(String)
             }
         ];

--- a/packages/api-elasticsearch/__tests__/utils/waitUntilHealthy.test.ts
+++ b/packages/api-elasticsearch/__tests__/utils/waitUntilHealthy.test.ts
@@ -16,13 +16,10 @@ describe("wait until healthy", () => {
             maxRamPercent: 101
         });
 
-        const { result, runs, runningTime } = await waitUntilHealthy.wait(async () => {
-            return "healthy";
-        });
+        const { runs, runningTime } = await waitUntilHealthy.wait();
 
         expect(runs).toEqual(1);
         expect(runningTime).toBeLessThan(30000);
-        expect(result).toEqual("healthy");
     });
 
     it("should wait until the cluster is health - processor - max waiting time hit", async () => {
@@ -36,9 +33,7 @@ describe("wait until healthy", () => {
         });
 
         try {
-            await waitUntilHealthy.wait(async () => {
-                return "should not reach this";
-            });
+            await waitUntilHealthy.wait();
         } catch (ex) {
             expect(ex).toBeInstanceOf(UnhealthyClusterError);
             expect(ex.message).toEqual("Cluster did not become healthy in 3 seconds.");
@@ -56,10 +51,8 @@ describe("wait until healthy", () => {
         });
 
         try {
-            const { result } = await waitUntilHealthy.wait(async () => {
-                return "should not reach this";
-            });
-            expect(result).toEqual("reaching here would fail the test");
+            const { runs } = await waitUntilHealthy.wait();
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(UnhealthyClusterError);
             expect(ex.message).toEqual("Cluster did not become healthy in 3 seconds.");
@@ -76,24 +69,20 @@ describe("wait until healthy", () => {
             maxRamPercent: 1
         });
 
-        const fn = jest.fn();
+        const onUnhealthy = jest.fn();
 
         try {
-            await waitUntilHealthy.wait(
-                async () => {
-                    return "should not reach this";
-                },
-                {
-                    async onUnhealthy() {
-                        fn();
-                    }
+            const { runs } = await waitUntilHealthy.wait({
+                async onUnhealthy() {
+                    onUnhealthy();
                 }
-            );
+            });
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(UnhealthyClusterError);
         }
 
-        expect(fn).toHaveBeenCalledTimes(1);
+        expect(onUnhealthy).toHaveBeenCalledTimes(1);
     });
 
     it("should trigger onUnhealthy callback - multiple times", async () => {
@@ -106,24 +95,20 @@ describe("wait until healthy", () => {
             maxRamPercent: 1
         });
 
-        const fn = jest.fn();
+        const onUnhealthy = jest.fn();
 
         try {
-            await waitUntilHealthy.wait(
-                async () => {
-                    return "should not reach this";
-                },
-                {
-                    async onUnhealthy() {
-                        fn();
-                    }
+            const { runs } = await waitUntilHealthy.wait({
+                async onUnhealthy() {
+                    onUnhealthy();
                 }
-            );
+            });
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(UnhealthyClusterError);
         }
 
-        expect(fn).toHaveBeenCalledTimes(3);
+        expect(onUnhealthy).toHaveBeenCalledTimes(3);
     });
 
     it("should trigger onTimeout callback - once", async () => {
@@ -140,19 +125,15 @@ describe("wait until healthy", () => {
         const onTimeout = jest.fn();
 
         try {
-            await waitUntilHealthy.wait(
-                async () => {
-                    return "should not reach this";
+            const { runs } = await waitUntilHealthy.wait({
+                async onUnhealthy() {
+                    onUnhealthy();
                 },
-                {
-                    async onUnhealthy() {
-                        onUnhealthy();
-                    },
-                    async onTimeout() {
-                        onTimeout();
-                    }
+                async onTimeout() {
+                    onTimeout();
                 }
-            );
+            });
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(UnhealthyClusterError);
         }
@@ -177,20 +158,16 @@ describe("wait until healthy", () => {
         const onTimeout = jest.fn();
 
         try {
-            await waitUntilHealthy.wait(
-                async () => {
-                    return "should not reach this";
+            const { runs } = await waitUntilHealthy.wait({
+                async onUnhealthy() {
+                    onUnhealthy();
+                    waitUntilHealthy.abort();
                 },
-                {
-                    async onUnhealthy() {
-                        onUnhealthy();
-                        waitUntilHealthy.abort();
-                    },
-                    async onTimeout() {
-                        onTimeout();
-                    }
+                async onTimeout() {
+                    onTimeout();
                 }
-            );
+            });
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(WaitingHealthyClusterAbortedError);
         }
@@ -212,17 +189,13 @@ describe("wait until healthy", () => {
         const onUnhealthy = jest.fn();
 
         try {
-            await waitUntilHealthy.wait(
-                async () => {
-                    return "should not reach this";
-                },
-                {
-                    async onUnhealthy() {
-                        onUnhealthy();
-                        waitUntilHealthy.abort();
-                    }
+            const { runs } = await waitUntilHealthy.wait({
+                async onUnhealthy() {
+                    onUnhealthy();
+                    waitUntilHealthy.abort();
                 }
-            );
+            });
+            expect(runs).toEqual("reaching here would fail the test");
         } catch (ex) {
             expect(ex).toBeInstanceOf(WaitingHealthyClusterAbortedError);
         }

--- a/packages/api-elasticsearch/__tests__/utils/waitUntilHealthy.test.ts
+++ b/packages/api-elasticsearch/__tests__/utils/waitUntilHealthy.test.ts
@@ -1,0 +1,66 @@
+import { createWaitUntilHealthy } from "~/utils/waitUntilHealthy";
+import { createElasticsearchClient } from "@webiny/project-utils/testing/elasticsearch/createClient";
+import { ElasticsearchCatHealthStatus } from "~/operations/types";
+import { UnhealthyClusterError } from "~/utils/waitUntilHealthy/UnhealthyClusterError";
+
+describe("wait until healthy", () => {
+    const client = createElasticsearchClient();
+    it("should wait until the cluster is healthy - single run", async () => {
+        const waitUntilHealthy = createWaitUntilHealthy(client, {
+            minStatus: ElasticsearchCatHealthStatus.Yellow,
+            maxProcessorPercent: 101,
+            maxWaitingTime: 30,
+            waitingTimeStep: 5,
+            maxRamPercent: 101
+        });
+
+        const { result, runs, runningTime } = await waitUntilHealthy.wait(async () => {
+            return "healthy";
+        });
+
+        expect(runs).toEqual(1);
+        expect(runningTime).toBeLessThan(30000);
+        expect(result).toEqual("healthy");
+    });
+
+    it("should wait until the cluster is health - processor - max waiting time hit", async () => {
+        expect.assertions(2);
+        const waitUntilHealthy = createWaitUntilHealthy(client, {
+            minStatus: ElasticsearchCatHealthStatus.Yellow,
+            maxProcessorPercent: 1,
+            maxWaitingTime: 3,
+            waitingTimeStep: 1,
+            maxRamPercent: 99
+        });
+
+        try {
+            await waitUntilHealthy.wait(async () => {
+                return "should not reach this";
+            });
+        } catch (ex) {
+            expect(ex).toBeInstanceOf(UnhealthyClusterError);
+            expect(ex.message).toEqual("Cluster did not become healthy in 3 seconds.");
+        }
+    });
+
+    it("should wait until the cluster is health - memory - max waiting time hit", async () => {
+        expect.assertions(2);
+        const waitUntilHealthy = createWaitUntilHealthy(client, {
+            minStatus: ElasticsearchCatHealthStatus.Yellow,
+            maxProcessorPercent: 99,
+            maxWaitingTime: 3,
+            waitingTimeStep: 1,
+            maxRamPercent: 1
+        });
+
+        try {
+            const { result } = await waitUntilHealthy.wait(async () => {
+                return "should not reach this";
+            });
+            expect(result).toEqual("reaching here would fail the test");
+        } catch (ex) {
+            expect(ex).toBeInstanceOf(UnhealthyClusterError);
+            expect(ex.message).toEqual("Cluster did not become healthy in 3 seconds.");
+        }
+    });
+});

--- a/packages/api-elasticsearch/src/index.ts
+++ b/packages/api-elasticsearch/src/index.ts
@@ -20,6 +20,7 @@ export * from "./operators";
 export * from "./cursors";
 export * from "./client";
 export * from "./utils";
+export * from "./operations";
 export { createGzipCompression } from "./plugins/GzipCompression";
 
 /**

--- a/packages/api-elasticsearch/src/operations/ElasticsearchCatHealth.ts
+++ b/packages/api-elasticsearch/src/operations/ElasticsearchCatHealth.ts
@@ -1,0 +1,37 @@
+import { WebinyError } from "@webiny/error";
+import { Client } from "~/client";
+import { IElasticsearchCatHealthResponse } from "./types";
+
+export class ElasticsearchCatHealth {
+    private readonly client: Client;
+
+    public constructor(client: Client) {
+        this.client = client;
+    }
+
+    public async getHealth(): Promise<IElasticsearchCatHealthResponse> {
+        try {
+            const response = await this.client.cat.health<
+                unknown | [IElasticsearchCatHealthResponse]
+            >({
+                format: "json"
+            });
+
+            if (!Array.isArray(response.body) || response.body.length === 0) {
+                throw new WebinyError({
+                    message: `There is no valid response from cat.health operation.`,
+                    code: "ELASTICSEARCH_HEALTH_INVALID_RESPONSE",
+                    data: response.body
+                });
+            }
+
+            return {
+                ...response.body[0]
+            };
+        } catch (ex) {
+            console.error(`Could not fetch cluster health information: ${ex.message}`);
+            console.log(ex);
+            throw ex;
+        }
+    }
+}

--- a/packages/api-elasticsearch/src/operations/ElasticsearchCatHealth.ts
+++ b/packages/api-elasticsearch/src/operations/ElasticsearchCatHealth.ts
@@ -1,6 +1,7 @@
 import { WebinyError } from "@webiny/error";
 import { Client } from "~/client";
 import { IElasticsearchCatHealthResponse } from "./types";
+import { stripConnectionFromException } from "~/operations/stripConnectionFromException";
 
 export class ElasticsearchCatHealth {
     private readonly client: Client;
@@ -30,8 +31,9 @@ export class ElasticsearchCatHealth {
             };
         } catch (ex) {
             console.error(`Could not fetch cluster health information: ${ex.message}`);
-            console.log(ex);
-            throw ex;
+            const error = stripConnectionFromException(ex);
+            console.log(JSON.stringify(error));
+            throw error;
         }
     }
 }

--- a/packages/api-elasticsearch/src/operations/ElasticsearchCatNodes.ts
+++ b/packages/api-elasticsearch/src/operations/ElasticsearchCatNodes.ts
@@ -1,6 +1,7 @@
 import { IElasticsearchCatNodesResponse } from "./types";
 import { Client } from "~/client";
 import { WebinyError } from "@webiny/error";
+import { stripConnectionFromException } from "~/operations/stripConnectionFromException";
 
 export class ElasticsearchCatNodes {
     private readonly client: Client;
@@ -15,13 +16,18 @@ export class ElasticsearchCatNodes {
                 format: "json"
             });
             if (!Array.isArray(response.body) || response.body.length === 0) {
-                throw new WebinyError(`There is no valid response from cat.nodes operation.`);
+                throw new WebinyError({
+                    message: `There is no valid response from cat.nodes operation.`,
+                    code: "ELASTICSEARCH_NODES_INVALID_RESPONSE",
+                    data: response.body
+                });
             }
             return response.body;
         } catch (ex) {
             console.error(`Could not fetch cluster nodes information: ${ex.message}`);
-            console.log(ex);
-            throw ex;
+            const error = stripConnectionFromException(ex);
+            console.log(JSON.stringify(error));
+            throw error;
         }
     }
 }

--- a/packages/api-elasticsearch/src/operations/ElasticsearchCatNodes.ts
+++ b/packages/api-elasticsearch/src/operations/ElasticsearchCatNodes.ts
@@ -1,0 +1,27 @@
+import { IElasticsearchCatNodesResponse } from "./types";
+import { Client } from "~/client";
+import { WebinyError } from "@webiny/error";
+
+export class ElasticsearchCatNodes {
+    private readonly client: Client;
+
+    public constructor(client: Client) {
+        this.client = client;
+    }
+
+    public async getNodes(): Promise<IElasticsearchCatNodesResponse> {
+        try {
+            const response = await this.client.cat.nodes<IElasticsearchCatNodesResponse>({
+                format: "json"
+            });
+            if (!Array.isArray(response.body) || response.body.length === 0) {
+                throw new WebinyError(`There is no valid response from cat.nodes operation.`);
+            }
+            return response.body;
+        } catch (ex) {
+            console.error(`Could not fetch cluster nodes information: ${ex.message}`);
+            console.log(ex);
+            throw ex;
+        }
+    }
+}

--- a/packages/api-elasticsearch/src/operations/index.ts
+++ b/packages/api-elasticsearch/src/operations/index.ts
@@ -1,0 +1,2 @@
+export * from "./ElasticsearchCatHealth";
+export * from "./ElasticsearchCatNodes";

--- a/packages/api-elasticsearch/src/operations/stripConnectionFromException.ts
+++ b/packages/api-elasticsearch/src/operations/stripConnectionFromException.ts
@@ -1,0 +1,15 @@
+export const stripConnectionFromException = (ex: any): any => {
+    if (typeof ex !== "object") {
+        return ex;
+    }
+    if (!ex?.meta?.meta?.connection) {
+        return ex;
+    }
+    return {
+        ...ex.meta,
+        meta: {
+            ...ex.meta.meta,
+            connection: null
+        }
+    };
+};

--- a/packages/api-elasticsearch/src/operations/types.ts
+++ b/packages/api-elasticsearch/src/operations/types.ts
@@ -1,0 +1,37 @@
+export enum ElasticsearchCatHealthStatus {
+    Green = "green",
+    Yellow = "yellow",
+    Red = "red"
+}
+
+export interface IElasticsearchCatHealthResponse {
+    epoch: number;
+    timestamp: `${number}:${number}:${number}`;
+    cluster: string;
+    status: ElasticsearchCatHealthStatus;
+    "node.total": `${number}`;
+    "node.data": `${number}`;
+    shards: `${number}`;
+    pri: `${number}`;
+    relo: `${number}`;
+    init: `${number}`;
+    unassign: `${number}`;
+    pending_tasks: `${number}`;
+    max_task_wait_time: string;
+    active_shards_percent: `${number}%`;
+}
+
+export interface IElasticsearchCatNodeResponse {
+    ip: string;
+    "heap.percent": `${number}`;
+    "ram.percent": `${number}`;
+    cpu: `${number}`;
+    load_1m: `${number}` | null;
+    load_5m: `${number}` | null;
+    load_15m: `${number}` | null;
+    "node.role": string;
+    master: string;
+    name: string;
+}
+
+export type IElasticsearchCatNodesResponse = IElasticsearchCatNodeResponse[];

--- a/packages/api-elasticsearch/src/operations/types.ts
+++ b/packages/api-elasticsearch/src/operations/types.ts
@@ -19,6 +19,7 @@ export interface IElasticsearchCatHealthResponse {
     pending_tasks: `${number}`;
     max_task_wait_time: string;
     active_shards_percent: `${number}%`;
+    discovered_cluster_manager?: `${boolean}`;
 }
 
 export interface IElasticsearchCatNodeResponse {
@@ -30,7 +31,7 @@ export interface IElasticsearchCatNodeResponse {
     load_5m: `${number}` | null;
     load_15m: `${number}` | null;
     "node.role": string;
-    master: string;
+    master?: string;
     name: string;
 }
 

--- a/packages/api-elasticsearch/src/utils/waitUntilHealthy/UnhealthyClusterError.ts
+++ b/packages/api-elasticsearch/src/utils/waitUntilHealthy/UnhealthyClusterError.ts
@@ -1,0 +1,10 @@
+import { WebinyError } from "@webiny/error";
+
+export class UnhealthyClusterError extends WebinyError {
+    public constructor(maxWaitingTime: number) {
+        super({
+            message: `Cluster did not become healthy in ${maxWaitingTime} seconds.`,
+            code: "UNHEALTHY_CLUSTER"
+        });
+    }
+}

--- a/packages/api-elasticsearch/src/utils/waitUntilHealthy/WaitUntilHealthy.ts
+++ b/packages/api-elasticsearch/src/utils/waitUntilHealthy/WaitUntilHealthy.ts
@@ -1,0 +1,156 @@
+import { Client } from "~/client";
+import { ElasticsearchCatHealth } from "~/operations/ElasticsearchCatHealth";
+import { ElasticsearchCatNodes } from "~/operations/ElasticsearchCatNodes";
+import { ElasticsearchCatHealthStatus, IElasticsearchCatNodesResponse } from "~/operations/types";
+import { UnhealthyClusterError } from "~/utils/waitUntilHealthy/UnhealthyClusterError";
+import { WaitingHealthyClusterAbortedError } from "./WaitingHealthyClusterAbortedError";
+
+const WAITING_TIME_STEP = 10;
+
+export interface IWaitUntilHealthyParams {
+    /**
+     * Minimum status allowed, otherwise the cluster is considered unhealthy.
+     */
+    minStatus: ElasticsearchCatHealthStatus.Green | ElasticsearchCatHealthStatus.Yellow;
+    /**
+     * Maximum processor percent allowed, otherwise the cluster is considered unhealthy.
+     */
+    maxProcessorPercent: number;
+    /**
+     * Maximum RAM percent allowed, otherwise the cluster is considered unhealthy.
+     */
+    maxRamPercent: number;
+    /**
+     * Maximum time to wait in seconds.
+     * This is to prevent infinite waiting in case the cluster never becomes healthy.
+     */
+    maxWaitingTime: number;
+    /**
+     * Time in seconds to wait between each check.
+     * This is to prevent spamming the cluster with requests.
+     * Default is WAITING_TIME_STEP seconds.
+     */
+    waitingTimeStep?: number;
+}
+
+export interface IWaitCb<T> {
+    (): Promise<T>;
+}
+
+export interface IWaitUntilHealthyWaitResponse<T> {
+    result: T;
+    runningTime: number;
+    runs: number;
+}
+
+class WaitUntilHealthy {
+    private readonly client: Client;
+    private readonly options: IWaitUntilHealthyParams;
+
+    private readonly catHealth: ElasticsearchCatHealth;
+    private readonly catNodes: ElasticsearchCatNodes;
+
+    private aborted = false;
+
+    public constructor(client: Client, options: IWaitUntilHealthyParams) {
+        this.client = client;
+        this.options = options;
+
+        this.catHealth = new ElasticsearchCatHealth(this.client);
+        this.catNodes = new ElasticsearchCatNodes(this.client);
+    }
+
+    public abort(): void {
+        this.aborted = true;
+    }
+
+    public async wait<T>(cb: IWaitCb<T>): Promise<IWaitUntilHealthyWaitResponse<T>> {
+        if (this.aborted) {
+            throw new WaitingHealthyClusterAbortedError(
+                `Waiting for the cluster to become healthy was aborted even before it started.`
+            );
+        }
+        const startedAt = new Date();
+        const mustEndAt = new Date(startedAt.getTime() + this.options.maxWaitingTime * 1000);
+        const waitingTimeStep = this.options.waitingTimeStep || WAITING_TIME_STEP;
+        let runs = 1;
+        while (await this.shouldWait()) {
+            if (this.aborted) {
+                throw new WaitingHealthyClusterAbortedError();
+            } else if (new Date() >= mustEndAt) {
+                throw new UnhealthyClusterError(this.options.maxWaitingTime);
+            }
+            runs++;
+            await new Promise(resolve => {
+                setTimeout(resolve, waitingTimeStep * 1000);
+            });
+        }
+
+        const runningTime = new Date().getTime() - startedAt.getTime();
+        const result = await cb();
+
+        return {
+            result,
+            runningTime,
+            runs
+        };
+    }
+
+    private async shouldWait(): Promise<boolean> {
+        const health = await this.catHealth.getHealth();
+        const nodes = await this.catNodes.getNodes();
+
+        const status = this.transformStatus(health.status);
+        if (status > this.transformStatus(this.options.minStatus)) {
+            return true;
+        }
+
+        const processorPercent = this.getProcessorPercent(nodes);
+        if (processorPercent > this.options.maxProcessorPercent) {
+            return true;
+        }
+
+        const ramPercent = this.getRamPercent(nodes);
+        if (ramPercent > this.options.maxRamPercent) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private getProcessorPercent(nodes: IElasticsearchCatNodesResponse): number {
+        const total = nodes.reduce<number>((total, node) => {
+            return total + parseFloat(node.cpu);
+        }, 0);
+        return total / nodes.length;
+    }
+
+    private getRamPercent(nodes: IElasticsearchCatNodesResponse): number {
+        const total = nodes.reduce<number>((total, node) => {
+            return total + parseFloat(node["ram.percent"]);
+        }, 0);
+        return total / nodes.length;
+    }
+
+    private transformStatus(status: ElasticsearchCatHealthStatus): number {
+        switch (status) {
+            case ElasticsearchCatHealthStatus.Green:
+                return 1;
+            case ElasticsearchCatHealthStatus.Yellow:
+                return 2;
+            case ElasticsearchCatHealthStatus.Red:
+                return 3;
+            default:
+                return 99;
+        }
+    }
+}
+
+export type { WaitUntilHealthy };
+
+export const createWaitUntilHealthy = (
+    client: Client,
+    params: IWaitUntilHealthyParams
+): WaitUntilHealthy => {
+    return new WaitUntilHealthy(client, params);
+};

--- a/packages/api-elasticsearch/src/utils/waitUntilHealthy/WaitingHealthyClusterAbortedError.ts
+++ b/packages/api-elasticsearch/src/utils/waitUntilHealthy/WaitingHealthyClusterAbortedError.ts
@@ -1,0 +1,10 @@
+import { WebinyError } from "@webiny/error";
+
+export class WaitingHealthyClusterAbortedError extends WebinyError {
+    public constructor(message?: string) {
+        super({
+            message: message || `Waiting for the cluster to become healthy was aborted.`,
+            code: "WAITING_HEALTHY_CLUSTER_ABORTED"
+        });
+    }
+}

--- a/packages/api-elasticsearch/src/utils/waitUntilHealthy/index.ts
+++ b/packages/api-elasticsearch/src/utils/waitUntilHealthy/index.ts
@@ -1,0 +1,1 @@
+export * from "./WaitUntilHealthy";

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -1,4 +1,5 @@
 import Error, { ErrorOptions } from "./Error";
 
 export default Error;
+export { Error as WebinyError };
 export { ErrorOptions };


### PR DESCRIPTION
## Changes
This PR introduces Elasticsearch/OpenSearch health and node checks.
They need to be called manually, but they will help with determining if the cluster is good for writes/reads.


## How Has This Been Tested?
Jest.

## Usage
```typescript
// Configure the utility.
const waitUntilHealthy = createWaitUntilHealthy(client, {
    minStatus: ElasticsearchCatHealthStatus.Yellow,
    maxProcessorPercent: 101,
    maxWaitingTime: 30,
    waitingTimeStep: 5,
    maxRamPercent: 101
});
// Wait until the cluster is healthy.
// It will throw an error on Abort and on Timeout (when maxWaitingTime is hit).
const { runs, runningTime } = await waitUntilHealthy.wait({
    async onUnhealthy(params) {
        const { runs, startedAt, mustEndAt, waitingTimeStep } = params;
    },
    async onTimeout(params) {
        const { runs, startedAt, mustEndAt, waitingTimeStep } = params;
        // log some info?
    }
});

// continue with your regular code
```