### PR TITLE
Introducing Webiny Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/docs/CODE_OF_CONDUCT.md)
 [![Join our Slack community https://www.webiny.com/slack](https://img.shields.io/badge/Slack-Join%20our%20community!-orange)](https://www.webiny.com/slack)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Webiny%20Guru-006BFF)](https://gurubase.io/g/webiny)
 
 </p>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Webiny Guru](https://gurubase.io/g/webiny) to Gurubase. Webiny Guru uses the data from this repo and data from the [docs](https://www.webiny.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Webiny Guru", which highlights that Webiny now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Webiny Guru in Gurubase, just let me know that's totally fine.
