### PR TITLE
fix(pulumi-aws): api gateway throttle

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiGateway.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiGateway.ts
@@ -31,8 +31,8 @@ export const ApiGateway = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: 100000,
-                    throttlingRateLimit: 100000
+                    throttlingBurstLimit: 5000,
+                    throttlingRateLimit: 10000
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/ApiGateway.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiGateway.ts
@@ -31,8 +31,8 @@ export const ApiGateway = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: -1,
-                    throttlingRateLimit: -1
+                    throttlingBurstLimit: 100000,
+                    throttlingRateLimit: 100000
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/ApiGateway.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiGateway.ts
@@ -25,7 +25,15 @@ export const ApiGateway = createAppModule({
             name: "default",
             config: {
                 apiId: api.output.id,
-                autoDeploy: true
+                autoDeploy: true,
+                defaultRouteSettings: {
+                    // Only enable when debugging. Note that by default, API Gateway does not
+                    // have the required permissions to write logs to CloudWatch logs. More:
+                    // https://coady.tech/aws-cloudwatch-logs-arn/
+                    // loggingLevel: "INFO",
+                    throttlingBurstLimit: -1,
+                    throttlingRateLimit: -1
+                }
             }
         });
 

--- a/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
@@ -135,8 +135,8 @@ export const ApiWebsocket = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: -1,
-                    throttlingRateLimit: -1
+                    throttlingBurstLimit: 100000,
+                    throttlingRateLimit: 100000
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
@@ -135,8 +135,8 @@ export const ApiWebsocket = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: 100000,
-                    throttlingRateLimit: 100000
+                    throttlingBurstLimit: 5000,
+                    throttlingRateLimit: 10000
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
@@ -135,8 +135,8 @@ export const ApiWebsocket = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: 1000,
-                    throttlingRateLimit: 500
+                    throttlingBurstLimit: -1,
+                    throttlingRateLimit: -1
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -301,6 +301,7 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 fileManager,
                 graphql,
                 apiGateway,
+                websocket,
                 cloudfront,
                 apwScheduler,
                 migration,


### PR DESCRIPTION
## Changes
Set throttle to 5k on burst limit and 10k on rate limit on all API Gateway deployments.

## How Has This Been Tested?
Manually.


## Screenshot

Setting the throttling works:

<img width="651" alt="throttling" src="https://github.com/user-attachments/assets/a9024bc7-e0a2-45f7-999b-a29860ab8434" />
