### PR TITLE
Update least-privilege AWS permissions

### DIFF
--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
@@ -263,7 +263,12 @@ Resources:
                 - states:UntagResource
                 - states:ListStateMachines
                 - states:UpdateStateMachine
+                - states:ListStateMachineVersions
                 Resource: arn:aws:states:*:*:stateMachine:wby-*
+              
+              - Effect: Allow
+                Action: ValidateStateMachineDefinition
+                Resource: "*"
 
               # AWS Lambda
               - Effect: Allow
@@ -293,6 +298,10 @@ Resources:
                   - lambda:EnableReplication
                 Resource:
                   - arn:aws:lambda:*:*:function:wby-*
+
+              - Effect: Allow
+                Action: ListTags
+                Resource: arn:aws:lambda:*:*:event-source-mapping:*
 
               - Effect: Allow
                 Action:

--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml
@@ -41,6 +41,11 @@ Resources:
                     "aws:ResourceTag/WbyProjectName": "false"
 
               - Effect: Allow
+                Resource: arn:*:cloudfront::*:distribution/*
+                Action:
+                  - cloudfront:GetDistribution
+
+              - Effect: Allow
                 Resource: arn:*:cloudfront::*:function/*
                 Action:
                   - cloudfront:CreateFunction


### PR DESCRIPTION
## Changes

Both `yarn webiny deploy` and `yarn webiny destroy` will fail if you run them as a least-privilege user per the [Configure AWS Credentials](https://www.webiny.com/docs/infrastructure/aws/configure-aws-credentials#deploy-webiny-project-aws-cloud-formation-template) docs. After iterating on adding additional permissions, this is the set that worked.

Closes #4320

## How Has This Been Tested?
With these permissions added to our user via a manual inline policy, both the `deploy` and `destroy` were successful.

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
No documentation changes should be necessary for this change.
