### PR TITLE
refactor(admin-ui): add tokens to Label

### DIFF
--- a/packages/admin-ui/src/Label/Label.stories.tsx
+++ b/packages/admin-ui/src/Label/Label.stories.tsx
@@ -49,23 +49,40 @@ export const Required: Story = {
     }
 };
 
-export const Optional: Story = {
+export const WithDescription: Story = {
     args: {
         ...Default.args,
-        optional: true
+        description: "(description)"
     }
 };
 
-export const WithInfo: Story = {
+export const WithHint: Story = {
     args: {
         ...Default.args,
-        info: "An informative text"
+        hint: "This is an additional message in case context to this label needs to be added"
     }
 };
 
 export const WithValue: Story = {
     args: {
         ...Default.args,
+        value: 24
+    },
+    render: args => (
+        <div className="w-64">
+            <Label {...args} />
+        </div>
+    )
+};
+
+export const Disabled: Story = {
+    args: {
+        htmlFor: "test-field-disabled",
+        text: "Test label",
+        description: "(description)",
+        hint: "This is an additional message in case context to this label needs to be added",
+        required: true,
+        disabled: true,
         value: 24
     },
     render: args => (

--- a/packages/admin-ui/src/Label/Label.tsx
+++ b/packages/admin-ui/src/Label/Label.tsx
@@ -1,55 +1,77 @@
 import * as React from "react";
 import { ReactComponent as InfoIcon } from "@material-design-icons/svg/outlined/info.svg";
 import * as LabelPrimitive from "@radix-ui/react-label";
-import { makeDecoratable } from "@webiny/react-composition";
 import { cva, type VariantProps } from "class-variance-authority";
-
 import { Icon } from "~/Icon";
 import { Text } from "~/Text";
 import { Tooltip } from "~/Tooltip";
-import { cn } from "~/utils";
+import { cn, makeDecoratable } from "~/utils";
 
 /**
  * Label Required
  */
-const LabelRequiredBase = () => <span className={"text-red-500"}>{"*"}</span>;
-const LabelRequired = makeDecoratable("LabelRequired", LabelRequiredBase);
+const labelRequiredVariants = cva("text-destructive-primary", {
+    variants: {
+        disabled: {
+            true: "text-destructive-muted"
+        }
+    }
+});
 
-/**
- * Label Optional
- */
-const LabelOptionalBase = () => (
-    <Text className={"ml-1 font-light text-gray-400"} text={"(optional)"} />
+type LabelRequiredProps = VariantProps<typeof labelRequiredVariants>;
+
+const DecoratableLabelRequired = ({ disabled }: LabelRequiredProps) => (
+    <span className={cn(labelRequiredVariants({ disabled }))}>{"*"}</span>
 );
-const LabelOptional = makeDecoratable("LabelOptional", LabelOptionalBase);
+const LabelRequired = makeDecoratable("LabelRequired", DecoratableLabelRequired);
 
 /**
- * Label Info
+ * Label Description
  */
-interface LabelInfoProps {
+const labelDescriptionVariants = cva("font-normal text-neutral-muted", {
+    variants: {
+        disabled: {
+            true: "text-neutral-disabled"
+        }
+    }
+});
+
+interface LabelDescriptionProps extends VariantProps<typeof labelDescriptionVariants> {
     content: React.ReactNode;
 }
 
-const LabelInfoBase = ({ content }: LabelInfoProps) => (
-    <span className={"ml-1"}>
-        <Tooltip
-            content={content}
-            trigger={
-                <Icon icon={<InfoIcon />} size="sm" label={"More information"} color={"dark"} />
-            }
-        />
-    </span>
+const DecoratableLabelDescription = ({ content, disabled }: LabelDescriptionProps) => (
+    <Text className={cn(labelDescriptionVariants({ disabled }))} text={content} size={"sm"} />
 );
-const LabelInfo = makeDecoratable("LabelInfo", LabelInfoBase);
+const LabelDescription = makeDecoratable("LabelDescription", DecoratableLabelDescription);
+
+/**
+ * Label Hint
+ */
+
+interface LabelHintProps {
+    content: React.ReactNode;
+}
+
+const DecoratableLabelHint = ({ content }: LabelHintProps) => (
+    <Tooltip
+        content={content}
+        trigger={<Icon icon={<InfoIcon />} size="sm" label={"More information"} color={"light"} />}
+    />
+);
+const LabelHint = makeDecoratable("LabelHint", DecoratableLabelHint);
 
 /**
  * Label Value
  */
-const labelValueVariants = cva("", {
+const labelValueVariants = cva("text-neutral-strong", {
     variants: {
         weight: {
-            strong: "font-medium",
-            light: "font-normal"
+            strong: "font-semibold",
+            light: "font-regular"
+        },
+        disabled: {
+            true: "text-neutral-disabled"
         }
     },
     defaultVariants: {
@@ -61,18 +83,24 @@ interface LabelValueProps extends VariantProps<typeof labelValueVariants> {
     value: React.ReactNode;
 }
 
-const LabelValueBase = ({ value, weight }: LabelValueProps) => (
-    <Text text={value} className={cn(labelValueVariants({ weight }))} />
+const DecoratableLabelValue = ({ value, weight, disabled }: LabelValueProps) => (
+    <Text text={value} size="sm" className={cn(labelValueVariants({ weight, disabled }))} />
 );
-const LabelValue = makeDecoratable("LabelValue", LabelValueBase);
+const LabelValue = makeDecoratable("LabelValue", DecoratableLabelValue);
 
 const labelVariants = cva(
-    "inline-flex items-center justify-between w-full text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+    [
+        "inline-flex items-center justify-between w-full text-sm leading-none",
+        "text-neutral-primary"
+    ],
     {
         variants: {
             weight: {
-                strong: "font-medium",
-                light: "font-normal"
+                strong: "font-semibold",
+                light: "font-regular"
+            },
+            disabled: {
+                true: "text-neutral-disabled cursor-not-allowed"
             }
         },
         defaultVariants: {
@@ -86,27 +114,28 @@ interface LabelProps
         VariantProps<typeof labelVariants> {
     text: React.ReactNode;
     value?: React.ReactNode;
+    description?: React.ReactNode;
+    hint?: React.ReactNode;
     required?: boolean;
-    optional?: boolean;
-    info?: React.ReactNode;
+    disabled?: boolean;
 }
 
 const LabelBase = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
-    ({ className, info, optional, required, value, text, weight, ...props }, ref) => (
+    ({ className, disabled, description, hint, required, value, text, weight, ...props }, ref) => (
         <LabelPrimitive.Root
             ref={ref}
-            className={cn(labelVariants({ weight }), className)}
+            className={cn(labelVariants({ disabled, weight }), className)}
             {...props}
         >
             <span>
-                <span className={"flex items-center"}>
+                <span className={"flex items-center gap-0.5"}>
                     {text}
-                    {required && <LabelRequired />}
-                    {info && <LabelInfo content={info} />}
-                    {optional && !required && <LabelOptional />}
+                    {description && <LabelDescription content={description} disabled={disabled} />}
+                    {hint && <LabelHint content={hint} />}
+                    {required && <LabelRequired disabled={disabled} />}
                 </span>
             </span>
-            {value && <LabelValue value={value} weight={weight} />}
+            {value && <LabelValue value={value} weight={weight} disabled={disabled} />}
         </LabelPrimitive.Root>
     )
 );


### PR DESCRIPTION
## Changes
This pull request enhances the `Label` component by updating the Tailwind class names according to our Design System tokens and changing some of the props: 

- optional: `boolean` -> description: `React.ReactNode`
- info: `React.ReactNode` -> hint: `React.ReactNode`
- disabled: `boolean`