### PR TITLE
fix(app-page-builder): fix pb template selector list

### DIFF
--- a/packages/app-page-builder/src/admin/views/Pages/PageTemplatesDialog.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/PageTemplatesDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState, useEffect, useMemo } from "react";
-import { css } from "emotion";
 import styled from "@emotion/styled";
 import classNames from "classnames";
 import { useQuery } from "@apollo/react-hooks";
@@ -27,8 +26,10 @@ import {
 import * as Styled from "~/templateEditor/config/Content/BlocksBrowser/StyledComponents";
 import { PbPageTemplate } from "~/types";
 
-const leftPanelStyle = css`
+const ListContainer = styled.div`
+    width: 100%;
     height: calc(100vh - 64px);
+    overflow: clip;
     display: flex;
     flex-direction: column;
 `;
@@ -91,7 +92,7 @@ const ModalTitleStyled = styled.div`
 `;
 
 const SearchInputWrapper = styled.div`
-    padding: 15px;
+    padding: 16px;
 `;
 
 const BlankTemplateButtonWrapper = styled.div`
@@ -152,54 +153,58 @@ const PageTemplatesDialog = ({ onClose, onSelect, isLoading }: PageTemplatesDial
     return (
         <OverlayLayout barLeft={<ModalTitle />} onExited={onClose}>
             <SplitView>
-                <LeftPanel span={3} className={leftPanelStyle}>
-                    <SearchInputWrapper>
-                        <Styled.Input>
-                            <Icon className={Styled.searchIcon} icon={<SearchIcon />} />
-                            <DelayedOnChange value={search} onChange={setSearch}>
-                                {({ value, onChange }) => (
-                                    <input
-                                        autoFocus
-                                        type={"text"}
-                                        placeholder="Search templates..."
-                                        value={value}
-                                        onChange={ev => onChange(ev.target.value)}
-                                    />
-                                )}
-                            </DelayedOnChange>
-                        </Styled.Input>
-                    </SearchInputWrapper>
-                    <ScrollList
-                        className={listStyle}
-                        data-testid={"pb-new-page-dialog-templates-list"}
-                    >
-                        {filteredPageTemplates.map(template => (
-                            <ListItem
-                                key={template.id}
-                                className={classNames(
-                                    listItem,
-                                    activeTemplate?.id === template.id && activeListItem
-                                )}
-                                onClick={() => {
-                                    setActiveTemplate(template);
-                                }}
-                            >
-                                <TitleContent>
-                                    <ListItemTitle>{template.title}</ListItemTitle>
-                                    <Typography use={"body2"}>{template.description}</Typography>
-                                </TitleContent>
-                            </ListItem>
-                        ))}
-                    </ScrollList>
-                    <BlankTemplateButtonWrapper>
-                        <ButtonSecondary
-                            disabled={isLoading}
-                            onClick={() => onSelect()}
-                            data-testid={"pb-new-page-dialog-use-blank-template-btn"}
+                <LeftPanel span={3}>
+                    <ListContainer>
+                        <SearchInputWrapper>
+                            <Styled.Input>
+                                <Icon className={Styled.searchIcon} icon={<SearchIcon />} />
+                                <DelayedOnChange value={search} onChange={setSearch}>
+                                    {({ value, onChange }) => (
+                                        <input
+                                            autoFocus
+                                            type={"text"}
+                                            placeholder="Search templates..."
+                                            value={value}
+                                            onChange={ev => onChange(ev.target.value)}
+                                        />
+                                    )}
+                                </DelayedOnChange>
+                            </Styled.Input>
+                        </SearchInputWrapper>
+                        <ScrollList
+                            className={listStyle}
+                            data-testid={"pb-new-page-dialog-templates-list"}
                         >
-                            Use a blank page template
-                        </ButtonSecondary>
-                    </BlankTemplateButtonWrapper>
+                            {filteredPageTemplates.map(template => (
+                                <ListItem
+                                    key={template.id}
+                                    className={classNames(
+                                        listItem,
+                                        activeTemplate?.id === template.id && activeListItem
+                                    )}
+                                    onClick={() => {
+                                        setActiveTemplate(template);
+                                    }}
+                                >
+                                    <TitleContent>
+                                        <ListItemTitle>{template.title}</ListItemTitle>
+                                        <Typography use={"body2"}>
+                                            {template.description}
+                                        </Typography>
+                                    </TitleContent>
+                                </ListItem>
+                            ))}
+                        </ScrollList>
+                        <BlankTemplateButtonWrapper>
+                            <ButtonSecondary
+                                disabled={isLoading}
+                                onClick={() => onSelect()}
+                                data-testid={"pb-new-page-dialog-use-blank-template-btn"}
+                            >
+                                Use a blank page template
+                            </ButtonSecondary>
+                        </BlankTemplateButtonWrapper>
+                    </ListContainer>
                 </LeftPanel>
                 <RightPanel span={9} data-testid={"pb-new-page-dialog-template-preview"}>
                     {activeTemplate && (

--- a/packages/app-page-builder/src/templateEditor/config/Content/BlocksBrowser/StyledComponents.ts
+++ b/packages/app-page-builder/src/templateEditor/config/Content/BlocksBrowser/StyledComponents.ts
@@ -15,16 +15,17 @@ export const List = styled("div")({
 export const Input = styled("div")({
     backgroundColor: "var(--mdc-theme-on-background)",
     position: "relative",
-    height: 30,
-    padding: 3,
+    height: 36,
     width: "100%",
     borderRadius: 2,
     "> input": {
         border: "none",
         fontSize: 16,
-        width: "calc(100% - 10px)",
-        height: "100%",
-        marginLeft: 50,
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 36,
+        right: 0,
         backgroundColor: "transparent",
         outline: "none",
         color: "var(--mdc-theme-text-primary-on-background)"
@@ -37,14 +38,13 @@ export const searchIcon = css({
         position: "absolute",
         width: 24,
         height: 24,
-        left: 15,
-        top: 7
+        left: 8,
+        top: 6
     }
 });
 
 export const wrapper = css({
     height: "100vh",
-    //overflow: "scroll",
     backgroundColor: "var(--mdc-theme-background)"
 });
 


### PR DESCRIPTION
## Changes
With this pull request, we are fixing the page builder template selector. The content of the left-hand side list was shifted to the left. The adjustable column feature might have introduced this bug (https://github.com/webiny/webiny-js/pull/4179).

We are also improving the styling of the search input to make it adaptable to its container sizes.

## How Has This Been Tested?
Manually