### PR TITLE
fix(ui): set Select label and placeholder values based on size prop

### DIFF
--- a/packages/ui/src/Select/Select.tsx
+++ b/packages/ui/src/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
     FormattedOption,
     Select as RmwcSelect,
@@ -92,13 +92,32 @@ const getRmwcProps = (props: SelectProps): FormComponentProps & RmwcSelectProps 
  * Error says to use the empty string in null/undefined case.
  */
 export const Select = (props: SelectProps) => {
-    const { value: initialValue, description, validation, placeholder, ...other } = props;
+    const { value: initialValue, description, validation, ...other } = props;
 
     const value = initialValue === null || initialValue === undefined ? "" : initialValue;
 
     const { isValid: validationIsValid, message: validationMessage } = validation || {};
 
     const options = getOptions(other.options);
+
+    // Memoize the label and placeholder values based on the component size.
+    const { label, placeholder } = useMemo(() => {
+        const { size, label, placeholder } = props;
+
+        // For small or medium size, we set only the placeholder, using label as fallback.
+        if (size === "small" || size === "medium") {
+            return {
+                label: undefined,
+                placeholder: placeholder || label
+            };
+        }
+
+        // For other sizes, use the provided label and placeholder.
+        return {
+            label,
+            placeholder
+        };
+    }, [props.label, props.placeholder, props.size]);
 
     return (
         <>
@@ -107,7 +126,8 @@ export const Select = (props: SelectProps) => {
                 ref={undefined}
                 options={options}
                 value={value}
-                placeholder={placeholder ?? ""} // Fix RMWC version 14.2.2 to make the label float by default when a predefined value is selected.
+                label={label}
+                placeholder={placeholder}
                 className={classNames(
                     "webiny-ui-select mdc-ripple-surface mdc-ripple-upgraded",
                     webinySelect,


### PR DESCRIPTION
## Changes
We fixed a bug that was introduced while upgrading the RMWC library and our `@webiny/form` library: 

- we remove the blank `placeholder` used to make the label float by default when a predefined value is selected;
- set `placeholder` value based on `size`: in case of `medium` or `small`, we use the label as a fallback for the placeholder.

**Before:**
`<Select size={"medium"} label={"I'm a label"} ... />`

![CleanShot 2024-05-29 at 09 36 24](https://github.com/webiny/webiny-js/assets/2866531/f386ccc7-b55d-4738-ae77-1276657f3304)
![CleanShot 2024-05-29 at 09 29 18](https://github.com/webiny/webiny-js/assets/2866531/ef096d00-c06a-4f59-a5ed-5ae4096c67ee)


**After:**
`<Select size={"medium"} label={"Placeholder/Label"} ... />`
![CleanShot 2024-05-29 at 09 30 22](https://github.com/webiny/webiny-js/assets/2866531/9b8be5b9-9958-4567-ae14-c93a434a5a0b)
![CleanShot 2024-05-29 at 09 34 48](https://github.com/webiny/webiny-js/assets/2866531/580b338f-6cd9-4e27-8528-6273356e4e7c)

## How Has This Been Tested?
Manually

## Documentation
Inline