### PR TITLE
Page Builder - Improving Text Rendering on Rendered Pages

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/paragraph.tsx
+++ b/packages/app-page-builder-elements/src/renderers/paragraph.tsx
@@ -14,6 +14,15 @@ export const elementInputs = {
     })
 };
 
+const isJson = (value: string) => {
+    try {
+        JSON.parse(value);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
 /**
  * This renderer works with plain HTML. In the past, we used to have the MediumEditor, and it produced plain HTML.
  * For the new Lexical Editor, we decorate this renderer from the `@webiny/app-page-builder` package.
@@ -23,6 +32,10 @@ export const ParagraphRenderer = createRenderer<unknown, typeof elementInputs>(
         const { getInputValues } = useRenderer();
         const inputs = getInputValues<typeof elementInputs>();
         const __html = inputs.text || "";
+
+        if (isJson(__html)) {
+            return null;
+        }
 
         // If the text already contains `p` tags (happens when c/p-ing text into the editor),
         // we don't want to wrap it with another pair of `p` tag.

--- a/packages/project-utils/packages/createBabelConfigForReact.js
+++ b/packages/project-utils/packages/createBabelConfigForReact.js
@@ -19,7 +19,8 @@ module.exports = ({ path, esm }) => ({
                     "@babel/plugin-proposal-optional-chaining",
                     "@babel/plugin-proposal-nullish-coalescing-operator",
                     "@babel/plugin-transform-async-to-generator",
-                    "@babel/plugin-transform-regenerator"
+                    "@babel/plugin-transform-regenerator",
+                    "@babel/plugin-proposal-dynamic-import"
                 ]
             }
         ],


### PR DESCRIPTION
## Changes
This PR adds two patches.

#### 1. Improving Text Rendering on Rendered Pages

First, it ensures that the old Medium editor (used before we introduced Lexical into PB), does not render anything if the received content is recognized as JSON. Without this fix, on rendered pages, users would sometimes be able to see a JSON string being printed for a brief amount of time (a couple of ms). 

Note that there is still some work to be done here, which will be done in the near future.

#### 2. Added `@babel/plugin-proposal-dynamic-import` To Babel Configuration For React Apps
As the title says, we've added `@babel/plugin-proposal-dynamic-import` to Babel configuration that's used with React apps.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.