### PR TITLE
Cloudfront Distributions - Ignore Changes In `staging` Property (5.40.x Port)

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiCloudfront.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiCloudfront.ts
@@ -123,6 +123,21 @@ export const ApiCloudfront = createAppModule({
                 viewerCertificate: {
                     cloudfrontDefaultCertificate: true
                 }
+            },
+            opts: {
+                // We are ignoring changes to the "staging" property. This is because of the following.
+                // With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change
+                // with how Cloudfront distributions are deployed, where Pulumi now also controls the new
+                // `staging` property.
+                // If not set, Pulumi will default it to `false`. Which is fine, but, the problem is
+                // that, because this property did not exist before, it will always be considered as a change
+                // upon deployment.
+                // We might think this is fine, but, the problem is that a change in this property causes
+                // a full replacement of the Cloudfront distribution, which is not acceptable. Especially
+                // if a custom domain has already been associated with the distribution. This then would
+                // require the user to disassociate the domain, wait for the distribution to be replaced,
+                // and then re-associate the domain. This is not a good experience.
+                ignoreChanges: ["staging"]
             }
         });
     }

--- a/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/react/createReactPulumiApp.ts
@@ -109,6 +109,21 @@ export const createReactPulumiApp = (projectAppParams: CreateReactPulumiAppParam
                     viewerCertificate: {
                         cloudfrontDefaultCertificate: true
                     }
+                },
+                opts: {
+                    // We are ignoring changes to the "staging" property. This is because of the following.
+                    // With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change
+                    // with how Cloudfront distributions are deployed, where Pulumi now also controls the new
+                    // `staging` property.
+                    // If not set, Pulumi will default it to `false`. Which is fine, but, the problem is
+                    // that, because this property did not exist before, it will always be considered as a change
+                    // upon deployment.
+                    // We might think this is fine, but, the problem is that a change in this property causes
+                    // a full replacement of the Cloudfront distribution, which is not acceptable. Especially
+                    // if a custom domain has already been associated with the distribution. This then would
+                    // require the user to disassociate the domain, wait for the distribution to be replaced,
+                    // and then re-associate the domain. This is not a good experience.
+                    ignoreChanges: ["staging"]
                 }
             });
 

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -201,23 +201,6 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                             minTtl: 0,
                             defaultTtl: 2592000, // 30 days
                             maxTtl: 2592000
-                        },
-                        // This forward is necessary for non-WCP projects. For WCP projects, the
-                        // forwarding is performed by the `website-router` Lambda@Edge function.
-                        {
-                            compress: true,
-                            allowedMethods: ["GET", "HEAD", "OPTIONS"],
-                            cachedMethods: ["GET", "HEAD", "OPTIONS"],
-                            forwardedValues: {
-                                cookies: {
-                                    forward: "none"
-                                },
-                                headers: [],
-                                queryString: false
-                            },
-                            pathPattern: "/robots.txt",
-                            viewerProtocolPolicy: "allow-all",
-                            targetOriginId: appBucket.origin.originId
                         }
                     ],
                     customErrorResponses: [

--- a/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/website/createWebsitePulumiApp.ts
@@ -122,6 +122,21 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     viewerCertificate: {
                         cloudfrontDefaultCertificate: true
                     }
+                },
+                opts: {
+                    // We are ignoring changes to the "staging" property. This is because of the following.
+                    // With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change
+                    // with how Cloudfront distributions are deployed, where Pulumi now also controls the new
+                    // `staging` property.
+                    // If not set, Pulumi will default it to `false`. Which is fine, but, the problem is
+                    // that, because this property did not exist before, it will always be considered as a change
+                    // upon deployment.
+                    // We might think this is fine, but, the problem is that a change in this property causes
+                    // a full replacement of the Cloudfront distribution, which is not acceptable. Especially
+                    // if a custom domain has already been associated with the distribution. This then would
+                    // require the user to disassociate the domain, wait for the distribution to be replaced,
+                    // and then re-associate the domain. This is not a good experience.
+                    ignoreChanges: ["staging"]
                 }
             });
 
@@ -186,6 +201,23 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                             minTtl: 0,
                             defaultTtl: 2592000, // 30 days
                             maxTtl: 2592000
+                        },
+                        // This forward is necessary for non-WCP projects. For WCP projects, the
+                        // forwarding is performed by the `website-router` Lambda@Edge function.
+                        {
+                            compress: true,
+                            allowedMethods: ["GET", "HEAD", "OPTIONS"],
+                            cachedMethods: ["GET", "HEAD", "OPTIONS"],
+                            forwardedValues: {
+                                cookies: {
+                                    forward: "none"
+                                },
+                                headers: [],
+                                queryString: false
+                            },
+                            pathPattern: "/robots.txt",
+                            viewerProtocolPolicy: "allow-all",
+                            targetOriginId: appBucket.origin.originId
                         }
                     ],
                     customErrorResponses: [
@@ -204,6 +236,10 @@ export const createWebsitePulumiApp = (projectAppParams: CreateWebsitePulumiAppP
                     viewerCertificate: {
                         cloudfrontDefaultCertificate: true
                     }
+                },
+                opts: {
+                    // Check the comment in the `appCloudfront` resource above for more info.
+                    ignoreChanges: ["staging"]
                 }
             });
 


### PR DESCRIPTION
## Changes
> [!NOTE]  
> This PR is an attempt to port https://github.com/webiny/webiny-js/pull/4401 into 5.40.x version of Webiny. 
>
> Note that, while doing that, we've detected an issue with the original PR, where we only addressed the `staging` property-related issue for CloudFront distributions deployed as part of the Website project apps. The same needs to be done with other distributions that are deployed with API and Admin apps.
>
> This is fully handled in this PR. So, for 5.40.x, once this is merged, there won't be any additional changes to be made. But, for 5.41.x, we'll be creating an additional PR that addresses the detected issue, which should be merged and released with 5.41.3.

With this PR, we are ignoring changes to the "staging" property when deploying Website app's Cloudfront distributions. I've added the following comment in the code:

> We are ignoring changes to the "staging" property. This is because of the following. 
>
> With the 5.41.0 release of Webiny, we also upgraded Pulumi to v6. This introduced a change with how Cloudfront distributions are deployed, where Pulumi now also controls the new `staging` property.
>
> If not set, Pulumi will default it to `false`. Which is fine, but, the problem is that, because this property did not exist before, it will always be considered as a change upon deployment.
>
> We might think this is fine, but, the problem is that a change in this property causes a full replacement of the Cloudfront distribution, which is not acceptable. Especially if a custom domain has already been associated with the distribution. This then would require the user to disassociate the domain, wait for the distribution to be replaced, and then re-associate the domain. This is not a good experience.

## How Has This Been Tested?
Manually. After adding `staging` to the `ignoreChanges` array, I was able to do any change to the property, and no replacements would be done by Pulumi.

## Documentation
Changelog.