### PR TITLE
fix(ui): convert table cell values to string for rendering

### DIFF
--- a/packages/ui/src/DataTable/DataTable.tsx
+++ b/packages/ui/src/DataTable/DataTable.tsx
@@ -215,7 +215,11 @@ const defineColumns = <T,>(
                     if (cell && typeof cell === "function") {
                         return cell(info.row.original);
                     } else {
-                        return info.getValue() || null;
+                        // Automatically convert any cell value to a string for rendering,
+                        // ensuring the table displays values correctly. This aligns with React's
+                        // rendering, which expects JSX, strings or null.
+                        // https://github.com/TanStack/table/issues/1042
+                        return info.getValue() ? String(info.getValue()) : null;
                     }
                 },
                 enableSorting,


### PR DESCRIPTION
## Changes
With this pull request, we address a bug encountered when adding a new column that targets a `boolean` field without specifying a custom cell renderer. As a result, the field content does not appear in the table.

We are fixing it by converting any cell value to a string for rendering to ensure the table displays values correctly. This aligns with React's rendering, which expects JSX, strings, or null.

## How Has This Been Tested?
Manually

