### PR TITLE
Page Builder / Button Page Element - Add `scrollToElement` Input

### DIFF
--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -206,7 +206,6 @@ export const ButtonRenderer = createRenderer<Props, typeof elementInputs>(
 
         // In the editor, we don't want to have buttons clickable.
         if (isEditor) {
-            console.log("noo");
             return <StyledButtonBody>{buttonInnerContent}</StyledButtonBody>;
         }
 

--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -97,6 +97,7 @@ export interface ButtonElementData {
 export interface Props {
     linkComponent?: LinkComponent;
     clickHandlers?: Array<ButtonClickHandler>;
+    isEditor?: boolean;
 }
 
 export const elementInputs = {
@@ -157,6 +158,7 @@ export const elementInputs = {
 export const ButtonRenderer = createRenderer<Props, typeof elementInputs>(
     props => {
         const LinkComponent = props.linkComponent || DefaultLinkComponent;
+        const { isEditor } = props;
         const { getElement, getInputValues } = useRenderer();
         const element = getElement<ButtonElementData>();
         const inputs = getInputValues<typeof elementInputs>();
@@ -201,6 +203,12 @@ export const ButtonRenderer = createRenderer<Props, typeof elementInputs>(
         const isLinkAction = useMemo(() => {
             return link?.href || ["link", "scrollToElement"].includes(action?.actionType);
         }, [link?.href, action?.actionType]);
+
+        // In the editor, we don't want to have buttons clickable.
+        if (isEditor) {
+            console.log("noo");
+            return <StyledButtonBody>{buttonInnerContent}</StyledButtonBody>;
+        }
 
         if (isLinkAction) {
             let href = "";

--- a/packages/app-page-builder-elements/src/renderers/button.tsx
+++ b/packages/app-page-builder-elements/src/renderers/button.tsx
@@ -143,6 +143,14 @@ export const elementInputs = {
         getDefaultValue: ({ element }) => {
             return element.data.action?.href;
         }
+    }),
+    actionScrollToElement: ElementInput.create<ButtonElementData["action"]["scrollToElement"]>({
+        name: "actionHref",
+        type: "link",
+        translatable: true,
+        getDefaultValue: ({ element }) => {
+            return element.data.action?.scrollToElement;
+        }
     })
 };
 
@@ -160,7 +168,8 @@ export const ButtonRenderer = createRenderer<Props, typeof elementInputs>(
         const action: ButtonElementData["action"] = {
             href: inputs.actionHref || "",
             newTab: inputs.actionNewTab || false,
-            actionType: inputs.actionType || "link"
+            actionType: inputs.actionType || "link",
+            scrollToElement: inputs.actionScrollToElement
         };
 
         let StyledButtonBody = ButtonBody;

--- a/packages/app-page-builder/src/editor/plugins/elements/button/index.tsx
+++ b/packages/app-page-builder/src/editor/plugins/elements/button/index.tsx
@@ -79,7 +79,7 @@ const buttonElementPluginsFactory = (args: PbEditorElementPluginArgs = {}) => {
                 return typeof args.create === "function" ? args.create(defaultValue) : defaultValue;
             },
             render({ element, ...rest }) {
-                return <ButtonRenderer element={element as Element} {...rest} />;
+                return <ButtonRenderer element={element as Element} {...rest} isEditor />;
             }
         } as PbEditorPageElementPlugin,
         {


### PR DESCRIPTION
## Changes

We're adding the `scrollToElement` input and making sure it's correctly passed when constructing the link's `href` attribute.

## How Has This Been Tested?

Manual testing.

## Documentation

Changelog.
