### PR TITLE
fix: add validateReferencedEntries option to entry creation inputs

### DIFF
--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
@@ -58,7 +58,7 @@ export const createEntryData = async ({
         context,
         model,
         input: initialInput,
-        validateEntries: true
+        validateEntries: options?.validateReferencedEntries !== false
     });
 
     const locale = getLocale();

--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -103,6 +103,7 @@ const createSchema = (plugins: PluginsContainer): IGraphQLSchemaPlugin<CmsContex
 
             input CreateCmsEntryOptionsInput {
                 skipValidators: [SkipValidatorEnum!]
+                validateReferencedEntries: Boolean
             }
 
             input CreateRevisionCmsEntryOptionsInput {

--- a/packages/api-headless-cms/src/types/types.ts
+++ b/packages/api-headless-cms/src/types/types.ts
@@ -1459,6 +1459,7 @@ export type CreateCmsEntryInput<TValues = CmsEntryValues> = TValues & {
 
 export interface CreateCmsEntryOptionsInput {
     skipValidators?: string[];
+    validateReferencedEntries?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Changes
With this PR, we've extended the CMS's `create` method with the `validateReferencedEntries` option. In other words, we can now create entries without its references being inspected. This can be needed in case a data migration is being performed, where we just want to kinda blindly insert a ton of data, without references being checked.

## How Has This Been Tested?
Manually. Relying on Jest tests.

## Documentation
Changelog.