### PR TITLE
feat(admin-ui): add tokens and presenter to Switch

### DIFF
--- a/packages/admin-ui/src/Switch/Switch.stories.tsx
+++ b/packages/admin-ui/src/Switch/Switch.stories.tsx
@@ -1,14 +1,14 @@
+import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-
 import { Switch } from "./Switch";
 
 const meta: Meta<typeof Switch> = {
     title: "Components/Switch",
     component: Switch,
     tags: ["autodocs"],
-    argTypes: {
-        // Note: after upgrading to Storybook 8.X, use `fn`from `@storybook/test` to spy on the onCheckedChange argument.
-        onCheckedChange: { action: "onCheckedChange" }
+    render: args => {
+        const [checked, setChecked] = useState(args.checked);
+        return <Switch {...args} checked={checked} onCheckedChange={value => setChecked(value)} />;
     }
 };
 
@@ -17,22 +17,14 @@ type Story = StoryObj<typeof Switch>;
 
 export const Default: Story = {};
 
-export const WithLabel: Story = {
+export const Checked: Story = {
     args: {
-        label: "Label"
+        checked: true
     }
 };
 
-export const WithLeadingLabel: Story = {
+export const Disabled: Story = {
     args: {
-        label: "Leading label",
-        labelPosition: "start"
-    }
-};
-
-export const WithTrailingLabel: Story = {
-    args: {
-        label: "Trailing label",
-        labelPosition: "end"
+        disabled: true
     }
 };

--- a/packages/admin-ui/src/Switch/Switch.tsx
+++ b/packages/admin-ui/src/Switch/Switch.tsx
@@ -1,56 +1,61 @@
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
-import { makeDecoratable } from "@webiny/react-composition";
-import { cva, type VariantProps } from "class-variance-authority";
-import { cn, generateId } from "~/utils";
-import { Label } from "~/Label";
+import { cn, makeDecoratable } from "~/utils";
+import { useSwitch } from "~/Switch/useSwitch";
 
-const switchVariants = cva("flex items-center space-x-2", {
-    variants: {
-        labelPosition: {
-            start: "",
-            end: "flex-row-reverse space-x-reverse "
-        }
-    },
-    defaultVariants: {
-        labelPosition: "start"
-    }
-});
+type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>;
 
-interface SwitchProps
-    extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>,
-        VariantProps<typeof switchVariants> {
-    label: React.ReactNode;
+type SwitchVm = {
+    checked: boolean;
+    disabled: boolean;
+};
+
+interface SwitchRendererProps {
+    switchVm: SwitchVm;
+    onCheckedChange: (checked: boolean) => void;
+    className?: string;
 }
+const DecoratableSwitchRenderer = React.forwardRef<
+    React.ElementRef<typeof SwitchPrimitives.Root>,
+    SwitchRendererProps
+>(({ switchVm, onCheckedChange, className }, ref) => {
+    return (
+        <SwitchPrimitives.Root
+            className={cn([
+                "peer inline-flex h-4 w-6 shrink-0 cursor-pointer items-center rounded-xxl border-sm transition-colors",
+                "border-transparent data-[state=checked]:bg-secondary-default data-[state=unchecked]:bg-neutral-strong",
+                "focus-visible:outline-none focus-visible:border-success-default focus-visible:ring-lg focus-visible:ring-primary-dimmed",
+                "disabled:cursor-not-allowed disabled:bg-neutral-muted disabled:data-[state=checked]:bg-neutral-muted",
+                className
+            ])}
+            onCheckedChange={onCheckedChange}
+            {...switchVm}
+            ref={ref}
+        >
+            <SwitchPrimitives.Thumb
+                className={cn(
+                    "pointer-events-none block h-2.5 w-2.5 rounded-xxl bg-neutral-base shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-2.5 data-[state=unchecked]:translate-x-0.5"
+                )}
+            />
+        </SwitchPrimitives.Root>
+    );
+});
+DecoratableSwitchRenderer.displayName = "SwitchRenderer";
 
-const SwitchBase = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, SwitchProps>(
-    ({ id: initialId, className, label, labelPosition, ...props }, ref) => {
-        const id = React.useMemo(() => generateId(initialId), [initialId]);
+const SwitchRenderer = makeDecoratable("SwitchRenderer", DecoratableSwitchRenderer);
 
-        return (
-            <div className={cn(switchVariants({ labelPosition, className }))}>
-                {label && <Label text={label} htmlFor={id} />}
-                <SwitchPrimitives.Root
-                    className={cn(
-                        "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
-                    )}
-                    {...props}
-                    ref={ref}
-                    id={id}
-                    aria-label={React.isValidElement(label) ? "Switch" : String(label)}
-                >
-                    <SwitchPrimitives.Thumb
-                        className={cn(
-                            "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
-                        )}
-                    />
-                </SwitchPrimitives.Root>
-            </div>
-        );
-    }
-);
-SwitchBase.displayName = SwitchPrimitives.Root.displayName;
+const DecoratableSwitch = (props: SwitchProps) => {
+    const { vm, changeValue } = useSwitch(props);
 
-const Switch = makeDecoratable("Switch", SwitchBase);
+    return (
+        <SwitchRenderer
+            switchVm={vm.switchVm}
+            onCheckedChange={changeValue}
+            className={props.className}
+        />
+    );
+};
 
-export { Switch, type SwitchProps };
+const Switch = makeDecoratable("Switch", DecoratableSwitch);
+
+export { Switch, type SwitchProps, type SwitchVm };

--- a/packages/admin-ui/src/Switch/Switch.tsx
+++ b/packages/admin-ui/src/Switch/Switch.tsx
@@ -5,7 +5,7 @@ import { useSwitch } from "~/Switch/useSwitch";
 
 type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>;
 
-type SwitchVm = {
+type SwitchVm = Omit<SwitchPrimitives.SwitchProps, "checked" | "disabled" | "onCheckedChange"> & {
     checked: boolean;
     disabled: boolean;
 };
@@ -22,7 +22,7 @@ const DecoratableSwitchRenderer = React.forwardRef<
     return (
         <SwitchPrimitives.Root
             className={cn([
-                "peer inline-flex h-4 w-6 shrink-0 cursor-pointer items-center rounded-xxl border-sm transition-colors",
+                "peer inline-flex h-4 w-[26px] shrink-0 cursor-pointer items-center rounded-xxl border-sm transition-colors",
                 "border-transparent data-[state=checked]:bg-secondary-default data-[state=unchecked]:bg-neutral-strong",
                 "focus-visible:outline-none focus-visible:border-success-default focus-visible:ring-lg focus-visible:ring-primary-dimmed",
                 "disabled:cursor-not-allowed disabled:bg-neutral-muted disabled:data-[state=checked]:bg-neutral-muted",
@@ -34,7 +34,7 @@ const DecoratableSwitchRenderer = React.forwardRef<
         >
             <SwitchPrimitives.Thumb
                 className={cn(
-                    "pointer-events-none block h-2.5 w-2.5 rounded-xxl bg-neutral-base shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-2.5 data-[state=unchecked]:translate-x-0.5"
+                    "pointer-events-none block h-2.5 w-2.5 rounded-xxl bg-neutral-base shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-3 data-[state=unchecked]:translate-x-0.5"
                 )}
             />
         </SwitchPrimitives.Root>

--- a/packages/admin-ui/src/Switch/SwitchPresenter.test.ts
+++ b/packages/admin-ui/src/Switch/SwitchPresenter.test.ts
@@ -1,0 +1,36 @@
+import { SwitchPresenter } from "./SwitchPresenter";
+
+describe("SwitchPresenter", () => {
+    const onCheckedChange = jest.fn();
+
+    it("should return the compatible `switchVm` based on props", () => {
+        // `checked`
+        {
+            const presenter = new SwitchPresenter();
+            presenter.init({ onCheckedChange, checked: true });
+            expect(presenter.vm.switchVm.checked).toEqual(true);
+        }
+
+        // `disabled`
+        {
+            const presenter = new SwitchPresenter();
+            presenter.init({ onCheckedChange, disabled: true });
+            expect(presenter.vm.switchVm.disabled).toEqual(true);
+        }
+
+        {
+            // default: no props
+            const presenter = new SwitchPresenter();
+            presenter.init({ onCheckedChange });
+            expect(presenter.vm.switchVm.checked).toEqual(false);
+            expect(presenter.vm.switchVm.disabled).toEqual(false);
+        }
+    });
+
+    it("should call `onCheckedChange` callback when `changeValue` is called", () => {
+        const presenter = new SwitchPresenter();
+        presenter.init({ onCheckedChange });
+        presenter.changeValue(true);
+        expect(onCheckedChange).toHaveBeenCalledWith(true);
+    });
+});

--- a/packages/admin-ui/src/Switch/SwitchPresenter.ts
+++ b/packages/admin-ui/src/Switch/SwitchPresenter.ts
@@ -1,0 +1,38 @@
+import { makeAutoObservable } from "mobx";
+import { SwitchProps, SwitchVm } from "./Switch";
+
+interface ISwitchPresenter<TProps extends SwitchProps = SwitchProps> {
+    get vm(): {
+        switchVm: SwitchVm;
+    };
+    init: (props: TProps) => void;
+    changeValue: (checked: boolean) => void;
+}
+
+class SwitchPresenter implements ISwitchPresenter {
+    private props?: SwitchProps;
+
+    constructor() {
+        this.props = undefined;
+        makeAutoObservable(this);
+    }
+
+    init(props: SwitchProps) {
+        this.props = props;
+    }
+
+    get vm() {
+        return {
+            switchVm: {
+                checked: this.props?.checked ?? false,
+                disabled: this.props?.disabled ?? false
+            }
+        };
+    }
+
+    public changeValue = (checked: boolean) => {
+        this.props?.onCheckedChange?.(checked);
+    };
+}
+
+export { SwitchPresenter, type ISwitchPresenter };

--- a/packages/admin-ui/src/Switch/SwitchPresenter.ts
+++ b/packages/admin-ui/src/Switch/SwitchPresenter.ts
@@ -1,4 +1,5 @@
 import { makeAutoObservable } from "mobx";
+import omit from "lodash/omit";
 import { SwitchProps, SwitchVm } from "./Switch";
 
 interface ISwitchPresenter<TProps extends SwitchProps = SwitchProps> {
@@ -24,6 +25,7 @@ class SwitchPresenter implements ISwitchPresenter {
     get vm() {
         return {
             switchVm: {
+                ...omit(this.props, ["onCheckedChange"]),
                 checked: this.props?.checked ?? false,
                 disabled: this.props?.disabled ?? false
             }

--- a/packages/admin-ui/src/Switch/index.ts
+++ b/packages/admin-ui/src/Switch/index.ts
@@ -1,1 +1,2 @@
 export * from "./Switch";
+export * from "./SwitchPresenter";

--- a/packages/admin-ui/src/Switch/useSwitch.ts
+++ b/packages/admin-ui/src/Switch/useSwitch.ts
@@ -1,0 +1,22 @@
+import { useEffect, useMemo, useState } from "react";
+import { autorun } from "mobx";
+import { SwitchProps } from "./Switch";
+import { SwitchPresenter } from "./SwitchPresenter";
+
+export const useSwitch = (props: SwitchProps) => {
+    const presenter = useMemo(() => new SwitchPresenter(), []);
+
+    const [vm, setVm] = useState(presenter.vm);
+
+    useEffect(() => {
+        presenter.init(props);
+    }, [props]);
+
+    useEffect(() => {
+        return autorun(() => {
+            setVm(presenter.vm);
+        });
+    }, [presenter]);
+
+    return { vm, changeValue: presenter.changeValue };
+};

--- a/packages/ui/src/Switch/Switch.tsx
+++ b/packages/ui/src/Switch/Switch.tsx
@@ -1,60 +1,36 @@
 import React from "react";
-import { Switch as SwitchBase } from "@webiny/admin-ui";
+import { Switch as RmwcSwitch, SwitchProps } from "@rmwc/switch";
 import { FormComponentProps } from "~/types";
+import pick from "lodash/pick";
 import { FormElementMessage } from "~/FormElementMessage";
+import { getClasses } from "~/Helpers";
 
-type Props = {
-    /** Unique identifier for the control. */
-    id?: string;
+type Props = Omit<SwitchProps, "value"> &
+    FormComponentProps<boolean> & {
+        // Description beneath the switch.
+        description?: string;
 
-    /** Disables the control when set to true. */
-    disabled?: boolean;
-
-    /** Sets the control to checked (on) or unchecked (off). */
-    checked?: boolean;
-
-    /** A label displayed alongside the control. Can be any React node. */
-    label?: React.ReactNode;
-
-    /** Additional description displayed beneath the control. */
-    description?: string;
-
-    /** Additional CSS classes to apply to the control. */
-    className?: string;
-} & FormComponentProps<boolean>;
+        // Optional class name.
+        className?: string;
+    };
 
 /**
- * @deprecated This component is deprecated and will be removed in future releases.
- * Please use the `Switch` component from the `@webiny/admin-ui` package instead.
+ * Switch component can be used to store simple boolean values.
  */
 class Switch extends React.Component<Props> {
     static rmwcProps = ["id", "disabled", "checked", "label", "rootProps", "className"];
 
     public override render() {
-        const {
-            checked,
-            className,
-            description,
-            disabled,
-            id,
-            label,
-            onChange,
-            validation,
-            value
-        } = this.props;
+        const { value, description, validation } = this.props;
 
         const { isValid: validationIsValid, message: validationMessage } = validation || {};
 
         return (
             <React.Fragment>
-                <SwitchBase
+                <RmwcSwitch
+                    {...getClasses({ ...pick(this.props, Switch.rmwcProps) }, "webiny-ui-switch")}
                     checked={Boolean(value)}
-                    className={className}
-                    defaultChecked={Boolean(checked)}
-                    disabled={disabled}
-                    id={id}
-                    label={label}
-                    onCheckedChange={(checked: boolean) => onChange && onChange(checked)}
+                    onClick={() => this.props.onChange && this.props.onChange(!value)}
                 />
 
                 {validationIsValid === false && (


### PR DESCRIPTION
## Changes
This pull request refactors various aspects of the `Switch` components, specifically:

- It uses the appropriate design tokens.
- The component state is now managed with `SwitchPresenter`.
- The `Label` component has been removed: a form variant will be created to manage labeling, messages, and errors.
