### PR TITLE
fix: use name instead of type

### DIFF
--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -70,30 +70,34 @@ export const configureAdminCognitoFederation = (
     );
 
     const providers: Array<{
-        type: string;
-        name: string;
+        config: aws.cognito.IdentityProviderArgs;
         resource: PulumiAppResource<typeof aws.cognito.IdentityProvider>;
     }> = [];
 
     for (const idp of config.identityProviders) {
-        // For built-in identity providers, we use the type as the name. Only for OIDC,
-        // we allow the user to provide a custom name and we only use the type as a fallback.
-        let name = idp.type as string;
-        if (idp.type === "oidc") {
-            name = idp.name || idp.type;
-        }
+        const config = getIdpConfig(idp.type, userPool.output.id, idp);
 
         providers.push({
-            type: idp.type,
-            name,
+            config,
             resource: app.addResource(aws.cognito.IdentityProvider, {
-                name,
-                config: getIdpConfig(idp.type, userPool.output.id, idp)
+                name: config.providerName.toString(),
+                config
             })
         });
     }
 
-    appClient.config.supportedIdentityProviders(["COGNITO", ...providers.map(p => p.name)]);
+    appClient.config.supportedIdentityProviders([
+        "COGNITO",
+        ...providers.map(p => {
+            // For built-in identity providers, we use the type as the name. Only for OIDC,
+            // we allow the user to provide a custom name, and we only use the type as a fallback.
+            if (p.config.providerType === "OIDC") {
+                return p.config.providerName;
+            }
+            return p.config.providerType;
+        })
+    ]);
+
     appClient.config.allowedOauthScopes(["profile", "email", "openid"]);
     appClient.config.allowedOauthFlows(["implicit", "code"]);
     appClient.config.allowedOauthFlowsUserPoolClient(true);

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -69,21 +69,31 @@ export const configureAdminCognitoFederation = (
         pulumi.interpolate`${userPoolDomain.output.domain}.auth.${region}.amazoncognito.com`
     );
 
