### PR TITLE
fix(app-page-builder): pass pid instead of id when bulk deleting pages

### DIFF
--- a/packages/app-page-builder/src/admin/components/BulkActions/ActionDelete.tsx
+++ b/packages/app-page-builder/src/admin/components/BulkActions/ActionDelete.tsx
@@ -28,7 +28,7 @@ export const ActionDelete = observer(() => {
                 await worker.processInSeries(async ({ item, report }) => {
                     try {
                         const response = await deletePage(
-                            { id: item.data.id },
+                            { id: item.data.pid },
                             {
                                 client: client,
                                 mutationOptions: {


### PR DESCRIPTION
## Changes
With this PR, we aim to fix a significant issue encountered when trying to delete pages via bulk actions with multiple revisions.

Previously, only the latest revision was deleted. This has been fixed by passing `pid` instead of the revision `id`.

## How Has This Been Tested?
Manually