### PR TITLE
`webiny extensions` Command - Enhance Error Message For Undetermined Extension Type

### DIFF
--- a/packages/cli-plugin-extensions/src/extensions/Extension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/Extension.ts
@@ -84,6 +84,8 @@ export class Extension extends AbstractExtension {
             }
         }
 
-        throw new Error(`Could not determine the extension type from the downloaded extension (package name: ${loadedPkgJson.name}). Make sure the package.json file contains the "keywords" field with the "webiny-extension-type:<type>" keyword.`);
+        throw new Error(
+            `Could not determine the extension type from the downloaded extension (package name: ${loadedPkgJson.name}). Make sure the package.json file contains the "keywords" field with the "webiny-extension-type:<type>" keyword.`
+        );
     }
 }

--- a/packages/cli-plugin-extensions/src/extensions/Extension.ts
+++ b/packages/cli-plugin-extensions/src/extensions/Extension.ts
@@ -84,6 +84,6 @@ export class Extension extends AbstractExtension {
             }
         }
 
-        throw new Error(`Could not determine the extension type from the downloaded extension.`);
+        throw new Error(`Could not determine the extension type from the downloaded extension (package name: ${loadedPkgJson.name}). Make sure the package.json file contains the "keywords" field with the "webiny-extension-type:<type>" keyword.`);
     }
 }


### PR DESCRIPTION
## Changes
This PR improves the error message that pops up when the `webiny extension` command fails to determine the extension type:

![image](https://github.com/user-attachments/assets/5c365343-bbd9-4c23-ab1b-5fc6bd39bc32)

All in all, the err message is now more informative, but, yeah, visually, this does not look visually appealing.

For now, it'll have to do.

## How Has This Been Tested?
Manually.

## Documentation
Changelog.