### PR TITLE
fix(MultiAutoComplete): use CSS variable instead of hardcoded values

### DIFF
--- a/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
+++ b/packages/ui/src/AutoComplete/MultiAutoComplete.tsx
@@ -37,7 +37,7 @@ const style = {
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            borderBottom: "2px solid #fa5723",
+            borderBottom: "2px solid var(--mdc-theme-primary, #fa5723)",
             padding: "6px 0"
         }),
         pages: css({
@@ -128,7 +128,7 @@ interface MultiAutoCompleteState {
 }
 
 const Spinner = () => {
-    return <MaterialSpinner size={24} spinnerColor={"#fa5723"} spinnerWidth={2} visible />;
+    return <MaterialSpinner size={24} spinnerColor={"var(--mdc-theme-primary, #fa5723)"} spinnerWidth={2} visible />;
 };
 
 interface RenderOptionsParams


### PR DESCRIPTION
## Changes
Replace hardcoded color value with theme variable, using default Webiny color as a fallback.
Closes #4472 

## How Has This Been Tested?
Visually