### PR TITLE
fix(api-aco): `extensions` default model field

### DIFF
--- a/packages/api-aco/src/folder/folder.model.ts
+++ b/packages/api-aco/src/folder/folder.model.ts
@@ -116,6 +116,7 @@ const permissionsField = () =>
 const extensionsField = () =>
     createModelField({
         label: "Extensions",
+        fieldId: "extensions",
         type: "object",
         settings: {
             layout: [],

--- a/packages/api-aco/src/folder/folder.model.ts
+++ b/packages/api-aco/src/folder/folder.model.ts
@@ -113,6 +113,16 @@ const permissionsField = () =>
         }
     });
 
+const extensionsField = () =>
+    createModelField({
+        label: "Extensions",
+        type: "object",
+        settings: {
+            layout: [],
+            fields: []
+        }
+    });
+
 export const FOLDER_MODEL_ID = "acoFolder";
 
 export const createFolderModel = () => {
@@ -127,6 +137,13 @@ export const createFolderModel = () => {
             // flp: true
         },
         titleFieldId: "title",
-        fields: [titleField(), slugField(), typeField(), parentIdField(), permissionsField()]
+        fields: [
+            titleField(),
+            slugField(),
+            typeField(),
+            parentIdField(),
+            permissionsField(),
+            extensionsField()
+        ]
     });
 };

--- a/packages/app-headless-cms-common/src/createFieldsList.ts
+++ b/packages/app-headless-cms-common/src/createFieldsList.ts
@@ -50,7 +50,7 @@ export function createFieldsList({
      * If there are no fields, let's always load the `id` field.
      */
     if (fields.length === 0) {
-        fields.push("id");
+        fields.push("_empty");
     }
     return fields.join("\n");
 }

--- a/packages/app-headless-cms-common/src/createFieldsList.ts
+++ b/packages/app-headless-cms-common/src/createFieldsList.ts
@@ -47,7 +47,7 @@ export function createFieldsList({
         })
         .filter(Boolean);
     /**
-     * If there are no fields, let's always load the `id` field.
+     * If there are no fields, let's always load the `_empty` field.
      */
     if (fields.length === 0) {
         fields.push("_empty");


### PR DESCRIPTION
## Changes
With this PR, we add the `extensions` field to the model definition. Consequently, `extensions` will always be defined as an empty object, even when no extensions are registered through the plugin.

## How Has This Been Tested?
Jest + Manually
