### PR TITLE
Make the HCMS Content Entry grey

### DIFF
--- a/packages/admin-ui/src/Dialog/components/DialogBody.tsx
+++ b/packages/admin-ui/src/Dialog/components/DialogBody.tsx
@@ -14,7 +14,7 @@ const dialogBodyVariants = cva("wby-flex-1", {
         },
         bodyPadding: {
             true: "",
-            false: "!wby-px-none"
+            false: "!wby-px-none !wby-py-none"
         }
     },
     defaultVariants: {

--- a/packages/admin-ui/src/Tabs/components/Content.tsx
+++ b/packages/admin-ui/src/Tabs/components/Content.tsx
@@ -4,7 +4,8 @@ import { cn, cva, type VariantProps } from "~/utils.js";
 
 const tabContentVariants = cva(
     [
-        "wby-bg-transparent",
+        "wby-bg-neutral-base",
+        "wby-my-lg wby-rounded-lg",
         "focus-visible:wby-outline-none focus-visible:wby-ring-lg focus-visible:wby-ring-primary-dimmed",
         // By default, the inner content is removed by the DOM when the tab becomes inactive.
         // This is a problem when we need to keep track of the state inside a tab content, such as forms.

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.styled.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.styled.tsx
@@ -24,7 +24,7 @@ export const Container = ({
             <div
                 className={cn(
                     [
-                        "wby-bg-neutral-base",
+                        "wby-bg-neutral-light",
                         "wby-fixed wby-z-15 wby-top-0 wby-left-0",
                         "wby-w-full wby-h-screen"
                     ],


### PR DESCRIPTION
## Changes
This pull request introduces UI improvements and minor refactoring to Tabs components, along with a visual update to the FullScreenContentEntry container. The most significant changes are grouped below by theme.

**Tabs component styling:**

* Changed the default background of tab content to `wby-bg-neutral-base` and added margin and rounded corners for a more polished look. (`packages/admin-ui/src/Tabs/components/Content.tsx`)

**FullScreenContentEntry container update:**

* Updated the container background from `wby-bg-neutral-base` to `wby-bg-neutral-light` for a lighter appearance. (`packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.styled.tsx`)

<details>
<summary>SCREENSHOTS</summary>

<img width="1398" height="1351" alt="Screenshot 2025-10-23 at 12 02 35" src="https://github.com/user-attachments/assets/37d5f982-a2de-4f9d-93ba-7ebfa1dc5ed9" />


</details>

Closes [WEB-5373](https://webiny.atlassian.net/browse/WEB-5373)
## How Has This Been Tested?
n/a

## Documentation
n/a
