### PR TITLE
fix(api-headless-cms): improve moveEntryToBin operation

### DIFF
--- a/packages/api-headless-cms/src/crud/contentEntry/afterDelete.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/afterDelete.ts
@@ -10,8 +10,12 @@ export const assignAfterEntryDelete = (params: AssignAfterEntryDeleteParams) => 
     const { context, onEntryAfterDelete } = params;
 
     onEntryAfterDelete.subscribe(async params => {
-        const { entry, model } = params;
+        const { entry, model, permanent } = params;
 
+        // If the entry is being moved to the trash, we keep the model fields locked because the entry can be restored.
+        if (!permanent) {
+            return;
+        }
         const { items } = await context.cms.storageOperations.entries.list(model, {
             where: {
                 entryId_not: entry.entryId,

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/DeleteEntry/TransformEntryMoveToBin.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/DeleteEntry/TransformEntryMoveToBin.ts
@@ -2,7 +2,6 @@ import { SecurityIdentity } from "@webiny/api-security/types";
 import { entryFromStorageTransform, entryToStorageTransform } from "~/utils/entryStorage";
 import { getDate } from "~/utils/date";
 import { getIdentity } from "~/utils/identity";
-import { validateModelEntryDataOrThrow } from "~/crud/contentEntry/entryDataValidation";
 import { CmsContext, CmsEntry, CmsEntryStorageOperationsMoveToBinParams, CmsModel } from "~/types";
 import { ROOT_FOLDER } from "~/constants";
 
@@ -29,14 +28,6 @@ export class TransformEntryMoveToBin {
     }
 
     private async createDeleteEntryData(model: CmsModel, originalEntry: CmsEntry) {
-        await validateModelEntryDataOrThrow({
-            context: this.context,
-            model,
-            data: originalEntry.values,
-            entry: originalEntry,
-            skipValidators: ["required"]
-        });
-
         const currentDateTime = new Date().toISOString();
         const currentIdentity = this.getIdentity();
 

--- a/packages/api-headless-cms/src/crud/contentEntry/useCases/RestoreEntryFromBin/TransformEntryRestoreFromBin.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/useCases/RestoreEntryFromBin/TransformEntryRestoreFromBin.ts
@@ -2,7 +2,6 @@ import { SecurityIdentity } from "@webiny/api-security/types";
 import { entryFromStorageTransform, entryToStorageTransform } from "~/utils/entryStorage";
 import { getDate } from "~/utils/date";
 import { getIdentity } from "~/utils/identity";
-import { validateModelEntryDataOrThrow } from "~/crud/contentEntry/entryDataValidation";
 import { CmsContext, CmsEntry, CmsEntryStorageOperationsMoveToBinParams, CmsModel } from "~/types";
 
 export class TransformEntryRestoreFromBin {
@@ -28,14 +27,6 @@ export class TransformEntryRestoreFromBin {
     }
 
     private async createRestoreFromBinEntryData(model: CmsModel, originalEntry: CmsEntry) {
-        await validateModelEntryDataOrThrow({
-            context: this.context,
-            model,
-            data: originalEntry.values,
-            entry: originalEntry,
-            skipValidators: ["required"]
-        });
-
         const currentDateTime = new Date().toISOString();
         const currentIdentity = this.getIdentity();
 


### PR DESCRIPTION
## Changes
With this PR we improve the performance of `moveEntryToBin` operation by:

- skipping the model fields unlocking logic, saving one database query
- skipping entry validation, since the system updates the entry programmatically

A similar validation is skipped in case the entry is restored from the trash bin.

## How Has This Been Tested?
Manually.

## Documentation
Inline.