### PR TITLE
Various Fixes - Data Validation + Missing `DB_TABLE_LOG` Env Var

### DIFF
--- a/.github/workflows/chromaticStorybook.yml
+++ b/.github/workflows/chromaticStorybook.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 20
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/versionApproval.yml
+++ b/.github/workflows/versionApproval.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - uses: actions/checkout@v4
 
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - uses: actions/checkout@v4
 
@@ -87,4 +87,4 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All Webiny apps can be customized easily to fully fit an enterprise publishing w
 **Prerequisites**
 
 - Node.js ^20
-- yarn ^1.22.21 || ^3 || ^4
+- yarn ^1.22.21
 - AWS account
 
 For the detailed install guide, please see 👉 https://www.webiny.com/docs/get-started/install-webiny

--- a/cypress-tests/cypress/e2e/admin/headlessCms/contentModel/contentModels.cy.js
+++ b/cypress-tests/cypress/e2e/admin/headlessCms/contentModel/contentModels.cy.js
@@ -173,12 +173,54 @@ context("Headless CMS - Content Models CRUD", () => {
                     cy.wait(1000);
                 });
         });
-        // b. Confirm delete model
-        cy.findByTestId("cms-delete-content-model-dialog").within(() => {
-            cy.findAllByTestId("dialog-accept").next().click();
+
+        const dialog = cy.findByTestId("cms-delete-content-model-dialog");
+
+        // b. Confirm understand the consequences
+        dialog.within(() => {
+            cy.findByTestId("cms-delete-content-model-confirm-button").click();
         });
-        // c. Check success message
-        cy.findByText(`Content model ${`Book - ${uniqueId}`} deleted successfully!.`);
+        // c. Confirm delete model - error because no model name typed into input
+        dialog.within(() => {
+            const button = cy.findByTestId("cms-delete-content-model-confirm-button");
+            button.contains("Yes, delete the model");
+            button.click();
+        });
+
+        // d. Should be an error message
+        dialog.within(() => {
+            cy.findByText("Confirmation value is not correct.");
+        });
+
+        // e. Write the model name into the input
+        dialog.within(() => {
+            cy.findByTestId("cms-delete-content-model-input")
+                .focus()
+                .wait(500)
+                .type(`delete ${lodashCamelCase(`Book - ${uniqueId}`)}`)
+                .wait(1000);
+        });
+
+        // f. Confirm delete model
+        dialog.within(() => {
+            const button = cy.findByTestId("cms-delete-content-model-confirm-button");
+            button.contains("Yes, delete the model");
+            button.click();
+        });
+
+        cy.wait(3000);
+
+        // g. Check success message
+        cy.findByTestId("cms-delete-content-model-dialog").within(() => {
+            cy.findByText(
+                `If the model has a large amount of entries, it will take some time to delete everything.`
+            );
+        });
+
+        // we will not go further for now because it gets complicated
+        /**
+         * TODO update the test to check model actually being deleted...
+         */
     });
 
     it("should create, edit, and delete content model - with fields", () => {
@@ -255,11 +297,52 @@ context("Headless CMS - Content Models CRUD", () => {
                     cy.wait(1000);
                 });
         });
-        // b. Confirm delete model
-        cy.findByTestId("cms-delete-content-model-dialog").within(() => {
-            cy.findAllByTestId("dialog-accept").next().click();
+        const dialog = cy.findByTestId("cms-delete-content-model-dialog");
+
+        // b. Confirm understand the consequences
+        dialog.within(() => {
+            cy.findByTestId("cms-delete-content-model-confirm-button").click();
         });
-        // c. Check success message
-        cy.findByText(`Content model ${`Book - ${uniqueId}`} deleted successfully!.`);
+        // c. Confirm delete model - error because no model name typed into input
+        dialog.within(() => {
+            const button = cy.findByTestId("cms-delete-content-model-confirm-button");
+            button.contains("Yes, delete the model");
+            button.click();
+        });
+
+        // d. Should be an error message
+        dialog.within(() => {
+            cy.findByText("Confirmation value is not correct.");
+        });
+
+        // e. Write the model name into the input
+        dialog.within(() => {
+            cy.findByTestId("cms-delete-content-model-input")
+                .focus()
+                .wait(500)
+                .type(`delete ${lodashCamelCase(`Book - ${uniqueId}`)}`)
+                .wait(1000);
+        });
+
+        // f. Confirm delete model
+        dialog.within(() => {
+            const button = cy.findByTestId("cms-delete-content-model-confirm-button");
+            button.contains("Yes, delete the model");
+            button.click();
+        });
+
+        cy.wait(3000);
+
+        // g. Check success message
+        cy.findByTestId("cms-delete-content-model-dialog").within(() => {
+            cy.findByText(
+                `If the model has a large amount of entries, it will take some time to delete everything.`
+            );
+        });
+
+        // we will not go further for now because it gets complicated
+        /**
+         * TODO update the test to check model actually being deleted...
+         */
     });
 });

