### PR TITLE
fix(app-admin-auth0): support auto-login and preserve location on redirect

### DIFF
--- a/apps/admin/src/App.auth0.tsx
+++ b/apps/admin/src/App.auth0.tsx
@@ -8,11 +8,22 @@ export const App = () => {
     return (
         <Admin>
             <Auth0
+                autoLogin={() => {
+                    const query = new URLSearchParams(window.location.search);
+                    return query.get("action") !== "logout";
+                }}
                 auth0={{
                     domain: String(process.env.REACT_APP_AUTH0_DOMAIN),
                     clientId: String(process.env.REACT_APP_AUTH0_CLIENT_ID)
                 }}
                 rootAppClientId={String(process.env.REACT_APP_AUTH0_CLIENT_ID)}
+                onLogout={logout => {
+                    logout({
+                        logoutParams: {
+                            returnTo: window.location.origin + "?action=logout"
+                        }
+                    });
+                }}
             />
             <Extensions />
         </Admin>

--- a/apps/api/graphql/src/security.auth0.ts
+++ b/apps/api/graphql/src/security.auth0.ts
@@ -78,7 +78,7 @@ export default ({ documentClient }: { documentClient: DynamoDBDocument }) => [
                 id: token["sub"],
                 type: "admin",
                 displayName: token["name"],
-                group: token["webiny_group"]
+                group: "full-access"
             };
         }
     }),

--- a/packages/app-admin-auth0/package.json
+++ b/packages/app-admin-auth0/package.json
@@ -21,6 +21,7 @@
     "@webiny/app-tenant-manager": "0.0.0",
     "@webiny/form": "0.0.0",
     "@webiny/plugins": "0.0.0",
+    "@webiny/react-router": "0.0.0",
     "@webiny/ui": "0.0.0",
     "@webiny/validation": "0.0.0",
     "apollo-client": "^2.6.10",

--- a/packages/app-admin-auth0/src/Auth0.tsx
+++ b/packages/app-admin-auth0/src/Auth0.tsx
@@ -3,22 +3,13 @@ import gql from "graphql-tag";
 import { useApolloClient } from "@apollo/react-hooks";
 import get from "lodash/get";
 import { LoginScreenRenderer, useTenancy, useTags } from "@webiny/app-serverless-cms";
-import {
-    createAuthentication,
-    Auth0Options,
-    CreateAuthenticationConfig,
-    OnLogout
-} from "./createAuthentication";
+import { createAuthentication, CreateAuthenticationConfig } from "./createAuthentication";
 import { UserMenuModule } from "~/modules/userMenu";
 import { AppClientModule } from "~/modules/appClient";
 import { NotAuthorizedError } from "./components";
 
