### PR TITLE
fix(app-page-builder): edit action redirect to revision url

### DIFF
--- a/packages/app-page-builder/src/admin/components/Table/Table/Actions/EditPage.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Actions/EditPage.tsx
@@ -10,9 +10,9 @@ export const EditPage = makeDecoratable("EditPage", () => {
     const { page } = usePage();
     const { OptionsMenuItem, OptionsMenuLink } = PageListConfig.Browser.PageAction;
     const { getPageEditorUrl, navigateToPageEditor } = useNavigatePage();
-    const { createPageForm, loading } = useCreatePageFrom({
-        page,
-        onSuccess: () => navigateToPageEditor(page.data.pid)
+    const { createPageFromMutation, loading } = useCreatePageFrom({
+        page: page.data,
+        onSuccess: data => navigateToPageEditor(data.id)
     });
 
     if (page.data.locked) {
@@ -20,7 +20,7 @@ export const EditPage = makeDecoratable("EditPage", () => {
             <OptionsMenuItem
                 icon={<Edit />}
                 label={"Edit"}
-                onAction={createPageForm}
+                onAction={createPageFromMutation}
                 disabled={loading}
                 data-testid={"aco.actions.pb.page.edit"}
             />
@@ -31,7 +31,7 @@ export const EditPage = makeDecoratable("EditPage", () => {
         <OptionsMenuLink
             icon={<Edit />}
             label={"Edit"}
-            to={getPageEditorUrl(page.id)}
+            to={getPageEditorUrl(page.data.id)}
             data-testid={"aco.actions.pb.page.edit"}
         />
     );

--- a/packages/app-page-builder/src/admin/views/Pages/hooks/useCreatePageFrom.ts
+++ b/packages/app-page-builder/src/admin/views/Pages/hooks/useCreatePageFrom.ts
@@ -4,11 +4,11 @@ import { useSnackbar } from "@webiny/app-admin";
 import { CREATE_PAGE } from "~/admin/graphql/pages";
 import * as GQLCache from "~/admin/views/Pages/cache";
 
-import { PbPageTableItem } from "~/types";
+import { PbPageDataItem, PbPageRevision } from "~/types";
 
 interface UseEditPageParams {
-    page: PbPageTableItem;
-    onSuccess?: () => void;
+    page: PbPageDataItem;
+    onSuccess?: (data: PbPageRevision) => void;
 }
 
 export const useCreatePageFrom = ({ page, onSuccess }: UseEditPageParams) => {
@@ -16,8 +16,9 @@ export const useCreatePageFrom = ({ page, onSuccess }: UseEditPageParams) => {
     const [createPageFrom] = useMutation(CREATE_PAGE);
     const { showSnackbar } = useSnackbar();
 
-    const createPageForm = useCallback(async () => {
+    const createPageFromMutation = useCallback(async () => {
         setLoading(true);
+
         const response = await createPageFrom({
             variables: { from: page.id },
             update(cache, { data }) {
@@ -30,18 +31,18 @@ export const useCreatePageFrom = ({ page, onSuccess }: UseEditPageParams) => {
         });
         setLoading(false);
 
-        const { error } = response.data.pageBuilder.createPage;
+        const { data, error } = response.data.pageBuilder.createPage;
         if (error) {
             return showSnackbar(error.message);
         }
 
         if (typeof onSuccess === "function") {
-            onSuccess();
+            onSuccess(data);
         }
     }, [page, onSuccess]);
 
     return {
-        createPageForm,
+        createPageFromMutation,
         loading
     };
 };


### PR DESCRIPTION
## Changes
This PR resolves an issue where users encountered errors when clicking the "Edit" action, as demonstrated in the video below:

https://github.com/user-attachments/assets/d014f0a6-ca11-459d-a6d7-552357db63eb

Key updates include:

- Correctly passing the ID with the revision number to `getPageEditorUrl` (e.g., `abc#0001` instead of `abc`).
- Ensuring that the `onSuccess` callback now receives the appropriate data from the `CREATE_PAGE` mutation in case a page is locked.
- Fixing a typo in the `createPageForm`.


## How Has This Been Tested?
Manually