### PR TITLE
fix: folder and content creation permission checks

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentEntries/Table/Main.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/Table/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import debounce from "lodash/debounce";
 import { useCreateDialog, useGetFolderLevelPermission } from "@webiny/app-aco";
 import { Scrollbar } from "@webiny/ui/Scrollbar";
@@ -35,13 +35,19 @@ export const Main = ({ folderId: initialFolderId }: MainProps) => {
     const { getFolderLevelPermission: canManageStructure } =
         useGetFolderLevelPermission("canManageStructure");
 
-    const canCreateFolder = useMemo(() => {
-        return canManageStructure(folderId);
-    }, [canManageStructure, folderId]);
+    const canCreateFolder = useCallback(
+        (folderId: string) => {
+            return canManageStructure(folderId);
+        },
+        [canManageStructure]
+    );
 
-    const canCreateContent = useMemo(() => {
-        return canCreate && canManageContent(folderId);
-    }, [canManageContent, folderId]);
+    const canCreateContent = useCallback(
+        (folderId: string) => {
+            return canCreate && canManageContent(folderId);
+        },
+        [canManageContent, canCreate]
+    );
 
     const createEntry = useCallback(() => {
         const folder = folderId ? `&folderId=${encodeURIComponent(folderId)}` : "";
@@ -81,8 +87,8 @@ export const Main = ({ folderId: initialFolderId }: MainProps) => {
             <MainContainer>
                 <Header
                     title={!list.isListLoading ? list.listTitle : undefined}
-                    canCreateFolder={canCreateFolder}
-                    canCreateContent={canCreateContent}
+                    canCreateFolder={canCreateFolder(folderId)}
+                    canCreateContent={canCreateContent(folderId)}
                     onCreateEntry={createEntry}
                     onCreateFolder={onCreateFolder}
                     searchValue={list.search}
@@ -97,8 +103,8 @@ export const Main = ({ folderId: initialFolderId }: MainProps) => {
                     !list.isListLoading ? (
                         <Empty
                             isSearch={list.isSearch}
-                            canCreateFolder={canCreateFolder}
-                            canCreateContent={canCreateContent}
+                            canCreateFolder={canCreateFolder(folderId)}
+                            canCreateContent={canCreateContent(folderId)}
                             onCreateEntry={createEntry}
                             onCreateFolder={onCreateFolder}
                         />

--- a/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
+++ b/packages/app-page-builder/src/admin/views/Pages/Table/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import debounce from "lodash/debounce";
 import { i18n } from "@webiny/app/i18n";
 import { useCreateDialog, useGetFolderLevelPermission } from "@webiny/app-aco";
@@ -51,13 +51,19 @@ export const Main = ({ folderId: initialFolderId }: Props) => {
     const { getFolderLevelPermission: canManageContent } =
         useGetFolderLevelPermission("canManageContent");
 
-    const canCreateFolder = useMemo(() => {
-        return canManageStructure(folderId);
-    }, [canManageStructure, folderId]);
+    const canCreateFolder = useCallback(
+        (folderId: string) => {
+            return canManageStructure(folderId);
+        },
+        [canManageStructure]
+    );
 
-    const canCreateContent = useMemo(() => {
-        return canCreate() && canManageContent(folderId);
-    }, [canManageContent, folderId]);
+    const canCreateContent = useCallback(
+        (folderId: string) => {
+            return canCreate() && canManageContent(folderId);
+        },
+        [canManageContent, canCreate]
+    );
 
     const { innerHeight: windowHeight } = window;
     const [tableHeight, setTableHeight] = useState(0);
@@ -100,8 +106,8 @@ export const Main = ({ folderId: initialFolderId }: Props) => {
             <MainContainer>
                 <Header
                     title={!list.isListLoading ? list.listTitle : undefined}
-                    canCreateFolder={canCreateFolder}
-                    canCreateContent={canCreateContent}
+                    canCreateFolder={canCreateFolder(folderId)}
+                    canCreateContent={canCreateContent(folderId)}
                     onCreatePage={openTemplatesDialog}
                     onImportPage={openCategoriesDialog}
                     onCreateFolder={onCreateFolder}
@@ -116,8 +122,8 @@ export const Main = ({ folderId: initialFolderId }: Props) => {
                     !list.isListLoading ? (
                         <Empty
                             isSearch={list.isSearch}
-                            canCreateFolder={canCreateFolder}
-                            canCreateContent={canCreateContent}
+                            canCreateFolder={canCreateFolder(folderId)}
+                            canCreateContent={canCreateContent(folderId)}
                             onCreatePage={openTemplatesDialog}
                             onCreateFolder={onCreateFolder}
                         />


### PR DESCRIPTION
## Changes
With this PR, we are improving how the folder permission is checked. 
Before, both `cancCreateFolder` and `canCreateContent` were memoised using `useMemo`. Now we cache a function definition instead.

## How Has This Been Tested?
Manually
