### PR TITLE
Pavel/fix/okta params

### DIFF
--- a/apps/api/graphql/src/security.okta.ts
+++ b/apps/api/graphql/src/security.okta.ts
@@ -1,0 +1,109 @@
+import { DynamoDBDocument } from "@webiny/aws-sdk/client-dynamodb";
+import { createTenancyContext, createTenancyGraphQL } from "@webiny/api-tenancy";
+import { createStorageOperations as tenancyStorageOperations } from "@webiny/api-tenancy-so-ddb";
+import { createSecurityContext, createSecurityGraphQL } from "@webiny/api-security";
+import { createStorageOperations as securityStorageOperations } from "@webiny/api-security-so-ddb";
+import { authenticateUsingHttpHeader } from "@webiny/api-security/plugins/authenticateUsingHttpHeader";
+import apiKeyAuthentication from "@webiny/api-security/plugins/apiKeyAuthentication";
+import apiKeyAuthorization from "@webiny/api-security/plugins/apiKeyAuthorization";
+import { createOkta } from "@webiny/api-security-okta";
+import anonymousAuthorization from "@webiny/api-security/plugins/anonymousAuthorization";
+import tenantLinkAuthorization from "@webiny/api-security/plugins/tenantLinkAuthorization";
+import createAdminUsersApp from "@webiny/api-admin-users";
+import { createStorageOperations as createAdminUsersStorageOperations } from "@webiny/api-admin-users-so-ddb";
+import { Context } from "./types";
+
+export default ({ documentClient }: { documentClient: DynamoDBDocument }) => [
+    /**
+     * Create Tenancy app in the `context`.
+     */
+    createTenancyContext({
+        storageOperations: tenancyStorageOperations({ documentClient })
+    }),
+
+    /**
+     * Expose tenancy GraphQL schema.
+     */
+    createTenancyGraphQL(),
+
+    /**
+     * Create Security app in the `context`.
+     */
+    createSecurityContext({
+        storageOperations: securityStorageOperations({ documentClient })
+    }),
+
+    /**
+     * Expose security GraphQL schema.
+     */
+    createSecurityGraphQL({
+        async getDefaultTenant(context) {
+            return context.tenancy.getRootTenant();
+        }
+    }),
+
+    /**
+     * Create Admin Users app.
+     */
+    createAdminUsersApp({
+        storageOperations: createAdminUsersStorageOperations({ documentClient })
+    }),
+
+    /**
+     * Perform authentication using the common "Authorization" HTTP header.
+     * This will fetch the value of the header, and execute the authentication process.
+     */
+    authenticateUsingHttpHeader(),
+
+    /**
+     * API Key authenticator.
+     * API Keys are a standalone entity, and are not connected to users in any way.
+     * They identify a project, a 3rd party client, not a particular user.
+     * They are used for programmatic API access, CMS data import/export, etc.
+     */
+    apiKeyAuthentication({ identityType: "api-key" }),
+
+    /**
+     * Configure Okta authentication and authorization.
+     */
+    createOkta<Context & { pavel: string }>({
+        /**
+         * `issuer` is required for token verification.
+         */
+        issuer: String(process.env.OKTA_ISSUER),
+        /**
+         * Construct the identity object and map token claims to arbitrary identity properties.
+         */
+        getIdentity({ token }) {
+            return {
+                id: token["sub"],
+                type: "admin",
+                displayName: token["name"],
+                group: "full-access"
+            };
+        }
+    }),
+
+    /**
+     * Authorization plugin to fetch permissions for a verified API key.
+     * The "identityType" must match the authentication plugin used to load the identity.
+     */
+    apiKeyAuthorization({ identityType: "api-key" }),
+
+    /**
+     * Authorization plugin to fetch permissions from a security role or team associated with the identity.
+     */
+    tenantLinkAuthorization({ identityType: "admin" }),
+
+    /**
+     * Authorization plugin to fetch permissions from the parent tenant.
+     */
+    tenantLinkAuthorization({ identityType: "admin", parent: true }),
+
+    /**
+     * Authorization plugin to load permissions for anonymous requests.
+     * This allows you to control which API resources can be accessed publicly.
+     * The authorization is performed by loading permissions from the "anonymous" user group.
+     */
+    anonymousAuthorization()
+];

--- a/packages/api-security-okta/src/createOkta.ts
+++ b/packages/api-security-okta/src/createOkta.ts
@@ -3,12 +3,17 @@ import { createGroupAuthorizer, GroupAuthorizerConfig } from "~/createGroupAutho
 import { createIdentityType } from "~/createIdentityType";
 import { extendTenancy } from "./extendTenancy";
 import { createAdminUsersHooks } from "./createAdminUsersHooks";
+import { Context } from "~/types";
 
-export interface CreateOktaConfig extends AuthenticatorConfig, GroupAuthorizerConfig {
+export interface CreateOktaConfig<TContext extends Context = Context>
+    extends AuthenticatorConfig,
+        GroupAuthorizerConfig<TContext> {
     graphQLIdentityType?: string;
 }
 
-export const createOkta = (config: CreateOktaConfig) => {
+export const createOkta = <TContext extends Context = Context>(
+    config: CreateOktaConfig<TContext>
+) => {
     const identityType = config.identityType || "admin";
     const graphQLIdentityType = config.graphQLIdentityType || "OktaIdentity";
 
@@ -17,7 +22,7 @@ export const createOkta = (config: CreateOktaConfig) => {
             issuer: config.issuer,
             getIdentity: config.getIdentity
         }),
-        createGroupAuthorizer({
+        createGroupAuthorizer<TContext>({
             identityType,
             getGroupSlug: config.getGroupSlug
         }),

--- a/packages/api-security-okta/src/types.ts
+++ b/packages/api-security-okta/src/types.ts
@@ -1,7 +1,15 @@
 import "@webiny/api-tenancy/types";
+import { SecurityContext } from "@webiny/api-security/types";
+import { TenancyContext } from "@webiny/api-tenancy/types";
+import { I18NContext } from "@webiny/api-i18n/types";
 
 declare module "@webiny/api-tenancy/types" {
     interface TenantSettings {
         appClientId: string;
     }
 }
+
+/**
+ * @internal
+ */
+export type Context = TenancyContext & SecurityContext & I18NContext;


### PR DESCRIPTION
## Changes
This PR fixes an issue in the Okta security factory, where `getGroupSlug` was a required parameter, but in reality, it is no longer required, since you can assign a `group` property to the `identity` object, right in the `getIdentity` function.

I've also used this opportunity to align the public API with that of the Auth0 package, where `getGroupSlug` can be `async`.

## How Has This Been Tested?
Manually.