### PR TITLE
Add website app permissions and service manifest

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiOutput.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiOutput.ts
@@ -19,6 +19,7 @@ export const ApiOutput = createAppModule({
             return {
                 apiDomain: output["apiDomain"] as string,
                 apiUrl: output["apiUrl"] as string,
+                graphqlLambdaRole: output["graphqlLambdaRole"] as string,
                 apwSchedulerEventRule: output["apwSchedulerEventRule"] as string | undefined,
                 apwSchedulerEventTargetId: output["apwSchedulerEventTargetId"] as
                     | string

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -265,6 +265,7 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 dynamoDbTable: core.primaryDynamodbTableName,
                 migrationLambdaArn: migration.function.output.arn,
                 graphqlLambdaName: graphql.functions.graphql.output.name,
+                graphqlLambdaRole: graphql.role.output.arn,
                 backgroundTaskLambdaArn: backgroundTask.backgroundTask.output.arn,
                 backgroundTaskStepFunctionArn: backgroundTask.stepFunction.output.arn,
                 websocketApiId: websocket.websocketApi.output.id,

--- a/packages/pulumi-aws/src/apps/createAppBucket.ts
+++ b/packages/pulumi-aws/src/apps/createAppBucket.ts
@@ -1,5 +1,6 @@
 import * as aws from "@pulumi/aws";
 import { PulumiApp } from "@webiny/pulumi";
+import { ApiOutput } from "~/apps/api";
 
 export function createPublicAppBucket(app: PulumiApp, name: string) {
     const bucket = app.addResource(aws.s3.Bucket, {
@@ -33,6 +34,8 @@ export function createPublicAppBucket(app: PulumiApp, name: string) {
 
 // Forces S3 buckets to be available only through a cloudfront distribution.
 export function createPrivateAppBucket(app: PulumiApp, name: string) {
+    const api = app.getModule(ApiOutput);
+
     const bucket = app.addResource(aws.s3.Bucket, {
         name: name,
         config: {
@@ -87,6 +90,19 @@ export function createPrivateAppBucket(app: PulumiApp, name: string) {
                             // we need GetObject to retrieve objects from S3
                             // and ListBucket allows to properly handle non-existing files (404)
                             Action: ["s3:ListBucket", "s3:GetObject"],
+                            Resource: [`${arn}`, `${arn}/*`]
+                        },
+                        {
+                            Effect: "Allow",
+                            Principal: { AWS: api.graphqlLambdaRole },
+                            Action: [
+                                "s3:GetObjectAcl",
+                                "s3:DeleteObject",
+                                "s3:PutObjectAcl",
+                                "s3:PutObject",
+                                "s3:GetObject",
+                                "s3:ListBucket"
+                            ],
                             Resource: [`${arn}`, `${arn}/*`]
                         }
                     ];

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -78,7 +78,7 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 app.params.create.productionEnvironments || DEFAULT_PROD_ENV_NAMES;
             const isProduction = productionEnvironments.includes(app.params.run.env);
 
-            // Register core and aou output as a module available for all other modules
+            // Register core and api output as a module, to be available to all other modules.
             const core = app.addModule(CoreOutput);
             app.addModule(ApiOutput);
 

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -5,7 +5,7 @@ import { createPulumiApp, PulumiAppParamCallback, PulumiAppParam } from "@webiny
 import { createPrivateAppBucket } from "../createAppBucket";
 import { applyCustomDomain, CustomDomainParams } from "../customDomain";
 import { createPrerenderingService } from "./WebsitePrerendering";
-import { CoreOutput, VpcConfig } from "~/apps";
+import { CoreOutput, ApiOutput, VpcConfig } from "~/apps";
 import { addDomainsUrlsOutputs, tagResources, withCommonLambdaEnvVariables } from "~/utils";
 import { applyTenantRouter } from "~/apps/tenantRouter";
 import { withServiceManifest } from "~/utils/withServiceManifest";
@@ -50,7 +50,7 @@ export interface CreateWebsitePulumiAppParams {
 }
 
 export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppParams = {}) => {
-    const app = createPulumiApp({
+    const baseApp = createPulumiApp({
         name: "website",
         path: "apps/website",
         config: projectAppParams,
@@ -78,8 +78,9 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                 app.params.create.productionEnvironments || DEFAULT_PROD_ENV_NAMES;
             const isProduction = productionEnvironments.includes(app.params.run.env);
 
-            // Register core output as a module available for all other modules
+            // Register core and aou output as a module available for all other modules
             const core = app.addModule(CoreOutput);
+            app.addModule(ApiOutput);
 
             // Register VPC config module to be available to other modules.
             const vpcEnabled = app.getParam(projectAppParams?.vpc) ?? isProduction;
@@ -308,5 +309,42 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
         }
     });
 
-    return withServiceManifest(withCommonLambdaEnvVariables(app));
+    const app = withServiceManifest(withCommonLambdaEnvVariables(baseApp));
+
+    app.addHandler(() => {
+        const preview = baseApp.resources.preview;
+        const delivery = baseApp.resources.delivery;
+
+        app.addServiceManifest({
+            name: "website",
+            manifest: {
+                preview: {
+                    cloudfront: {
+                        distributionId: preview.cloudfront.output.id,
+                        domainName: preview.cloudfront.output.domainName
+                    },
+                    bucket: {
+                        name: preview.bucket.output.id,
+                        arn: preview.bucket.output.arn,
+                        bucketDomainName: preview.bucket.output.bucketDomainName,
+                        bucketRegionalDomainName: preview.bucket.output.bucketRegionalDomainName
+                    }
+                },
+                delivery: {
+                    cloudfront: {
+                        distributionId: delivery.cloudfront.output.id,
+                        domainName: delivery.cloudfront.output.domainName
+                    },
+                    bucket: {
+                        name: delivery.bucket.output.id,
+                        arn: delivery.bucket.output.arn,
+                        bucketDomainName: delivery.bucket.output.bucketDomainName,
+                        bucketRegionalDomainName: delivery.bucket.output.bucketRegionalDomainName
+                    }
+                }
+            }
+        });
+    });
+
+    return app;
 };


### PR DESCRIPTION
## Changes
This PR updates `website` app buckets with permissions that allow all API lambda functions to read and write its buckets (app and delivery).

We also added a `website` service manifest, which stores `preview` and `delivery` resources, so that API lambda functions can access that information programmatically.

## How Has This Been Tested?
Manually.
