### PR TITLE
fix(api-aco): check security authorization while decorating cms methods

### DIFF
--- a/packages/api-aco/src/utils/decorators/CmsEntriesCrudDecorators.ts
+++ b/packages/api-aco/src/utils/decorators/CmsEntriesCrudDecorators.ts
@@ -4,7 +4,7 @@ import { ListEntriesFactory } from "./ListEntriesFactory";
 import { FilterEntriesByFolderFactory } from "./FilterEntriesByFolderFactory";
 import { decorateIfModelAuthorizationEnabled } from "./decorateIfModelAuthorizationEnabled";
 
-type Context = Pick<AcoContext, "aco" | "cms">;
+type Context = AcoContext;
 
 interface EntryManagerCrudDecoratorsParams {
     context: Context;
@@ -24,22 +24,18 @@ export class CmsEntriesCrudDecorators {
         const filterEntriesByFolder = new FilterEntriesByFolderFactory(folderLevelPermissions);
         const listEntriesHandler = new ListEntriesFactory(folderLevelPermissions);
 
-        decorateIfModelAuthorizationEnabled(context.cms, "listEntries", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "listEntries", async (...allParams) => {
+            const [decoratee, model, initialParams] = allParams;
+            return await listEntriesHandler.execute({ decoratee, model, initialParams });
+        });
+
+        decorateIfModelAuthorizationEnabled(context, "listLatestEntries", async (...allParams) => {
             const [decoratee, model, initialParams] = allParams;
             return await listEntriesHandler.execute({ decoratee, model, initialParams });
         });
 
         decorateIfModelAuthorizationEnabled(
-            context.cms,
-            "listLatestEntries",
-            async (...allParams) => {
-                const [decoratee, model, initialParams] = allParams;
-                return await listEntriesHandler.execute({ decoratee, model, initialParams });
-            }
-        );
-
-        decorateIfModelAuthorizationEnabled(
-            context.cms,
+            context,
             "listPublishedEntries",
             async (...allParams) => {
                 const [decoratee, model, initialParams] = allParams;
@@ -47,16 +43,12 @@ export class CmsEntriesCrudDecorators {
             }
         );
 
-        decorateIfModelAuthorizationEnabled(
-            context.cms,
-            "listDeletedEntries",
-            async (...allParams) => {
-                const [decoratee, model, initialParams] = allParams;
-                return await listEntriesHandler.execute({ decoratee, model, initialParams });
-            }
-        );
+        decorateIfModelAuthorizationEnabled(context, "listDeletedEntries", async (...allParams) => {
+            const [decoratee, model, initialParams] = allParams;
+            return await listEntriesHandler.execute({ decoratee, model, initialParams });
+        });
 
-        decorateIfModelAuthorizationEnabled(context.cms, "getEntry", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "getEntry", async (...allParams) => {
             const [decoratee, model, params] = allParams;
             const entry = await decoratee(model, params);
 
@@ -74,7 +66,7 @@ export class CmsEntriesCrudDecorators {
             return entry;
         });
 
-        decorateIfModelAuthorizationEnabled(context.cms, "getEntryById", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "getEntryById", async (...allParams) => {
             const [decoratee, model, params] = allParams;
             const entry = await decoratee(model, params);
 
@@ -91,7 +83,7 @@ export class CmsEntriesCrudDecorators {
         });
 
         decorateIfModelAuthorizationEnabled(
-            context.cms,
+            context,
             "getLatestEntriesByIds",
             async (...allParams) => {
                 const [decoratee, model, ids] = allParams;
@@ -103,7 +95,7 @@ export class CmsEntriesCrudDecorators {
         );
 
         decorateIfModelAuthorizationEnabled(
-            context.cms,
+            context,
             "getPublishedEntriesByIds",
             async (...allParams) => {
                 const [decoratee, model, ids] = allParams;
@@ -113,7 +105,7 @@ export class CmsEntriesCrudDecorators {
             }
         );
 
-        decorateIfModelAuthorizationEnabled(context.cms, "createEntry", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "createEntry", async (...allParams) => {
             const [decoratee, model, params, options] = allParams;
             const folderId = params.wbyAco_location?.folderId || params.location?.folderId;
 
@@ -131,7 +123,7 @@ export class CmsEntriesCrudDecorators {
         });
 
         decorateIfModelAuthorizationEnabled(
-            context.cms,
+            context,
             "createEntryRevisionFrom",
             async (...allParams) => {
                 const [decoratee, model, id, input, options] = allParams;
@@ -157,7 +149,7 @@ export class CmsEntriesCrudDecorators {
             }
         );
 
-        decorateIfModelAuthorizationEnabled(context.cms, "updateEntry", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "updateEntry", async (...allParams) => {
             const [decoratee, model, id, input, meta, options] = allParams;
             const entry = await context.cms.storageOperations.entries.getRevisionById(model, {
                 id
@@ -177,7 +169,7 @@ export class CmsEntriesCrudDecorators {
             return decoratee(model, id, input, meta, options);
         });
 
-        decorateIfModelAuthorizationEnabled(context.cms, "deleteEntry", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "deleteEntry", async (...allParams) => {
             const [decoratee, model, id, options] = allParams;
 
             const entry = await context.cms.storageOperations.entries.getLatestRevisionByEntryId(
@@ -202,7 +194,7 @@ export class CmsEntriesCrudDecorators {
         });
 
         decorateIfModelAuthorizationEnabled(
-            context.cms,
+            context,
             "deleteEntryRevision",
             async (...allParams) => {
                 const [decoratee, model, id] = allParams;
@@ -228,7 +220,7 @@ export class CmsEntriesCrudDecorators {
             }
         );
 
-        decorateIfModelAuthorizationEnabled(context.cms, "moveEntry", async (...allParams) => {
+        decorateIfModelAuthorizationEnabled(context, "moveEntry", async (...allParams) => {
             const [decoratee, model, id, targetFolderId] = allParams;
 
             /**

--- a/packages/api-aco/src/utils/decorators/decorateIfModelAuthorizationEnabled.ts
+++ b/packages/api-aco/src/utils/decorators/decorateIfModelAuthorizationEnabled.ts
@@ -1,5 +1,6 @@
 import { CmsModel, HeadlessCms } from "@webiny/api-headless-cms/types";
 import { FOLDER_MODEL_ID } from "~/folder/folder.model";
+import type { AcoContext } from "~/types";
 
 /**
  * This type matches any function that has a CmsModel as the first parameter.
@@ -44,7 +45,7 @@ export const decorateIfModelAuthorizationEnabled = <
     M extends keyof ModelMethods<HeadlessCms>,
     D extends Decorator<ModelMethods<HeadlessCms>[M]>
 >(
-    root: ModelMethods<HeadlessCms>,
+    context: AcoContext,
     method: M,
     decorator: D
 ) => {
@@ -52,9 +53,15 @@ export const decorateIfModelAuthorizationEnabled = <
      * We cast to `ModelCallable` because within the generic function, we only know that the first
      * parameter is a `CmsModel`, and we forward the rest.
      */
+    const root = context.cms;
     const decoratee = root[method].bind(root) as ModelCallable;
     root[method] = ((...params: Parameters<ModelMethods<HeadlessCms>[M]>) => {
         const [model, ...rest] = params;
+
+        if (!context.security.isAuthorizationEnabled()) {
+            return decoratee(model, ...rest);
+        }
+
         if (isFolderModel(model)) {
             return decoratee(model, ...rest);
         }


### PR DESCRIPTION
## Changes
With this PR, we are disabling FLP decoration applied to CMS CRUD methods when authorisation is disabled, such as when using `context.security.withoutAuthorization`.

## How Has This Been Tested?
Manually
