### PR TITLE
fix(app-admin): improve styling for ListItem and ListItemGraphic components

### DIFF
--- a/packages/app-admin/src/components/BulkActions/useDialogWithReport/useDialogWithReport.styled.tsx
+++ b/packages/app-admin/src/components/BulkActions/useDialogWithReport/useDialogWithReport.styled.tsx
@@ -6,7 +6,16 @@ export const MessageContainer = styled("div")`
 `;
 
 export const ListItem = styled(BaseListItem)`
-    overflow: visible !important;
+    overflow: visible;
+    height: auto !important;
+    align-items: flex-start;
+
+    .mdc-deprecated-list-item__secondary-text {
+        display: block;
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+    }
 `;
 
 type ListItemGraphicProps = {
@@ -14,6 +23,7 @@ type ListItemGraphicProps = {
 };
 
 export const ListItemGraphic = styled(BaseListItemGraphic)<ListItemGraphicProps>`
+    margin-top: 12px;
     color: ${props =>
         props.status === "failure"
             ? "var(--mdc-theme-error)"


### PR DESCRIPTION
## Changes
In this PR, we override the default Material Design `ListItem` components to display long messages rather than truncate the overflowing text. 

This modification is applied solely in the report dialog presented to the user after executing a bulk action.

## Screenshots

### Before
![CleanShot 2025-02-21 at 07 56 04@2x](https://github.com/user-attachments/assets/80a99dfa-e96a-4b5c-8700-3328cf53fa3c)

### After
![CleanShot 2025-02-21 at 07 50 55@2x](https://github.com/user-attachments/assets/4918eef3-398c-4945-97bd-98f5d4494e62)



## How Has This Been Tested?
Manually

