### PR TITLE
fix(api-page-builder-so-ddb-es): add missing logger into tests

### DIFF
--- a/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
+++ b/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
@@ -41,6 +41,7 @@ import { configurations as cmsConfigurations } from "@webiny/api-headless-cms-dd
 import { SEARCH_RECORD_MODEL_ID } from "@webiny/api-aco/record/record.model";
 import { FOLDER_MODEL_ID } from "@webiny/api-aco/folder/folder.model";
 import { LambdaContext } from "@webiny/handler-aws/types";
+// @ts-expect-error
 import { createMockApiLogContextPlugin } from "@webiny/project-utils/testing/mockApiLog";
 
 interface Params {
@@ -101,6 +102,7 @@ export const useHandler = (params: Params) => {
         createHandler({
             plugins: [
                 elasticsearchClientContext,
+                createMockApiLogContextPlugin(),
                 createDynamoDBToElasticsearchHandler(),
                 createGzipCompression()
             ]

--- a/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
+++ b/packages/api-page-builder-so-ddb-es/__tests__/useHandler.ts
@@ -41,6 +41,7 @@ import { configurations as cmsConfigurations } from "@webiny/api-headless-cms-dd
 import { SEARCH_RECORD_MODEL_ID } from "@webiny/api-aco/record/record.model";
 import { FOLDER_MODEL_ID } from "@webiny/api-aco/folder/folder.model";
 import { LambdaContext } from "@webiny/handler-aws/types";
+import { createMockApiLogContextPlugin } from "@webiny/project-utils/testing/mockApiLog";
 
 interface Params {
     plugins?: PluginCollection;
@@ -121,6 +122,7 @@ export const useHandler = (params: Params) => {
             ...createTenancyAndSecurity({
                 documentClient
             }),
+            createMockApiLogContextPlugin(),
             i18nContext(),
             i18nDynamoDbStorageOperations(),
             mockLocalesPlugins(),

--- a/packages/project-utils/testing/mockApiLog.js
+++ b/packages/project-utils/testing/mockApiLog.js
@@ -1,3 +1,5 @@
+const { ContextPlugin } = require("@webiny/api");
+
 export const createMockApiLog = () => {
     const logging = {
         notice: () => {
@@ -25,4 +27,12 @@ export const createMockApiLog = () => {
         },
         ...logging
     };
+};
+
+export const createMockApiLogContextPlugin = () => {
+    return new ContextPlugin(async context => {
+        context.logger = {
+            ...createMockApiLog()
+        };
+    });
 };


### PR DESCRIPTION
## Changes
Missing logger init when testing Page Builder DDB+ES package.

## How Has This Been Tested?
Jest.