### PR TITLE
CMS - Ensure Field Values Are Preserved When Deleting Latest Revision

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -66,6 +66,11 @@ export interface CreateEntriesStorageOperationsParams {
     plugins: PluginsContainer;
 }
 
+interface ConvertStorageEntryParams {
+    storageEntry: CmsStorageEntry;
+    model: StorageOperationsCmsModel;
+}
+
 const convertToStorageEntry = (params: ConvertStorageEntryParams): CmsStorageEntry => {
     const { model, storageEntry } = params;
 

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -2,6 +2,7 @@ import WebinyError from "@webiny/error";
 import {
     CmsEntry,
     CmsModel,
+    CmsStorageEntry,
     CONTENT_ENTRY_STATUS,
     StorageOperationsCmsModel
 } from "@webiny/api-headless-cms/types";
@@ -64,6 +65,19 @@ export interface CreateEntriesStorageOperationsParams {
     elasticsearch: Client;
     plugins: PluginsContainer;
 }
+
+const convertToStorageEntry = (params: ConvertStorageEntryParams): CmsStorageEntry => {
+    const { model, storageEntry } = params;
+
+    const values = model.convertValueKeyToStorage({
+        fields: model.fields,
+        values: storageEntry.values
+    });
+    return {
+        ...storageEntry,
+        values
+    };
+};
 
 export const createEntriesStorageOperations = (
     params: CreateEntriesStorageOperationsParams
@@ -812,7 +826,7 @@ export const createEntriesStorageOperations = (
         initialModel,
         params
     ) => {
-        const { entry, latestEntry, latestStorageEntry } = params;
+        const { entry, latestEntry, latestStorageEntry: initialLatestStorageEntry } = params;
         const model = getStorageOperationsModel(initialModel);
 
         const partitionKey = createPartitionKey({
@@ -864,7 +878,12 @@ export const createEntriesStorageOperations = (
             );
         }
 
-        if (latestEntry && latestStorageEntry) {
+        if (latestEntry && initialLatestStorageEntry) {
+            const latestStorageEntry = convertToStorageEntry({
+                storageEntry: initialLatestStorageEntry,
+                model
+            });
+
             /**
              * In the end we need to set the new latest entry.
              */
@@ -885,11 +904,11 @@ export const createEntriesStorageOperations = (
                 entity.putBatch({
                     ...latestStorageEntry,
                     PK: createPartitionKey({
-                        id: latestStorageEntry.id,
+                        id: initialLatestStorageEntry.id,
                         locale: model.locale,
                         tenant: model.tenant
                     }),
-                    SK: createRevisionSortKey(latestStorageEntry),
+                    SK: createRevisionSortKey(initialLatestStorageEntry),
                     TYPE: createRecordType()
                 })
             );
@@ -898,7 +917,7 @@ export const createEntriesStorageOperations = (
                 plugins,
                 model,
                 entry: latestEntry,
-                storageEntry: latestStorageEntry
+                storageEntry: initialLatestStorageEntry
             });
 
             const esLatestData = await latestTransformer.getElasticsearchLatestEntryData();
@@ -929,7 +948,7 @@ export const createEntriesStorageOperations = (
                     error: ex,
                     entry,
                     latestEntry,
-                    latestStorageEntry
+                    initialLatestStorageEntry
                 }
             );
         }
@@ -952,7 +971,7 @@ export const createEntriesStorageOperations = (
                     error: ex,
                     entry,
                     latestEntry,
-                    latestStorageEntry
+                    initialLatestStorageEntry
                 }
             );
         }

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -604,7 +604,7 @@ export const createEntriesStorageOperations = (
             // entry-level meta fields to match the previous revision's entry-level meta fields.
             items.push(
                 entity.putBatch({
-                    ...initialLatestStorageEntry,
+                    ...latestStorageEntry,
                     PK: partitionKey,
                     SK: createRevisionSortKey(initialLatestStorageEntry),
                     TYPE: createType(),

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFields.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFields.test.ts
@@ -215,6 +215,9 @@ describe("Content entries - Entry Meta Fields", () => {
         expect(revision2.savedOn).toBe(entriesList[0].savedOn);
         expect(revision2.savedBy).toEqual(entriesList[0].savedBy);
 
+        // TODO: ensure that the regular fields are still here.
+        expect(revision2.title).toBeTruthy();
+
         // Delete revision 2 and ensure that revision 1's entry-level meta fields are propagated.
         await manageApiIdentityB.deleteTestEntry({
             revision: revision2.id

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFields.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFields.test.ts
@@ -184,6 +184,8 @@ describe("Content entries - Entry Meta Fields", () => {
     test("deleting latest revision should cause the entry-level meta field values to be propagated to the new latest revision", async () => {
         let { data: revision1 } = await manageApiIdentityA.createTestEntry();
 
+        const { title, slug } = revision1;
+
         let { data: revision2 } = await manageApiIdentityA.createTestEntryFrom({
             revision: revision1.id
         });
@@ -215,8 +217,8 @@ describe("Content entries - Entry Meta Fields", () => {
         expect(revision2.savedOn).toBe(entriesList[0].savedOn);
         expect(revision2.savedBy).toEqual(entriesList[0].savedBy);
 
-        // TODO: ensure that the regular fields are still here.
-        expect(revision2.title).toBeTruthy();
+        expect(revision2.title).toBe(title);
+        expect(revision2.slug).toBe(slug);
 
         // Delete revision 2 and ensure that revision 1's entry-level meta fields are propagated.
         await manageApiIdentityB.deleteTestEntry({
@@ -240,5 +242,8 @@ describe("Content entries - Entry Meta Fields", () => {
         expect(revision1.modifiedBy).toEqual(entriesList[0].modifiedBy);
         expect(revision1.savedOn).toBe(entriesList[0].savedOn);
         expect(revision1.savedBy).toEqual(entriesList[0].savedBy);
+
+        expect(revision1.title).toBe(title);
+        expect(revision1.slug).toBe(slug);
     });
 });


### PR DESCRIPTION
## Changes
This PR addresses an issue that would occur when deleting the latest revision of a CMS entry. While deleting the latest revision, the new latest revision would end up loosing data in its fields. This was caused by a bad spread of properties in both DDB and DDB+ES storage ops code.

## How Has This Been Tested?
Manually and Jest.

## Documentation
Changelog.