### PR TITLE
feat(app-headless-cms): add object and DZ renderer settings

### DIFF
--- a/packages/api-headless-cms/src/graphql/schema/contentModels.ts
+++ b/packages/api-headless-cms/src/graphql/schema/contentModels.ts
@@ -35,6 +35,15 @@ export const createModelsSchema = ({ context }: Params): ICmsGraphQLSchemaPlugin
             }
         },
         CmsContentModelField: {
+            renderer: field => {
+                // Make sure `settings` is an object.
+                if (field.renderer) {
+                    // We're using `||` here, because we want to use the fallback value for both `undefined` and `null`.
+                    return { ...field.renderer, settings: field.renderer.settings || {} };
+                }
+
+                return field.renderer;
+            },
             tags(field) {
                 // Make sure `tags` are always returned as an array.
                 return Array.isArray(field.tags) ? field.tags : [];

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/AccordionRenderSettings.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/AccordionRenderSettings.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Bind } from "@webiny/form";
+import { Cell } from "@webiny/ui/Grid";
+import { Switch } from "@webiny/ui/Switch";
+import {
+    CmsModelField,
+    CmsModelFieldRendererSettingsProps
+} from "@webiny/app-headless-cms-common/types";
+
+export interface IAccordionRenderSettings {
+    open: boolean;
+}
+
+const DEFAULT_ACCORDION_RENDER_SETTINGS: IAccordionRenderSettings = {
+    open: false
+};
+
+export const getAccordionRenderSettings = (field: CmsModelField) => {
+    if (typeof field.renderer === "function") {
+        return DEFAULT_ACCORDION_RENDER_SETTINGS;
+    }
+
+    return field.renderer.settings as IAccordionRenderSettings;
+};
+
+export const AccordionRenderSettings = ({ field }: CmsModelFieldRendererSettingsProps) => {
+    return (
+        <>
+            <Cell span={12}>
+                <Bind name={"renderer.settings.open"} defaultValue={false}>
+                    <Switch
+                        label={"Expand Accordion"}
+                        description={`Enable if "${field.label}" is to be expanded by default.`}
+                    />
+                </Bind>
+            </Cell>
+        </>
+    );
+};

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
@@ -47,7 +47,7 @@ export const DynamicZoneContainer = makeDecoratable(
         } = props;
 
         const defaultClassName = field.multipleValues ? noBottomPadding : undefined;
-        const open = getAccordionRenderSettings(field).open;
+        const { open } = getAccordionRenderSettings(field);
 
         return (
             <>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.tsx
@@ -11,6 +11,7 @@ import {
 } from "~/types";
 import { SingleValueDynamicZone } from "./SingleValueDynamicZone";
 import { MultiValueDynamicZone } from "./MultiValueDynamicZone";
+import { AccordionRenderSettings, getAccordionRenderSettings } from "../AccordionRenderSettings";
 import { FormElementMessage } from "@webiny/ui/FormElementMessage";
 import { makeDecoratable } from "@webiny/react-composition";
 
@@ -46,6 +47,7 @@ export const DynamicZoneContainer = makeDecoratable(
         } = props;
 
         const defaultClassName = field.multipleValues ? noBottomPadding : undefined;
+        const open = getAccordionRenderSettings(field).open;
 
         return (
             <>
@@ -54,6 +56,7 @@ export const DynamicZoneContainer = makeDecoratable(
                         title={title}
                         description={description}
                         className={className || defaultClassName}
+                        open={open}
                     >
                         {children}
                     </AccordionItem>
@@ -114,6 +117,9 @@ export const dynamicZoneFieldRenderer: CmsModelFieldRendererPlugin = {
         },
         render(props) {
             return <DynamicZoneContent {...props} />;
+        },
+        renderSettings({ field }) {
+            return <AccordionRenderSettings field={field} />;
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
@@ -23,6 +23,7 @@ import {
 } from "./StyledComponents";
 import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
 import { FieldSettings } from "./FieldSettings";
+import { AccordionRenderSettings, getAccordionRenderSettings } from "../AccordionRenderSettings";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -83,10 +84,11 @@ const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     }
 
     const settings = fieldSettings.getSettings();
+    const open = getAccordionRenderSettings(field).open;
 
     return (
         <RootAccordion>
-            <AccordionItem title={field.label} description={field.helpText}>
+            <AccordionItem title={field.label} description={field.helpText} open={open}>
                 <DynamicSection
                     {...props}
                     emptyValue={{}}
@@ -140,6 +142,9 @@ const plugin: CmsModelFieldRendererPlugin = {
         },
         render(props) {
             return <ObjectsRenderer {...props} />;
+        },
+        renderSettings({ field }) {
+            return <AccordionRenderSettings field={field} />;
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
@@ -84,7 +84,7 @@ const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     }
 
     const settings = fieldSettings.getSettings();
-    const open = getAccordionRenderSettings(field).open;
+    const { open } = getAccordionRenderSettings(field);
 
     return (
         <RootAccordion>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
@@ -6,6 +6,10 @@ import { Fields } from "~/admin/components/ContentEntryForm/Fields";
 import { FieldSettings } from "./FieldSettings";
 import { ParentFieldProvider } from "~/admin/hooks";
 import { ParentValueIndexProvider } from "~/admin/components/ModelFieldProvider";
+import {
+    AccordionRenderSettings,
+    getAccordionRenderSettings
+} from "~/admin/plugins/fieldRenderers/AccordionRenderSettings";
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
@@ -30,6 +34,7 @@ const plugin: CmsModelFieldRendererPlugin = {
             }
 
             const settings = fieldSettings.getSettings();
+            const open = getAccordionRenderSettings(field).open;
 
             return (
                 <Bind>
@@ -37,7 +42,11 @@ const plugin: CmsModelFieldRendererPlugin = {
                         <ParentFieldProvider value={bindProps.value} path={Bind.parentName}>
                             <ParentValueIndexProvider index={-1}>
                                 <Accordion>
-                                    <AccordionItem title={field.label} description={field.helpText}>
+                                    <AccordionItem
+                                        title={field.label}
+                                        description={field.helpText}
+                                        open={open}
+                                    >
                                         <Fields
                                             Bind={Bind}
                                             contentModel={contentModel}
@@ -51,6 +60,9 @@ const plugin: CmsModelFieldRendererPlugin = {
                     )}
                 </Bind>
             );
+        },
+        renderSettings({ field }) {
+            return <AccordionRenderSettings field={field} />;
         }
     }
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectAccordion.tsx
@@ -34,7 +34,7 @@ const plugin: CmsModelFieldRendererPlugin = {
             }
 
             const settings = fieldSettings.getSettings();
-            const open = getAccordionRenderSettings(field).open;
+            const { open } = getAccordionRenderSettings(field);
 
             return (
                 <Bind>


### PR DESCRIPTION
## Changes
Okay, this is the 2nd iteration of the new feature to expand object and dynamic zone HCMS fields by default. According to @Pavel910's [recommendation](https://github.com/webiny/webiny-js/pull/4153#pullrequestreview-2096283885), I'm using the new **renderer settings** feature to define an `open` attribute. If this attribute is set to `true`, the accordion of the object or dynamic zone field is expanded.

BREAKING CHANGE: none
Closes: #4109

## How Has This Been Tested?
Manually, with an in-code content model.
![Screenshot 2024-06-05 at 20 16 10](https://github.com/webiny/webiny-js/assets/19306046/680598d8-906b-47c6-859d-c16fa80d5f50)

## Documentation
We could use this implementation as an example for the section that describes the renderer settings feature.