### PR TITLE
Trigger `cli-create-webiny-project-end` Before Auto Deployment

### DIFF
--- a/packages/create-webiny-project/package.json
+++ b/packages/create-webiny-project/package.json
@@ -29,7 +29,8 @@
     "uuid": "8.3.2",
     "validate-npm-package-name": "3.0.0",
     "write-json-file": "4.3.0",
-    "yargs": "15.4.1"
+    "yargs": "15.4.1",
+    "yesno": "^0.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-webiny-project/utils/createProject.js
+++ b/packages/create-webiny-project/utils/createProject.js
@@ -12,6 +12,7 @@ const validateProjectName = require("./validateProjectName");
 const yaml = require("js-yaml");
 const findUp = require("find-up");
 const { GracefulError } = require("./GracefulError");
+const yesno = require("yesno");
 
 const NOT_APPLICABLE = gray("N/A");
 const HL = bold(gray("—")).repeat(30);
@@ -260,7 +261,8 @@ module.exports = async function createProject({
 
         console.log();
 
-        await require(templatePath)({
+        const setupTemplate = require(templatePath);
+        await setupTemplate({
             log,
             isGitAvailable,
             projectName,
@@ -365,4 +367,61 @@ module.exports = async function createProject({
 
         process.exit(1);
     }
+
+    console.log();
+    console.log(
+        `🎉 Your new Webiny project ${green(
+            projectName
+        )} has been created and is ready to be deployed for the first time!`
+    );
+    console.log();
+
+    const ok = await yesno({
+        question: bold(`${green("?")} Would you like to deploy your project now (Y/n)?`),
+        defaultValue: true
+    });
+
+    console.log();
+
+    if (ok) {
+        console.log("🚀 Deploying your new Webiny project...");
+        console.log();
+
+        try {
+            const command = ["webiny", "deploy"];
+            if (debug) {
+                command.push("--debug");
+            }
+
+            await execa("yarn", command, {
+                cwd: projectRoot,
+                stdio: "inherit"
+            });
+        } catch {
+            // Don't do anything. This is because the `webiny deploy` command has its own
+            // error handling and will print the error message. As far as this setup script
+            // is concerned, it succeeded, and it doesn't need to do anything else.
+        }
+
+        return;
+    }
+
+    console.log(
+        [
+            `Finish the setup by running the following command: ${green(
+                `cd ${projectName} && yarn webiny deploy`
+            )}`,
+            "",
+            `To see all of the available CLI commands, run ${green(
+                "yarn webiny --help"
+            )} in your ${green(projectName)} directory.`,
+            "",
+            "Want to dive deeper into Webiny? Check out https://webiny.com/docs/!",
+            "Like the project? Star us on https://github.com/webiny/webiny-js!",
+            "",
+            "Need help? Join our Slack community! https://www.webiny.com/slack",
+            "",
+            "🚀 Happy coding!"
+        ].join("\n")
+    );
 };

--- a/packages/cwp-template-aws/package.json
+++ b/packages/cwp-template-aws/package.json
@@ -24,8 +24,7 @@
     "lodash": "^4.17.21",
     "open": "^8.4.0",
     "ora": "4.1.1",
-    "write-json-file": "4.3.0",
-    "yesno": "^0.4.0"
+    "write-json-file": "4.3.0"
   },
   "devDependencies": {
     "dotenv": "^8.2.0"

--- a/packages/cwp-template-aws/setup.js
+++ b/packages/cwp-template-aws/setup.js
@@ -7,8 +7,7 @@ const merge = require("lodash/merge");
 const writeJsonFile = require("write-json-file");
 const loadJsonFile = require("load-json-file");
 const getPackages = require("get-yarn-workspaces");
-const { green, yellow, bold } = require("chalk");
-const yesno = require("yesno");
+const { yellow } = require("chalk");
 const ora = require("ora");
 
 const IS_TEST = process.env.NODE_ENV === "test";
@@ -125,89 +124,30 @@ const setup = async args => {
         await writeJsonFile(packageJsonPath, packageJson);
     }
 
-    if (!IS_TEST) {
-        // Install dependencies.
-        console.log();
-        const spinner = ora("Installing packages...").start();
-        try {
-            const subprocess = execa("yarn", [], {
-                cwd: projectRoot,
-                maxBuffer: "500_000_000"
-            });
-            await subprocess;
-            spinner.succeed("Packages installed successfully.");
-        } catch (e) {
-            spinner.fail("Failed to install packages.");
-
-            console.log(e.message);
-
-            throw new Error(
-                "Failed while installing project dependencies. Please check the above Yarn logs for more information.",
-                { cause: e }
-            );
-        }
-    }
-
     if (IS_TEST) {
         return;
     }
 
+    // Install dependencies.
     console.log();
-    console.log(
-        `🎉 Your new Webiny project ${green(
-            projectName
-        )} has been created and is ready to be deployed for the first time!`
-    );
-    console.log();
+    const spinner = ora("Installing packages...").start();
+    try {
+        const subprocess = execa("yarn", [], {
+            cwd: projectRoot,
+            maxBuffer: "500_000_000"
+        });
+        await subprocess;
+        spinner.succeed("Packages installed successfully.");
+    } catch (e) {
+        spinner.fail("Failed to install packages.");
 
-    const ok = await yesno({
-        question: bold(`${green("?")} Would you like to deploy your project now (Y/n)?`),
-        defaultValue: true
-    });
+        console.log(e.message);
 
-    console.log();
-
-    if (ok) {
-        console.log("🚀 Deploying your new Webiny project...");
-        console.log();
-
-        try {
-            const command = ["webiny", "deploy"];
-            if (args.debug) {
-                command.push("--debug");
-            }
-
-            await execa("yarn", command, {
-                cwd: projectRoot,
-                stdio: "inherit"
-            });
-        } catch {
-            // Don't do anything. This is because the `webiny deploy` command has its own
-            // error handling and will print the error message. As far as this setup script
-            // is concerned, it succeeded, and it doesn't need to do anything else.
-        }
-
-        return;
+        throw new Error(
+            "Failed while installing project dependencies. Please check the above Yarn logs for more information.",
+            { cause: e }
+        );
     }
-
-    console.log(
-        [
-            `Finish the setup by running the following command: ${green(
-                `cd ${projectName} && yarn webiny deploy`
-            )}`,
-            "",
-            `To see all of the available CLI commands, run ${green(
-                "yarn webiny --help"
-            )} in your ${green(projectName)} directory.`,
-            "",
-            "Want to dive deeper into Webiny? Check out https://webiny.com/docs/!",
-            "Like the project? Star us on https://github.com/webiny/webiny-js!",
-            "",
-            "Need help? Join our Slack community! https://www.webiny.com/slack",
-            "",
-            "🚀 Happy coding!"
-        ].join("\n")
-    );
 };
 
 module.exports = setup;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18999,7 +18999,6 @@ __metadata:
     open: ^8.4.0
     ora: 4.1.1
     write-json-file: 4.3.0
-    yesno: ^0.4.0
   languageName: unknown
   linkType: soft
 
@@ -24053,6 +24052,7 @@ __metadata:
     validate-npm-package-name: 3.0.0
     write-json-file: 4.3.0
     yargs: 15.4.1
+    yesno: ^0.4.0
   bin:
     create-webiny-project: ./bin.js
   languageName: unknown


### PR DESCRIPTION
## Changes
When a project template has been fully set up, we ask the user if they want to continue with deploying their project.

If they answer yes, then the `cli-create-webiny-project-end` event would trigger only after that deployment has finished. Which should not be the case. The event should be triggered before that deployment.

Note that if the user answered "no", then the event would be triggered, this time correctly because there is no auto deployment happening, and the process would shut down.

## How Has This Been Tested?
Manually.

## Documentation
N/A