### PR TITLE
refactor(tasks): disable logs on task definition

### DIFF
--- a/packages/api-elasticsearch-tasks/__tests__/mocks/store.ts
+++ b/packages/api-elasticsearch-tasks/__tests__/mocks/store.ts
@@ -13,5 +13,9 @@ export const createTaskManagerStoreMock = (params?: Params) => {
     const context = params?.context || createContextMock();
     const task = params?.task || createTaskMock();
     const log = params?.log || createTaskLogMock(task);
-    return new TaskManagerStore(context, task, log);
+    return new TaskManagerStore({
+        context,
+        task,
+        log
+    });
 };

--- a/packages/tasks/__tests__/live/store.ts
+++ b/packages/tasks/__tests__/live/store.ts
@@ -15,7 +15,11 @@ export const createLiveStore = async <C extends Context = Context>(
 ) => {
     const context = params.context || (await createLiveContext(params));
 
-    const store = new TaskManagerStore(context, params.task, params.taskLog);
+    const store = new TaskManagerStore({
+        context,
+        task: params.task,
+        log: params.taskLog
+    });
 
     return {
         store,

--- a/packages/tasks/src/types.ts
+++ b/packages/tasks/src/types.ts
@@ -394,6 +394,10 @@ export interface ITaskDefinition<
      */
     maxIterations: number;
     /**
+     * Disable storing logs in database for this task.
+     */
+    disableDatabaseLogs?: boolean;
+    /**
      * Task run method.
      */
     run(params: ITaskRunParams<C, I, O>): Promise<ITaskResponseResult>;


### PR DESCRIPTION
## Changes
Add possibility to disable storing logs in the database when defining the task.

## How Has This Been Tested?
Jest and manually.