### PR TITLE
fix(api-headless-cms-tasks): race conditions while emptying the entries

### DIFF
--- a/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
+++ b/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
@@ -39,6 +39,43 @@ const listDeletedEntries = async (context: HcmsTasksContext, modelId: string) =>
 jest.setTimeout(720000);
 
 describe("Empty Trash Bin By Model", () => {
+    it("should fail in case of invalid input - missing `modelId`", async () => {
+        const taskDefinition = createEmptyTrashBinByModelTask();
+        const { handler } = useHandler<HcmsTasksContext>({
+            plugins: [taskDefinition, ...createMockModels()]
+        });
+
+        const context = await handler();
+
+        const task = await context.tasks.createTask({
+            name: "Empty Trash Bin By Model",
+            definitionId: taskDefinition.id,
+            input: {}
+        });
+
+        const runner = createRunner({
+            context,
+            task: taskDefinition
+        });
+
+        const result = await runner({
+            webinyTaskId: task.id
+        });
+
+        expect(result).toBeInstanceOf(ResponseErrorResult);
+
+        expect(result).toMatchObject({
+            status: "error",
+            error: {
+                message: `Missing "modelId" in the input.`
+            },
+            webinyTaskId: task.id,
+            webinyTaskDefinitionId: EntriesTask.EmptyTrashBinByModel,
+            tenant: "root",
+            locale: "en-US"
+        });
+    });
+
     it("should fail in case of not existing model", async () => {
         const taskDefinition = createEmptyTrashBinByModelTask();
         const { handler } = useHandler<HcmsTasksContext>({

--- a/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
+++ b/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
@@ -109,7 +109,7 @@ describe("Empty Trash Bin By Model", () => {
 
         expect(result).toMatchObject({
             status: "done",
-            message: "Task done: No entries to delete.",
+            message: "Task done: no entries to delete.",
             webinyTaskId: task.id,
             webinyTaskDefinitionId: EntriesTask.EmptyTrashBinByModel,
             tenant: "root",

--- a/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
+++ b/packages/api-headless-cms-tasks/__tests__/tasks/emptyTrashBinByModel.test.ts
@@ -146,7 +146,7 @@ describe("Empty Trash Bin By Model", () => {
 
         expect(result).toMatchObject({
             status: "done",
-            message: "Task done: no entries to delete.",
+            message: `Task done: no entries to delete for the "${MODEL_ID}" model.`,
             webinyTaskId: task.id,
             webinyTaskDefinitionId: EntriesTask.EmptyTrashBinByModel,
             tenant: "root",

--- a/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/CreateDeleteEntriesTasks.ts
+++ b/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/CreateDeleteEntriesTasks.ts
@@ -2,36 +2,34 @@ import { ITaskResponseResult } from "@webiny/tasks";
 import { CmsEntryListParams } from "@webiny/api-headless-cms/types";
 import { EntriesTask, IDeleteTrashBinEntriesInput, IEmptyTrashBinByModelTaskParams } from "~/types";
 
-const DELETE_ENTRIES_IN_BATCH = 50;
-const DELETE_ENTRIES_WAIT_TIME = 5;
+const BATCH_SIZE = 50;
+const WAITING_TIME = 5;
 
 export class CreateDeleteEntriesTasks {
     public async execute(params: IEmptyTrashBinByModelTaskParams): Promise<ITaskResponseResult> {
         const { input, response, isAborted, isCloseToTimeout, context, store } = params;
 
         try {
+            if (!input.modelId) {
+                return response.error(`Missing "modelId" in the input.`);
+            }
+
             const model = await context.cms.getModel(input.modelId);
 
             if (!model) {
                 return response.error(`Model with ${input.modelId} not found!`);
             }
 
-            const totalCount = input.totalCount || 0;
+            const listEntriesParams: CmsEntryListParams = {
+                where: input.where,
+                after: input.after,
+                limit: BATCH_SIZE
+            };
+
             let currentBatch = input.currentBatch || 1;
             let hasMoreEntries = true;
 
             while (hasMoreEntries) {
-                const listEntriesParams: CmsEntryListParams = {
-                    where: input.where,
-                    after: input.after,
-                    limit: DELETE_ENTRIES_IN_BATCH
-                };
-
-                const [entries, meta] = await context.cms.listDeletedEntries(
-                    model,
-                    listEntriesParams
-                );
-
                 if (isAborted()) {
                     return response.aborted();
                 } else if (isCloseToTimeout()) {
@@ -42,25 +40,36 @@ export class CreateDeleteEntriesTasks {
                     });
                 }
 
-                if (meta.totalCount === 0) {
-                    if (totalCount > 0) {
-                        return response.continue(
-                            {
-                                ...input,
-                                ...listEntriesParams,
-                                currentBatch,
-                                processing: true
-                            },
-                            {
-                                seconds: DELETE_ENTRIES_WAIT_TIME
-                            }
-                        );
-                    }
+                const [entries, meta] = await context.cms.listDeletedEntries(
+                    model,
+                    listEntriesParams
+                );
 
-                    return response.done("Task done: No entries to delete.");
+                hasMoreEntries = meta.hasMoreItems;
+                listEntriesParams.after = meta.cursor;
+
+                // If no entries exist for the provided query, let's return done.
+                if (meta.totalCount === 0) {
+                    return response.done("Task done: no entries to delete.");
                 }
 
-                const entryIds = entries.map(entry => entry.entryId);
+                // If no entries are returned, let's continue with the task, but in `processing` mode.
+                if (entries.length === 0) {
+                    return response.continue(
+                        {
+                            ...input,
+                            ...listEntriesParams,
+                            currentBatch,
+                            totalCount: meta.totalCount,
+                            processing: true
+                        },
+                        {
+                            seconds: WAITING_TIME
+                        }
+                    );
+                }
+
+                const entryIds = entries.map(entry => entry.id);
 
                 if (entryIds.length > 0) {
                     await context.tasks.trigger<IDeleteTrashBinEntriesInput>({
@@ -74,19 +83,34 @@ export class CreateDeleteEntriesTasks {
                     });
                 }
 
-                hasMoreEntries = meta.hasMoreItems;
-                input.after = meta.cursor;
-                input.totalCount = meta.totalCount;
+                // If there are no more entries to load, we can continue the controller task in a `processing` mode, with some delay.
+                if (!meta.hasMoreItems || !meta.cursor) {
+                    return response.continue(
+                        {
+                            ...input,
+                            ...listEntriesParams,
+                            currentBatch,
+                            totalCount: meta.totalCount,
+                            processing: true
+                        },
+                        {
+                            seconds: WAITING_TIME
+                        }
+                    );
+                }
+
                 currentBatch++;
             }
 
+            // Should not be possible to exit the loop without returning a response, but let's have a continue response here just in case.
             return response.continue(
                 {
                     ...input,
+                    ...listEntriesParams,
                     currentBatch
                 },
                 {
-                    seconds: DELETE_ENTRIES_WAIT_TIME
+                    seconds: WAITING_TIME
                 }
             );
         } catch (ex) {

--- a/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/ProcessDeleteEntriesTasks.ts
+++ b/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/ProcessDeleteEntriesTasks.ts
@@ -37,7 +37,7 @@ export class ProcessDeleteEntriesTasks {
             }
 
             return response.done(
-                `Task done: The trash bin has been emptied for the ${input.modelId} model.`
+                `Task done: trash bin for the "${input.modelId}" model has been emptied.`
             );
         } catch (ex) {
             return response.error(ex.message ?? "Error while executing ProcessDeleteEntriesTasks");

--- a/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/TaskCache.ts
+++ b/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/TaskCache.ts
@@ -1,0 +1,20 @@
+interface TaskCacheItem {
+    modelId: string;
+    entryIds: string[];
+}
+
+export class TaskCache {
+    private taskCache: TaskCacheItem[] = [];
+
+    cacheTask(modelId: string, entryIds: string[]): void {
+        this.taskCache.push({ modelId, entryIds });
+    }
+
+    getTasks(): TaskCacheItem[] {
+        return this.taskCache;
+    }
+
+    clear(): void {
+        this.taskCache = [];
+    }
+}

--- a/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/TaskTrigger.ts
+++ b/packages/api-headless-cms-tasks/src/tasks/entries/useCases/EmptyTrashBinByModel/TaskTrigger.ts
@@ -1,0 +1,38 @@
+import { ITaskManagerStore } from "@webiny/tasks";
+import { TaskCache } from "./TaskCache";
+import {
+    EntriesTask,
+    HcmsTasksContext,
+    IDeleteTrashBinEntriesInput,
+    IEmptyTrashBinByModelInput
+} from "~/types";
+
+export class TaskTrigger {
+    constructor(private taskCache: TaskCache) {}
+
+    async execute(context: HcmsTasksContext, store: ITaskManagerStore<IEmptyTrashBinByModelInput>) {
+        const tasks = this.taskCache.getTasks();
+        if (tasks.length === 0) {
+            return;
+        }
+
+        for (const task of tasks) {
+            try {
+                await context.tasks.trigger<IDeleteTrashBinEntriesInput>({
+                    definition: EntriesTask.DeleteTrashBinEntries,
+                    name: `Headless CMS - Delete Entries - ${task.modelId}`,
+                    parent: store.getTask(),
+                    input: {
+                        modelId: task.modelId,
+                        entryIds: task.entryIds
+                    }
+                });
+            } catch (error) {
+                console.error(`Error triggering task for model ${task.modelId}:`, error);
+            }
+        }
+
+        // Clear the cache after processing
+        this.taskCache.clear();
+    }
+}


### PR DESCRIPTION
## Changes
With this PR, we aim to: 

- refactor CreateDeleteEntriesTasks class for improved readability and efficiency;
- remove redundant variables;
- simplify loop conditions;
- ensure proper handling of edge cases and pagination;
- uniform messages returned by the task execution.

### `TaskCache` and `TaskTrigger`
The main change introduced by this fix is the use of a cache to store all the subtasks created while looping through the entries that need to be deleted.

Previously, when dealing with a large number of entries, the child tasks would start executing while the main task was still executing. This could cause a race condition and lead to failures when deleting some entries that had already been deleted by other subtasks.

With this pull request, we are now storing inputs for subtasks inside an internal cache and executing them after the main task loop finishes.

## How Has This Been Tested?
Manually + Jest
