### PR TITLE
Fix Webpack Watch Command (Local AWS Lambda Development)

### DIFF
--- a/packages/cli-plugin-deploy-pulumi/src/commands/newWatch/watchers/MultiplePackagesWatcher.ts
+++ b/packages/cli-plugin-deploy-pulumi/src/commands/newWatch/watchers/MultiplePackagesWatcher.ts
@@ -99,7 +99,8 @@ const createLog = ({ context, packageName }: ICreateLogParams) => {
             }
         }
 
-        console.log(send);
+        // Trim new lines.
+        console.log(send.replace(/\n/g, "").trim());
     };
 };
 

--- a/packages/project-utils/bundling/function/bundlers/WebpackBundler.js
+++ b/packages/project-utils/bundling/function/bundlers/WebpackBundler.js
@@ -72,12 +72,20 @@ class WebpackBundler extends BaseFunctionBundler {
 
     watch() {
         return new Promise(async (resolve, reject) => {
-            console.log("Compiling...");
+            let projectApplication;
+            try {
+                projectApplication = getProjectApplication({ cwd: this.params.cwd });
+            } catch {
+                // No need to do anything.
+            }
 
             const webpackConfig = createWebpackConfig({
                 ...this.params,
-                production: true
+                projectApplication,
+                production: false
             });
+
+            console.log("Compiling...");
 
             return webpack(webpackConfig).watch({}, async (err, stats) => {
                 if (err) {


### PR DESCRIPTION
## Changes
With the 5.43.0 release and introduction of the experimental Rspack bundler, we've introduced a regression within the current Webpack-based bundling. 

Because of this, the `webiny watch` command would be slow when it comes to backend development. More importantly, any changes done on the code would not be immediately reflected when rerunning the backend code. The only way to test it would be to just deploy the code via `webiny deploy`, which is of course far from ideal.

This PR addresses the underlying issue and the backend watch command now works as expected.

## Additional Changes
We're now trimming new lines in the output received from Babel. The trimming was also something that was lost upon introducing the experimental Rspack bundler.

![image](https://github.com/user-attachments/assets/53bca9af-b0cc-4a07-bfe2-35577c021308)


## How Has This Been Tested?
Manually.

## Documentation
Changelog.