### PR TITLE
Website Cloudfront Distributions - Ignore Changes In `staging` Property

### DIFF
--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -132,9 +132,10 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     // that, because this property did not exist before, it will always be considered as a change
                     // upon deployment.
                     // We might think this is fine, but, the problem is that a change in this property causes
-                    // a full replacement of the Cloudfront distribution, which is not acceptable.
-                    // Note that we've seen this being especially problematic in cases where a user already
-                    // has a custom domain associated with the Cloudfront distribution.
+                    // a full replacement of the Cloudfront distribution, which is not acceptable. Especially
+                    // if a custom domain has already been associated with the distribution. This then would
+                    // require the user to disassociate the domain, wait for the distribution to be replaced,
+                    // and then re-associate the domain. This is not a good experience.
                     ignoreChanges: ["staging"]
                 }
             });

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -135,7 +135,6 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     // a full replacement of the Cloudfront distribution, which is not acceptable.
                     // Note that we've seen this being especially problematic in cases where a user already
                     // has a custom domain associated with the Cloudfront distribution.
-
                     ignoreChanges: ["staging"]
                 }
             });

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -122,6 +122,21 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     viewerCertificate: {
                         cloudfrontDefaultCertificate: true
                     }
+                },
+                opts: {
+                    // We are ignoring changes to the "staging" property. This is because of the following.
+                    // With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change
+                    // with how Cloudfront distributions are deployed, where Pulumi now also controls the new
+                    // `staging` property.
+                    // If not set, Pulumi will default it to `false`. Which is fine, but, the problem is
+                    // that, because this property did not exist before, it will always be considered as a change
+                    // upon deployment.
+                    // We might think this is fine, but, the problem is that a change in this property causes
+                    // a full replacement of the Cloudfront distribution, which is not acceptable.
+                    // Note that we've seen this being especially problematic in cases where a user already
+                    // has a custom domain associated with the Cloudfront distribution.
+
+                    ignoreChanges: ["staging"]
                 }
             });
 

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -235,6 +235,10 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     viewerCertificate: {
                         cloudfrontDefaultCertificate: true
                     }
+                },
+                opts: {
+                    // Check the comment in the `appCloudfront` resource above for more info.
+                    ignoreChanges: ["staging"]
                 }
             });
 


### PR DESCRIPTION
## Changes
With this PR, we are ignoring changes to the "staging" property when deploying Website app's Cloudfront distributions. I've added the following comment in the code:

> We are ignoring changes to the "staging" property. This is because of the following. 
>
> With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change with how Cloudfront distributions are deployed, where Pulumi now also controls the new `staging` property.
>
> If not set, Pulumi will default it to `false`. Which is fine, but, the problem is that, because this property did not exist before, it will always be considered as a change upon deployment.
>
> We might think this is fine, but, the problem is that a change in this property causes a full replacement of the Cloudfront distribution, which is not acceptable. Especially if a custom domain has already been associated with the distribution. This then would require the user to disassociate the domain, wait for the distribution to be replaced, and then re-associate the domain. This is not a good experience.

## How Has This Been Tested?
Manually. After adding `staging` to the `ignoreChanges` array, I was able to do any change to the property, and no replacements would be done by Pulumi.

## Documentation
Changelog.