### PR TITLE
fix(api-headless-cms): generate model schema

### DIFF
--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -38,13 +38,6 @@ export const createManageResolvers: CreateManageResolvers = ({
     model,
     fieldTypePlugins
 }) => {
-    if (model.fields.length === 0) {
-        return {
-            Query: {},
-            Mutation: {}
-        };
-    }
-
     const createFieldResolvers = createFieldResolversFactory({
         endpointType: "manage",
         models,

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -30,9 +30,7 @@ export const createManageSDL: CreateManageSDL = ({
         fields: model.fields,
         fieldTypePlugins
     });
-    if (inputFields.length === 0) {
-        return "";
-    }
+
     const listFilterFieldsRender = renderListFilterFields({
         model,
         fields: model.fields,

--- a/packages/api-headless-cms/src/graphql/schema/createPreviewResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createPreviewResolvers.ts
@@ -20,12 +20,6 @@ export const createPreviewResolvers: CreateReadResolvers = ({
     model,
     fieldTypePlugins
 }) => {
-    if (model.fields.length === 0) {
-        return {
-            Query: {}
-        };
-    }
-
     const createFieldResolvers = createFieldResolversFactory({
         endpointType: "read",
         models,

--- a/packages/api-headless-cms/src/graphql/schema/createReadResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createReadResolvers.ts
@@ -16,12 +16,6 @@ export interface CreateReadResolvers {
 }
 
 export const createReadResolvers: CreateReadResolvers = ({ models, model, fieldTypePlugins }) => {
-    if (model.fields.length === 0) {
-        return {
-            Query: {}
-        };
-    }
-
     const createFieldResolvers = createFieldResolversFactory({
         endpointType: "read",
         models,

--- a/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createReadSDL.ts
@@ -33,9 +33,6 @@ export const createReadSDL: CreateReadSDL = ({
         fieldTypePlugins
     });
 
-    if (fieldsRender.length === 0) {
-        return "";
-    }
     const listFilterFieldsRender = renderListFilterFields({
         model,
         fields: model.fields,
@@ -70,7 +67,7 @@ export const createReadSDL: CreateReadSDL = ({
             entryId: String!
             ${hasModelIdField ? "" : "modelId: String!"}
             
-            ${onByMetaGqlFields} 
+            ${onByMetaGqlFields}
             
             publishedOn: DateTime @deprecated(reason: "Field was removed with the 5.39.0 release. Use 'firstPublishedOn' or 'lastPublishedOn' field.")
             ownedBy: CmsIdentity @deprecated(reason: "Field was removed with the 5.39.0 release. Use 'createdBy' field.")

--- a/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
+++ b/packages/api-headless-cms/src/graphql/schema/schemaPlugins.ts
@@ -45,65 +45,61 @@ export const generateSchemaPlugins = async (
         type
     });
 
-    models
-        .filter(model => {
-            return model.fields.length > 0;
-        })
-        .forEach(model => {
-            switch (type) {
-                case "manage":
-                    {
-                        const plugin = createCmsGraphQLSchemaPlugin({
-                            typeDefs: createManageSDL({
-                                models,
-                                model,
-                                fieldTypePlugins,
-                                sorterPlugins
-                            }),
-                            resolvers: createManageResolvers({
-                                models,
-                                model,
-                                fieldTypePlugins,
-                                context
-                            })
-                        });
-                        plugin.name = `headless-cms.graphql.schema.manage.${model.modelId}`;
-                        schemaPlugins.push(plugin);
-                    }
+    models.forEach(model => {
+        switch (type) {
+            case "manage":
+                {
+                    const plugin = createCmsGraphQLSchemaPlugin({
+                        typeDefs: createManageSDL({
+                            models,
+                            model,
+                            fieldTypePlugins,
+                            sorterPlugins
+                        }),
+                        resolvers: createManageResolvers({
+                            models,
+                            model,
+                            fieldTypePlugins,
+                            context
+                        })
+                    });
+                    plugin.name = `headless-cms.graphql.schema.manage.${model.modelId}`;
+                    schemaPlugins.push(plugin);
+                }
 
-                    break;
-                case "preview":
-                case "read":
-                    {
-                        const plugin = createCmsGraphQLSchemaPlugin({
-                            typeDefs: createReadSDL({
-                                models,
-                                model,
-                                fieldTypePlugins,
-                                sorterPlugins
-                            }),
-                            resolvers: cms.READ
-                                ? createReadResolvers({
-                                      models,
-                                      model,
-                                      fieldTypePlugins,
-                                      context
-                                  })
-                                : createPreviewResolvers({
-                                      models,
-                                      model,
-                                      fieldTypePlugins,
-                                      context
-                                  })
-                        });
-                        plugin.name = `headless-cms.graphql.schema.${type}.${model.modelId}`;
-                        schemaPlugins.push(plugin);
-                    }
-                    break;
-                default:
-                    return;
-            }
-        });
+                break;
+            case "preview":
+            case "read":
+                {
+                    const plugin = createCmsGraphQLSchemaPlugin({
+                        typeDefs: createReadSDL({
+                            models,
+                            model,
+                            fieldTypePlugins,
+                            sorterPlugins
+                        }),
+                        resolvers: cms.READ
+                            ? createReadResolvers({
+                                  models,
+                                  model,
+                                  fieldTypePlugins,
+                                  context
+                              })
+                            : createPreviewResolvers({
+                                  models,
+                                  model,
+                                  fieldTypePlugins,
+                                  context
+                              })
+                    });
+                    plugin.name = `headless-cms.graphql.schema.${type}.${model.modelId}`;
+                    schemaPlugins.push(plugin);
+                }
+                break;
+            default:
+                return;
+        }
+    });
 
     return schemaPlugins.filter(pl => !!pl.schema.typeDefs);
 };


### PR DESCRIPTION
## Changes
This PR fixes a model schema generation which was introduced with the Trash Bin.
Bug manifests when a user creates a model without default fields - the GraphQL Schema breaks at that point.

## How Has This Been Tested?
Jest and manually.