### PR TITLE
fix(tasks): validate input via zod

### DIFF
--- a/packages/tasks/__tests__/mocks/definition.ts
+++ b/packages/tasks/__tests__/mocks/definition.ts
@@ -1,10 +1,12 @@
-import { Context, ITaskDefinition } from "~/types";
+import { Context, ITaskDataInput, ITaskDefinition } from "~/types";
 import { createTaskDefinition } from "~/task";
 
 export const MOCK_TASK_DEFINITION_ID = "myCustomTaskDefinition";
 
-export const createMockTaskDefinition = (definition?: Partial<ITaskDefinition>) => {
-    return createTaskDefinition<Context, any>({
+export const createMockTaskDefinition = <I extends ITaskDataInput = ITaskDataInput>(
+    definition?: Partial<ITaskDefinition>
+) => {
+    return createTaskDefinition<Context, I>({
         id: MOCK_TASK_DEFINITION_ID,
         title: "A custom task defined via method",
         run: async ({ response, isCloseToTimeout, input }) => {

--- a/packages/tasks/src/task/plugin.ts
+++ b/packages/tasks/src/task/plugin.ts
@@ -54,6 +54,10 @@ export class TaskDefinitionPlugin<
         return this.task.fields;
     }
 
+    public get createInputValidation() {
+        return this.task.createInputValidation;
+    }
+
     public get run() {
         return this.task.run;
     }

--- a/packages/tasks/src/types.ts
+++ b/packages/tasks/src/types.ts
@@ -18,6 +18,8 @@ import { SecurityPermission } from "@webiny/api-security/types";
 import { GenericRecord } from "@webiny/api/types";
 import { IStepFunctionServiceFetchResult } from "~/service/StepFunctionServicePlugin";
 
+import type zod from "zod";
+
 export * from "./handler/types";
 export * from "./response/abstractions";
 export * from "./runner/abstractions";
@@ -393,6 +395,11 @@ export interface ITaskBeforeTriggerParams<C extends Context = Context, I = ITask
     data: ITaskCreateData<I>;
 }
 
+export interface ITaskCreateInputValidationParams<C extends Context = Context> {
+    validator: typeof zod;
+    context: C;
+}
+
 export interface ITaskDefinition<
     C extends Context = Context,
     I = ITaskDataInput,
@@ -451,6 +458,13 @@ export interface ITaskDefinition<
      * This will be called during the run time of the task.
      */
     onMaxIterations?(params: ITaskOnMaxIterationsParams<C>): Promise<void>;
+    /**
+     * Create a validation schema for the task input.
+     * This will be used to validate the input before the task is triggered.
+     */
+    createInputValidation?: (
+        params: ITaskCreateInputValidationParams<C>
+    ) => GenericRecord<keyof I, zod.Schema>;
     /**
      * Custom input fields and layout for the task input.
      */


### PR DESCRIPTION
## Changes
Users can now add task input validation, which will run before the task is actually triggered.


## How Has This Been Tested?
Jest and manually.