### PR TITLE
fix(utils): compression should not run if not needed

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/richTextField.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/richTextField.test.ts
@@ -246,7 +246,7 @@ describe("richTextField", () => {
 
         const category = await createCategory();
 
-        const { createProduct, updateProduct } = useProductManageHandler({
+        const { createProduct, updateProduct, getProduct } = useProductManageHandler({
             ...manageOpts
         });
 
@@ -322,6 +322,24 @@ describe("richTextField", () => {
                 }
             }
         });
+
+        const product = createProductResponse.data.createProduct.data;
+
+        const [getAfterCreateResult] = await getProduct({
+            revision: product.id
+        });
+
+        expect(getAfterCreateResult).toMatchObject({
+            data: {
+                getProduct: {
+                    data: {
+                        id: product.id,
+                        ...productData
+                    },
+                    error: null
+                }
+            }
+        });
         /**
          * We now update the rich text field with some value.
          */
@@ -342,6 +360,23 @@ describe("richTextField", () => {
                         ...expectedCreatedProduct,
                         richText: richTextMock,
                         modifiedOn: expect.toBeDateString()
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [getAfterUpdateResult] = await getProduct({
+            revision: product.id
+        });
+
+        expect(getAfterUpdateResult).toMatchObject({
+            data: {
+                getProduct: {
+                    data: {
+                        id: product.id,
+                        ...productData,
+                        richText: richTextMock
                     },
                     error: null
                 }

--- a/packages/utils/src/compression/plugins/GzipCompression.ts
+++ b/packages/utils/src/compression/plugins/GzipCompression.ts
@@ -23,7 +23,7 @@ export class GzipCompression extends CompressionPlugin {
     }
 
     public override async compress(data: any): Promise<ICompressedValue> {
-        if (!data) {
+        if (data === null || data === undefined) {
             return data;
         }
         // This stringifies both regular strings and JSON objects.

--- a/packages/utils/src/compression/plugins/GzipCompression.ts
+++ b/packages/utils/src/compression/plugins/GzipCompression.ts
@@ -23,6 +23,9 @@ export class GzipCompression extends CompressionPlugin {
     }
 
     public override async compress(data: any): Promise<ICompressedValue> {
+        if (!data) {
+            return data;
+        }
         // This stringifies both regular strings and JSON objects.
         const value = await gzip(JSON.stringify(data));
 
@@ -43,6 +46,11 @@ export class GzipCompression extends CompressionPlugin {
     }
 
     public override async decompress(data: ICompressedValue): Promise<any> {
+        if (!data) {
+            return data;
+        } else if (!data.value) {
+            return null;
+        }
         try {
             const buf = await ungzip(convertToBuffer(data.value));
             const value = buf.toString(FROM_STORAGE_ENCODING);

--- a/packages/utils/src/compression/plugins/JsonpackCompression.ts
+++ b/packages/utils/src/compression/plugins/JsonpackCompression.ts
@@ -17,7 +17,7 @@ export class JsonpackCompression extends CompressionPlugin {
     }
 
     public override async compress(data: any): Promise<ICompressedValue> {
-        if (!data) {
+        if (data === null || data === undefined) {
             return data;
         }
         const value = await compress(data);
@@ -42,6 +42,8 @@ export class JsonpackCompression extends CompressionPlugin {
     public override async decompress(data: ICompressedValue): Promise<any> {
         if (!data) {
             return data;
+        } else if (!data.value) {
+            return null;
         }
         try {
             return await decompress(data.value);

--- a/packages/utils/src/compression/plugins/JsonpackCompression.ts
+++ b/packages/utils/src/compression/plugins/JsonpackCompression.ts
@@ -17,6 +17,9 @@ export class JsonpackCompression extends CompressionPlugin {
     }
 
     public override async compress(data: any): Promise<ICompressedValue> {
+        if (!data) {
+            return data;
+        }
         const value = await compress(data);
 
         return {
@@ -37,6 +40,9 @@ export class JsonpackCompression extends CompressionPlugin {
     }
 
     public override async decompress(data: ICompressedValue): Promise<any> {
+        if (!data) {
+            return data;
+        }
         try {
             return await decompress(data.value);
         } catch (ex) {


### PR DESCRIPTION
## Changes
There is a possibility that a null or undefined value hits compression method. At that point, compression should not do anything.

## How Has This Been Tested?
Jest.