### PR TITLE
feat(db): store key - value items in database

### DIFF
--- a/packages/db-dynamodb/__tests__/DynamoDbDriver.test.ts
+++ b/packages/db-dynamodb/__tests__/DynamoDbDriver.test.ts
@@ -125,4 +125,98 @@ describe("DynamoDbDriver", () => {
 
         expect(results.data).toEqual(items);
     });
+
+    it("should properly remove an item", async () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        const key = "test";
+        const value = {
+            test: "test",
+            andEvenSomeComplexData: {
+                str: "string",
+                orMoreComplex: {
+                    boolean: true,
+                    moreData: 1234
+                }
+            }
+        };
+        await driver.storeValue(key, value);
+
+        const stored = await driver.getValue(key);
+        expect(stored.error).toBeUndefined();
+        expect(stored.key).toEqual(key);
+        expect(stored.data).toEqual(value);
+
+        const result = await driver.removeValue(key);
+        expect(result.error).toBeUndefined();
+        expect(result.key).toEqual(key);
+        expect(result.data).toEqual(value);
+
+        const results = await driver.getValues([key]);
+        expect(results.error).toBeUndefined();
+        expect(results.keys).toEqual([key]);
+        // @ts-expect-error
+        expect(results.data[key]).toBeNull();
+    });
+
+    it("should remove a list of items", async () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        const items = {
+            testing1: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            },
+            testing2: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            },
+            testing3: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            }
+        };
+
+        await driver.storeValues(items);
+
+        const results = await driver.getValues(Object.keys(items));
+        expect(results.error).toBeUndefined();
+        expect(results.keys).toEqual(Object.keys(items));
+        expect(results.data).toEqual(items);
+
+        const storedList = await driver.listValues();
+        expect(storedList.error).toBeUndefined();
+        expect(storedList.data).toEqual(items);
+
+        const keys = Object.keys(items);
+        const removed = await driver.removeValues(keys);
+        expect(removed.error).toBeUndefined();
+        expect(removed.keys).toEqual(keys);
+
+        const listed = await driver.listValues();
+        expect(listed.error).toBeUndefined();
+        expect(listed.data).toEqual({});
+    });
 });

--- a/packages/db-dynamodb/__tests__/DynamoDbDriver.test.ts
+++ b/packages/db-dynamodb/__tests__/DynamoDbDriver.test.ts
@@ -1,0 +1,128 @@
+import DynamoDbDriver from "~/DynamoDbDriver";
+import { getDocumentClient } from "@webiny/project-utils/testing/dynamodb";
+
+describe("DynamoDbDriver", () => {
+    const __testing = "aTestingTag";
+    const documentClient = getDocumentClient();
+    // @ts-expect-error
+    documentClient.__testing = __testing;
+
+    it("should properly construct DynamoDbDriver", () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        // @ts-expect-error
+        expect(driver.documentClient.__testing).toEqual(__testing);
+        // @ts-expect-error
+        expect(driver.getClient().__testing).toEqual(documentClient.__testing);
+    });
+
+    it("should properly store an item", async () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        const key = "test";
+        const value = {
+            test: "test",
+            andEvenSomeComplexData: {
+                str: "string",
+                orMoreComplex: {
+                    boolean: true,
+                    moreData: 1234
+                }
+            }
+        };
+        const result = await driver.storeValue(key, value);
+
+        expect(result.error).toBeUndefined();
+        expect(result.key).toEqual(key);
+        expect(result.data).toEqual(value);
+    });
+
+    it("should properly store an item and retrieve it", async () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        const key = "test";
+        const value = {
+            test: "test",
+            andEvenSomeComplexData: {
+                str: "string",
+                orMoreComplex: {
+                    boolean: true,
+                    moreData: 1234
+                }
+            }
+        };
+        await driver.storeValue(key, value);
+
+        const result = await driver.getValue(key);
+
+        expect(result.error).toBeUndefined();
+        expect(result.key).toEqual(key);
+        expect(result.data).toEqual(value);
+
+        const results = await driver.getValues([key]);
+        expect(results.error).toBeUndefined();
+        expect(results.keys).toEqual([key]);
+        // @ts-expect-error
+        expect(results.data[key]).toEqual(value);
+
+        const listed = await driver.listValues();
+        expect(listed.error).toBeUndefined();
+        // @ts-expect-error
+        expect(listed.keys).toEqual([key]);
+        // @ts-expect-error
+        expect(listed.data[key]).toEqual(value);
+    });
+
+    it("should properly store a list of items and retrieve them", async () => {
+        const driver = new DynamoDbDriver({
+            documentClient
+        });
+
+        const items = {
+            testing1: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            },
+            testing2: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            },
+            testing3: {
+                test: "test",
+                andEvenSomeComplexData: {
+                    str: "string",
+                    orMoreComplex: {
+                        boolean: true,
+                        moreData: 1234
+                    }
+                }
+            }
+        };
+
+        await driver.storeValues(items);
+
+        const results = await driver.getValues(Object.keys(items));
+        expect(results.error).toBeUndefined();
+        expect(results.keys).toEqual(Object.keys(items));
+
+        expect(results.data).toEqual(items);
+    });
+});

