### PR TITLE
fix(api-headless-cms-ddb-es): add default tie breaker for elasticsearch

### DIFF
--- a/packages/api-elasticsearch/src/sort.ts
+++ b/packages/api-elasticsearch/src/sort.ts
@@ -1,5 +1,5 @@
 import WebinyError from "@webiny/error";
-import { FieldSortOptions, SortType, SortOrder } from "~/types";
+import { FieldSortOptions, SortOrder, SortType } from "~/types";
 import { ElasticsearchFieldPlugin } from "~/plugins";
 
 const sortRegExp = new RegExp(/^([a-zA-Z-0-9_@]+)_(ASC|DESC)$/);
@@ -31,7 +31,7 @@ export const createSort = (params: CreateSortParams): SortType => {
     /**
      * Cast as string because nothing else should be allowed yet.
      */
-    return sort.reduce((acc, value) => {
+    const result = sort.reduce((acc, value) => {
         if (typeof value !== "string") {
             throw new WebinyError(`Sort as object is not supported..`);
         }
@@ -61,4 +61,13 @@ export const createSort = (params: CreateSortParams): SortType => {
 
         return acc;
     }, {} as Record<string, FieldSortOptions>);
+    /**
+     * If we do not have id in the sort, we add it as we need a tie_breaker for the Elasticsearch to be able to sort consistently.
+     */
+    if (!result["id.keyword"] && !result["id"]) {
+        result["id.keyword"] = {
+            order: "desc"
+        };
+    }
+    return result;
 };

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
@@ -17,7 +17,13 @@ export const createElasticsearchSort = (params: Params): esSort => {
     const { sort, modelFields, plugins } = params;
 
     if (!sort || sort.length === 0) {
-        return [];
+        return [
+            {
+                ["id.keyword"]: {
+                    order: "desc"
+                }
+            }
+        ];
     }
 
     const searchPlugins = createSearchPluginList({


### PR DESCRIPTION
## Changes
Elasticsearch needs a default sorting field to be able to paginate correctly.
If user was sorting by fields which are no unique on the record (or combination of multiple sorters are not unique), they would get inconsistent results.

## How Has This Been Tested?
Jest and manually.