### PR TITLE
fix: remove hiding of sections based on GQL access

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
@@ -43,6 +43,7 @@ export interface CMSPermissionsProps {
     value: CmsSecurityPermission[];
     onChange: (value: CmsSecurityPermission[]) => void;
 }
+
 export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
     const { getPermission } = useSecurity();
 
@@ -177,7 +178,7 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
         [value]
     );
 
-    const formData = useMemo(() => {
+    const initialFormData = useMemo(() => {
         // This function only runs once on Form mount
         if (!Array.isArray(value)) {
             return {
@@ -262,10 +263,10 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
     }, []);
 
     return (
-        <Form<CmsSecurityPermission> data={formData} onChange={onFormChange}>
+        <Form<CmsSecurityPermission> data={initialFormData} onChange={onFormChange}>
             {({ data, Bind, setValue }) => {
                 const endpoints = data.endpoints || [];
-                const graphQLEndpointAccess =
+                const hasGqlApiAccess =
                     endpoints.includes("read") ||
                     endpoints.includes("manage") ||
                     endpoints.includes("preview");
@@ -328,42 +329,43 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
                                         </Bind>
                                     </Cell>
                                 </Grid>
-                                {graphQLEndpointAccess && (
-                                    <ContentModelGroupPermission
-                                        data={data}
-                                        Bind={Bind}
-                                        disabled={cannotUseAAcl}
-                                        entity={"contentModelGroup"}
-                                        title={"Content Model Groups"}
-                                        locales={locales}
-                                    />
-                                )}
-
-                                {graphQLEndpointAccess &&
-                                    canRead(value, "cms.contentModelGroup") && (
-                                        <ContentModelPermission
-                                            locales={locales}
+                                {hasGqlApiAccess && (
+                                    <>
+                                        <ContentModelGroupPermission
                                             data={data}
-                                            setValue={setValue}
                                             Bind={Bind}
                                             disabled={cannotUseAAcl}
-                                            entity={"contentModel"}
-                                            title={"Content Models"}
-                                            selectedContentModelGroups={getSelectedContentModelGroups(
-                                                data
-                                            )}
+                                            entity={"contentModelGroup"}
+                                            title={"Content Model Groups"}
+                                            locales={locales}
                                         />
-                                    )}
 
-                                {graphQLEndpointAccess && canRead(value, "cms.contentModel") && (
-                                    <ContentEntryPermission
-                                        data={data}
-                                        Bind={Bind}
-                                        disabled={cannotUseAAcl}
-                                        setValue={setValue}
-                                        entity={"contentEntry"}
-                                        title={"Content Entries"}
-                                    />
+                                        {canRead(value, "cms.contentModelGroup") && (
+                                            <ContentModelPermission
+                                                locales={locales}
+                                                data={data}
+                                                setValue={setValue}
+                                                Bind={Bind}
+                                                disabled={cannotUseAAcl}
+                                                entity={"contentModel"}
+                                                title={"Content Models"}
+                                                selectedContentModelGroups={getSelectedContentModelGroups(
+                                                    data
+                                                )}
+                                            />
+                                        )}
+
+                                        {canRead(value, "cms.contentModel") && (
+                                            <ContentEntryPermission
+                                                data={data}
+                                                Bind={Bind}
+                                                disabled={cannotUseAAcl}
+                                                setValue={setValue}
+                                                entity={"contentEntry"}
+                                                title={"Content Entries"}
+                                            />
+                                        )}
+                                    </>
                                 )}
                             </>
                         )}

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
@@ -264,99 +264,97 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
 
     return (
         <Form<CmsSecurityPermission> data={initialFormData} onChange={onFormChange}>
-            {({ data, Bind, setValue }) => {
-                return (
-                    <Fragment>
-                        <Grid className={gridNoPaddingClass}>
-                            <Cell span={12}>
-                                {data.accessLevel === "custom" && cannotUseAAcl && (
-                                    <CannotUseAaclAlert />
-                                )}
-                            </Cell>
-                        </Grid>
+            {({ data, Bind, setValue }) => (
+                <>
+                    <Grid className={gridNoPaddingClass}>
+                        <Cell span={12}>
+                            {data.accessLevel === "custom" && cannotUseAAcl && (
+                                <CannotUseAaclAlert />
+                            )}
+                        </Cell>
+                    </Grid>
 
-                        <Grid className={gridNoPaddingClass}>
-                            <Cell span={6}>
-                                <PermissionInfo title={t`Access Level`} />
-                            </Cell>
-                            <Cell span={6}>
-                                <Bind name={"accessLevel"}>
-                                    <Select label={t`Access Level`}>
-                                        <option value={NO_ACCESS}>{t`No access`}</option>
-                                        <option value={FULL_ACCESS}>{t`Full access`}</option>
-                                        <option value={CUSTOM_ACCESS}>{t`Custom access`}</option>
-                                    </Select>
-                                </Bind>
-                            </Cell>
-                        </Grid>
-                        {data.accessLevel === CUSTOM_ACCESS && (
-                            <>
-                                <Grid>
-                                    <Cell span={12}>
-                                        <Bind name={"endpoints"}>
-                                            <CheckboxGroup
-                                                label={t`GraphQL API types`}
-                                                description={t`Each type has a separate URL and a specific purpose.
+                    <Grid className={gridNoPaddingClass}>
+                        <Cell span={6}>
+                            <PermissionInfo title={t`Access Level`} />
+                        </Cell>
+                        <Cell span={6}>
+                            <Bind name={"accessLevel"}>
+                                <Select label={t`Access Level`}>
+                                    <option value={NO_ACCESS}>{t`No access`}</option>
+                                    <option value={FULL_ACCESS}>{t`Full access`}</option>
+                                    <option value={CUSTOM_ACCESS}>{t`Custom access`}</option>
+                                </Select>
+                            </Bind>
+                        </Cell>
+                    </Grid>
+                    {data.accessLevel === CUSTOM_ACCESS && (
+                        <>
+                            <Grid>
+                                <Cell span={12}>
+                                    <Bind name={"endpoints"}>
+                                        <CheckboxGroup
+                                            label={t`GraphQL API types`}
+                                            description={t`Each type has a separate URL and a specific purpose.
                                                  Check out the {link} key topic to learn more.`({
-                                                    link: (
-                                                        <Link
-                                                            to={GRAPHQL_API_TYPES_LINK}
-                                                            target={"_blank"}
-                                                        >
-                                                            Headless CMS GraphQL API
-                                                        </Link>
-                                                    )
-                                                })}
-                                            >
-                                                {({ getValue, onChange }) =>
-                                                    API_ENDPOINTS.map(({ id, name }) => (
-                                                        <Checkbox
-                                                            key={id}
-                                                            label={name}
-                                                            value={getValue(id)}
-                                                            onChange={onChange(id)}
-                                                            disabled={cannotUseAAcl}
-                                                        />
-                                                    ))
-                                                }
-                                            </CheckboxGroup>
-                                        </Bind>
-                                    </Cell>
-                                </Grid>
+                                                link: (
+                                                    <Link
+                                                        to={GRAPHQL_API_TYPES_LINK}
+                                                        target={"_blank"}
+                                                    >
+                                                        Headless CMS GraphQL API
+                                                    </Link>
+                                                )
+                                            })}
+                                        >
+                                            {({ getValue, onChange }) =>
+                                                API_ENDPOINTS.map(({ id, name }) => (
+                                                    <Checkbox
+                                                        key={id}
+                                                        label={name}
+                                                        value={getValue(id)}
+                                                        onChange={onChange(id)}
+                                                        disabled={cannotUseAAcl}
+                                                    />
+                                                ))
+                                            }
+                                        </CheckboxGroup>
+                                    </Bind>
+                                </Cell>
+                            </Grid>
 
-                                <ContentModelGroupPermission
-                                    data={data}
-                                    Bind={Bind}
-                                    disabled={cannotUseAAcl}
-                                    entity={"contentModelGroup"}
-                                    title={"Content Model Groups"}
-                                    locales={locales}
-                                />
+                            <ContentModelGroupPermission
+                                data={data}
+                                Bind={Bind}
+                                disabled={cannotUseAAcl}
+                                entity={"contentModelGroup"}
+                                title={"Content Model Groups"}
+                                locales={locales}
+                            />
 
-                                <ContentModelPermission
-                                    locales={locales}
-                                    data={data}
-                                    setValue={setValue}
-                                    Bind={Bind}
-                                    disabled={cannotUseAAcl}
-                                    entity={"contentModel"}
-                                    title={"Content Models"}
-                                    selectedContentModelGroups={getSelectedContentModelGroups(data)}
-                                />
+                            <ContentModelPermission
+                                locales={locales}
+                                data={data}
+                                setValue={setValue}
+                                Bind={Bind}
+                                disabled={cannotUseAAcl}
+                                entity={"contentModel"}
+                                title={"Content Models"}
+                                selectedContentModelGroups={getSelectedContentModelGroups(data)}
+                            />
 
-                                <ContentEntryPermission
-                                    data={data}
-                                    Bind={Bind}
-                                    disabled={cannotUseAAcl}
-                                    setValue={setValue}
-                                    entity={"contentEntry"}
-                                    title={"Content Entries"}
-                                />
-                            </>
-                        )}
-                    </Fragment>
-                );
-            }}
+                            <ContentEntryPermission
+                                data={data}
+                                Bind={Bind}
+                                disabled={cannotUseAAcl}
+                                setValue={setValue}
+                                entity={"contentEntry"}
+                                title={"Content Entries"}
+                            />
+                        </>
+                    )}
+                </>
+            )}
         </Form>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/CmsPermissions.tsx
@@ -265,12 +265,6 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
     return (
         <Form<CmsSecurityPermission> data={initialFormData} onChange={onFormChange}>
             {({ data, Bind, setValue }) => {
-                const endpoints = data.endpoints || [];
-                const hasGqlApiAccess =
-                    endpoints.includes("read") ||
-                    endpoints.includes("manage") ||
-                    endpoints.includes("preview");
-
                 return (
                     <Fragment>
                         <Grid className={gridNoPaddingClass}>
@@ -329,44 +323,35 @@ export const CMSPermissions = ({ value, onChange }: CMSPermissionsProps) => {
                                         </Bind>
                                     </Cell>
                                 </Grid>
-                                {hasGqlApiAccess && (
-                                    <>
-                                        <ContentModelGroupPermission
-                                            data={data}
-                                            Bind={Bind}
-                                            disabled={cannotUseAAcl}
-                                            entity={"contentModelGroup"}
-                                            title={"Content Model Groups"}
-                                            locales={locales}
-                                        />
 
-                                        {canRead(value, "cms.contentModelGroup") && (
-                                            <ContentModelPermission
-                                                locales={locales}
-                                                data={data}
-                                                setValue={setValue}
-                                                Bind={Bind}
-                                                disabled={cannotUseAAcl}
-                                                entity={"contentModel"}
-                                                title={"Content Models"}
-                                                selectedContentModelGroups={getSelectedContentModelGroups(
-                                                    data
-                                                )}
-                                            />
-                                        )}
+                                <ContentModelGroupPermission
+                                    data={data}
+                                    Bind={Bind}
+                                    disabled={cannotUseAAcl}
+                                    entity={"contentModelGroup"}
+                                    title={"Content Model Groups"}
+                                    locales={locales}
+                                />
 
-                                        {canRead(value, "cms.contentModel") && (
-                                            <ContentEntryPermission
-                                                data={data}
-                                                Bind={Bind}
-                                                disabled={cannotUseAAcl}
-                                                setValue={setValue}
-                                                entity={"contentEntry"}
-                                                title={"Content Entries"}
-                                            />
-                                        )}
-                                    </>
-                                )}
+                                <ContentModelPermission
+                                    locales={locales}
+                                    data={data}
+                                    setValue={setValue}
+                                    Bind={Bind}
+                                    disabled={cannotUseAAcl}
+                                    entity={"contentModel"}
+                                    title={"Content Models"}
+                                    selectedContentModelGroups={getSelectedContentModelGroups(data)}
+                                />
+
+                                <ContentEntryPermission
+                                    data={data}
+                                    Bind={Bind}
+                                    disabled={cannotUseAAcl}
+                                    setValue={setValue}
+                                    entity={"contentEntry"}
+                                    title={"Content Entries"}
+                                />
                             </>
                         )}
                     </Fragment>

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentEntryPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentEntryPermission.tsx
@@ -99,9 +99,10 @@ export const ContentEntryPermission = ({
                             <Bind name={`${entity}RWD`}>
                                 <Select
                                     label={t`Primary Actions`}
+                                    placeholder={"Read-only"}
                                     disabled={disabled || disabledPrimaryActions}
                                 >
-                                    <option value={"r"}>{t`Read`}</option>
+                                    <option value={"r"}>{t`Read-only`}</option>
                                     {endpoints.includes("manage") ? (
                                         <option value={"rw"}>{t`Read, write`}</option>
                                     ) : (

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelGroupPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelGroupPermission.tsx
@@ -79,9 +79,10 @@ const ContentModelGroupPermission = ({
                             <Bind name={`${entity}RWD`}>
                                 <Select
                                     label={t`Primary Actions`}
+                                    placeholder={"Read-only"}
                                     disabled={disabled || disabledPrimaryActions}
                                 >
-                                    <option value={"r"}>{t`Read`}</option>
+                                    <option value={"r"}>{t`Read-only`}</option>
                                     {endpoints.includes("manage") ? (
                                         <option value={"rw"}>{t`Read, write`}</option>
                                     ) : (

--- a/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelPermission.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/permissionRenderer/components/ContentModelPermission.tsx
@@ -120,9 +120,10 @@ export const ContentModelPermission = ({
                             <Bind name={`${entity}RWD`}>
                                 <Select
                                     label={t`Primary Actions`}
+                                    placeholder={"Read-only"}
                                     disabled={disabled || disabledPrimaryActions}
                                 >
-                                    <option value={"r"}>{t`Read`}</option>
+                                    <option value={"r"}>{t`Read-only`}</option>
                                     {endpoints.includes("manage") ? (
                                         <option value={"rw"}>{t`Read, write`}</option>
                                     ) : (


### PR DESCRIPTION
## Changes
This PR improves UX in the Headless CMS permissions section:

![image](https://github.com/user-attachments/assets/608830a9-8c5d-45f4-b472-105ae53b9fb1)

It all began with the fact that, when you set access lvl to "Custom access", and you enable the READ GQL API access, you would first see the Content Model Groups section (the first section out of the three). 

Then, if you were to disable the access, and then enable it again, instead of just seeing the Content Model Groups section, you'd also see Content Models section. And finally, if you were to again disable READ GQL API and enable it, you'd see Content Model Groups, Content Model, and Content Model Entries section. 

And this is the inconsistency we set out to resolve initially.

After a bit of debugging, I realized this was happening because the three above-mentioned sections render `Bind` components, which, as they get rendered, create values in parent form component's state. Which were ultimately determining if the section should be rendered or not. In other words, as these sections are rendered/hidden (by clicking checking/unchecking the READ GQL API access checkbox), the form state gets incrementally populated with values, and then components start to render.

Ultimately, I decided to resolve this simply by not conditionally rendering these three sections. Not only this fixes the above issue, but also, this way, users immediately see which options they have. And it's not like things start to pop up randomly.

## Additional Changes

In order for the UI to more clearly convey the default settings in Primary Actions for all three sections, I've added a placeholder and also changed the word "Read" to "Read-only".

![image](https://github.com/user-attachments/assets/71817f59-7798-464f-a43b-c1e96209acd9)

## How Has This Been Tested?
Manually.

## Documentation
Changelog.