### PR TITLE
fix: handle missing table cell metadata values gracefully

### DIFF
--- a/packages/app-file-manager/src/components/Table/Cells/CellAuthor.tsx
+++ b/packages/app-file-manager/src/components/Table/Cells/CellAuthor.tsx
@@ -5,5 +5,9 @@ export const CellAuthor = () => {
     const { useTableRow } = FileManagerViewConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdBy) {
+        return <>{"-"}</>;
+    }
+
     return <>{row.createdBy.displayName}</>;
 };

--- a/packages/app-file-manager/src/components/Table/Cells/CellCreated.tsx
+++ b/packages/app-file-manager/src/components/Table/Cells/CellCreated.tsx
@@ -6,5 +6,9 @@ export const CellCreated = () => {
     const { useTableRow } = FileManagerViewConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.createdOn} />;
 };

--- a/packages/app-file-manager/src/components/Table/Cells/CellModified.tsx
+++ b/packages/app-file-manager/src/components/Table/Cells/CellModified.tsx
@@ -6,5 +6,9 @@ export const CellModified = () => {
     const { useTableRow } = FileManagerViewConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.savedOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.savedOn} />;
 };

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellAuthor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellAuthor.tsx
@@ -5,5 +5,9 @@ export const CellAuthor = () => {
     const { useTableRow } = ContentEntryListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdBy) {
+        return <>{"-"}</>;
+    }
+
     return <>{row.createdBy.displayName}</>;
 };

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellCreated.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellCreated.tsx
@@ -6,5 +6,9 @@ export const CellCreated = () => {
     const { useTableRow } = ContentEntryListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.createdOn} />;
 };

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellModified.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Cells/CellModified.tsx
@@ -6,5 +6,9 @@ export const CellModified = () => {
     const { useTableRow } = ContentEntryListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.savedOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.savedOn} />;
 };

--- a/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellAuthor.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellAuthor.tsx
@@ -5,5 +5,9 @@ export const CellAuthor = () => {
     const { useTableRow } = PageListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdBy) {
+        return <>{"-"}</>;
+    }
+
     return <>{row.createdBy.displayName}</>;
 };

--- a/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellCreated.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellCreated.tsx
@@ -6,5 +6,9 @@ export const CellCreated = () => {
     const { useTableRow } = PageListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.createdOn} />;
 };

--- a/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellModified.tsx
+++ b/packages/app-page-builder/src/admin/components/Table/Table/Cells/CellModified.tsx
@@ -6,5 +6,9 @@ export const CellModified = () => {
     const { useTableRow } = PageListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.savedOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.savedOn} />;
 };

--- a/packages/app-trash-bin/src/Presentation/components/Cells/CellCreatedBy/CellCreatedBy.tsx
+++ b/packages/app-trash-bin/src/Presentation/components/Cells/CellCreatedBy/CellCreatedBy.tsx
@@ -5,5 +5,9 @@ export const CellCreatedBy = () => {
     const { useTableRow } = TrashBinListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.createdBy) {
+        return <>{"-"}</>;
+    }
+
     return <>{row.createdBy.displayName}</>;
 };

--- a/packages/app-trash-bin/src/Presentation/components/Cells/CellDeletedBy/CellDeletedBy.tsx
+++ b/packages/app-trash-bin/src/Presentation/components/Cells/CellDeletedBy/CellDeletedBy.tsx
@@ -5,5 +5,9 @@ export const CellDeletedBy = () => {
     const { useTableRow } = TrashBinListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.deletedBy) {
+        return <>{"-"}</>;
+    }
+
     return <>{row.deletedBy.displayName}</>;
 };

--- a/packages/app-trash-bin/src/Presentation/components/Cells/CellDeletedOn/CellDeletedOn.tsx
+++ b/packages/app-trash-bin/src/Presentation/components/Cells/CellDeletedOn/CellDeletedOn.tsx
@@ -6,5 +6,9 @@ export const CellDeletedOn = () => {
     const { useTableRow } = TrashBinListConfig.Browser.Table.Column;
     const { row } = useTableRow();
 
+    if (!row.deletedOn) {
+        return <>{"-"}</>;
+    }
+
     return <TimeAgo datetime={row.deletedOn} />;
 };


### PR DESCRIPTION
## Changes
This PR aims to fix missing table cell metadata gracefully: if some metadata do not exist, the table cell renders a "dash" (`-`). It previously failed by throwing an error.

<img width="1428" height="442" alt="CleanShot 2025-07-29 at 16 55 25@2x" src="https://github.com/user-attachments/assets/eb947d2c-a258-4d4f-98ea-ec2886c6a159" />

### Applications involved:
- Headless CMS
- Page Builder
- File Manager
- Trash Bin

## How Has This Been Tested?
Manually