-interface AppClientIdLoaderProps {
-    auth0: Auth0Options;
-    rootAppClientId: string;
+interface AppClientIdLoaderProps extends Auth0Props {
     children: React.ReactNode;
-    onLogout?: OnLogout;
-    onError?: CreateAuthenticationConfig["onError"];
 }
 
 const GET_CLIENT_ID = gql`
@@ -32,14 +23,24 @@ const GET_CLIENT_ID = gql`
 const AppClientIdLoader = ({
     auth0,
     rootAppClientId,
-    onLogout,
-    onError,
-    children
+    children,
+    ...rest
 }: AppClientIdLoaderProps) => {
     const [loaded, setState] = useState<boolean>(false);
     const authRef = useRef<React.ComponentType | null>(null);
     const client = useApolloClient();
     const { tenant, setTenant } = useTenancy();
+
+    const setupAuthForClientId = (clientId: string) => {
+        console.info(`Configuring Auth0 with App Client Id "${rootAppClientId}"`);
+        return createAuthentication({
+            ...rest,
+            auth0: {
+                ...auth0,
+                clientId
+            }
+        });
+    };
 
     useEffect(() => {
         // Check if `tenantId` query parameter is set.
@@ -51,15 +52,7 @@ const AppClientIdLoader = ({
         }
 
         if (tenantId === "root") {
-            console.info(`Configuring Auth0 with App Client Id "${rootAppClientId}"`);
-            authRef.current = createAuthentication({
-                onLogout,
-                onError,
-                auth0: {
-                    ...auth0,
-                    clientId: rootAppClientId
-                }
-            });
+            authRef.current = setupAuthForClientId(rootAppClientId);
             setState(true);
             return;
         }
@@ -67,14 +60,7 @@ const AppClientIdLoader = ({
         client.query({ query: GET_CLIENT_ID }).then(({ data }) => {
             const clientId = get(data, "tenancy.appClientId");
             if (clientId) {
-                console.info(`Configuring Auth0 with App Client Id "${clientId}"`);
-                authRef.current = createAuthentication({
-                    onError,
-                    auth0: {
-                        ...auth0,
-                        clientId
-                    }
-                });
+                authRef.current = setupAuthForClientId(clientId);
                 setState(true);
             } else {
                 console.warn(`Couldn't load appClientId for tenant "${tenantId}"`);
@@ -96,6 +82,7 @@ const createLoginScreenPlugin = (params: Auth0Props) => {
 
             const onError = useCallback((error: Error) => {
                 setError(error.message);
+                params.onError && params.onError(error);
             }, []);
 
             if (error && !installer) {
@@ -103,11 +90,7 @@ const createLoginScreenPlugin = (params: Auth0Props) => {
             }
 
             return (
-                <AppClientIdLoader
-                    auth0={params.auth0}
-                    rootAppClientId={params.rootAppClientId}
-                    onError={onError}
-                >
+                <AppClientIdLoader {...params} onError={onError}>
                     {children}
                 </AppClientIdLoader>
             );
@@ -115,13 +98,13 @@ const createLoginScreenPlugin = (params: Auth0Props) => {
     });
 };
 
-export interface Auth0Props {
-    auth0: Auth0Options;
+export type Auth0Props = Pick<
+    CreateAuthenticationConfig,
+    "auth0" | "autoLogin" | "onLogin" | "onLogout" | "onRedirect" | "onError"
+> & {
     rootAppClientId: string;
-    onLogout?: OnLogout;
-    onRedirect?: OnLogout;
     children?: React.ReactNode;
-}
+};
 
 export const Auth0 = (props: Auth0Props) => {
     const LoginScreenPlugin = createLoginScreenPlugin(props);

--- a/packages/app-admin-auth0/src/Auth0.tsx
+++ b/packages/app-admin-auth0/src/Auth0.tsx
@@ -119,6 +119,7 @@ export interface Auth0Props {
     auth0: Auth0Options;
     rootAppClientId: string;
     onLogout?: OnLogout;
+    onRedirect?: OnLogout;
     children?: React.ReactNode;
 }
 

--- a/packages/app-admin-auth0/src/components/LoginContent.tsx
+++ b/packages/app-admin-auth0/src/components/LoginContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { makeDecoratable } from "@webiny/app-serverless-cms";
 import { CircularProgress } from "@webiny/ui/Progress";
 import { alignCenter, Title } from "~/components/StyledComponents";
@@ -7,12 +7,12 @@ import { ButtonIcon, ButtonPrimary } from "@webiny/ui/Button";
 import { ReactComponent as Auth0Icon } from "~/assets/icons/auth0-icon.svg";
 import { useAuth0 } from "@auth0/auth0-react";
 
-export const LoginContent = makeDecoratable("LoginContent", () => {
-    const { isAuthenticated, loginWithRedirect } = useAuth0();
+export interface LoginContentProps {
+    onLogin: () => void;
+}
 
-    const login = useCallback(() => {
-        loginWithRedirect();
-    }, []);
+export const LoginContent = makeDecoratable("LoginContent", ({ onLogin }: LoginContentProps) => {
+    const { isAuthenticated } = useAuth0();
 
     return (
         <>
@@ -33,7 +33,7 @@ export const LoginContent = makeDecoratable("LoginContent", () => {
                         </Typography>
                     </div>
                     <div className={alignCenter} style={{ marginTop: 20 }}>
-                        <ButtonPrimary onClick={login}>
+                        <ButtonPrimary onClick={onLogin}>
                             <ButtonIcon icon={<Auth0Icon />} />
                             Sign in via Auth0
                         </ButtonPrimary>

--- a/packages/app-admin-auth0/src/components/LoginContent.tsx
+++ b/packages/app-admin-auth0/src/components/LoginContent.tsx
@@ -8,38 +8,44 @@ import { ReactComponent as Auth0Icon } from "~/assets/icons/auth0-icon.svg";
 import { useAuth0 } from "@auth0/auth0-react";
 
 export interface LoginContentProps {
+    isLoading: boolean;
     onLogin: () => void;
 }
 
-export const LoginContent = makeDecoratable("LoginContent", ({ onLogin }: LoginContentProps) => {
-    const { isAuthenticated } = useAuth0();
+export const LoginContent = makeDecoratable(
+    "LoginContent",
+    ({ onLogin, isLoading }: LoginContentProps) => {
+        const { isAuthenticated } = useAuth0();
 
-    return (
-        <>
-            {isAuthenticated ? (
-                <CircularProgress label={"Logging in..."} />
-            ) : (
-                <>
-                    <Title>
-                        <Typography tag={"h1"} use={"headline4"}>
-                            Sign In
-                        </Typography>
-                    </Title>
-                    <div className={alignCenter}>
-                        <Typography use={"body1"}>
-                            You will be taken to Auth0 website to complete
-                            <br />
-                            the sign in process.
-                        </Typography>
-                    </div>
-                    <div className={alignCenter} style={{ marginTop: 20 }}>
-                        <ButtonPrimary onClick={onLogin}>
-                            <ButtonIcon icon={<Auth0Icon />} />
-                            Sign in via Auth0
-                        </ButtonPrimary>
-                    </div>
-                </>
-            )}
-        </>
-    );
-});
+        return (
+            <>
+                {isAuthenticated ? <CircularProgress label={"Logging in..."} /> : null}
+                {!isAuthenticated && isLoading ? (
+                    <CircularProgress label={"Checking user session..."} />
+                ) : null}
+                {!isAuthenticated && !isLoading ? (
+                    <>
+                        <Title>
+                            <Typography tag={"h1"} use={"headline4"}>
+                                Sign In
+                            </Typography>
+                        </Title>
+                        <div className={alignCenter}>
+                            <Typography use={"body1"}>
+                                You will be taken to Auth0 website to complete
+                                <br />
+                                the sign in process.
+                            </Typography>
+                        </div>
+                        <div className={alignCenter} style={{ marginTop: 20 }}>
+                            <ButtonPrimary onClick={onLogin}>
+                                <ButtonIcon icon={<Auth0Icon />} />
+                                Sign in via Auth0
+                            </ButtonPrimary>
+                        </div>
+                    </>
+                ) : null}
+            </>
+        );
+    }
+);

--- a/packages/app-admin-auth0/tsconfig.build.json
+++ b/packages/app-admin-auth0/tsconfig.build.json
@@ -10,6 +10,7 @@
     { "path": "../app-tenant-manager/tsconfig.build.json" },
     { "path": "../form/tsconfig.build.json" },
     { "path": "../plugins/tsconfig.build.json" },
+    { "path": "../react-router/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
     { "path": "../validation/tsconfig.build.json" }
   ],

--- a/packages/app-admin-auth0/tsconfig.json
+++ b/packages/app-admin-auth0/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../app-tenant-manager" },
     { "path": "../form" },
     { "path": "../plugins" },
+    { "path": "../react-router" },
     { "path": "../ui" },
     { "path": "../validation" }
   ],
@@ -36,6 +37,8 @@
       "@webiny/form": ["../form/src"],
       "@webiny/plugins/*": ["../plugins/src/*"],
       "@webiny/plugins": ["../plugins/src"],
+      "@webiny/react-router/*": ["../react-router/src/*"],
+      "@webiny/react-router": ["../react-router/src"],
       "@webiny/ui/*": ["../ui/src/*"],
       "@webiny/ui": ["../ui/src"],
       "@webiny/validation/*": ["../validation/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -16978,6 +16978,7 @@ __metadata:
     "@webiny/form": 0.0.0
     "@webiny/plugins": 0.0.0
     "@webiny/project-utils": 0.0.0
+    "@webiny/react-router": 0.0.0
     "@webiny/ui": 0.0.0
     "@webiny/validation": 0.0.0
     apollo-client: ^2.6.10


### PR DESCRIPTION
## Changes
This PR contains the following improvements:
- support for auto-login, so that users don't have to click the login button
- track current location through `appState`, and return to the same location on login redirect
- expose props to control `onLogin`, `onLogout`, and `onRedirect`

```tsx
export const App = () => {
    return (
        <Admin>
            <Auth0
                autoLogin={() => {
                    // Control when you want auto-login to kick in. 
                    // It is a good idea to prevent it after user logs out.
                    const query = new URLSearchParams(window.location.search);
                    return query.get("action") !== "logout";
                }}
                auth0={{
                    domain: String(process.env.REACT_APP_AUTH0_DOMAIN),
                    clientId: String(process.env.REACT_APP_AUTH0_CLIENT_ID)
                }}
                rootAppClientId={String(process.env.REACT_APP_AUTH0_CLIENT_ID)}
                onLogout={logout => {
                    logout({
                        logoutParams: {
                            // On logout, we append an arbitrary query parameter 
                            // to know that this was a redirect from a logout process.
                            returnTo: window.location.origin + "?action=logout"
                        }
                    });
                }}
            />
            <Extensions />
        </Admin>
    );
};

```


https://github.com/user-attachments/assets/5d6d5828-d8f6-4402-9027-f370c9e5e6d0




## How Has This Been Tested?
Manually.
