### PR TITLE
Watching Admin/Website Apps Without Having API Deployed: Improve Error Handling

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/plugins/AfterBuildPlugin.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/AfterBuildPlugin.d.ts
@@ -1,5 +1,10 @@
-import { PulumiCommandLifecycleEventHookPlugin } from "./PulumiCommandLifecycleEventHookPlugin";
+import {
+    Callable,
+    PulumiCommandLifecycleEventHookPlugin
+} from "./PulumiCommandLifecycleEventHookPlugin";
 
 export class AfterBuildPlugin extends PulumiCommandLifecycleEventHookPlugin {
     public static override readonly type: "hook-after-build";
 }
+
+export function createAfterBuildPlugin(callable: Callable): AfterBuildPlugin;

--- a/packages/cli-plugin-deploy-pulumi/plugins/AfterBuildPlugin.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/AfterBuildPlugin.js
@@ -6,4 +6,8 @@ class AfterBuildPlugin extends PulumiCommandLifecycleEventHookPlugin {
     static type = "hook-after-build";
 }
 
-module.exports = { AfterBuildPlugin };
+const createAfterBuildPlugin = callable => {
+    return new AfterBuildPlugin(callable);
+};
+
+module.exports = { AfterBuildPlugin, createAfterBuildPlugin };

--- a/packages/cli-plugin-deploy-pulumi/plugins/AfterDeployPlugin.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/AfterDeployPlugin.d.ts
@@ -1,5 +1,10 @@
-import { PulumiCommandLifecycleEventHookPlugin } from "./PulumiCommandLifecycleEventHookPlugin";
+import {
+    Callable,
+    PulumiCommandLifecycleEventHookPlugin
+} from "./PulumiCommandLifecycleEventHookPlugin";
 
 export class AfterDeployPlugin extends PulumiCommandLifecycleEventHookPlugin {
     public static override readonly type: "hook-after-deploy";
 }
+
+export function createAfterDeployPlugin(callable: Callable): AfterDeployPlugin;

--- a/packages/cli-plugin-deploy-pulumi/plugins/AfterDeployPlugin.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/AfterDeployPlugin.js
@@ -6,4 +6,8 @@ class AfterDeployPlugin extends PulumiCommandLifecycleEventHookPlugin {
     static type = "hook-after-deploy";
 }
 
-module.exports = { AfterDeployPlugin };
+const createAfterDeployPlugin = callable => {
+    return new AfterDeployPlugin(callable);
+};
+
+module.exports = { AfterDeployPlugin, createAfterDeployPlugin };

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeBuildPlugin.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeBuildPlugin.d.ts
@@ -1,5 +1,10 @@
-import { PulumiCommandLifecycleEventHookPlugin } from "./PulumiCommandLifecycleEventHookPlugin";
+import {
+    Callable,
+    PulumiCommandLifecycleEventHookPlugin
+} from "./PulumiCommandLifecycleEventHookPlugin";
 
 export class BeforeBuildPlugin extends PulumiCommandLifecycleEventHookPlugin {
     public static override readonly type: "hook-before-build";
 }
+
+export function createBeforeBuildPlugin(callable: Callable): BeforeBuildPlugin;

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeBuildPlugin.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeBuildPlugin.js
@@ -6,4 +6,8 @@ class BeforeBuildPlugin extends PulumiCommandLifecycleEventHookPlugin {
     static type = "hook-before-build";
 }
 
-module.exports = { BeforeBuildPlugin };
+const createBeforeBuildPlugin = callable => {
+    return new BeforeBuildPlugin(callable);
+};
+
+module.exports = { BeforeBuildPlugin, createBeforeBuildPlugin };

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeDeployPlugin.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeDeployPlugin.d.ts
@@ -1,5 +1,10 @@
-import { PulumiCommandLifecycleEventHookPlugin } from "./PulumiCommandLifecycleEventHookPlugin";
+import {
+    Callable,
+    PulumiCommandLifecycleEventHookPlugin
+} from "./PulumiCommandLifecycleEventHookPlugin";
 
 export class BeforeDeployPlugin extends PulumiCommandLifecycleEventHookPlugin {
     public static override readonly type: "hook-before-deploy";
 }
+
+export function createBeforeDeployPlugin(callable: Callable): BeforeDeployPlugin;

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeDeployPlugin.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeDeployPlugin.js
@@ -6,4 +6,8 @@ class BeforeDeployPlugin extends PulumiCommandLifecycleEventHookPlugin {
     static type = "hook-before-deploy";
 }
 