-    const providers = [];
+    const providers: Array<{
+        type: string;
+        name: string;
+        resource: PulumiAppResource<typeof aws.cognito.IdentityProvider>;
+    }> = [];
+
     for (const idp of config.identityProviders) {
-        providers.push(
-            app.addResource(aws.cognito.IdentityProvider, {
-                name: idp.name || idp.type,
+        // For built-in identity providers, we use the type as the name. Only for OIDC,
+        // we allow the user to provide a custom name and we only use the type as a fallback.
+        let name: string = idp.type;
+        if (idp.type === "oidc") {
+            name = idp.name || idp.type;
+        }
+
+        providers.push({
+            type: idp.type,
+            name,
+            resource: app.addResource(aws.cognito.IdentityProvider, {
+                name,
                 config: getIdpConfig(idp.type, userPool.output.id, idp)
             })
-        );
+        });
     }
 
-    appClient.config.supportedIdentityProviders([
-        "COGNITO",
-        ...providers.map(p => p.output.providerName)
-    ]);
-
+    appClient.config.supportedIdentityProviders(["COGNITO", ...providers.map(p => p.name)]);
     appClient.config.allowedOauthScopes(["profile", "email", "openid"]);
     appClient.config.allowedOauthFlows(["implicit", "code"]);
     appClient.config.allowedOauthFlowsUserPoolClient(true);

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -73,7 +73,7 @@ export const configureAdminCognitoFederation = (
     for (const idp of config.identityProviders) {
         providers.push(
             app.addResource(aws.cognito.IdentityProvider, {
-                name: idp.type,
+                name: idp.name || idp.type,
                 config: getIdpConfig(idp.type, userPool.output.id, idp)
             })
         );
@@ -81,7 +81,7 @@ export const configureAdminCognitoFederation = (
 
     appClient.config.supportedIdentityProviders([
         "COGNITO",
-        ...providers.map(p => p.output.providerType)
+        ...providers.map(p => p.output.providerName)
     ]);
 
     appClient.config.allowedOauthScopes(["profile", "email", "openid"]);

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -78,7 +78,7 @@ export const configureAdminCognitoFederation = (
     for (const idp of config.identityProviders) {
         // For built-in identity providers, we use the type as the name. Only for OIDC,
         // we allow the user to provide a custom name and we only use the type as a fallback.
-        let name: string = idp.type;
+        let name = idp.type as string;
         if (idp.type === "oidc") {
             name = idp.name || idp.type;
         }

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -69,32 +69,28 @@ export const configureAdminCognitoFederation = (
         pulumi.interpolate`${userPoolDomain.output.domain}.auth.${region}.amazoncognito.com`
     );
 
-    const providers: Array<{
-        config: aws.cognito.IdentityProviderArgs;
-        resource: PulumiAppResource<typeof aws.cognito.IdentityProvider>;
-    }> = [];
+    const providerConfigs: aws.cognito.IdentityProviderArgs[] = [];
 
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
 
-        providers.push({
-            config,
-            resource: app.addResource(aws.cognito.IdentityProvider, {
-                name: config.providerName.toString(),
-                config
-            })
+        app.addResource(aws.cognito.IdentityProvider, {
+            name: config.providerName.toString(),
+            config
         });
+
+        providerConfigs.push(config);
     }
 
     appClient.config.supportedIdentityProviders([
         "COGNITO",
-        ...providers.map(p => {
+        ...providerConfigs.map(config => {
             // For built-in identity providers, we use the type as the name. Only for OIDC,
             // we allow the user to provide a custom name, and we only use the type as a fallback.
-            if (p.config.providerType === "OIDC") {
-                return p.config.providerName;
+            if (config.providerType === "OIDC") {
+                return config.providerName;
             }
-            return p.config.providerType;
+            return config.providerType;
         })
     ]);
 

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -69,7 +69,7 @@ export const configureAdminCognitoFederation = (
         pulumi.interpolate`${userPoolDomain.output.domain}.auth.${region}.amazoncognito.com`
     );
 
-    const providerConfigs: aws.cognito.IdentityProviderArgs[] = [];
+    const idpConfigs: aws.cognito.IdentityProviderArgs[] = [];
 
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
@@ -79,12 +79,12 @@ export const configureAdminCognitoFederation = (
             config
         });
 
-        providerConfigs.push(config);
+        idpConfigs.push(config);
     }
 
     appClient.config.supportedIdentityProviders([
         "COGNITO",
-        ...providerConfigs.map(config => {
+        ...idpConfigs.map(config => {
             // For built-in identity providers, we use the type as the name. Only for OIDC,
             // we allow the user to provide a custom name, and we only use the type as a fallback.
             if (config.providerType === "OIDC") {


### PR DESCRIPTION
## Changes
With this PR, we're addressing an issue where, upon using the `configureAdminCognitoFederation` and the `name` prop with the OIDC provider, the deployment would fail with with the following error message:

```bash
InvalidParameterException: The provider OIDC does not exist for User Pool eu-central-1_k5dRgsz9W
```

This was happening because, in case `name` is provided, internally, instead of using _it_ when linking with the user pool client, the provider `type` would be used. 

In other words, if we take a look at the example below, the identity provider `auth0` would get created, but when it comes to [linking it with the user pool client](https://github.com/webiny/webiny-js/pull/4506/files#diff-ee95664488624b9af5358924e46ed46fc35fa757360e5dc01d5033a4af2cefe7L84), the `OIDC` value would be used, instead of `auth0`. And, of course, since the `OIDC` provider does not exist, Pulumi throws the above error.

![image](https://github.com/user-attachments/assets/2a3cae93-b95a-4881-b57d-ce39b81ce127)

So, with this PR, we're addressing this issue, by ensuring the name is actually used when linking with the UPC, instead of the type.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.