### PR TITLE
Data Migrations: Improve Disabling and Restoration of ElasticSearch Indexing Settings

### DIFF
--- a/packages/migrations/src/migrations/5.38.0/002/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.38.0/002/ddb-es/index.ts
@@ -35,7 +35,6 @@ interface LastEvaluatedKey {
 }
 
 interface IndexSettings {
-    number_of_replicas: number;
     refresh_interval: `${number}s`;
 }
 

--- a/packages/migrations/src/migrations/5.39.0/001/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.39.0/001/ddb-es/index.ts
@@ -39,7 +39,6 @@ interface LastEvaluatedKey {
 }
 
 interface IndexSettings {
-    number_of_replicas: number;
     refresh_interval: `${number}s`;
 }
 

--- a/packages/migrations/src/migrations/5.39.2/001/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.39.2/001/ddb-es/index.ts
@@ -43,7 +43,6 @@ interface LastEvaluatedKey {
 }
 
 interface IndexSettings {
-    number_of_replicas: number;
     refresh_interval: `${number}s`;
 }
 

--- a/packages/migrations/src/migrations/5.39.6/001/ddb-es/index.ts
+++ b/packages/migrations/src/migrations/5.39.6/001/ddb-es/index.ts
@@ -46,7 +46,6 @@ interface LastEvaluatedKey {
 }
 
 interface IndexSettings {
-    number_of_replicas: number;
     refresh_interval: `${number}s`;
 }
 

--- a/packages/migrations/src/utils/elasticsearch/disableEsIndexing.ts
+++ b/packages/migrations/src/utils/elasticsearch/disableEsIndexing.ts
@@ -18,7 +18,6 @@ export const disableElasticsearchIndexing = async (
             elasticsearchClient: params.elasticsearchClient,
             index,
             settings: {
-                number_of_replicas: 0,
                 refresh_interval: -1
             }
         });

--- a/packages/migrations/src/utils/elasticsearch/fetchOriginalEsSettings.ts
+++ b/packages/migrations/src/utils/elasticsearch/fetchOriginalEsSettings.ts
@@ -9,7 +9,6 @@ interface FetchOriginalElasticsearchSettingsParams {
 }
 
 interface IndexSettings {
-    number_of_replicas: number;
     refresh_interval: `${number}s`;
 }
 
@@ -21,10 +20,9 @@ export const fetchOriginalElasticsearchSettings = async (
         const settings = await esGetIndexSettings({
             elasticsearchClient: params.elasticsearchClient,
             index,
-            fields: ["number_of_replicas", "refresh_interval"]
+            fields: ["refresh_interval"]
         });
         return {
-            number_of_replicas: settings.number_of_replicas || 1,
             refresh_interval: settings.refresh_interval || "1s"
         };
     } catch (ex) {


### PR DESCRIPTION
## Changes
With this PR, we're improving the disablement and restoration of ES indexing settings. Having these improvements would also be useful for previous data migrations, but for now, we won't be porting them to those. We'll start thinking about it when an actual need arises.

First of all, when disabling indexing on an index, we no longer set the `number_of_replicas` to zero. From [this](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/tune-for-indexing-speed.html#_disable_refresh_and_replicas_for_initial_loads) doc:

> This will temporarily put your index at risk since the loss of any shard will cause data loss, but at the same time indexing will be faster since ...

So, because there is risk involved, we decided to simply not fiddle with this setting.

Furthermore, we've addressed an index restoration issue. Prior to this PR, when doing a restoration, previously retrieved ES index would be used. Which is OK, because this way we ensure the original index settings are applied back to the inedx.

But, if a user stopped the data migration manually, and then rerun it, then the restoration step would incorrectly again set "disable indexing" settings. This is because it would use the index settings that were retrieved at the beginning of the new run, which, because the previous run has been manually stopped, still contain `refresh_interval: -1`. Ultimately, this setting would be applied when restoring index settings, effectively leaving the "indexing: disabled" setting still active.

## How Has This Been Tested?
Manually. Relying on existing Jest tests.

## Documentation
Changelog.