### PR TITLE
FLP - Improved Permissions Inheritance

### DIFF
--- a/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
+++ b/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
@@ -128,7 +128,7 @@ describe("DefaultPermissionsMerger", () => {
             ],
             [
                 { level: "viewer", target: "admin:1" },
-                { level: "owner", target: "admin:2" },
+                { level: "owner", target: "admin:2" }
             ]
         );
 
@@ -140,7 +140,7 @@ describe("DefaultPermissionsMerger", () => {
             ],
             [
                 { level: "editor", target: "admin:1" },
-                { level: "owner", target: "admin:2" },
+                { level: "owner", target: "admin:2" }
             ]
         );
     });
@@ -175,7 +175,7 @@ describe("DefaultPermissionsMerger", () => {
                 level: "owner",
                 target: "admin:1"
             },
-            { level: "owner", target: "admin:2" },
+            { level: "owner", target: "admin:2" }
         ]);
     });
 });

--- a/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
+++ b/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
@@ -127,8 +127,8 @@ describe("DefaultPermissionsMerger", () => {
                 { target: "admin:2", level: "owner" }
             ],
             [
+                { level: "viewer", target: "admin:1" },
                 { level: "owner", target: "admin:2" },
-                { level: "viewer", target: "admin:1" }
             ]
         );
 
@@ -139,8 +139,8 @@ describe("DefaultPermissionsMerger", () => {
                 { target: "admin:2", level: "owner" }
             ],
             [
+                { level: "editor", target: "admin:1" },
                 { level: "owner", target: "admin:2" },
-                { level: "editor", target: "admin:1" }
             ]
         );
     });
@@ -170,12 +170,12 @@ describe("DefaultPermissionsMerger", () => {
         );
 
         expect(result).toEqual([
-            { level: "owner", target: "admin:2" },
             {
                 inheritedFrom: "role:full-access",
                 level: "owner",
                 target: "admin:1"
-            }
+            },
+            { level: "owner", target: "admin:2" },
         ]);
     });
 });

--- a/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
+++ b/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
@@ -56,7 +56,7 @@ describe("DefaultPermissionsMerger", () => {
         );
     });
 
-    it("no-access level can be overridden only if an owner level has been assigned", async () => {
+    it("no-access permission cannot be overridden", async () => {
         expectMergeToEqual(
             [
                 { target: "admin:1", level: "no-access" },
@@ -92,9 +92,34 @@ describe("DefaultPermissionsMerger", () => {
                 { level: "no-access", target: "admin:1" }
             ]
         );
+
+        // parent-inherited `no-access` permission also cannot be overridden.
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1", inheritedFrom: "parent:xyz" }
+            ]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "owner" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1", inheritedFrom: "parent:xyz" }
+            ]
+        );
     });
 
-    it("permissions inherited from parent are overridden by new permissions", async () => {
+    it("permissions inherited from parent can be overridden by new permissions", async () => {
         expectMergeToEqual(
             [
                 { target: "admin:1", level: "editor", inheritedFrom: "parent:xyz" },
@@ -116,32 +141,6 @@ describe("DefaultPermissionsMerger", () => {
             [
                 { level: "owner", target: "admin:2" },
                 { level: "editor", target: "admin:1" }
-            ]
-        );
-    });
-
-    it("parent-inherited `no-access` permission cannot only be overridden by `owner` permission", async () => {
-        expectMergeToEqual(
-            [
-                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
-                { target: "admin:1", level: "viewer" },
-                { target: "admin:2", level: "owner" }
-            ],
-            [
-                { level: "owner", target: "admin:2" },
-                { level: "no-access", target: "admin:1", inheritedFrom: "parent:xyz" }
-            ]
-        );
-
-        expectMergeToEqual(
-            [
-                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
-                { target: "admin:1", level: "owner" },
-                { target: "admin:2", level: "owner" }
-            ],
-            [
-                { level: "owner", target: "admin:2" },
-                { inheritedFrom: "parent:xyz", level: "no-access", target: "admin:1" }
             ]
         );
     });

--- a/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
+++ b/packages/api-aco/__tests__/defaultPermissionsMerger.test.ts
@@ -1,0 +1,182 @@
+import { DefaultPermissionsMerger } from "~/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger";
+import { createIdentity } from "./utils/identity";
+import { SecurityPermission } from "@webiny/api-security/types";
+import { FolderPermission } from "~/flp/flp.types";
+
+const identity1 = createIdentity({ id: "1", type: "admin", displayName: "Identity 1" });
+
+const merge = (
+    folderPermissions: FolderPermission[],
+    userPermissions: SecurityPermission[] = []
+) => {
+    return DefaultPermissionsMerger.merge(identity1, userPermissions, folderPermissions);
+};
+
+const expectMergeToEqual = (permissions: FolderPermission[], result: FolderPermission[]) => {
+    const merged = merge(permissions);
+    expect(merged).toEqual(result);
+};
+
+describe("DefaultPermissionsMerger", () => {
+    it("when comparing different permissions, the most permissive one wins", async () => {
+        // This is just a basic test that ensures the following: no-access > owner > editor > viewer.
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:1", level: "editor" }
+            ],
+            [{ level: "no-access", target: "admin:1" }]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:1", level: "editor" },
+                { target: "admin:1", level: "owner" }
+            ],
+            [{ level: "no-access", target: "admin:1" }]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:1", level: "editor" }
+            ],
+            [{ level: "editor", target: "admin:1" }]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "editor" },
+                { target: "admin:1", level: "owner" }
+            ],
+            [{ level: "owner", target: "admin:1" }]
+        );
+    });
+
+    it("no-access level can be overridden only if an owner level has been assigned", async () => {
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1" }
+            ]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "editor" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1" }
+            ]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "owner" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1" }
+            ]
+        );
+    });
+
+    it("permissions inherited from parent are overridden by new permissions", async () => {
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "editor", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "viewer", target: "admin:1" }
+            ]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "viewer", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "editor" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "editor", target: "admin:1" }
+            ]
+        );
+    });
+
+    it("parent-inherited `no-access` permission cannot only be overridden by `owner` permission", async () => {
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1", inheritedFrom: "parent:xyz" }
+            ]
+        );
+
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "no-access", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "owner" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { inheritedFrom: "parent:xyz", level: "no-access", target: "admin:1" }
+            ]
+        );
+    });
+
+    it("parent-inherited `owner` permission can be overridden", async () => {
+        expectMergeToEqual(
+            [
+                { target: "admin:1", level: "owner", inheritedFrom: "parent:xyz" },
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [
+                { level: "owner", target: "admin:2" },
+                { level: "no-access", target: "admin:1" }
+            ]
+        );
+    });
+
+    it("if a u user has `full-access` permission, then they're an `owner` of all folders", async () => {
+        const result = merge(
+            [
+                { target: "admin:1", level: "no-access" },
+                { target: "admin:1", level: "viewer" },
+                { target: "admin:2", level: "owner" }
+            ],
+            [{ name: "*" }]
+        );
+
+        expect(result).toEqual([
+            { level: "owner", target: "admin:2" },
+            {
+                inheritedFrom: "role:full-access",
+                level: "owner",
+                target: "admin:1"
+            }
+        ]);
+    });
+});

