### PR TITLE
fix(app-headless-cms): bulk action enum

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionDelete.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionDelete.tsx
@@ -28,7 +28,7 @@ export const ActionDelete = observer(() => {
             loadingLabel: `Processing ${entriesLabel}`,
             execute: async () => {
                 if (worker.isSelectedAll) {
-                    await worker.processInBulk("moveToTrash");
+                    await worker.processInBulk("MoveToTrash");
                     worker.resetItems();
                     showSnackbar(
                         "All entries will be moved to trash. This process will be carried out in the background and may take some time. You can safely navigate away from this page while the process is running.",

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionMove.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionMove.tsx
@@ -29,7 +29,7 @@ export const ActionMove = observer(() => {
                 loadingLabel: `Processing ${entriesLabel}`,
                 execute: async () => {
                     if (worker.isSelectedAll) {
-                        await worker.processInBulk("moveToFolder", {
+                        await worker.processInBulk("MoveToFolder", {
                             folderId: folder.id
                         });
                         worker.resetItems();

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionPublish.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionPublish.tsx
@@ -28,7 +28,7 @@ export const ActionPublish = observer(() => {
             loadingLabel: `Processing ${entriesLabel}`,
             execute: async () => {
                 if (worker.isSelectedAll) {
-                    await worker.processInBulk("publish");
+                    await worker.processInBulk("Publish");
                     worker.resetItems();
                     showSnackbar(
                         "All entries will be published. This process will be carried out in the background and may take some time. You can safely navigate away from this page while the process is running.",

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionUnpublish.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/BulkActions/ActionUnpublish.tsx
@@ -28,7 +28,7 @@ export const ActionUnpublish = observer(() => {
             loadingLabel: `Processing ${entriesLabel}`,
             execute: async () => {
                 if (worker.isSelectedAll) {
-                    await worker.processInBulk("unpublish");
+                    await worker.processInBulk("Unpublish");
                     worker.resetItems();
                     showSnackbar(
                         "All entries will be unpublished. This process will be carried out in the background and may take some time. You can safely navigate away from this page while the process is running.",

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/TrashBin/components/TrashBin.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/TrashBin/components/TrashBin.tsx
@@ -58,8 +58,8 @@ export const TrashBin = () => {
                 return <TrashBinButton onClick={showTrashBin} />;
             }}
             bulkActionsGateway={bulkActionsGateway}
-            deleteBulkActionName={"delete"}
-            restoreBulkActionName={"restore"}
+            deleteBulkActionName={"Delete"}
+            restoreBulkActionName={"Restore"}
             listGateway={listGateway}
             deleteGateway={deleteGateway}
             restoreGateway={restoreGateway}


### PR DESCRIPTION
## Changes
This PR corrects the value assigned to the action variable required by the CmsBulkAction mutation. The action value is now properly formatted in Title Case.

![CleanShot 2024-09-03 at 16 18 58](https://github.com/user-attachments/assets/9f46e7f5-a8a5-4eb7-bc71-222a9623f5e0)


## How Has This Been Tested?
Manually
