### PR TITLE
fix(pulumi-aws): api gateway throttle

### DIFF
--- a/packages/pulumi-aws/src/apps/api/ApiGateway.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiGateway.ts
@@ -25,7 +25,15 @@ export const ApiGateway = createAppModule({
             name: "default",
             config: {
                 apiId: api.output.id,
-                autoDeploy: true
+                autoDeploy: true,
+                defaultRouteSettings: {
+                    // Only enable when debugging. Note that by default, API Gateway does not
+                    // have the required permissions to write logs to CloudWatch logs. More:
+                    // https://coady.tech/aws-cloudwatch-logs-arn/
+                    // loggingLevel: "INFO",
+                    throttlingBurstLimit: 5000,
+                    throttlingRateLimit: 10000
+                }
             }
         });
 

--- a/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
+++ b/packages/pulumi-aws/src/apps/api/ApiWebsocket.ts
@@ -135,8 +135,8 @@ export const ApiWebsocket = createAppModule({
                     // have the required permissions to write logs to CloudWatch logs. More:
                     // https://coady.tech/aws-cloudwatch-logs-arn/
                     // loggingLevel: "INFO",
-                    throttlingBurstLimit: 1000,
-                    throttlingRateLimit: 500
+                    throttlingBurstLimit: 5000,
+                    throttlingRateLimit: 10000
                 }
             }
         });

--- a/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/apps/api/createApiPulumiApp.ts
@@ -311,6 +311,7 @@ export const createApiPulumiApp = (projectAppParams: CreateApiPulumiAppParams = 
                 fileManager,
                 graphql,
                 apiGateway,
+                websocket,
                 cloudfront,
                 apwScheduler,
                 migration,


### PR DESCRIPTION
## Changes
This PR adds default values to API Gateway throttling:
- burst limit - 5000 - max concurrent request
- rate limit - 10000 - max allowed requests per second

## How Has This Been Tested?
Jest and manually.