### PR TITLE
fix(api-headless-cms-ddb-es): add default tie breaker for elasticsearch

### DIFF
--- a/packages/api-elasticsearch/src/sort.ts
+++ b/packages/api-elasticsearch/src/sort.ts
@@ -1,5 +1,5 @@
 import WebinyError from "@webiny/error";
-import { FieldSortOptions, SortType, SortOrder } from "~/types";
+import { FieldSortOptions, SortOrder, SortType } from "~/types";
 import { ElasticsearchFieldPlugin } from "~/plugins";
 
 const sortRegExp = new RegExp(/^([a-zA-Z-0-9_@]+)_(ASC|DESC)$/);
@@ -31,7 +31,7 @@ export const createSort = (params: CreateSortParams): SortType => {
     /**
      * Cast as string because nothing else should be allowed yet.
      */
-    return sort.reduce((acc, value) => {
+    const result = sort.reduce((acc, value) => {
         if (typeof value !== "string") {
             throw new WebinyError(`Sort as object is not supported..`);
         }
@@ -61,4 +61,13 @@ export const createSort = (params: CreateSortParams): SortType => {
 
         return acc;
     }, {} as Record<string, FieldSortOptions>);
+    /**
+     * If we do not have id in the sort, we add it as we need a tie_breaker for the Elasticsearch to be able to sort consistently.
+     */
+    if (!result["id.keyword"] && !result["id"]) {
+        result["_shard_doc"] = {
+            order: "asc"
+        };
+    }
+    return result;
 };

--- a/packages/api-elasticsearch/src/sort.ts
+++ b/packages/api-elasticsearch/src/sort.ts
@@ -65,7 +65,7 @@ export const createSort = (params: CreateSortParams): SortType => {
      * If we do not have id in the sort, we add it as we need a tie_breaker for the Elasticsearch to be able to sort consistently.
      */
     if (!result["id.keyword"] && !result["id"]) {
-        result["_shard_doc"] = {
+        result["id.keyword"] = {
             order: "asc"
         };
     }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
@@ -19,7 +19,7 @@ export const createElasticsearchSort = (params: Params): esSort => {
     if (!sort || sort.length === 0) {
         return [
             {
-                ["_shard_doc"]: {
+                ["id.keyword"]: {
                     order: "asc"
                 }
             }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/sort.ts
@@ -17,7 +17,13 @@ export const createElasticsearchSort = (params: Params): esSort => {
     const { sort, modelFields, plugins } = params;
 
     if (!sort || sort.length === 0) {
-        return [];
+        return [
+            {
+                ["_shard_doc"]: {
+                    order: "asc"
+                }
+            }
+        ];
     }
 
     const searchPlugins = createSearchPluginList({

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -1020,7 +1020,7 @@ export const createEntriesStorageOperations = (
          * Although we do not need a cursor here, we will use it as such to keep it standardized.
          * Number is simply encoded.
          */
-        const cursor = totalCount > start + limit ? encodeCursor(`${start + limit}`) : null;
+        const cursor = encodeCursor(`${start + limit}`);
         return {
             hasMoreItems,
             totalCount,

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntryMetaField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntryMetaField.test.ts
@@ -2,6 +2,7 @@ import models from "./mocks/contentModels";
 import { CmsEntry, CmsGroup, CmsModel } from "~/types";
 import { useCategoryManageHandler } from "../testHelpers/useCategoryManageHandler";
 import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
+import { createMockCmsEntry } from "~tests/helpers/createMockCmsEntry";
 
 const manageOpts = {
     path: "manage/en-US"
@@ -90,7 +91,7 @@ describe("Content Entry Meta Field", () => {
     it("storage operations - should have meta field data in the retrieved record", async () => {
         const { model } = await setup();
         const entryId = generateAlphaNumericLowerCaseId(8);
-        const entry: CmsEntry = {
+        const entry = createMockCmsEntry({
             id: `${entryId}#0001`,
             entryId,
             version: 1,
@@ -117,7 +118,7 @@ describe("Content Entry Meta Field", () => {
             status: "draft",
             webinyVersion: "5.27.0",
             meta: createMetaData()
-        };
+        });
 
         const createdRecord = await storageOperations.entries.create(model, {
             entry,
@@ -177,7 +178,7 @@ describe("Content Entry Meta Field", () => {
                     meta: createMetaData()
                 }
             ],
-            cursor: null,
+            cursor: expect.any(String),
             totalCount: 1
         });
 

--- a/packages/api-headless-cms/__tests__/helpers/createMockCmsEntry.ts
+++ b/packages/api-headless-cms/__tests__/helpers/createMockCmsEntry.ts
@@ -1,0 +1,7 @@
+import { CmsEntry } from "~/types";
+
+export const createMockCmsEntry = <T extends CmsEntry = CmsEntry>(input: Partial<T>): T => {
+    return {
+        ...input
+    } as T;
+};

--- a/packages/api-headless-cms/__tests__/storageOperations/entries.test.ts
+++ b/packages/api-headless-cms/__tests__/storageOperations/entries.test.ts
@@ -107,7 +107,7 @@ describe("Entries storage operations", () => {
 
         expect(result.items).toHaveLength(amount);
         expect(result).toMatchObject({
-            cursor: null,
+            cursor: expect.any(String),
             hasMoreItems: false,
             totalCount: amount
         });

--- a/packages/api-page-builder-so-ddb-es/src/operations/pages/logIgnoredEsResponseError.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pages/logIgnoredEsResponseError.ts
@@ -1,0 +1,23 @@
+import WebinyError from "@webiny/error";
+
+interface LogIgnoredElasticsearchExceptionParams {
+    error: WebinyError;
+    indexName: string;
+}
+
+export const logIgnoredEsResponseError = (params: LogIgnoredElasticsearchExceptionParams) => {
+    const { error, indexName } = params;
+    if (process.env.DEBUG !== "true") {
+        return;
+    }
+    console.log(`Ignoring Elasticsearch response error: ${error.message}`, {
+        usedIndexName: indexName,
+        error: {
+            ...error,
+            message: error.message,
+            code: error.code,
+            data: error.data,
+            stack: error.stack
+        }
+    });
+};

--- a/packages/api-page-builder-so-ddb-es/src/operations/pages/shouldIgnoreEsResponseError.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pages/shouldIgnoreEsResponseError.ts
@@ -1,0 +1,10 @@
+import WebinyError from "@webiny/error";
+
+const IGNORED_ES_SEARCH_EXCEPTIONS = [
+    "index_not_found_exception",
+    "search_phase_execution_exception"
+];
+
+export const shouldIgnoreEsResponseError = (error: WebinyError) => {
+    return IGNORED_ES_SEARCH_EXCEPTIONS.includes(error.message);
+};


### PR DESCRIPTION
## Changes
Elasticsearch needs a default sorting field to be able to paginate correctly.
If user was sorting by fields which are no unique on the record (or combination of multiple sorters are not unique), they would get inconsistent results.

## How Has This Been Tested?
Jest and manually.