### PR TITLE
Webiny Telemetry - Use `wts-client` NPM Package

### DIFF
--- a/packages/telemetry/cli.js
+++ b/packages/telemetry/cli.js
@@ -1,6 +1,6 @@
 const { globalConfig } = require("@webiny/global-config");
 const isCI = require("is-ci");
-const { WTS } = require("wts/src/node");
+const { WTS } = require("wts-client/node");
 const baseSendEvent = require("./sendEvent");
 
 const sendEvent = async ({ event, user, version, properties }) => {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,7 +7,7 @@
     "is-ci": "3.0.0",
     "jsesc": "^3.0.2",
     "strip-ansi": "^6.0.1",
-    "wts": "https://github.com/webiny/wts#51fd5a89a8d12b27def57ff99a71e071e9085e6c"
+    "wts-client": "^1.0.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/telemetry/react.js
+++ b/packages/telemetry/react.js
@@ -1,5 +1,5 @@
 const baseSendEvent = require("./sendEvent");
-const { WTS } = require("wts/src/admin");
+const { WTS } = require("wts-client/admin");
 
 const sendEvent = async (event, properties = {}) => {
     const shouldSend = process.env.REACT_APP_WEBINY_TELEMETRY !== "false";

--- a/yarn.lock
+++ b/yarn.lock
@@ -18930,7 +18930,7 @@ __metadata:
     is-ci: 3.0.0
     jsesc: ^3.0.2
     strip-ansi: ^6.0.1
-    wts: "https://github.com/webiny/wts#51fd5a89a8d12b27def57ff99a71e071e9085e6c"
+    wts-client: ^1.0.1
   languageName: unknown
   linkType: soft
 
@@ -41570,14 +41570,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wts@https://github.com/webiny/wts#51fd5a89a8d12b27def57ff99a71e071e9085e6c":
-  version: 2.0.0
-  resolution: "wts@https://github.com/webiny/wts.git#commit=51fd5a89a8d12b27def57ff99a71e071e9085e6c"
+"wts-client@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wts-client@npm:1.0.1"
   dependencies:
     btoa: ^1.2.1
     js-cookie: ^2.2.1
     node-fetch: ^2.6.1
-  checksum: d807a0ad235419c93662eb3da92250677c9baf5a93b3976784f0db6aca63ada465fb1e1a6716f1cbea7e069fcf43a2f9a175d84b860b78af52f54413d0f26a8a
+  checksum: 252b3f371dac0142df9e8cd1f6906fa557df46d9a124302fa1585703231309a8c6de257ad1ff4fa83aa9ccbcfc2f33be4764e12dfc2d0fef6e08be5fe17caa9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
Prior to this PR, [Webiny's telemetry client package](https://github.com/webiny/wts) has been pulled in users' projects [directly from a GitHub release.](https://github.com/webiny/webiny-js/pull/4183/files#diff-0d43c70cbc6a9d4bc14487388a77cd45ce912f5fb30e8aba690c1fa6f9ab3afc) 

Because a user had an issue pulling this (Yarn complained), in order to avoid these issues, we decided to just publish the [`wts-client`](https://www.npmjs.com/package/wts-client) package to NPM and pull the package in users' projects like any other package.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.