### PR TITLE
fix: consolidate and export plugin factories via `@webiny/api-serverless-cms`

### DIFF
--- a/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsGroupPlugin.ts
@@ -32,6 +32,13 @@ export const createCmsGroup = (group: CmsGroup): CmsGroupPlugin => {
     return new CmsGroupPlugin(group);
 };
 
+/**
+ * @deprecated Use `createModelGroupPlugin` instead.
+ */
 export const createCmsGroupPlugin = (group: CmsGroup): CmsGroupPlugin => {
+    return new CmsGroupPlugin(group);
+};
+
+export const createModelGroupPlugin = (group: CmsGroup): CmsGroupPlugin => {
     return new CmsGroupPlugin(group);
 };

--- a/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsModelPlugin.ts
@@ -337,6 +337,9 @@ export const createCmsModel = (
     return new CmsModelPlugin(model, options);
 };
 
+/**
+ * @deprecated Use `createModelPlugin` instead.
+ */
 export const createCmsModelPlugin = (
     model: CmsModelInput,
     options?: CmsModelPluginOptions
@@ -344,6 +347,16 @@ export const createCmsModelPlugin = (
     return new CmsModelPlugin(model, options);
 };
 
+export const createModelPlugin = (
+    model: CmsModelInput,
+    options?: CmsModelPluginOptions
+): CmsModelPlugin => {
+    return new CmsModelPlugin(model, options);
+};
+
+/**
+ * @deprecated Use `createPrivateModelPlugin` instead.
+ */
 export const createPrivateModel = (
     input: Omit<CmsPrivateModelFull, "group" | "isPrivate">
 ): CmsPrivateModelFull => {
@@ -359,11 +372,34 @@ export const createPrivateModel = (
     };
 };
 
+export const createPrivateModelPlugin = (
+    input: Omit<CmsPrivateModelFull, "group" | "isPrivate">
+): CmsModelPlugin => {
+    return createModelPlugin(
+        {
+            authorization: false,
+            noValidate: true,
+            isPrivate: true,
+            group: {
+                id: "private",
+                name: "Private Models"
+            },
+            ...input
+        },
+        {
+            validateLayout: false
+        }
+    );
+};
+
 const ensureSingletonTag = (input?: string[]) => {
     const tags = input || [];
     return tags.includes(CMS_MODEL_SINGLETON_TAG) ? tags : [...tags, CMS_MODEL_SINGLETON_TAG];
 };
 
+/**
+ * @deprecated Use `createSingleEntryModelPlugin` instead.
+ */
 export const createSingleEntryModel = (input: CmsModelInput, options?: CmsModelPluginOptions) => {
     return createCmsModelPlugin(
         {
@@ -374,10 +410,35 @@ export const createSingleEntryModel = (input: CmsModelInput, options?: CmsModelP
     );
 };
 
+export const createSingleEntryModelPlugin = (
+    input: CmsModelInput,
+    options?: CmsModelPluginOptions
+) => {
+    return createModelPlugin(
+        {
+            ...input,
+            tags: ensureSingletonTag(input.tags)
+        },
+        options
+    );
+};
+
+/**
+ * @deprecated Use `createSingleEntryPrivateModelPlugin` instead.
+ */
 export const createSingleEntryPrivateModel = (
     input: Omit<CmsPrivateModelFull, "group" | "isPrivate">
 ) => {
     return createPrivateModel({
+        ...input,
+        tags: ensureSingletonTag(input.tags)
+    });
+};
+
+export const createPrivateSingleEntryModelPlugin = (
+    input: Omit<CmsPrivateModelFull, "group" | "isPrivate">
+) => {
+    return createPrivateModelPlugin({
         ...input,
         tags: ensureSingletonTag(input.tags)
     });

--- a/packages/api-headless-cms/src/plugins/StorageTransformPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/StorageTransformPlugin.ts
@@ -53,3 +53,13 @@ export class StorageTransformPlugin<
         return this.config.fromStorage(params);
     }
 }
+
+export const createStorageTransformPlugin = <
+    T = any,
+    R = any,
+    F extends CmsModelField = CmsModelField
+>(
+    config: StorageTransformPluginParams<T, R, F>
+) => {
+    return new StorageTransformPlugin(config);
+};

--- a/packages/api-serverless-cms/src/index.ts
+++ b/packages/api-serverless-cms/src/index.ts
@@ -50,3 +50,17 @@ export const createGraphQLSchemaPlugin = <T extends Context = Context>(
 export { createSecurityRolePlugin, createSecurityTeamPlugin };
 
 export * from "./tenancy/InstallTenant";
+
+export {
+    // Model groups.
+    createModelGroupPlugin,
+
+    // Models.
+    createModelPlugin,
+    createSingleEntryModelPlugin,
+    createPrivateModelPlugin,
+    createPrivateSingleEntryModelPlugin,
+
+    // Other.
+    createStorageTransformPlugin
+} from "@webiny/api-headless-cms";


### PR DESCRIPTION
## Changes
With this PR, we're doing two things.

First, we're improving naming consistency for HCMS-related plugin factories.

Second, we're [exporting](https://github.com/webiny/webiny-js/blob/4aa64214a28678374495a0fbf49c6ffd813dfdec/packages/api-serverless-cms/src/index.ts#L54-L66) all of the factories from the central `@webiny/api-serverless-cms` package.  Previously, the user had to import these from the `@webiny/api-headless-cms` package, forcing users to be aware of it. Ofc, not that big of a deal, but it's easier if users only deal with one package, if possible.

Ultimately, this is what users get:

```ts
import {
    // Model groups.
    createModelGroupPlugin,

    // Models.
    createModelPlugin,
    createSingleEntryModelPlugin,
    createPrivateModelPlugin,
    createPrivateSingleEntryModelPlugin,

    // Other.
    createStorageTransformPlugin
} from "@webiny/api-headless-cms";
```

## How Has This Been Tested?
Manually.

## Documentation
Changelog. We'll be announcing the deprecation, and fully remove the deprecated plugin factories with the future **5.44.0** release.