### PR TITLE
fix(pulumi-aws): ddb to es log permissions

### DIFF
--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -281,6 +281,8 @@ function getDynamoDbToElasticLambdaPolicy(
     app: PulumiApp,
     domain: pulumi.Output<aws.elasticsearch.Domain | aws.elasticsearch.GetDomainResult>
 ) {
+    const logDynamoDbTable = app.getModule(LogDynamo);
+
     return app.addResource(aws.iam.Policy, {
         name: "DynamoDbToElasticLambdaPolicy-updated",
         config: {
@@ -296,7 +298,17 @@ function getDynamoDbToElasticLambdaPolicy(
                             "es:ESHttpDelete",
                             "es:ESHttpPatch",
                             "es:ESHttpPost",
-                            "es:ESHttpPut",
+                            "es:ESHttpPut"
+                        ],
+                        Resource: [
+                            pulumi.interpolate`${domain.arn}`,
+                            pulumi.interpolate`${domain.arn}/*`
+                        ]
+                    },
+                    {
+                        Sid: "PermissionForDynamoDbLog",
+                        Effect: "Allow",
+                        Action: [
                             "dynamodb:BatchGetItem",
                             "dynamodb:BatchWriteItem",
                             "dynamodb:PutItem",
@@ -306,8 +318,8 @@ function getDynamoDbToElasticLambdaPolicy(
                             "dynamodb:UpdateItem"
                         ],
                         Resource: [
-                            pulumi.interpolate`${domain.arn}`,
-                            pulumi.interpolate`${domain.arn}/*`
+                            pulumi.interpolate`${logDynamoDbTable.output.arn}`,
+                            pulumi.interpolate`${logDynamoDbTable.output.arn}/*`
                         ]
                     }
                 ]

--- a/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreElasticSearch.ts
@@ -309,13 +309,14 @@ function getDynamoDbToElasticLambdaPolicy(
                         Sid: "PermissionForDynamoDbLog",
                         Effect: "Allow",
                         Action: [
+                            "dynamodb:GetItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:UpdateItem",
+                            "dynamodb:DeleteItem",
                             "dynamodb:BatchGetItem",
                             "dynamodb:BatchWriteItem",
-                            "dynamodb:PutItem",
-                            "dynamodb:GetItem",
-                            "dynamodb:DeleteItem",
-                            "dynamodb:Query",
-                            "dynamodb:UpdateItem"
+                            "dynamodb:Scan",
+                            "dynamodb:Query"
                         ],
                         Resource: [
                             pulumi.interpolate`${logDynamoDbTable.output.arn}`,

--- a/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
@@ -322,13 +322,14 @@ function getDynamoDbToElasticLambdaPolicy(
                         Sid: "PermissionForDynamoDbLog",
                         Effect: "Allow",
                         Action: [
+                            "dynamodb:GetItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:UpdateItem",
+                            "dynamodb:DeleteItem",
                             "dynamodb:BatchGetItem",
                             "dynamodb:BatchWriteItem",
-                            "dynamodb:PutItem",
-                            "dynamodb:GetItem",
-                            "dynamodb:DeleteItem",
-                            "dynamodb:Query",
-                            "dynamodb:UpdateItem"
+                            "dynamodb:Scan",
+                            "dynamodb:Query"
                         ],
                         Resource: [
                             pulumi.interpolate`${logDynamoDbTable.output.arn}`,

--- a/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
+++ b/packages/pulumi-aws/src/apps/core/CoreOpenSearch.ts
@@ -10,9 +10,9 @@ import * as random from "@pulumi/random";
 import {
     createAppModule,
     PulumiApp,
+    PulumiAppRemoteResource,
     PulumiAppResource,
-    PulumiAppResourceConstructor,
-    PulumiAppRemoteResource
+    PulumiAppResourceConstructor
 } from "@webiny/pulumi";
 
 import { getAwsAccountId } from "../awsUtils";
@@ -294,6 +294,8 @@ function getDynamoDbToElasticLambdaPolicy(
     app: PulumiApp,
     domain: pulumi.Output<aws.opensearch.Domain | aws.opensearch.GetDomainResult>
 ) {
+    const logDynamoDbTable = app.getModule(LogDynamo);
+
     return app.addResource(aws.iam.Policy, {
         name: "DynamoDbToElasticLambdaPolicy-updated",
         config: {
@@ -309,7 +311,17 @@ function getDynamoDbToElasticLambdaPolicy(
                             "es:ESHttpDelete",
                             "es:ESHttpPatch",
                             "es:ESHttpPost",
-                            "es:ESHttpPut",
+                            "es:ESHttpPut"
+                        ],
+                        Resource: [
+                            pulumi.interpolate`${domain.arn}`,
+                            pulumi.interpolate`${domain.arn}/*`
+                        ]
+                    },
+                    {
+                        Sid: "PermissionForDynamoDbLog",
+                        Effect: "Allow",
+                        Action: [
                             "dynamodb:BatchGetItem",
                             "dynamodb:BatchWriteItem",
                             "dynamodb:PutItem",
@@ -319,8 +331,8 @@ function getDynamoDbToElasticLambdaPolicy(
                             "dynamodb:UpdateItem"
                         ],
                         Resource: [
-                            pulumi.interpolate`${domain.arn}`,
-                            pulumi.interpolate`${domain.arn}/*`
+                            pulumi.interpolate`${logDynamoDbTable.output.arn}`,
+                            pulumi.interpolate`${logDynamoDbTable.output.arn}/*`
                         ]
                     }
                 ]


### PR DESCRIPTION
## Changes
Add DynamoDB to Elasticsearch/OpenSearch Lambda permissions to add logs into DDB log table

## How Has This Been Tested?
Manually.