### PR TITLE
fix: handle notification error during deployment on Apple M4

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/utils/notify.js
+++ b/packages/cli-plugin-deploy-pulumi/utils/notify.js
@@ -12,5 +12,8 @@ module.exports = ({ message }) => {
         });
 
         setTimeout(resolve, 100);
+    }).catch(() => {
+        // Suppress any unexpected promise rejections to ensure smooth user experience.
+        // Notification errors are non-critical and can be safely ignored.
     });
 };


### PR DESCRIPTION
## Changes
On an Apple M4 machine, while running the deploy command, the deployment was successful, but the CLI displayed an error caused by the notifier. Since notification errors are non-critical and do not affect the deployment outcome, they are now caught and safely ignored.

## How Has This Been Tested?

Manually. I deployed the `webiny-js` repository project with this code, and the deployment completed successfully without any errors.

Thank you, @Pavel910, for your inputs!
