### PR TITLE
fix(app-headless-cms): delete code model entries

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -333,35 +333,21 @@ const ContentModelsDataList = ({
 
                                                 {canDelete(contentModel, "cms.contentModel") && (
                                                     <>
-                                                        {contentModel.plugin ? (
-                                                            <Tooltip
-                                                                content={t`Content model is registered via a plugin.`}
-                                                                placement={"top"}
-                                                            >
-                                                                <DeleteIcon
-                                                                    disabled
-                                                                    data-testid={
-                                                                        "cms-delete-content-model-button"
-                                                                    }
-                                                                />
-                                                            </Tooltip>
-                                                        ) : (
-                                                            <Tooltip
-                                                                content={t`Delete content model`}
-                                                                placement={"top"}
-                                                            >
-                                                                <DeleteIcon
-                                                                    onClick={() => {
-                                                                        setModelToBeDeleted(
-                                                                            contentModel
-                                                                        );
-                                                                    }}
-                                                                    data-testid={
-                                                                        "cms-delete-content-model-button"
-                                                                    }
-                                                                />
-                                                            </Tooltip>
-                                                        )}
+                                                        <Tooltip
+                                                            content={t`Delete content model`}
+                                                            placement={"top"}
+                                                        >
+                                                            <DeleteIcon
+                                                                onClick={() => {
+                                                                    setModelToBeDeleted(
+                                                                        contentModel
+                                                                    );
+                                                                }}
+                                                                data-testid={
+                                                                    "cms-delete-content-model-button"
+                                                                }
+                                                            />
+                                                        </Tooltip>
                                                     </>
                                                 )}
                                             </UIL.ListActions>

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/Information.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/Information.tsx
@@ -14,7 +14,7 @@ export const Information = (props: IInformationProps) => {
     const { model } = props;
     return (
         <>
-            {model.plugin && (
+            {model.plugin ? (
                 <>
                     <p>
                         This model is a plugin one, and it cannot be deleted. Only its entries can
@@ -23,9 +23,11 @@ export const Information = (props: IInformationProps) => {
                     <p>
                         <br />
                     </p>
+                    <p>- This action will permanently delete all model entries.</p>
                 </>
+            ) : (
+                <p>- This action will permanently delete the model and all its entries.</p>
             )}
-            <p>- This action will permanently delete the model and all its associated data.</p>
             <p>- References to this model in other parts of the system will be emptied.</p>
             <p>- All relevant lifecycle events will be triggered.</p>
             <p className={warningClassName}> - This action cannot be undone!</p>


### PR DESCRIPTION
## Changes
This PR fixes possibility to delete a code content model (actually, only entries).

## How Has This Been Tested?
Manually.