### PR TITLE
Fixed VPC Configuration for Production Deployment

### DIFF
--- a/packages/pulumi-aws/src/enterprise/createApiPulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createApiPulumiApp.ts
@@ -23,8 +23,19 @@ export function createApiPulumiApp(projectAppParams: CreateApiPulumiAppParams = 
         // If using existing VPC, we ensure `vpc` param is set to `false`.
         vpc: ({ getParam }) => {
             const vpc = getParam(projectAppParams.vpc);
-            const usingAdvancedVpcParams = vpc && typeof vpc !== "boolean";
-            return usingAdvancedVpcParams && vpc.useExistingVpc ? false : Boolean(vpc);
+            if (!vpc) {
+                // This could be `false` or `undefined`. If `undefined`, down the line,
+                // this means "deploy into VPC if dealing with a production environment".
+                return vpc;
+            }
+
+            // If using an existing VPC, we ensure Webiny does not deploy its own VPC.
+            const usingAdvancedVpcParams = typeof vpc !== "boolean";
+            if (usingAdvancedVpcParams && vpc.useExistingVpc) {
+                return false;
+            }
+
+            return true;
         },
         pulumi(...args) {
             const [{ getParam }] = args;

--- a/packages/pulumi-aws/src/enterprise/createCorePulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createCorePulumiApp.ts
@@ -27,8 +27,19 @@ export function createCorePulumiApp(projectAppParams: CreateCorePulumiAppParams 
         // If using existing VPC, we ensure `vpc` param is set to `false`.
         vpc: ({ getParam }) => {
             const vpc = getParam(projectAppParams.vpc);
-            const usingAdvancedVpcParams = vpc && typeof vpc !== "boolean";
-            return usingAdvancedVpcParams && vpc.useExistingVpc ? false : Boolean(vpc);
+            if (!vpc) {
+                // This could be `false` or `undefined`. If `undefined`, down the line,
+                // this means "deploy into VPC if dealing with a production environment".
+                return vpc;
+            }
+
+            // If using an existing VPC, we ensure Webiny does not deploy its own VPC.
+            const usingAdvancedVpcParams = typeof vpc !== "boolean";
+            if (usingAdvancedVpcParams && vpc.useExistingVpc) {
+                return false;
+            }
+
+            return true;
         },
         pulumi(...args) {
             const [app] = args;

--- a/packages/pulumi-aws/src/enterprise/createWebsitePulumiApp.ts
+++ b/packages/pulumi-aws/src/enterprise/createWebsitePulumiApp.ts
@@ -24,8 +24,19 @@ export function createWebsitePulumiApp(projectAppParams: CreateWebsitePulumiAppP
         // If using existing VPC, we ensure `vpc` param is set to `false`.
         vpc: ({ getParam }) => {
             const vpc = getParam(projectAppParams.vpc);
-            const usingAdvancedVpcParams = vpc && typeof vpc !== "boolean";
-            return usingAdvancedVpcParams && vpc.useExistingVpc ? false : Boolean(vpc);
+            if (!vpc) {
+                // This could be `false` or `undefined`. If `undefined`, down the line,
+                // this means "deploy into VPC if dealing with a production environment".
+                return vpc;
+            }
+
+            // If using an existing VPC, we ensure Webiny does not deploy its own VPC.
+            const usingAdvancedVpcParams = typeof vpc !== "boolean";
+            if (usingAdvancedVpcParams && vpc.useExistingVpc) {
+                return false;
+            }
+
+            return true;
         },
         pulumi(...args) {
             const [{ getParam }] = args;


### PR DESCRIPTION
With this PR, we've fixed an issue where the VPC configuration would not get applied when deploying in production mode.

Note that this issue would only occur when using the `/enterprise` version of **Core**, **API**, and **Website** project applications, within respective `webiny.application.ts` files:

```ts
// apps/core/webiny.application.ts
import { createCoreApp } from "@webiny/serverless-cms-aws/enterprise";

// apps/api/webiny.application.ts
import { createApiApp } from "@webiny/serverless-cms-aws/enterprise";

// apps/website/webiny.application.ts
import { createWebsiteApp } from "@webiny/serverless-cms-aws/enterprise";
```

When not using the `/enterprise` version, the VPC configuration would be applied correctly.