### PR TITLE
refactor: add ContentEntryForm.Header.Meta and ContentEntryForm.Header.Title decoratable components

### DIFF
--- a/packages/app-headless-cms/src/ContentEntryEditorConfig.ts
+++ b/packages/app-headless-cms/src/ContentEntryEditorConfig.ts
@@ -27,9 +27,10 @@ export const ContentEntryEditorConfig = Object.assign(BaseContentEntryEditorConf
         DefaultLayout,
         ContentEntryForm: Object.assign(BaseContentEntryForm, {
             useContentEntryForm,
-            Title: ContentEntryFormTitle,
-            Meta: ContentEntryFormMeta,
-            Header: ContentEntryFormHeader
+            Header: Object.assign(ContentEntryFormHeader, {
+                Title: ContentEntryFormTitle,
+                Meta: ContentEntryFormMeta
+            })
         }),
         ContentEntryFormPreview
     }),

--- a/packages/app-headless-cms/src/ContentEntryEditorConfig.ts
+++ b/packages/app-headless-cms/src/ContentEntryEditorConfig.ts
@@ -16,6 +16,10 @@ import { ContentEntry } from "~/admin/views/contentEntries/ContentEntry";
 import { ContentEntryEditorConfig as BaseContentEntryEditorConfig } from "./admin/config/contentEntries";
 import { SingletonContentEntry } from "~/admin/views/contentEntries/ContentEntry/SingletonContentEntry";
 import { useSingletonContentEntry } from "~/admin/views/contentEntries/hooks/useSingletonContentEntry";
