### PR TITLE
fix(api-headless-cms): revert storageId validation logic

### DIFF
--- a/packages/api-headless-cms/__tests__/helpers/validateStorageId.test.ts
+++ b/packages/api-headless-cms/__tests__/helpers/validateStorageId.test.ts
@@ -1,0 +1,17 @@
+import { validateStorageId } from "~/crud/contentModel/validateStorageId";
+
+describe("validateStorageId", () => {
+    it("should validate storage ids", async () => {
+        // Valid storage IDs
+        expect(() => validateStorageId("pageTeaserMedia")).not.toThrow();
+        expect(() => validateStorageId("number@productPrice123")).not.toThrow();
+        expect(() => validateStorageId("long-text@description")).not.toThrow();
+        expect(() => validateStorageId("text@0b6vu1w0")).not.toThrow();
+        expect(() => validateStorageId("0b6vu1w0")).not.toThrow();
+        expect(() => validateStorageId("0b6vu1w0-abc")).not.toThrow();
+
+        // Invalid storage IDs
+        expect(() => validateStorageId("some_weird_$_id")).toThrow();
+        expect(() => validateStorageId("my!R3ally$creWedI\\d^^")).toThrow();
+    });
+});

--- a/packages/api-headless-cms/__tests__/helpers/validateStorageId.test.ts
+++ b/packages/api-headless-cms/__tests__/helpers/validateStorageId.test.ts
@@ -1,17 +1,21 @@
 import { validateStorageId } from "~/crud/contentModel/validateStorageId";
 
 describe("validateStorageId", () => {
-    it("should validate storage ids", async () => {
-        // Valid storage IDs
-        expect(() => validateStorageId("pageTeaserMedia")).not.toThrow();
-        expect(() => validateStorageId("number@productPrice123")).not.toThrow();
-        expect(() => validateStorageId("long-text@description")).not.toThrow();
-        expect(() => validateStorageId("text@0b6vu1w0")).not.toThrow();
-        expect(() => validateStorageId("0b6vu1w0")).not.toThrow();
-        expect(() => validateStorageId("0b6vu1w0-abc")).not.toThrow();
-
-        // Invalid storage IDs
-        expect(() => validateStorageId("some_weird_$_id")).toThrow();
-        expect(() => validateStorageId("my!R3ally$creWedI\\d^^")).toThrow();
+    it.each([
+        ["pageTeaserMedia"],
+        ["number@productPrice123"],
+        ["long-text@description"],
+        ["text@0b6vu1w0"],
+        ["0b6vu1w0"],
+        ["0b6vu1w0-abc"]
+    ])(`should pass storage id validation - "%s"`, async storageId => {
+        expect(() => validateStorageId(storageId)).not.toThrow();
     });
+
+    it.each([["some_weird_$_id"], ["my!/[R]{3}ally$creWedI:_+\\d^^"], ["读写汉字 - 学中文"]])(
+        `should fail storage id validation - "%s"`,
+        async storageId => {
+            expect(() => validateStorageId(storageId)).toThrow();
+        }
+    );
 });

--- a/packages/api-headless-cms/src/crud/contentModel/validateStorageId.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateStorageId.ts
@@ -1,4 +1,3 @@
-import lodashCamelCase from "lodash/camelCase";
 import WebinyError from "@webiny/error";
 
 // We allow "@" because that's how we construct storageIds with `createModelField` utility.
@@ -6,15 +5,11 @@ const VALID_STORAGE_ID_REGEX = /^([@a-zA-Z-0-9]+)$/;
 
 export const validateStorageId = (storageId: string) => {
     if (!storageId.match(VALID_STORAGE_ID_REGEX)) {
-        const camelCasedStorageId = lodashCamelCase(storageId);
+        const message = [
+            `Invalid storageId provided ("${storageId}").`,
+            'Only alphanumeric characters and "@" are allowed.'
+        ].join(" ");
 
-        if (storageId !== camelCasedStorageId) {
-            const message = [
-                `Invalid storageId provided ("${storageId}").`,
-                "Must be a camelCased string."
-            ].join(" ");
-
-            throw new WebinyError(message, "STORAGE_ID_NOT_CAMEL_CASED_ERROR");
-        }
+        throw new WebinyError(message, "STORAGE_ID_NOT_ALPHANUMERIC_ERROR");
     }
 };

--- a/packages/api-headless-cms/src/crud/contentModel/validateStorageId.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validateStorageId.ts
@@ -1,30 +1,20 @@
 import lodashCamelCase from "lodash/camelCase";
 import WebinyError from "@webiny/error";
 
-// We allow "@" because that's we use it with the `createModelField` function.
+// We allow "@" because that's how we construct storageIds with `createModelField` utility.
 const VALID_STORAGE_ID_REGEX = /^([@a-zA-Z-0-9]+)$/;
 
 export const validateStorageId = (storageId: string) => {
     if (!storageId.match(VALID_STORAGE_ID_REGEX)) {
-        const message = [
-            `Invalid storageId provided ("${storageId}").`,
-            'Only alphanumeric characters and "@" are allowed.'
-        ].join(" ");
+        const camelCasedStorageId = lodashCamelCase(storageId);
 
-        throw new WebinyError(message, "STORAGE_ID_NOT_ALPHANUMERIC_ERROR");
-    }
+        if (storageId !== camelCasedStorageId) {
+            const message = [
+                `Invalid storageId provided ("${storageId}").`,
+                "Must be a camelCased string."
+            ].join(" ");
 
-    // We must do this because in the process of camel casing, Lodash removes the `@`
-    // character from the string. For example, if we received `text@productName`, we
-    // would be doing the `text@productName` vs. `textProductName` (camel cased) comparison.
-    storageId = storageId.replace("@", "");
-
-    if (storageId !== lodashCamelCase(storageId)) {
-        const message = [
-            `Invalid storageId provided ("${storageId}").`,
-            "Must be a camelCased string."
-        ].join(" ");
-
-        throw new WebinyError(message, "STORAGE_ID_NOT_CAMEL_CASED_ERROR");
+            throw new WebinyError(message, "STORAGE_ID_NOT_CAMEL_CASED_ERROR");
+        }
     }
 };


### PR DESCRIPTION
## Changes
This PR fixes (reverts) the logic of storageId validation, and adds a test for various storageId formats.

## How Has This Been Tested?
Jest.