### PR TITLE
Webiny CLI - Improve  Developer Experience

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/newWatch.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/newWatch.js
@@ -121,8 +121,10 @@ module.exports = async (inputs, context) => {
     const learnMoreLink = "https://webiny.link/local-aws-lambda-development";
 
     context.info(`Local AWS Lambda development session started.`);
-    context.info(
-        `Note that you should deploy your changes once you're done. To do so, run: %s. Learn more: %s.`,
+    context.warning(
+        `Note that once the session is terminated, the %s application will no longer work. To fix this, you %s redeploy it via the %s command. Learn more: %s.`,
+        projectApplication.name,
+        "MUST",
         deployCommand,
         learnMoreLink
     );
@@ -141,9 +143,11 @@ module.exports = async (inputs, context) => {
         console.log();
         console.log();
 
-        context.info(`Stopping local AWS Lambda development session.`);
-        context.info(
-            `Note that you should deploy your changes. To do so, run: %s. Learn more: %s.`,
+        context.info(`Terminating local AWS Lambda development session.`);
+        context.warning(
+            `Note that once the session is terminated, the %s application will no longer work. To fix this, you %s redeploy it via the %s command. Learn more: %s.`,
+            projectApplication.name,
+            "MUST",
             deployCommand,
             learnMoreLink
         );

--- a/packages/cli-plugin-deploy-pulumi/commands/newWatch/listPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/newWatch/listPackages.js
@@ -56,6 +56,12 @@ const listPackages = async ({ inputs }) => {
                 ? path.join(root, "webiny.config.ts")
                 : path.join(root, "webiny.config.js");
 
+            // We need this because newly introduced extension
+            // packages do not have a Webiny config file.
+            if (!fs.existsSync(configPath)) {
+                continue;
+            }
+
             packages.push({
                 name: packageName,
                 config: require(configPath).default || require(configPath),

--- a/packages/cli-plugin-extensions/src/downloadAndLinkExtension.ts
+++ b/packages/cli-plugin-extensions/src/downloadAndLinkExtension.ts
@@ -159,6 +159,10 @@ export const downloadAndLinkExtension = async ({
                 console.log(`  ‣ ${context.success.hl(p)}`);
             });
         }
+
+        console.log();
+        console.log(chalk.bold("Additional Notes"));
+        console.log(`‣ note that if you already have the ${context.success.hl("webiny watch")} command running, you'll need to restart it`);
     } catch (e) {
         switch (e.code) {
             case "NO_OBJECTS_FOUND":

--- a/packages/cli-plugin-extensions/src/downloadAndLinkExtension.ts
+++ b/packages/cli-plugin-extensions/src/downloadAndLinkExtension.ts
@@ -162,7 +162,11 @@ export const downloadAndLinkExtension = async ({
 
         console.log();
         console.log(chalk.bold("Additional Notes"));
-        console.log(`‣ note that if you already have the ${context.success.hl("webiny watch")} command running, you'll need to restart it`);
+        console.log(
+            `‣ note that if you already have the ${context.success.hl(
+                "webiny watch"
+            )} command running, you'll need to restart it`
+        );
     } catch (e) {
         switch (e.code) {
             case "NO_OBJECTS_FOUND":

--- a/packages/cli-plugin-extensions/src/extensions/AdminExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/AdminExtension.ts
@@ -30,7 +30,7 @@ export class AdminExtension extends AbstractExtension {
         const indexTsxFilePath = `${extensionsFolderPath}/src/index.tsx`;
 
         return [
-            `run ${chalk.green(watchCommand)} to start a new local development session`,
+            `run (or restart if already running) ${chalk.green(watchCommand)} to start local development`,
             `open ${chalk.green(indexTsxFilePath)} and start coding`,
             `to install additional dependencies, run ${chalk.green(
                 `yarn workspace ${this.params.packageName} add <package-name>`

--- a/packages/cli-plugin-extensions/src/extensions/AdminExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/AdminExtension.ts
@@ -30,7 +30,7 @@ export class AdminExtension extends AbstractExtension {
         const indexTsxFilePath = `${extensionsFolderPath}/src/index.tsx`;
 
         return [
-            `run (or restart if already running) ${chalk.green(watchCommand)} to start local development`,
+            `run ${chalk.green(watchCommand)} to start local development`,
             `open ${chalk.green(indexTsxFilePath)} and start coding`,
             `to install additional dependencies, run ${chalk.green(
                 `yarn workspace ${this.params.packageName} add <package-name>`

--- a/packages/cli-plugin-extensions/src/extensions/ApiExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/ApiExtension.ts
@@ -30,7 +30,7 @@ export class ApiExtension extends AbstractExtension {
         const indexTsxFilePath = `${extensionsFolderPath}/src/index.ts`;
 
         return [
-            `run ${chalk.green(watchCommand)} to start a new local development session`,
+            `run (or restart if already running) ${chalk.green(watchCommand)} to start local development`,
             `open ${chalk.green(indexTsxFilePath)} and start coding`,
             `to install additional dependencies, run ${chalk.green(
                 `yarn workspace ${this.params.packageName} add <package-name>`

--- a/packages/cli-plugin-extensions/src/extensions/ApiExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/ApiExtension.ts
@@ -30,7 +30,7 @@ export class ApiExtension extends AbstractExtension {
         const indexTsxFilePath = `${extensionsFolderPath}/src/index.ts`;
 
         return [
-            `run (or restart if already running) ${chalk.green(watchCommand)} to start local development`,
+            `run ${chalk.green(watchCommand)} to start local development`,
             `open ${chalk.green(indexTsxFilePath)} and start coding`,
             `to install additional dependencies, run ${chalk.green(
                 `yarn workspace ${this.params.packageName} add <package-name>`

--- a/packages/cli-plugin-extensions/src/extensions/PbElementExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/PbElementExtension.ts
@@ -37,7 +37,7 @@ export class PbElementExtension extends AbstractExtension {
 
         return [
             [
-                `run (or restart if already running) the following commands to start local development:`,
+                `run the following commands to start local development:`,
                 `  ∙ ${chalk.green(watchCommandAdmin)}`,
                 `  ∙ ${chalk.green(watchCommandWebsite)}`
             ].join("\n"),

--- a/packages/cli-plugin-extensions/src/extensions/PbElementExtension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/PbElementExtension.ts
@@ -37,7 +37,7 @@ export class PbElementExtension extends AbstractExtension {
 
         return [
             [
-                `run the following commands to start local development sessions:`,
+                `run (or restart if already running) the following commands to start local development:`,
                 `  ∙ ${chalk.green(watchCommandAdmin)}`,
                 `  ∙ ${chalk.green(watchCommandWebsite)}`
             ].join("\n"),

--- a/packages/cli-plugin-extensions/src/generateExtension.ts
+++ b/packages/cli-plugin-extensions/src/generateExtension.ts
@@ -160,8 +160,12 @@ export const generateExtension = async ({ input, ora, context }: GenerateExtensi
         }
 
         console.log();
-            console.log(chalk.bold("Additional Notes"));
-        console.log(`‣ note that if you already have the ${context.success.hl("webiny watch")} command running, you'll need to restart it`);
+        console.log(chalk.bold("Additional Notes"));
+        console.log(
+            `‣ note that if you already have the ${context.success.hl(
+                "webiny watch"
+            )} command running, you'll need to restart it`
+        );
     } catch (err) {
         ora.fail("Could not create extension. Please check the logs below.");
         console.log();

--- a/packages/cli-plugin-extensions/src/generateExtension.ts
+++ b/packages/cli-plugin-extensions/src/generateExtension.ts
@@ -158,6 +158,10 @@ export const generateExtension = async ({ input, ora, context }: GenerateExtensi
                 console.log(`‣ ${message}`);
             });
         }
+
+        console.log();
+            console.log(chalk.bold("Additional Notes"));
+        console.log(`‣ note that if you already have the ${context.success.hl("webiny watch")} command running, you'll need to restart it`);
     } catch (err) {
         ora.fail("Could not create extension. Please check the logs below.");
         console.log();

--- a/packages/project-utils/bundling/function/watchFunction.js
+++ b/packages/project-utils/bundling/function/watchFunction.js
@@ -30,15 +30,28 @@ module.exports = async options => {
         webpackConfig = overrides.webpack(webpackConfig);
     }
 
+    let initialCompilation = true;
     return new Promise(async (resolve, reject) => {
-        options.logs && console.log("Compiling...");
+        if (options.logs) {
+            if (initialCompilation) {
+                console.log("Initial compilation started...");
+            } else {
+                console.log("Compiling...");
+            }
+        }
+
         return webpack(webpackConfig).watch({}, async (err, stats) => {
             if (err) {
                 return reject(err);
             }
 
             if (!stats.hasErrors()) {
-                options.logs && console.log("Compiled successfully.");
+                if (initialCompilation) {
+                    initialCompilation = false;
+                    console.log("Initial compilation completed. Watching for changes...");
+                } else {
+                    options.logs && console.log("Compiled successfully.");
+                }
             } else {
                 options.logs && console.log(stats.toString("errors-warnings"));
             }

--- a/packages/project-utils/bundling/function/watchFunction.js
+++ b/packages/project-utils/bundling/function/watchFunction.js
@@ -30,14 +30,11 @@ module.exports = async options => {
         webpackConfig = overrides.webpack(webpackConfig);
     }
 
-    let initialCompilation = true;
     return new Promise(async (resolve, reject) => {
+        let initialCompilation = true;
         if (options.logs) {
-            if (initialCompilation) {
-                console.log("Initial compilation started...");
-            } else {
-                console.log("Compiling...");
-            }
+            const message = initialCompilation ? "Initial compilation started..." : "Compiling...";
+            console.log(message);
         }
 
         return webpack(webpackConfig).watch({}, async (err, stats) => {
@@ -45,15 +42,18 @@ module.exports = async options => {
                 return reject(err);
             }
 
-            if (!stats.hasErrors()) {
-                if (initialCompilation) {
-                    initialCompilation = false;
-                    console.log("Initial compilation completed. Watching for changes...");
-                } else {
-                    options.logs && console.log("Compiled successfully.");
-                }
-            } else {
-                options.logs && console.log(stats.toString("errors-warnings"));
+            if (!options.logs) {
+                return;
+            }
+
+            if (stats.hasErrors()) {
+                console.log(stats.toString("errors-warnings"));
+                return;
+            }
+
+            if (initialCompilation) {
+                initialCompilation = false;
+                console.log("Initial compilation completed. Watching for changes...");
             }
         });
     });


### PR DESCRIPTION
## Changes

This PR introduces the following CLI DX improvements.

#### 1. New `webiny watch` Command - Improved Messaging
A couple of things changed with the `webiny watch` command / when running the command against API project application.

For starters, we've made it more clear that, once the dev session is terminated, the watched app (API) will stop working (point 1 in screenshot). Apart from using `webiny warning` prefix and making it yellow, one other thing we changed here is, instead of using "should redeploy", we're now using "MUST redeploy" (point 2 in sshot). This should give a much stronger signal to the user that a redeployment is needed.

Finally, when the compilation starts, users will see the "Initial compilation started...". once it's done, another "Initial compilation completed. Watching for changes..." message will be shown, indicating to the user that they can start developing (points 3 and 4 in screenshot).

![image](https://github.com/user-attachments/assets/33a15ca6-f143-4b3d-b7af-47c9daa26008)

#### 2. Handled A Webiny Config-related Bug
In some cases, upon running the new watch command, users would receive an error related to `webiny.config.js` / `webiny.config.ts` file missing in their extension. This file does not need to exist.

The command is now aware of this and should now work as expected.

#### 3. Extensions - Added Additional Notes Section

Once an extension has been generated, users will now also see a new Additional Notes section. 

For now, we're using the section to warn users that, if they've generated an extension while the `webiny watch` command was running, that they should restart the command.

![image](https://github.com/user-attachments/assets/768e5d1c-9e75-4e0e-898a-4959189e11af)

![image](https://github.com/user-attachments/assets/2f344cc6-b02a-4b72-92cd-292c9a31963e)

## How Has This Been Tested?
Manually.

## Documentation
Changelog.