### PR TITLE
5.41.0 Data Migration - Fix Accessing of ID With Tenant Records

### DIFF
--- a/packages/migrations/__tests__/migrations/5.41.0/001/001.data.ts
+++ b/packages/migrations/__tests__/migrations/5.41.0/001/001.data.ts
@@ -2,17 +2,20 @@ export const testData = [
     {
         PK: "T#root",
         SK: "A",
-        createdOn: "2023-01-25T09:37:58.183Z",
-        description: "The top-level Webiny tenant.",
+        data: {
+            createdOn: "2023-01-25T09:37:58.183Z",
+            description: "The top-level Webiny tenant.",
+            id: "root",
+            name: "Root",
+            savedOn: "2023-01-25T09:37:58.183Z",
+            settings: {
+                domains: []
+            },
+            status: "active"
+        },
+
         GSI1_PK: "TENANTS",
         GSI1_SK: "T#null#2023-01-25T09:37:58.183Z",
-        id: "root",
-        name: "Root",
-        savedOn: "2023-01-25T09:37:58.183Z",
-        settings: {
-            domains: []
-        },
-        status: "active",
         TYPE: "tenancy.tenant",
         webinyVersion: "0.0.0",
         _ct: "2023-01-25T09:37:58.220Z",

--- a/packages/migrations/src/migrations/5.41.0/001/index.ts
+++ b/packages/migrations/src/migrations/5.41.0/001/index.ts
@@ -47,7 +47,7 @@ export class AdminUsers_5_41_0_001 {
     }
 
     async execute({ logger }: DataMigrationContext): Promise<void> {
-        const tenants = await queryAll<{ id: string; name: string }>({
+        const tenants = await queryAll<{ data: { id: string; name: string } }>({
             entity: this.tenantEntity,
             partitionKey: "TENANTS",
             options: {
@@ -59,7 +59,7 @@ export class AdminUsers_5_41_0_001 {
         for (const tenant of tenants) {
             const users = await queryAll<{ id: string; email: string; data?: any }>({
                 entity: this.newUserEntity,
-                partitionKey: `T#${tenant.id}#ADMIN_USERS`,
+                partitionKey: `T#${tenant.data.id}#ADMIN_USERS`,
                 options: {
                     index: "GSI1",
                     gt: " "
@@ -67,7 +67,7 @@ export class AdminUsers_5_41_0_001 {
             });
 
             if (users.length === 0) {
-                logger.info(`No users found on tenant "${tenant.id}".`);
+                logger.info(`No users found on tenant "${tenant.data.id}".`);
                 continue;
             }
 


### PR DESCRIPTION
## Changes
5.41.0-001 data migration was tested against old data, where a tenant record did not have all of the data in `data` object.

So, despite tests succeeding, migration failed while testing it on a real project.

## How Has This Been Tested?
Fixed test data and rerun tests.

## Documentation
N/A