### PR TITLE
feat: add PB page migration

### DIFF
--- a/packages/api-page-builder-so-ddb-es/src/definitions/pageEntity.ts
+++ b/packages/api-page-builder-so-ddb-es/src/definitions/pageEntity.ts
@@ -22,6 +22,9 @@ export const createPageEntity = (params: Params): Entity<any> => {
             TYPE: {
                 type: "string"
             },
+            data: {
+                type: "map"
+            },
             id: {
                 type: "string"
             },

--- a/packages/api-page-builder-so-ddb-es/src/operations/pages/index.ts
+++ b/packages/api-page-builder-so-ddb-es/src/operations/pages/index.ts
@@ -58,6 +58,25 @@ function removePageAttributes(item: Page): Page {
     return omit(item, ["home", "notFound", "visibility"]) as Page;
 }
 
+type PageWithOptionalData = Page & { data?: Page };
+
+const unpackPageData = <T extends PageWithOptionalData>(page: T) => {
+    if (page.data) {
+        return removePageAttributes(page.data);
+    }
+
+    return removePageAttributes(page);
+};
+
+const preparePageData = (page: Page) => {
+    return {
+        ...page,
+        data: {
+            ...page
+        }
+    };
+};
+
 export interface CreatePageStorageOperationsParams {
     entity: Entity<any>;
     esEntity: Entity<any>;
@@ -72,6 +91,8 @@ export const createPageStorageOperations = (
     const create = async (params: PageStorageOperationsCreateParams): Promise<Page> => {
         const { page, input } = params;
 
+        const pageToStore = preparePageData(page);
+
         const versionKeys = {
             PK: createPartitionKey(page),
             SK: createSortKey(page)
@@ -83,12 +104,12 @@ export const createPageStorageOperations = (
 
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...versionKeys,
                 TYPE: createBasicType()
             }),
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...latestKeys,
                 TYPE: createLatestType()
             })
@@ -133,14 +154,16 @@ export const createPageStorageOperations = (
             SK: createLatestSortKey()
         };
 
+        const pageToStore = preparePageData(page);
+
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createBasicType(),
                 ...versionKeys
             }),
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createLatestType(),
                 ...latestKeys
             })
@@ -186,6 +209,8 @@ export const createPageStorageOperations = (
             SK: createSortKey(page)
         };
 
+        const pageToStore = preparePageData(page);
+
         const latestKeys = {
             ...keys,
             SK: createLatestSortKey()
@@ -197,7 +222,7 @@ export const createPageStorageOperations = (
 
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createBasicType(),
                 ...keys
             })
