### PR TITLE
Various Improvements

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/index.ts
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/index.ts
@@ -1,4 +1,5 @@
 import textInput from "./textInput";
 import textInputs from "./textInputs";
+import { tags } from "./tags";
 
-export default [textInput, textInputs];
+export default [textInput, textInputs, tags];

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/tags.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/tags.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Tags } from "@webiny/ui/Tags";
+import { CmsModelFieldRendererPlugin } from "~/types";
+
+export const tags: CmsModelFieldRendererPlugin = {
+    type: "cms-editor-field-renderer",
+    name: "cms-editor-field-renderer-tags",
+    renderer: {
+        rendererName: "tags",
+        name: "Tags",
+        description: `Renders a tags component.`,
+        canUse({ field }) {
+            return (
+                field.type === "text" &&
+                field.multipleValues === true &&
+                !field.predefinedValues?.enabled
+            );
+        },
+        render({ field, getBind }) {
+            const Bind = getBind();
+
+            return (
+                <Bind defaultValue={[]}>
+                    <Tags
+                        label={field.label}
+                        placeholder={field.placeholderText || "Add values"}
+                        description={field.helpText}
+                    />
+                </Bind>
+            );
+        }
+    }
+};

--- a/packages/cli-plugin-scaffold-extensions/.eslintrc.js
+++ b/packages/cli-plugin-scaffold-extensions/.eslintrc.js
@@ -1,0 +1,9 @@
+const defaultConfig = require("../../.eslintrc");
+
+module.exports = {
+    ...defaultConfig,
+    rules: {
+        ...defaultConfig.rules,
+        "import/dynamic-import-chunkname": 0
+    }
+};

--- a/packages/cli-plugin-scaffold-extensions/package.json
+++ b/packages/cli-plugin-scaffold-extensions/package.json
@@ -24,6 +24,7 @@
     "@webiny/error": "0.0.0",
     "case": "^1.6.3",
     "execa": "^5.0.0",
+    "glob": "^7.1.2",
     "load-json-file": "^6.2.0",
     "ncp": "^2.0.0",
     "replace-in-path": "^1.1.0",

--- a/packages/cli-plugin-scaffold-extensions/src/generators/utils/generateAdminExtensions.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/generators/utils/generateAdminExtensions.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+import { formatCode } from "@webiny/cli-plugin-scaffold/utils";
+import { ExtensionWorkspace } from "./getExtensionsFromFilesystem";
+
+export const generateAdminExtensions = async (extensions: ExtensionWorkspace[]) => {
+    const extensionsFilePath = path.join("apps", "admin", "src", "Extensions.tsx");
+
+    const code: string[][] = [];
+
+    extensions.forEach(extension => {
+        const name = path.basename(extension.path);
+        const ucFirstName = name.charAt(0).toUpperCase() + name.slice(1);
+        const componentName = ucFirstName + "Extension";
+        const importStatement = `import { Extension as ${componentName}} from "${extension.packageJson.name}";`;
+        code.push([importStatement, `<${componentName}/>`]);
+    });
+
+    const extensionsFile = [
+        `// This file is automatically updated via scaffolding utilities.`,
+        `import React from "react";`,
+        ...code.map(ext => ext[0]),
+        "",
+        `export const Extensions = () => { return (<>${code.map(ext => ext[1]).join("\n")}</>); };`
+    ];
+
+    fs.writeFileSync(extensionsFilePath, extensionsFile.join("\n"));
+
+    await formatCode(extensionsFilePath, {});
+};

