### PR TITLE
fix: increase lambda memory size

### DIFF
--- a/packages/cli-plugin-scaffold-graphql-api/template/pulumi/dev/graphql.ts
+++ b/packages/cli-plugin-scaffold-graphql-api/template/pulumi/dev/graphql.ts
@@ -72,7 +72,7 @@ class Graphql {
                 description: "Project application name - GraphQL API Lambda function.",
                 role: role.arn,
                 timeout: 30,
-                memorySize: 512,
+                memorySize: 1024,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")
                 }),

--- a/packages/cli-plugin-scaffold-graphql-api/template/pulumi/prod/graphql.ts
+++ b/packages/cli-plugin-scaffold-graphql-api/template/pulumi/prod/graphql.ts
@@ -74,7 +74,7 @@ class Graphql {
                 description: "Project application name - GraphQL API Lambda function.",
                 role: this.role.arn,
                 timeout: 30,
-                memorySize: 512,
+                memorySize: 1024,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive("../code/graphql/build")
                 }),

--- a/packages/pulumi-aws/src/apps/api/ApiApwScheduler.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiApwScheduler.ts
@@ -108,7 +108,7 @@ function createExecuteActionLambda(app: PulumiApp, params: ScheduleActionParams)
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 128,
+            memorySize: 512,
             description: "Handle execute action workflow in apw scheduler",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(
@@ -211,7 +211,7 @@ function createScheduleActionLambda(
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 128,
+            memorySize: 512,
             description: "Handle schedule action workflow in apw scheduler",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(

--- a/packages/pulumi-aws/src/apps/api/ApiBackgroundTask.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiBackgroundTask.ts
@@ -26,7 +26,7 @@ export const ApiBackgroundTask = createAppModule({
                     return Array.from(new Set([...(arns || []), getLayerArn("sharp")]));
                 }),
                 timeout: 900,
-                memorySize: 512,
+                memorySize: 1024,
                 description: "Performs background tasks."
             }
         });

--- a/packages/pulumi-aws/src/apps/api/ApiFileManager.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiFileManager.ts
@@ -35,7 +35,7 @@ export const ApiFileManager = createAppModule({
                 runtime: LAMBDA_RUNTIME,
                 handler: "handler.handler",
                 timeout: 30,
-                memorySize: 512,
+                memorySize: 1024,
                 description: "Triggered when a file is deleted.",
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive(

--- a/packages/pulumi-aws/src/apps/api/ApiGraphql.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiGraphql.ts
@@ -48,7 +48,7 @@ export const ApiGraphql = createAppModule({
                 handler: "handler.handler",
                 role: role.output.arn,
                 timeout: 30,
-                memorySize: 512,
+                memorySize: 1024,
                 code: new pulumi.asset.AssetArchive({
                     ".": new pulumi.asset.FileArchive(
                         path.join(app.paths.workspace, "graphql/build")

--- a/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiPageBuilder.ts
@@ -58,7 +58,7 @@ function createExportResources(app: PulumiApp, params: PageBuilderParams) {
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 512,
+            memorySize: 1024,
             description: "Handle export's combine workflow",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(
@@ -82,7 +82,7 @@ function createExportResources(app: PulumiApp, params: PageBuilderParams) {
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 512,
+            memorySize: 1024,
             description: "Handle export's process workflow",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(
@@ -199,7 +199,7 @@ function createImportResources(app: PulumiApp, params: PageBuilderParams) {
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 512,
+            memorySize: 1024,
             description: "Handle import queue process workflow",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(
@@ -223,7 +223,7 @@ function createImportResources(app: PulumiApp, params: PageBuilderParams) {
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 60,
-            memorySize: 512,
+            memorySize: 1024,
             description: "Handle import queue create workflow",
             code: new pulumi.asset.AssetArchive({
                 ".": new pulumi.asset.FileArchive(

--- a/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
+++ b/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
@@ -100,7 +100,7 @@ function createRenderSubscriber(
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 30,
-            memorySize: 512,
+            memorySize: 1024,
             environment: {
                 variables: getCommonLambdaEnvVariables().apply(value => ({
                     ...value,
@@ -235,7 +235,7 @@ function createFlushService(
             runtime: LAMBDA_RUNTIME,
             handler: "handler.handler",
             timeout: 30,
-            memorySize: 512,
+            memorySize: 1024,
             environment: {
                 variables: getCommonLambdaEnvVariables().apply(value => ({
                     ...value,


### PR DESCRIPTION
## Changes
This PR increases `memorySize` for most of our Lambdas which are getting deployed.

128MB will be left on `WebsiteTenantRouter` and `tenantRouter` Lambdas as it is custom code, which does not load whole Webiny system.

## How Has This Been Tested?
Jest and manually.