### PR TITLE
Fix listPackages and watch command

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/commands/newWatch/listPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/newWatch/listPackages.js
@@ -19,6 +19,7 @@ const listPackages = async ({ inputs }) => {
         packagesList.push(...webinyPrefixedPackagesToAdd);
     } else {
         packagesList = await execa("yarn", [
+            "--silent",
             "webiny",
             "workspaces",
             "tree",
@@ -32,6 +33,7 @@ const listPackages = async ({ inputs }) => {
     }
 
     const commandArgs = [
+        "--silent",
         "webiny",
         "workspaces",
         "list",

--- a/packages/cli-plugin-deploy-pulumi/commands/watch/listPackages.js
+++ b/packages/cli-plugin-deploy-pulumi/commands/watch/listPackages.js
@@ -7,6 +7,7 @@ const listPackages = async ({ inputs }) => {
         packagesList = Array.isArray(inputs.package) ? inputs.package : [inputs.package];
     } else {
         packagesList = await execa("yarn", [
+            "--silent",
             "webiny",
             "workspaces",
             "tree",
@@ -20,6 +21,7 @@ const listPackages = async ({ inputs }) => {
     }
 
     const commandArgs = [
+        "--silent",
         "webiny",
         "workspaces",
         "list",


### PR DESCRIPTION
## Changes
Added --silent option to yarn commands so the output doesn't have unnecessary lines that starts with $
![image](https://github.com/user-attachments/assets/58150482-0959-4d30-8e3e-6b9f2db45a1b)

Closes #4608

## How Has This Been Tested?
Manually
