### PR TITLE
fix: add `createModelField` to `@webiny/api-serverless-cms` 

### DIFF
--- a/packages/api-serverless-cms/src/index.ts
+++ b/packages/api-serverless-cms/src/index.ts
@@ -61,6 +61,9 @@ export {
     createPrivateModelPlugin,
     createPrivateSingleEntryModelPlugin,
 
+    // Model fields.
+    createModelField,
+
     // Other.
     createStorageTransformPlugin
 } from "@webiny/api-headless-cms";


### PR DESCRIPTION
## Changes
In `v5.42.1` (PR #4502), we consolidated Headless CMS backend plugins and fixed naming issues. `createModelField` was not aligned with the new pattern. This commit deprecates `createModelField`, adds `createModelFieldPlugin`, and exports it from `@webiny/api-serverless-cms` for consistency.

## How Has This Been Tested?
Manually.

## Documentation
We will mention this in the changelog of the next patch release.
