### PR TITLE
refactor(api-headless-cms-bulk-action): wait for subtasks to finish before cleanup

### DIFF
--- a/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
@@ -1,4 +1,4 @@
-import { createTaskDefinition } from "@webiny/tasks";
+import { createTaskDefinition, TaskDataStatus } from "@webiny/tasks";
 import { HcmsBulkActionsContext, IBulkActionOperationByModelInput } from "~/types";
 import { ChildTasksCleanup } from "~/useCases/internals";
 
@@ -18,24 +18,87 @@ const calculateDateTimeString = () => {
     // Return the calculated date-time string in ISO 8601 format.
     return currentDate.toISOString();
 };
+// TODO fix
+const cleanup = async ({ context, task }: any) => {
+    /**
+     * We want to clean all child tasks and logs, which have no errors.
+     */
+    const childTasksCleanup = new ChildTasksCleanup();
+    try {
+        await childTasksCleanup.execute({
+            context,
+            task
+        });
+    } catch (ex) {
+        console.error("Error while cleaning `EmptyTrashBins` child tasks.", ex);
+    }
+};
 
 export const createEmptyTrashBinsTask = () => {
     return createTaskDefinition<HcmsBulkActionsContext>({
-        isPrivate: true,
+        // TODO put to true when done with testing
+        isPrivate: false,
         id: "hcmsEntriesEmptyTrashBins",
         title: "Headless CMS - Empty all trash bins",
         description:
             "Delete all entries found in the trash bin, for each model found in the system.",
-        maxIterations: 1,
+        maxIterations: 24,
         disableDatabaseLogs: true,
         run: async params => {
-            const { response, isAborted, context } = params;
+            const { response, isAborted, isCloseToTimeout, context, trigger, input, store } =
+                params;
+            if (isAborted()) {
+                return response.aborted();
+            } else if (isCloseToTimeout()) {
+                return response.continue(
+                    {
+                        ...input
+                    },
+                    {
+                        seconds: 30
+                    }
+                );
+            }
 
-            try {
-                if (isAborted()) {
-                    return response.aborted();
+            if (input.triggered) {
+                const { items } = await context.tasks.listTasks({
+                    where: {
+                        parentId: store.getTask().id
+                    },
+                    limit: 100000
+                });
+                for (const item of items) {
+                    if (
+                        item.taskStatus === TaskDataStatus.RUNNING ||
+                        item.taskStatus === TaskDataStatus.PENDING
+                    ) {
+                        const status = await context.tasks.fetchServiceInfo(item.id);
+                        if (status?.status === "FAILED" || status?.status === "TIMED_OUT") {
+                            await context.tasks.updateTask(item.id, {
+                                taskStatus: TaskDataStatus.FAILED
+                            });
+                            continue;
+                        } else if (status?.status === "ABORTED") {
+                            await context.tasks.updateTask(item.id, {
+                                taskStatus: TaskDataStatus.ABORTED
+                            });
+                            continue;
+                        }
+                        return response.continue(
+                            {
+                                ...input
+                            },
+                            {
+                                seconds: 3600
+                            }
+                        );
+                    }
                 }
 
+                return response.done();
+            }
+
+            try {
                 const locales = context.i18n.getLocales();
 
                 await context.i18n.withEachLocale(locales, async () => {
@@ -44,7 +107,7 @@ export const createEmptyTrashBinsTask = () => {
                     });
 
                     for (const model of models) {
-                        await context.tasks.trigger<IBulkActionOperationByModelInput>({
+                        await trigger<IBulkActionOperationByModelInput>({
                             name: `Headless CMS - Empty trash bin for "${model.name}" model.`,
                             definition: "hcmsBulkListDeleteEntries",
                             input: {
@@ -55,29 +118,23 @@ export const createEmptyTrashBinsTask = () => {
                             }
                         });
                     }
-                    return;
                 });
 
-                return response.done(
-                    `Task done: emptying the trash bin for all registered models.`
+                return response.continue(
+                    {
+                        triggered: true
+                    },
+                    {
+                        seconds: 60
+                    }
                 );
             } catch (ex) {
                 return response.error(ex.message ?? "Error while executing EmptyTrashBins task");
             }
         },
-        onDone: async ({ context, task }) => {
-            /**
-             * We want to clean all child tasks and logs, which have no errors.
-             */
-            const childTasksCleanup = new ChildTasksCleanup();
-            try {
-                await childTasksCleanup.execute({
-                    context,
-                    task
-                });
-            } catch (ex) {
-                console.error("Error while cleaning `EmptyTrashBins` child tasks.", ex);
-            }
-        }
+        onMaxIterations: cleanup,
+        onDone: cleanup,
+        onError: cleanup,
+        onAbort: cleanup
     });
 };

--- a/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
@@ -46,7 +46,6 @@ export const createEmptyTrashBinsTask = () => {
                         await context.tasks.trigger<IBulkActionOperationByModelInput>({
                             name: `Headless CMS - Empty trash bin for "${model.name}" model.`,
                             definition: "hcmsBulkListDeleteEntries",
-                            parent: params.store.getTask(),
                             input: {
                                 modelId: model.modelId,
                                 where: {

--- a/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/createEmptyTrashBinsTask.ts
@@ -27,6 +27,7 @@ export const createEmptyTrashBinsTask = () => {
         description:
             "Delete all entries found in the trash bin, for each model found in the system.",
         maxIterations: 1,
+        disableDatabaseLogs: true,
         run: async params => {
             const { response, isAborted, context } = params;
 

--- a/packages/api-headless-cms-bulk-actions/src/types.ts
+++ b/packages/api-headless-cms-bulk-actions/src/types.ts
@@ -2,6 +2,10 @@ import { CmsContext } from "@webiny/api-headless-cms/types";
 import { Context as BaseContext } from "@webiny/handler/types";
 import {
     Context as TasksContext,
+    ITaskOnAbortParams,
+    ITaskOnErrorParams,
+    ITaskOnMaxIterationsParams,
+    ITaskOnSuccessParams,
     ITaskResponseDoneResultOutput,
     ITaskRunParams
 } from "@webiny/tasks/types";
@@ -64,3 +68,13 @@ export type IBulkActionOperationByModelTaskParams = ITaskRunParams<
     IBulkActionOperationByModelInput,
     IBulkActionOperationByModelOutput
 >;
+
+/**
+ * Trash Bin
+ */
+
+export type TrashBinCleanUpParams =
+    | ITaskOnSuccessParams<HcmsBulkActionsContext>
+    | ITaskOnErrorParams<HcmsBulkActionsContext>
+    | ITaskOnAbortParams<HcmsBulkActionsContext>
+    | ITaskOnMaxIterationsParams<HcmsBulkActionsContext>;

--- a/packages/tasks/src/crud/service.tasks.ts
+++ b/packages/tasks/src/crud/service.tasks.ts
@@ -75,7 +75,13 @@ export const createServiceCrud = (context: Context): ITasksContextServiceObject 
                 delay
             });
 
-            const task = await context.tasks.createTask<T>(input);
+            let task: ITask<T>;
+            try {
+                task = await context.tasks.createTask<T>(input);
+            } catch (ex) {
+                console.log("Could not create the task.", ex);
+                throw ex;
+            }
 
             let result: Awaited<ReturnType<typeof service.send>> | null = null;
             try {
@@ -91,6 +97,8 @@ export const createServiceCrud = (context: Context): ITasksContextServiceObject 
                     );
                 }
             } catch (ex) {
+                console.log("Could not trigger the step function.");
+                console.error(ex);
                 /**
                  * In case of failure to create the Event Bridge Event, we need to delete the task that was meant to be created.
                  * TODO maybe we can leave the task and update it as failed - with event bridge error?


### PR DESCRIPTION
## Changes
In this pull request, we are introducing a controller to verify the successful execution of all subtasks triggered by `hcmsEntriesEmptyTrashBins`. Previously, we were clearing the main task before the subtasks were executed, leading to errors.

## How Has This Been Tested?
Manually