### PR TITLE
fix(app-file-manager): stack tags when container width is limited

### DIFF
--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/components/TagsList/TagsList.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/components/TagsList/TagsList.tsx
@@ -3,10 +3,8 @@ import { Loader } from "@webiny/app-aco";
 import { Empty } from "./Empty";
 import { Tag } from "./Tag";
 import { TagItem } from "@webiny/app-aco/types";
-import { Select } from "@webiny/ui/Select";
 import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerViewProvider";
-import { Typography } from "@webiny/ui/Typography";
-import { TagListWrapper } from "./styled";
+import { TagListWrapper, TagsFilterSelect, TagsTitle } from "./styled";
 
 interface TagListProps {
     loading: boolean;
@@ -59,15 +57,14 @@ export const TagsList = ({
         return (
             <>
                 <TagListWrapper>
-                    <Typography use="subtitle1">Filter by tag</Typography>
+                    <TagsTitle use="subtitle1">Filter by tag</TagsTitle>
                     {tags.length > 1 ? (
-                        <Select
+                        <TagsFilterSelect
                             disabled={fmView.tags.activeTags.length < 2}
                             size={"small"}
                             value={fmView.tags.filterMode}
                             onChange={mode => fmView.tags.setFilterMode(mode)}
                             options={options}
-                            className="tag-filter"
                         />
                     ) : null}
                 </TagListWrapper>

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/components/TagsList/styled.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/components/TagsList/styled.tsx
@@ -1,4 +1,6 @@
 import styled from "@emotion/styled";
+import { Select } from "@webiny/ui/Select";
+import { Typography } from "@webiny/ui/Typography";
 
 export const TagContainer = styled("div")`
     display: flex;
@@ -36,13 +38,21 @@ export const EmptyContainer = styled("div")`
     color: var(--webiny-theme-color-text-secondary);
     fill: currentColor;
 `;
+export const TagListWrapper = styled("div")`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    margin: 8px;
+`;
 
-export const TagListWrapper = styled("div")({
-    display: "flex",
-    justifyContent: "space-between",
-    marginBottom: 10,
-    padding: "0 10px",
-    ".tag-filter": {
-        width: 110
-    }
-});
+export const TagsFilterSelect = styled(Select)`
+    max-width: 150px;
+    min-width: auto;
+    flex-shrink: 0;
+`;
+
+export const TagsTitle = styled(Typography)`
+    margin: 0 0 5px;
+    flex: 1 1 auto;
+`;


### PR DESCRIPTION
## Changes
With this PR, we improve the responsiveness of the tag filter section used in the file manager. The position of the select and the section title change based on container width, enhancing the user experience on smaller screens.

https://github.com/user-attachments/assets/cb449a70-babb-4cd9-99f4-6c43ce3c1511

## How Has This Been Tested?
Manually