+import {
+    ContentEntryFormMeta,
+    ContentEntryFormTitle
+} from "~/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft";
 
 export const ContentEntryEditorConfig = Object.assign(BaseContentEntryEditorConfig, {
     ContentEntry: Object.assign(ContentEntry, {
@@ -23,6 +27,8 @@ export const ContentEntryEditorConfig = Object.assign(BaseContentEntryEditorConf
         DefaultLayout,
         ContentEntryForm: Object.assign(BaseContentEntryForm, {
             useContentEntryForm,
+            Title: ContentEntryFormTitle,
+            Meta: ContentEntryFormMeta,
             Header: ContentEntryFormHeader
         }),
         ContentEntryFormPreview

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
@@ -12,59 +12,44 @@ import {
     TitleWrapper,
     EntryName
 } from "./FullScreenContentEntry.styled";
-import { CmsContentEntryStatusType, CmsModel } from "@webiny/app-headless-cms-common/types";
 
-export interface ContentEntryFormMetaProps {
-    model: CmsModel;
-    status: CmsContentEntryStatusType;
-}
-
-export const ContentEntryFormMeta = makeDecoratable(
-    "ContentEntryFormMeta",
-    ({ model, status }: ContentEntryFormMetaProps) => {
-        return (
-            <EntryMeta>
-                <Typography use="overline">
-                    {`Model: ${model.name} ${status ? `(status: ${status})` : ""}`}
-                </Typography>
-            </EntryMeta>
-        );
-    }
-);
-
-export interface ContentEntryFormTitleProps {
-    title: string;
-    version: number;
-    newEntry: boolean;
-}
-
-export const ContentEntryFormTitle = makeDecoratable(
-    "ContentEntryFormTitle",
-    ({ newEntry, title, version }: ContentEntryFormTitleProps) => {
-        return (
-            <EntryTitle>
-                <EntryName isNewEntry={newEntry}>{title}</EntryName>
-                {version && <EntryVersion>{`(v${version})`}</EntryVersion>}
-            </EntryTitle>
-        );
-    }
-);
-
-export const FullScreenContentEntryHeaderLeft = () => {
+export const ContentEntryFormMeta = makeDecoratable("ContentEntryFormMeta", () => {
     const { entry, contentModel } = useContentEntry();
-    const { navigateToFolder, currentFolderId } = useNavigateFolder();
+    const status = entry.meta?.status ?? null;
+
+    return (
+        <EntryMeta>
+            <Typography use="overline">
+                {`Model: ${contentModel.name} ${status ? `(status: ${status})` : ""}`}
+            </Typography>
+        </EntryMeta>
+    );
+});
+
+export const ContentEntryFormTitle = makeDecoratable("ContentEntryFormTitle", () => {
+    const { entry, contentModel } = useContentEntry();
 
     const title = entry?.meta?.title || `New ${contentModel.name}`;
     const isNewEntry = !entry.meta?.title;
     const version = entry.meta?.version ?? null;
-    const status = entry.meta?.status ?? null;
+
+    return (
+        <EntryTitle>
+            <EntryName isNewEntry={isNewEntry}>{title}</EntryName>
+            {version && <EntryVersion>{`(v${version})`}</EntryVersion>}
+        </EntryTitle>
+    );
+});
+
+export const FullScreenContentEntryHeaderLeft = () => {
+    const { navigateToFolder, currentFolderId } = useNavigateFolder();
 
     return (
         <>
             <IconButton onClick={() => navigateToFolder(currentFolderId)} icon={<BackIcon />} />
             <TitleWrapper>
-                <ContentEntryFormMeta status={status} model={contentModel} />
-                <ContentEntryFormTitle newEntry={isNewEntry} title={title} version={version} />
+                <ContentEntryFormMeta />
+                <ContentEntryFormTitle />
             </TitleWrapper>
         </>
     );

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ReactComponent as BackIcon } from "@material-design-icons/svg/round/arrow_back.svg";
 import { useNavigateFolder } from "@webiny/app-aco";
+import { makeDecoratable } from "@webiny/react-composition";
 import { IconButton } from "@webiny/ui/Button";
 import { Typography } from "@webiny/ui/Typography";
 import { useContentEntry } from "~/admin/views/contentEntries/hooks";
@@ -11,6 +12,43 @@ import {
     TitleWrapper,
     EntryName
 } from "./FullScreenContentEntry.styled";
+import { CmsContentEntryStatusType, CmsModel } from "@webiny/app-headless-cms-common/types";
+
+export interface ContentEntryFormMetaProps {
+    model: CmsModel;
+    status: CmsContentEntryStatusType;
+}
+
+export const ContentEntryFormMeta = makeDecoratable(
+    "ContentEntryFormMeta",
+    ({ model, status }: ContentEntryFormMetaProps) => {
+        return (
+            <EntryMeta>
+                <Typography use="overline">
+                    {`Model: ${model.name} ${status ? `(status: ${status})` : ""}`}
+                </Typography>
+            </EntryMeta>
+        );
+    }
+);
+
+export interface ContentEntryFormTitleProps {
+    title: string;
+    version: number;
+    newEntry: boolean;
+}
+
+export const ContentEntryFormTitle = makeDecoratable(
+    "ContentEntryFormTitle",
+    ({ newEntry, title, version }: ContentEntryFormTitleProps) => {
+        return (
+            <EntryTitle>
+                <EntryName isNewEntry={newEntry}>{title}</EntryName>
+                {version && <EntryVersion>{`(v${version})`}</EntryVersion>}
+            </EntryTitle>
+        );
+    }
+);
 
 export const FullScreenContentEntryHeaderLeft = () => {
     const { entry, contentModel } = useContentEntry();
@@ -25,15 +63,8 @@ export const FullScreenContentEntryHeaderLeft = () => {
         <>
             <IconButton onClick={() => navigateToFolder(currentFolderId)} icon={<BackIcon />} />
             <TitleWrapper>
-                <EntryMeta>
-                    <Typography use="overline">
-                        {`Model: ${contentModel.name} ${status ? `(status: ${status})` : ""}`}
-                    </Typography>
-                </EntryMeta>
-                <EntryTitle>
-                    <EntryName isNewEntry={isNewEntry}>{title}</EntryName>
-                    {version && <EntryVersion>{`(v${version})`}</EntryVersion>}
-                </EntryTitle>
+                <ContentEntryFormMeta status={status} model={contentModel} />
+                <ContentEntryFormTitle newEntry={isNewEntry} title={title} version={version} />
             </TitleWrapper>
         </>
     );


### PR DESCRIPTION
## Changes
With this PR, we are exposing to third-party developers two new decoratable components:

- `ContentEntryForm.Header.Meta`
- `ContentEntryForm.Header.Title`

![CleanShot 2025-02-26 at 13 54 35@2x](https://github.com/user-attachments/assets/cf60ab12-51d2-4731-8cf4-2ab31fbfe5ca)


## How Has This Been Tested?
Manually
