### PR TITLE
fix: export `createModelFieldPlugin` from `@webiny/api-serverless-cms` for consistency

### DIFF
--- a/packages/api-headless-cms/src/utils/createModelField.ts
+++ b/packages/api-headless-cms/src/utils/createModelField.ts
@@ -8,7 +8,53 @@ export interface CreateModelFieldParams
     storageId?: string;
 }
 
+/**
+ * @deprecated Use createModelFieldPlugin instead.
+ */
 export const createModelField = (params: CreateModelFieldParams): CmsModelField => {
+    // We are not just spreading `params` because we want to ensure
+    // a default value is set for every property of the model field.
+    const {
+        id,
+        label,
+        fieldId: initialFieldId,
+        storageId,
+        type,
+        tags,
+        settings = {},
+        listValidation = [],
+        validation = [],
+        multipleValues = false,
+        predefinedValues = {
+            values: [],
+            enabled: false
+        },
+        helpText = null,
+        placeholderText = null,
+        renderer = null
+    } = params;
+
+    const fieldId = initialFieldId ? camelCase(initialFieldId) : camelCase(label);
+
+    return {
+        id: id ?? fieldId,
+        storageId: storageId ?? `${type}@${fieldId}`,
+        fieldId,
+        label,
+        type,
+        settings,
+        tags,
+        listValidation,
+        validation,
+        multipleValues,
+        predefinedValues,
+        helpText,
+        placeholderText,
+        renderer
+    };
+};
+
+export const createModelFieldPlugin = (params: CreateModelFieldParams): CmsModelField => {
     // We are not just spreading `params` because we want to ensure
     // a default value is set for every property of the model field.
     const {

--- a/packages/api-serverless-cms/src/index.ts
+++ b/packages/api-serverless-cms/src/index.ts
@@ -61,6 +61,9 @@ export {
     createPrivateModelPlugin,
     createPrivateSingleEntryModelPlugin,
 
+    // Model fields.
+    createModelFieldPlugin,
+
     // Other.
     createStorageTransformPlugin
 } from "@webiny/api-headless-cms";


### PR DESCRIPTION
## Changes
In `v5.42.1` (PR #4502), we consolidated Headless CMS backend plugins and fixed naming issues. `createModelField` was not aligned with the new pattern. This commit deprecates `createModelField`, adds `createModelFieldPlugin`, and exports it from `@webiny/api-serverless-cms` for consistency.

## How Has This Been Tested?
Manually.

## Documentation
We will mention this in the changelog of the next patch release.