-module.exports = { BeforeDeployPlugin };
+const createBeforeDeployPlugin = callable => {
+    return new BeforeDeployPlugin(callable);
+};
+
+module.exports = { BeforeDeployPlugin, createBeforeDeployPlugin };

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeWatchPlugin.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeWatchPlugin.d.ts
@@ -1,0 +1,10 @@
+import {
+    Callable,
+    PulumiCommandLifecycleEventHookPlugin
+} from "./PulumiCommandLifecycleEventHookPlugin";
+
+export class BeforeWatchPlugin extends PulumiCommandLifecycleEventHookPlugin {
+    public static override readonly type: "hook-before-watch";
+}
+
+export function createBeforeWatchPlugin(callable: Callable): BeforeWatchPlugin;

--- a/packages/cli-plugin-deploy-pulumi/plugins/BeforeWatchPlugin.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/BeforeWatchPlugin.js
@@ -1,0 +1,13 @@
+const {
+    PulumiCommandLifecycleEventHookPlugin
+} = require("./PulumiCommandLifecycleEventHookPlugin");
+
+class BeforeWatchPlugin extends PulumiCommandLifecycleEventHookPlugin {
+    static type = "hook-before-watch";
+}
+
+const createBeforeWatchPlugin = callable => {
+    return new BeforeWatchPlugin(callable);
+};
+
+module.exports = { BeforeWatchPlugin, createBeforeWatchPlugin };

--- a/packages/cli-plugin-deploy-pulumi/plugins/index.d.ts
+++ b/packages/cli-plugin-deploy-pulumi/plugins/index.d.ts
@@ -2,3 +2,6 @@ export * from "./AfterBuildPlugin";
 export * from "./AfterDeployPlugin";
 export * from "./BeforeBuildPlugin";
 export * from "./BeforeDeployPlugin";
+
+// Watch only has before-watch hook.
+export * from "./BeforeWatchPlugin";

--- a/packages/cli-plugin-deploy-pulumi/plugins/index.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/index.js
@@ -2,5 +2,6 @@ module.exports = {
     ...require("./AfterBuildPlugin"),
     ...require("./AfterDeployPlugin"),
     ...require("./BeforeBuildPlugin"),
-    ...require("./BeforeDeployPlugin")
+    ...require("./BeforeDeployPlugin"),
+    ...require("./BeforeWatchPlugin"),
 };

--- a/packages/cli-plugin-deploy-pulumi/plugins/index.js
+++ b/packages/cli-plugin-deploy-pulumi/plugins/index.js
@@ -3,5 +3,5 @@ module.exports = {
     ...require("./AfterDeployPlugin"),
     ...require("./BeforeBuildPlugin"),
     ...require("./BeforeDeployPlugin"),
-    ...require("./BeforeWatchPlugin"),
+    ...require("./BeforeWatchPlugin")
 };

--- a/packages/serverless-cms-aws/src/createAdminApp.ts
+++ b/packages/serverless-cms-aws/src/createAdminApp.ts
@@ -1,6 +1,6 @@
 import { createAdminPulumiApp, CreateAdminPulumiAppParams } from "@webiny/pulumi-aws";
 import { uploadAppToS3 } from "./react/plugins";
