### PR TITLE
Improve InstallTenant error handling

### DIFF
--- a/packages/api-serverless-cms/src/tenancy/InstallTenant.ts
+++ b/packages/api-serverless-cms/src/tenancy/InstallTenant.ts
@@ -59,50 +59,99 @@ export class InstallTenant {
             await this.context.tenancy.setVersion(this.context.WEBINY_VERSION);
 
             // SECURITY: Create initial security groups.
-            await this.context.security.install();
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.security.getVersion();
+                if (!isInstalled) {
+                    await this.context.security.install();
+                }
+            }, "SECURITY_INSTALL");
 
             // ADMIN USERS: Optionally, create an admin user for this tenant.
-            if (config.adminUsers) {
-                await this.context.adminUsers.install(config.adminUsers);
-            } else {
-                // We always mark `adminUsers` as installed, regardless of the config.
-                await this.context.adminUsers.setVersion(this.context.WEBINY_VERSION);
-            }
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.adminUsers.getVersion();
+                if (isInstalled) {
+                    return;
+                }
+
+                if (config.adminUsers) {
+                    await this.context.adminUsers.install(config.adminUsers);
+                } else {
+                    // We always mark `adminUsers` as installed, regardless of the config.
+                    await this.context.adminUsers.setVersion(this.context.WEBINY_VERSION);
+                }
+            }, "ADMIN_USERS_INSTALL");
 
             // I18N: Create a default locale.
-            await this.context.i18n.system.installSystem({
-                code: config.i18n.defaultLocaleCode
-            });
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.i18n.system.getSystemVersion();
+                if (isInstalled) {
+                    return;
+                }
+
+                await this.context.i18n.system.installSystem({
+                    code: config.i18n.defaultLocaleCode
+                });
+            }, "I18N_INSTALL");
 
             // CMS
-            await this.context.cms.installSystem();
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.cms.getSystemVersion();
+                if (isInstalled) {
+                    return;
+                }
+                await this.context.cms.installSystem();
+            }, "CMS_INSTALL");
 
             // FILE MANAGER: Create File Manager settings.
             const srcPrefix = config.fileManager
                 ? `${new URL(config.fileManager.assetDeliveryDomain).origin}/files/`
                 : fmSettings?.srcPrefix;
 
-            await this.context.fileManager.install({ srcPrefix: srcPrefix || "" });
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.fileManager.getVersion();
+                if (isInstalled) {
+                    return;
+                }
+
+                await this.context.fileManager.install({ srcPrefix: srcPrefix || "" });
+            }, "FILE_MANAGER_INSTALL");
 
             // PAGE BUILDER: Create Page Builder settings.
-            await this.context.pageBuilder.installSystem({
-                name: config.pageBuilder?.websiteName ?? tenant.name,
-                insertDemoData: config.pageBuilder?.insertDemoData ?? false
-            });
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.pageBuilder.getSystemVersion();
+                if (isInstalled) {
+                    return;
+                }
+                await this.context.pageBuilder.installSystem({
+                    name: config.pageBuilder?.websiteName ?? tenant.name,
+                    insertDemoData: config.pageBuilder?.insertDemoData ?? false
+                });
+            }, "PAGE_BUILDER_INSTALL");
 
             // FORM BUILDER
-            await this.context.formBuilder.installSystem({});
-        } catch (e) {
-            throw new Error({
-                message: e.message,
-                code: "INSTALL_TENANT",
-                data: {
-                    config,
-                    error: e
+            await this.runOrThrow(async () => {
+                const isInstalled = await this.context.formBuilder.getSystemVersion();
+                if (isInstalled) {
+                    return;
                 }
-            });
+                await this.context.formBuilder.installSystem({});
+            }, "FORM_BUILDER_INSTALL");
         } finally {
             this.context.tenancy.setCurrentTenant(currentTenant);
+        }
+    }
+
+    private async runOrThrow(cb: () => Promise<void>, errorCode: string): Promise<void> {
+        try {
+            await cb();
+        } catch (err) {
+            throw new Error({
+                message: err.message,
+                code: `INSTALL_TENANT:${errorCode}`,
+                data: {
+                    error: err
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
## Changes
This PR improves our `InstallTenant` utility for programmatic tenant installation; we've improved error handling, and also added checks whether a particular app is already installed.

## How Has This Been Tested?
Manually, by running a custom mutation which triggers this utility.

## Documentation
None necessary.