### PR TITLE
Headless CMS - Make Entry/Revision Action Labels More Explicit

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/DeleteEntry/DeleteEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/Header/DeleteEntry/DeleteEntry.tsx
@@ -27,7 +27,7 @@ export const DeleteEntry = () => {
     return (
         <OptionsMenuItem
             icon={<DeleteIcon />}
-            label={"Delete"}
+            label={"Delete entry"}
             onAction={() =>
                 showConfirmationDialog({
                     onAccept: navigateBacktoList

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/PublishEntryRevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/PublishEntryRevisionListItem.tsx
@@ -13,7 +13,7 @@ const PublishEntryRevisionListItemComponent = () => {
             <ListItemGraphic>
                 <Icon icon={<PublishIcon />} />
             </ListItemGraphic>
-            {t`Publish`}
+            {t`Publish revision`}
         </>
     );
 };

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionListItem.tsx
@@ -34,7 +34,7 @@ const t = i18n.ns("app-headless-cms/admin/plugins/content-details/content-revisi
 const primaryColor = css({ color: "var(--mdc-theme-primary)" });
 
 const revisionsMenu = css({
-    width: 250,
+    width: 300,
     right: -105,
     left: "auto !important"
 });
@@ -123,7 +123,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                             <ListItemGraphic>
                                 <Icon icon={<AddIcon />} />
                             </ListItemGraphic>
-                            {t`New from current`}
+                            {t`New revision from current`}
                         </MenuItem>
                     )}
 
@@ -137,7 +137,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                             <ListItemGraphic>
                                 <Icon icon={<EditIcon />} />
                             </ListItemGraphic>
-                            {t`Edit`}
+                            {t`Edit revision`}
                         </MenuItem>
                     )}
 
@@ -155,7 +155,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                             <ListItemGraphic>
                                 <Icon icon={<UnpublishIcon />} />
                             </ListItemGraphic>
-                            {t`Unpublish`}
+                            {t`Unpublish revision`}
                         </MenuItem>
                     )}
 
@@ -166,7 +166,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                                 <ListItemGraphic>
                                     <Icon icon={<DeleteIcon />} />
                                 </ListItemGraphic>
-                                {t` Delete`}
+                                {t` Delete revision`}
                             </MenuItem>
                         </div>
                     )}


### PR DESCRIPTION
## Changes
This PR makes the labels of actions a bit more explicit, by prefixing them with Entry or Revision words accordingly.

This way we're trying to make it more obvious for the user what the action will actually do behind the scenes (delete a whole entry or just a specific revision).

When it comes to the dropdown in the revisions tab, we've added the 'Revision' prefix for all actions, as seen in the screenshots below.

![image](https://github.com/user-attachments/assets/9043092b-526d-4b02-85f4-d9c527343e90)

![image](https://github.com/user-attachments/assets/a7ae326b-6daf-4d57-9e09-d640dea55ced)



## How Has This Been Tested?
Manually.

## Documentation
Changelog.