### PR TITLE
fix(api-file-manager-s3): use withoutEnlargement when resizing images

### DIFF
--- a/packages/api-file-manager-s3/src/assetDelivery/s3/SharpTransform.ts
+++ b/packages/api-file-manager-s3/src/assetDelivery/s3/SharpTransform.ts
@@ -76,7 +76,7 @@ export class SharpTransform implements AssetTransformationStrategy {
                 const buffer = await optimizedImage.getContents();
                 const transformedBuffer = sharp(buffer, { animated: this.isAssetAnimated(asset) })
                     .withMetadata()
-                    .resize({ width })
+                    .resize({ width, withoutEnlargement: true })
                     .toBuffer();
 
                 /**


### PR DESCRIPTION
## Changes
This PR ensures that images are not upscaled when the requested size is larger than the original image.

## How Has This Been Tested?
Manually, by uploading an image of size 290x290, and requesting a `width=2500`. The returned image was of the original image size.

