### PR TITLE
fix(api-headless-cms): validate model import

### DIFF
--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -82,7 +82,7 @@ const fieldSchema = zod.object({
     renderer: zod
         .object({
             name: shortString,
-            settings: zod.object({}).passthrough().optional()
+            settings: zod.object({}).passthrough().nullish().optional()
         })
         .optional()
         .nullable()

--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -1,4 +1,5 @@
 import { CmsModel } from "./model";
+import { GenericRecord } from "@webiny/api/types";
 
 export type CmsModelFieldType =
     | "boolean"
@@ -258,7 +259,7 @@ interface CmsModelFieldRenderer {
     /**
      * Renderer settings allow you to configure field renderer on a field level.
      */
-    settings?: Record<string, any>;
+    settings?: GenericRecord<string> | null;
 }
 
 /**


### PR DESCRIPTION
## Changes
Model import validation failed when renderer settings were set to null. We now allow null.

## How Has This Been Tested?
Jest and manually.