--- a/packages/api-aco/__tests__/flp.tasks.test.ts
+++ b/packages/api-aco/__tests__/flp.tasks.test.ts
@@ -499,13 +499,13 @@ describe("Folder Level Permissions -  UPDATE FLP - Complex", () => {
             path: `${ROOT_FOLDER}/${mainFolder.slug}/${branch1.slug}/${branch1Subfolder.slug}`,
             permissions: [
                 {
-                    target: "admin:user1",
-                    level: "viewer",
+                    target: "admin:user2",
+                    level: "editor",
                     inheritedFrom: `parent:${branch1.id}`
                 },
                 {
-                    target: "admin:user2",
-                    level: "editor",
+                    target: "admin:user1",
+                    level: "viewer",
                     inheritedFrom: `parent:${branch1.id}`
                 }
             ]

--- a/packages/api-aco/__tests__/flp.tasks.test.ts
+++ b/packages/api-aco/__tests__/flp.tasks.test.ts
@@ -499,13 +499,13 @@ describe("Folder Level Permissions -  UPDATE FLP - Complex", () => {
             path: `${ROOT_FOLDER}/${mainFolder.slug}/${branch1.slug}/${branch1Subfolder.slug}`,
             permissions: [
                 {
-                    target: "admin:user2",
-                    level: "editor",
+                    target: "admin:user1",
+                    level: "viewer",
                     inheritedFrom: `parent:${branch1.id}`
                 },
                 {
-                    target: "admin:user1",
-                    level: "viewer",
+                    target: "admin:user2",
+                    level: "editor",
                     inheritedFrom: `parent:${branch1.id}`
                 }
             ]

--- a/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
+++ b/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
@@ -303,4 +303,160 @@ describe("Folder Level Permissions - Inheritance", () => {
             ]
         });
     });
+
+    it("removing parent permissions should be reflected in child folders", async () => {
+        const folderA = await aco
+            .createFolder({
+                data: {
+                    title: "Folder A",
+                    slug: "folder-a",
+                    type: FOLDER_TYPE,
+                    permissions: [
+                        { level: "viewer", target: `team:test-team-1` },
+                        { level: "editor", target: `team:test-team-2` }
+                    ]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderB = await aco
+            .createFolder({
+                data: {
+                    title: "Folder B",
+                    slug: "folder-b",
+                    type: FOLDER_TYPE,
+                    parentId: folderA.id,
+                    permissions: [
+                        { level: "viewer", target: `team:test-team-2` },
+                        { level: "editor", target: `team:test-team-1` }
+                    ]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderC = await aco
+            .createFolder({
+                data: {
+                    title: "Folder C",
+                    slug: "folder-c",
+                    type: FOLDER_TYPE,
+                    parentId: folderB.id,
+                    permissions: [{ level: "owner", target: `team:test-team-2` }]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        let refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "owner",
+                    inheritedFrom: null
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "editor",
+                    inheritedFrom: `parent:${folderB.id}`
+                }
+            ]
+        });
+
+        await aco.updateFolder({
+            id: folderC.id,
+            data: {
+                permissions: []
+            }
+        });
+
+        refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "editor",
+                    inheritedFrom: `parent:${folderB.id}`
+                }
+            ]
+        });
+
+        await aco.updateFolder({
+            id: folderB.id,
+            data: {
+                permissions: []
+            }
+        });
+
+        refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "editor",
+                    inheritedFrom: `parent:${folderB.id}`
+                }
+            ]
+        });
+
+        await aco.updateFolder({
+            id: folderA.id,
+            data: {
+                permissions: []
+            }
+        });
+
+        refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                }
+            ]
+        });
+    });
 });

