### PR TITLE
docs: improved design system documentation - button

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "webiny-admin-storybook": "cd packages/admin-ui && yarn storybook",
     "webiny-admin-storybook-docs": "cd packages/admin-ui && yarn storybook-docs",
     "webiny-admin-build-storybook": "cd packages/admin-ui && cross-env OUT=../../netlify-static yarn build-storybook",
-    "webiny-admin-build-storybook-docs": "cd packages/admin-ui && cross-env OUT=../../netlify-static yarn build-storybook-docs",
     "webiny-admin-import-from-figma": "node packages/admin-ui/scripts/importFromFigma.js"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,9 @@
     "system:build": "yarn && yarn ghawac build && yarn webiny sync-dependencies && yarn build",
     "wby": "./node_modules/.bin/wby",
     "webiny-admin-storybook": "cd packages/admin-ui && yarn storybook",
+    "webiny-admin-storybook-docs": "cd packages/admin-ui && yarn storybook-docs",
     "webiny-admin-build-storybook": "cd packages/admin-ui && cross-env OUT=../../netlify-static yarn build-storybook",
+    "webiny-admin-build-storybook-docs": "cd packages/admin-ui && cross-env OUT=../../netlify-static yarn build-storybook-docs",
     "webiny-admin-import-from-figma": "node packages/admin-ui/scripts/importFromFigma.js"
   },
   "husky": {

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -70,7 +70,9 @@
     "build": "yarn webiny run build",
     "watch": "yarn webiny run watch",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "storybook-docs": "storybook dev --docs -p 6007",
+    "build-storybook": "storybook build",
+    "build-storybook-docs": "storybook build --docs"
   },
   "adio": {
     "ignore": {

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -71,8 +71,7 @@
     "watch": "yarn webiny run watch",
     "storybook": "storybook dev -p 6006",
     "storybook-docs": "storybook dev --docs -p 6007",
-    "build-storybook": "storybook build",
-    "build-storybook-docs": "storybook build --docs"
+    "build-storybook": "storybook build --docs"
   },
   "adio": {
     "ignore": {

--- a/packages/admin-ui/src/Button/Button.mdx
+++ b/packages/admin-ui/src/Button/Button.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta } from '@storybook/blocks';
+import { Canvas, Meta, Controls } from '@storybook/blocks';
 
 import * as ButtonStories from './Button.stories';
 
@@ -8,13 +8,125 @@ import * as ButtonStories from './Button.stories';
 
 The Button component is a key UI element that enables users to trigger actions or events, such as submitting forms, navigating pages, or interacting with system functionality. Its purpose is to provide a clear, intuitive way for users to interact with an system. Buttons are relevant in virtually all interfaces, ensuring user engagement by offering a simple, recognizable mechanism for executing commands. They are essential for usability, guiding user behavior and driving application workflows.
 
-<Canvas of={ButtonStories.Primary} />
-
 ## Usage
 
-```
+```jsx
 import { Button } from '@webiny/admin-ui';
 ```
+
+```jsx
+<Button variant="primary">Button</Button>
+```
+## Props
+
+<Canvas of={ButtonStories.Documentation}
+    source={ { code:
+        ` // Code for a Primary, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="primary" size="md">Button</Button>
+
+         ` } }
+    additionalActions={[
+        {
+            title: 'Open in GitHub',
+            onClick: () => {
+                window.open(
+                    'https://github.com/webiny/webiny-js/blob/feat/new-admin-ui/packages/admin-ui/src/Button/Button.tsx',
+                    '_blank'
+                );
+            },
+        }
+    ]}
+/>
+
+<Controls of={ButtonStories.Documentation} exclude={"onClick"} />
+
+## Examples
+
+### Primary
+
+<Canvas of={ButtonStories.Primary}
+        source={ { code:
+        `// Code for a Primary, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="primary" size="md">Button</Button>
+
+        ` } }
+/>
+
+
+### Secondary
+
+<Canvas of={ButtonStories.Secondary}
+        source={ { code:
+        `// Code for a Secondary, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="secondary" size="md">Button</Button>
+
+` } }
+/>
+
+### Tertiary
+
+<Canvas of={ButtonStories.Tertiary}
+        source={ { code:
+        `// Code for a Tertiary, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="tertiary" size="md">Button</Button>
+
+` } }
+/>
+
+### Ghost
+
+<Canvas of={ButtonStories.Ghost}
+        source={ { code:
+        `// Code for a Ghost, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="ghost" size="md">Button</Button>
+
+` } }
+/>
+
+### Ghost Negative
+
+<Canvas of={ButtonStories.GhostNegative}
+        source={ { code:
+                `// Code for a Ghost Negative, Medium sized button
+        \n import { Button } from '@webiny/admin-ui';
+        \n <Button variant="ghost-negative" size="md">Button</Button>
+
+` } }
+/>
+
+### With Icon
+
+<Canvas of={ButtonStories.WithIcon} story={ {inline: false}}
+        source={ { code:
+                `// Code for a With Icon, Medium sized button
+
+import { Button } from '@webiny/admin-ui';
+import { ReactComponent as PencilIcon } from "@material-design-icons/svg/filled/edit.svg";
+\n<Button variant="primary" size="md" icon={<PencilIcon />} iconPosition="start">Button</Button>
+` } }
+/>
+
+
+### As Child
+The Button component can be used as a wrapper for other elements, allowing flexible composition. This is particularly useful when integrating custom text elements, or any other components inside a button.
+
+<Canvas of={ButtonStories.WithAsChild} story={ {inline: false}}
+        source={ { code:
+                `// Code for a As Child button
+
+\n import { Button } from '@webiny/admin-ui';
+\n import { ReactComponent as PencilIcon } from "@material-design-icons/svg/filled/edit.svg";
+<Button variant="primary" size="md" asChild=true>
+    <span>Button</span>
+</Button>
+
+` } }
+/>
 
 ## Anatomy
 

--- a/packages/admin-ui/src/Button/Button.stories.tsx
+++ b/packages/admin-ui/src/Button/Button.stories.tsx
@@ -7,16 +7,45 @@ import { Button } from "./Button";
 const meta: Meta<typeof Button> = {
     title: "Components/Button",
     component: Button,
-    // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-    // More on argTypes: https://storybook.js.org/docs/api/argtypes
     argTypes: {
         variant: {
+            description: "Type",
             control: "select",
-            options: ["primary", "secondary", "tertiary", "ghost", "ghost-negative"]
+            options: ["primary", "secondary", "tertiary", "ghost", "ghost-negative"],
+            defaultValue: "primary"
         },
-        size: { control: "select", options: ["sm", "md", "lg", "xl"] },
-        disabled: { control: "boolean" },
-        text: { control: "text" },
+        size: {
+            description: "Size",
+            control: "select",
+            options: ["sm", "md", "lg", "xl"],
+            defaultValue: "md"
+        },
+        text: {
+            description: "Label",
+            control: "text",
+            defaultValue: "Button"
+        },
+        disabled: {
+            description: "State",
+            control: "boolean",
+            defaultValue: false
+        },
+        icon: {
+            description:
+                "Please refer to the '[With Icon](#with-icon)' button example below for details.",
+            control: "none"
+        },
+        iconPosition: {
+            description: "Icon Position",
+            control: "select",
+            options: ["start", "end"],
+            defaultValue: "start"
+        },
+        asChild: {
+            description:
+                "Please refer to the '[As Child](#as-child)' button example below for details.",
+            control: "none"
+        },
         // Note: after upgrading to Storybook 8.X, use `fn`from `@storybook/test` to spy on the onClick argument.
         onClick: { action: "onClick" }
     }
@@ -55,8 +84,8 @@ export const Ghost: Story = {
 
 export const GhostNegative: Story = {
     decorators: [
-        Story => (
-            <div className="wby-bg-[#25292e] wby-p-[300px] wby-rounded-[5px]">
+        (Story: any) => (
+            <div className="wby-bg-[#25292e] wby-p-[50px] wby-rounded-[5px]">
                 <Story />
             </div>
         )
@@ -115,5 +144,23 @@ export const WithAsChild: Story = {
         ...Primary.args,
         asChild: true,
         text: <span>Button</span>
+    }
+};
+
+/* The Documentation story is created for the Docs page.
+ * The description column for the `iconPosition` and `icon` props displays
+ * an extra dash (-), and the formatting breaks unless defined in the story.
+ * Hence, this Documentation story was created.
+ */
+
+export const Documentation: Story = {
+    args: {
+        variant: "primary",
+        text: "Button",
+        size: "md",
+        disabled: false,
+        icon: "",
+        iconPosition: "start",
+        asChild: ""
     }
 };

--- a/packages/admin-ui/src/Button/Button.stories.tsx
+++ b/packages/admin-ui/src/Button/Button.stories.tsx
@@ -161,6 +161,6 @@ export const Documentation: Story = {
         disabled: false,
         icon: "",
         iconPosition: "start",
-        asChild: ""
+        asChild: false
     }
 };


### PR DESCRIPTION
## Changes
Improved button design system documentation
Revamped the button documentation to enhance the developer experience.
The new docs consolidate all stories in one place,
including sample code and provide interactive props
table where users can modify props and see live variations of the button.

Done the following changes:

1. Added `webiny-admin-storybook-docs` command in `package.json` to generate docs
while skipping the story list in the side navigation.
2. Added `storybook-docs` command to start Storybook in docs-only mode on port 6007.
3. Added `--docs` prefix to `build-storybook` to publish only MDX docs (skipping the story list in side navigation) while building the Storybook project that is deployed via `npx chromatic --project-token` command and our [
Chromatic - Storybook Preview GitHub action](https://github.com/webiny/webiny-js/actions/workflows/chromaticStorybook.yml) to Chromatic.
4. Included button variation examples with code samples.
5. Defined all `argTypes` (props) in `Button.stories.tsx` to make them available in the Props table.
This improves the discoverability, usability, and interactivity of the button documentation.

## How Has This Been Tested?
Manually 
