### PR TITLE
Add Model ID and Used Index Name When Logging Ignored ES Response Errors

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
@@ -1,0 +1,25 @@
+import WebinyError from "@webiny/error";
+import { CmsModel } from "@webiny/api-headless-cms/types";
+
+interface LogIgnoredElasticsearchExceptionParams {
+    error: WebinyError;
+    model: CmsModel;
+    indexName: string;
+}
+
+export const logIgnoredElasticsearchException = (
+    params: LogIgnoredElasticsearchExceptionParams
+) => {
+    const { error, indexName, model } = params;
+
+    console.log(`Ignoring Elasticsearch response error: ${error.message}`, {
+        modelId: model.modelId,
+        usedIndexName: indexName,
+        error: {
+            message: error.message,
+            code: error.code,
+            data: error.data,
+            stack: error.stack
+        }
+    });
+};

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
@@ -7,7 +7,7 @@ interface LogIgnoredElasticsearchExceptionParams {
     indexName: string;
 }
 
-export const logIgnoredElasticsearchException = (
+export const logIgnoredEsResponseError = (
     params: LogIgnoredElasticsearchExceptionParams
 ) => {
     const { error, indexName, model } = params;

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/logIgnoredEsResponseError.ts
@@ -7,9 +7,7 @@ interface LogIgnoredElasticsearchExceptionParams {
     indexName: string;
 }
 
-export const logIgnoredEsResponseError = (
-    params: LogIgnoredElasticsearchExceptionParams
-) => {
+export const logIgnoredEsResponseError = (params: LogIgnoredElasticsearchExceptionParams) => {
     const { error, indexName, model } = params;
 
     console.log(`Ignoring Elasticsearch response error: ${error.message}`, {

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/shouldIgnoreEsResponseError.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/shouldIgnoreEsResponseError.ts
@@ -5,6 +5,6 @@ const IGNORED_ES_SEARCH_EXCEPTIONS = [
     "search_phase_execution_exception"
 ];
 
-export const shouldIgnoreElasticsearchException = (error: WebinyError) => {
+export const shouldIgnoreEsResponseError = (error: WebinyError) => {
     return IGNORED_ES_SEARCH_EXCEPTIONS.includes(error.message);
 };

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/shouldIgnoreEsResponseError.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/shouldIgnoreEsResponseError.ts
@@ -1,0 +1,10 @@
+import WebinyError from "@webiny/error";
+
+const IGNORED_ES_SEARCH_EXCEPTIONS = [
+    "index_not_found_exception",
+    "search_phase_execution_exception"
+];
+
+export const shouldIgnoreElasticsearchException = (error: WebinyError) => {
+    return IGNORED_ES_SEARCH_EXCEPTIONS.includes(error.message);
+};

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -287,10 +287,6 @@ export const createEntriesStorageOperations = (
             })
         ];
 
-        const { index } = configurations.es({
-            model
-        });
-
         if (isPublished) {
             items.push(
                 entity.putBatch({

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -40,6 +40,8 @@ import {
 } from "@webiny/api-elasticsearch/types";
 import { CmsEntryStorageOperations, CmsIndexEntry } from "~/types";
 import { createElasticsearchBody } from "./elasticsearch/body";
+import { logIgnoredEsResponseError } from "./elasticsearch/logIgnoredEsResponseError";
+import { shouldIgnoreEsResponseError } from "./elasticsearch/shouldIgnoreEsResponseError";
 import { createLatestRecordType, createPublishedRecordType, createRecordType } from "./recordType";
 import { StorageOperationsCmsModelPlugin } from "@webiny/api-headless-cms";
 import { WriteRequest } from "@webiny/aws-sdk/client-dynamodb";
@@ -62,24 +64,6 @@ export interface CreateEntriesStorageOperationsParams {
     elasticsearch: Client;
     plugins: PluginsContainer;
 }
-
-const IGNORED_ES_SEARCH_EXCEPTIONS = [
-    "index_not_found_exception",
-    "search_phase_execution_exception"
-];
-
-const shouldIgnoreElasticsearchException = (ex: WebinyError) => {
-    if (IGNORED_ES_SEARCH_EXCEPTIONS.includes(ex.message)) {
-        console.log(`Ignoring Elasticsearch exception: ${ex.message}`);
-        console.log({
-            code: ex.code,
-            data: ex.data,
-            stack: ex.stack
-        });
-        return true;
-    }
-    return false;
-};
 
 export const createEntriesStorageOperations = (
     params: CreateEntriesStorageOperationsParams
@@ -1056,12 +1040,18 @@ export const createEntriesStorageOperations = (
                 index,
                 body
             });
-        } catch (ex) {
+        } catch (error) {
             /**
              * We will silently ignore the `index_not_found_exception` error and return an empty result set.
              * This is because the index might not exist yet, and we don't want to throw an error.
              */
-            if (shouldIgnoreElasticsearchException(ex)) {
+            if (shouldIgnoreEsResponseError(error)) {
+                logIgnoredEsResponseError({
+                    error,
+                    model,
+                    indexName: index
+                });
+
                 return {
                     hasMoreItems: false,
                     totalCount: 0,
@@ -1069,8 +1059,9 @@ export const createEntriesStorageOperations = (
                     items: []
                 };
             }
-            throw new WebinyError(ex.message, ex.code || "ELASTICSEARCH_ERROR", {
-                error: ex,
+
+            throw new WebinyError(error.message, error.code || "ELASTICSEARCH_ERROR", {
+                error,
                 index,
                 body,
                 model
@@ -1767,15 +1758,21 @@ export const createEntriesStorageOperations = (
                 index,
                 body
             });
-        } catch (ex) {
-            if (shouldIgnoreElasticsearchException(ex)) {
+        } catch (error) {
+            if (shouldIgnoreEsResponseError(error)) {
+                logIgnoredEsResponseError({
+                    error,
+                    model,
+                    indexName: index
+                });
                 return [];
             }
+
             throw new WebinyError(
-                ex.message || "Error in the Elasticsearch query.",
-                ex.code || "ELASTICSEARCH_ERROR",
+                error.message || "Error in the Elasticsearch query.",
+                error.code || "ELASTICSEARCH_ERROR",
                 {
-                    error: ex,
+                    error,
                     index,
                     model,
                     body


### PR DESCRIPTION
## Changes
With this PR, we're adding model ID and ES index name to the log that is produced when an ES response error is ignored.

Prior to this PR, these weren't here, which would make it really hard to figure out to which model ID / ES index name was the error related.

## Additional Changes
Instead of handling everything in a single function, I split the code into two functions and extracted them into separate files.

## How Has This Been Tested?
Manually / relying on existing Jest tests.

## Documentation
Changelog.