### PR TITLE
fix(pulumi-aws): dynamodb permissions for ddb to es lambda

### DIFF
--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -296,7 +296,14 @@ function getDynamoDbToElasticLambdaPolicy(
                             "es:ESHttpDelete",
                             "es:ESHttpPatch",
                             "es:ESHttpPost",
-                            "es:ESHttpPut"
+                            "es:ESHttpPut",
+                            "dynamodb:BatchGetItem",
+                            "dynamodb:BatchWriteItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:GetItem",
+                            "dynamodb:DeleteItem",
+                            "dynamodb:Query",
+                            "dynamodb:UpdateItem"
                         ],
                         Resource: [
                             pulumi.interpolate`${domain.arn}`,

--- a/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
@@ -309,7 +309,14 @@ function getDynamoDbToElasticLambdaPolicy(
                             "es:ESHttpDelete",
                             "es:ESHttpPatch",
                             "es:ESHttpPost",
-                            "es:ESHttpPut"
+                            "es:ESHttpPut",
+                            "dynamodb:BatchGetItem",
+                            "dynamodb:BatchWriteItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:GetItem",
+                            "dynamodb:DeleteItem",
+                            "dynamodb:Query",
+                            "dynamodb:UpdateItem"
                         ],
                         Resource: [
                             pulumi.interpolate`${domain.arn}`,


### PR DESCRIPTION
## Changes
Add missing DynamoDB permissions to DynamoDB to Elasticsearch/OpenSearch Lambda.

## How Has This Been Tested?
Manually.