### PR TITLE
Add `AddButtonLinkComponent` Decorator

### DIFF
--- a/packages/app-page-builder/src/render/PageBuilder.tsx
+++ b/packages/app-page-builder/src/render/PageBuilder.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { AddButtonClickHandlers } from "~/elementDecorators/AddButtonClickHandlers";
+import { AddButtonLinkComponent } from "~/elementDecorators/AddButtonLinkComponent";
 import { InjectElementVariables } from "~/render/variables/InjectElementVariables";
 import { LexicalParagraphRenderer } from "~/render/plugins/elements/paragraph/LexicalParagraph";
 import { LexicalHeadingRenderer } from "~/render/plugins/elements/heading/LexicalHeading";
@@ -7,6 +8,7 @@ import { LexicalHeadingRenderer } from "~/render/plugins/elements/heading/Lexica
 export const PageBuilder = () => {
     return (
         <>
+            <AddButtonLinkComponent />
             <AddButtonClickHandlers />
             <InjectElementVariables />
             <LexicalParagraphRenderer />


### PR DESCRIPTION
## Changes
On a rendered page, when clicking on a button that contains a link to another page created with PB, users should be redirected without a full page refresh. Prior to this PR, this was not the case.

This happened because the `AddButtonLinkComponent` decorator was not applied  in `packages/app-page-builder/src/render/PageBuilder.tsx`.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.