### PR TITLE
Refresh Github Actions CI/CD Workflows

### DIFF
--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
@@ -48,10 +48,6 @@ jobs:
       - name: ESLint
         run: yarn eslint
 
-      # 3. Build custom packages located within the "packages" folder (if any).
-      - name: Build packages
-        run: yarn webiny workspaces run build --folder packages
-
       # 4. Run unit tests.
       - name: Run unit tests
         run: yarn test:unit
@@ -86,10 +82,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn --immutable
-
-      # 2. Build custom packages located within the "packages" folder (if any).
-      - name: Build packages
-        run: yarn webiny workspaces run build --folder packages
 
       # 3. Deploy to a short-lived environment (will be destroyed once the PR is closed).
       - name: Deploy

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequest.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -41,14 +41,14 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 2. Run static code analysis.
+      # Run static code analysis.
       - name: Check code formatting
         run: yarn prettier:check
 
       - name: ESLint
         run: yarn eslint
 
-      # 4. Run unit tests.
+      # Run unit tests.
       - name: Run unit tests
         run: yarn test:unit
 
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -83,15 +83,15 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 3. Deploy to a short-lived environment (will be destroyed once the PR is closed).
+      # Deploy to a short-lived environment (will be destroyed once the PR is closed).
       - name: Deploy
         run: yarn webiny deploy --env pr${{ github.event.pull_request.number }}
 
-      # 4. Run integration tests.
+      # Run integration tests.
       - name: Run integration tests
         run: yarn test:integration
 
-      # 5. Run end-to-end tests.
+      # Run end-to-end tests.
       - name: Run end-to-end tests
         run: yarn test:e2e
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 2. Destroy short-lived environment.
+      # Destroy short-lived environment.
       - name: Destroy Website project application
         run: yarn webiny destroy apps/website --env pr${{ github.event.pull_request.number }}
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pullRequestClosed.yml
@@ -52,14 +52,5 @@ jobs:
         run: yarn --immutable
 
       # Destroy short-lived environment.
-      - name: Destroy Website project application
-        run: yarn webiny destroy apps/website --env pr${{ github.event.pull_request.number }}
-
-      - name: Destroy Admin Area project application
-        run: yarn webiny destroy apps/admin --env pr${{ github.event.pull_request.number }}
-
-      - name: Destroy API project application
-        run: yarn webiny destroy apps/api --env pr${{ github.event.pull_request.number }}
-
-      - name: Destroy Core project application
-        run: yarn webiny destroy apps/core --env pr${{ github.event.pull_request.number }}
+      - name: Destroy
+        run: yarn webiny destroy --env pr${{ github.event.pull_request.number }} --confirm-destroy-env pr${{ github.event.pull_request.number }}

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -53,25 +53,25 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 2. Run static code analysis.
+      # Run static code analysis.
       - name: Check code formatting
         run: yarn prettier:check
 
       - name: ESLint
         run: yarn eslint
 
-      # 4. Run unit tests.
+      # Run unit tests.
       - name: Run unit tests
         run: yarn test:unit
 
       - name: Deploy
         run: yarn webiny deploy --env dev
 
-      # 6. Run integration tests.
+      # Run integration tests.
       - name: Run integration tests
         run: yarn test:integration
 
-      # 7. Run end-to-end tests.
+      # Run end-to-end tests.
       - name: Run end-to-end tests
         run: yarn test:e2e
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushDev.yml
@@ -60,10 +60,6 @@ jobs:
       - name: ESLint
         run: yarn eslint
 
-      # 3. Build custom packages located within the "packages" folder (if any).
-      - name: Build packages
-        run: yarn webiny workspaces run build --folder packages
-
       # 4. Run unit tests.
       - name: Run unit tests
         run: yarn test:unit

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -53,25 +53,25 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 2. Run static code analysis.
+      # Run static code analysis.
       - name: Check code formatting
         run: yarn prettier:check
 
       - name: ESLint
         run: yarn eslint
 
-      # 4. Run unit tests.
+      # Run unit tests.
       - name: Run unit tests
         run: yarn test:unit
 
       - name: Deploy
         run: yarn webiny deploy --env prod
 
-      # 6. Run integration tests.
+      # Run integration tests.
       - name: Run integration tests
         run: yarn test:integration
 
-      # 7. Run end-to-end tests.
+      # Run end-to-end tests.
       - name: Run end-to-end tests
         run: yarn test:e2e
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushProd.yml
@@ -60,10 +60,6 @@ jobs:
       - name: ESLint
         run: yarn eslint
 
-      # 3. Build custom packages located within the "packages" folder (if any).
-      - name: Build packages
-        run: yarn webiny workspaces run build --folder packages
-
       # 4. Run unit tests.
       - name: Run unit tests
         run: yarn test:unit

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 20
 
       - uses: actions/checkout@v2
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # 1. Install and cache dependencies.
+      # Install and cache dependencies.
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -53,25 +53,25 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
-      # 2. Run static code analysis.
+      # Run static code analysis.
       - name: Check code formatting
         run: yarn prettier:check
 
       - name: ESLint
         run: yarn eslint
 
-      # 4. Run unit tests.
+      # Run unit tests.
       - name: Run unit tests
         run: yarn test:unit
 
       - name: Deploy
         run: yarn webiny deploy --env staging
 
-      # 6. Run integration tests.
+      # Run integration tests.
       - name: Run integration tests
         run: yarn test:integration
 
-      # 7. Run end-to-end tests.
+      # Run end-to-end tests.
       - name: Run end-to-end tests
         run: yarn test:e2e
 

--- a/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
+++ b/packages/cli-plugin-scaffold-ci/src/githubActions/files/workflows/.github/workflows/pushStaging.yml
@@ -60,10 +60,6 @@ jobs:
       - name: ESLint
         run: yarn eslint
 
-      # 3. Build custom packages located within the "packages" folder (if any).
-      - name: Build packages
-        run: yarn webiny workspaces run build --folder packages
-
       # 4. Run unit tests.
       - name: Run unit tests
         run: yarn test:unit


### PR DESCRIPTION
## Changes
This PR refreshes the workflows that are included in our CI/CD GH Actions scaffold. Mainly, it bumps to Node.js version from 14 to 20.

Apart from that, I've also removed the "Build packages" step, as it's no longer needed (at least, our latest docs are no longer requiring it). 

## How Has This Been Tested?
Manually.

## Documentation
Changelog.