### PR TITLE
WCP License - Remove Hardcoded `false` For Audit Logs

### DIFF
--- a/packages/app-wcp/src/ReactLicense.ts
+++ b/packages/app-wcp/src/ReactLicense.ts
@@ -17,7 +17,7 @@ export class ReactLicense implements ILicense {
     }
 
     canUseAuditLogs(): boolean {
-        return false;
+        return this.license.canUseAuditLogs();
     }
 
     canUseFeature(featureId: keyof typeof WCP_FEATURE_LABEL): boolean {


### PR DESCRIPTION
Because of a mistake in the 5.42.0 release, the Audit Logs menu item was not visible in the sidebar for users that had this feature enabled.

This issue has been fixed and the Audit Logs menu item is now visible in the sidebar for users that have this feature enabled.