### PR TITLE
Headless CMS / `createRevisionFrom` - Ensure Published Records Are Updated Accordingly

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -43,7 +43,7 @@ import { createElasticsearchBody } from "./elasticsearch/body";
 import { createLatestRecordType, createPublishedRecordType, createRecordType } from "./recordType";
 import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
 import { WriteRequest } from "@webiny/aws-sdk/client-dynamodb";
-import { batchReadAll, BatchReadItem, put } from "@webiny/db-dynamodb";
+import { batchReadAll, BatchReadItem } from "@webiny/db-dynamodb";
 import { createTransformer } from "./transformations";
 import { convertEntryKeysFromStorage } from "./transformations/convertEntryKeys";
 import {
@@ -276,6 +276,18 @@ export const createEntriesStorageOperations = (
             SK: createLatestSortKey()
         };
 
+        const publishedKeys = {
+            PK: createPartitionKey({
+                id: entry.id,
+                locale: model.locale,
+                tenant: model.tenant
+            }),
+            SK: createPublishedSortKey()
+        };
+
+        // We'll need this flag below.
+        const isPublished = entry.status === "published";
+
         const esLatestData = await transformer.getElasticsearchLatestEntryData();
 
         const items = [
@@ -294,6 +306,17 @@ export const createEntriesStorageOperations = (
         const { index } = configurations.es({
             model
         });
+
+        if (isPublished) {
+            items.push(
+                entity.putBatch({
+                    ...storageEntry,
+                    TYPE: createPublishedRecordType(),
+                    ...publishedKeys
+                })
+            );
+        }
+
         try {
             await batchWriteAll({
                 table: entity.table,
@@ -313,17 +336,34 @@ export const createEntriesStorageOperations = (
                 }
             );
         }
-        /**
-         * Update the "latest" entry item in the Elasticsearch
-         */
+
+        const { index: esIndex } = configurations.es({
+            model
+        });
+
+        const esItems: BatchWriteItem[] = [
+            esEntity.putBatch({
+                ...latestKeys,
+                index: esIndex,
+                data: esLatestData
+            })
+        ];
+
+        if (isPublished) {
+            const esPublishedData = await transformer.getElasticsearchPublishedEntryData();
+            esItems.push(
+                esEntity.putBatch({
+                    ...publishedKeys,
+                    index: esIndex,
+                    data: esPublishedData
+                })
+            );
+        }
+
         try {
-            await put({
-                entity: esEntity,
-                item: {
-                    ...latestKeys,
-                    index,
-                    data: esLatestData
-                }
+            await batchWriteAll({
+                table: esEntity.table,
+                items: esItems
             });
         } catch (ex) {
             throw new WebinyError(

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFieldsOverrides.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFieldsOverrides.test.ts
@@ -95,7 +95,7 @@ describe("Content entries - Entry Meta Fields Overrides", () => {
         expect(publishedRevWithCustomLastPublishedValues.savedOn > rev.savedOn).toBeTrue();
         expect(
             publishedRevWithCustomLastPublishedValues.revisionFirstPublishedOn >
-            rev.revisionFirstPublishedOn
+                rev.revisionFirstPublishedOn
         ).toBeTrue();
 
         const { data: publishedRevWithAllCustomValues } = await manageIdentityA.createTestEntryFrom(


### PR DESCRIPTION
## Changes
Prior to this PR, if a user would be using the `createRevisionFrom` method (directly or via GraphQL API), and also set the initial status of the revision to `published`, then, subsequently trying to read the entry via the READ GraphQL API would still return the old published version. 

This was happening because, upon creating+publishing the new entry revision, the storage operations code would not take the `status` into account, and do required updates on the "published" record for the CMS entry in question.

With this PR, this issue has been fixed.

## How Has This Been Tested?
Jest.

## Documentation
Changelog.