### PR TITLE
fix(api-headless-cms): gracefully fall back to applicable fields

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentModel.crud.test.ts
@@ -602,7 +602,7 @@ describe("content model test", () => {
         });
     });
 
-    test("error when assigning titleFieldId on non existing field", async () => {
+    test("when assigning `titleFieldId` to a non-existing field, fall back to the first applicable field", async () => {
         const { createContentModelMutation, updateContentModelMutation } =
             useGraphQLHandler(manageHandlerOpts);
         const [createResponse] = await createContentModelMutation({
@@ -649,15 +649,10 @@ describe("content model test", () => {
         expect(response).toMatchObject({
             data: {
                 updateContentModel: {
-                    data: null,
-                    error: {
-                        code: "VALIDATION_ERROR",
-                        message: `Field selected for the title field does not exist in the model.`,
-                        data: {
-                            fieldId: "nonExistingTitleFieldId",
-                            fields: expect.any(Array)
-                        }
-                    }
+                    data: {
+                        titleFieldId: "field1"
+                    },
+                    error: null
                 }
             }
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/multipleValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/multipleValues.test.ts
@@ -135,20 +135,13 @@ describe("multiple values in field", () => {
             }
         });
 
-        expect(response).toEqual({
+        expect(response).toMatchObject({
             data: {
                 updateContentModel: {
-                    data: null,
-                    error: {
-                        code: "ENTRY_TITLE_FIELD_TYPE",
-                        message:
-                            "Fields that accept multiple values cannot be used as the entry title.",
-                        data: {
-                            storageId: expect.stringMatching("text@"),
-                            fieldId: "availableSizes",
-                            type: "text"
-                        }
-                    }
+                    data: {
+                        titleFieldId: "title"
+                    },
+                    error: null
                 }
             }
         });

--- a/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/predefinedValues.test.ts
@@ -26,7 +26,7 @@ describe("predefined values", () => {
 
     const setupBugModel = async (
         contentModelGroup: CmsGroup,
-        overrides: Record<string, any> = {}
+        overrides: (model: CmsModel) => Partial<CmsModel> = () => ({})
     ): Promise<CmsModel> => {
         const model = models.find(m => m.modelId === "bug");
         if (!model) {
@@ -53,7 +53,7 @@ describe("predefined values", () => {
             data: {
                 fields: model.fields,
                 layout: model.layout,
-                ...overrides
+                ...(overrides ? overrides(model) : {})
             }
         });
         return update.data.updateContentModel.data;
@@ -61,7 +61,7 @@ describe("predefined values", () => {
 
     test("should create an entry with predefined values selected", async () => {
         const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {});
+        await setupBugModel(contentModelGroup);
 
         const { createBug } = useBugManageHandler({
             ...manageOpts
@@ -111,7 +111,7 @@ describe("predefined values", () => {
 
     test("should fail creating an entry with wrong predefined text value selected", async () => {
         const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {});
+        await setupBugModel(contentModelGroup);
 
         const { createBug } = useBugManageHandler({
             ...manageOpts
@@ -150,7 +150,7 @@ describe("predefined values", () => {
 
     test("should fail creating an entry with wrong predefined number value selected", async () => {
         const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {});
+        await setupBugModel(contentModelGroup);
 
         const { createBug } = useBugManageHandler({
             ...manageOpts
@@ -189,7 +189,7 @@ describe("predefined values", () => {
 
     test("should fail creating an entry with wrong predefined number and text values selected", async () => {
         const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {});
+        await setupBugModel(contentModelGroup);
 
         const { createBug } = useBugManageHandler({
             ...manageOpts
@@ -233,115 +233,11 @@ describe("predefined values", () => {
         });
     });
 
-    test("title should be a selected predefined text value label", async () => {
-        const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {
-            titleFieldId: "bugType"
-        });
-
-        const { createBug } = useBugManageHandler({
-            ...manageOpts
-        });
-
-        const [response] = await createBug({
-            data: {
-                name: "A hard debuggable bug",
-                bugType: "critical",
-                bugValue: 2,
-                bugFixed: 3
-            }
-        });
-
-        expect(response).toEqual({
-            data: {
-                createBug: {
-                    data: {
-                        id: expect.any(String),
-                        createdOn: expect.stringMatching(/^20/),
-                        modifiedOn: null,
-                        savedOn: expect.stringMatching(/^20/),
-                        createdBy: {
-                            id: "id-12345678",
-                            displayName: "John Doe",
-                            type: "admin"
-                        },
-                        lastPublishedOn: null,
-                        firstPublishedOn: null,
-                        meta: {
-                            locked: false,
-                            modelId: "bug",
-                            status: "draft",
-                            title: "Critical bug!",
-                            version: 1
-                        },
-                        name: "A hard debuggable bug",
-                        bugType: "critical",
-                        bugValue: 2,
-                        bugFixed: 3
-                    },
-                    error: null
-                }
-            }
-        });
-    });
-
-    test("title should be a selected predefined number value label", async () => {
-        const contentModelGroup = await setupContentModelGroup();
-        await setupBugModel(contentModelGroup, {
-            titleFieldId: "bugValue"
-        });
-
-        const { createBug } = useBugManageHandler({
-            ...manageOpts
-        });
-
-        const [response] = await createBug({
-            data: {
-                name: "A hard debuggable bug",
-                bugType: "critical",
-                bugValue: 3,
-                bugFixed: 3
-            }
-        });
-
-        expect(response).toEqual({
-            data: {
-                createBug: {
-                    data: {
-                        id: expect.any(String),
-                        createdOn: expect.stringMatching(/^20/),
-                        modifiedOn: null,
-                        savedOn: expect.stringMatching(/^20/),
-                        createdBy: {
-                            id: "id-12345678",
-                            displayName: "John Doe",
-                            type: "admin"
-                        },
-                        lastPublishedOn: null,
-                        firstPublishedOn: null,
-                        meta: {
-                            locked: false,
-                            modelId: "bug",
-                            status: "draft",
-                            title: "High bug value",
-                            version: 1
-                        },
-                        name: "A hard debuggable bug",
-                        bugType: "critical",
-                        bugValue: 3,
-                        bugFixed: 3
-                    },
-                    error: null
-                }
-            }
-        });
-    });
-
     it("should be able to create an entry with default bug type value", async () => {
         const contentModelGroup = await setupContentModelGroup();
-        const bugModel = await setupBugModel(contentModelGroup, {
+        const bugModel = await setupBugModel(contentModelGroup, () => ({
             titleFieldId: "bugValue"
-        });
+        }));
 
         const { createBug } = useBugManageHandler({
             ...manageOpts
@@ -377,7 +273,7 @@ describe("predefined values", () => {
                             locked: false,
                             modelId: "bug",
                             status: "draft",
-                            title: "High bug value",
+                            title: "A hard debuggable bug - none",
                             version: 1
                         },
                         name: "A hard debuggable bug - none",
@@ -456,7 +352,7 @@ describe("predefined values", () => {
                             locked: false,
                             modelId: "bug",
                             status: "draft",
-                            title: "High bug value",
+                            title: "A hard debuggable bug - undefined",
                             version: 1
                         },
                         name: "A hard debuggable bug - undefined",

--- a/packages/api-headless-cms/src/crud/contentModel/fields/getApplicableFieldById.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/fields/getApplicableFieldById.ts
@@ -1,0 +1,13 @@
+import { CmsModelField } from "~/types";
+
+export const getApplicableFieldById = (
+    fields: CmsModelField[],
+    id: string | null | undefined,
+    isApplicable: (field: CmsModelField) => boolean
+) => {
+    if (!id) {
+        return undefined;
+    }
+
+    return fields.find(field => field.fieldId === id && isApplicable(field));
+};

--- a/packages/api-headless-cms/src/crud/contentModel/fields/imageField.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/fields/imageField.ts
@@ -1,57 +1,27 @@
 import { CmsModelField } from "~/types";
 import { getBaseFieldType } from "~/utils/getBaseFieldType";
-import WebinyError from "@webiny/error";
+import { getApplicableFieldById } from "./getApplicableFieldById";
+
+const isFieldApplicable = (field: CmsModelField) => {
+    return Boolean(
+        getBaseFieldType(field) === "file" && !field.multipleValues && field.settings?.imagesOnly
+    );
+};
 
 export const getContentModelImageFieldId = (
     fields: CmsModelField[],
     imageFieldId?: string | null
-): string | null | undefined => {
-    /**
-     * If there are no fields defined, we will just set as null.
-     */
+) => {
     if (fields.length === 0) {
         return null;
     }
-    /**
-     * If image field is not defined, let us find possible one.
-     */
-    if (!imageFieldId) {
-        const imageField = fields.find(field => {
-            return (
-                getBaseFieldType(field) === "file" &&
-                !field.multipleValues &&
-                field.settings?.imagesOnly
-            );
-        });
-        return imageField?.fieldId || null;
-    }
-    const target = fields.find(
-        field =>
-            field.fieldId === imageFieldId &&
-            getBaseFieldType(field) === "file" &&
-            field.settings?.imagesOnly
-    );
-    if (!target) {
-        throw new WebinyError(
-            `Field selected for the image field does not exist in the model.`,
-            "VALIDATION_ERROR",
-            {
-                fieldId: imageFieldId,
-                fields
-            }
-        );
-    }
-    if (target.multipleValues) {
-        throw new WebinyError(
-            `Fields that accept multiple values cannot be used as the entry image.`,
-            "ENTRY_TITLE_FIELD_TYPE",
-            {
-                storageId: target.storageId,
-                fieldId: target.fieldId,
-                type: target.type
-            }
-        );
+
+    const target = getApplicableFieldById(fields, imageFieldId, isFieldApplicable);
+
+    if (target) {
+        return target.fieldId;
     }
 
-    return target.fieldId;
+    const imageField = fields.find(isFieldApplicable);
+    return imageField ? imageField.fieldId : null;
 };

--- a/packages/api-headless-cms/src/types/model.ts
+++ b/packages/api-headless-cms/src/types/model.ts
@@ -94,7 +94,7 @@ export interface CmsModel {
      * The field that is used as an entry title.
      * If not specified by the user, the system tries to assign the first available `text` field.
      */
-    titleFieldId: string | null;
+    titleFieldId: string;
     /**
      * The field that is used as an entry description.
      * If not set by the user, the system will try to assign the first available `long-text` field.

--- a/packages/api-headless-cms/src/types/model.ts
+++ b/packages/api-headless-cms/src/types/model.ts
@@ -91,18 +91,18 @@ export interface CmsModel {
      */
     lockedFields?: LockedField[];
     /**
-     * The field that is being displayed as entry title.
-     * It is picked as first available text field. Or user can select own field.
+     * The field that is used as an entry title.
+     * If not specified by the user, the system tries to assign the first available `text` field.
      */
-    titleFieldId: string;
+    titleFieldId: string | null;
     /**
-     * The field which is displayed as the description one.
-     * Only way this is null or undefined is that there are no long-text fields to be set as description.
+     * The field that is used as an entry description.
+     * If not set by the user, the system will try to assign the first available `long-text` field.
      */
     descriptionFieldId?: string | null;
     /**
-     * The field which is displayed as the image.
-     * Only way this is null or undefined is that there are no file fields, with images only set, to be set as image.
+     * The field that is used as an entry image.
+     * If not set by the user, the system will try to assign a `file` field which has `imagesOnly` enabled.
      */
     imageFieldId?: string | null;
     /**


### PR DESCRIPTION
## Changes
This PR removes throwing of errors when dealing with `titleFieldId`, `descriptionFieldId`, and `imageFieldId` in the CMS model editor. If an inapplicable field is sent to the API (which is not even possible through the UI, you can only do this via a programmatic API call), the API will no longer throw errors. Instead, it will gracefully fall back to the applicable fields, if possible. Otherwise, the field roles will simply be set to: `id` for `titleFieldId`, and `null` for `descriptionFieldId` and `imageFieldId`.

## How Has This Been Tested?
---