### PR TITLE
fix(app-headless-cms): deleting entry revision incorrectly moves entire entry to trash

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import get from "lodash/get";
 import { useRouter } from "@webiny/react-router";
-import { useSnackbar, useIsMounted } from "@webiny/app-admin";
+import { useIsMounted, useSnackbar } from "@webiny/app-admin";
 import { useCms, useQuery } from "~/admin/hooks";
 import { ContentEntriesContext } from "~/admin/views/contentEntries/ContentEntriesContext";
 import { useContentEntries } from "~/admin/views/contentEntries/hooks/useContentEntries";
@@ -51,6 +51,7 @@ export interface ContentEntryCrud {
         params: UnpublishEntryRevisionParams
     ) => Promise<Cms.UnpublishEntryRevisionResponse>;
     deleteEntry: (params: DeleteEntryParams) => Promise<Cms.DeleteEntryResponse>;
+    deleteEntryRevision: (params: DeleteEntryParams) => Promise<Cms.DeleteEntryResponse>;
 }
 
 export interface ContentEntryContext extends ContentEntriesContext, ContentEntryCrud {
@@ -262,6 +263,10 @@ export const ContentEntryProvider = ({
         return response;
     };
 
+    const deleteEntryRevision: ContentEntryCrud["deleteEntry"] = async params => {
+        return await cms.deleteEntry({ model, ...params });
+    };
+
     const publishEntryRevision: ContentEntryCrud["publishEntryRevision"] = async params => {
         const response = await cms.publishEntryRevision({ model, ...params });
         if (response.entry) {
@@ -288,6 +293,7 @@ export const ContentEntryProvider = ({
         createEntry,
         createEntryRevisionFrom,
         deleteEntry,
+        deleteEntryRevision,
         entry: (entry || {}) as CmsContentEntry,
         loading,
         publishEntryRevision,

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList/useRevision.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList/useRevision.tsx
@@ -77,18 +77,36 @@ export const useRevision = ({ revision }: UseRevisionProps) => {
                     ({ entry }): DeleteRevisionHandler =>
                     async (id): Promise<void> => {
                         const revisionId = id || entry.id;
-                        const response = await contentEntry.deleteEntry({
+                        const response = await contentEntry.deleteEntryRevision({
                             id: revisionId
                         });
 
                         if (typeof response === "boolean") {
+                            if (!response) {
+                                showSnackbar(
+                                    <span>
+                                        Error while deleting revision entry{" "}
+                                        <strong>#{entry.meta.version}</strong>!
+                                    </span>
+                                );
+                                return;
+                            }
+
                             // Redirect to the first revision in the list of all entry revisions.
                             const targetRevision = contentEntry.revisions.filter(
                                 rev => rev.id !== revisionId
                             )[0];
+
                             history.push(
                                 `/cms/content-entries/${modelId}?id=` +
                                     encodeURIComponent(targetRevision!.id)
+                            );
+
+                            showSnackbar(
+                                <span>
+                                    Successfully deleted revision{" "}
+                                    <strong>#{entry.meta.version}</strong>!
+                                </span>
                             );
                             return;
                         }


### PR DESCRIPTION
## Changes
This PR addresses a bug where deleting a specific entry revision from the revision list inadvertently moves the entire entry to the trash bin instead of only removing the selected revision.

To resolve this issue, we’ve introduced a new `publishEntryRevision` method in the context (use case). This allows us to handle revision deletions more cleanly by decorating the existing `deleteEntry` method without causing overlap or unintended behaviour.

## How Has This Been Tested?
Manually

