### PR TITLE
refactor(admin-ui): update Text and Heading components to use children prop

### DIFF
--- a/packages/admin-ui/src/Card/components/CardHeader.tsx
+++ b/packages/admin-ui/src/Card/components/CardHeader.tsx
@@ -13,9 +13,17 @@ const CardHeader = ({ title, description, options }: CardHeaderProps) => {
     return (
         <div className={"wby-flex wby-flex-row wby-justify-between"}>
             <div className={"wby-flex wby-flex-col wby-gap-y-xs"}>
-                {typeof title === "string" ? <Heading level={6} as={"h1"} text={title} /> : title}
+                {typeof title === "string" ? (
+                    <Heading level={6} as={"h1"}>
+                        {title}
+                    </Heading>
+                ) : (
+                    title
+                )}
                 {typeof description === "string" ? (
-                    <Text text={description} size="sm" className={"wby-text-neutral-strong"} />
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {description}
+                    </Text>
                 ) : (
                     description
                 )}

--- a/packages/admin-ui/src/DataList/DataList.tsx
+++ b/packages/admin-ui/src/DataList/DataList.tsx
@@ -69,11 +69,9 @@ export const DataList = <TData,>(propsInput: DataListProps<TData>) => {
             <div className={"wby-pt-md-extra wby-pb-md wby-px-md wby-border"}>
                 {(props.title || props.actions) && (
                     <div className={"wby-flex wby-justify-between wby-items-center wby-mb-md-plus"}>
-                        <Heading
-                            className={"wby-text-accent-primary"}
-                            level={4}
-                            text={props.title}
-                        />
+                        <Heading className={"wby-text-accent-primary"} level={4}>
+                            {props.title}
+                        </Heading>
                         <div className={"wby-flex wby-items-center wby-justify-end wby-gap-xs"}>
                             {props.actions}
                         </div>

--- a/packages/admin-ui/src/DataList/DataListWithSections.tsx
+++ b/packages/admin-ui/src/DataList/DataListWithSections.tsx
@@ -69,11 +69,9 @@ export const DataListWithSections = <TData,>(propsInput: DataListProps<TData>) =
             <div className={"wby-pt-md-extra wby-pb-md wby-px-md wby-border"}>
                 {(props.title || props.actions) && (
                     <div className={"wby-flex wby-justify-between wby-items-center"}>
-                        <Heading
-                            className={"wby-text-accent-primary"}
-                            level={4}
-                            text={props.title}
-                        />
+                        <Heading className={"wby-text-accent-primary"} level={4}>
+                            {props.title}
+                        </Heading>
                         <div className={"wby-flex wby-items-center wby-justify-end wby-gap-xs"}>
                             {props.actions}
                         </div>

--- a/packages/admin-ui/src/DataList/components/NoData.tsx
+++ b/packages/admin-ui/src/DataList/components/NoData.tsx
@@ -3,7 +3,7 @@ import { Text } from "~/Text";
 
 const NoData = () => (
     <div className={"wby-text-center wby-p-24"}>
-        <Text text={"No records found."} />
+        <Text>{"No records found."}</Text>
     </div>
 );
 

--- a/packages/admin-ui/src/DataTable/DataTable.stories.tsx
+++ b/packages/admin-ui/src/DataTable/DataTable.stories.tsx
@@ -149,16 +149,16 @@ export const WithCustomCellRenderer: Story<Entry> = {
                             />
                             <div>
                                 <Text
-                                    text={entry.name}
                                     className={"wby-text-neutral-primary wby-font-semibold"}
                                     as={"div"}
-                                />
+                                >
+                                    {entry.name}
+                                </Text>
                                 <Text
-                                    text={`Last updated: ${entry.lastModified}`}
                                     size={"sm"}
                                     className={"wby-text-neutral-strong"}
                                     as={"div"}
-                                />
+                                >{`Last updated: ${entry.lastModified}`}</Text>
                             </div>
                         </div>
                     );

--- a/packages/admin-ui/src/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/admin-ui/src/DropdownMenu/DropdownMenu.stories.tsx
@@ -250,13 +250,10 @@ export const WithCheckboxItems: Story = {
                         checked={level.id === "viewer"}
                         text={
                             <div>
-                                <Text as={"div"} text={level.label} />
-                                <Text
-                                    as={"div"}
-                                    text={level.description}
-                                    size={"sm"}
-                                    className={"wby-text-neutral-strong"}
-                                />
+                                <Text as={"div"}>{level.label}</Text>
+                                <Text as={"div"} size={"sm"} className={"wby-text-neutral-strong"}>
+                                    {level.description}
+                                </Text>
                             </div>
                         }
                         onClick={() => {

--- a/packages/admin-ui/src/FilePicker/primitives/components/previews/ItemDescription.tsx
+++ b/packages/admin-ui/src/FilePicker/primitives/components/previews/ItemDescription.tsx
@@ -22,23 +22,25 @@ const ItemDescription = ({ className, disabled, item, small, ...props }: ItemDes
             {...props}
         >
             <Text
-                text={item.name}
                 size="sm"
                 as="div"
                 className={cn(
                     "wby-truncate wby-overflow-hidden wby-whitespace-nowrap wby-w-full",
                     disabled ? "wby-text-neutral-disabled" : "wby-text-neutral-primary"
                 )}
-            />
+            >
+                {item.name}
+            </Text>
             {!small && (formattedSize || item.mimeType) && (
                 <Text
                     size="sm"
-                    text={[formattedSize, item.mimeType].filter(Boolean).join(" - ")}
                     className={cn(
                         "wby-truncate wby-overflow-hidden wby-whitespace-nowrap wby-w-full",
                         disabled ? "wby-text-neutral-disabled" : "wby-text-neutral-muted"
                     )}
-                />
+                >
+                    {[formattedSize, item.mimeType].filter(Boolean).join(" - ")}
+                </Text>
             )}
         </div>
     );

--- a/packages/admin-ui/src/FormComponent/Description.tsx
+++ b/packages/admin-ui/src/FormComponent/Description.tsx
@@ -13,12 +13,9 @@ const DecoratableFormComponentDescription = (props: FormComponentDescriptionProp
     }
 
     return (
-        <Text
-            text={props.text}
-            size={"sm"}
-            as={"div"}
-            className={"wby-mb-sm wby-text-neutral-strong"}
-        />
+        <Text size={"sm"} as={"div"} className={"wby-mb-sm wby-text-neutral-strong"}>
+            {props.text}
+        </Text>
     );
 };
 

--- a/packages/admin-ui/src/FormComponent/ErrorMessage.tsx
+++ b/packages/admin-ui/src/FormComponent/ErrorMessage.tsx
@@ -15,11 +15,12 @@ const DecoratableFormComponentErrorMessage = (props: FormComponentErrorMessagePr
 
     return (
         <Text
-            text={props.text}
             size={"sm"}
             as={"div"}
             className={"wby-mt-xs wby-text-destructive-primary wby-font-semibold"}
-        />
+        >
+            {props.text}
+        </Text>
     );
 };
 

--- a/packages/admin-ui/src/FormComponent/Note.tsx
+++ b/packages/admin-ui/src/FormComponent/Note.tsx
@@ -12,12 +12,9 @@ const DecoratableFormComponentNote = (props: FormComponentNoteProps) => {
     }
 
     return (
-        <Text
-            text={props.text}
-            size={"sm"}
-            as={"div"}
-            className={"wby-mt-sm wby-text-neutral-strong"}
-        />
+        <Text size={"sm"} as={"div"} className={"wby-mt-sm wby-text-neutral-strong"}>
+            {props.text}
+        </Text>
     );
 };
 

--- a/packages/admin-ui/src/HeaderBar/HeaderBar.stories.tsx
+++ b/packages/admin-ui/src/HeaderBar/HeaderBar.stories.tsx
@@ -23,11 +23,9 @@ export default meta;
 type Story = StoryObj<typeof HeaderBar>;
 
 const StartExample = () => (
-    <Text
-        size={"sm"}
-        className={"wby-text-neutral-dimmed"}
-        text={"Headless CMS / Articles / The best article ever"}
-    />
+    <Text size={"sm"} className={"wby-text-neutral-dimmed"}>
+        {"Headless CMS / Articles / The best article ever"}
+    </Text>
 );
 
 const MiddleExample = () => <>Content in the middle</>;

--- a/packages/admin-ui/src/Heading/Heading.stories.tsx
+++ b/packages/admin-ui/src/Heading/Heading.stories.tsx
@@ -23,41 +23,47 @@ type Story = StoryObj<typeof Heading>;
 export const Heading1: Story = {
     args: {
         level: 1,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const Heading2: Story = {
     args: {
         level: 2,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const Heading3: Story = {
     args: {
         level: 3,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const Heading4: Story = {
     args: {
         level: 4,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const Heading5: Story = {
     args: {
         level: 5,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const Heading6: Story = {
     args: {
         level: 6,
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };

--- a/packages/admin-ui/src/Heading/Heading.tsx
+++ b/packages/admin-ui/src/Heading/Heading.tsx
@@ -34,17 +34,16 @@ interface HeadingProps
     extends React.HTMLAttributes<HTMLHeadingElement>,
         VariantProps<typeof headingVariants> {
     as?: HeadingTags;
-    text: React.ReactNode;
 }
 
-const HeadingBase = ({ level, text, className, as }: HeadingProps) => {
+const HeadingBase = ({ children, level, className, as }: HeadingProps) => {
     // Ensure `level` is a valid number, or fallback to a default value 1
     const validatedLevel = level && level in TAG_MAP ? level : 1;
 
     // Choose the tag: prefer `as`, otherwise use `TAG_MAP[validatedLevel]`
     const Tag = as || TAG_MAP[validatedLevel];
 
-    return <Tag className={cn(headingVariants({ level }), className)}>{text}</Tag>;
+    return <Tag className={cn(headingVariants({ level }), className)}>{children}</Tag>;
 };
 
 const Heading = makeDecoratable("Heading", HeadingBase);

--- a/packages/admin-ui/src/IconPicker/primitives/components/IconPickerGrid.tsx
+++ b/packages/admin-ui/src/IconPicker/primitives/components/IconPickerGrid.tsx
@@ -55,9 +55,10 @@ const IconPickerGrid = (props: IconPickerGridProps) => {
                     <Text
                         as={"div"}
                         size={"sm"}
-                        text={item.name}
                         className={"wby-w-full wby-truncate wby-text-center wby-text-neutral-muted"}
-                    />
+                    >
+                        {item.name}
+                    </Text>
                 </div>
             );
         };
@@ -67,7 +68,7 @@ const IconPickerGrid = (props: IconPickerGridProps) => {
         <div>
             {props.iconsLength === 0 ? (
                 <div className={`wby-px-sm-extra wby-py-md wby-text-neutral-strong`}>
-                    <Text text={"No results found."} />
+                    <Text>{"No results found."}</Text>
                 </div>
             ) : (
                 <Grid

--- a/packages/admin-ui/src/Label/components/LabelDescription.tsx
+++ b/packages/admin-ui/src/Label/components/LabelDescription.tsx
@@ -15,7 +15,9 @@ interface LabelDescriptionProps extends VariantProps<typeof labelDescriptionVari
 }
 
 const LabelDescription = ({ content, disabled }: LabelDescriptionProps) => (
-    <Text className={cn(labelDescriptionVariants({ disabled }))} text={content} size={"sm"} />
+    <Text className={cn(labelDescriptionVariants({ disabled }))} size={"sm"}>
+        {content}
+    </Text>
 );
 
 export { LabelDescription, type LabelDescriptionProps };

--- a/packages/admin-ui/src/Label/components/LabelValue.tsx
+++ b/packages/admin-ui/src/Label/components/LabelValue.tsx
@@ -22,7 +22,9 @@ interface LabelValueProps extends VariantProps<typeof labelValueVariants> {
 }
 
 const LabelValue = ({ value, weight, disabled }: LabelValueProps) => (
-    <Text text={value} size="sm" className={cn(labelValueVariants({ weight, disabled }))} />
+    <Text size="sm" className={cn(labelValueVariants({ weight, disabled }))}>
+        {value}
+    </Text>
 );
 
 export { LabelValue, type LabelValueProps };

--- a/packages/admin-ui/src/Link/Link.stories.tsx
+++ b/packages/admin-ui/src/Link/Link.stories.tsx
@@ -72,22 +72,13 @@ export const InheritedSize: Story = {
     name: "Link with inherited size",
     render: linkProps => {
         return (
-            <Text
-                text={
-                    <>
-                        <Text
-                            size="lg"
-                            text={
-                                <>
-                                    Size of this text is set to large, so,&nbsp;
-                                    <Link {...linkProps}>this link&apos;s</Link> size is also
-                                    automatically set to large.
-                                </>
-                            }
-                        />
-                    </>
-                }
-            />
+            <Text>
+                <Text size="lg">
+                    Size of this text is set to large, so,&nbsp;
+                    <Link {...linkProps}>this link&apos;s</Link> size is also automatically set to
+                    large.
+                </Text>
+            </Text>
         );
     },
     args: {
@@ -116,14 +107,10 @@ export const PrimaryNegative: Story = {
     ],
     render: args => {
         return (
-            <Text
-                text={
-                    <>
-                        Lorem <Link {...args}>ipsum dolor sit amet</Link>, consectetur adipiscing
-                        elit. Fusce tempus tortor eu sapien interdum rhoncus.
-                    </>
-                }
-            />
+            <Text>
+                Lorem <Link {...args}>ipsum dolor sit amet</Link>, consectetur adipiscing elit.
+                Fusce tempus tortor eu sapien interdum rhoncus.
+            </Text>
         );
     },
     args: {
@@ -142,14 +129,10 @@ export const SecondaryNegative: Story = {
     ],
     render: args => {
         return (
-            <Text
-                text={
-                    <>
-                        Lorem <Link {...args}>ipsum dolor sit amet</Link>, consectetur adipiscing
-                        elit. Fusce tempus tortor eu sapien interdum rhoncus.
-                    </>
-                }
-            />
+            <Text>
+                Lorem <Link {...args}>ipsum dolor sit amet</Link>, consectetur adipiscing elit.
+                Fusce tempus tortor eu sapien interdum rhoncus.
+            </Text>
         );
     },
     args: {

--- a/packages/admin-ui/src/List/components/ListItem.tsx
+++ b/packages/admin-ui/src/List/components/ListItem.tsx
@@ -73,16 +73,14 @@ const DecoratableListItem = ({
                     >
                         <Text
                             size={"md"}
-                            text={title}
                             as={"div"}
                             className={"wby-font-semibold wby-text-neutral-primary"}
-                        />
-                        <Text
-                            size={"sm"}
-                            text={description}
-                            as={"div"}
-                            className={"wby-text-neutral-strong"}
-                        />
+                        >
+                            {title}
+                        </Text>
+                        <Text size={"sm"} as={"div"} className={"wby-text-neutral-strong"}>
+                            {description}
+                        </Text>
                     </div>
                 </div>
                 {actions && (

--- a/packages/admin-ui/src/Loader/Loader.tsx
+++ b/packages/admin-ui/src/Loader/Loader.tsx
@@ -126,11 +126,9 @@ const DecoratableLoader = ({
                 </svg>
             </div>
             {text && (
-                <Text
-                    text={text}
-                    as={"div"}
-                    className={"wby-text-neutral-strong wby-w-full wby-pt-sm-plus"}
-                />
+                <Text as={"div"} className={"wby-text-neutral-strong wby-w-full wby-pt-sm-plus"}>
+                    {text}
+                </Text>
             )}
         </div>
     );

--- a/packages/admin-ui/src/RadioGroup/primitives/RadioGroupPrimitive.stories.tsx
+++ b/packages/admin-ui/src/RadioGroup/primitives/RadioGroupPrimitive.stories.tsx
@@ -145,7 +145,7 @@ export const WithComplexOptions: Story = {
                 label: (
                     <div>
                         <div>{"Value 1"}</div>
-                        <Text text={"Option description 1"} size={"sm"} />
+                        <Text size={"sm"}>{"Option description 1"}</Text>
                     </div>
                 )
             },
@@ -155,7 +155,7 @@ export const WithComplexOptions: Story = {
                 label: (
                     <div>
                         <div>{"Value 2"}</div>
-                        <Text text={"Option description 2"} size={"sm"} />
+                        <Text size={"sm"}>{"Option description 2"}</Text>
                     </div>
                 )
             },
@@ -165,7 +165,7 @@ export const WithComplexOptions: Story = {
                 label: (
                     <div>
                         <div>{"Value 3"}</div>
-                        <Text text={"Option description 3"} size={"sm"} />
+                        <Text size={"sm"}>{"Option description 3"}</Text>
                     </div>
                 )
             }

--- a/packages/admin-ui/src/Separator/Separator.stories.tsx
+++ b/packages/admin-ui/src/Separator/Separator.stories.tsx
@@ -31,16 +31,14 @@ export const Default: Story = {
         return (
             <div>
                 <div className="wby-space-y-1">
-                    <Heading level={6} text={"This is a heading."} />
-                    <Text
-                        text={"This is a short description here"}
-                        size="sm"
-                        className={"wby-text-neutral-strong"}
-                    />
+                    <Heading level={6}>{"This is a heading."}</Heading>
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {"This is a short description here"}
+                    </Text>
                 </div>
                 <Separator margin={props.margin} variant={props.variant} />
                 <div className="wby-flex wby-items-center wby-h-6 wby-text-sm">
-                    <Text text={"This is text 1."} />
+                    <Text>{"This is text 1."}</Text>
                 </div>
             </div>
         );
@@ -62,20 +60,18 @@ export const VerticalAndHorizontal: Story = {
         return (
             <div>
                 <div className="wby-space-y-1">
-                    <Heading level={6} text={"This is a heading."} />
-                    <Text
-                        text={"This is a short description here"}
-                        size="sm"
-                        className={"wby-text-neutral-strong"}
-                    />
+                    <Heading level={6}>{"This is a heading."}</Heading>
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {"This is a short description here"}
+                    </Text>
                 </div>
                 <Separator margin={"lg"} />
                 <div className="wby-flex wby-items-center wby-h-6 wby-text-sm">
-                    <Text text={"This is text 1."} />
+                    <Text>{"This is text 1."}</Text>
                     <Separator orientation="vertical" margin={"lg"} />
-                    <Text text={"This is text 2."} />
+                    <Text>{"This is text 2."}</Text>
                     <Separator orientation="vertical" margin={"lg"} />
-                    <Text text={"This is text 3."} />
+                    <Text>{"This is text 3."}</Text>
                 </div>
             </div>
         );
@@ -90,16 +86,14 @@ export const HorizontalOrientation: Story = {
         return (
             <div>
                 <div className="wby-space-y-1">
-                    <Heading level={6} text={"This is a heading."} />
-                    <Text
-                        text={"This is a short description here"}
-                        size="sm"
-                        className={"wby-text-neutral-strong"}
-                    />
+                    <Heading level={6}>{"This is a heading."}</Heading>
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {"This is a short description here"}
+                    </Text>
                 </div>
                 <Separator margin={"lg"} />
                 <div className="wby-flex wby-items-center wby-h-6 wby-text-sm">
-                    <Text text={"This is text 1."} />
+                    <Text>{"This is text 1."}</Text>
                 </div>
             </div>
         );
@@ -113,11 +107,11 @@ export const VerticalOrientation: Story = {
     render: () => {
         return (
             <div className="wby-flex wby-justify-center wby-h-6 wby-text-sm">
-                <Text text={"This is text 1."} />
+                <Text>{"This is text 1."}</Text>
                 <Separator orientation="vertical" margin={"lg"} />
-                <Text text={"This is text 2."} />
+                <Text>{"This is text 2."}</Text>
                 <Separator orientation="vertical" margin={"lg"} />
-                <Text text={"This is text 3."} />
+                <Text>{"This is text 3."}</Text>
             </div>
         );
     }
@@ -128,20 +122,18 @@ export const LessMargin: Story = {
         return (
             <div>
                 <div className="wby-space-y-1">
-                    <Heading level={6} text={"This is a heading."} />
-                    <Text
-                        text={"This is a short description here"}
-                        size="sm"
-                        className={"wby-text-neutral-strong"}
-                    />
+                    <Heading level={6}>{"This is a heading."}</Heading>
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {"This is a short description here"}
+                    </Text>
                 </div>
                 <Separator margin={"md"} />
                 <div className="wby-flex wby-items-center wby-h-6 wby-text-sm">
-                    <Text text={"This is text 1."} />
+                    <Text>{"This is text 1."}</Text>
                     <Separator orientation="vertical" margin={"md"} />
-                    <Text text={"This is text 2."} />
+                    <Text>{"This is text 2."}</Text>
                     <Separator orientation="vertical" margin={"md"} />
-                    <Text text={"This is text 3."} />
+                    <Text>{"This is text 3."}</Text>
                 </div>
             </div>
         );
@@ -153,20 +145,18 @@ export const MoreMargin: Story = {
         return (
             <div>
                 <div className="wby-space-y-1">
-                    <Heading level={6} text={"This is a heading."} />
-                    <Text
-                        text={"This is a short description here"}
-                        size="sm"
-                        className={"wby-text-neutral-strong"}
-                    />
+                    <Heading level={6}>{"This is a heading."}</Heading>
+                    <Text size="sm" className={"wby-text-neutral-strong"}>
+                        {"This is a short description here"}
+                    </Text>
                 </div>
                 <Separator margin={"xl"} />
                 <div className="wby-flex wby-items-center wby-h-6 wby-text-sm">
-                    <Text text={"This is text 1."} />
+                    <Text>{"This is text 1."}</Text>
                     <Separator orientation="vertical" margin={"xl"} />
-                    <Text text={"This is text 2."} />
+                    <Text>{"This is text 1."}</Text>
                     <Separator orientation="vertical" margin={"xl"} />
-                    <Text text={"This is text 3."} />
+                    <Text>{"This is text 1."}</Text>
                 </div>
             </div>
         );

--- a/packages/admin-ui/src/Slider/primitives/components/SliderTooltip.tsx
+++ b/packages/admin-ui/src/Slider/primitives/components/SliderTooltip.tsx
@@ -33,7 +33,9 @@ const SliderTooltip = ({ textValue, showTooltip, tooltipSide }: SliderTooltipPro
 
     return (
         <div className={cn(sliderTooltipVariants({ side: tooltipSide }))}>
-            <Text text={textValue} size={"sm"} as={"div"} />
+            <Text size={"sm"} as={"div"}>
+                {textValue}
+            </Text>
         </div>
     );
 };

--- a/packages/admin-ui/src/Text/Text.stories.tsx
+++ b/packages/admin-ui/src/Text/Text.stories.tsx
@@ -17,27 +17,31 @@ type Story = StoryObj<typeof Text>;
 export const TextXl: Story = {
     args: {
         size: "xl",
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const TextLg: Story = {
     args: {
         size: "lg",
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const TextMd: Story = {
     args: {
         size: "md",
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };
 
 export const TextSm: Story = {
     args: {
         size: "sm",
-        text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
+        children:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus tortor eu sapien interdum rhoncus."
     }
 };

--- a/packages/admin-ui/src/Text/Text.tsx
+++ b/packages/admin-ui/src/Text/Text.tsx
@@ -19,11 +19,10 @@ const textVariants = cva("wby-font-sans", {
 
 interface TextProps extends React.HTMLAttributes<HTMLElement>, VariantProps<typeof textVariants> {
     as?: TextTags;
-    text: React.ReactNode;
 }
 
-const TextBase = ({ size, text, className, as: Tag = "span" }: TextProps) => {
-    return <Tag className={cn(textVariants({ size }), className)}>{text}</Tag>;
+const TextBase = ({ children, size, className, as: Tag = "span" }: TextProps) => {
+    return <Tag className={cn(textVariants({ size }), className)}>{children}</Tag>;
 };
 
 const Text = makeDecoratable("Text", TextBase);

--- a/packages/admin-ui/src/Toast/components/ToastDescription.tsx
+++ b/packages/admin-ui/src/Toast/components/ToastDescription.tsx
@@ -14,7 +14,9 @@ const DecoratableToastDescription = ({ text, className, ...props }: DescriptionP
             className
         )}
     >
-        <Text text={text} as={"div"} size={"md"} className={"wby-text-neutral-dimmed"} />
+        <Text as={"div"} size={"md"} className={"wby-text-neutral-dimmed"}>
+            {text}
+        </Text>
     </div>
 );
 

--- a/packages/admin-ui/src/Toast/components/ToastTitle.tsx
+++ b/packages/admin-ui/src/Toast/components/ToastTitle.tsx
@@ -14,7 +14,7 @@ const DecoratableToastTitle = ({ text, className, ...props }: ToastTitleProps) =
             className
         )}
     >
-        <Heading level={6} text={text} />
+        <Heading level={6}>{text}</Heading>
     </div>
 );
 

--- a/packages/app-aco/src/dialogs/DialogSetPermissions/UsersTeamsSelection/ListItemMeta.tsx
+++ b/packages/app-aco/src/dialogs/DialogSetPermissions/UsersTeamsSelection/ListItemMeta.tsx
@@ -105,13 +105,14 @@ export const ListItemMeta = ({
                             checked={currentLevel.id === level.id}
                             text={
                                 <div>
-                                    <Text as={"div"} text={level.label} />
+                                    <Text as={"div"}>{level.label}</Text>
                                     <Text
                                         as={"div"}
-                                        text={level.description}
                                         size={"sm"}
                                         className={"wby-text-neutral-strong"}
-                                    />
+                                    >
+                                        {level.description}
+                                    </Text>
                                 </div>
                             }
                             onClick={() => {

--- a/packages/app-admin/src/components/IconPicker/IconPickerTab.tsx
+++ b/packages/app-admin/src/components/IconPicker/IconPickerTab.tsx
@@ -86,9 +86,10 @@ const RowRenderer = ({ row, style, cellDecorator, onIconClick }: RenderRowProps)
             <IconPickerRow style={style}>
                 <Text
                     size={"sm"}
-                    text={row.name}
                     className={"wby-uppercase wby-self-end wby-text-neutral-muted wby-mb-sm"}
-                />
+                >
+                    {row.name}
+                </Text>
             </IconPickerRow>
         );
     }
@@ -169,7 +170,7 @@ export const IconPickerTab = ({
                     <div className={"wby-relative"}>
                         {isEmpty ? (
                             <div className={"wby-pt-md wby-text-neutral-strong"}>
-                                <Text text={"No results found."} />
+                                <Text>{"No results found."}</Text>
                             </div>
                         ) : (
                             <List

--- a/packages/ui/src/Typography/Typography.tsx
+++ b/packages/ui/src/Typography/Typography.tsx
@@ -46,10 +46,18 @@ const Typography = (props: TypographyProps) => {
 
     if (use in headingLevelMap) {
         const level = headingLevelMap[use];
-        return <Heading level={level} text={children} className={className} />;
+        return (
+            <Heading level={level} className={className}>
+                {children}
+            </Heading>
+        );
     }
 
-    return <Text size={"md"} text={children} className={className} />;
+    return (
+        <Text size={"md"} className={className}>
+            {children}
+        </Text>
+    );
 };
 
 export { Typography, TypographyProps };


### PR DESCRIPTION
## Changes  
With this PR, we are refactoring the `Text` and `Heading` components, deprecating the `text` prop in favor of the default `children` prop.  

### Motivations  
- **Improved Developer Experience** – Using the `children` prop aligns with standard React patterns, making the API more intuitive and reducing the cognitive load for developers.  
- **Better Flexibility** – The `children` prop allows for greater flexibility, such as supporting rich text, inline elements, and nested components (e.g., `<Text><strong>Bold text</strong></Text>`), which the `text` prop does not handle well.  
