### PR TITLE
fix(ui): make dropdown fill the available space

### DIFF
--- a/packages/ui/src/Select/styled.tsx
+++ b/packages/ui/src/Select/styled.tsx
@@ -8,7 +8,7 @@ export const webinySelect = css`
     background-color: transparent;
     border-color: transparent;
     color: var(--webiny-theme-color-primary);
-    min-width: 200px;
+    width: 100%;
 
     .rmwc-select__native-control {
         opacity: 0;


### PR DESCRIPTION
## Changes
This PR addresses an issue with dropdown/select component, where it bleeds out of the parent element on smaller screens. The `min-width: 200px` is replaced with `width: 100%` to make the component fill all the available space. THe exact size of the element in any particular view is controlled via a parent container.

![image](https://github.com/user-attachments/assets/6709955a-5929-4c90-8f8f-616e673db2de)
![image](https://github.com/user-attachments/assets/3ce7df9d-295f-4d31-adaf-c1dc3fc75a15)
![image](https://github.com/user-attachments/assets/40a9bc0e-4b1a-4b77-bb6e-3213a955bfe0)


## How Has This Been Tested?
Manually.
