### PR TITLE
fix: improve backwards compatibility

### DIFF
--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -74,10 +74,15 @@ export const configureAdminCognitoFederation = (
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
 
-        app.addResource(aws.cognito.IdentityProvider, {
-            name: config.providerName.toString(),
-            config
-        });
+        let name = config.providerName.toString();
+
+        // For backwards compatibility, in case a user didn't provide a name, we
+        // want to ensure that the OIDC provider is named "oidc" (and not "OIDC").
+        if (idp.type === "oidc" && !idp.name) {
+            name = "oidc";
+        }
+
+        app.addResource(aws.cognito.IdentityProvider, { name, config });
 
         idpConfigs.push(config);
     }

--- a/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/pulumi-aws/src/apps/core/cognitoIdentityProviders/configure.ts
@@ -74,13 +74,13 @@ export const configureAdminCognitoFederation = (
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
 
-        let name = config.providerName.toString();
-
-        // For backwards compatibility, in case a user didn't provide a name, we
-        // want to ensure that the OIDC provider is named "oidc" (and not "OIDC").
-        if (idp.type === "oidc" && !idp.name) {
-            name = "oidc";
-        }
+        // The idea to lowercase the provider name emerged while working on backwards compatibility issue.
+        // Basically, in cases where a user used the OIDC provider and did not specify a name, instead of
+        // using `OIDC` as the name, we wanted to ensure `oidc` is used. But, what I soon realized is that
+        // by simply lowercasing the name, we can avoid the need to check for the provider type and name.
+        // And although this will now happen for all providers, it's not a problem since Pulumi requires
+        // names to be all lowercase anyway.
+        const name = config.providerName.toString().toLowerCase();
 
         app.addResource(aws.cognito.IdentityProvider, { name, config });
 


### PR DESCRIPTION
## Changes
This PR ensures existing users of OIDC provider (used with Cognito Federation) are not affected. This is a continuation of https://github.com/webiny/webiny-js/pull/4506/files. 

## How Has This Been Tested?
Manually.

## Documentation
Changelog.