### PR TITLE
Deployments - Skip 'First Deployment" Check When In CI

### DIFF
--- a/packages/cwp-template-aws/cli/deploy/deploy.js
+++ b/packages/cwp-template-aws/cli/deploy/deploy.js
@@ -10,6 +10,7 @@ const { getInfo } = require("../info");
 const sleep = require("../utils/sleep");
 const open = require("open");
 const ora = require("ora");
+const isCI = require("is-ci");
 
 const deployApp = async ({ name, folder, inputs, context, isFirstDeployment }) => {
     context.info(`Deploying %s project application...`, name);
@@ -47,7 +48,7 @@ module.exports = async (inputs, context) => {
         installed && console.log();
 
         // 2. Check if first deployment.
-        const isFirstDeployment = !getStackOutput({ folder: "apps/core", env });
+        const isFirstDeployment = !isCI && !getStackOutput({ folder: "apps/core", env });
         if (isFirstDeployment) {
             context.info(`Looks like this is your first time deploying the project.`);
             context.info(

--- a/packages/cwp-template-aws/package.json
+++ b/packages/cwp-template-aws/package.json
@@ -20,6 +20,7 @@
     "fs-extra": "^11.2.0",
     "get-yarn-workspaces": "1.0.2",
     "inquirer": "8.2.6",
+    "is-ci": "^3.0.0",
     "load-json-file": "6.2.0",
     "lodash": "^4.17.21",
     "open": "^8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17247,6 +17247,7 @@ __metadata:
     fs-extra: ^11.2.0
     get-yarn-workspaces: 1.0.2
     inquirer: 8.2.6
+    is-ci: ^3.0.0
     load-json-file: 6.2.0
     lodash: ^4.17.21
     open: ^8.4.0


### PR DESCRIPTION
## Changes
When users deploy their project for the first time via the `yarn webiny deploy` command, we show the following short message:
![image](https://github.com/user-attachments/assets/56479f86-70e8-4fd1-80f1-2b58ceb7754a)

While this is fine when really deploying Webiny for the first time from a local machine, in CI environments, it turns out it's best we just don't show it. 

This is because the message we see above relies on the result of the internal call of the `yarn webiny output core --env xyz`, which doesn't work actually if the Core application wasn't built or deployed beforehand. Which is actually the case when running `yarn webiny deploy`, so the above message is actually incorrectly shown to the user. 

To quickly address this, with this PR, we just ignore showing this message when in CI.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.