### PR TITLE
Introduce Default `robots.txt` Files

### DIFF
--- a/apps/admin/public/robots.txt
+++ b/apps/admin/public/robots.txt
@@ -1,0 +1,3 @@
+# No robots allowed.
+User-agent: *
+Disallow: /`;

--- a/apps/admin/public/robots.txt
+++ b/apps/admin/public/robots.txt
@@ -1,3 +1,3 @@
 # No robots allowed.
 User-agent: *
-Disallow: /`;
+Disallow: /

--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -1,0 +1,1 @@
+# All robots allowed.

--- a/packages/cwp-template-aws/template/common/apps/admin/public/robots.txt
+++ b/packages/cwp-template-aws/template/common/apps/admin/public/robots.txt
@@ -1,0 +1,3 @@
+# No robots allowed.
+User-agent: *
+Disallow: /`;

--- a/packages/cwp-template-aws/template/common/apps/admin/public/robots.txt
+++ b/packages/cwp-template-aws/template/common/apps/admin/public/robots.txt
@@ -1,3 +1,3 @@
 # No robots allowed.
 User-agent: *
-Disallow: /`;
+Disallow: /

--- a/packages/cwp-template-aws/template/common/apps/website/public/robots.txt
+++ b/packages/cwp-template-aws/template/common/apps/website/public/robots.txt
@@ -1,0 +1,1 @@
+# All robots allowed.

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -186,6 +186,25 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                             minTtl: 0,
                             defaultTtl: 2592000, // 30 days
                             maxTtl: 2592000
+                        },
+                        {
+                            compress: true,
+                            allowedMethods: ["GET", "HEAD", "OPTIONS"],
+                            cachedMethods: ["GET", "HEAD", "OPTIONS"],
+                            forwardedValues: {
+                                cookies: {
+                                    forward: "none"
+                                },
+                                headers: [],
+                                queryString: false
+                            },
+                            pathPattern: "/robots.txt",
+                            viewerProtocolPolicy: "allow-all",
+                            targetOriginId: appBucket.origin.originId,
+                            // MinTTL <= DefaultTTL <= MaxTTL
+                            minTtl: 0,
+                            defaultTtl: 2592000, // 30 days
+                            maxTtl: 2592000
                         }
                     ],
                     customErrorResponses: [

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -187,6 +187,8 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                             defaultTtl: 2592000, // 30 days
                             maxTtl: 2592000
                         },
+                        // This forward is necessary for non-WCP projects. For WCP projects, the
+                        // forwarding is performed by the `website-router` Lambda@Edge function.
                         {
                             compress: true,
                             allowedMethods: ["GET", "HEAD", "OPTIONS"],

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -202,11 +202,7 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                             },
                             pathPattern: "/robots.txt",
                             viewerProtocolPolicy: "allow-all",
-                            targetOriginId: appBucket.origin.originId,
-                            // MinTTL <= DefaultTTL <= MaxTTL
-                            minTtl: 0,
-                            defaultTtl: 2592000, // 30 days
-                            maxTtl: 2592000
+                            targetOriginId: appBucket.origin.originId
                         }
                     ],
                     customErrorResponses: [

--- a/packages/serverless-cms-aws/src/react/plugins/uploadAppToS3.ts
+++ b/packages/serverless-cms-aws/src/react/plugins/uploadAppToS3.ts
@@ -58,6 +58,10 @@ export const uploadAppToS3 = ({ folder, ...config }: UploadAppToS3Config) => ({
                     value: "no-cache, no-store, must-revalidate"
                 },
                 {
+                    pattern: /robots\.txt/,
+                    value: "no-cache, no-store, must-revalidate"
+                },
+                {
                     pattern: /.*/,
                     value: "max-age=31536000"
                 }


### PR DESCRIPTION
## Changes
With this PR, we're introducing default `robots.tsx` files, that will be included with every Webiny project:
- `apps/admin/public/robots.txt`
- `apps/website/public/robots.txt`

Out of the two, the one that's used with the Admin app is more important, as it'll reject all robots/crawlers.

> [!NOTE]  
> Prior to this PR, there would be a chance user's Admin app would get picked up by search engines, which is certainly something we don't want. 😬  

Note that, for existing project, the new `robots.txt` files will be created during the project upgrade process.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.