### PR TITLE
`createRevisionFrom` - Ensure Previously Published Version Is Marked as Unpublished

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -314,6 +314,30 @@ export const createEntriesStorageOperations = (
                     ...publishedKeys
                 })
             );
+
+            // Unpublish previously published revision (if any).
+            const [publishedRevisionStorageEntry] = await dataLoaders.getPublishedRevisionByEntryId(
+                {
+                    model,
+                    ids: [entry.id]
+                }
+            );
+
+            if (publishedRevisionStorageEntry) {
+                items.push(
+                    entity.putBatch({
+                        ...publishedRevisionStorageEntry,
+                        PK: createPartitionKey({
+                            id: publishedRevisionStorageEntry.id,
+                            locale: model.locale,
+                            tenant: model.tenant
+                        }),
+                        SK: createRevisionSortKey(publishedRevisionStorageEntry),
+                        TYPE: createRecordType(),
+                        status: CONTENT_ENTRY_STATUS.UNPUBLISHED
+                    })
+                );
+            }
         }
 
         try {

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -245,8 +245,10 @@ export const createEntriesStorageOperations = (
         /**
          * We need to:
          *  - create the main entry item
-         *  - update the last entry item to a current one
-         *  - update the published entry item to a current one (if the entry is published)
+         *  - update the latest entry item to the current one
+         *  - if the entry's status was set to "published":
+         *      - update the published entry item to the current one
+         *      - unpublish previously published revision (if any)
          */
         const items = [
             entity.putBatch({
@@ -279,6 +281,22 @@ export const createEntriesStorageOperations = (
                     GSI1_SK: createGSISortKey(storageEntry)
                 })
             );
+
+            // Unpublish previously published revision (if any).
+            const publishedRevisionStorageEntry = await getPublishedRevisionByEntryId(model, entry);
+            if (publishedRevisionStorageEntry) {
+                items.push(
+                    entity.putBatch({
+                        ...publishedRevisionStorageEntry,
+                        PK: partitionKey,
+                        SK: createRevisionSortKey(publishedRevisionStorageEntry),
+                        TYPE: createType(),
+                        status: CONTENT_ENTRY_STATUS.UNPUBLISHED,
+                        GSI1_PK: createGSIPartitionKey(model, "A"),
+                        GSI1_SK: createGSISortKey(publishedRevisionStorageEntry)
+                    })
+                );
+            }
         }
 
         try {

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFieldsOverrides.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntriesOnByMetaFieldsOverrides.test.ts
@@ -163,5 +163,17 @@ describe("Content entries - Entry Meta Fields Overrides", () => {
 
         const { data: listEntriesRead } = await readIdentityA.listTestEntries();
         expect(listEntriesRead[0].id).toEndWith("#0003");
+
+        // Extra check - ensure the previous revision is no longer published.
+        const { data: firstPublishedRevision } = await manageIdentityA.getTestEntry({
+            revision: `${rev.entryId}#0001`
+        });
+
+        const { data: secondPublishedRevision } = await manageIdentityA.getTestEntry({
+            revision: `${rev.entryId}#0001`
+        });
+
+        expect(firstPublishedRevision.meta.status).toBe("unpublished");
+        expect(secondPublishedRevision.meta.status).toBe("unpublished");
     });
 });


### PR DESCRIPTION
## Changes
When creating a new revision using the `createFrom` mutation, users have the ability to also mark the newly created revision as "published".

And while this functionality works, still, if there is a previous revision that was already marked as published, the revision's status would still be left as "published", when in fact it should be changed to "unpublished".

This PR addresses this issue. So, when creating a new revision and immediately publishing it, in case there is a previous revision that is published, it'll get unpublished as part of the new revision creation.

Note that here we're only talking about revision records. Updates on dedicated latest/published records were working fine even before this PR.

## How Has This Been Tested?
Jest.

## Documentation
Changelog.