### PR TITLE
fix(app): trim quotes when reading tenant id

### DIFF
--- a/packages/app/src/utils/getTenantId.ts
+++ b/packages/app/src/utils/getTenantId.ts
@@ -28,8 +28,9 @@ export const getTenantId = (): string | null => {
                 return value;
             }
         } catch {
-            return tenant.replace(/"/g, "");
+            // do nothing
         }
+        return tenant;
     }
 
     // 4. Finally, for development purposes, we take the `WEBINY_WEBSITE_TENANT_ID`

--- a/packages/app/src/utils/getTenantId.ts
+++ b/packages/app/src/utils/getTenantId.ts
@@ -10,14 +10,12 @@ export const getTenantId = (): string | null => {
     // 1. Get tenant via the `__tenant` query param. Useful when doing page previews.
     let tenant = new URLSearchParams(location.search).get("__tenant");
     if (tenant) {
-        console.log("taking from query param");
         return tenant;
     }
 
     // 2. Get tenant via `window.__PS_RENDER_TENANT__`. Used with prerendered pages.
     tenant = window.__PS_RENDER_TENANT__;
     if (tenant) {
-        console.log("__PS_RENDER_TENANT__");
         return tenant;
     }
 

--- a/packages/app/src/utils/getTenantId.ts
+++ b/packages/app/src/utils/getTenantId.ts
@@ -10,19 +10,28 @@ export const getTenantId = (): string | null => {
     // 1. Get tenant via the `__tenant` query param. Useful when doing page previews.
     let tenant = new URLSearchParams(location.search).get("__tenant");
     if (tenant) {
+        console.log("taking from query param");
         return tenant;
     }
 
     // 2. Get tenant via `window.__PS_RENDER_TENANT__`. Used with prerendered pages.
     tenant = window.__PS_RENDER_TENANT__;
     if (tenant) {
+        console.log("__PS_RENDER_TENANT__");
         return tenant;
     }
 
     // 3. Get tenant via `window.localStorage.webiny_tenant`. Used within the Admin app.
     tenant = window.localStorage.webiny_tenant;
     if (tenant) {
-        return tenant;
+        try {
+            const value = JSON.parse(tenant);
+            if (value) {
+                return value;
+            }
+        } finally {
+            return tenant.replace(/"/g, "");
+        }
     }
 
     // 4. Finally, for development purposes, we take the `WEBINY_WEBSITE_TENANT_ID`

--- a/packages/app/src/utils/getTenantId.ts
+++ b/packages/app/src/utils/getTenantId.ts
@@ -29,7 +29,7 @@ export const getTenantId = (): string | null => {
             if (value) {
                 return value;
             }
-        } finally {
+        } catch {
             return tenant.replace(/"/g, "");
         }
     }


### PR DESCRIPTION
## Changes
When getting a tenant via the `@webiny/app/utils/getTenantId` method, and it is fetched from the local storage, it has quotes around the value. This fix will remove those quotes either via JSON.parse or just stripping the quotes.

## How Has This Been Tested?
Manually.