### PR TITLE
feat: expand object + DZ fields via settings parameter >open<

### DIFF
--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -293,6 +293,10 @@ export interface CmsModelFieldSettings {
      * Disable full text search explicitly on this field.
      */
     disableFullTextSearch?: boolean;
+    /**
+     * Expand accordion appearances of dynamic zone and objects.
+     */
+    open?: boolean;
 
     /**
      * There are a lot of other settings that are possible to add, so we keep the type opened.

--- a/packages/app-headless-cms-common/src/types/model.ts
+++ b/packages/app-headless-cms-common/src/types/model.ts
@@ -21,6 +21,7 @@ export interface CmsModelFieldSettings<T = unknown> {
     models?: Pick<CmsModel, "modelId">[];
     templates?: CmsDynamicZoneTemplate[];
     imagesOnly?: boolean;
+    open?: boolean;
     [key: string]: any;
 }
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
@@ -29,6 +29,7 @@ export type DynamicZoneContainerProps = {
     title?: string;
     description?: string;
     className?: string;
+    open?: boolean;
 };
 
 export const DynamicZoneContainer = makeDecoratable(
@@ -42,7 +43,8 @@ export const DynamicZoneContainer = makeDecoratable(
             title = field.label,
             description = field.helpText,
             className,
-            children
+            children,
+            open = field.settings?.open || false
         } = props;
 
         const defaultClassName = field.multipleValues ? noBottomPadding : undefined;
@@ -54,6 +56,7 @@ export const DynamicZoneContainer = makeDecoratable(
                         title={title}
                         description={description}
                         className={className || defaultClassName}
+                        open={open || false}
                     >
                         {children}
                     </AccordionItem>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
@@ -86,7 +86,11 @@ const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
 
     return (
         <RootAccordion>
-            <AccordionItem title={field.label} description={field.helpText}>
+            <AccordionItem
+                title={field.label}
+                description={field.helpText}
+                open={settings?.open || false}
+            >
                 <DynamicSection
                     {...props}
                     emptyValue={{}}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
@@ -37,7 +37,11 @@ const plugin: CmsModelFieldRendererPlugin = {
                         <ParentFieldProvider value={bindProps.value} path={Bind.parentName}>
                             <ParentValueIndexProvider index={-1}>
                                 <Accordion>
-                                    <AccordionItem title={field.label} description={field.helpText}>
+                                    <AccordionItem
+                                        title={field.label}
+                                        description={field.helpText}
+                                        open={settings?.open || false}
+                                    >
                                         <Fields
                                             Bind={Bind}
                                             contentModel={contentModel}


### PR DESCRIPTION
## Changes
The new attribute `open` of interface `CmsModelFieldSettings` controls whether the accordion renderer of objects and dynamic zones are expanded by default.
BREAKING CHANGE: none
Closes #4109

![Screenshot 2024-06-04 at 14 19 45](https://github.com/webiny/webiny-js/assets/19306046/d9b437b2-f0c6-4da7-8837-6d657bf528d8)
![Screenshot 2024-06-04 at 14 20 41](https://github.com/webiny/webiny-js/assets/19306046/e2375633-511b-4d92-9b12-c2992d3a76fa)


## How Has This Been Tested?
Manually.

## Documentation
I'm planning to add a "How to" section below this on in webiny.com/docs:
https://www.webiny.com/docs/headless-cms/extending/content-models-via-code#how-to-set-a-default-value-of-a-field