### PR TITLE
fix(app-headless-cms): do not set dirty model unless it changed

### DIFF
--- a/packages/app/src/utils/createHashing.ts
+++ b/packages/app/src/utils/createHashing.ts
@@ -1,4 +1,4 @@
-export type IHashingAlgorithm = "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
+export type IHashingAlgorithm = "SHA-1" | "SHA-256" | "SHA-512";
 
 export const createHashing = (algorithm: IHashingAlgorithm) => {
     return async (value: unknown) => {

--- a/packages/app/src/utils/createHashing.ts
+++ b/packages/app/src/utils/createHashing.ts
@@ -1,0 +1,18 @@
+export type IHashingAlgorithm = "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
+
+export const createHashing = (algorithm: IHashingAlgorithm) => {
+    return async (value: unknown) => {
+        const data = JSON.stringify(value);
+        return new Promise<string>(resolve => {
+            window.crypto.subtle.digest(algorithm, new TextEncoder().encode(data)).then(encoded => {
+                const hexes: string[] = [];
+                const view = new DataView(encoded);
+                for (let i = 0; i < view.byteLength; i += 4) {
+                    hexes.push(("00000000" + view.getUint32(i).toString(16)).slice(-8));
+                }
+                const hash = hexes.join("");
+                resolve(hash);
+            });
+        });
+    };
+};

--- a/packages/app/src/utils/index.ts
+++ b/packages/app/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./createHashing";
 export * from "./getApiUrl";
 export * from "./getGqlApiUrl";
 export * from "./getHeadlessCmsGqlApiUrl";


### PR DESCRIPTION
## Changes
When user tries to edit a model, but they do not change anything, and then try to navigate away from the model - they get a popup blocking them from navigating away.
This was because we set a model as a dirty (changed) on model load.

## How Has This Been Tested?
Manually.