### PR TITLE
Forms - Fixing the "Cmd+enter Not Submitting the Form with the Latest Value in an Input" Issue

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -164,13 +164,7 @@ const NewContentModelDialog = ({ open, onClose }: NewContentModelDialogProps) =>
     return (
         <Dialog open={open} onClose={onClose} data-testid="cms-new-content-model-modal">
             {open && (
-                <Form<CmsModelData>
-                    data={{ group, singleton: false }}
-                    onSubmit={data => {
-                        console.log("submitting", data);
-                        onSubmit(data);
-                    }}
-                >
+                <Form<CmsModelData> data={{ group, singleton: false }} onSubmit={onSubmit}>
                     {({ Bind, submit, data }) => {
                         return (
                             <>

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -288,12 +288,7 @@ const NewContentModelDialog = ({ open, onClose }: NewContentModelDialogProps) =>
                                     </Grid>
                                 </UID.DialogContent>
                                 <UID.DialogActions>
-                                    <ButtonPrimary
-                                        onClick={ev => {
-                                            console.log("submitting click", data);
-                                            submit(ev);
-                                        }}
-                                    >
+                                    <ButtonPrimary onClick={submit}>
                                         + {t`Create Model`}
                                     </ButtonPrimary>
                                 </UID.DialogActions>

--- a/packages/ui/src/DelayedOnChange/DelayedOnChange.ts
+++ b/packages/ui/src/DelayedOnChange/DelayedOnChange.ts
@@ -8,6 +8,7 @@ const emptyFunction = (): undefined => {
 export interface ApplyValueCb<TValue> {
     (value: TValue): void;
 }
+
 /**
  * This component is used to wrap Input and Textarea components to optimize form re-render.
  * These 2 are the only components that trigger form model change on each character input.
@@ -145,7 +146,7 @@ export const DelayedOnChange = <TValue = any>({
         if (ev.key === "Tab") {
             applyValue((ev.target as HTMLInputElement).value as any as TValue);
             realOnKeyDown(ev);
-        } else if (ev.key === "Enter" && props["data-on-enter"]) {
+        } else if (ev.key === "Enter") {
             applyValue((ev.target as HTMLInputElement).value as any as TValue);
             realOnKeyDown(ev);
         } else {


### PR DESCRIPTION
## Changes
This PR addresses an issue where a user used CMD+Enter keyboard shortcut to submit the form. If the shortcut was pressed "too quickly" after typing something into an input field, the form would be submitted with the old value of the input field.

https://github.com/user-attachments/assets/9f068491-1872-4108-ae4b-dbea4a00deb0

Ultimately, the fix for this was just the removal of `data-on-enter` prop inspection in an if statement in the [DelayedOnChange](https://github.com/webiny/webiny-js/pull/4295/files#diff-26340c9b18c2a19cc69c76290b033b823c4d029767ec998a7892f03b3113d9ad) component. Turns out this prop was blocking the `applyValue` call. 

What's also interesting is that the `data-on-enter` was not used anywhere in the entire codebase, so this was one extra signal that we can remove this.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.