### PR TITLE
fix(api-aco): clone original permissions to prevent mutation while decorating with teams' permissions

### DIFF
--- a/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/GetDefaultPermissionsWithTeams.ts
+++ b/packages/api-aco/src/flp/FolderLevelPermissions/useCases/GetDefaultPermissions/GetDefaultPermissionsWithTeams.ts
@@ -21,7 +21,7 @@ export class GetDefaultPermissionsWithTeams implements IGetDefaultPermissions {
         this.decoretee = decoretee;
     }
 
-    async execute(permissions: FolderPermission[]) {
+    async execute(originalPermissions: FolderPermission[]) {
         /**
          * Retrieves the list of teams the current identity belongs to and checks if any of these teams
          * have permissions for the folder. If a team has permissions, the current identity is granted
@@ -29,6 +29,8 @@ export class GetDefaultPermissionsWithTeams implements IGetDefaultPermissions {
          */
         const identity = this.getIdentityGateway.execute();
         const identityTeams: Team[] = (await this.listIdentityTeamsGateway.execute()) ?? [];
+
+        const permissions = [...originalPermissions]; // Clone the original permissions to avoid mutation.
 
         if (identityTeams.length) {
             for (const identityTeam of identityTeams) {


### PR DESCRIPTION
## Changes
The PR resolves a bug when updating a folder with team permissions. 

The bug has been solved by cloning the permissions array before processing to ensure the original array remains unmodified.

## How Has This Been Tested?
Manually
