### PR TITLE
fix(project-utils): resolve all lexical packages to a CJS build

### DIFF
--- a/packages/project-utils/bundling/app/config/lexicalAliases.js
+++ b/packages/project-utils/bundling/app/config/lexicalAliases.js
@@ -1,0 +1,33 @@
+// A fix for CJS resolution.
+const path = require("path");
+const readJsonSync = require("read-json-sync");
+const glob = require("glob");
+
+module.exports.getLexicalAliases = () => {
+    // Find location of node_modules where the core "lexical" package is installed.
+    const nodeModules = require.resolve("lexical").split("/lexical/")[0];
+
+    // Identify all @lexical/* packages.
+    const allLexicalPackages = glob.sync("@lexical/*/package.json", {
+        cwd: nodeModules,
+        absolute: true
+    });
+
+    const lexicalAliases = {
+        lexical: require.resolve("lexical")
+    };
+
+    // For every package, we want to resolve all of its exports to CJS.
+    for (const pkgJsonPath of allLexicalPackages) {
+        const pkgJson = readJsonSync(pkgJsonPath);
+        const packageDir = pkgJsonPath.replace("/package.json", "");
+
+        Object.keys(pkgJson.exports).forEach(key => {
+            const value = path.join(packageDir, pkgJson.exports[key].require.default);
+
+            lexicalAliases[path.join(pkgJson.name, key)] = value;
+        });
+    }
+
+    return lexicalAliases;
+};

--- a/packages/project-utils/bundling/app/config/webpack.config.js
+++ b/packages/project-utils/bundling/app/config/webpack.config.js
@@ -13,6 +13,7 @@ const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
 const InterpolateHtmlPlugin = require("react-dev-utils/InterpolateHtmlPlugin");
 const getCSSModuleLocalIdent = require("react-dev-utils/getCSSModuleLocalIdent");
 const getClientEnvironment = require("./env");
+const { getLexicalAliases } = require("./lexicalAliases");
 const ESLintPlugin = require("eslint-webpack-plugin");
 const ModuleNotFoundPlugin = require("react-dev-utils/ModuleNotFoundPlugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
@@ -225,9 +226,8 @@ module.exports = function (webpackEnv, { paths, options }) {
                 }),
                 // This is a temporary fix, until we sort out the `react-butterfiles` dependency.
                 "react-butterfiles": require.resolve("@webiny/app/react-butterfiles"),
-                // Force `lexical` to use the CJS export.
-                lexical: require.resolve("lexical"),
-                ...(modules.webpackAliases || {})
+                ...(modules.webpackAliases || {}),
+                ...getLexicalAliases()
             },
             fallback: {
                 assert: require.resolve("assert-browserify"),


### PR DESCRIPTION
## Changes
This PR forces all Lexical packages to be resolved to their CJS builds. This is necessary until we get to a full ESM setup.

## How Has This Been Tested?
Manually, by adding `@lexical/table` to a project, and testing it in the page editor.