### PR TITLE
fix(tasks): set proper tenant and locale when running task

### DIFF
--- a/packages/api-file-manager/src/delivery/setupAssetDelivery.ts
+++ b/packages/api-file-manager/src/delivery/setupAssetDelivery.ts
@@ -98,10 +98,12 @@ export const setupAssetDelivery = (params: AssetDeliveryParams) => {
                     return false;
                 }
 
+                const assetLocale = resolvedAsset.getLocale();
+
                 request.headers = {
                     ...request.headers,
                     "x-tenant": resolvedAsset.getTenant(),
-                    "x-i18n-locale": resolvedAsset.getLocale()
+                    "x-i18n-locale": `default:${assetLocale};content:${assetLocale};`
                 };
 
                 return;

--- a/packages/api-page-builder-import-export/src/import/pages/ImportPagesProcessPages.ts
+++ b/packages/api-page-builder-import-export/src/import/pages/ImportPagesProcessPages.ts
@@ -52,6 +52,7 @@ export class ImportPagesProcessPages {
                 pageIdList.push(page.pid);
                 done.push(item.key);
             } catch (ex) {
+                console.error(ex);
                 await store.addErrorLog({
                     error: ex,
                     message: `Could not import page: ${item.key}.`,

--- a/packages/api-page-builder-import-export/src/import/utils/extractAndUploadZipFileContents.ts
+++ b/packages/api-page-builder-import-export/src/import/utils/extractAndUploadZipFileContents.ts
@@ -29,7 +29,7 @@ export async function extractAndUploadZipFileContents(zipFileUrl: string): Promi
     const response = await fetch(zipFileUrl);
     const readStream = response.body;
     if (!response.ok || !readStream) {
-        throw new WebinyError(`Unable to downloading file: "${zipFileUrl}"`, response.statusText);
+        throw new WebinyError(`Unable to download file: "${zipFileUrl}"`, response.statusText);
     }
 
     const uniquePath = uniqueId("IMPORTS/");

--- a/packages/tasks/__tests__/crud/definitions.test.ts
+++ b/packages/tasks/__tests__/crud/definitions.test.ts
@@ -1,8 +1,8 @@
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { createTaskDefinition } from "~/task";
 
 describe("definitions crud", () => {
-    const handler = useHandler({
+    const handler = useRawHandler({
         plugins: [
             createTaskDefinition({
                 id: "testDefinitionNumber1",

--- a/packages/tasks/__tests__/crud/store.test.ts
+++ b/packages/tasks/__tests__/crud/store.test.ts
@@ -1,4 +1,4 @@
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { createTaskDefinition } from "~/task";
 import { ITask, TaskDataStatus } from "~/types";
 import { NotFoundError } from "@webiny/handler-graphql";
@@ -6,7 +6,7 @@ import WebinyError from "@webiny/error";
 import { createMockIdentity } from "~tests/mocks/identity";
 
 describe("store crud", () => {
-    const handler = useHandler({
+    const handler = useRawHandler({
         plugins: [
             createTaskDefinition({
                 id: "testDefinition",

--- a/packages/tasks/__tests__/crud/trigger.test.ts
+++ b/packages/tasks/__tests__/crud/trigger.test.ts
@@ -1,4 +1,4 @@
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { createMockTaskDefinitions } from "~tests/mocks/definition";
 import { createMockIdentity } from "~tests/mocks/identity";
 import { TaskDataStatus } from "~/types";
@@ -23,7 +23,7 @@ jest.mock("@webiny/aws-sdk/client-eventbridge", () => {
 });
 
 describe("trigger crud", () => {
-    const handler = useHandler({
+    const handler = useRawHandler({
         plugins: [...createMockTaskDefinitions()]
     });
 

--- a/packages/tasks/__tests__/graphql/logs.test.ts
+++ b/packages/tasks/__tests__/graphql/logs.test.ts
@@ -1,11 +1,11 @@
 import { useGraphQLHandler } from "~tests/helpers/useGraphQLHandler";
 import { createMockTaskDefinitions } from "~tests/mocks/definition";
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { ITaskLogItemType } from "~/types";
 import { createMockIdentity } from "~tests/mocks/identity";
 
 describe("graphql - logs", () => {
-    const contextHandler = useHandler({
+    const contextHandler = useRawHandler({
         plugins: [...createMockTaskDefinitions()]
     });
     const handler = useGraphQLHandler({

--- a/packages/tasks/__tests__/graphql/tasks.test.ts
+++ b/packages/tasks/__tests__/graphql/tasks.test.ts
@@ -1,11 +1,11 @@
 import { useGraphQLHandler } from "~tests/helpers/useGraphQLHandler";
 import { createMockTaskDefinitions } from "~tests/mocks/definition";
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { TaskDataStatus } from "~/types";
 import { createMockIdentity } from "~tests/mocks/identity";
 
 describe("graphql - tasks", () => {
-    const contextHandler = useHandler({
+    const contextHandler = useRawHandler({
         plugins: [...createMockTaskDefinitions()]
     });
     const handler = useGraphQLHandler({

--- a/packages/tasks/__tests__/helpers/useRawHandler.ts
+++ b/packages/tasks/__tests__/helpers/useRawHandler.ts
@@ -1,0 +1,56 @@
+import { createHeadlessCmsContext, createHeadlessCmsGraphQL } from "@webiny/api-headless-cms";
+import graphQLHandlerPlugins from "@webiny/handler-graphql";
+import { getStorageOps } from "@webiny/project-utils/testing/environment";
+import { HeadlessCmsStorageOperations } from "@webiny/api-headless-cms/types";
+import { createWcpContext } from "@webiny/api-wcp";
+import { createTenancyAndSecurity } from "./tenancySecurity";
+import { createDummyLocales, createIdentity, createPermissions } from "./helpers";
+import { mockLocalesPlugins } from "@webiny/api-i18n/graphql/testing";
+import i18nContext from "@webiny/api-i18n/graphql/context";
+import { createRawEventHandler, createRawHandler } from "@webiny/handler-aws";
+import { LambdaContext } from "@webiny/handler-aws/types";
+import { Context } from "~tests/types";
+import { PluginCollection } from "@webiny/plugins/types";
+import { createBackgroundTaskContext } from "~/index";
+
+export interface UseHandlerParams {
+    plugins?: PluginCollection;
+}
+
+export const useRawHandler = <C extends Context = Context>(params?: UseHandlerParams) => {
+    const { plugins = [] } = params || {};
+    const cmsStorage = getStorageOps<HeadlessCmsStorageOperations>("cms");
+    const i18nStorage = getStorageOps<any[]>("i18n");
+
+    const handler = createRawHandler<any, C>({
+        plugins: [
+            createWcpContext(),
+            ...cmsStorage.plugins,
+            ...createTenancyAndSecurity({
+                setupGraphQL: false,
+                permissions: createPermissions(),
+                identity: createIdentity()
+            }),
+            i18nContext(),
+            i18nStorage.storageOperations,
+            createDummyLocales(),
+            mockLocalesPlugins(),
+            createHeadlessCmsContext({
+                storageOperations: cmsStorage.storageOperations
+            }),
+            createHeadlessCmsGraphQL(),
+            graphQLHandlerPlugins(),
+            createBackgroundTaskContext(),
+            createRawEventHandler(async ({ context }) => {
+                return context;
+            }),
+            ...plugins
+        ]
+    });
+
+    return {
+        handle: async (payload?: Record<string, any>) => {
+            return await handler(payload || {}, {} as LambdaContext);
+        }
+    };
+};

--- a/packages/tasks/__tests__/helpers/useRawHandler.ts
+++ b/packages/tasks/__tests__/helpers/useRawHandler.ts
@@ -50,7 +50,17 @@ export const useRawHandler = <C extends Context = Context>(params?: UseHandlerPa
 
     return {
         handle: async (payload?: Record<string, any>) => {
-            return await handler(payload || {}, {} as LambdaContext);
+            const headers = {
+                ["x-tenant"]: "root",
+                ...(payload?.headers || {})
+            };
+            return await handler(
+                {
+                    ...payload,
+                    headers
+                },
+                {} as LambdaContext
+            );
         }
     };
 };

--- a/packages/tasks/__tests__/helpers/useTaskHandler.ts
+++ b/packages/tasks/__tests__/helpers/useTaskHandler.ts
@@ -1,28 +1,29 @@
+import { createHandler } from "~/handler";
+import { createWcpContext } from "@webiny/api-wcp";
+import { createTenancyAndSecurity } from "~tests/helpers/tenancySecurity";
+import { createDummyLocales, createIdentity, createPermissions } from "~tests/helpers/helpers";
+import i18nContext from "@webiny/api-i18n/graphql/context";
+import { mockLocalesPlugins } from "@webiny/api-i18n/graphql/testing";
 import { createHeadlessCmsContext, createHeadlessCmsGraphQL } from "@webiny/api-headless-cms";
 import graphQLHandlerPlugins from "@webiny/handler-graphql";
+import { createBackgroundTaskContext } from "~/context";
+import { createRawEventHandler } from "@webiny/handler-aws";
 import { getStorageOps } from "@webiny/project-utils/testing/environment";
 import { HeadlessCmsStorageOperations } from "@webiny/api-headless-cms/types";
-import { createWcpContext } from "@webiny/api-wcp";
-import { createTenancyAndSecurity } from "./tenancySecurity";
-import { createDummyLocales, createIdentity, createPermissions } from "./helpers";
-import { mockLocalesPlugins } from "@webiny/api-i18n/graphql/testing";
-import i18nContext from "@webiny/api-i18n/graphql/context";
-import { createRawEventHandler, createRawHandler } from "@webiny/handler-aws";
-import { LambdaContext } from "@webiny/handler-aws/types";
-import { Context } from "~tests/types";
 import { PluginCollection } from "@webiny/plugins/types";
-import { createBackgroundTaskContext } from "~/index";
+import { LambdaContext } from "@webiny/handler-aws/types";
+import { ITaskRawEvent } from "~/handler/types";
 
-export interface UseHandlerParams {
+export interface UseTaskHandlerParams {
     plugins?: PluginCollection;
 }
 
-export const useHandler = <C extends Context = Context>(params?: UseHandlerParams) => {
+export const useTaskHandler = (params?: UseTaskHandlerParams) => {
     const { plugins = [] } = params || {};
     const cmsStorage = getStorageOps<HeadlessCmsStorageOperations>("cms");
     const i18nStorage = getStorageOps<any[]>("i18n");
 
-    const handler = createRawHandler<any, C>({
+    const handler = createHandler({
         plugins: [
             createWcpContext(),
             ...cmsStorage.plugins,
@@ -49,8 +50,8 @@ export const useHandler = <C extends Context = Context>(params?: UseHandlerParam
     });
 
     return {
-        handle: async () => {
-            return await handler({}, {} as LambdaContext);
+        handle: async (payload: ITaskRawEvent) => {
+            return await handler(payload, {} as LambdaContext);
         }
     };
 };

--- a/packages/tasks/__tests__/live/context.ts
+++ b/packages/tasks/__tests__/live/context.ts
@@ -1,29 +1,30 @@
 import { PluginCollection } from "@webiny/plugins/types";
-import { useHandler } from "~tests/helpers/useHandler";
+import { useRawHandler } from "~tests/helpers/useRawHandler";
 import { Context } from "~tests/types";
 
 export interface CreateLiveContextParams<C extends Context = Context> {
     plugins?: PluginCollection;
-    handler?: ReturnType<typeof useHandler<C>>;
+    handler?: ReturnType<typeof useRawHandler<C>>;
 }
 
 export const createLiveContext = async <C extends Context = Context>(
-    params?: CreateLiveContextParams<C>
+    params?: CreateLiveContextParams<C>,
+    payload?: Record<string, any>
 ) => {
     if (params?.handler) {
-        return params.handler.handle();
+        return params.handler.handle(payload);
     }
-    const handler = useHandler<C>({
+    const handler = useRawHandler<C>({
         plugins: [...(params?.plugins || [])]
     });
 
-    return handler.handle();
+    return handler.handle(payload);
 };
 
 export const createLiveContextFactory = <C extends Context = Context>(
     params?: CreateLiveContextParams<C>
 ) => {
-    return () => {
-        return createLiveContext<C>(params);
+    return (payload: Record<string, any> = {}) => {
+        return createLiveContext<C>(params, payload);
     };
 };

--- a/packages/tasks/__tests__/runner/taskTenantAndLocale.test.ts
+++ b/packages/tasks/__tests__/runner/taskTenantAndLocale.test.ts
@@ -1,0 +1,75 @@
+import { createMockEvent } from "~tests/mocks";
+import { createLiveContextFactory } from "~tests/live";
+import { createTaskDefinition } from "~/task";
+import { useTaskHandler } from "~tests/helpers/useTaskHandler";
+
+const taskDefinition = createTaskDefinition({
+    id: "taskRunnerTask",
+    title: "Task Runner Task",
+    maxIterations: 2,
+    run: async ({ response, context }) => {
+        return response.done("Task is done!", {
+            tenant: context.tenancy.getCurrentTenant().id,
+            locale: context.cms.getLocale().code,
+            defaultLocale: context.i18n.getCurrentLocale("default")!.code,
+            contentLocale: context.i18n.getCurrentLocale("content")!.code
+        });
+    }
+});
+
+const defaults = {
+    tenant: "aCustomTenantId",
+    locale: "de-DE"
+};
+
+describe("task tenant and locale", () => {
+    it("should properly set the tenant and locale", async () => {
+        const contextFactory = createLiveContextFactory({
+            plugins: [taskDefinition]
+        });
+
+        const context = await contextFactory({
+            headers: {
+                ["x-tenant"]: defaults.tenant,
+                ["x-webiny-cms-endpoint"]: "manage",
+                ["x-webiny-cms-locale"]: defaults.locale,
+                ["x-i18n-locale"]: defaults.locale,
+                ["accept-language"]: defaults.locale
+            }
+        });
+
+        const task = await context.tasks.createTask({
+            definitionId: taskDefinition.id,
+            input: {},
+            name: "My task name"
+        });
+
+        const { handle } = useTaskHandler({
+            plugins: [taskDefinition]
+        });
+
+        const result = await handle(
+            createMockEvent({
+                webinyTaskId: task.id,
+                webinyTaskDefinitionId: taskDefinition.id,
+                tenant: defaults.tenant,
+                locale: defaults.locale
+            })
+        );
+
+        expect(result).toEqual({
+            status: "done",
+            webinyTaskId: task.id,
+            webinyTaskDefinitionId: taskDefinition.id,
+            tenant: "aCustomTenantId",
+            locale: "de-DE",
+            message: "Task is done!",
+            output: {
+                tenant: "aCustomTenantId",
+                locale: "de-DE",
+                defaultLocale: "de-DE",
+                contentLocale: "de-DE"
+            }
+        });
+    });
+});

--- a/packages/tasks/src/handler/index.ts
+++ b/packages/tasks/src/handler/index.ts
@@ -71,7 +71,9 @@ export const createHandler = (params: HandlerParams): HandlerCallable => {
                 headers: {
                     ["x-tenant"]: event.tenant,
                     ["x-webiny-cms-endpoint"]: event.endpoint,
-                    ["x-webiny-cms-locale"]: event.locale
+                    ["x-webiny-cms-locale"]: event.locale,
+                    ["x-i18n-locale"]: event.locale,
+                    ["accept-language"]: event.locale
                 }
             }
         });

--- a/packages/tasks/src/runner/TaskControl.ts
+++ b/packages/tasks/src/runner/TaskControl.ts
@@ -38,6 +38,7 @@ export class TaskControl implements ITaskControl {
         let task: ITask<ITaskDataInput>;
         try {
             task = await this.getTask(taskId);
+            this.context.security.setIdentity(task.createdBy);
         } catch (error) {
             return this.response.error({
                 error
@@ -111,8 +112,6 @@ export class TaskControl implements ITaskControl {
         }
 
         try {
-            this.context.security.setIdentity(task.createdBy);
-
             const result = await manager.run(definition);
 
             await this.runEvents(result, definition, task);


### PR DESCRIPTION
## Changes
A problem with BG tasks which manifests on non-default tenant and locales, where the tenant and locale were not properly set. Also, File Manager Asset Delivery was setting the `x-i18n-locale` header using the wrong value format, making all assets be loaded as if they're located on a default locale.

## How Has This Been Tested?
Jest.