### PR TITLE
fix: hide tabs bar on full screen entry form

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.styled.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.styled.tsx
@@ -16,7 +16,7 @@ export const FullScreenContentEntryContainer = styled.div`
         margin: 0;
     }
 
-    #cms-content-details-tabs .webiny-ui-tabs__tab-bar {
+    #cms-content-details-tabs > .webiny-ui-tabs__tab-bar {
         display: none;
     }
 `;


### PR DESCRIPTION
## Changes
With this PR, we are fixing a bug that was raised while deploying the 5.42.0 version with MT project specs.

In a fullscreen entry editor, the tabs bar is hidden, and the content of the revision tab is displayed in a separate drawer. 

The previously set CSS is hiding all tab bars, including the one inserted into the entry form. This PR fixes it.

## How Has This Been Tested?
Manualy
