### PR TITLE
Form Builder - Delete Settings Entry On Locale Deletion

### DIFF
--- a/packages/api-form-builder/__tests__/graphql/i18n.ts
+++ b/packages/api-form-builder/__tests__/graphql/i18n.ts
@@ -13,3 +13,19 @@ export const CREATE_LOCALE = /* GraphQL */ `
         }
     }
 `;
+
+export const DELETE_LOCALE = /* GraphQL */ `
+    mutation DeleteI18NLocale($code: String!) {
+        i18n {
+            deleteI18NLocale(code: $code) {
+                data {
+                    code
+                }
+                error {
+                    message
+                    code
+                }
+            }
+        }
+    }
+`;

--- a/packages/api-form-builder/__tests__/settings.test.ts
+++ b/packages/api-form-builder/__tests__/settings.test.ts
@@ -2,9 +2,16 @@ import useGqlHandler from "./useGqlHandler";
 import { GET_SETTINGS } from "~tests/graphql/formBuilderSettings";
 
 describe("Settings Test", () => {
-    const { getSettings, updateSettings, install, createI18NLocale, isInstalled } = useGqlHandler();
+    const {
+        getSettings,
+        updateSettings,
+        install,
+        createI18NLocale,
+        deleteI18NLocale,
+        isInstalled
+    } = useGqlHandler();
 
-    test(`Should not be able to get & update settings before "install"`, async () => {
+    it(`Should not be able to get & update settings before "install"`, async () => {
         // Should not have any settings without install
         const [getSettingsResponse] = await getSettings();
 
@@ -40,7 +47,7 @@ describe("Settings Test", () => {
         });
     });
 
-    test("Should be able to install `Form Builder`", async () => {
+    it("Should be able to install `Form Builder`", async () => {
         // "isInstalled" should return false prior "install"
         const [isInstalledResponse] = await isInstalled();
 
@@ -78,7 +85,7 @@ describe("Settings Test", () => {
         });
     });
 
-    test(`Should be able to get & update settings after "install"`, async () => {
+    it(`Should be able to get & update settings after "install"`, async () => {
         // Let's install the `Form builder`
         const [installResponse] = await install({ domain: "http://localhost:3001" });
 
@@ -156,7 +163,7 @@ describe("Settings Test", () => {
         });
     });
 
-    test(`Should be able to get & update settings after in a new locale`, async () => {
+    it(`Should be able to get & update settings after in a new locale`, async () => {
         // Let's install the `Form builder`
         await install({ domain: "http://localhost:3001" });
 
@@ -168,9 +175,7 @@ describe("Settings Test", () => {
         // set the locale header. Wasn't easily possible via the `getSettings` helper.
         const [newLocaleFbSettings] = await invoke({
             body: { query: GET_SETTINGS },
-            headers: {
-                "x-i18n-locale": "default:de-DE;content:de-DE;"
-            }
+            headers: { "x-i18n-locale": "default:de-DE;content:de-DE;" }
         });
 
         // Settings should exist in the newly created locale.
@@ -185,6 +190,40 @@ describe("Settings Test", () => {
                                 secretKey: null,
                                 siteKey: null
                             }
+                        },
+                        error: null
+                    }
+                }
+            }
+        });
+    });
+
+    it(`Should be able to create a locale, delete it, and again create it`, async () => {
+        // Let's install the `Form builder`
+        await install({ domain: "http://localhost:3001" });
+
+        await createI18NLocale({ data: { code: "en-US" } });
+        await createI18NLocale({ data: { code: "de-DE" } });
+
+        const [deleteDeLocaleResponse] = await deleteI18NLocale({ code: "de-DE" });
+        expect(deleteDeLocaleResponse).toEqual({
+            data: {
+                i18n: {
+                    deleteI18NLocale: {
+                        data: { code: "de-DE" },
+                        error: null
+                    }
+                }
+            }
+        });
+
+        const [createDeLocaleResponse] = await createI18NLocale({ data: { code: "de-DE" } });
+        expect(createDeLocaleResponse).toEqual({
+            data: {
+                i18n: {
+                    createI18NLocale: {
+                        data: {
+                            code: "de-DE"
                         },
                         error: null
                     }

--- a/packages/api-form-builder/__tests__/useGqlHandler.ts
+++ b/packages/api-form-builder/__tests__/useGqlHandler.ts
@@ -12,7 +12,7 @@ import { createI18NGraphQL } from "@webiny/api-i18n/graphql";
 
 // Graphql
 import { INSTALL as INSTALL_FILE_MANAGER } from "./graphql/fileManagerSettings";
-import { CREATE_LOCALE } from "./graphql/i18n";
+import { DELETE_LOCALE, CREATE_LOCALE } from "./graphql/i18n";
 
 import {
     GET_SETTINGS,
@@ -228,6 +228,9 @@ export default (params: UseGqlHandlerParams = {}) => {
         // Locales.
         async createI18NLocale(variables: Record<string, any>) {
             return invoke({ body: { query: CREATE_LOCALE, variables } });
+        },
+        async deleteI18NLocale(variables: Record<string, any>) {
+            return invoke({ body: { query: DELETE_LOCALE, variables } });
         }
     };
 };

--- a/packages/api-form-builder/src/plugins/crud/index.ts
+++ b/packages/api-form-builder/src/plugins/crud/index.ts
@@ -122,6 +122,13 @@ export default (params: CreateFormBuilderCrudParams) => {
                     return context.formBuilder.createSettings({});
                 });
             });
+
+            context.i18n.locales.onLocaleAfterDelete.subscribe(async params => {
+                const { locale } = params;
+                await context.i18n.withLocale(locale, async () => {
+                    return context.formBuilder.deleteSettings();
+                });
+            });
         })
     ];
 };


### PR DESCRIPTION
## Changes
With this PR, we're ensuring that Form Builder's settings entry is deleted.


## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
