### PR TITLE
fix(app-headless-cms): ensure trash bin is empty before deleting content model

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/model.delete.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/model.delete.test.ts
@@ -102,7 +102,9 @@ describe("model delete", () => {
                     data: null,
                     error: {
                         code: "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED",
-                        data: null,
+                        data: {
+                            model: expect.any(Object)
+                        },
                         message: `Cannot delete content model "category" because there are existing entries.`
                     }
                 }

--- a/packages/api-headless-cms/src/crud/contentModel.crud.ts
+++ b/packages/api-headless-cms/src/crud/contentModel.crud.ts
@@ -269,8 +269,7 @@ export const createModelsCrud = (params: CreateModelsCrudParams): CmsModelContex
     });
     assignModelBeforeDelete({
         onModelBeforeDelete,
-        plugins: context.plugins,
-        storageOperations
+        context
     });
 
     /**

--- a/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
@@ -32,7 +32,7 @@ export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) =
 
             if (latestEntries.length > 0) {
                 throw new WebinyError(
-                    `The content model "${model.modelId}" cannot be deleted because there are existing entries.`,
+                    `Cannot delete content model "${model.modelId}" because there are existing entries.`,
                     "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED"
                 );
             }
@@ -41,7 +41,7 @@ export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) =
 
             if (deletedEntries.length > 0) {
                 throw new WebinyError(
-                    `The content model "${model.modelId}" cannot be deleted because there are entries in the trash.`,
+                    `Cannot delete content model "${model.modelId}" because there are existing entries in the trash.`,
                     "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED"
                 );
             }
@@ -50,7 +50,6 @@ export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) =
                 message: "Could not retrieve a list of content entries from the model.",
                 code: "ENTRIES_ERROR",
                 data: {
-                    error: ex,
                     model
                 }
             });

--- a/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/beforeDelete.ts
@@ -1,21 +1,19 @@
 import { Topic } from "@webiny/pubsub/types";
-import { HeadlessCmsStorageOperations, OnModelBeforeDeleteTopicParams } from "~/types";
-import { PluginsContainer } from "@webiny/plugins";
+import { CmsContext, OnModelBeforeDeleteTopicParams } from "~/types";
 import WebinyError from "@webiny/error";
 import { CmsModelPlugin } from "~/plugins/CmsModelPlugin";
 
 interface AssignBeforeModelDeleteParams {
     onModelBeforeDelete: Topic<OnModelBeforeDeleteTopicParams>;
-    storageOperations: HeadlessCmsStorageOperations;
-    plugins: PluginsContainer;
+    context: CmsContext;
 }
 export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) => {
-    const { onModelBeforeDelete, storageOperations, plugins } = params;
+    const { onModelBeforeDelete, context } = params;
 
     onModelBeforeDelete.subscribe(async params => {
         const { model } = params;
 
-        const modelPlugin = plugins
+        const modelPlugin = context.plugins
             .byType<CmsModelPlugin>(CmsModelPlugin.type)
             .find(item => item.contentModel.modelId === model.modelId);
 
@@ -29,30 +27,33 @@ export const assignModelBeforeDelete = (params: AssignBeforeModelDeleteParams) =
             );
         }
 
-        let entries = [];
         try {
-            const result = await storageOperations.entries.list(model, {
-                where: {
-                    latest: true
-                },
-                limit: 1
-            });
-            entries = result.items;
+            const [latestEntries] = await context.cms.listLatestEntries(model, { limit: 1 });
+
+            if (latestEntries.length > 0) {
+                throw new WebinyError(
+                    `The content model "${model.modelId}" cannot be deleted because there are existing entries.`,
+                    "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED"
+                );
+            }
+
+            const [deletedEntries] = await context.cms.listDeletedEntries(model, { limit: 1 });
+
+            if (deletedEntries.length > 0) {
+                throw new WebinyError(
+                    `The content model "${model.modelId}" cannot be deleted because there are entries in the trash.`,
+                    "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED"
+                );
+            }
         } catch (ex) {
-            throw new WebinyError(
-                "Could not retrieve a list of content entries from the model.",
-                "ENTRIES_ERROR",
-                {
+            throw WebinyError.from(ex, {
+                message: "Could not retrieve a list of content entries from the model.",
+                code: "ENTRIES_ERROR",
+                data: {
                     error: ex,
                     model
                 }
-            );
-        }
-        if (entries.length > 0) {
-            throw new WebinyError(
-                `Cannot delete content model "${model.modelId}" because there are existing entries.`,
-                "CONTENT_MODEL_BEFORE_DELETE_HOOK_FAILED"
-            );
+            });
         }
     });
 };


### PR DESCRIPTION
## Changes
With this PR, we are enhancing the deletion process of a content model by providing a specific error message if the trash bin for the selected content model is not empty.

## How Has This Been Tested?
Jest + manually
