### PR TITLE
fix(app-headless-cms): ensure time value contains seconds

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/DateTimeWithoutTimezone.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Grid, Cell } from "@webiny/ui/Grid";
 import {
     getCurrentDate,
     getCurrentLocalTime,
     getDefaultFieldValue,
+    getHHmm,
+    getHHmmss,
     RemoveFieldButton
 } from "./utils";
 import { Input } from "./Input";
@@ -55,21 +57,14 @@ export const DateTimeWithoutTimezone = ({
     trailingIcon
 }: DateTimeWithoutTimezoneProps) => {
     // "2020-05-18 09:00:00"
-    const initialValue = getDefaultFieldValue(field, bind, () => {
-        const date = new Date();
-        return `${getCurrentDate(date)} ${getCurrentLocalTime(date)}`;
-    });
+    const value =
+        bind.value ||
+        getDefaultFieldValue(field, bind, () => {
+            const date = new Date();
+            return `${getCurrentDate(date)} ${getCurrentLocalTime(date)}`;
+        });
 
-    const { date, time } = parseDateTime(initialValue);
-
-    const bindValue = bind.value || "";
-
-    useEffect(() => {
-        if (!date || !time || bindValue === initialValue) {
-            return;
-        }
-        bind.onChange(initialValue);
-    }, [bindValue]);
+    const { date, time } = parseDateTime(value);
 
     const cellSize = trailingIcon ? 5 : 6;
 
@@ -87,7 +82,7 @@ export const DateTimeWithoutTimezone = ({
                                 }
                                 return bind.onChange("");
                             }
-                            return bind.onChange(`${value} ${time || getCurrentLocalTime()}`);
+                            return bind.onChange(`${value} ${getHHmmss(time)}`);
                         }
                     }}
                     field={{
@@ -101,7 +96,7 @@ export const DateTimeWithoutTimezone = ({
                 <Input
                     bind={{
                         ...bind,
-                        value: time,
+                        value: getHHmm(time),
                         onChange: async value => {
                             if (!value) {
                                 if (!bind.value) {
@@ -109,7 +104,7 @@ export const DateTimeWithoutTimezone = ({
                                 }
                                 return bind.onChange("");
                             }
-                            return bind.onChange(`${date || getCurrentDate()} ${value}`);
+                            return bind.onChange(`${date || getCurrentDate()} ${getHHmmss(value)}`);
                         }
                     }}
                     field={{

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/utils.tsx
@@ -58,6 +58,22 @@ export const getCurrentDate = (date?: Date): string => {
     return `${year}-${month}-${day}`;
 };
 
+export const getHHmm = (time?: string) => {
+    if (!time) {
+        return "";
+    }
+    const parsableTime = time || getCurrentLocalTime();
+    return parsableTime.split(":").slice(0, 2).join(":");
+};
+
+// Ensure a valid HH:mm:ss string, ending with :00 for seconds.
+export const getHHmmss = (time?: string) => {
+    const parsableTime = time || getCurrentLocalTime();
+    const parts = [...parsableTime.split(":").slice(0, 2), "00"];
+
+    return parts.join(":");
+};
+
 const deleteIconStyles = css({
     width: "100% !important",
     height: "100% !important",


### PR DESCRIPTION
## Changes
This PR improves handling of datetime, and datetime with timezone field renderers, by ensuring that time string always contains seconds when binding to the form.

## How Has This Been Tested?
Manually.