--- a/package.json
+++ b/package.json
@@ -261,6 +261,6 @@
     "@types/hoist-non-react-statics": "^3.3.5"
   },
   "engines": {
-    "node": ">=22.0.0 <23.0.0"
+    "node": ">=20.0.0 <23.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@octokit/rest": "^20.0.2",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.1",
+    "@types/node": "^20.17.10",
     "@types/prettier": "^2.7.3",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",

--- a/packages/api-admin-users/src/createAdminUsers/users.validation.ts
+++ b/packages/api-admin-users/src/createAdminUsers/users.validation.ts
@@ -18,8 +18,6 @@ const createUserDataValidation = zod.object({
 
 const updateUserDataValidation = zod.object({
     displayName: zod.string().min(1).optional(),
-
-    // Allow null. This is important because we want to allow users to remove their e-mail.
     avatar: zod.object({}).passthrough().optional().nullable(),
     firstName: zod.string().min(1).optional(),
     lastName: zod.string().min(1).optional(),

--- a/packages/api-admin-users/src/createAdminUsers/users.validation.ts
+++ b/packages/api-admin-users/src/createAdminUsers/users.validation.ts
@@ -45,7 +45,6 @@ export const attachUserValidation = (
         if (validation.success) {
             return;
         }
-
         throw createZodError(validation.error);
     });
 };

--- a/packages/api-admin-users/src/createAdminUsers/users.validation.ts
+++ b/packages/api-admin-users/src/createAdminUsers/users.validation.ts
@@ -18,7 +18,9 @@ const createUserDataValidation = zod.object({
 
 const updateUserDataValidation = zod.object({
     displayName: zod.string().min(1).optional(),
-    avatar: zod.object({}).passthrough().optional(),
+
+    // Allow null. This is important because we want to allow users to remove their e-mail.
+    avatar: zod.object({}).passthrough().optional().nullable(),
     firstName: zod.string().min(1).optional(),
     lastName: zod.string().min(1).optional(),
     group: zod.string().optional(),
@@ -43,6 +45,8 @@ export const attachUserValidation = (
         if (validation.success) {
             return;
         }
+
+        console.log(validation.error)
         throw createZodError(validation.error);
     });
 };

--- a/packages/api-admin-users/src/createAdminUsers/users.validation.ts
+++ b/packages/api-admin-users/src/createAdminUsers/users.validation.ts
@@ -46,7 +46,6 @@ export const attachUserValidation = (
             return;
         }
 
-        console.log(validation.error)
         throw createZodError(validation.error);
     });
 };

--- a/packages/api-form-builder/src/plugins/crud/forms.models.ts
+++ b/packages/api-form-builder/src/plugins/crud/forms.models.ts
@@ -44,13 +44,13 @@ export const FormSettingsModel = zod.object({
         .default({
             renderer: "default"
         }),
-    submitButtonLabel: zod.string().optional().default(""),
+    submitButtonLabel: zod.string().optional().default("").nullable(),
     fullWidthSubmitButton: zod.boolean().optional().default(false),
-    successMessage: zod.object({}).passthrough().optional(),
+    successMessage: zod.object({}).passthrough().optional().nullable(),
     termsOfServiceMessage: zod
         .object({
             message: zod.object({}).optional().default({}),
-            errorMessage: zod.string().optional().default(""),
+            errorMessage: zod.string().optional().default("").nullable(),
             enabled: zod.boolean().optional().nullish().default(null)
         })
         .default({
@@ -68,8 +68,8 @@ export const FormSettingsModel = zod.object({
                 .string()
                 .optional()
                 .default("Please verify that you are not a robot."),
-            secretKey: zod.string().optional().nullish().default(""),
-            siteKey: zod.string().optional().nullish().default("")
+            secretKey: zod.string().optional().nullish().default("").nullable(),
+            siteKey: zod.string().optional().nullish().default("").nullable()
         })
         .passthrough()
         .optional()
@@ -87,7 +87,7 @@ export const FormUpdateDataModel = zod.object({
     fields: zod.array(FormFieldsModel).optional(),
     steps: zod.array(FormStepsModel).optional(),
     settings: FormSettingsModel.optional(),
-    triggers: zod.object({}).passthrough().optional()
+    triggers: zod.object({}).passthrough().optional().nullable()
 });
 
 export const FormSubmissionCreateDataModel = zod.object({

--- a/packages/api-headless-cms-tasks/src/tasks/deleteModel/graphql/attachLifecycleEvents.ts
+++ b/packages/api-headless-cms-tasks/src/tasks/deleteModel/graphql/attachLifecycleEvents.ts
@@ -45,7 +45,5 @@ export const attachLifecycleEvents = ({ context }: IAttachLifecycleEventsParams)
      */
     context.cms.onModelBeforeUpdate.subscribe(blockActionOnEvent);
 
-    context.cms.onModelBeforeDelete.subscribe(blockActionOnEvent);
-
     context.cms.onModelBeforeCreateFrom.subscribe(blockActionOnEvent);
 };

--- a/packages/api-prerendering-service/__tests__/render/handlers/render/renderUrl.test.ts
+++ b/packages/api-prerendering-service/__tests__/render/handlers/render/renderUrl.test.ts
@@ -1,6 +1,6 @@
 import render from "~/render/renderUrl";
 import prettier from "prettier";
-import { Context } from "@webiny/handler/types";
+import { Context } from "~/render/types";
 
 const BASE_HTML = `<html lang="en"><head><meta charset="utf-8" /></head><body><div id="root">A sample page.</div></body></html>`;
 

--- a/packages/api-prerendering-service/package.json
+++ b/packages/api-prerendering-service/package.json
@@ -15,7 +15,7 @@
   "author": "Webiny Ltd",
   "license": "MIT",
   "dependencies": {
-    "@sparticuz/chromium": "123.0.1",
+    "@sparticuz/chromium": "131.0.1",
     "@webiny/api": "0.0.0",
     "@webiny/api-log": "0.0.0",
     "@webiny/aws-sdk": "0.0.0",
@@ -30,12 +30,12 @@
     "posthtml": "^0.15.0",
     "posthtml-noopener": "^1.0.5",
     "posthtml-plugin-link-preload": "^1.0.0",
-    "puppeteer-core": "^23.9.0",
+    "puppeteer-core": "^23.11.1",
     "srcset": "^4.0.0"
   },
   "devDependencies": {
     "@types/object-hash": "^2.2.1",
-    "@types/puppeteer-core": "^7.0.4",
+    "@types/puppeteer-core": "7.0.4",
     "@webiny/cli": "0.0.0",
     "@webiny/handler-aws": "0.0.0",
     "@webiny/project-utils": "0.0.0",

--- a/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/EditFieldDialog.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/EditFieldDialog.tsx
@@ -1,25 +1,26 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import cloneDeep from "lodash/cloneDeep";
 import { css } from "emotion";
 import styled from "@emotion/styled";
 import {
     Dialog,
-    DialogContent,
-    DialogTitle,
-    DialogCancel,
     DialogActions,
-    DialogButton
+    DialogButton,
+    DialogCancel,
+    DialogContent,
+    DialogTitle
 } from "@webiny/ui/Dialog";
 import { Form, FormOnSubmit } from "@webiny/form";
 import { plugins } from "@webiny/plugins";
-import { Tabs, Tab } from "@webiny/ui/Tabs";
+import { Tab, Tabs } from "@webiny/ui/Tabs";
 import GeneralTab from "./EditFieldDialog/GeneralTab";
 import ValidatorsTab from "./EditFieldDialog/ValidatorsTab";
 import FieldTypeSelector from "./EditFieldDialog/FieldTypeSelector";
 import { i18n } from "@webiny/app/i18n";
-const t = i18n.namespace("FormEditor.EditFieldDialog");
 import { useFormEditor } from "../../Context";
 import { FbBuilderFieldPlugin, FbFormModelField } from "~/types";
+
+const t = i18n.namespace("FormEditor.EditFieldDialog");
 
 const dialogBody = css({
     "&.webiny-ui-dialog__content": {

--- a/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/EditTab.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/EditTab.tsx
@@ -21,7 +21,7 @@ export const EditTab = () => {
     return (
         <EditContainer>
             <FieldErrors errors={errors} />
-            {data.steps.map((formStep: FbFormStep, index: number) => (
+            {(data.steps || []).map((formStep: FbFormStep, index: number) => (
                 <EditTabStep
                     key={`edit-tab-step${index}`}
                     formStep={formStep}

--- a/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/FormStep/FormStepWithFields.tsx
+++ b/packages/app-form-builder/src/admin/components/FormEditor/Tabs/EditTab/FormStep/FormStepWithFields.tsx
@@ -10,7 +10,7 @@ export interface FormStepWithFieldsProps {
 export const FormStepWithFields = ({ fields, formStep }: FormStepWithFieldsProps) => {
     return (
         <React.Fragment>
-            {fields.map((row, rowIndex) => (
+            {(fields || []).map((row, rowIndex) => (
                 <FormStepRow
                     key={`row-${rowIndex}`}
                     row={row}

--- a/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
+++ b/packages/app-form-builder/src/admin/plugins/formDetails/formSubmissions/FormSubmissionsList/FormSubmissionsList.tsx
@@ -107,10 +107,10 @@ export const FormSubmissionsList = ({ form }: FormSubmissionsListProps) => {
                         pagination: true
                     }}
                 >
-                    {({ data = [] }: { data: FbFormSubmissionData[] }) => (
+                    {({ data }: { data: FbFormSubmissionData[] }) => (
                         <>
                             <Scrollbar onScrollFrame={scrollFrame => loadMoreOnScroll(scrollFrame)}>
-                                {data.map(submission => {
+                                {(data || []).map(submission => {
                                     const submittedOn = submission.meta
                                         ? new Date(submission.meta.submittedOn)
                                         : new Date();

--- a/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
+++ b/packages/app-form-builder/src/admin/views/Forms/FormsDataList.tsx
@@ -283,9 +283,9 @@ const FormsDataList = (props: FormsDataListProps) => {
             modalOverlay={formsDataListModalOverlay}
             modalOverlayAction={<DataListModalOverlayAction icon={<FilterIcon />} />}
         >
-            {({ data = [] }: { data: FbFormModel[] }) => (
+            {({ data }: { data: FbFormModel[] | null }) => (
                 <List data-testid="default-data-list">
-                    {data.map(form => {
+                    {(data || []).map(form => {
                         const name = form.createdBy.displayName;
                         return (
                             <ListItem

--- a/packages/app-form-builder/src/admin/views/cache.ts
+++ b/packages/app-form-builder/src/admin/views/cache.ts
@@ -29,6 +29,9 @@ export const updateLatestRevisionInListCache = (
     }
 
     const index = formBuilder.listForms.data.findIndex(item => item.id.startsWith(uniqueId));
+    if (index < 0) {
+        return;
+    }
 
     cache.writeQuery({
         ...gqlParams,
@@ -99,6 +102,9 @@ export const removeFormFromListCache = (cache: DataProxy, form: FbRevisionModel)
     }
 
     const index = formBuilder.listForms.data.findIndex(item => item.id === form.id);
+    if (index < 0) {
+        return;
+    }
 
     cache.writeQuery({
         ...gqlParams,

--- a/packages/app-form-builder/src/page-builder/admin/plugins/components/FormElementAdvancedSettings.tsx
+++ b/packages/app-form-builder/src/page-builder/admin/plugins/components/FormElementAdvancedSettings.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { useLazyQuery, useQuery } from "@apollo/react-hooks";
-import get from "lodash/get";
 import { Cell, Grid } from "@webiny/ui/Grid";
 import { Alert } from "@webiny/ui/Alert";
 import { AutoComplete } from "@webiny/ui/AutoComplete";
@@ -20,7 +19,6 @@ import {
     ListFormsQueryResponse
 } from "./graphql";
 import { BindComponent, FormOnSubmit } from "@webiny/form";
-import { FbRevisionModel } from "~/types";
 
 const FormOptionsWrapper = styled("div")({
     minHeight: 250
@@ -96,10 +94,10 @@ const FormElementAdvancedSettings = ({ Bind, submit, data }: FormElementAdvanced
             value: null
         };
 
-        if (getQuery.data) {
-            const publishedRevisions = (
-                get(getQuery, "data.formBuilder.getFormRevisions.data") as FbRevisionModel[]
-            ).filter(revision => revision.published);
+        if (getQuery.data?.formBuilder?.getFormRevisions?.data) {
+            const publishedRevisions = getQuery.data.formBuilder.getFormRevisions.data.filter(
+                revision => revision.published
+            );
             output.options = publishedRevisions.map(item => ({
                 id: item.id,
                 name: `${item.name} (version ${item.version})`

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/FullyDeleteModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/FullyDeleteModelDialog.tsx
@@ -104,7 +104,12 @@ export const FullyDeleteModelDialog = ({
     }, [setStatusUnderstood, startProcessing, status]);
 
     return (
-        <Dialog open={!!model} onClose={onClose} preventOutsideDismiss={true}>
+        <Dialog
+            open={!!model}
+            onClose={onClose}
+            preventOutsideDismiss={true}
+            data-testid="cms-delete-content-model-dialog"
+        >
             <DialogTitle>{title}</DialogTitle>
             <DialogContent>
                 <Content
@@ -116,7 +121,7 @@ export const FullyDeleteModelDialog = ({
                 />
             </DialogContent>
             <DialogActions>
-                <DialogCancel>
+                <DialogCancel data-testid="cms-delete-content-model-close-button">
                     {status === FullyDeleteModelStateStatus.PROCESSED ||
                     status === FullyDeleteModelStateStatus.ERROR
                         ? "OK"
@@ -124,7 +129,12 @@ export const FullyDeleteModelDialog = ({
                 </DialogCancel>
                 {(status === FullyDeleteModelStateStatus.NONE ||
                     status === FullyDeleteModelStateStatus.UNDERSTOOD) && (
-                    <ButtonPrimary onClick={onYesClick}>{primaryButtonText}</ButtonPrimary>
+                    <ButtonPrimary
+                        data-testid="cms-delete-content-model-confirm-button"
+                        onClick={onYesClick}
+                    >
+                        {primaryButtonText}
+                    </ButtonPrimary>
                 )}
             </DialogActions>
         </Dialog>

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/Confirmation.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/Confirmation.tsx
@@ -47,7 +47,12 @@ export const Confirmation = (props: IConfirmationProps) => {
                 <br />
             </p>
             <div>
-                <Input onChange={onChange} placeholder={placeholder} value={confirmation} />
+                <Input
+                    data-testid="cms-delete-content-model-input"
+                    onChange={onChange}
+                    placeholder={placeholder}
+                    value={confirmation}
+                />
                 {error && <p className={errorClassName}>{error.message}</p>}
             </div>
         </>

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -7,11 +7,11 @@ const semver = require("semver");
 const currentNodeVersion = process.versions.node;
 
 (async () => {
-    if (!semver.satisfies(currentNodeVersion, "^22")) {
+    if (!semver.satisfies(currentNodeVersion, ">=20")) {
         console.error(
             chalk.red(
                 [
-                    `You are running Node.js ${currentNodeVersion}, but Webiny requires version ^22.`,
+                    `You are running Node.js ${currentNodeVersion}, but Webiny requires version >=20.`,
                     `Please switch to one of the required versions and try again.`,
                     `For more information, please visit https://www.webiny.com/docs/get-started/install-webiny#prerequisites.`
                 ].join(" ")

--- a/packages/create-webiny-project/bin.js
+++ b/packages/create-webiny-project/bin.js
@@ -14,11 +14,11 @@ const verifyConfig = require("./utils/verifyConfig");
      * Node
      */
     const nodeVersion = process.versions.node;
-    if (!semver.satisfies(nodeVersion, `^22`)) {
+    if (!semver.satisfies(nodeVersion, `>=20`)) {
         console.error(
             chalk.red(
                 [
-                    `You are running Node.js ${nodeVersion}, but Webiny requires version ^22.`,
+                    `You are running Node.js ${nodeVersion}, but Webiny requires version >=20.`,
                     `Please switch to one of the required versions and try again.`,
                     "For more information, please visit https://www.webiny.com/docs/get-started/install-webiny#prerequisites."
                 ].join(" ")

--- a/packages/cwp-template-aws/template/ddb-es/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-es/dependencies.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.1",
+    "@types/node": "^20.17.10",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",
     "@typescript-eslint/eslint-plugin": "^5.5.0",

--- a/packages/cwp-template-aws/template/ddb-os/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb-os/dependencies.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.1",
+    "@types/node": "^20.17.10",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",
     "@typescript-eslint/eslint-plugin": "^5.5.0",

--- a/packages/cwp-template-aws/template/ddb/dependencies.json
+++ b/packages/cwp-template-aws/template/ddb/dependencies.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.10.1",
+    "@types/node": "^20.17.10",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",
     "@typescript-eslint/eslint-plugin": "^5.5.0",

--- a/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
+++ b/packages/pulumi-aws/src/apps/website/WebsitePrerendering.ts
@@ -188,7 +188,8 @@ function createRenderer(
             environment: {
                 variables: getCommonLambdaEnvVariables().apply(value => ({
                     ...value,
-                    DB_TABLE: params.dbTableName
+                    DB_TABLE: params.dbTableName,
+                    DB_TABLE_LOG: params.logDbTableName
                 }))
             },
             description: "Renders pages and stores output in an S3 bucket of choice.",
@@ -241,7 +242,8 @@ function createFlushService(
             environment: {
                 variables: getCommonLambdaEnvVariables().apply(value => ({
                     ...value,
-                    DB_TABLE: params.dbTableName
+                    DB_TABLE: params.dbTableName,
+                    DB_TABLE_LOG: params.logDbTableName
                 }))
             },
             description: "Subscribes to flush events on event bus",

--- a/packages/pulumi-aws/src/constants.ts
+++ b/packages/pulumi-aws/src/constants.ts
@@ -1,5 +1,5 @@
 import { lambda } from "@pulumi/aws";
 
-export const LAMBDA_RUNTIME = lambda.Runtime.NodeJS22dX;
+export const LAMBDA_RUNTIME = lambda.Runtime.NodeJS20dX;
 
 export const DEFAULT_PROD_ENV_NAMES = ["prod", "production"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8421,21 +8421,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@puppeteer/browsers@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@puppeteer/browsers@npm:2.5.0"
+"@puppeteer/browsers@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@puppeteer/browsers@npm:2.6.1"
   dependencies:
-    debug: "npm:^4.3.7"
+    debug: "npm:^4.4.0"
     extract-zip: "npm:^2.0.1"
     progress: "npm:^2.0.3"
-    proxy-agent: "npm:^6.4.0"
+    proxy-agent: "npm:^6.5.0"
     semver: "npm:^7.6.3"
     tar-fs: "npm:^3.0.6"
     unbzip2-stream: "npm:^1.4.3"
     yargs: "npm:^17.7.2"
   bin:
     browsers: lib/cjs/main-cli.js
-  checksum: 10/7c8e15be5394da3ccd271317b47fd9dfae2f64434b66bcbd74035de3b9fb01db0a045fa3ed93b36864d7ff1cbd17f334f43c1e9dbb8e9a0784ba20f25daf8557
+  checksum: 10/9351e942e00d048a687c5bc5926035774b8c49f0eae593e56f48c6e2fd6be8d8b5e0e5747d8fb94ba4ceb616fd05da2429f5730ad593b6f211493042df01ea94
   languageName: node
   linkType: hard
 
@@ -9807,13 +9807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sparticuz/chromium@npm:123.0.1":
-  version: 123.0.1
-  resolution: "@sparticuz/chromium@npm:123.0.1"
+"@sparticuz/chromium@npm:131.0.1":
+  version: 131.0.1
+  resolution: "@sparticuz/chromium@npm:131.0.1"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    tar-fs: "npm:^3.0.5"
-  checksum: 10/5991aee6d954dcfdc68245d1aa80e5ebb48106bdda73edeafc0f36ea689d163c59cc3d7d637813bd3726db9214b9b5532ee61ffa308201a935d2ea9ede0d02ce
+    follow-redirects: "npm:^1.15.9"
+    tar-fs: "npm:^3.0.6"
+  checksum: 10/0ec2ecc4daded47c938698f9c13abdc01216b723ecbff186518e383c0ab966c9a934e24e568306b343d4ab124891f57d6c1521d00d34b8bd65f2ad4bd6d718bd
   languageName: node
   linkType: hard
 
@@ -10772,12 +10772,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:>=6, @types/node@npm:^22.10.1":
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:>=6":
   version: 22.10.1
   resolution: "@types/node@npm:22.10.1"
   dependencies:
     undici-types: "npm:~6.20.0"
   checksum: 10/c802a526da2f3fa3ccefd00a71244e7cb825329951719e79e8fec62b1dbc2855388c830489770611584665ce10be23c05ed585982038b24924e1ba2c2cce03fd
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.17.10":
+  version: 20.17.10
+  resolution: "@types/node@npm:20.17.10"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10/9a1bcb2f25ce1ad249497e5f10ed984bf0ec476439fad2e965c3d6cc4642abb23c5e8400f7e48e55ff121d2b80b14bdc1bd4eac7ff6848154033a2be25fffb17
   languageName: node
   linkType: hard
 
@@ -10860,7 +10869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/puppeteer-core@npm:^7.0.4":
+"@types/puppeteer-core@npm:7.0.4":
   version: 7.0.4
   resolution: "@types/puppeteer-core@npm:7.0.4"
   dependencies:
@@ -12991,9 +13000,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webiny/api-prerendering-service@workspace:packages/api-prerendering-service"
   dependencies:
-    "@sparticuz/chromium": "npm:123.0.1"
+    "@sparticuz/chromium": "npm:131.0.1"
     "@types/object-hash": "npm:^2.2.1"
-    "@types/puppeteer-core": "npm:^7.0.4"
+    "@types/puppeteer-core": "npm:7.0.4"
     "@webiny/api": "npm:0.0.0"
     "@webiny/api-log": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
@@ -13012,7 +13021,7 @@ __metadata:
     posthtml-noopener: "npm:^1.0.5"
     posthtml-plugin-link-preload: "npm:^1.0.0"
     prettier: "npm:^2.8.8"
-    puppeteer-core: "npm:^23.9.0"
+    puppeteer-core: "npm:^23.11.1"
     rimraf: "npm:^6.0.1"
     srcset: "npm:^4.0.0"
     ttypescript: "npm:^1.5.15"
@@ -18938,16 +18947,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromium-bidi@npm:0.8.0":
-  version: 0.8.0
-  resolution: "chromium-bidi@npm:0.8.0"
+"chromium-bidi@npm:0.11.0":
+  version: 0.11.0
+  resolution: "chromium-bidi@npm:0.11.0"
   dependencies:
     mitt: "npm:3.0.1"
-    urlpattern-polyfill: "npm:10.0.0"
     zod: "npm:3.23.8"
   peerDependencies:
     devtools-protocol: "*"
-  checksum: 10/4fb8ca03f690f899a5a4e6eb41b490e5ba49b9b106e15a26d5ab4bf18c95c49d070b96a02803d44e9ab02672d5ee7712c89f1279ca812db3e501ab3ba155a196
+  checksum: 10/065d0b47a8a5fd8cfcae8820fbf5600d0c14f8ba00e5acbd736ebf4bd614652564d0a7e2f4c4057f801c42890977ab864d3a06ac3a03873175472585be568b63
   languageName: node
   linkType: hard
 
@@ -20808,7 +20816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.7":
+"debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -32965,7 +32973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-agent@npm:^6.4.0":
+"proxy-agent@npm:^6.5.0":
   version: 6.5.0
   resolution: "proxy-agent@npm:6.5.0"
   dependencies:
@@ -33088,17 +33096,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:*, puppeteer-core@npm:^23.9.0":
-  version: 23.10.1
-  resolution: "puppeteer-core@npm:23.10.1"
+"puppeteer-core@npm:*, puppeteer-core@npm:^23.11.1":
+  version: 23.11.1
+  resolution: "puppeteer-core@npm:23.11.1"
   dependencies:
-    "@puppeteer/browsers": "npm:2.5.0"
-    chromium-bidi: "npm:0.8.0"
-    debug: "npm:^4.3.7"
+    "@puppeteer/browsers": "npm:2.6.1"
+    chromium-bidi: "npm:0.11.0"
+    debug: "npm:^4.4.0"
     devtools-protocol: "npm:0.0.1367902"
     typed-query-selector: "npm:^2.12.0"
     ws: "npm:^8.18.0"
-  checksum: 10/1a10f3ecadbf1c8d4c81595436bdd8dd6252c870862eed2e39a11df5496e53520e2b8abcd8f0efe5610b7bf6209e61ea4bf9e64a9bda3e3f15aeee4e1da70a7e
+  checksum: 10/cd8d1514f3fc53b6103a5be20a33af4e830daaeb2350216d96d121cdc33a031ebf388d182e9c5c3a93b41e51bec9e973631cf1d9686bb9a0d769411f0379b0fc
   languageName: node
   linkType: hard
 
@@ -34794,7 +34802,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     "@types/hoist-non-react-statics": "npm:^3.3.5"
     "@types/jest": "npm:^29.5.14"
-    "@types/node": "npm:^22.10.1"
+    "@types/node": "npm:^20.17.10"
     "@types/prettier": "npm:^2.7.3"
     "@types/react": "npm:18.2.79"
     "@types/react-dom": "npm:18.2.25"
@@ -36715,23 +36723,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "tar-fs@npm:3.0.5"
-  dependencies:
-    bare-fs: "npm:^2.1.1"
-    bare-path: "npm:^2.1.0"
-    pump: "npm:^3.0.0"
-    tar-stream: "npm:^3.1.5"
-  dependenciesMeta:
-    bare-fs:
-      optional: true
-    bare-path:
-      optional: true
-  checksum: 10/a15c18e80b872918c7dff22ff29db367c8014d1b3d34b0ec57cfe11645836dc01487c078a975a9d5e358f078f59e7b8adc5c671cc0848ba27b9b429669722bd8
-  languageName: node
-  linkType: hard
-
 "tar-fs@npm:^3.0.6":
   version: 3.0.6
   resolution: "tar-fs@npm:3.0.6"
@@ -37793,6 +37784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.20.0":
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
@@ -38103,13 +38101,6 @@ __metadata:
     punycode: "npm:^1.4.1"
     qs: "npm:^6.12.3"
   checksum: 10/e787d070f0756518b982a4653ef6cdf4d9030d8691eee2d483344faf2b530b71d302287fa63b292299455fea5075c502a5ad5f920cb790e95605847f957a65e4
-  languageName: node
-  linkType: hard
-
-"urlpattern-polyfill@npm:10.0.0":
-  version: 10.0.0
-  resolution: "urlpattern-polyfill@npm:10.0.0"
-  checksum: 10/346819dbe718e929988298d02a988b8ddfa601d08daaa7e69b1148eab699c86c0f0f933d68d8c8cf913166fe64156ed28904e673200d18ef7e9ed6b58cea3fc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR tackles a couple of newly introduced backend data validation (Zod) issues, where some of the fields were missing the `nullable` option enabled. These were introduced with the migration from Commodo (and its removal) to Zod.

I also fixed missing `DB_TABLE_LOG` env vars in Pulumi code.

## How Has This Been Tested?
Cypress tests that have been failing should now be passing.

## Documentation
None.