### PR TITLE
fix(tasks): convert all event response dates into strings

### DIFF
--- a/packages/tasks/__tests__/utils/convertDateToString.test.ts
+++ b/packages/tasks/__tests__/utils/convertDateToString.test.ts
@@ -1,0 +1,21 @@
+import { convertDateToString } from "~/utils/convertDateToString";
+
+describe("convertDateToString", () => {
+    it("should convert Date objects to ISO strings", () => {
+        const result = convertDateToString({
+            date: new Date("2023-10-01T12:00:00Z"),
+            nested: {
+                date: new Date("2023-10-02T12:00:00Z")
+            },
+            array: [new Date("2023-10-03T12:00:00Z"), { date: new Date("2023-10-04T12:00:00Z") }]
+        });
+
+        expect(result).toEqual({
+            date: "2023-10-01T12:00:00.000Z",
+            nested: {
+                date: "2023-10-02T12:00:00.000Z"
+            },
+            array: ["2023-10-03T12:00:00.000Z", { date: "2023-10-04T12:00:00.000Z" }]
+        });
+    });
+});

--- a/packages/tasks/src/crud/service.tasks.ts
+++ b/packages/tasks/src/crud/service.tasks.ts
@@ -14,6 +14,7 @@ import { TaskDataStatus, TaskLogItemType } from "~/types";
 import { NotFoundError } from "@webiny/handler-graphql";
 import { createService } from "~/service";
 import { IStepFunctionServiceFetchResult } from "~/service/StepFunctionServicePlugin";
+import { convertDateToString } from "~/utils/convertDateToString";
 
 const MAX_DELAY_DAYS = 355;
 const MAX_DELAY_SECONDS = MAX_DELAY_DAYS * 24 * 60 * 60;
@@ -107,7 +108,7 @@ export const createServiceCrud = (context: Context): ITasksContextServiceObject 
                 throw ex;
             }
             return await context.tasks.updateTask<T, O>(task.id, {
-                eventResponse: result
+                eventResponse: convertDateToString(result)
             });
         },
         fetchServiceInfo: async (

--- a/packages/tasks/src/utils/convertDateToString.ts
+++ b/packages/tasks/src/utils/convertDateToString.ts
@@ -1,0 +1,20 @@
+export const convertDateToString = <T>(input: T): T => {
+    if (input instanceof Date) {
+        return input.toISOString() as unknown as T;
+    }
+
+    if (Array.isArray(input)) {
+        return input.map(item => convertDateToString(item)) as unknown as T;
+    }
+
+    if (input !== null && typeof input === "object") {
+        const output: Record<string, unknown> = {};
+        for (const key in input) {
+            const value = input[key];
+            output[key] = convertDateToString(value);
+        }
+        return output as T;
+    }
+
+    return input;
+};


### PR DESCRIPTION
## Changes
Convert all service event response dates into strings.

## How Has This Been Tested?
Jest and manually.