### PR TITLE
Improve multi value field renderers

### DIFF
--- a/packages/api-headless-cms/src/fieldConverters/CmsModelObjectFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelObjectFieldConverterPlugin.ts
@@ -39,7 +39,7 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
         if (field.multipleValues) {
             if (Array.isArray(value) === false) {
                 return {
-                    [field.storageId]: []
+                    [field.storageId]: null
                 };
             }
             return {
@@ -163,7 +163,7 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
         if (field.multipleValues) {
             if (Array.isArray(value) === false) {
                 return {
-                    [field.fieldId]: []
+                    [field.fieldId]: null
                 };
             }
             return {

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormProvider.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/ContentEntryFormProvider.tsx
@@ -136,6 +136,7 @@ export const ContentEntryFormProvider = ({
             onSubmit={onFormSubmit}
             data={entry}
             ref={ref}
+            validateOnFirstSubmit
             invalidFields={invalidFields}
             onInvalid={invalidFields => {
                 setInvalidFields(formValidationToMap(invalidFields));

--- a/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntryForm/useBind.tsx
@@ -99,7 +99,7 @@ export function useBind({ Bind, field }: UseBindProps) {
                                     let value = bind.value;
                                     value = [...value.slice(0, index), ...value.slice(index + 1)];
 
-                                    bind.onChange(value);
+                                    bind.onChange(value.length === 0 ? null : value);
 
                                     // To make sure the field is still valid, we must trigger validation.
                                     form.validateInput(field.fieldId);

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/Input.tsx
@@ -29,7 +29,7 @@ export const Input = ({ bind, ...props }: InputProps) => {
             }}
             label={props.field.label}
             placeholder={props.field.placeholderText}
-            description={props.field.helpText}
+            description={props.field.multipleValues ? undefined : props.field.helpText}
             type={props.type}
             trailingIcon={props.trailingIcon}
             data-testid={`fr.input.${props.field.label}`}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dateTime/dateTimeFields.tsx
@@ -33,13 +33,10 @@ const plugin: CmsModelFieldRendererPlugin = {
             return (
                 <DynamicSection {...props}>
                     {({ bind, index }) => {
-                        let trailingIcon = undefined;
-                        if (index > 0) {
-                            trailingIcon = {
-                                icon: <DeleteIcon />,
-                                onClick: () => bind.field.removeValue(index)
-                            };
-                        }
+                        const trailingIcon = {
+                            icon: <DeleteIcon />,
+                            onClick: () => bind.field.removeValue(index)
+                        };
 
                         if (fieldSettingsType === "dateTimeWithoutTimezone") {
                             return (

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/lexicalText/lexicalTextInputs.tsx
@@ -66,13 +66,13 @@ const plugin: CmsModelFieldRendererPlugin = {
                                     />
                                 )}
                             </DelayedOnChange>
-                            <FormElementMessage>{field.helpText}</FormElementMessage>
-                            {index > 0 && (
-                                <IconButton
-                                    icon={<DeleteIcon />}
-                                    onClick={() => bind.field.removeValue(index)}
-                                />
+                            {field.multipleValues ? null : (
+                                <FormElementMessage>{field.helpText}</FormElementMessage>
                             )}
+                            <IconButton
+                                icon={<DeleteIcon />}
+                                onClick={() => bind.field.removeValue(index)}
+                            />
                         </EditorWrapper>
                     )}
                 </DynamicSection>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/longText/longTexts.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/longText/longTexts.tsx
@@ -37,14 +37,11 @@ const plugin: CmsModelFieldRendererPlugin = {
                                 rows={5}
                                 label={t`Value {number}`({ number: index + 1 })}
                                 placeholder={props.field.placeholderText}
-                                description={props.field.helpText}
                                 data-testid={`fr.input.longTexts.${props.field.label}.${index + 1}`}
-                                trailingIcon={
-                                    index > 0 && {
-                                        icon: <DeleteIcon />,
-                                        onClick: () => bind.field.removeValue(index)
-                                    }
-                                }
+                                trailingIcon={{
+                                    icon: <DeleteIcon />,
+                                    onClick: () => bind.field.removeValue(index)
+                                }}
                             />
                         </DelayedOnChange>
                     )}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/number/numberInputs.tsx
@@ -37,15 +37,12 @@ const plugin: CmsModelFieldRendererPlugin = {
                                 onEnter={() => bind.field.appendValue("")}
                                 label={t`Value {number}`({ number: index + 1 })}
                                 placeholder={props.field.placeholderText}
-                                description={props.field.helpText}
                                 data-testid={`fr.input.numbers.${props.field.label}.${index + 1}`}
                                 type="number"
-                                trailingIcon={
-                                    index > 0 && {
-                                        icon: <DeleteIcon />,
-                                        onClick: () => bind.field.removeValue(index)
-                                    }
-                                }
+                                trailingIcon={{
+                                    icon: <DeleteIcon />,
+                                    onClick: () => bind.field.removeValue(index)
+                                }}
                             />
                         </DelayedOnChange>
                     )}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -64,13 +64,13 @@ const Actions = ({ setHighlightIndex, bind, index }: ActionsProps) => {
         [moveValueUp, index]
     );
 
-    return index > 0 ? (
+    return (
         <>
             <IconButton icon={<ArrowDown />} onClick={onDown} />
             <IconButton icon={<ArrowUp />} onClick={onUp} />
             <IconButton icon={<DeleteIcon />} onClick={() => bind.field.removeValue(index)} />
         </>
-    ) : null;
+    );
 };
 
 const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
@@ -87,20 +87,7 @@ const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     const settings = fieldSettings.getSettings();
 
     return (
-        <DynamicSection
-            {...props}
-            emptyValue={{}}
-            showLabel={false}
-            renderTitle={value => (
-                <Cell span={12} className={dynamicSectionTitleStyle}>
-                    <Typography use={"headline5"}>
-                        {`${field.label} ${value.length ? `(${value.length})` : ""}`}
-                    </Typography>
-                    {field.helpText && <FormElementMessage>{field.helpText}</FormElementMessage>}
-                </Cell>
-            )}
-            gridClassName={dynamicSectionGridStyle}
-        >
+        <DynamicSection {...props} emptyValue={{}} gridClassName={dynamicSectionGridStyle}>
             {({ Bind, bind, index }) => (
                 <ObjectItem>
                     {highlightMap[index] ? <ItemHighLight key={highlightMap[index]} /> : null}

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjects.tsx
@@ -2,8 +2,6 @@ import React, { Dispatch, SetStateAction, useState, useCallback } from "react";
 import { i18n } from "@webiny/app/i18n";
 import { IconButton } from "@webiny/ui/Button";
 import { Cell } from "@webiny/ui/Grid";
-import { FormElementMessage } from "@webiny/ui/FormElementMessage";
-import { Typography } from "@webiny/ui/Typography";
 import {
     BindComponentRenderProp,
     CmsModelFieldRendererPlugin,
@@ -17,7 +15,6 @@ import { ReactComponent as ArrowDown } from "./arrow_drop_down.svg";
 import Accordion from "~/admin/plugins/fieldRenderers/Accordion";
 import {
     fieldsWrapperStyle,
-    dynamicSectionTitleStyle,
     dynamicSectionGridStyle,
     fieldsGridStyle,
     ItemHighLight,

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/multipleObjectsAccordion.tsx
@@ -63,18 +63,18 @@ const Actions = ({ setHighlightIndex, bind, index }: ActionsProps) => {
         [moveValueUp, index]
     );
 
-    return index > 0 ? (
+    return (
         <>
             <IconButton icon={<ArrowDown />} onClick={onDown} />
             <IconButton icon={<ArrowUp />} onClick={onUp} />
             <IconButton icon={<DeleteIcon />} onClick={() => bind.field.removeValue(index)} />
         </>
-    ) : null;
+    );
 };
 
 const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     const [highlightMap, setHighlightIndex] = useState<{ [key: number]: string }>({});
-    const { field, contentModel } = props;
+    const { field, contentModel, getBind } = props;
 
     const fieldSettings = FieldSettings.createFrom(field);
 
@@ -86,47 +86,58 @@ const ObjectsRenderer = (props: CmsModelFieldRendererProps) => {
     const settings = fieldSettings.getSettings();
     const { open } = getAccordionRenderSettings(field);
 
+    const Bind = getBind();
+
     return (
-        <RootAccordion>
-            <AccordionItem title={field.label} description={field.helpText} open={open}>
-                <DynamicSection
-                    {...props}
-                    emptyValue={{}}
-                    showLabel={false}
-                    gridClassName={dynamicSectionGridStyle}
-                >
-                    {({ Bind, bind, index }) => (
-                        <ObjectItem>
-                            {highlightMap[index] ? (
-                                <ItemHighLight key={highlightMap[index]} />
-                            ) : null}
-                            <Accordion
-                                title={`${props.field.label} #${index + 1}`}
-                                action={
-                                    <Actions
-                                        setHighlightIndex={setHighlightIndex}
-                                        index={index}
-                                        bind={bind}
-                                    />
-                                }
-                                // Open first Accordion by default
-                                defaultValue={index === 0}
+        <Bind>
+            {({ value }) => {
+                const values = value || [];
+                const label = `${field.label} ${values.length ? `(${values.length})` : ""}`;
+
+                return (
+                    <RootAccordion>
+                        <AccordionItem title={label} description={field.helpText} open={open}>
+                            <DynamicSection
+                                {...props}
+                                emptyValue={{}}
+                                showLabel={false}
+                                gridClassName={dynamicSectionGridStyle}
                             >
-                                <Cell span={12} className={fieldsWrapperStyle}>
-                                    <Fields
-                                        Bind={Bind}
-                                        contentModel={contentModel}
-                                        fields={settings.fields}
-                                        layout={settings.layout}
-                                        gridClassName={fieldsGridStyle}
-                                    />
-                                </Cell>
-                            </Accordion>
-                        </ObjectItem>
-                    )}
-                </DynamicSection>
-            </AccordionItem>
-        </RootAccordion>
+                                {({ Bind, bind, index }) => (
+                                    <ObjectItem>
+                                        {highlightMap[index] ? (
+                                            <ItemHighLight key={highlightMap[index]} />
+                                        ) : null}
+                                        <Accordion
+                                            title={`${props.field.label} #${index + 1}`}
+                                            action={
+                                                <Actions
+                                                    setHighlightIndex={setHighlightIndex}
+                                                    index={index}
+                                                    bind={bind}
+                                                />
+                                            }
+                                            // Open first Accordion by default
+                                            defaultValue={index === 0}
+                                        >
+                                            <Cell span={12} className={fieldsWrapperStyle}>
+                                                <Fields
+                                                    Bind={Bind}
+                                                    contentModel={contentModel}
+                                                    fields={settings.fields}
+                                                    layout={settings.layout}
+                                                    gridClassName={fieldsGridStyle}
+                                                />
+                                            </Cell>
+                                        </Accordion>
+                                    </ObjectItem>
+                                )}
+                            </DynamicSection>
+                        </AccordionItem>
+                    </RootAccordion>
+                );
+            }}
+        </Bind>
     );
 };
 

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/richText/richTextInputs.tsx
@@ -98,7 +98,6 @@ const plugin: CmsModelFieldRendererPlugin = {
                                     {...rteProps}
                                     label={`Value ${index + 1}`}
                                     placeholder={field.placeholderText}
-                                    description={field.helpText}
                                 />
                             </DelayedOnChange>
                         </EditorWrapper>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/textInputs.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/text/textInputs.tsx
@@ -37,14 +37,11 @@ const plugin: CmsModelFieldRendererPlugin = {
                                 onEnter={() => bind.field.appendValue("")}
                                 label={t`Value {number}`({ number: index + 1 })}
                                 placeholder={props.field.placeholderText}
-                                description={props.field.helpText}
                                 data-testid={`fr.input.texts.${props.field.label}.${index + 1}`}
-                                trailingIcon={
-                                    index > 0 && {
-                                        icon: <DeleteIcon />,
-                                        onClick: () => bind.field.removeValue(index)
-                                    }
-                                }
+                                trailingIcon={{
+                                    icon: <DeleteIcon />,
+                                    onClick: () => bind.field.removeValue(index)
+                                }}
                             />
                         </DelayedOnChange>
                     )}


### PR DESCRIPTION
## Changes
This PR is focusing on multi-value field renderers in the Headless CMS. The `DynamicSection` component no longer adds the initial item UI, which was causing many issues with validation, and users were unable to remove that first item, which was also unintuitive. 

The labels and behavior is now standardized across all multi-value renderers, the field label looks the same, prints help text in the same place across all fields, and also counts the number of items in the data set. The initial UI is no longer added, and users can remove all items from the data set.

![image](https://github.com/user-attachments/assets/d1087d7e-4957-42a7-921d-54b39b20791e)


## How Has This Been Tested?
Manually.