--- a/packages/db-dynamodb/jest-dynalite-config.js
+++ b/packages/db-dynamodb/jest-dynalite-config.js
@@ -1,4 +1,3 @@
-module.exports = {
-    tables: [],
-    basePort: 8000
-};
+const { createDynaliteTables } = require("../../jest.config.base");
+
+module.exports = createDynaliteTables();

--- a/packages/db-dynamodb/src/DynamoDbDriver.ts
+++ b/packages/db-dynamodb/src/DynamoDbDriver.ts
@@ -1,5 +1,26 @@
 import { DynamoDBDocument } from "@webiny/aws-sdk/client-dynamodb";
-import { DbDriver } from "@webiny/db";
+import {
+    DbDriver,
+    GetValueResult,
+    GetValuesResult,
+    ListValuesResult,
+    StorageKey,
+    StoreValueResult,
+    StoreValuesResult
+} from "@webiny/db";
+import { Entity } from "dynamodb-toolbox";
+import { createTable, Table } from "~/utils/createTable";
+import { GenericRecord } from "@webiny/api/types";
+import { createEntity } from "~/store/entity";
+import { batchReadAll, batchWriteAll, get, put, queryAll } from "~/utils";
+import {
+    createGSI1PartitionKey,
+    createGSI1SortKey,
+    createPartitionKey,
+    createSortKey,
+    createType
+} from "~/store/keys";
+import { IStoreItem } from "~/store/types";
 
 interface ConstructorArgs {
     documentClient: DynamoDBDocument;
@@ -7,12 +28,214 @@ interface ConstructorArgs {
 
 class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
     public readonly documentClient: DynamoDBDocument;
+
+    private _table: Table | undefined = undefined;
+    private _entity: Entity | undefined = undefined;
+
+    public table(): Table {
+        if (this._table) {
+            return this._table;
+        }
+        this._table = createTable({
+            documentClient: this.documentClient
+        });
+        return this._table;
+    }
+
+    public entity(): Entity {
+        if (this._entity) {
+            return this._entity;
+        }
+        this._entity = createEntity({
+            table: this.table()
+        });
+        return this._entity;
+    }
+
     constructor({ documentClient }: ConstructorArgs) {
         this.documentClient = documentClient;
     }
 
-    getClient() {
+    public getClient() {
         return this.documentClient;
+    }
+
+    public async storeValue<V>(key: string, input: V): Promise<StoreValueResult<V>> {
+        let value: string | undefined;
+        try {
+            value = JSON.stringify(input);
+        } catch (ex) {
+            return {
+                key,
+                error: ex
+            };
+        }
+
+        try {
+            await put<IStoreItem>({
+                entity: this.entity(),
+                item: {
+                    PK: createPartitionKey({ key }),
+                    SK: createSortKey({ key }),
+                    GSI1_PK: createGSI1PartitionKey(),
+                    GSI1_SK: createGSI1SortKey({ key }),
+                    TYPE: createType(),
+                    key,
+                    value
+                }
+            });
+
+            return {
+                key,
+                data: input
+            };
+        } catch (ex) {
+            return {
+                key,
+                error: ex
+            };
+        }
+    }
+    public async storeValues<V extends GenericRecord<StorageKey>>(
+        values: V
+    ): Promise<StoreValuesResult<V>> {
+        const keys = Object.keys(values);
+        try {
+            const batch = keys.map(key => {
+                const input = values[key];
+                let value: string | undefined;
+                try {
+                    value = JSON.stringify(input);
+                } catch (ex) {
+                    throw ex;
+                }
+                const item: IStoreItem = {
+                    PK: createPartitionKey({ key }),
+                    SK: createSortKey({ key }),
+                    GSI1_PK: createGSI1PartitionKey(),
+                    GSI1_SK: createGSI1SortKey({ key }),
+                    TYPE: createType(),
+                    key,
+                    value
+                };
+                return this.entity().putBatch(item);
+            });
+
+            await batchWriteAll({
+                table: this.table(),
+                items: batch
+            });
+            return {
+                keys,
+                data: values
+            };
+        } catch (ex) {
+            return {
+                keys,
+                error: ex
+            };
+        }
+    }
+    public async getValue<V>(key: StorageKey): Promise<GetValueResult<V>> {
+        try {
+            const result = await get<IStoreItem>({
+                entity: this.entity(),
+                keys: {
+                    PK: createPartitionKey({ key }),
+                    SK: createSortKey({ key })
+                }
+            });
+            return {
+                key,
+                data: result ? JSON.parse(result.value) : null
+            };
+        } catch (ex) {
+            return {
+                key,
+                error: ex
+            };
+        }
+    }
+    public async getValues<V extends GenericRecord<StorageKey>>(
+        input: (keyof V)[]
+    ): Promise<GetValuesResult<V>> {
+        const keys = [...input] as string[];
+        const batch = keys.map(key => {
+            return this.entity().getBatch({
+                PK: createPartitionKey({ key }),
+                SK: createSortKey({ key })
+            });
+        });
+
+        try {
+            const results = await batchReadAll<IStoreItem>({
+                table: this.table(),
+                items: batch
+            });
+            const data = keys.reduce((collection, key) => {
+                const result = results.find(item => {
+                    return (
+                        item.PK === createPartitionKey({ key }) &&
+                        item.SK === createSortKey({ key })
+                    );
+                });
+                if (!result?.value) {
+                    // @ts-expect-error
+                    collection[key] = null;
+                    return collection;
+                }
+                try {
+                    // @ts-expect-error
+                    collection[key] = JSON.parse(result.value);
+                } catch {
+                    // @ts-expect-error
+                    collection[key] = null;
+                }
+
+                return collection;
+            }, {} as V);
+            return {
+                keys,
+                data
+            };
+        } catch (ex) {
+            return {
+                keys,
+                error: ex
+            };
+        }
+    }
+    public async listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>> {
+        try {
+            const results = await queryAll<IStoreItem>({
+                entity: this.entity(),
+                partitionKey: createGSI1PartitionKey(),
+                options: {
+                    index: "GSI1"
+                }
+            });
+
+            const data = results.reduce((collection, item) => {
+                try {
+                    // @ts-expect-error
+                    collection[item.key] = JSON.parse(item.value);
+                } catch (ex) {
+                    // @ts-expect-error
+                    collection[item.key] = null;
+                }
+
+                return collection;
+            }, {} as V);
+
+            return {
+                keys: Object.keys(data),
+                data
+            };
+        } catch (ex) {
+            return {
+                error: ex
+            };
+        }
     }
 }
 

--- a/packages/db-dynamodb/src/DynamoDbDriver.ts
+++ b/packages/db-dynamodb/src/DynamoDbDriver.ts
@@ -5,6 +5,8 @@ import {
     GetValuesResult,
     IListValuesParams,
     ListValuesResult,
+    RemoveValueResult,
+    RemoveValuesResult,
     StorageKey,
     StoreValueResult,
     StoreValuesResult
@@ -223,6 +225,58 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
             };
         } catch (ex) {
             return {
+                error: ex
+            };
+        }
+    }
+
+    public async removeValue<V>(key: StorageKey): Promise<RemoveValueResult<V>> {
+        const result = await this.getValue<V>(key);
+        if (result.error) {
+            return {
+                key,
+                error: result.error
+            };
+        }
+        try {
+            await this.entity().delete({
+                PK: createPartitionKey(),
+                SK: createSortKey({ key })
+            });
+            return {
+                key,
+                data: result.data
+            };
+        } catch (ex) {
+            return {
+                key,
+                error: ex
+            };
+        }
+    }
+
+    public async removeValues<V extends GenericRecord<StorageKey>>(
+        input: (keyof V)[]
+    ): Promise<RemoveValuesResult<V>> {
+        const keys = [...input] as string[];
+        const batch = keys.map(key => {
+            return this.entity().deleteBatch({
+                PK: createPartitionKey(),
+                SK: createSortKey({ key })
+            });
+        });
+
+        try {
+            await batchWriteAll({
+                table: this.table(),
+                items: batch
+            });
+            return {
+                keys
+            };
+        } catch (ex) {
+            return {
+                keys,
                 error: ex
             };
         }

--- a/packages/db-dynamodb/src/DynamoDbDriver.ts
+++ b/packages/db-dynamodb/src/DynamoDbDriver.ts
@@ -3,6 +3,7 @@ import {
     DbDriver,
     GetValueResult,
     GetValuesResult,
+    IListValuesParams,
     ListValuesResult,
     StorageKey,
     StoreValueResult,
@@ -13,13 +14,7 @@ import { createTable, Table } from "~/utils/createTable";
 import { GenericRecord } from "@webiny/api/types";
 import { createEntity } from "~/store/entity";
 import { batchReadAll, batchWriteAll, get, put, queryAll } from "~/utils";
-import {
-    createGSI1PartitionKey,
-    createGSI1SortKey,
-    createPartitionKey,
-    createSortKey,
-    createType
-} from "~/store/keys";
+import { createPartitionKey, createSortKey, createType } from "~/store/keys";
 import { IStoreItem } from "~/store/types";
 
 interface ConstructorArgs {
@@ -75,10 +70,8 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
             await put<IStoreItem>({
                 entity: this.entity(),
                 item: {
-                    PK: createPartitionKey({ key }),
+                    PK: createPartitionKey(),
                     SK: createSortKey({ key }),
-                    GSI1_PK: createGSI1PartitionKey(),
-                    GSI1_SK: createGSI1SortKey({ key }),
                     TYPE: createType(),
                     key,
                     value
@@ -110,10 +103,8 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
                     throw ex;
                 }
                 const item: IStoreItem = {
-                    PK: createPartitionKey({ key }),
+                    PK: createPartitionKey(),
                     SK: createSortKey({ key }),
-                    GSI1_PK: createGSI1PartitionKey(),
-                    GSI1_SK: createGSI1SortKey({ key }),
                     TYPE: createType(),
                     key,
                     value
@@ -141,7 +132,7 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
             const result = await get<IStoreItem>({
                 entity: this.entity(),
                 keys: {
-                    PK: createPartitionKey({ key }),
+                    PK: createPartitionKey(),
                     SK: createSortKey({ key })
                 }
             });
@@ -162,7 +153,7 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
         const keys = [...input] as string[];
         const batch = keys.map(key => {
             return this.entity().getBatch({
-                PK: createPartitionKey({ key }),
+                PK: createPartitionKey(),
                 SK: createSortKey({ key })
             });
         });
@@ -174,10 +165,7 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
             });
             const data = keys.reduce((collection, key) => {
                 const result = results.find(item => {
-                    return (
-                        item.PK === createPartitionKey({ key }) &&
-                        item.SK === createSortKey({ key })
-                    );
+                    return item.PK === createPartitionKey() && item.SK === createSortKey({ key });
                 });
                 if (!result?.value) {
                     // @ts-expect-error
@@ -205,13 +193,15 @@ class DynamoDbDriver implements DbDriver<DynamoDBDocument> {
             };
         }
     }
-    public async listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>> {
+    public async listValues<V extends GenericRecord<StorageKey>>(
+        params?: IListValuesParams
+    ): Promise<ListValuesResult<V>> {
         try {
             const results = await queryAll<IStoreItem>({
                 entity: this.entity(),
-                partitionKey: createGSI1PartitionKey(),
+                partitionKey: createPartitionKey(),
                 options: {
-                    index: "GSI1"
+                    ...params
                 }
             });
 

--- a/packages/db-dynamodb/src/store/entity.ts
+++ b/packages/db-dynamodb/src/store/entity.ts
@@ -1,0 +1,41 @@
+/**
+ * TODO determine if GSIs are needed
+ */
+import { Entity } from "~/toolbox";
+import { Table } from "~/utils";
+
+export interface ICreateEntityParams {
+    table: Table;
+}
+
+export const createEntity = ({ table }: ICreateEntityParams) => {
+    return new Entity({
+        table,
+        name: "WebinyKeyValue",
+        attributes: {
+            PK: {
+                partitionKey: true
+            },
+            SK: {
+                sortKey: true
+            },
+            GSI1_PK: {
+                type: "string"
+            },
+            GSI1_SK: {
+                type: "string"
+            },
+            TYPE: {
+                type: "string"
+            },
+            key: {
+                type: "string"
+            },
+            value: {
+                type: "string"
+            }
+        },
+        autoExecute: true,
+        autoParse: true
+    });
+};

--- a/packages/db-dynamodb/src/store/entity.ts
+++ b/packages/db-dynamodb/src/store/entity.ts
@@ -19,12 +19,6 @@ export const createEntity = ({ table }: ICreateEntityParams) => {
             SK: {
                 sortKey: true
             },
-            GSI1_PK: {
-                type: "string"
-            },
-            GSI1_SK: {
-                type: "string"
-            },
             TYPE: {
                 type: "string"
             },

--- a/packages/db-dynamodb/src/store/keys.ts
+++ b/packages/db-dynamodb/src/store/keys.ts
@@ -2,20 +2,11 @@ export interface IParams {
     key: string;
 }
 
-export const createPartitionKey = ({ key }: IParams) => {
-    return `W#internal#${key}`;
+export const createPartitionKey = () => {
+    return `W#internal`;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const createSortKey = (_: IParams) => {
-    return "A";
-};
-
-export const createGSI1PartitionKey = () => {
-    return "W#internal";
-};
-
-export const createGSI1SortKey = ({ key }: IParams) => {
+export const createSortKey = ({ key }: IParams) => {
     return key;
 };
 

--- a/packages/db-dynamodb/src/store/keys.ts
+++ b/packages/db-dynamodb/src/store/keys.ts
@@ -1,0 +1,24 @@
+export interface IParams {
+    key: string;
+}
+
+export const createPartitionKey = ({ key }: IParams) => {
+    return `W#internal#${key}`;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const createSortKey = (_: IParams) => {
+    return "A";
+};
+
+export const createGSI1PartitionKey = () => {
+    return "W#internal";
+};
+
+export const createGSI1SortKey = ({ key }: IParams) => {
+    return key;
+};
+
+export const createType = () => {
+    return "internal";
+};

--- a/packages/db-dynamodb/src/store/types.ts
+++ b/packages/db-dynamodb/src/store/types.ts
@@ -1,0 +1,9 @@
+export interface IStoreItem {
+    PK: string;
+    SK: string;
+    GSI1_PK: string;
+    GSI1_SK: string;
+    TYPE: string;
+    key: string;
+    value: string;
+}

--- a/packages/db-dynamodb/src/store/types.ts
+++ b/packages/db-dynamodb/src/store/types.ts
@@ -1,8 +1,6 @@
 export interface IStoreItem {
     PK: string;
     SK: string;
-    GSI1_PK: string;
-    GSI1_SK: string;
     TYPE: string;
     key: string;
     value: string;

--- a/packages/db-dynamodb/src/utils/createTable.ts
+++ b/packages/db-dynamodb/src/utils/createTable.ts
@@ -1,13 +1,15 @@
 import { DynamoDBDocument } from "@webiny/aws-sdk/client-dynamodb";
-import { Table } from "~/toolbox";
+import { Table as BaseTable } from "~/toolbox";
 
 export interface CreateTableParams {
     name?: string;
     documentClient: DynamoDBDocument;
 }
 
-export const createTable = ({ name, documentClient }: CreateTableParams) => {
-    return new Table({
+export type Table = BaseTable<string, "PK", "SK">;
+
+export const createTable = ({ name, documentClient }: CreateTableParams): Table => {
+    return new BaseTable({
         name: name || String(process.env.DB_TABLE),
         partitionKey: "PK",
         sortKey: "SK",

--- a/packages/db-dynamodb/src/utils/put.ts
+++ b/packages/db-dynamodb/src/utils/put.ts
@@ -1,15 +1,17 @@
 import { Entity } from "~/toolbox";
 
-interface Params {
+export type IPutItem<T extends Record<string, any>> = {
+    PK: string;
+    SK: string;
+    [key: string]: any;
+} & T;
+
+export interface IPutParams<T extends Record<string, any>> {
     entity: Entity;
-    item: {
-        PK: string;
-        SK: string;
-        [key: string]: any;
-    };
+    item: IPutItem<T>;
 }
 
-export const put = async (params: Params) => {
+export const put = async <T extends Record<string, any>>(params: IPutParams<T>) => {
     const { entity, item } = params;
 
     return await entity.put(item, {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,7 +13,8 @@
     "directory": "dist"
   },
   "dependencies": {
-    "@webiny/api": "0.0.0"
+    "@webiny/api": "0.0.0",
+    "type-fest": "^3.13.1"
   },
   "devDependencies": {
     "@webiny/cli": "0.0.0",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,8 +1,10 @@
 import { DbRegistry } from "~/DbRegistry";
+import { IStore } from "~/store/types";
+import { Store } from "~/store/Store";
 
 export * from "./types";
 
-export interface DbDriver<T> {
+export interface DbDriver<T> extends IStore {
     getClient(): T;
 }
 
@@ -14,12 +16,16 @@ export interface ConstructorArgs<T> {
 class Db<T> {
     public driver: DbDriver<T>;
     public readonly table?: string;
+    public readonly store: IStore;
 
     public readonly registry = new DbRegistry();
 
     constructor({ driver, table }: ConstructorArgs<T>) {
         this.table = table;
         this.driver = driver;
+        this.store = new Store<T>({
+            driver
+        });
     }
 }
 

--- a/packages/db/src/store/Store.ts
+++ b/packages/db/src/store/Store.ts
@@ -1,0 +1,47 @@
+import {
+    IStore,
+    StorageKey,
+    StoreValueResult,
+    StoreValuesResult,
+    GetValuesResult,
+    GetValueResult,
+    ListValuesResult
+} from "./types";
+import { GenericRecord } from "@webiny/api/types";
+import { DbDriver } from "~/index";
+
+export interface IStoreParams<T> {
+    driver: DbDriver<T>;
+}
+
+export class Store<T> implements IStore {
+    private driver: DbDriver<T>;
+
+    public constructor(params: IStoreParams<T>) {
+        this.driver = params.driver;
+    }
+
+    public storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>> {
+        return this.driver.storeValue<V>(key, value);
+    }
+
+    public storeValues<V extends GenericRecord<StorageKey>>(
+        values: V
+    ): Promise<StoreValuesResult<V>> {
+        return this.driver.storeValues<V>(values);
+    }
+
+    public getValue<V>(key: StorageKey): Promise<GetValueResult<V>> {
+        return this.driver.getValue<V>(key);
+    }
+
+    public async getValues<V extends GenericRecord<StorageKey>>(
+        keys: (keyof V)[]
+    ): Promise<GetValuesResult<V>> {
+        return this.driver.getValues<V>(keys);
+    }
+
+    public listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>> {
+        return this.driver.listValues<V>();
+    }
+}

--- a/packages/db/src/store/Store.ts
+++ b/packages/db/src/store/Store.ts
@@ -1,11 +1,13 @@
 import {
+    GetValueResult,
+    GetValuesResult,
     IStore,
+    ListValuesResult,
+    RemoveValueResult,
+    RemoveValuesResult,
     StorageKey,
     StoreValueResult,
-    StoreValuesResult,
-    GetValuesResult,
-    GetValueResult,
-    ListValuesResult
+    StoreValuesResult
 } from "./types";
 import { GenericRecord } from "@webiny/api/types";
 import { DbDriver } from "~/index";
@@ -21,17 +23,17 @@ export class Store<T> implements IStore {
         this.driver = params.driver;
     }
 
-    public storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>> {
+    public async storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>> {
         return this.driver.storeValue<V>(key, value);
     }
 
-    public storeValues<V extends GenericRecord<StorageKey>>(
+    public async storeValues<V extends GenericRecord<StorageKey>>(
         values: V
     ): Promise<StoreValuesResult<V>> {
         return this.driver.storeValues<V>(values);
     }
 
-    public getValue<V>(key: StorageKey): Promise<GetValueResult<V>> {
+    public async getValue<V>(key: StorageKey): Promise<GetValueResult<V>> {
         return this.driver.getValue<V>(key);
     }
 
@@ -41,7 +43,17 @@ export class Store<T> implements IStore {
         return this.driver.getValues<V>(keys);
     }
 
-    public listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>> {
+    public async listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>> {
         return this.driver.listValues<V>();
+    }
+
+    public async removeValue<V>(key: StorageKey): Promise<RemoveValueResult<V>> {
+        return this.driver.removeValue<V>(key);
+    }
+
+    public async removeValues<V extends GenericRecord<StorageKey>>(
+        keys: (keyof V)[]
+    ): Promise<RemoveValuesResult<V>> {
+        return this.driver.removeValues<V>(keys);
     }
 }

--- a/packages/db/src/store/types.ts
+++ b/packages/db/src/store/types.ts
@@ -1,0 +1,87 @@
+import { CamelCase } from "type-fest";
+import { GenericRecord } from "@webiny/api/types";
+
+export type StorageKey = `${CamelCase<string>}`;
+
+export interface IStoreValueSuccessResult<V> {
+    key: StorageKey;
+    data: V | null | undefined;
+    error?: never;
+}
+
+export interface IStoreValueErrorResult {
+    key: StorageKey;
+    data?: never;
+    error: Error;
+}
+
+export type StoreValueResult<V> = IStoreValueSuccessResult<V> | IStoreValueErrorResult;
+
+export interface IStoreValuesSuccessResult<V extends GenericRecord<StorageKey>> {
+    keys: (keyof V)[];
+    data: V;
+    error?: never;
+}
+
+export interface IStoreValuesErrorResult<V> {
+    keys: (keyof V)[];
+    data?: never;
+    error: Error;
+}
+
+export type StoreValuesResult<V extends GenericRecord<StorageKey>> =
+    | IStoreValuesSuccessResult<V>
+    | IStoreValuesErrorResult<V>;
+
+export interface IGetValueSuccessResult<V> {
+    key: StorageKey;
+    data: V | null | undefined;
+    error?: never;
+}
+
+export interface IGetValueErrorResult {
+    key: StorageKey;
+    data?: never;
+    error: Error;
+}
+
+export type GetValueResult<V> = IGetValueSuccessResult<V> | IGetValueErrorResult;
+
+export interface IGetValuesSuccessResult<V extends GenericRecord<StorageKey>> {
+    keys: (keyof V)[];
+    data: V;
+    error?: never;
+}
+
+export interface IGetValuesErrorResult<V> {
+    keys: (keyof V)[];
+    data?: never;
+    error: Error;
+}
+
+export type GetValuesResult<V extends GenericRecord<StorageKey>> =
+    | IGetValuesSuccessResult<V>
+    | IGetValuesErrorResult<V>;
+
+export interface IListValuesSuccessResult<V extends GenericRecord<StorageKey>> {
+    keys: (keyof V)[];
+    data: V;
+    error?: never;
+}
+
+export interface IListValuesErrorResult {
+    data?: never;
+    error: Error;
+}
+
+export type ListValuesResult<V extends GenericRecord<StorageKey>> =
+    | IListValuesSuccessResult<V>
+    | IListValuesErrorResult;
+
+export interface IStore {
+    storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>>;
+    storeValues<V extends GenericRecord<StorageKey>>(values: V): Promise<StoreValuesResult<V>>;
+    getValue<V>(key: StorageKey): Promise<GetValueResult<V>>;
+    getValues<V extends GenericRecord<StorageKey>>(keys: (keyof V)[]): Promise<GetValuesResult<V>>;
+    listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>>;
+}

--- a/packages/db/src/store/types.ts
+++ b/packages/db/src/store/types.ts
@@ -6,7 +6,7 @@ export type StorageKey = `${CamelCase<string>}`;
 export interface IStoreValueSuccessResult<V> {
     key: StorageKey;
     data: V | null | undefined;
-    error?: never;
+    error?: undefined;
 }
 
 export interface IStoreValueErrorResult {
@@ -20,7 +20,7 @@ export type StoreValueResult<V> = IStoreValueSuccessResult<V> | IStoreValueError
 export interface IStoreValuesSuccessResult<V extends GenericRecord<StorageKey>> {
     keys: (keyof V)[];
     data: V;
-    error?: never;
+    error?: undefined;
 }
 
 export interface IStoreValuesErrorResult<V> {
@@ -36,7 +36,7 @@ export type StoreValuesResult<V extends GenericRecord<StorageKey>> =
 export interface IGetValueSuccessResult<V> {
     key: StorageKey;
     data: V | null | undefined;
-    error?: never;
+    error?: undefined;
 }
 
 export interface IGetValueErrorResult {
@@ -50,7 +50,7 @@ export type GetValueResult<V> = IGetValueSuccessResult<V> | IGetValueErrorResult
 export interface IGetValuesSuccessResult<V extends GenericRecord<StorageKey>> {
     keys: (keyof V)[];
     data: V;
-    error?: never;
+    error?: undefined;
 }
 
 export interface IGetValuesErrorResult<V> {
@@ -66,7 +66,7 @@ export type GetValuesResult<V extends GenericRecord<StorageKey>> =
 export interface IListValuesSuccessResult<V extends GenericRecord<StorageKey>> {
     keys: (keyof V)[];
     data: V;
-    error?: never;
+    error?: undefined;
 }
 
 export interface IListValuesErrorResult {
@@ -78,10 +78,32 @@ export type ListValuesResult<V extends GenericRecord<StorageKey>> =
     | IListValuesSuccessResult<V>
     | IListValuesErrorResult;
 
+export type IListValuesParams =
+    | {
+          beginsWith: string;
+      }
+    | {
+          eq: string;
+      }
+    | {
+          gt: string;
+      }
+    | {
+          gte: string;
+      }
+    | {
+          lt: string;
+      }
+    | {
+          lte: string;
+      };
+
 export interface IStore {
     storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>>;
     storeValues<V extends GenericRecord<StorageKey>>(values: V): Promise<StoreValuesResult<V>>;
     getValue<V>(key: StorageKey): Promise<GetValueResult<V>>;
     getValues<V extends GenericRecord<StorageKey>>(keys: (keyof V)[]): Promise<GetValuesResult<V>>;
-    listValues<V extends GenericRecord<StorageKey>>(): Promise<ListValuesResult<V>>;
+    listValues<V extends GenericRecord<StorageKey>>(
+        params?: IListValuesParams
+    ): Promise<ListValuesResult<V>>;
 }

--- a/packages/db/src/store/types.ts
+++ b/packages/db/src/store/types.ts
@@ -98,6 +98,13 @@ export type IListValuesParams =
           lte: string;
       };
 
+export type RemoveValueResult<V> = StoreValueResult<V>;
+
+export interface RemoveValuesResult<V extends GenericRecord<StorageKey>> {
+    keys: (keyof V)[];
+    error?: Error;
+}
+
 export interface IStore {
     storeValue<V>(key: StorageKey, value: V): Promise<StoreValueResult<V>>;
     storeValues<V extends GenericRecord<StorageKey>>(values: V): Promise<StoreValuesResult<V>>;
@@ -106,4 +113,8 @@ export interface IStore {
     listValues<V extends GenericRecord<StorageKey>>(
         params?: IListValuesParams
     ): Promise<ListValuesResult<V>>;
+    removeValue<V>(key: StorageKey): Promise<RemoveValueResult<V>>;
+    removeValues<V extends GenericRecord<StorageKey>>(
+        keys: (keyof V)[]
+    ): Promise<RemoveValuesResult<V>>;
 }

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -24,3 +24,5 @@ export interface IRegistry {
     getItem<T = unknown>(cb: (item: IRegistryItem<T>) => boolean): IRegistryItem<T> | null;
     getItems<T = unknown>(cb: (item: IRegistryItem<T>) => boolean): IRegistryItem<T>[];
 }
+
+export * from "./store/types";

--- a/yarn.lock
+++ b/yarn.lock
@@ -15192,6 +15192,7 @@ __metadata:
     "@webiny/cli": 0.0.0
     "@webiny/project-utils": 0.0.0
     rimraf: ^6.0.1
+    type-fest: ^3.13.1
     typescript: 4.9.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Changes
This PR adds a simple key - value store to the database.
It adds an abstraction layer to the `db` package and actual implementation in `db-dynamodb` package.

## How Has This Been Tested?
Jest.