### PR TITLE
5.39.6-001 Data Migration - Add Support For `WEBINY_MIGRATION_FORCE_EXECUTE_5_39_6_001` Env Var

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -303,10 +303,6 @@ export const createEntriesStorageOperations = (
             })
         ];
 
-        const { index } = configurations.es({
-            model
-        });
-
         if (isPublished) {
             items.push(
                 entity.putBatch({

--- a/packages/migrations/src/migrations/5.39.6/001/ddb-es/MetaFieldsMigration.ts
+++ b/packages/migrations/src/migrations/5.39.6/001/ddb-es/MetaFieldsMigration.ts
@@ -71,8 +71,16 @@ export class MetaFieldsMigration {
         });
 
         if (dataMigrationRecordExists) {
-            this.logger.info("5.39.6-001 migration has already been executed. Exiting...");
-            return;
+            const forceExecuteEnvVar = process.env["WEBINY_MIGRATION_FORCE_EXECUTE_5_39_6_001"];
+            const forceExecute = forceExecuteEnvVar === "true";
+            if (!forceExecute) {
+                this.logger.info("5.39.6-001 migration has already been executed. Exiting...");
+                return;
+            }
+
+            this.logger.info(
+                "5.39.6-001 migration has already been executed, but force execution was requested."
+            );
         }
 
         this.logger.info("Starting 5.39.6-001 meta fields data migration...");


### PR DESCRIPTION
## Changes
With this PR, users are able to set `WEBINY_MIGRATION_FORCE_EXECUTE_5_39_6_001=true` upon running the new 5.39.6-001 data migration. Previously this was not the case. The only way to force the reexecution of the data migration would be by deleting the data migration record in the database.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.