### PR TITLE
fix(app-headless-cms): pass default value to nested multiple values

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
@@ -38,13 +38,20 @@ export function useBind({ Bind, field }: UseBindProps) {
 
     return useCallback(
         (index = -1) => {
-            const { parentName } = Bind;
+            const { parentName, displayName } = Bind;
 
             // If there's a parent name assigned to the given Bind component, we need to include it in the new field "name".
             // This allows us to have nested fields (like "object" field with nested properties)
             const name = [parentName, field.fieldId, index >= 0 ? index : undefined]
                 .filter(v => v !== undefined)
                 .join(".");
+
+            console.log("=========== START ===========");
+            console.log("displayName", displayName);
+            console.log("parentName", parentName);
+            console.log("name", name);
+            console.log("index", index);
+            console.log("=========== END ===========");
 
             const componentId = `${name};${cacheKey}`;
 
@@ -69,7 +76,7 @@ export function useBind({ Bind, field }: UseBindProps) {
                     <Bind
                         name={childName || name}
                         validators={childValidators || inputValidators}
-                        defaultValue={index === -1 ? defaultValue : null}
+                        defaultValue={!isMultipleValues ? defaultValue : null}
                     >
                         {bind => {
                             // Multiple-values functions below.

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
@@ -38,20 +38,13 @@ export function useBind({ Bind, field }: UseBindProps) {
 
     return useCallback(
         (index = -1) => {
-            const { parentName, displayName } = Bind;
+            const { parentName } = Bind;
 
             // If there's a parent name assigned to the given Bind component, we need to include it in the new field "name".
             // This allows us to have nested fields (like "object" field with nested properties)
             const name = [parentName, field.fieldId, index >= 0 ? index : undefined]
                 .filter(v => v !== undefined)
                 .join(".");
-
-            console.log("=========== START ===========");
-            console.log("displayName", displayName);
-            console.log("parentName", parentName);
-            console.log("name", name);
-            console.log("index", index);
-            console.log("=========== END ===========");
 
             const componentId = `${name};${cacheKey}`;
 


### PR DESCRIPTION
## Changes
With this PR, we are fixing a bug that occurs when setting `defaultValues` to a field with multiple values inside a dynamic zone template.

### Steps to reproduce:
**Dynamic zone + field with multiple values**

- Create a Dynamic Zone template with `multiple values` set to `true`.
- Inside of it, add a text field with either of the two renderers, `select-box` or `radio-buttons`, with predefined values, one of them being `selected: true`.
- Switch to Preview tab, the default value is not set.
- If `multiple values` is set to `false` the default value is set correctly.

## How Has This Been Tested?
Manually
