### PR TITLE
fix(app-headless-cms): fixing useParentField hook for high level parents

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ParentValue.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ParentValue.tsx
@@ -30,7 +30,7 @@ export function useParentField(level = 0): ParentField | undefined {
         return undefined;
     }
 
-    return level === 0 ? parent : parent.getParentField(level);
+    return level === 0 ? parent : parent.getParentField(level - 1);
 }
 
 interface ParentFieldProviderProps {


### PR DESCRIPTION
Refs: #4163

## Changes
Just a tiny fix to the `useParentField()` hook. In case of `level>0` it was calling function `getParentField()` with a wrong level.
Closes #4163

## How Has This Been Tested?
Manually with an in-code content model `product` and a field decorator `ProductRenderDecorator`. See #4163 for more details. This test setup provides the expected console log after the fix:
```
current field is metaData.generalMetaData.specificMetaData.isoCode
1st level parent: specificMetaData
2nd level parent: generalMetaData
3rd level parent: metaData
```

## Documentation
not needed