### PR TITLE
fix(api-headless-cms): skip invalid DZ values instead of throwing

### DIFF
--- a/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/graphqlFields/dynamicZone/dynamicZoneField.ts
@@ -92,7 +92,7 @@ const createResolver = (
         const resolver = (parent: any) => {
             const value = parent[field.fieldId];
             if (!value) {
-                return field.multipleValues ? [] : value;
+                return value;
             }
 
             const typeName = `${graphQLType}_${createTypeName(field.fieldId)}`;


### PR DESCRIPTION
## Changes
This PR ensures that DZ field storage doesn't create a default `[]` value, because it will break subsequent partial draft saving. To make this possible, we had to reduce the amount of errors being thrown by DZ field transform plugin, and instead use reasonable fallbacks. If the incoming value is not valid for storage,  we simply skip it. Doing it this way ensures data consistency in the database/opensearch, and also allows us to save partial entries, where a DZ field can be `null` or `undefined`.

## How Has This Been Tested?
Manually, and Jest tests.