### PR TITLE
fix: refresh revisions list on publish/unpublish actions too

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/ContentEntryContext.tsx
@@ -129,13 +129,6 @@ export const ContentEntryProvider = ({
     const [isLoading, setLoading] = useState<boolean>(false);
     const contentEntryProviderProps = useContentEntryProviderProps();
 
-    const newEntry =
-        typeof isNewEntry === "function" ? isNewEntry() : contentEntryProviderProps.isNewEntry();
-    const contentId =
-        typeof getContentId === "function"
-            ? getContentId()
-            : contentEntryProviderProps.getContentId();
-
     const updateRevisionInRevisionsCache = useCallback(
         (updatedRevisions: CmsContentEntryRevision | CmsContentEntryRevision[]) => {
             const updatedRevisionsArray = Array.isArray(updatedRevisions)
@@ -154,6 +147,13 @@ export const ContentEntryProvider = ({
         },
         []
     );
+
+    const newEntry =
+        typeof isNewEntry === "function" ? isNewEntry() : contentEntryProviderProps.isNewEntry();
+    const contentId =
+        typeof getContentId === "function"
+            ? getContentId()
+            : contentEntryProviderProps.getContentId();
 
     const revisionId = contentId ? decodeURIComponent(contentId) : null;
     let entryId: string | null = null;


### PR DESCRIPTION
## Changes
Addition to https://github.com/webiny/webiny-js/pull/4286.

This PR makes sure the revisions list is also updated when a revision is published/unpublished.
![image](https://github.com/user-attachments/assets/8e210d22-e754-4646-8dbe-eb3c4171c34d)

## How Has This Been Tested?
Manually.

## Documentation
Changelog.