### PR TITLE
Patching GraphQL Playground

### DIFF
--- a/packages/app-graphql-playground/src/plugins/Playground.tsx
+++ b/packages/app-graphql-playground/src/plugins/Playground.tsx
@@ -53,6 +53,7 @@ const initScripts = () => {
 interface CreateApolloClientParams {
     uri: string;
 }
+
 interface PlaygroundProps {
     createApolloClient: (params: CreateApolloClientParams) => ApolloClient<any>;
 }
@@ -61,9 +62,11 @@ interface CreateApolloLinkCallableParams {
     endpoint: string;
     headers: Record<string, string>;
 }
+
 interface CreateApolloLinkCallableResult {
     link: ApolloLink;
 }
+
 interface CreateApolloLinkCallable {
     (params: CreateApolloLinkCallableParams): CreateApolloLinkCallableResult;
 }

--- a/packages/app-graphql-playground/src/plugins/Playground.tsx
+++ b/packages/app-graphql-playground/src/plugins/Playground.tsx
@@ -17,6 +17,7 @@ import { config as appConfig } from "@webiny/app/config";
 import ApolloClient from "apollo-client";
 import { GraphQLPlaygroundTabPlugin } from "~/types";
 import { SecurityIdentity } from "@webiny/app-security/types";
+import { ORIGINAL_GQL_PLAYGROUND_URL, PATCHED_GQL_PLAYGROUND_URL } from "./constants";
 
 const withHeaders = (link: ApolloLink, headers: Record<string, string>): ApolloLink => {
     return ApolloLink.from([
@@ -39,10 +40,13 @@ const initScripts = () => {
             return resolve();
         }
 
-        return loadScript(
-            "https://cdn.jsdelivr.net/npm/@apollographql/graphql-playground-react@1.7.32/build/static/js/middleware.js",
-            resolve
-        );
+        loadScript(PATCHED_GQL_PLAYGROUND_URL, (err: Error) => {
+            if (err) {
+                return loadScript(ORIGINAL_GQL_PLAYGROUND_URL, resolve);
+            }
+
+            resolve();
+        });
     });
 };
 

--- a/packages/app-graphql-playground/src/plugins/constants.ts
+++ b/packages/app-graphql-playground/src/plugins/constants.ts
@@ -1,0 +1,5 @@
+export const ORIGINAL_GQL_PLAYGROUND_URL =
+    "https://cdn.jsdelivr.net/npm/@apollographql/graphql-playground-react@1.7.32/build/static/js/middleware.js";
+
+export const PATCHED_GQL_PLAYGROUND_URL =
+    "https://webiny-public.s3.us-east-2.amazonaws.com/project-scripts/gql-playground-mw-1.7.42-patched.js";


### PR DESCRIPTION
## Changes

Before the fix (with the old `@apollographql/graphql-playground-react@1.7.32/build/static/js/middleware.js` code):

![fixed2](https://github.com/user-attachments/assets/05029595-5f04-4161-88dd-6e6e93345ef7)

After the fix (loading our own patched version of the same file no longer shows warnings in console):

![fixed1](https://github.com/user-attachments/assets/4968b789-8217-4729-93f8-0baa4a4cf6d8)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

Manually.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