--- a/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
+++ b/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
@@ -291,13 +291,13 @@ describe("Folder Level Permissions - Inheritance", () => {
                     inheritedFrom: "role:full-access"
                 },
                 {
-                    target: "team:test-team-1",
-                    level: "viewer",
+                    target: "team:test-team-2",
+                    level: "no-access",
                     inheritedFrom: `parent:${folderB.id}`
                 },
                 {
-                    target: "team:test-team-2",
-                    level: "no-access",
+                    target: "team:test-team-1",
+                    level: "viewer",
                     inheritedFrom: `parent:${folderB.id}`
                 }
             ]

--- a/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
+++ b/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
@@ -1,0 +1,307 @@
+import { useGraphQlHandler } from "./utils/useGraphQlHandler";
+import { SecurityIdentity } from "@webiny/api-security/types";
+import { createSecurityTeamPlugin } from "@webiny/api-security";
+
+const FOLDER_TYPE = "test-folders";
+
+const identityA: SecurityIdentity = { id: "1", type: "admin", displayName: "A" };
+
+describe("Folder Level Permissions - Inheritance", () => {
+    const { aco } = useGraphQlHandler({
+        identity: identityA,
+        plugins: [
+            createSecurityTeamPlugin({
+                id: "test-team-1",
+                name: "Test Team 1",
+                description: "",
+                roles: ["test-role"]
+            }),
+            createSecurityTeamPlugin({
+                id: "test-team-2",
+                name: "Test Team 2",
+                description: "",
+                roles: ["test-role"]
+            })
+        ]
+    });
+
+    it("child folders should inherit parent permissions", async () => {
+        const folderA = await aco
+            .createFolder({
+                data: {
+                    title: "Folder A",
+                    slug: "folder-a",
+                    type: FOLDER_TYPE,
+                    permissions: [
+                        { level: "viewer", target: `admin:2` },
+                        { level: "viewer", target: `team:test-team-1` },
+                        { level: "editor", target: `team:test-team-2` }
+                    ]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const refetchedFolderA = await aco.getFolder({ id: folderA.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderA).toMatchObject({
+            slug: "folder-a",
+            permissions: [
+                { target: "admin:1", level: "owner", inheritedFrom: "role:full-access" },
+                { target: "admin:2", level: "viewer", inheritedFrom: null },
+                { target: "team:test-team-1", level: "viewer", inheritedFrom: null },
+                { target: "team:test-team-2", level: "editor", inheritedFrom: null }
+            ]
+        });
+
+        const folderB = await aco
+            .createFolder({
+                data: {
+                    title: "Folder B",
+                    slug: "folder-b",
+                    type: FOLDER_TYPE,
+                    parentId: folderA.id
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const refetchedFolderB = await aco.getFolder({ id: folderB.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        const folderC = await aco
+            .createFolder({
+                data: {
+                    title: "Folder C",
+                    slug: "folder-c",
+                    type: FOLDER_TYPE,
+                    parentId: folderB.id
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderB).toMatchObject({
+            slug: "folder-b",
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "admin:2",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderA.id}`
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderA.id}`
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "editor",
+                    inheritedFrom: `parent:${folderA.id}`
+                }
+            ]
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            slug: "folder-c",
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "admin:2",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "editor",
+                    inheritedFrom: `parent:${folderB.id}`
+                }
+            ]
+        });
+    });
+
+    it("overriding inherited permissions must be possible", async () => {
+        const folderA = await aco
+            .createFolder({
+                data: {
+                    title: "Folder A",
+                    slug: "folder-a",
+                    type: FOLDER_TYPE,
+                    permissions: [
+                        { level: "viewer", target: `team:test-team-1` },
+                        { level: "editor", target: `team:test-team-2` }
+                    ]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderB = await aco
+            .createFolder({
+                data: {
+                    title: "Folder B",
+                    slug: "folder-b",
+                    type: FOLDER_TYPE,
+                    parentId: folderA.id,
+                    permissions: [{ level: "viewer", target: `team:test-team-2` }]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const refetchedFolderB = await aco.getFolder({ id: folderB.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderB).toMatchObject({
+            slug: "folder-b",
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "viewer",
+                    inheritedFrom: null
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderA.id}`
+                }
+            ]
+        });
+    });
+
+    it("overriding `no-access` permissions must not be possible", async () => {
+        const folderA = await aco
+            .createFolder({
+                data: {
+                    title: "Folder A",
+                    slug: "folder-a",
+                    type: FOLDER_TYPE,
+                    permissions: [
+                        { level: "viewer", target: `team:test-team-1` },
+                        { level: "editor", target: `team:test-team-2` }
+                    ]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderB = await aco
+            .createFolder({
+                data: {
+                    title: "Folder B",
+                    slug: "folder-b",
+                    type: FOLDER_TYPE,
+                    parentId: folderA.id,
+                    permissions: []
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderC = await aco
+            .createFolder({
+                data: {
+                    title: "Folder C",
+                    slug: "folder-c",
+                    type: FOLDER_TYPE,
+                    parentId: folderB.id,
+                    permissions: [{ level: "owner", target: `team:test-team-2` }]
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        let refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            slug: "folder-c",
+            permissions: [
+                {
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
+                },
+                {
+                    target: "team:test-team-2",
+                    level: "owner",
+                    inheritedFrom: null
+                },
+                {
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
+                }
+            ]
+        });
+
+        await aco.updateFolder({
+            id: folderB.id,
+            data: {
+                permissions: [{ level: "no-access", target: `team:test-team-2` }]
+
+            }
+        });
+
+        refetchedFolderC = await aco.getFolder({ id: folderC.id }).then(([response]) => {
+            return response.data.aco.getFolder.data;
+        });
+
+        expect(refetchedFolderC).toMatchObject({
+            slug: "folder-c",
+            permissions: [
+                {
+                    "target": "admin:1",
+                    "level": "owner",
+                    "inheritedFrom": "role:full-access"
+                },
+                {
+                    "target": "team:test-team-1",
+                    "level": "viewer",
+                    "inheritedFrom": `parent:${folderB.id}`
+                },
+                {
+                    "target": "team:test-team-2",
+                    "level": "no-access",
+                    "inheritedFrom": `parent:${folderB.id}`
+                }
+            ]
+        });
+    });
+});

--- a/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
+++ b/packages/api-aco/__tests__/folder.flp.inheritance.test.ts
@@ -275,7 +275,6 @@ describe("Folder Level Permissions - Inheritance", () => {
             id: folderB.id,
             data: {
                 permissions: [{ level: "no-access", target: `team:test-team-2` }]
-
             }
         });
 
@@ -287,19 +286,19 @@ describe("Folder Level Permissions - Inheritance", () => {
             slug: "folder-c",
             permissions: [
                 {
-                    "target": "admin:1",
-                    "level": "owner",
-                    "inheritedFrom": "role:full-access"
+                    target: "admin:1",
+                    level: "owner",
+                    inheritedFrom: "role:full-access"
                 },
                 {
-                    "target": "team:test-team-1",
-                    "level": "viewer",
-                    "inheritedFrom": `parent:${folderB.id}`
+                    target: "team:test-team-1",
+                    level: "viewer",
+                    inheritedFrom: `parent:${folderB.id}`
                 },
                 {
-                    "target": "team:test-team-2",
-                    "level": "no-access",
-                    "inheritedFrom": `parent:${folderB.id}`
+                    target: "team:test-team-2",
+                    level: "no-access",
+                    inheritedFrom: `parent:${folderB.id}`
                 }
             ]
         });

--- a/packages/api-aco/__tests__/utils/identity.ts
+++ b/packages/api-aco/__tests__/utils/identity.ts
@@ -1,9 +1,10 @@
 import { SecurityIdentity } from "@webiny/api-security/types";
 
-export const createIdentity = (): SecurityIdentity => {
+export const createIdentity = (identity: Partial<SecurityIdentity> = {}): SecurityIdentity => {
     return {
         id: "12345678",
         type: "admin",
-        displayName: "John Doe"
+        displayName: "John Doe",
+        ...identity
     };
 };

--- a/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
+++ b/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
@@ -1,0 +1,108 @@
+import type { FolderAccessLevel, FolderPermission } from "~/flp/flp.types";
+import { Identity } from "@webiny/api-authentication/types";
+import { SecurityPermission } from "@webiny/api-security/types";
+
+export class DefaultPermissionsMerger {
+    static merge(
+        identity: Identity,
+        identityPermissions: SecurityPermission[],
+        folderPermissions: FolderPermission[]
+    ): FolderPermission[] {
+        // If the user has full access permission, add a specific "owner" permission to the list.
+        // This ensures the user has complete control over the folder.
+        const hasFullAccess = identityPermissions.some(p => p.name === "*");
+        if (hasFullAccess) {
+            return [
+                // Remove any permissions related to the full access user,
+                // as these are always superseded by the "owner" permission defined above.
+                ...folderPermissions.filter(p => p.target !== `admin:${identity.id}`),
+                {
+                    target: `admin:${identity.id}`,
+                    level: "owner" as FolderAccessLevel,
+                    inheritedFrom: "role:full-access"
+                }
+            ];
+        }
+
+        if (folderPermissions.length === 0) {
+            // No permissions provided. This means the folder is public.
+            // Add a specific "public" permission to the list to ensure the folder is accessible to everyone.
+            return [
+                {
+                    target: `admin:${identity.id}`,
+                    level: "public" as FolderAccessLevel,
+                    inheritedFrom: "public"
+                }
+            ];
+        }
+
+        // If there are multiple `admin:${identity.id}` permissions in the array,
+        // we need to pick the one with the highest access level. We also remove
+        // other permissions for the same identity.
+
+        // Get distinct levels for the current identity.
+        const currentAdminPermissions = folderPermissions.filter(
+            p => p.target === `admin:${identity.id}`
+        );
+
+        if (currentAdminPermissions.length === 0) {
+            return folderPermissions;
+        }
+
+        const noAccessPermission = currentAdminPermissions.find(
+            p => p.level === "no-access" && p.target === `admin:${identity.id}`
+        );
+
+        if (noAccessPermission) {
+            // If one of the permissions is `no-access`, then we can immediately return it. This is
+            // because `no-access` is the ultimate level of access, and no other permission can override it.
+            // Remove all permissions for the current identity and add the winning one.
+            const filteredPermissions = folderPermissions.filter(
+                p => p.target !== `admin:${identity.id}`
+            );
+
+            return [...filteredPermissions, noAccessPermission];
+        }
+
+        const [firstAdminPermission, ...restAdminPermissions] = currentAdminPermissions;
+
+        let resultPermission: FolderPermission = firstAdminPermission;
+
+        // Here we're comparing the rest of the permissions with the first one. Levels
+        // that are possible here are: `viewer`, `editor`, and `owner`.
+        for (const currentPermission of restAdminPermissions) {
+            const resultPermissionInheritsFromParent =
+                resultPermission.inheritedFrom?.startsWith("parent:");
+
+            const currentPermissionInheritsFromParent =
+                currentPermission.inheritedFrom?.startsWith("parent:");
+
+            if (resultPermissionInheritsFromParent && !currentPermissionInheritsFromParent) {
+                resultPermission = currentPermission;
+                continue;
+            }
+
+            if (currentPermissionInheritsFromParent && !resultPermissionInheritsFromParent) {
+                continue;
+            }
+
+            // At this point, we're either comparing two permissions with `inheritedFrom` or two without it.
+            // In other words, we're now at a point where we start comparing the levels.
+            if (currentPermission.level === "owner") {
+                resultPermission = currentPermission;
+                continue;
+            }
+
+            if (currentPermission.level === "editor") {
+                if (resultPermission.level === "viewer") {
+                    resultPermission = currentPermission;
+                }
+            }
+        }
+
+        // Remove all permissions for the current identity and add the winning one.
+        return folderPermissions
+            .filter(p => p.target !== `admin:${identity.id}`)
+            .concat(resultPermission);
+    }
+}

--- a/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
+++ b/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
@@ -13,14 +13,15 @@ export class DefaultPermissionsMerger {
         const hasFullAccess = identityPermissions.some(p => p.name === "*");
         if (hasFullAccess) {
             return [
-                // Remove any permissions related to the full access user,
-                // as these are always superseded by the "owner" permission defined above.
-                ...folderPermissions.filter(p => p.target !== `admin:${identity.id}`),
                 {
                     target: `admin:${identity.id}`,
                     level: "owner" as FolderAccessLevel,
                     inheritedFrom: "role:full-access"
-                }
+                },
+
+                // Remove any permissions related to the full access user,
+                // as these are always superseded by the "owner" permission defined above.
+                ...folderPermissions.filter(p => p.target !== `admin:${identity.id}`)
             ];
         }
 
@@ -40,7 +41,7 @@ export class DefaultPermissionsMerger {
         // we need to pick the one with the highest access level. We also remove
         // other permissions for the same identity.
 
-        // Get distinct levels for the current identity.
+        // Get permissions related to the current identity (admin).
         const currentAdminPermissions = folderPermissions.filter(
             p => p.target === `admin:${identity.id}`
         );
@@ -101,8 +102,9 @@ export class DefaultPermissionsMerger {
         }
 
         // Remove all permissions for the current identity and add the winning one.
-        return folderPermissions
-            .filter(p => p.target !== `admin:${identity.id}`)
-            .concat(resultPermission);
+        return [
+            resultPermission,
+            ...folderPermissions.filter(p => p.target !== `admin:${identity.id}`)
+        ];
     }
 }

--- a/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
+++ b/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/DefaultPermissionsMerger.ts
@@ -67,39 +67,29 @@ export class DefaultPermissionsMerger {
 
         const [firstAdminPermission, ...restAdminPermissions] = currentAdminPermissions;
 
-        let resultPermission: FolderPermission = firstAdminPermission;
+        const resultPermission = restAdminPermissions.reduce((winner, current) => {
+            const winnerInherits = winner.inheritedFrom?.startsWith("parent:");
+            const currentInherits = current.inheritedFrom?.startsWith("parent:");
 
-        // Here we're comparing the rest of the permissions with the first one. Levels
-        // that are possible here are: `viewer`, `editor`, and `owner`.
-        for (const currentPermission of restAdminPermissions) {
-            const resultPermissionInheritsFromParent =
-                resultPermission.inheritedFrom?.startsWith("parent:");
-
-            const currentPermissionInheritsFromParent =
-                currentPermission.inheritedFrom?.startsWith("parent:");
-
-            if (resultPermissionInheritsFromParent && !currentPermissionInheritsFromParent) {
-                resultPermission = currentPermission;
-                continue;
+            if (winnerInherits && !currentInherits) {
+                return current;
             }
-
-            if (currentPermissionInheritsFromParent && !resultPermissionInheritsFromParent) {
-                continue;
+            if (currentInherits && !winnerInherits) {
+                return winner;
             }
 
             // At this point, we're either comparing two permissions with `inheritedFrom` or two without it.
-            // In other words, we're now at a point where we start comparing the levels.
-            if (currentPermission.level === "owner") {
-                resultPermission = currentPermission;
-                continue;
+            // In other words, we're now at a point where we start comparing the levels (owner > editor > viewer).
+            if (current.level === "owner") {
+                return current;
             }
 
-            if (currentPermission.level === "editor") {
-                if (resultPermission.level === "viewer") {
-                    resultPermission = currentPermission;
-                }
+            if (current.level === "editor" && winner.level === "viewer") {
+                return current;
             }
-        }
+
+            return winner;
+        }, firstAdminPermission);
 
         // Remove all permissions for the current identity and add the winning one.
         return [

--- a/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/GetDefaultPermissions.ts
+++ b/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/GetDefaultPermissions.ts
@@ -1,6 +1,7 @@
 import type { IGetDefaultPermissions } from "./IGetDefaultPermissions";
 import type { IGetIdentityGateway, IListPermissionsGateway } from "../../gateways";
-import type { FolderAccessLevel, FolderPermission } from "~/flp/flp.types";
+import type { FolderPermission } from "~/flp/flp.types";
+import { DefaultPermissionsMerger } from "./DefaultPermissionsMerger";
 
 export class GetDefaultPermissions implements IGetDefaultPermissions {
     private getIdentityGateway: IGetIdentityGateway;
@@ -15,47 +16,9 @@ export class GetDefaultPermissions implements IGetDefaultPermissions {
     }
 
     async execute(permissions: FolderPermission[]) {
-        const hasFullAccess = await this.hasFullAccess();
         const identity = this.getIdentityGateway.execute();
+        const identityPermissions = await this.listPermissionsGateway.execute();
 
-        /**
-         * If the user has full access to the application, add a specific "owner" permission to the list.
-         * This ensures the user has complete control over the folder.
-         */
-        if (hasFullAccess) {
-            return [
-                {
-                    target: `admin:${identity.id}`,
-                    level: "owner" as FolderAccessLevel,
-                    inheritedFrom: "role:full-access"
-                },
-                /**
-                 * Remove any permissions related to the full access user,
-                 * as these are always superseded by the "owner" permission defined above.
-                 */
-                ...permissions.filter(p => p.target !== `admin:${identity.id}`)
-            ];
-        }
-
-        if (permissions.length > 0) {
-            return permissions;
-        }
-
-        /**
-         * No permissions provided. This means the folder is public.
-         * Add a specific "public" permission to the list to ensure the folder is accessible to everyone.
-         */
-        return [
-            {
-                target: `admin:${identity.id}`,
-                level: "public" as FolderAccessLevel,
-                inheritedFrom: "public"
-            }
-        ];
-    }
-
-    private async hasFullAccess(): Promise<boolean> {
-        const permissions = await this.listPermissionsGateway.execute();
-        return permissions.some(p => p.name === "*");
+        return DefaultPermissionsMerger.merge(identity, identityPermissions, permissions);
     }
 }

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -8,8 +8,9 @@ export class Permissions {
         permissions?: FolderPermission[],
         parentFlp?: Pick<IFolderLevelPermission, "id" | "permissions"> | null
     ): FolderPermission[] {
-        const currentFolderPermissions = permissions ?? [];
         const parentFolderPermissions = parentFlp?.permissions || [];
+        const currentFolderPermissions =
+            permissions?.filter(p => p.inheritedFrom !== `parent:${parentFlp?.id}`) || [];
 
         // If there are no parent folder permissions, we can return the current folder permissions.
         if (!parentFolderPermissions.length) {

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -19,27 +19,27 @@ export class Permissions {
         // Merge parent and current folder permissions:
         // - current folder permissions take precedence over parent permissions
         // - only if parent permission's level is set to `no-access`, then we ignore the current folder permission
-        const parentInheritedPermissions: FolderPermission[] = [];
+        const permissionsInheritedFromParentFolder: FolderPermission[] = [];
 
-        for (const parentPermission of parentInheritedPermissions) {
-            if (parentPermission.level === "no-access") {
-                parentInheritedPermissions.push({
-                    ...parentPermission,
+        for (const parentFolderPermission of parentFolderPermissions) {
+            if (parentFolderPermission.level === "no-access") {
+                permissionsInheritedFromParentFolder.push({
+                    ...parentFolderPermission,
                     inheritedFrom: `parent:${parentFlp!.id}`
                 });
                 continue;
             }
 
-            const overridePermissionExistsOnCurrentFolder = currentFolderPermissions.some(
-                permission => permission.target === parentPermission.target
+            const currentFolderHasOverridePermission = currentFolderPermissions.some(
+                permission => permission.target === parentFolderPermission.target
             );
 
-            if (overridePermissionExistsOnCurrentFolder) {
+            if (currentFolderHasOverridePermission) {
                 continue;
             }
 
-            parentInheritedPermissions.push({
-                ...parentPermission,
+            permissionsInheritedFromParentFolder.push({
+                ...parentFolderPermission,
                 inheritedFrom: `parent:${parentFlp!.id}`
             });
         }
@@ -49,6 +49,6 @@ export class Permissions {
             permission => !parentFolderPermissions.some(p => p.target === permission.target)
         );
 
-        return [...parentInheritedPermissions, ...applicableCurrentFolderPermissions];
+        return [...permissionsInheritedFromParentFolder, ...applicableCurrentFolderPermissions];
     }
 }

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -3,7 +3,7 @@ import type { FolderLevelPermission, FolderPermission } from "~/flp/flp.types";
 export class Permissions {
     public static create(
         permissions?: FolderPermission[],
-        parentFlp?: FolderLevelPermission
+        parentFlp?: FolderLevelPermission | null
     ): FolderPermission[] {
         const parentFolderPermissions = parentFlp?.permissions || [];
         const currentFolderPermissions =

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -1,18 +1,14 @@
-import type {
-    FolderLevelPermission as IFolderLevelPermission,
-    FolderPermission
-} from "~/flp/flp.types";
+import type { FolderLevelPermission, FolderPermission } from "~/flp/flp.types";
 
 export class Permissions {
     public static create(
         permissions?: FolderPermission[],
-        parentFlp?: Pick<IFolderLevelPermission, "id" | "permissions"> | null
+        parentFlp?: FolderLevelPermission
     ): FolderPermission[] {
         const parentFolderPermissions = parentFlp?.permissions || [];
         const currentFolderPermissions =
             permissions?.filter(p => p.inheritedFrom !== `parent:${parentFlp?.id}`) || [];
 
-        // If there are no parent folder permissions, we can return the current folder permissions.
         if (!parentFolderPermissions.length) {
             return currentFolderPermissions;
         }

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -8,33 +8,47 @@ export class Permissions {
         permissions?: FolderPermission[],
         parentFlp?: Pick<IFolderLevelPermission, "id" | "permissions"> | null
     ): FolderPermission[] {
-        const folderPermissions = permissions ?? [];
+        const currentFolderPermissions = permissions ?? [];
+        const parentFolderPermissions = parentFlp?.permissions || [];
 
-        // No permissions from the parent, let's return the permissions provided by the folder.
-        if (!parentFlp || !parentFlp.permissions?.length) {
-            return folderPermissions;
+        // If there are no parent folder permissions, we can return the current folder permissions.
+        if (!parentFolderPermissions.length) {
+            return currentFolderPermissions;
         }
 
-        const { id: parentId, permissions: parentPermissions } = parentFlp;
+        // Merge parent and current folder permissions:
+        // - current folder permissions take precedence over parent permissions
+        // - only if parent permission's level is set to `no-access`, then we ignore the current folder permission
+        const parentInheritedPermissions: FolderPermission[] = [];
 
-        // Remove all previously inherited permissions
-        const cleanedPermissions = folderPermissions.filter(
-            p => p.inheritedFrom !== `parent:${parentId}`
+        for (const parentPermission of parentInheritedPermissions) {
+            if (parentPermission.level === "no-access") {
+                parentInheritedPermissions.push({
+                    ...parentPermission,
+                    inheritedFrom: `parent:${parentFlp!.id}`
+                });
+                continue;
+            }
+
+            const overridePermissionExistsOnCurrentFolder = currentFolderPermissions.some(
+                permission => permission.target === parentPermission.target
+            );
+
+            if (overridePermissionExistsOnCurrentFolder) {
+                continue;
+            }
+
+            parentInheritedPermissions.push({
+                ...parentPermission,
+                inheritedFrom: `parent:${parentFlp!.id}`
+            });
+        }
+
+        // Add current folder permissions that are not present in the parent folder permissions
+        const applicableCurrentFolderPermissions = currentFolderPermissions.filter(
+            permission => !parentFolderPermissions.some(p => p.target === permission.target)
         );
 
-        // Store the `target` values from the current cleaned permissions.
-        // These will be used to exclude inherited permissions that target the same entities as the current folder's permissions.
-        const permissionsTargets = new Set(cleanedPermissions.map(p => p.target));
-
-        // Get inherited permissions from parent, preserving the original inheritance chain
-        const inheritedPermissions = parentPermissions
-            .filter(p => !permissionsTargets.has(p.target))
-            .map(p => ({
-                ...p,
-                // If the permission was already inherited, keep its original source
-                inheritedFrom: `parent:${parentId}`
-            }));
-
-        return [...cleanedPermissions, ...inheritedPermissions];
+        return [...parentInheritedPermissions, ...applicableCurrentFolderPermissions];
     }
 }

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -44,10 +44,14 @@ export class Permissions {
             });
         }
 
-        // Add current folder permissions that are not present in the parent folder permissions
-        const applicableCurrentFolderPermissions = currentFolderPermissions.filter(
-            permission => !parentFolderPermissions.some(p => p.target === permission.target)
-        );
+        // Add current folder permissions that are not present in the parent folder permissions.
+        const applicableCurrentFolderPermissions = currentFolderPermissions.filter(permission => {
+            const alreadyInInheritedPermissions = permissionsInheritedFromParentFolder.some(
+                p => p.target === permission.target
+            );
+
+            return !alreadyInInheritedPermissions;
+        });
 
         return [...applicableCurrentFolderPermissions, ...permissionsInheritedFromParentFolder];
     }

--- a/packages/api-aco/src/flp/useCases/Permissions.ts
+++ b/packages/api-aco/src/flp/useCases/Permissions.ts
@@ -49,6 +49,6 @@ export class Permissions {
             permission => !parentFolderPermissions.some(p => p.target === permission.target)
         );
 
-        return [...permissionsInheritedFromParentFolder, ...applicableCurrentFolderPermissions];
+        return [...applicableCurrentFolderPermissions, ...permissionsInheritedFromParentFolder];
     }
 }


### PR DESCRIPTION
## Changes
With this PR, we're improving FLP folder permissions inheritance.

First of all, once all of the permissions for a folder have been collected, then, the newly introduced `DefaultPermissionsMerger` class will inspect them and decide which permission is the winning one.

Some of the use cases the merger tackles:
- permissions inherited from parent can be overridden by new permissions (except `no-access`)
- `no-access` permission cannot be overridden, even if an owner level permission has been assigned

Second, we've also revisited the `Permissions.ts` class, which is responsible for merging folder permissions during the creation of FLP records. Nothing changed here drastically, except the fact that, if parent folder has the `no-access` permission for a particular target, then the permissions for that same target will also be no-access for all child folders. This cannot be overridden.

While changing the `Permissions.ts` file, I've also slightly refactored the file.

## How Has This Been Tested?
Jest.

## Documentation
Changelog.