--- a/packages/cli-plugin-scaffold-extensions/src/generators/utils/generateApiExtensions.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/generators/utils/generateApiExtensions.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import { formatCode } from "@webiny/cli-plugin-scaffold/utils";
+import { ExtensionWorkspace } from "./getExtensionsFromFilesystem";
+
+export const generateApiExtensions = async (extensions: ExtensionWorkspace[]) => {
+    const extensionsFilePath = path.join("apps", "api", "graphql", "src", "extensions.ts");
+    const code: string[][] = [];
+
+    extensions.forEach(extension => {
+        const name = path.basename(extension.path);
+        const extensionFactory = name + "ExtensionFactory";
+        const importStatement = `import { createExtension as ${extensionFactory}} from "${extension.packageJson.name}";`;
+        code.push([importStatement, `${extensionFactory}()`]);
+    });
+
+    const extensionsFile = [
+        "// This file is automatically updated via scaffolding utilities.",
+        ...code.map(ext => ext[0]),
+        "export const extensions = () => {",
+        "return [",
+        code.map(ext => ext[1]).join(","),
+        "];};"
+    ];
+
+    fs.writeFileSync(extensionsFilePath, extensionsFile.join("\n"));
+
+    await formatCode(extensionsFilePath, {});
+};

--- a/packages/cli-plugin-scaffold-extensions/src/generators/utils/getExtensionsFromFilesystem.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/generators/utils/getExtensionsFromFilesystem.ts
@@ -1,0 +1,33 @@
+import loadJson from "load-json-file";
+import glob from "glob";
+import path from "path";
+import { PackageJson } from "@webiny/cli-plugin-scaffold/types";
+
+export type ExtensionType = "api" | "admin" | undefined;
+
+export type ExtensionWorkspace = {
+    path: string;
+    type: ExtensionType;
+    packageJson: PackageJson;
+};
+
+export const getExtensionsFromFilesystem = (): ExtensionWorkspace[] => {
+    const workspaces = glob.sync(`extensions/**/package.json`);
+    return workspaces
+        .map(pkg => ({
+            path: path.dirname(pkg),
+            packageJson: loadJson.sync<PackageJson>(pkg)
+        }))
+        .map(workspace => {
+            const typeKeyword = (workspace.packageJson.keywords || []).find(kw => {
+                return kw.startsWith("webiny-extension-type:");
+            });
+
+            const type = (typeKeyword ? typeKeyword.split(":")[1] : undefined) as ExtensionType;
+
+            return {
+                ...workspace,
+                type
+            };
+        });
+};

--- a/packages/cli-plugin-scaffold-extensions/src/generators/utils/linkAllExtensions.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/generators/utils/linkAllExtensions.ts
@@ -1,0 +1,16 @@
+import { getExtensionsFromFilesystem } from "./getExtensionsFromFilesystem";
+import { generateApiExtensions } from "./generateApiExtensions";
+import { generateAdminExtensions } from "./generateAdminExtensions";
+import { registerWorkspaces } from "./registerWorkspaces";
+
+export const linkAllExtensions = async () => {
+    const allExtensions = getExtensionsFromFilesystem();
+    const apiExtensions = allExtensions.filter(extension => extension.type === "api");
+    const adminExtensions = allExtensions.filter(extension => extension.type === "admin");
+
+    await Promise.all([
+        generateApiExtensions(apiExtensions),
+        generateAdminExtensions(adminExtensions),
+        registerWorkspaces(allExtensions)
+    ]);
+};

--- a/packages/cli-plugin-scaffold-extensions/src/generators/utils/registerWorkspaces.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/generators/utils/registerWorkspaces.ts
@@ -1,0 +1,24 @@
+import execa from "execa";
+import loadJson from "load-json-file";
+import writeJson from "write-json-file";
+import type { ExtensionWorkspace } from "./getExtensionsFromFilesystem";
+import { PackageJson } from "@webiny/cli-plugin-scaffold/types";
+import { formatCode } from "@webiny/cli-plugin-scaffold/utils";
+
+export const registerWorkspaces = async (extensions: ExtensionWorkspace[]) => {
+    const packageJsonPath = "package.json";
+    const rootPkgJson = await loadJson<PackageJson>(packageJsonPath);
+
+    extensions.forEach(extension => {
+        const workspacePath = extension.path.replace(`${process.cwd()}/`, "");
+
+        if (!rootPkgJson.workspaces.packages.includes(workspacePath)) {
+            rootPkgJson.workspaces.packages.push(workspacePath);
+        }
+    });
+
+    await writeJson(packageJsonPath, rootPkgJson);
+    await formatCode(packageJsonPath, {});
+
+    await execa("yarn");
+};