@@ -211,7 +236,7 @@ export const createPageStorageOperations = (
              */
             items.push(
                 entity.putBatch({
-                    ...page,
+                    ...pageToStore,
                     TYPE: createLatestType(),
                     ...latestKeys
                 })
@@ -301,11 +326,12 @@ export const createPageStorageOperations = (
                     lt: createSortKey(latestPage),
                     reverse: true
                 }
-            });
+            }).then(item => (item ? unpackPageData(item) : null));
+
             if (previousLatestRecord) {
                 items.push(
                     entity.putBatch({
-                        ...previousLatestRecord,
+                        ...preparePageData(previousLatestRecord),
                         TYPE: createLatestType(),
                         PK: partitionKey,
                         SK: createLatestSortKey()
@@ -454,12 +480,14 @@ export const createPageStorageOperations = (
 
         page.status = "published";
 
+        const pageToStore = preparePageData(page);
+
         /**
          * Update the given revision of the page.
          */
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createBasicType(),
                 PK: createPartitionKey(page),
                 SK: createSortKey(page)
@@ -473,7 +501,7 @@ export const createPageStorageOperations = (
         if (latestPage.id === page.id) {
             items.push(
                 entity.putBatch({
-                    ...page,
+                    ...pageToStore,
                     TYPE: createLatestType(),
                     PK: createPartitionKey(page),
                     SK: createLatestSortKey()
@@ -494,10 +522,14 @@ export const createPageStorageOperations = (
          *  - set the existing published revision to "unpublished"
          */
         if (publishedPage && publishedPage.id !== page.id) {
+            const publishedPageToStore = preparePageData({
+                ...publishedPage,
+                status: "unpublished"
+            });
+
             items.push(
                 entity.putBatch({
-                    ...publishedPage,
-                    status: "unpublished",
+                    ...publishedPageToStore,
                     PK: createPartitionKey(publishedPage),
                     SK: createSortKey(publishedPage)
                 })
@@ -529,7 +561,7 @@ export const createPageStorageOperations = (
          */
         items.push(
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createPublishedPathType(),
                 PK: createPathPartitionKey(page),
                 SK: createPathSortKey(page)
@@ -540,7 +572,7 @@ export const createPageStorageOperations = (
          */
         items.push(
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createPublishedType(),
                 PK: createPartitionKey(page),
                 SK: createPublishedSortKey()
@@ -584,6 +616,8 @@ export const createPageStorageOperations = (
 
         page.status = "unpublished";
 
+        const pageToStore = preparePageData(page);
+
         const items = [
             entity.deleteBatch({
                 PK: createPartitionKey(page),
@@ -594,7 +628,7 @@ export const createPageStorageOperations = (
                 SK: createPathSortKey(page)
             }),
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 TYPE: createBasicType(),
                 PK: createPartitionKey(page),
                 SK: createSortKey(page)
@@ -607,7 +641,7 @@ export const createPageStorageOperations = (
         if (latestPage.id === page.id) {
             items.push(
                 entity.putBatch({
-                    ...page,
+                    ...pageToStore,
                     TYPE: createLatestType(),
                     PK: createPartitionKey(page),
                     SK: createLatestSortKey()
@@ -700,10 +734,12 @@ export const createPageStorageOperations = (
             SK: sortKey
         };
         try {
-            return await getClean({
+            const cleanRecord = await getClean<Page>({
                 entity,
                 keys
             });
+
+            return cleanRecord ? unpackPageData(cleanRecord) : null;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load page by given params.",
@@ -943,7 +979,7 @@ export const createPageStorageOperations = (
         );
 
         return sortItems({
-            items: items.map(item => removePageAttributes(item)),
+            items: items.map(item => unpackPageData(item)),
             fields,
             sort
         });

--- a/packages/api-page-builder-so-ddb/src/definitions/pageEntity.ts
+++ b/packages/api-page-builder-so-ddb/src/definitions/pageEntity.ts
@@ -28,6 +28,9 @@ export const createPageEntity = (params: Params): Entity<any> => {
             TYPE: {
                 type: "string"
             },
+            data: {
+                type: "map"
+            },
             id: {
                 type: "string"
             },

--- a/packages/api-page-builder-so-ddb/src/operations/pages/index.ts
+++ b/packages/api-page-builder-so-ddb/src/operations/pages/index.ts
@@ -78,6 +78,29 @@ const createPublishedType = (): string => {
     return "pb.page.p";
 };
 
+type PageWithOptionalData = Page & { data?: Page };
+
+const unpackPageData = (page: PageWithOptionalData): Page => {
+    if (page.data) {
+        return page.data;
+    }
+
+    return page;
+};
+
+const preparePageData = (page: Page) => {
+    const titleLC = page.title.toLowerCase();
+
+    return {
+        ...page,
+        titleLC,
+        data: {
+            ...page,
+            titleLC
+        }
+    };
+};
+
 export interface CreatePageStorageOperationsParams {
     entity: Entity<any>;
     plugins: PluginsContainer;
@@ -99,7 +122,8 @@ export const createPageStorageOperations = (
             SK: createLatestSortKey(page)
         };
 
-        const titleLC = page.title.toLowerCase();
+        const pageToStore = preparePageData(page);
+
         /**
          * We need to create
          * - latest
@@ -107,14 +131,12 @@ export const createPageStorageOperations = (
          */
         const items = [
             entity.putBatch({
-                ...page,
-                titleLC,
+                ...pageToStore,
                 ...latestKeys,
                 TYPE: createLatestType()
             }),
             entity.putBatch({
-                ...page,
-                titleLC,
+                ...pageToStore,
                 ...revisionKeys,
                 TYPE: createRevisionType()
             })
@@ -149,6 +171,9 @@ export const createPageStorageOperations = (
             PK: createLatestPartitionKey(page),
             SK: createLatestSortKey(page)
         };
+
+        const pageToStore = preparePageData(page);
+
         /**
          * We need to create
          * - latest
@@ -156,12 +181,12 @@ export const createPageStorageOperations = (
          */
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...latestKeys,
                 TYPE: createLatestType()
             }),
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...revisionKeys,
                 TYPE: createRevisionType()
             })
@@ -203,9 +228,10 @@ export const createPageStorageOperations = (
         const latestPage = await getClean<Page>({
             entity,
             keys: latestKeys
-        });
+        }).then(item => (item ? unpackPageData(item) : null));
 
-        const titleLC = page.title.toLowerCase();
+        const pageToStore = preparePageData(page);
+
         /**
          * We need to update
          * - revision
@@ -213,8 +239,7 @@ export const createPageStorageOperations = (
          */
         const items = [
             entity.putBatch({
-                ...page,
-                titleLC,
+                ...pageToStore,
                 ...revisionKeys,
                 TYPE: createRevisionType()
             })
@@ -225,8 +250,7 @@ export const createPageStorageOperations = (
         if (latestPage && latestPage.id === page.id) {
             items.push(
                 entity.putBatch({
-                    ...page,
-                    titleLC,
+                    ...pageToStore,
                     ...latestKeys,
                     TYPE: createLatestType()
                 })
@@ -295,7 +319,10 @@ export const createPageStorageOperations = (
                     reverse: true
                 }
             });
+
             if (previousLatestRecord) {
+                previousLatestPage = unpackPageData(cleanupItem(entity, previousLatestRecord)!);
+
                 items.push(
                     entity.putBatch({
                         ...previousLatestRecord,
@@ -303,7 +330,6 @@ export const createPageStorageOperations = (
                         TYPE: createLatestType()
                     })
                 );
-                previousLatestPage = cleanupItem(entity, previousLatestRecord);
             }
         }
         try {
@@ -417,12 +443,15 @@ export const createPageStorageOperations = (
             PK: createPublishedPartitionKey(page),
             SK: createPublishedSortKey(page)
         };
+
+        const pageToStore = preparePageData(page);
+
         /**
          * Update the given revision of the page.
          */
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...revisionKeys,
                 TYPE: createRevisionType()
             })
@@ -431,7 +460,7 @@ export const createPageStorageOperations = (
         if (latestPage.id === page.id) {
             items.push(
                 entity.putBatch({
-                    ...page,
+                    ...pageToStore,
                     ...latestKeys,
                     TYPE: createLatestType()
                 })
@@ -446,10 +475,15 @@ export const createPageStorageOperations = (
                 PK: createRevisionPartitionKey(publishedPage),
                 SK: createRevisionSortKey(publishedPage)
             };
+
+            const publishedPageToStore = preparePageData({
+                ...publishedPage,
+                status: "unpublished"
+            });
+
             items.push(
                 entity.putBatch({
-                    ...publishedPage,
-                    status: "unpublished",
+                    ...publishedPageToStore,
                     ...publishedRevisionKeys,
                     TYPE: createRevisionType()
                 })
@@ -458,7 +492,7 @@ export const createPageStorageOperations = (
 
         items.push(
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...publishedKeys,
                 GSI1_PK: createPathPartitionKey(page),
                 GSI1_SK: page.path,
@@ -504,9 +538,11 @@ export const createPageStorageOperations = (
             SK: createPublishedSortKey(page)
         };
 
+        const pageToStore = preparePageData(page);
+
         const items = [
             entity.putBatch({
-                ...page,
+                ...pageToStore,
                 ...revisionKeys,
                 TYPE: createRevisionType()
             }),
@@ -516,7 +552,7 @@ export const createPageStorageOperations = (
         if (latestPage.id === page.id) {
             items.push(
                 entity.putBatch({
-                    ...page,
+                    ...pageToStore,
                     ...latestKeys,
                     TYPE: createLatestType()
                 })
@@ -589,10 +625,12 @@ export const createPageStorageOperations = (
             };
         }
         try {
-            return await getClean<Page>({
+            const cleanPage = await getClean<Page>({
                 entity,
                 keys
             });
+
+            return cleanPage ? unpackPageData(cleanPage) : cleanPage;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load page by given params.",
@@ -623,7 +661,8 @@ export const createPageStorageOperations = (
             }
         };
         try {
-            return await queryOneClean<Page>(queryOptions);
+            const cleanData = await queryOneClean<Page>(queryOptions);
+            return cleanData ? unpackPageData(cleanData) : cleanData;
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not get page by given path.",
@@ -710,7 +749,9 @@ export const createPageStorageOperations = (
 
         let dbRecords: Page[] = [];
         try {
-            dbRecords = await queryAll<Page>(queryAllParams);
+            dbRecords = await queryAll<Page>(queryAllParams).then(records => {
+                return records.map(unpackPageData) as Page[];
+            });
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load pages by given query params.",
@@ -784,7 +825,9 @@ export const createPageStorageOperations = (
 
         let items: any[] = [];
         try {
-            items = await queryAll<Page>(queryAllParams);
+            items = await queryAll<Page>(queryAllParams).then(records => {
+                return records.map(unpackPageData);
+            });
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load all the revisions from requested page.",
@@ -819,9 +862,11 @@ export const createPageStorageOperations = (
             options
         };
 
-        let pages: DbItem<Page>[] = [];
+        let pages: Page[] = [];
         try {
-            pages = await queryAll<Page>(queryAllParams);
+            pages = await queryAll<Page>(queryAllParams).then(records => {
+                return records.map(unpackPageData) as Page[];
+            });
         } catch (ex) {
             throw new WebinyError(
                 ex.message || "Could not load pages by given query params.",

--- a/packages/api-page-builder/__tests__/graphql/pages.test.ts
+++ b/packages/api-page-builder/__tests__/graphql/pages.test.ts
@@ -543,10 +543,10 @@ describe("CRUD Test", () => {
         const id = createPageResponse.data.pageBuilder.createPage.data.id;
         expect(id).toMatch("#0001");
 
-        const content = createPageContent("3.2MB");
+        const content = createPageContent("1.6MB");
         const size = calculateSize(content);
 
-        expect(size).toBeGreaterThan(bytes("3.19MB"));
+        expect(size).toBeGreaterThan(Number(bytes("1.5MB")));
 
         const [updatePageResponse] = await updatePage({
             id,
@@ -604,7 +604,7 @@ describe("CRUD Test", () => {
         const content = createPageContent("4MB");
         const size = calculateSize(content);
 
-        expect(size).toBeGreaterThan(bytes("3.99MB"));
+        expect(size).toBeGreaterThan(Number(bytes("3.99MB")));
 
         const [updatePageResponse] = await updatePage({
             id,

--- a/packages/db-dynamodb/src/utils/query.ts
+++ b/packages/db-dynamodb/src/utils/query.ts
@@ -166,7 +166,7 @@ export const queryPerPageClean = async <T>(
  */
 export const queryAllWithCallback = async <T>(
     params: QueryAllParams,
-    callback: (items: DbItem<T>[]) => Promise<void>
+    callback: (items: DbItem<T>[]) => Promise<void | boolean>
 ): Promise<void> => {
     let results: QueryResult<DbItem<T>>;
     let previousResult: any = undefined;
@@ -174,7 +174,10 @@ export const queryAllWithCallback = async <T>(
         if (!results.result) {
             break;
         }
-        await callback(results.items);
+        const callbackResult = await callback(results.items);
+        if (callbackResult === false) {
+            break;
+        }
         previousResult = results.result;
     }
 };

--- a/packages/migrations/src/ddb.ts
+++ b/packages/migrations/src/ddb.ts
@@ -1,8 +1,8 @@
 // We only list current version migrations here. No need to have them all
 // listed, as we only need the latest version migrations to be executed.
 // This also helps with keeping the bundle size down / faster boot times.
-import { AdminUsers_5_41_0_001 } from "~/migrations/5.41.0/001";
+import { Pages_5_42_0_001 } from "~/migrations/5.42.0/001";
 
 export const migrations = () => {
-    return [AdminUsers_5_41_0_001];
+    return [Pages_5_42_0_001];
 };

--- a/packages/migrations/src/migrations/5.42.0/001/createPageEntity.ts
+++ b/packages/migrations/src/migrations/5.42.0/001/createPageEntity.ts
@@ -1,0 +1,90 @@
+import { Table, AttributeDefinitions } from "@webiny/db-dynamodb/toolbox";
+import { createLegacyEntity } from "~/utils";
+
+const oldAttributes: AttributeDefinitions = {
+    PK: {
+        partitionKey: true
+    },
+    SK: {
+        sortKey: true
+    },
+    TYPE: {
+        type: "string"
+    },
+    id: {
+        type: "string"
+    },
+    pid: {
+        type: "string"
+    },
+    tenant: {
+        type: "string"
+    },
+    locale: {
+        type: "string"
+    },
+    title: {
+        type: "string"
+    },
+    titleLC: {
+        type: "string"
+    },
+    editor: {
+        type: "string"
+    },
+    createdFrom: {
+        type: "string"
+    },
+    path: {
+        type: "string"
+    },
+    category: {
+        type: "string"
+    },
+    content: {
+        type: "map"
+    },
+    publishedOn: {
+        type: "string"
+    },
+    version: {
+        type: "number"
+    },
+    settings: {
+        type: "map"
+    },
+    locked: {
+        type: "boolean"
+    },
+    status: {
+        type: "string"
+    },
+    createdOn: {
+        type: "string"
+    },
+    savedOn: {
+        type: "string"
+    },
+    createdBy: {
+        type: "map"
+    },
+    ownedBy: {
+        type: "map"
+    },
+    webinyVersion: {
+        type: "string"
+    }
+};
+
+export const createOldPageEntity = (table: Table<string, string, string>) => {
+    return createLegacyEntity(table, "PbPage", oldAttributes);
+};
+
+export const createNewPageEntity = (table: Table<string, string, string>) => {
+    return createLegacyEntity(table, "PbPage", {
+        ...oldAttributes,
+        data: {
+            type: "map"
+        }
+    });
+};

--- a/packages/migrations/src/migrations/5.42.0/001/index.ts
+++ b/packages/migrations/src/migrations/5.42.0/001/index.ts
@@ -1,0 +1,241 @@
+import omit from "lodash/omit";
+import { Table } from "@webiny/db-dynamodb/toolbox";
+import { inject, makeInjectable } from "@webiny/ioc";
+import { executeWithRetry } from "@webiny/utils";
+import type { PrimitiveValue } from "@webiny/api-elasticsearch/types";
+import type { DbItem } from "@webiny/db-dynamodb/utils";
+import {
+    DataMigration,
+    DataMigrationContext,
+    PrimaryDynamoTableSymbol
+} from "@webiny/data-migration";
+import {
+    batchWriteAll,
+    BatchWriteItem,
+    ddbQueryAllWithCallback,
+    forEachTenantLocale,
+    queryAll,
+    queryOne
+} from "~/utils";
+import { createNewPageEntity, createOldPageEntity } from "./createPageEntity";
+import type { PbPage } from "./types";
+
+const isGroupMigrationCompleted = (
+    status: PrimitiveValue[] | boolean | undefined
+): status is boolean => {
+    return typeof status === "boolean";
+};
+
+const pageShouldBeMigrated = (page: DbItem<PbPage> & { data?: PbPage }) => {
+    /*
+     * In case the migration is being executed multiple times, we must check if the record
+     * already has a `data` envelope. If it does, we must check if the `savedOn` attribute in the
+     * old record is newer than the one in the `data` envelope. This can happen if the user upgrades,
+     * then downgrades, updates a page, then upgrades again.
+     */
+    const dataSavedOn = page.data?.savedOn;
+    if (dataSavedOn) {
+        return new Date(dataSavedOn).getTime() < new Date(page.savedOn).getTime();
+    }
+
+    return true;
+};
+
+// Latest pages: T#root#L#en-US#PB#L
+// Published pages: T#root#L#en-US#PB#P
+// Page revisions: T#root#L#en-US#PB#{pid}
+
+export class Pages_5_42_0_001 implements DataMigration {
+    private readonly oldPageEntity: ReturnType<typeof createOldPageEntity>;
+    private readonly newPageEntity: ReturnType<typeof createNewPageEntity>;
+    private readonly table: Table<string, string, string>;
+
+    constructor(table: Table<string, string, string>) {
+        this.table = table;
+        this.oldPageEntity = createOldPageEntity(table);
+        this.newPageEntity = createNewPageEntity(table);
+    }
+
+    getId() {
+        return "5.42.0-001";
+    }
+
+    getDescription() {
+        return "Move page attributes to 'data' envelope.";
+    }
+
+    async shouldExecute({ logger }: DataMigrationContext): Promise<boolean> {
+        let shouldExecute = false;
+
+        await forEachTenantLocale({
+            table: this.table,
+            logger,
+            callback: async ({ tenantId, localeCode }) => {
+                await ddbQueryAllWithCallback<PbPage>(
+                    {
+                        entity: this.oldPageEntity,
+                        partitionKey: `T#${tenantId}#L#${localeCode}#PB#L`,
+                        options: {
+                            gt: " "
+                        }
+                    },
+                    async oldPages => {
+                        if (oldPages.some(pageShouldBeMigrated)) {
+                            shouldExecute = true;
+                            // Abort ddb querying.
+                            return false;
+                        }
+
+                        // Continue.
+                        return true;
+                    }
+                );
+
+                if (shouldExecute) {
+                    return false;
+                }
+
+                // Continue to the next locale.
+                return true;
+            }
+        });
+
+        return shouldExecute;
+    }
+
+    async execute({ logger, ...context }: DataMigrationContext): Promise<void> {
+        const migrationStatus = context.checkpoint || {};
+
+        let batch = 0;
+
+        await forEachTenantLocale({
+            table: this.table,
+            logger,
+            callback: async ({ tenantId, localeCode }) => {
+                const groupId = `${tenantId}:${localeCode}`;
+                const status = migrationStatus[groupId];
+
+                if (isGroupMigrationCompleted(status)) {
+                    return true;
+                }
+
+                // We start by listing all "latest" pages, then, as we process individual "latest" page,
+                // we'll also query for an optional "published" page, and all the related revisions.
+                await ddbQueryAllWithCallback<PbPage>(
+                    {
+                        entity: this.oldPageEntity,
+                        partitionKey: `T#${tenantId}#L#${localeCode}#PB#L`,
+                        options: {
+                            gt: status || " "
+                        }
+                    },
+                    async oldPages => {
+                        batch++;
+
+                        logger.info(
+                            `Processing batch #${batch} in group ${groupId} (${oldPages.length} pages).`
+                        );
+
+                        // Items to write
+                        const items: BatchWriteItem[] = [];
+                        const pagesToProcess = oldPages.filter(pageShouldBeMigrated);
+
+                        for (const oldPage of pagesToProcess) {
+                            // Process the "latest" record.
+                            items.push(this.processPage(oldPage));
+                            // Optionally, process the "published" record.
+                            const publishedRecord = await this.getPublishedRecord(
+                                tenantId,
+                                localeCode,
+                                oldPage.pid
+                            );
+
+                            if (publishedRecord) {
+                                items.push(this.processPage(publishedRecord));
+                            }
+
+                            // Process all page revisions.
+                            const revisions = await this.getPageRevisions(
+                                tenantId,
+                                localeCode,
+                                oldPage.pid
+                            );
+
+                            revisions.forEach(revision => {
+                                items.push(this.processPage(revision));
+                            });
+                        }
+
+                        const execute = () => {
+                            return batchWriteAll({ table: this.newPageEntity.table, items });
+                        };
+
+                        await executeWithRetry(execute, {
+                            onFailedAttempt: error => {
+                                logger.error(
+                                    `"batchWriteAll" attempt #${error.attemptNumber} failed.`
+                                );
+                                logger.error(error.message);
+                            }
+                        });
+
+                        // Update checkpoint after every batch.
+                        migrationStatus[groupId] = oldPages[oldPages.length - 1]?.id;
+
+                        // Check if we should store checkpoint and exit.
+                        if (context.runningOutOfTime()) {
+                            await context.createCheckpointAndExit(migrationStatus);
+                        } else {
+                            await context.createCheckpoint(migrationStatus);
+                        }
+                    }
+                );
+
+                // Mark group as completed.
+                migrationStatus[groupId] = true;
+
+                // Store checkpoint.
+                await context.createCheckpoint(migrationStatus);
+
+                // Continue processing.
+                return true;
+            }
+        });
+    }
+
+    private getPageAttributes(page: PbPage) {
+        return omit(page, ["PK", "SK", "TYPE", "_ct", "_et", "_md"]);
+    }
+
+    private processPage(page: PbPage) {
+        return this.newPageEntity.putBatch(
+            {
+                ...page,
+                data: this.getPageAttributes(page)
+            },
+            { strictSchemaCheck: false }
+        );
+    }
+
+    private async getPublishedRecord(tenant: string, locale: string, pid: string) {
+        return await queryOne<PbPage>({
+            entity: this.oldPageEntity,
+            partitionKey: `T#${tenant}#L#${locale}#PB#P`,
+            options: {
+                eq: pid
+            }
+        });
+    }
+
+    private async getPageRevisions(tenant: string, locale: string, pid: string) {
+        return await queryAll<PbPage>({
+            entity: this.oldPageEntity,
+            partitionKey: `T#${tenant}#L#${locale}#PB${pid}`,
+            options: {
+                gt: " "
+            }
+        });
+    }
+}
+
+makeInjectable(Pages_5_42_0_001, [inject(PrimaryDynamoTableSymbol)]);

--- a/packages/migrations/src/migrations/5.42.0/001/types.ts
+++ b/packages/migrations/src/migrations/5.42.0/001/types.ts
@@ -1,0 +1,5 @@
+export type PbPage = {
+    id: string;
+    savedOn: string;
+    [key: string]: any;
+};


### PR DESCRIPTION
## Changes
This PR adds a PB Pages migration, which moves page attributes from the root of the dynamo entity to the `data` envelope. This makes adding new attributes much easier, and will not require updates to the Entity definition in the future.

In the storage operations, all actions performed against Dynamo DB now include a compatibility layer, which ensures that the data is written to both the root of the record and the new `data` attribute. Once we get to 5.43., this compatibility layer can be removed.

TODO: PB Blocks migration to achieve the same goal.

## How Has This Been Tested?
Jest tests and manually.