-import { ensureApiDeployed } from "./admin/plugins";
+import { ensureApiDeployedBeforeBuild, ensureApiDeployedBeforeWatch } from "./admin/plugins";
 import { PluginCollection } from "@webiny/plugins/types";
 
 export interface CreateAdminAppParams extends CreateAdminPulumiAppParams {
@@ -8,7 +8,11 @@ export interface CreateAdminAppParams extends CreateAdminPulumiAppParams {
 }
 
 export function createAdminApp(projectAppParams: CreateAdminAppParams = {}) {
-    const builtInPlugins = [uploadAppToS3({ folder: "apps/admin" }), ensureApiDeployed];
+    const builtInPlugins = [
+        uploadAppToS3({ folder: "apps/admin" }),
+        ensureApiDeployedBeforeBuild,
+        ensureApiDeployedBeforeWatch
+    ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];
 

--- a/packages/serverless-cms-aws/src/createWebsiteApp.ts
+++ b/packages/serverless-cms-aws/src/createWebsiteApp.ts
@@ -4,7 +4,9 @@ import {
     generateCommonHandlers,
     lambdaEdgeWarning,
     renderWebsite,
-    telemetryNoLongerNewUser
+    telemetryNoLongerNewUser,
+    ensureApiDeployedBeforeWatch,
+    ensureApiDeployedBeforeBuild
 } from "./website/plugins";
 import { uploadAppToS3 } from "./react/plugins";
 
@@ -18,7 +20,9 @@ export function createWebsiteApp(projectAppParams: CreateWebsiteAppParams = {}) 
         generateCommonHandlers,
         lambdaEdgeWarning,
         renderWebsite,
-        telemetryNoLongerNewUser
+        telemetryNoLongerNewUser,
+        ensureApiDeployedBeforeBuild,
+        ensureApiDeployedBeforeWatch
     ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];

--- a/packages/serverless-cms-aws/src/enterprise/createAdminApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createAdminApp.ts
@@ -1,20 +1,25 @@
 import { createAdminPulumiApp, CreateAdminPulumiAppParams } from "@webiny/pulumi-aws/enterprise";
 import { uploadAppToS3 } from "~/react/plugins";
 import { PluginCollection } from "@webiny/plugins/types";
+import { ensureApiDeployedBeforeBuild, ensureApiDeployedBeforeWatch } from "~/website/plugins";
 
 export interface CreateAdminAppParams extends CreateAdminPulumiAppParams {
     plugins?: PluginCollection;
 }
 
 export function createAdminApp(projectAppParams: CreateAdminAppParams = {}) {
-    const builtInPlugins = [uploadAppToS3({ folder: "apps/admin" })];
+    const builtInPlugins = [
+        uploadAppToS3({ folder: "apps/admin" }),
+        ensureApiDeployedBeforeBuild,
+        ensureApiDeployedBeforeWatch
+    ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];
 
     return {
         id: "admin",
         name: "Admin",
-        description: "Your project's admin area.",
+        description: "Your project's admin area§.",
         cli: {
             // Default args for the "yarn webiny watch ..." command (we don't need deploy option while developing).
             watch: {

--- a/packages/serverless-cms-aws/src/enterprise/createWebsiteApp.ts
+++ b/packages/serverless-cms-aws/src/enterprise/createWebsiteApp.ts
@@ -7,7 +7,9 @@ import {
     generateCommonHandlers,
     lambdaEdgeWarning,
     renderWebsite,
-    telemetryNoLongerNewUser
+    telemetryNoLongerNewUser,
+    ensureApiDeployedBeforeBuild,
+    ensureApiDeployedBeforeWatch
 } from "~/website/plugins";
 import { uploadAppToS3 } from "~/react/plugins";
 
@@ -21,7 +23,9 @@ export function createWebsiteApp(projectAppParams: CreateWebsiteAppParams = {}) 
         generateCommonHandlers,
         lambdaEdgeWarning,
         renderWebsite,
-        telemetryNoLongerNewUser
+        telemetryNoLongerNewUser,
+        ensureApiDeployedBeforeBuild,
+        ensureApiDeployedBeforeWatch
     ];
 
     const customPlugins = projectAppParams.plugins ? [...projectAppParams.plugins] : [];

--- a/packages/serverless-cms-aws/src/website/plugins/ensureApiDeployed.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/ensureApiDeployed.ts
@@ -16,22 +16,22 @@ const createPluginCallable: (command: "build" | "watch") => Callable =
         }
 
         const apiAppName = ctx.error.hl("API");
-        const adminAppName = ctx.error.hl("Admin");
+        const websiteAppName = ctx.error.hl("Website");
         const cmd = ctx.error.hl(`yarn webiny deploy api --env ${env}`);
         ctx.error(
-            `Cannot ${command} ${adminAppName} project application before deploying ${apiAppName}.`
+            `Cannot ${command} ${websiteAppName} project application before deploying ${apiAppName}.`
         );
 
         throw new GracefulError(
             [
-                `Before ${command}ing ${adminAppName} project application, please`,
+                `Before ${command}ing ${websiteAppName} project application, please`,
                 `deploy ${apiAppName} first by running: ${cmd}.`
             ].join(" ")
         );
     };
 
 export const ensureApiDeployedBeforeBuild = createBeforeBuildPlugin(createPluginCallable("build"));
-ensureApiDeployedBeforeBuild.name = "admin.before-deploy.ensure-api-deployed";
+ensureApiDeployedBeforeBuild.name = "website.before-deploy.ensure-api-deployed";
 
 export const ensureApiDeployedBeforeWatch = createBeforeWatchPlugin(createPluginCallable("watch"));
-ensureApiDeployedBeforeWatch.name = "admin.before-watch.ensure-api-deployed";
+ensureApiDeployedBeforeWatch.name = "website.before-watch.ensure-api-deployed";

--- a/packages/serverless-cms-aws/src/website/plugins/index.ts
+++ b/packages/serverless-cms-aws/src/website/plugins/index.ts
@@ -2,3 +2,4 @@ export * from "./renderWebsite";
 export * from "./generateCommonHandlers";
 export * from "./lambdaEdgeWarning";
 export * from "./telemetryNoLongerNewUser";
+export * from "./ensureApiDeployed";


### PR DESCRIPTION
## Changes
This PR improves error handling in case a user tries to watch Admin/Website apps, without having the API previously deployed. Prior to this PR, users would just receive:

```bash
webiny error: Cannot read properties of null (reading 'apiUrl')
```

With this PR, users will now see a user friendly error message:
```bash
webiny error: Cannot watch Website project application before deploying API.

webiny error: Before watching Website project application, please deploy API first by running: yarn webiny deploy api --env XXX.
```


## How Has This Been Tested?
Manually.

## Documentation
Changelog.