--- a/packages/cli-plugin-scaffold-extensions/src/index.ts
+++ b/packages/cli-plugin-scaffold-extensions/src/index.ts
@@ -29,204 +29,220 @@ interface Input {
 
 const EXTENSIONS_ROOT_FOLDER = "extensions";
 
-export default (): CliCommandScaffoldTemplate<Input> => ({
-    name: "cli-plugin-scaffold-template-extensions",
-    type: "cli-plugin-scaffold-template",
-    templateName: "extension",
-    scaffold: {
-        name: "New Extension",
-        description: "Scaffolds essential files for creating a new extension.",
-        questions: () => {
-            return [
-                {
-                    name: "type",
-                    message: "What type of an extension do you want to create?",
-                    type: "list",
-                    choices: [
-                        { name: "Admin extension", value: "admin" },
-                        { name: "API extension", value: "api" }
-                    ]
-                },
-                {
-                    name: "name",
-                    message: "Enter the extension name:",
-                    default: "myCustomExtension",
-                    validate: name => {
-                        if (!name) {
-                            return "Missing extension name.";
-                        }
+export default () => [
+    {
+        type: "cli-command",
+        name: "cli-command-link-extensions",
+        // @ts-ignore This plugin doesn't have a type
+        create({ yargs }) {
+            yargs.command(["link-extensions"], `Link all project extensions.`, async () => {
+                await import(__dirname + "/generators/utils/linkAllExtensions.js").then(m =>
+                    m.linkAllExtensions()
+                );
 
-                        const isValidName = name === Case.camel(name);
-                        if (!isValidName) {
-                            return `Please use camel case when providing the name of the extension (for example "myCustomExtension").`;
-                        }
-
-                        return true;
-                    }
-                },
-                {
-                    name: "location",
-                    message: `Enter the extension location:`,
-                    default: (answers: Input) => {
-                        return `${EXTENSIONS_ROOT_FOLDER}/${answers.name}`;
-                    },
-                    validate: location => {
-                        if (!location) {
-                            return "Please enter the package location.";
-                        }
-
-                        if (!location.startsWith(`${EXTENSIONS_ROOT_FOLDER}/`)) {
-                            return `Package location must start with "${EXTENSIONS_ROOT_FOLDER}/".`;
-                        }
-
-                        const locationPath = path.resolve(location);
-                        if (fs.existsSync(locationPath)) {
-                            return `The target location already exists "${location}".`;
-                        }
-
-                        return true;
-                    }
-                },
-                {
-                    name: "packageName",
-                    message: "Enter the package name:",
-                    default: (answers: Input) => {
-                        return Case.kebab(answers.name);
-                    },
-                    validate: pkgName => {
-                        if (!pkgName) {
-                            return "Missing package name.";
-                        }
-
-                        const isValidName = validateNpmPackageName(pkgName);
-                        if (!isValidName) {
-                            return `Package name must be a valid NPM package name, for example "my-custom-extension".`;
-                        }
-
-                        return true;
-                    }
-                },
-                {
-                    name: "dependencies",
-                    message: "Enter one or more NPM dependencies (optional):",
-                    required: false
-                }
-            ];
-        },
-        generate: async ({ input, ora, context }) => {
-            const { type, name } = input;
-            if (!type) {
-                throw new Error("Missing extension type.");
-            }
-
-            const templatePath = path.join(__dirname, "templates", type);
-            const templateExists = fs.existsSync(templatePath);
-            if (!templateExists) {
-                throw new Error("Unknown extension type.");
-            }
-
-            if (!name) {
-                throw new Error("Missing extension name.");
-            }
-
-            let { packageName, location } = input;
-            if (!packageName) {
-                packageName = Case.kebab(name);
-            }
-
-            if (!location) {
-                location = `${EXTENSIONS_ROOT_FOLDER}/${name}`;
-            }
-
-            if (fs.existsSync(location)) {
-                throw new WebinyError(`The target location already exists "${location}"`);
-            }
-
-            try {
-                ora.start(`Creating ${log.success.hl(name)} extension...`);
-
-                // Copy template files
-                fs.mkdirSync(location, { recursive: true });
-                await ncp(templatePath, location);
-
-                const project = getProject();
-
-                const baseTsConfigFullPath = path.resolve(project.root, "tsconfig.json");
-                const baseTsConfigRelativePath = path.relative(location, baseTsConfigFullPath);
-
-                const codeReplacements = [
-                    { find: "PACKAGE_NAME", replaceWith: packageName },
+                process.exit(0);
+            });
+        }
+    },
+    {
+        name: "cli-plugin-scaffold-template-extensions",
+        type: "cli-plugin-scaffold-template",
+        templateName: "extension",
+        scaffold: {
+            name: "New Extension",
+            description: "Scaffolds essential files for creating a new extension.",
+            questions: () => {
+                return [
                     {
-                        find: "BASE_TSCONFIG_PATH",
-                        replaceWith: baseTsConfigRelativePath
+                        name: "type",
+                        message: "What type of an extension do you want to create?",
+                        type: "list",
+                        choices: [
+                            { name: "Admin extension", value: "admin" },
+                            { name: "API extension", value: "api" }
+                        ]
+                    },
+                    {
+                        name: "name",
+                        message: "Enter the extension name:",
+                        default: "myCustomExtension",
+                        validate: name => {
+                            if (!name) {
+                                return "Missing extension name.";
+                            }
+
+                            const isValidName = name === Case.camel(name);
+                            if (!isValidName) {
+                                return `Please use camel case when providing the name of the extension (for example "myCustomExtension").`;
+                            }
+
+                            return true;
+                        }
+                    },
+                    {
+                        name: "location",
+                        message: `Enter the extension location:`,
+                        default: (answers: Input) => {
+                            return `${EXTENSIONS_ROOT_FOLDER}/${answers.name}`;
+                        },
+                        validate: location => {
+                            if (!location) {
+                                return "Please enter the package location.";
+                            }
+
+                            if (!location.startsWith(`${EXTENSIONS_ROOT_FOLDER}/`)) {
+                                return `Package location must start with "${EXTENSIONS_ROOT_FOLDER}/".`;
+                            }
+
+                            const locationPath = path.resolve(location);
+                            if (fs.existsSync(locationPath)) {
+                                return `The target location already exists "${location}".`;
+                            }
+
+                            return true;
+                        }
+                    },
+                    {
+                        name: "packageName",
+                        message: "Enter the package name:",
+                        default: (answers: Input) => {
+                            return Case.kebab(answers.name);
+                        },
+                        validate: pkgName => {
+                            if (!pkgName) {
+                                return "Missing package name.";
+                            }
+
+                            const isValidName = validateNpmPackageName(pkgName);
+                            if (!isValidName) {
+                                return `Package name must be a valid NPM package name, for example "my-custom-extension".`;
+                            }
+
+                            return true;
+                        }
+                    },
+                    {
+                        name: "dependencies",
+                        message: "Enter one or more NPM dependencies (optional):",
+                        required: false
                     }
                 ];
+            },
+            generate: async ({ input, ora, context }) => {
+                const { type, name } = input;
+                if (!type) {
+                    throw new Error("Missing extension type.");
+                }
 
-                replaceInPath(path.join(location, "**/*.*"), codeReplacements);
+                const templatePath = path.join(__dirname, "templates", type);
+                const templateExists = fs.existsSync(templatePath);
+                if (!templateExists) {
+                    throw new Error("Unknown extension type.");
+                }
 
-                if (input.dependencies) {
-                    const packageJsonPath = path.join(location, "package.json");
-                    const packageJson = await readJson<PackageJson>(packageJsonPath);
-                    if (!packageJson.dependencies) {
-                        packageJson.dependencies = {};
-                    }
+                if (!name) {
+                    throw new Error("Missing extension name.");
+                }
 
-                    const packages = input.dependencies.split(",");
-                    for (const packageName of packages) {
-                        const isWebinyPackage = packageName.startsWith("@webiny/");
-                        if (isWebinyPackage) {
-                            packageJson.dependencies[packageName] = context.version;
-                            continue;
+                let { packageName, location } = input;
+                if (!packageName) {
+                    packageName = Case.kebab(name);
+                }
+
+                if (!location) {
+                    location = `${EXTENSIONS_ROOT_FOLDER}/${name}`;
+                }
+
+                if (fs.existsSync(location)) {
+                    throw new WebinyError(`The target location already exists "${location}"`);
+                }
+
+                try {
+                    ora.start(`Creating ${log.success.hl(name)} extension...`);
+
+                    // Copy template files
+                    fs.mkdirSync(location, { recursive: true });
+                    await ncp(templatePath, location);
+
+                    const project = getProject();
+
+                    const baseTsConfigFullPath = path.resolve(project.root, "tsconfig.json");
+                    const baseTsConfigRelativePath = path.relative(location, baseTsConfigFullPath);
+
+                    const codeReplacements = [
+                        { find: "PACKAGE_NAME", replaceWith: packageName },
+                        {
+                            find: "BASE_TSCONFIG_PATH",
+                            replaceWith: baseTsConfigRelativePath
+                        }
+                    ];
+
+                    replaceInPath(path.join(location, "**/*.*"), codeReplacements);
+
+                    if (input.dependencies) {
+                        const packageJsonPath = path.join(location, "package.json");
+                        const packageJson = await readJson<PackageJson>(packageJsonPath);
+                        if (!packageJson.dependencies) {
+                            packageJson.dependencies = {};
                         }
 
-                        try {
-                            const { stdout } = await execa("npm", [
-                                "view",
-                                packageName,
-                                "version",
-                                "json"
-                            ]);
+                        const packages = input.dependencies.split(",");
+                        for (const packageName of packages) {
+                            const isWebinyPackage = packageName.startsWith("@webiny/");
+                            if (isWebinyPackage) {
+                                packageJson.dependencies[packageName] = context.version;
+                                continue;
+                            }
 
-                            packageJson.dependencies[packageName] = `^${stdout}`;
-                        } catch (e) {
-                            throw new Error(
-                                `Could not find ${log.error.hl(
-                                    packageName
-                                )} NPM package. Please double-check the package name and try again.`,
-                                { cause: e }
-                            );
+                            try {
+                                const { stdout } = await execa("npm", [
+                                    "view",
+                                    packageName,
+                                    "version",
+                                    "json"
+                                ]);
+
+                                packageJson.dependencies[packageName] = `^${stdout}`;
+                            } catch (e) {
+                                throw new Error(
+                                    `Could not find ${log.error.hl(
+                                        packageName
+                                    )} NPM package. Please double-check the package name and try again.`,
+                                    { cause: e }
+                                );
+                            }
                         }
+
+                        await writeJson(packageJsonPath, packageJson);
                     }
 
-                    await writeJson(packageJsonPath, packageJson);
+                    // Add package to workspaces
+                    const rootPackageJsonPath = path.join(project.root, "package.json");
+                    const rootPackageJson = await readJson<PackageJson>(rootPackageJsonPath);
+                    if (!rootPackageJson.workspaces.packages.includes(location)) {
+                        rootPackageJson.workspaces.packages.push(location);
+                        await writeJson(rootPackageJsonPath, rootPackageJson);
+                    }
+
+                    if (typeof generators[type] === "function") {
+                        await generators[type]({ input: { name, packageName } });
+                    }
+
+                    // Sleep for 1 second before proceeding with yarn installation.
+                    await new Promise(resolve => {
+                        setTimeout(resolve, 1000);
+                    });
+
+                    // Once everything is done, run `yarn` so the new packages are installed.
+                    await execa("yarn");
+
+                    ora.succeed(`New extension created in ${log.success.hl(location)}.`);
+                } catch (err) {
+                    ora.fail("Could not create extension. Please check the logs below.");
+                    console.log();
+                    console.log(err);
                 }
-
-                // Add package to workspaces
-                const rootPackageJsonPath = path.join(project.root, "package.json");
-                const rootPackageJson = await readJson<PackageJson>(rootPackageJsonPath);
-                if (!rootPackageJson.workspaces.packages.includes(location)) {
-                    rootPackageJson.workspaces.packages.push(location);
-                    await writeJson(rootPackageJsonPath, rootPackageJson);
-                }
-
-                if (typeof generators[type] === "function") {
-                    await generators[type]({ input: { name, packageName } });
-                }
-
-                // Sleep for 1 second before proceeding with yarn installation.
-                await new Promise(resolve => {
-                    setTimeout(resolve, 1000);
-                });
-
-                // Once everything is done, run `yarn` so the new packages are installed.
-                await execa("yarn");
-
-                ora.succeed(`New extension created in ${log.success.hl(location)}.`);
-            } catch (err) {
-                ora.fail("Could not create extension. Please check the logs below.");
-                console.log();
-                console.log(err);
             }
         }
-    }
-});
+    } as CliCommandScaffoldTemplate<Input>
+];

--- a/packages/cli-plugin-scaffold-extensions/templates/admin/package.json
+++ b/packages/cli-plugin-scaffold-extensions/templates/admin/package.json
@@ -2,6 +2,10 @@
   "name": "PACKAGE_NAME",
   "main": "src/index.tsx",
   "version": "1.0.0",
+  "keywords": [
+    "webiny-extension",
+    "webiny-extension-type:admin"
+  ],
   "dependencies": {
     "react": "18.2.0"
   }

--- a/packages/cli-plugin-scaffold-extensions/templates/api/package.json
+++ b/packages/cli-plugin-scaffold-extensions/templates/api/package.json
@@ -1,5 +1,9 @@
 {
   "name": "PACKAGE_NAME",
   "main": "src/index.ts",
+  "keywords": [
+    "webiny-extension",
+    "webiny-extension-type:api"
+  ],
   "version": "1.0.0"
 }

--- a/packages/cli-plugin-scaffold/src/types.ts
+++ b/packages/cli-plugin-scaffold/src/types.ts
@@ -148,6 +148,7 @@ export interface PackageJson {
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
     peerDependencies: Record<string, string>;
+    keywords?: string[];
     workspaces: {
         packages: string[];
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17736,6 +17736,7 @@ __metadata:
     "@webiny/project-utils": 0.0.0
     case: ^1.6.3
     execa: ^5.0.0
+    glob: ^7.1.2
     load-json-file: ^6.2.0
     ncp: ^2.0.0
     replace-in-path: ^1.1.0


### PR DESCRIPTION
## Changes
This PR contains several improvements:

1) A new `Tags` field renderer was added to Headless CMS multi-value text field
2) Our CLI now has a `link-extensions` command, which scans extensions in your project, and regenerates API and Admin extensions entry points. It also registers workspaces in the root package.json file. This command was inspired by our latest docs articles on writing extensions, and it will make it super easy to just C/P the code from `webiny-examples` repo, and just run `yarn webiny link-extensions`. The system will do the rest for you.
3) Extensions generated via a scaffold will now contain keywords to help us differentiate between api/admin extensions, which makes it possible to build more tooling around extensions.

## How Has This Been Tested?
Manually.