### PR TITLE
fix(app-file-manager): use bind prefix context to render extensions

### DIFF
--- a/packages/app-file-manager/src/components/FileDetails/components/Extensions.tsx
+++ b/packages/app-file-manager/src/components/FileDetails/components/Extensions.tsx
@@ -4,7 +4,7 @@ import { CompositionScope } from "@webiny/app-admin";
 import { CmsModel } from "@webiny/app-headless-cms/types";
 import { ModelProvider } from "@webiny/app-headless-cms/admin/components/ModelProvider";
 import { Fields } from "@webiny/app-headless-cms/admin/components/ContentEntryForm/Fields";
-import { Bind, BindComponentProps } from "@webiny/form";
+import { Bind, BindPrefix } from "@webiny/form";
 
 const HideEmptyCells = styled.div`
     .mdc-layout-grid__cell:empty {
@@ -16,13 +16,6 @@ interface ExtensionsProps {
     model: CmsModel;
 }
 
-function BindWithPrefix(props: BindComponentProps) {
-    return (
-        <Bind {...props} name={`extensions.${props.name}`}>
-            {props.children}
-        </Bind>
-    );
-}
 export const Extensions = ({ model }: ExtensionsProps) => {
     const extensionsField = useMemo(() => {
         return model.fields.find(f => f.fieldId === "extensions");
@@ -42,15 +35,17 @@ export const Extensions = ({ model }: ExtensionsProps) => {
     return (
         <CompositionScope name={"fm.fileDetails.extensionFields"}>
             <ModelProvider model={model}>
-                <HideEmptyCells>
-                    <Fields
-                        contentModel={model}
-                        // @ts-expect-error
-                        Bind={BindWithPrefix}
-                        fields={fields}
-                        layout={layout}
-                    />
-                </HideEmptyCells>
+                <BindPrefix name={"extensions"}>
+                    <HideEmptyCells>
+                        <Fields
+                            contentModel={model}
+                            // @ts-expect-error
+                            Bind={Bind}
+                            fields={fields}
+                            layout={layout}
+                        />
+                    </HideEmptyCells>
+                </BindPrefix>
             </ModelProvider>
         </CompositionScope>
     );


### PR DESCRIPTION
## Changes
This PR fixes the problem of prefixing FM extension fields with the `extensions` prefix in the File Details drawer. The problem here is that we support custom CMS field renderers, which are used in the FM extension fields UI. These renderers are unaware of the surroundings, and they simply use the `useBind` hook to bind to whatever the parent Form component is. In case of the File extensions, these fields need to bind to the file `extensions` object field, and not the root file object. We now target this object with `<BindPrefix>` component, which intercepts all child fields, and adds a prefix to the `name`, so, for example `useBind({ name: "myField" })` is automatically bound to `extensions.myField`.

## This used to work before, when did this break?
This used to work in `5.38`, but the implementation worked with nested Form components, where `extensions` had a dedicated Form mounted to handle the nested object. When we got to `Private Files` feature (5.39), the implementation with nested forms started causing state inconsistencies (long story). So we "fixed" it by removing the nested form, and instead passed a decorated `Bind` component to CMS field renderers. This worked great for the built-in field renderers, but for custom renderers that used the `useBind` hook, this broke the field binding path.

## Solution
Using the `<BindPrefix>` removes the need to have nested forms, but allows us to remap all child binds to the desired object within the parent form. This way developers of custom renderers don't need to worry _where_ their field renderer is being used.

## How Has This Been Tested?
Manually, by testing both the File Details drawer and the Bulk Edit action.