### PR TITLE
fix(app-headless-cms-common): push id in the list if no other field exists

### DIFF
--- a/packages/app-headless-cms-common/src/createFieldsList.ts
+++ b/packages/app-headless-cms-common/src/createFieldsList.ts
@@ -1,4 +1,4 @@
-import { CmsModelField, CmsModelFieldTypePlugin, CmsModel } from "~/types";
+import { CmsModel, CmsModelField, CmsModelFieldTypePlugin } from "~/types";
 import { plugins } from "@webiny/plugins";
 
 interface CreateFieldsListParams {
@@ -9,7 +9,7 @@ interface CreateFieldsListParams {
 
 export function createFieldsList({
     model,
-    fields,
+    fields: inputFields,
     graphQLTypePrefix
 }: CreateFieldsListParams): string {
     const fieldPlugins: Record<string, CmsModelFieldTypePlugin["field"]> = plugins
@@ -18,7 +18,7 @@ export function createFieldsList({
 
     const typePrefix = graphQLTypePrefix ?? model.singularApiName;
 
-    const allFields = fields
+    const fields = inputFields
         .map(field => {
             if (!fieldPlugins[field.type]) {
                 console.log(`Unknown field plugin for field type "${field.type}".`);
@@ -46,14 +46,11 @@ export function createFieldsList({
             return field.fieldId;
         })
         .filter(Boolean);
-
     /**
-     * If there are no fields for a given type, we add a dummy `_empty` field, which will also be present in the schema
-     * on the API side, to protect the schema from invalid types.
+     * If there are no fields, let's always load the `id` field.
      */
-    if (!allFields.length) {
-        allFields.push("_empty");
+    if (fields.length === 0) {
+        fields.push("id");
     }
-
-    return allFields.join("\n");
+    return fields.join("\n");
 }

--- a/packages/app-headless-cms-common/src/entries.graphql.ts
+++ b/packages/app-headless-cms-common/src/entries.graphql.ts
@@ -112,36 +112,6 @@ const createEntrySystemFields = (model: CmsModel) => {
             type
             displayName
         }
-        revisionCreatedOn
-        revisionSavedOn
-        revisionModifiedOn
-        revisionFirstPublishedOn
-        revisionLastPublishedOn
-        revisionCreatedBy {
-            id
-            type
-            displayName
-        }
-        revisionSavedBy {
-            id
-            type
-            displayName
-        }
-        revisionModifiedBy {
-            id
-            type
-            displayName
-        }
-        revisionFirstPublishedBy {
-            id
-            type
-            displayName
-        }
-        revisionLastPublishedBy {
-            id
-            type
-            displayName
-        }
         ${optionalFields}
     `;
 };


### PR DESCRIPTION
## Changes
When the user deletes all the fields except rich-text one, the UI generated a GraphQL query with `_empty` selector, which in turn broke the UI.

The _fix_ is simple: push `id` field in the field list when no other field exists.

Additionally I found some fields getting queried more than once (check [here](https://github.com/webiny/webiny-js/pull/4370/files#diff-dbac9692b70a218e03e47bc8eca7b94b27600e68d2eee078329d449bc477266c)), probably due to a bad merge, so I removed those.

## How Has This Been Tested?
Manually.