### PR TITLE
fix: prevent folder move without permissions and add move confirmation dialog

### DIFF
--- a/packages/api-aco/__tests__/folder.flp.security.test.ts
+++ b/packages/api-aco/__tests__/folder.flp.security.test.ts
@@ -371,6 +371,119 @@ describe("Folder Level Permissions - Security Checks", () => {
         });
     });
 
+    it("should not allow moving a folder to an inaccessible folder, based on permission level (owner vs editor vs viewer)", async () => {
+        const folderA = await acoIdentityA
+            .createFolder({
+                data: {
+                    title: "Folder A",
+                    slug: "folder-a",
+                    type: FOLDER_TYPE
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderB = await acoIdentityA
+            .createFolder({
+                data: {
+                    title: "Folder B",
+                    slug: "folder-b",
+                    type: FOLDER_TYPE
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const folderC = await acoIdentityA
+            .createFolder({
+                data: {
+                    title: "Folder C",
+                    slug: "folder-c",
+                    type: FOLDER_TYPE
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        const subFolder = await acoIdentityA
+            .createFolder({
+                data: {
+                    title: "Sub Folder",
+                    slug: "subfolder",
+                    type: FOLDER_TYPE,
+                    parentId: folderA.id
+                }
+            })
+            .then(([response]) => {
+                return response.data.aco.createFolder.data;
+            });
+
+        await acoIdentityA.updateFolder({
+            id: folderA.id,
+            data: {
+                permissions: [{ level: "owner", target: `admin:${identityB.id}` }]
+            }
+        });
+
+        await acoIdentityA.updateFolder({
+            id: folderB.id,
+            data: {
+                permissions: [{ level: "editor", target: `admin:${identityB.id}` }]
+            }
+        });
+
+        await acoIdentityA.updateFolder({
+            id: folderC.id,
+            data: {
+                permissions: [{ level: "viewer", target: `admin:${identityB.id}` }]
+            }
+        });
+
+        // Should be allowed to move a subfolder from folder A to folder B, because user B has "owner" access to folder A and "editor" access to folder B.
+        await expect(
+            acoIdentityB
+                .updateFolder({
+                    id: subFolder.id,
+                    data: { parentId: folderB.id }
+                })
+                .then(([response]) => {
+                    return response.data.aco.updateFolder.data;
+                })
+        ).resolves.toMatchObject({ id: subFolder.id, parentId: folderB.id });
+
+        // Should be allowed to move a subfolder from folder B to folder A, because user B has "owner" access to folder A and "editor" access to folder B.
+        await expect(
+            acoIdentityB
+                .updateFolder({
+                    id: subFolder.id,
+                    data: { parentId: folderA.id }
+                })
+                .then(([response]) => {
+                    return response.data.aco.updateFolder.data;
+                })
+        ).resolves.toMatchObject({ id: subFolder.id, parentId: folderA.id });
+
+        // Should not be allowed to move a subfolder from folder A to folder C, because user A has "owner" access to folder A and "viewer" access to folder C.
+        await expect(
+            acoIdentityB
+                .updateFolder({
+                    id: folderB.id,
+                    data: { parentId: folderC.id }
+                })
+                .then(([response]) => {
+                    return response.data.aco.updateFolder.error;
+                })
+        ).resolves.toEqual({
+            code: "CANNOT_MOVE_FOLDER_TO_NEW_PARENT",
+            data: null,
+            message:
+                "Cannot move folder to a new parent because you don't have access to the new parent."
+        });
+    });
+
     it("should still be be able to access a folder if its parent is inaccessible", async () => {
         const folderA = await acoIdentityA
             .createFolder({

--- a/packages/api-aco/src/folder/useCases/UpdateFolder/UpdateFolderWithFolderLevelPermissions.ts
+++ b/packages/api-aco/src/folder/useCases/UpdateFolder/UpdateFolderWithFolderLevelPermissions.ts
@@ -70,7 +70,7 @@ export class UpdateFolderWithFolderLevelPermissions implements IUpdateFolder {
 
                 await this.folderLevelPermissions.ensureCanAccessFolder({
                     permissions: parentPermissions,
-                    rwd: "r"
+                    rwd: "w"
                 });
             } catch (e) {
                 if (e instanceof NotAuthorizedError) {

--- a/packages/app-aco/src/components/FolderTree/List/index.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/index.tsx
@@ -21,6 +21,8 @@ import {
 import { ROOT_FOLDER } from "~/constants";
 import { DndFolderItemData, FolderItem } from "~/types";
 import { FolderProvider } from "~/contexts/folder";
+import { useAcoConfig } from "~/config";
+import { useConfirmMoveFolderDialog } from "~/dialogs";
 
 interface ListProps {
     folders: FolderItem[];
@@ -45,6 +47,8 @@ export const List = ({
     const [treeData, setTreeData] = useState<NodeModel<DndFolderItemData>[]>([]);
     const [initialOpenList, setInitialOpenList] = useState<undefined | InitialOpen>();
     const [openFolderIds, setOpenFolderIds] = useState<string[]>([ROOT_FOLDER]);
+    const { showDialog: showConfirmMoveFolderDialog } = useConfirmMoveFolderDialog();
+    const { folder: folderConfigs } = useAcoConfig();
 
     useEffect(() => {
         if (folders) {
@@ -62,6 +66,35 @@ export const List = ({
     useEffect(() => {
         setInitialOpenList(memoCreateInitialOpenList(focusedFolderId));
     }, [focusedFolderId]);
+
+    const onDrop = useCallback(
+        async (newTree: NodeModel<DndFolderItemData>[], options: DropOptions) => {
+            const { dragSourceId, dropTargetId } = options;
+            const folder = folders.find(f => f.id === dragSourceId);
+            const targetFolder = folders.find(f => f.id === dropTargetId);
+
+            // Abort if either folder is not found
+            if (!folder || !targetFolder) {
+                return;
+            }
+
+            // Function to execute the drop logic
+            const runDrop = () => handleDrop(newTree, options);
+
+            // If drop confirmation is enabled, show dialog before proceeding
+            if (folderConfigs.dropConfirmation) {
+                showConfirmMoveFolderDialog({
+                    folder,
+                    targetFolder,
+                    onAccept: runDrop
+                });
+            } else {
+                // Otherwise, perform the drop immediately
+                await runDrop();
+            }
+        },
+        [folders, folderConfigs.dropConfirmation, showConfirmMoveFolderDialog]
+    );
 
     const handleDrop = async (
         newTree: NodeModel<DndFolderItemData>[],
@@ -139,7 +172,7 @@ export const List = ({
                 <Tree
                     tree={treeData}
                     rootId={"0"}
-                    onDrop={handleDrop}
+                    onDrop={onDrop}
                     onChangeOpen={ids => handleChangeOpen(ids as string[])}
                     sort={sort}
                     canDrag={item => canDrag(item!.id as string)}

--- a/packages/app-aco/src/components/FolderTree/List/index.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/index.tsx
@@ -69,20 +69,20 @@ export const List = ({
 
     const onDrop = useCallback(
         async (newTree: NodeModel<DndFolderItemData>[], options: DropOptions) => {
-            const { dragSourceId, dropTargetId } = options;
-            const folder = folders.find(f => f.id === dragSourceId);
-            const targetFolder = folders.find(f => f.id === dropTargetId);
-
-            // Abort if either folder is not found
-            if (!folder || !targetFolder) {
-                return;
-            }
-
             // Function to execute the drop logic
             const runDrop = () => handleDrop(newTree, options);
 
             // If drop confirmation is enabled, show dialog before proceeding
             if (folderConfigs.dropConfirmation) {
+                const { dragSourceId, dropTargetId } = options;
+                const folder = folders.find(f => f.id === dragSourceId);
+                const targetFolder = folders.find(f => f.id === dropTargetId);
+
+                // Abort if either folder is not found
+                if (!folder || !targetFolder) {
+                    return;
+                }
+
                 showConfirmMoveFolderDialog({
                     folder,
                     targetFolder,

--- a/packages/app-aco/src/config/AcoConfig.tsx
+++ b/packages/app-aco/src/config/AcoConfig.tsx
@@ -39,7 +39,8 @@ export function useAcoConfig() {
             },
             folder: {
                 ...folder,
-                actions: [...(folder.actions || [])]
+                actions: [...(folder.actions || [])],
+                dropConfirmation: folder.dropConfirmation || false
             },
             record: {
                 ...record,

--- a/packages/app-aco/src/config/folder/DropConfirmation.tsx
+++ b/packages/app-aco/src/config/folder/DropConfirmation.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Property, useIdGenerator } from "@webiny/react-properties";
+
+export interface DropConfirmationProps {
+    value: boolean;
+}
+
+export const DropConfirmation = ({ value }: DropConfirmationProps) => {
+    const getId = useIdGenerator("dropConfirmation");
+
+    return (
+        <Property id="folder" name={"folder"}>
+            <Property id={getId()} name={"dropConfirmation"} value={value} />
+        </Property>
+    );
+};

--- a/packages/app-aco/src/config/folder/index.ts
+++ b/packages/app-aco/src/config/folder/index.ts
@@ -1,9 +1,12 @@
 import { Action, ActionConfig } from "./Action";
+import { DropConfirmation } from "./DropConfirmation";
 
 export interface FolderConfig {
     actions: ActionConfig[];
+    dropConfirmation: boolean;
 }
 
 export const Folder = {
-    Action
+    Action,
+    DropConfirmation
 };

--- a/packages/app-aco/src/dialogs/index.tsx
+++ b/packages/app-aco/src/dialogs/index.tsx
@@ -1,3 +1,4 @@
+export * from "./useConfirmMoveFolderDialog";
 export * from "./useCreateDialog";
 export * from "./useDeleteDialog";
 export * from "./useEditDialog";

--- a/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
+++ b/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
@@ -1,0 +1,31 @@
+import { useDialogs } from "@webiny/app-admin";
+import { FolderItem } from "~/types";
+
+interface ShowDialogParams {
+    folder: FolderItem;
+    targetFolder: FolderItem;
+    onAccept: (folder: FolderItem, targetFolder: FolderItem) => Promise<void>;
+}
+
+interface UseConfirmMoveFolderDialogResponse {
+    showDialog: (params: ShowDialogParams) => void;
+}
+
+export const useConfirmMoveFolderDialog = (): UseConfirmMoveFolderDialogResponse => {
+    const dialogs = useDialogs();
+
+    const showDialog = ({ folder, targetFolder, onAccept }: ShowDialogParams) => {
+        dialogs.showDialog({
+            title: "Move folder",
+            content: `You are about to move the folder "${folder.title}" into "${targetFolder.title}"! Are you sure you want to continue?`,
+            acceptLabel: "Move folder",
+            cancelLabel: "Cancel",
+            loadingLabel: "Moving folder...",
+            onAccept: () => onAccept(folder, targetFolder)
+        });
+    };
+
+    return {
+        showDialog
+    };
+};

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FolderDropConfirmation.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/FolderDropConfirmation.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { AcoConfig } from "@webiny/app-aco";
+
+const { Folder } = AcoConfig;
+
+type FolderDropConfirmationProps = React.ComponentProps<typeof AcoConfig.Folder.DropConfirmation>;
+
+export const FolderDropConfirmation = (props: FolderDropConfirmationProps) => {
+    return (
+        <AcoConfig>
+            <Folder.DropConfirmation {...props} />
+        </AcoConfig>
+    );
+};

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/configComponents/Browser/index.ts
@@ -13,6 +13,7 @@ import { GridConfig } from "./Grid";
 import { ActionButton } from "~/components/Grid/ActionButton";
 import { File } from "~/components/Grid/File";
 import { shouldDecorateFolderField } from "./FolderFieldDecorator";
+import { FolderDropConfirmation } from "./FolderDropConfirmation";
 
 export interface BrowserConfig {
     bulkActions: BulkActionConfig[];
@@ -45,7 +46,8 @@ export const Browser = {
                 shouldDecorate: shouldDecorateFolderField
             })
         },
-        Action: FolderAction
+        Action: FolderAction,
+        DropConfirmation: FolderDropConfirmation
     },
     /**
      * @deprecated

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderDropConfirmation.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/FolderDropConfirmation.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { AcoConfig } from "@webiny/app-aco";
+import { useModel } from "@webiny/app-headless-cms-common";
+
+const { Folder } = AcoConfig;
+
+export interface FolderDropConfirmationProps
+    extends React.ComponentProps<typeof AcoConfig.Folder.DropConfirmation> {
+    modelIds?: string[];
+}
+
+export const FolderDropConfirmation = ({
+    modelIds = [],
+    ...props
+}: FolderDropConfirmationProps) => {
+    const { model } = useModel();
+
+    if (modelIds.length > 0 && !modelIds.includes(model.modelId)) {
+        return null;
+    }
+
+    return (
+        <AcoConfig>
+            <Folder.DropConfirmation {...props} />
+        </AcoConfig>
+    );
+};

--- a/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/index.ts
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/list/Browser/index.ts
@@ -7,6 +7,7 @@ import { FiltersToWhere, FiltersToWhereConverter } from "./FiltersToWhere";
 import { FolderAction, FolderActionConfig } from "./FolderAction";
 import { Table, TableConfig } from "./Table";
 import { shouldDecorateFolderField } from "./FolderFieldDecorator";
+import { FolderDropConfirmation } from "./FolderDropConfirmation";
 
 export interface BrowserConfig {
     advancedSearch: AdvancedSearchConfig;
@@ -31,7 +32,8 @@ export const Browser = {
                 shouldDecorate: shouldDecorateFolderField
             })
         },
-        Action: FolderAction
+        Action: FolderAction,
+        DropConfirmation: FolderDropConfirmation
     },
     Table,
     /**

--- a/packages/app-page-builder/src/admin/config/pages/list/Browser/FolderDropConfirmation.tsx
+++ b/packages/app-page-builder/src/admin/config/pages/list/Browser/FolderDropConfirmation.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { AcoConfig } from "@webiny/app-aco";
+
+const { Folder } = AcoConfig;
+
+type FolderDropConfirmationProps = React.ComponentProps<typeof AcoConfig.Folder.DropConfirmation>;
+
+export const FolderDropConfirmation = (props: FolderDropConfirmationProps) => {
+    return (
+        <AcoConfig>
+            <Folder.DropConfirmation {...props} />
+        </AcoConfig>
+    );
+};

--- a/packages/app-page-builder/src/admin/config/pages/list/Browser/index.ts
+++ b/packages/app-page-builder/src/admin/config/pages/list/Browser/index.ts
@@ -4,6 +4,7 @@ import { FolderAction, FolderActionConfig } from "./FolderAction";
 import { PageAction, PageActionConfig } from "./PageAction";
 import { Table, TableConfig } from "./Table";
 import { shouldDecorateFolderField } from "./FolderFieldDecorator";
+import { FolderDropConfirmation } from "./FolderDropConfirmation";
 
 export interface BrowserConfig {
     bulkActions: BulkActionConfig[];
@@ -23,7 +24,8 @@ export const Browser = {
                 shouldDecorate: shouldDecorateFolderField
             })
         },
-        Action: FolderAction
+        Action: FolderAction,
+        DropConfirmation: FolderDropConfirmation
     },
     /**
      * @deprecated


### PR DESCRIPTION
## Changes
This PR introduces a new feature and fixes an existing bug, both of which are related to folders.

### Confirmation dialog on folder drag & drop
We are introducing a new config called `DropConfirmation` under the `Browser.Folder` namespace. The config is available for the following apps: 

- CMS - `ContentEntryListConfig`
- Page Builder - `PageListConfig`
- File Manager - `FileManagerViewConfig `

The default value for this config is `false`.  When the value is set to `true`, the editor must confirm the action when moving a folder from one parent to another.

For example, this config enables a confirmation dialog when the user attempts to move a folder within a model of `type: "article"`:

```
<ContentEntryListConfig>
    <Browser.Folder.DropConfirmation value={true} modelIds={["article"]} />
</ContentEntryListConfig>
```
![CleanShot 2025-06-19 at 12 13 23](https://github.com/user-attachments/assets/6546b78f-babe-4b5d-8332-34a0e5def103)

### Check folder permission on folder move 
This PR also fixes a bug: users should not be able to move a folder into a parent folder they do not have access to, based on their permission level (`viewer`).

## How Has This Been Tested?
Manually + Jest
