### PR TITLE
feat(api-headless-cms): status step

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
@@ -104,8 +104,8 @@ export const createEntryEntity = (params: CreateEntryEntityParams): Entity<any> 
             status: {
                 type: "string"
             },
-            statusStep: {
-                type: "string"
+            state: {
+                type: "map"
             },
             location: {
                 type: "map"

--- a/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb-es/src/definitions/entry.ts
@@ -104,6 +104,9 @@ export const createEntryEntity = (params: CreateEntryEntityParams): Entity<any> 
             status: {
                 type: "string"
             },
+            statusStep: {
+                type: "string"
+            },
             location: {
                 type: "map"
             },

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fields.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/elasticsearch/fields.ts
@@ -174,6 +174,60 @@ const createSystemFields = (): ModelFields => {
             }),
             parents: []
         },
+        state: {
+            type: "object",
+            unmappedType: undefined,
+            keyword: false,
+            systemField: true,
+            searchable: false,
+            sortable: false,
+            field: createSystemField({
+                storageId: "state",
+                fieldId: "state",
+                type: "object"
+            }),
+            parents: []
+        },
+        ["state.name"]: {
+            type: "text",
+            unmappedType: undefined,
+            keyword: true,
+            systemField: true,
+            searchable: true,
+            sortable: false,
+            field: createSystemField({
+                storageId: "name",
+                fieldId: "name",
+                type: "text"
+            }),
+            parents: [
+                {
+                    fieldId: "state",
+                    storageId: "state",
+                    type: "object"
+                }
+            ]
+        },
+        ["state.comment"]: {
+            type: "text",
+            unmappedType: undefined,
+            keyword: true,
+            systemField: true,
+            searchable: true,
+            sortable: false,
+            field: createSystemField({
+                storageId: "comment",
+                fieldId: "comment",
+                type: "text"
+            }),
+            parents: [
+                {
+                    fieldId: "state",
+                    storageId: "state",
+                    type: "object"
+                }
+            ]
+        },
         wbyDeleted: {
             type: "boolean",
             unmappedType: undefined,

--- a/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
@@ -433,16 +433,34 @@ const expectedSystemFields: Record<string, Field> = {
             path: "location.folderId"
         }
     },
