### PR TITLE
Lifecycle Event Handlers - Add Error Logging

### DIFF
--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -38,7 +38,23 @@ export const createTopic = <TEvent extends Event = Event>(topicName?: string): T
         },
         async publish(event: TEvent) {
             for (const cb of subscribers) {
-                await cb(event);
+                try {
+                    await cb(event);
+                } catch (e) {
+                    console.error(
+                        `An error occurred while publishing an event (topic: ${topicName}).`,
+                        {
+                            topicName: topicName,
+                            error: {
+                                message: e.message,
+                                code: e.code,
+                                data: e.data,
+                                stack: e.stack
+                            }
+                        }
+                    );
+                    throw e;
+                }
             }
         }
     };


### PR DESCRIPTION
## Changes
With this PR, we've added basic error logging during the execution of lifecycle event handlers. 

This will help users debug issues because, not only will they be able to see the newly added logs in their CloudWatch, but also, in their browser. 

The following example shows a log that happened because of an error that occurred in a `onEntryBeforePublish` lifecycle event:
![Snipaste_2024-11-15_12-34-43](https://github.com/user-attachments/assets/b3250e02-bd57-48b8-9393-a42c5bfde4df)

> [!NOTE]  
> In case you missed it, with the `DEBUG` env variable set to `true`, all of the logs that happened during a single API HTTP requests are actually forwarded to user's console.

> [!NOTE]  
> The `DEBUG` env variable is usually used with dev and pre-prod Webiny instances.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.