-    statusStep: {
+    state: {
         createPath: expect.any(Function),
         transform: expect.any(Function),
-        fieldId: "statusStep",
-        id: "statusStep",
-        label: "Status Step",
+        fieldId: "state",
+        id: "state",
+        label: "State",
         parents: [],
-        storageId: "statusStep",
+        storageId: "object@state",
         system: true,
-        type: "text"
+        type: "object",
+        settings: {
+            fields: [
+                {
+                    id: "name",
+                    fieldId: "name",
+                    label: "Name",
+                    storageId: "text@name",
+                    type: "text"
+                },
+                {
+                    id: "comment",
+                    fieldId: "comment",
+                    label: "Comment",
+                    storageId: "text@comment",
+                    type: "long-text"
+                }
+            ]
+        }
     },
     version: {
         id: "version",

--- a/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
@@ -473,6 +473,38 @@ const expectedSystemFields: Record<string, Field> = {
         transform: expect.any(Function),
         label: "Version"
     },
+    "state.comment": {
+        createPath: expect.any(Function),
+        fieldId: "comment",
+        id: "comment",
+        label: "Comment",
+        parents: [
+            {
+                fieldId: "state",
+                multipleValues: undefined
+            }
+        ],
+        storageId: "text@comment",
+        system: true,
+        transform: expect.any(Function),
+        type: "long-text"
+    },
+    "state.name": {
+        createPath: expect.any(Function),
+        fieldId: "name",
+        id: "name",
+        label: "Name",
+        parents: [
+            {
+                fieldId: "state",
+                multipleValues: undefined
+            }
+        ],
+        storageId: "text@name",
+        system: true,
+        transform: expect.any(Function),
+        type: "text"
+    },
 
     status: {
         id: "status",

--- a/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
+++ b/packages/api-headless-cms-ddb/__tests__/operations/entry/filtering/createFields.test.ts
@@ -433,6 +433,17 @@ const expectedSystemFields: Record<string, Field> = {
             path: "location.folderId"
         }
     },
+    statusStep: {
+        createPath: expect.any(Function),
+        transform: expect.any(Function),
+        fieldId: "statusStep",
+        id: "statusStep",
+        label: "Status Step",
+        parents: [],
+        storageId: "statusStep",
+        system: true,
+        type: "text"
+    },
     version: {
         id: "version",
         parents: [],
@@ -522,9 +533,9 @@ describe("create system and model fields", () => {
                 type: "text",
                 storageId: "text@titleStorageId",
                 fieldId: "title",
-                createPath: expect.any(Function),
                 system: false,
                 multipleValues: false,
+                createPath: expect.any(Function),
                 transform: expect.any(Function),
                 label: "Title"
             },

--- a/packages/api-headless-cms-ddb/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/entry.ts
@@ -111,8 +111,8 @@ export const createEntryEntity = (params: Params): Entity<any> => {
             status: {
                 type: "string"
             },
-            statusStep: {
-                type: "string"
+            state: {
+                type: "map"
             },
             location: {
                 type: "map"

--- a/packages/api-headless-cms-ddb/src/definitions/entry.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/entry.ts
@@ -111,6 +111,9 @@ export const createEntryEntity = (params: Params): Entity<any> => {
             status: {
                 type: "string"
             },
+            statusStep: {
+                type: "string"
+            },
             location: {
                 type: "map"
             },

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
@@ -95,11 +95,29 @@ export const createSystemFields = (): Field[] => {
             label: "Status"
         },
         {
-            id: "statusStep",
-            type: "text",
-            storageId: "statusStep",
-            fieldId: "statusStep",
-            label: "Status Step"
+            id: "state",
+            type: "object",
+            storageId: "object@state",
+            fieldId: "state",
+            label: "State",
+            settings: {
+                fields: [
+                    {
+                        id: "name",
+                        fieldId: "name",
+                        label: "Name",
+                        storageId: "text@name",
+                        type: "text"
+                    },
+                    {
+                        id: "comment",
+                        fieldId: "comment",
+                        label: "Comment",
+                        storageId: "text@comment",
+                        type: "long-text"
+                    }
+                ]
+            }
         },
         {
             id: "wbyDeleted",

--- a/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/filtering/systemFields.ts
@@ -95,6 +95,13 @@ export const createSystemFields = (): Field[] => {
             label: "Status"
         },
         {
+            id: "statusStep",
+            type: "text",
+            storageId: "statusStep",
+            fieldId: "statusStep",
+            label: "Status Step"
+        },
+        {
             id: "wbyDeleted",
             type: "boolean",
             storageId: "wbyDeleted",

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.state.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.state.test.ts
@@ -3,9 +3,9 @@ import { setupGroupAndModels } from "~tests/testHelpers/setup.js";
 
 const title = "Category Regular Identity";
 const slug = "category-regular-identity";
-const statusStep = "beforeTranslation";
+const stateName = "beforeTranslation";
 
-describe("entry status step", () => {
+describe("entry state", () => {
     const manager = useCategoryManageHandler({
         path: "manage/en-US"
     });
@@ -13,16 +13,18 @@ describe("entry status step", () => {
     beforeEach(async () => {
         await setupGroupAndModels({
             manager,
-            models: undefined
+            models: ["category"]
         });
     });
 
-    it("should create a category in draft with status step and update it accordingly", async () => {
+    it("should create a category in draft with state status and update it accordingly", async () => {
         const [result] = await manager.createCategory({
             data: {
                 title,
                 slug,
-                statusStep
+                state: {
+                    name: stateName
+                }
             }
         });
 
@@ -34,7 +36,10 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "draft",
-                            statusStep
+                            state: {
+                                name: stateName,
+                                comment: null
+                            }
                         }
                     },
                     error: null
@@ -46,7 +51,10 @@ describe("entry status step", () => {
         const [updateStatusStepResult] = await manager.updateCategory({
             revision: id,
             data: {
-                statusStep: "afterTranslation"
+                state: {
+                    name: "afterTranslation",
+                    comment: "Translated to Spanish"
+                }
             }
         });
 
@@ -58,7 +66,10 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "draft",
-                            statusStep: "afterTranslation"
+                            state: {
+                                name: "afterTranslation",
+                                comment: "Translated to Spanish"
+                            }
                         }
                     },
                     error: null
@@ -80,8 +91,45 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "draft",
-                            statusStep: "afterTranslation"
+                            state: {
+                                name: "afterTranslation",
+                                comment: "Translated to Spanish"
+                            }
                         }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [listByStateNameResult] = await manager.listCategories({
+            where: {
+                state: {
+                    name: "afterTranslation"
+                }
+            }
+        });
+
+        expect(listByStateNameResult).toMatchObject({
+            data: {
+                listCategories: {
+                    data: [
+                        {
+                            title: "New Title",
+                            slug,
+                            meta: {
+                                status: "draft",
+                                state: {
+                                    name: "afterTranslation",
+                                    comment: "Translated to Spanish"
+                                }
+                            }
+                        }
+                    ],
+                    meta: {
+                        totalCount: 1,
+                        hasMoreItems: false,
+                        cursor: null
                     },
                     error: null
                 }
@@ -89,12 +137,14 @@ describe("entry status step", () => {
         });
     });
 
-    it("should remove a status step when publishing, unpublishing or republishing an entry", async () => {
+    it("should remove a state status when publishing, unpublishing or republishing an entry", async () => {
         const [result] = await manager.createCategory({
             data: {
                 title,
                 slug,
-                statusStep
+                state: {
+                    name: stateName
+                }
             }
         });
         const id = result.data.createCategory.data.id;
@@ -110,7 +160,10 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "published",
-                            statusStep: null
+                            state: {
+                                name: null,
+                                comment: null
+                            }
                         }
                     },
                     error: null
@@ -129,7 +182,10 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "published",
-                            statusStep: null
+                            state: {
+                                name: null,
+                                comment: null
+                            }
                         }
                     },
                     error: null
@@ -148,7 +204,10 @@ describe("entry status step", () => {
                         slug,
                         meta: {
                             status: "unpublished",
-                            statusStep: null
+                            state: {
+                                name: null,
+                                comment: null
+                            }
                         }
                     },
                     error: null

--- a/packages/api-headless-cms/__tests__/contentAPI/contentEntry.statusStep.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/contentEntry.statusStep.test.ts
@@ -1,0 +1,159 @@
+import { useCategoryManageHandler } from "~tests/testHelpers/useCategoryManageHandler.js";
+import { setupGroupAndModels } from "~tests/testHelpers/setup.js";
+
+const title = "Category Regular Identity";
+const slug = "category-regular-identity";
+const statusStep = "beforeTranslation";
+
+describe("entry status step", () => {
+    const manager = useCategoryManageHandler({
+        path: "manage/en-US"
+    });
+
+    beforeEach(async () => {
+        await setupGroupAndModels({
+            manager,
+            models: undefined
+        });
+    });
+
+    it("should create a category in draft with status step and update it accordingly", async () => {
+        const [result] = await manager.createCategory({
+            data: {
+                title,
+                slug,
+                statusStep
+            }
+        });
+
+        expect(result).toMatchObject({
+            data: {
+                createCategory: {
+                    data: {
+                        title,
+                        slug,
+                        meta: {
+                            status: "draft",
+                            statusStep
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+        const id = result.data.createCategory.data.id;
+
+        const [updateStatusStepResult] = await manager.updateCategory({
+            revision: id,
+            data: {
+                statusStep: "afterTranslation"
+            }
+        });
+
+        expect(updateStatusStepResult).toMatchObject({
+            data: {
+                updateCategory: {
+                    data: {
+                        title,
+                        slug,
+                        meta: {
+                            status: "draft",
+                            statusStep: "afterTranslation"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [doNotTouchStatusStepResult] = await manager.updateCategory({
+            revision: id,
+            data: {
+                title: "New Title"
+            }
+        });
+        expect(doNotTouchStatusStepResult).toMatchObject({
+            data: {
+                updateCategory: {
+                    data: {
+                        title: "New Title",
+                        slug,
+                        meta: {
+                            status: "draft",
+                            statusStep: "afterTranslation"
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+
+    it("should remove a status step when publishing, unpublishing or republishing an entry", async () => {
+        const [result] = await manager.createCategory({
+            data: {
+                title,
+                slug,
+                statusStep
+            }
+        });
+        const id = result.data.createCategory.data.id;
+
+        const [publishResult] = await manager.publishCategory({
+            revision: id
+        });
+        expect(publishResult).toMatchObject({
+            data: {
+                publishCategory: {
+                    data: {
+                        title,
+                        slug,
+                        meta: {
+                            status: "published",
+                            statusStep: null
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [republishResult] = await manager.republishCategory({
+            revision: id
+        });
+        expect(republishResult).toMatchObject({
+            data: {
+                republishCategory: {
+                    data: {
+                        title,
+                        slug,
+                        meta: {
+                            status: "published",
+                            statusStep: null
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+
+        const [unpublishResult] = await manager.unpublishCategory({
+            revision: id
+        });
+        expect(unpublishResult).toMatchObject({
+            data: {
+                unpublishCategory: {
+                    data: {
+                        title,
+                        slug,
+                        meta: {
+                            status: "unpublished",
+                            statusStep: null
+                        }
+                    },
+                    error: null
+                }
+            }
+        });
+    });
+});

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.manage.test.ts
@@ -1,5 +1,5 @@
 import WebinyError from "@webiny/error";
-import type { CmsEntry, CmsGroup, CmsModel } from "~/types";
+import type { CmsEntry, CmsEntryListParams, CmsGroup, CmsModel } from "~/types";
 import { useGraphQLHandler } from "../testHelpers/useGraphQLHandler";
 import { useCategoryManageHandler } from "../testHelpers/useCategoryManageHandler";
 import { useCategoryReadHandler } from "../testHelpers/useCategoryReadHandler";
@@ -851,7 +851,7 @@ describe("MANAGE - Resolvers", () => {
         const { animals, fruits, vegetables, trees } = await createCategories();
         const { listCategories } = useCategoryManageHandler(manageOpts);
 
-        const defaultQueryVars = {
+        const defaultQueryVars: CmsEntryListParams = {
             sort: ["title_ASC"]
         };
 

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -55,6 +55,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
+        statusStep: String
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -74,6 +75,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
+        statusStep: String
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -285,6 +287,10 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
+        statusStep: String
+        statusStep_not: String
+        statusStep_in: [String!]
+        statusStep_not_in: [String!]
 
         title: String
         title_not: String

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/category.manage.ts
@@ -55,7 +55,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
-        statusStep: String
+        state: CmsEntryState!
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -75,7 +75,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
-        statusStep: String
+        state: CmsEntryStateInput
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -287,10 +287,7 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
-        statusStep: String
-        statusStep_not: String
-        statusStep_in: [String!]
-        statusStep_not_in: [String!]
+        state: CmsEntryStateWhereInput
 
         title: String
         title_not: String

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -60,6 +60,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
+        statusStep: String
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -464,6 +465,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
+        statusStep: String
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -678,6 +680,10 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
+        statusStep: String
+        statusStep_not: String
+        statusStep_in: [String!]
+        statusStep_not_in: [String!]
         ghostObject: PageModelApiName_GhostObjectWhereInput
         AND: [PageModelApiNameListWhereInput!]
         OR: [PageModelApiNameListWhereInput!]

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -60,7 +60,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
-        statusStep: String
+        state: CmsEntryState!
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -465,7 +465,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
-        statusStep: String
+        state: CmsEntryStateInput
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -680,10 +680,7 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
-        statusStep: String
-        statusStep_not: String
-        statusStep_in: [String!]
-        statusStep_not_in: [String!]
+        state: CmsEntryStateWhereInput
         ghostObject: PageModelApiName_GhostObjectWhereInput
         AND: [PageModelApiNameListWhereInput!]
         OR: [PageModelApiNameListWhereInput!]

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -65,6 +65,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
+        statusStep: String
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -196,6 +197,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
+        statusStep: String
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -422,6 +424,10 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
+        statusStep: String
+        statusStep_not: String
+        statusStep_in: [String!]
+        statusStep_not_in: [String!]
 
         title: String
         title_not: String

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -65,7 +65,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
-        statusStep: String
+        state: CmsEntryState!
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -197,7 +197,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
-        statusStep: String
+        state: CmsEntryStateInput
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -424,10 +424,7 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
-        statusStep: String
-        statusStep_not: String
-        statusStep_in: [String!]
-        statusStep_not_in: [String!]
+        state: CmsEntryStateWhereInput
 
         title: String
         title_not: String

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -57,6 +57,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
+        statusStep: String
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -76,6 +77,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
+        statusStep: String
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -289,6 +291,10 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
+        statusStep: String
+        statusStep_not: String
+        statusStep_in: [String!]
+        statusStep_not_in: [String!]
 
         text: String
         text_not: String

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/review.manage.ts
@@ -57,7 +57,7 @@ export default /* GraphQL */ `
         locked: Boolean
 
         status: String
-        statusStep: String
+        state: CmsEntryState!
         """
         CAUTION: this field is resolved by making an extra query to DB.
         RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -77,7 +77,7 @@ export default /* GraphQL */ `
 
         # Set status of the entry.
         status: String
-        statusStep: String
+        state: CmsEntryStateInput
 
         createdOn: DateTime
         modifiedOn: DateTime
@@ -291,10 +291,7 @@ export default /* GraphQL */ `
         status_not: String
         status_in: [String!]
         status_not_in: [String!]
-        statusStep: String
-        statusStep_not: String
-        statusStep_in: [String!]
-        statusStep_not_in: [String!]
+        state: CmsEntryStateWhereInput
 
         text: String
         text_not: String

--- a/packages/api-headless-cms/__tests__/testHelpers/setup.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/setup.ts
@@ -1,5 +1,5 @@
 import type { CmsGroup } from "~/types";
-import models from "../contentAPI/mocks/contentModels";
+import allModels from "../contentAPI/mocks/contentModels";
 import type { useGraphQLHandler } from "./useGraphQLHandler";
 import type { CmsModel } from "../types";
 
@@ -50,7 +50,7 @@ export const setupContentModel = async (params: SetupContentModelParams) => {
 
 export const getModel = (item: CmsModel | string): CmsModel => {
     if (typeof item === "string") {
-        const model = models.find(m => m.modelId === item);
+        const model = allModels.find(m => m.modelId === item);
         if (!model) {
             console.log(`[setupContentModel] There is no model "${name}" defined.`);
             process.exit(1);
@@ -62,12 +62,14 @@ export const getModel = (item: CmsModel | string): CmsModel => {
 
 interface SetupGroupAndModelsParams {
     manager: ReturnType<typeof useGraphQLHandler>;
-    models: (CmsModel | string)[];
+    models: (CmsModel | string)[] | undefined;
 }
 
 export const setupGroupAndModels = async (params: SetupGroupAndModelsParams) => {
-    const { manager, models } = params;
+    const { manager, models: initialModels } = params;
     const group = await setupContentModelGroup(manager);
+
+    const models = initialModels || allModels.map(m => m.modelId);
 
     const results: CmsModel[] = [];
     for (const item of models) {
@@ -130,7 +132,7 @@ export const setupContentModels = async (
         if (items.hasOwnProperty(name) === false) {
             continue;
         }
-        const model = models.find(m => m.modelId === name);
+        const model = allModels.find(m => m.modelId === name);
         if (!model) {
             console.log(`[setupContentModel] There is no model "${name}" defined.`);
             process.exit(1);

--- a/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
@@ -32,6 +32,7 @@ const categoryFields = `
         version
         locked
         status
+        statusStep
        
         revisions {
             id

--- a/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
+++ b/packages/api-headless-cms/__tests__/testHelpers/useCategoryManageHandler.ts
@@ -32,7 +32,10 @@ const categoryFields = `
         version
         locked
         status
-        statusStep
+        state {
+            name
+            comment
+        }
        
         revisions {
             id

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
@@ -86,6 +86,7 @@ export const createEntryData = async ({
             await accessControl.ensureCanAccessEntry({ model, pw: "u" });
         }
     }
+    const statusStep = rawInput.statusStep || null;
 
     const locked = status !== STATUS_DRAFT;
 
@@ -171,6 +172,7 @@ export const createEntryData = async ({
 
         version,
         status,
+        statusStep,
         locked,
         values: input,
         location: {

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryData.ts
@@ -18,6 +18,7 @@ import type { SecurityIdentity } from "@webiny/api-security/types";
 import type { Tenant } from "@webiny/api-tenancy/types";
 import { getIdentity } from "~/utils/identity";
 import type { AccessControl } from "~/crud/AccessControl/AccessControl";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type DefaultValue = boolean | number | string | null;
 
@@ -86,7 +87,7 @@ export const createEntryData = async ({
             await accessControl.ensureCanAccessEntry({ model, pw: "u" });
         }
     }
-    const statusStep = rawInput.statusStep || null;
+    const state = createState(rawInput.state);
 
     const locked = status !== STATUS_DRAFT;
 
@@ -172,7 +173,7 @@ export const createEntryData = async ({
 
         version,
         status,
-        statusStep,
+        state,
         locked,
         values: input,
         location: {

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryRevisionFromData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryRevisionFromData.ts
@@ -174,6 +174,7 @@ export const createEntryRevisionFromData = async ({
 
         locked,
         status,
+        statusStep: null,
         values
     };
 

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryRevisionFromData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createEntryRevisionFromData.ts
@@ -17,6 +17,7 @@ import { createIdentifier, parseIdentifier } from "@webiny/utils";
 import WebinyError from "@webiny/error";
 import { STATUS_DRAFT, STATUS_PUBLISHED, STATUS_UNPUBLISHED } from "./statuses";
 import type { AccessControl } from "~/crud/AccessControl/AccessControl";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type CreateEntryRevisionFromDataParams = {
     sourceId: string;
@@ -174,7 +175,7 @@ export const createEntryRevisionFromData = async ({
 
         locked,
         status,
-        statusStep: null,
+        state: createState(undefined),
         values
     };
 

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
@@ -35,6 +35,7 @@ export const createPublishEntryData = async <T extends CmsEntryValues = CmsEntry
     const entry: CmsEntry<T> = {
         ...originalEntry,
         status: STATUS_PUBLISHED,
+        statusStep: null,
         locked: true,
 
         /**

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createPublishEntryData.ts
@@ -4,6 +4,7 @@ import type { SecurityIdentity } from "@webiny/api-security/types";
 import { validateModelEntryDataOrThrow } from "~/crud/contentEntry/entryDataValidation";
 import { getIdentity } from "~/utils/identity";
 import { getDate } from "~/utils/date";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type CreatePublishEntryDataParams = {
     model: CmsModel;
@@ -35,7 +36,7 @@ export const createPublishEntryData = async <T extends CmsEntryValues = CmsEntry
     const entry: CmsEntry<T> = {
         ...originalEntry,
         status: STATUS_PUBLISHED,
-        statusStep: null,
+        state: createState(undefined),
         locked: true,
 
         /**

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
@@ -33,6 +33,7 @@ export const createRepublishEntryData = async ({
     const entry: CmsEntry = {
         ...originalEntry,
         status: STATUS_PUBLISHED,
+        statusStep: null,
 
         /**
          * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createRepublishEntryData.ts
@@ -4,6 +4,7 @@ import { STATUS_PUBLISHED } from "./statuses";
 import type { SecurityIdentity } from "@webiny/api-security/types";
 import { getIdentity } from "~/utils/identity";
 import { getDate } from "~/utils/date";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -33,7 +34,7 @@ export const createRepublishEntryData = async ({
     const entry: CmsEntry = {
         ...originalEntry,
         status: STATUS_PUBLISHED,
-        statusStep: null,
+        state: createState(undefined),
 
         /**
          * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
@@ -3,6 +3,7 @@ import { STATUS_UNPUBLISHED } from "./statuses";
 import type { SecurityIdentity } from "@webiny/api-security/types";
 import { getIdentity } from "~/utils/identity";
 import { getDate } from "~/utils/date";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type CreateRepublishEntryDataParams = {
     model: CmsModel;
@@ -23,7 +24,7 @@ export const createUnpublishEntryData = async <T extends CmsEntryValues = CmsEnt
     const entry: CmsEntry<T> = {
         ...originalEntry,
         status: STATUS_UNPUBLISHED,
-        statusStep: null,
+        state: createState(undefined),
 
         /**
          * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUnpublishEntryData.ts
@@ -23,6 +23,7 @@ export const createUnpublishEntryData = async <T extends CmsEntryValues = CmsEnt
     const entry: CmsEntry<T> = {
         ...originalEntry,
         status: STATUS_UNPUBLISHED,
+        statusStep: null,
 
         /**
          * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUpdateEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUpdateEntryData.ts
@@ -138,7 +138,8 @@ export const createUpdateEntryData = async ({
 
         values,
         meta,
-        status: transformEntryStatus(originalEntry.status)
+        status: transformEntryStatus(originalEntry.status),
+        statusStep: rawInput.statusStep ?? originalEntry.statusStep
     };
 
     const folderId = rawInput.wbyAco_location?.folderId;

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUpdateEntryData.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/createUpdateEntryData.ts
@@ -16,6 +16,7 @@ import { referenceFieldsMapping } from "../referenceFieldsMapping";
 import { mapAndCleanUpdatedInputData } from "./mapAndCleanUpdatedInputData";
 import lodashMerge from "lodash/merge";
 import { removeNullValues, removeUndefinedValues } from "@webiny/utils";
+import { createState } from "~/crud/contentEntry/entryDataFactories/state.js";
 
 type CreateEntryRevisionFromDataParams = {
     metaInput?: Record<string, any>;
@@ -139,7 +140,7 @@ export const createUpdateEntryData = async ({
         values,
         meta,
         status: transformEntryStatus(originalEntry.status),
-        statusStep: rawInput.statusStep ?? originalEntry.statusStep
+        state: createState(rawInput.state ?? originalEntry.state)
     };
 
     const folderId = rawInput.wbyAco_location?.folderId;

--- a/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/state.ts
+++ b/packages/api-headless-cms/src/crud/contentEntry/entryDataFactories/state.ts
@@ -1,0 +1,27 @@
+import type { ICmsEntryState } from "~/types/index.js";
+import zod from "zod";
+
+const schema = zod.object({
+    name: zod
+        .string()
+        .optional()
+        .nullish()
+        .transform(value => value || null),
+    comment: zod
+        .string()
+        .optional()
+        .nullish()
+        .transform(value => value || null)
+});
+
+export const createState = (input: unknown): ICmsEntryState | null => {
+    if (!input) {
+        return null;
+    }
+
+    const parsed = schema.safeParse(input);
+    if (!parsed.success) {
+        return null;
+    }
+    return parsed.data;
+};

--- a/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
+++ b/packages/api-headless-cms/src/graphql/schema/baseSchema.ts
@@ -131,6 +131,25 @@ const createSchema = (plugins: PluginsContainer): IGraphQLSchemaPlugin<CmsContex
                 data: [CmsEntryValidationResponseData!]
                 error: CmsError
             }
+
+            input CmsEntryStateWhereInput {
+                name: String
+                name_in: [String!]
+                name_not: String
+                name_not_in: [String!]
+                comment_contains: String
+                comment_not_contains: String
+            }
+
+            input CmsEntryStateInput {
+                name: String
+                comment: String
+            }
+
+            type CmsEntryState {
+                name: String
+                comment: String
+            }
         `,
         resolvers: {}
     });

--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -91,10 +91,10 @@ export const createManageResolvers: CreateManageResolvers = ({
         },
         ...fieldResolvers,
         [`${model.singularApiName}Meta`]: {
-            title(entry: CmsEntry) {
+            title(entry: Pick<CmsEntry, "id" | "values">) {
                 return getEntryTitle(model, entry);
             },
-            description: (entry: CmsEntry, _: any, context: CmsContext) => {
+            description: (entry: Pick<CmsEntry, "values">, _: any, context: CmsContext) => {
                 if (!model.descriptionFieldId) {
                     return "";
                 }
@@ -110,16 +110,19 @@ export const createManageResolvers: CreateManageResolvers = ({
                     value: entry.values[field.fieldId]
                 });
             },
-            image: (entry: CmsEntry) => {
+            image: (entry: Pick<CmsEntry, "values">) => {
                 return getEntryImage(model, entry);
             },
-            status(entry: CmsEntry) {
+            status(entry: Pick<CmsEntry, "status">) {
                 return entry.status;
             },
-            data: (entry: CmsEntry) => {
+            statusStep(entry: Pick<CmsEntry, "statusStep">) {
+                return entry.statusStep;
+            },
+            data: (entry: Pick<CmsEntry, "meta">) => {
                 return entry.meta || {};
             },
-            async revisions(entry: CmsEntry, _: any, context: CmsContext) {
+            async revisions(entry: Pick<CmsEntry, "entryId">, _: any, context: CmsContext) {
                 const revisions = await context.cms.getEntryRevisions(model, entry.entryId);
                 return revisions.sort((a, b) => b.version - a.version);
             }

--- a/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageResolvers.ts
@@ -1,4 +1,4 @@
-import type { CmsContext, CmsEntry, CmsFieldTypePlugins, CmsModel } from "~/types";
+import type { CmsContext, CmsEntry, CmsFieldTypePlugins, CmsModel, ICmsEntryState } from "~/types";
 import { resolveGet } from "./resolvers/manage/resolveGet";
 import { resolveList } from "./resolvers/manage/resolveList";
 import { resolveListDeleted } from "./resolvers/manage/resolveListDeleted";
@@ -116,8 +116,12 @@ export const createManageResolvers: CreateManageResolvers = ({
             status(entry: Pick<CmsEntry, "status">) {
                 return entry.status;
             },
-            statusStep(entry: Pick<CmsEntry, "statusStep">) {
-                return entry.statusStep;
+            state(entry: Pick<CmsEntry, "state">): ICmsEntryState {
+                return {
+                    comment: null,
+                    name: null,
+                    ...entry.state
+                };
             },
             data: (entry: Pick<CmsEntry, "meta">) => {
                 return entry.meta || {};

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -97,7 +97,7 @@ export const createManageSDL: CreateManageSDL = ({
             locked: Boolean
             
             status: String
-            statusStep: String
+            state: CmsEntryState!
             """
             CAUTION: this field is resolved by making an extra query to DB.
             RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -121,7 +121,7 @@ export const createManageSDL: CreateManageSDL = ({
             
             # Set status of the entry.
             status: String
-            statusStep: String
+            state: CmsEntryStateInput
             
             ${onByMetaInputGqlFields}
             

--- a/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createManageSDL.ts
@@ -97,6 +97,7 @@ export const createManageSDL: CreateManageSDL = ({
             locked: Boolean
             
             status: String
+            statusStep: String
             """
             CAUTION: this field is resolved by making an extra query to DB.
             RECOMMENDATION: Use it only with "get" queries (avoid in "list")
@@ -120,6 +121,7 @@ export const createManageSDL: CreateManageSDL = ({
             
             # Set status of the entry.
             status: String
+            statusStep: String
             
             ${onByMetaInputGqlFields}
             

--- a/packages/api-headless-cms/src/types/types.ts
+++ b/packages/api-headless-cms/src/types/types.ts
@@ -648,6 +648,11 @@ export interface CmsEntry<T = CmsEntryValues> {
      */
     status: CmsEntryStatus;
     /**
+     * With v6 we have added a status step. We have some default ones, but users can add their own.
+     * Note that the status step does not need to be defined.
+     */
+    statusStep: string | null;
+    /**
      * A mapped storageId -> value object.
      *
      * @see CmsModelField
@@ -982,6 +987,10 @@ export interface CmsEntryListWhere {
     status_not?: CmsEntryStatus;
     status_in?: CmsEntryStatus[];
     status_not_in?: CmsEntryStatus[];
+    statusStep?: string;
+    statusStep_not?: string;
+    statusStep_in?: string[];
+    statusStep_not_in?: string[];
 
     /**
      * Revision-level meta fields. 👇
@@ -1421,6 +1430,7 @@ export interface EntryBeforeListTopicParams {
 export type CreateCmsEntryInput<TValues = CmsEntryValues> = TValues & {
     id?: string;
     status?: CmsEntryStatus;
+    statusStep?: string | null;
 
     /**
      * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/types/types.ts
+++ b/packages/api-headless-cms/src/types/types.ts
@@ -651,7 +651,7 @@ export interface CmsEntry<T = CmsEntryValues> {
      * With v6 we have added a status step. We have some default ones, but users can add their own.
      * Note that the status step does not need to be defined.
      */
-    statusStep: string | null;
+    state: ICmsEntryState | null;
     /**
      * A mapped storageId -> value object.
      *
@@ -948,6 +948,11 @@ export interface CmsModelContext {
  */
 export type CmsEntryStatus = "published" | "unpublished" | "draft";
 
+export interface ICmsEntryState {
+    name: string | null;
+    comment: string | null;
+}
+
 export interface CmsEntryListWhereRef {
     id?: string;
     id_in?: string[];
@@ -959,6 +964,14 @@ export interface CmsEntryListWhereRef {
     entryId_not_in?: string[];
 }
 
+export interface ICmsEntryStateWhereInput {
+    name?: string;
+    name_not?: string;
+    name_in?: string[];
+    name_not_in?: string[];
+    comment_contains?: string;
+    comment_not_contains?: string;
+}
 /**
  * Entry listing where params.
  *
@@ -987,10 +1000,7 @@ export interface CmsEntryListWhere {
     status_not?: CmsEntryStatus;
     status_in?: CmsEntryStatus[];
     status_not_in?: CmsEntryStatus[];
-    statusStep?: string;
-    statusStep_not?: string;
-    statusStep_in?: string[];
-    statusStep_not_in?: string[];
+    state?: ICmsEntryStateWhereInput;
 
     /**
      * Revision-level meta fields. 👇
@@ -1099,7 +1109,8 @@ export interface CmsEntryListWhere {
         | null
         | CmsEntryListWhere[]
         | CmsEntryListWhere
-        | CmsEntryListWhereRef;
+        | CmsEntryListWhereRef
+        | ICmsEntryStateWhereInput;
 
     /**
      * To allow querying via nested queries, we added the AND / OR properties.
@@ -1430,7 +1441,7 @@ export interface EntryBeforeListTopicParams {
 export type CreateCmsEntryInput<TValues = CmsEntryValues> = TValues & {
     id?: string;
     status?: CmsEntryStatus;
-    statusStep?: string | null;
+    state?: ICmsEntryState;
 
     /**
      * Entry-level meta fields. 👇

--- a/packages/api-headless-cms/src/utils/getEntryImage.ts
+++ b/packages/api-headless-cms/src/utils/getEntryImage.ts
@@ -2,7 +2,7 @@ import type { CmsEntry, CmsModel } from "~/types";
 
 export function getEntryImage(
     model: Pick<CmsModel, "imageFieldId" | "fields">,
-    entry: CmsEntry
+    entry: Pick<CmsEntry, "values">
 ): string | null {
     if (!model.imageFieldId) {
         return null;

--- a/packages/api-headless-cms/src/utils/getEntryTitle.ts
+++ b/packages/api-headless-cms/src/utils/getEntryTitle.ts
@@ -2,7 +2,7 @@ import type { CmsEntry, CmsModel } from "~/types";
 
 export function getEntryTitle(
     model: Pick<CmsModel, "titleFieldId" | "fields">,
-    entry: CmsEntry
+    entry: Pick<CmsEntry, "id" | "values">
 ): string {
     if (!model.titleFieldId) {
         return entry.id;

--- a/packages/api-headless-cms/src/utils/renderListFilterFields.ts
+++ b/packages/api-headless-cms/src/utils/renderListFilterFields.ts
@@ -67,10 +67,7 @@ export const renderListFilterFields: RenderListFilterFields = (params): string =
             "status_not: String",
             "status_in: [String!]",
             "status_not_in: [String!]",
-            "statusStep: String",
-            "statusStep_not: String",
-            "statusStep_in: [String!]",
-            "statusStep_not_in: [String!]"
+            "state: CmsEntryStateWhereInput"
         );
     }
 

--- a/packages/api-headless-cms/src/utils/renderListFilterFields.ts
+++ b/packages/api-headless-cms/src/utils/renderListFilterFields.ts
@@ -66,7 +66,11 @@ export const renderListFilterFields: RenderListFilterFields = (params): string =
             "status: String",
             "status_not: String",
             "status_in: [String!]",
-            "status_not_in: [String!]"
+            "status_not_in: [String!]",
+            "statusStep: String",
+            "statusStep_not: String",
+            "statusStep_in: [String!]",
+            "statusStep_not_in: [String!]"
         );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,21 +108,21 @@ __metadata:
   linkType: hard
 
 "@auth0/auth0-react@npm:^2.2.4":
-  version: 2.2.4
-  resolution: "@auth0/auth0-react@npm:2.2.4"
+  version: 2.4.0
+  resolution: "@auth0/auth0-react@npm:2.4.0"
   dependencies:
-    "@auth0/auth0-spa-js": "npm:^2.1.3"
+    "@auth0/auth0-spa-js": "npm:^2.2.0"
   peerDependencies:
-    react: ^16.11.0 || ^17 || ^18
-    react-dom: ^16.11.0 || ^17 || ^18
-  checksum: 10/90974eadf39161dea33757bbdc2a1bda92015a7687915196b1e4b6adb92af910c566cab3b5d0b3e5d3d3ce7fa5591843f1926e2306b33b67a50e1a250bcb828b
+    react: ^16.11.0 || ^17 || ^18 || ^19
+    react-dom: ^16.11.0 || ^17 || ^18 || ^19
+  checksum: 10/4b69e694176056c9d119972cc49ced7c9b516abc0782c5e53b6f25af09356ea86526109174c626352cfd5a4839cc0df932529e5c0923a220a4e9f608ef962153
   languageName: node
   linkType: hard
 
-"@auth0/auth0-spa-js@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@auth0/auth0-spa-js@npm:2.1.3"
-  checksum: 10/c0585a7f6c8f8929bf6c7402f2d049cda2c64f82c1736e700cc6ca668d3e23c2c0d22722e8f2aa2d24478e5e6676349e3d5f7ec197a44d093c5607ea8a831adc
+"@auth0/auth0-spa-js@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "@auth0/auth0-spa-js@npm:2.3.0"
+  checksum: 10/f48e1a2a314c7cf30287dc63ef4fee33c4d6fc078c33a0b091bf7a0c09778a3bd7dbf2c395b6556996c1bd6560f6444a1736dce0ea68f5e8cb51a82c3011833a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
This PR adds a `state` object field to the CMS Entry.
State object field has `name`(text) and `comment`(text) fields, none of which are mandatory.

## How Has This Been Tested?
Jest and manually.

## TODO
We will probably need a method to set the state of an entry, regardless of the status of the entry.
Currently we cannot change published or unpublished entries as they are locked. New method which would only update status could circumvent that.