### PR TITLE
Refactor Headless CMS Field Section and Object Field Wrapper Styling to Align with Design System

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/DynamicSection.tsx
@@ -82,27 +82,25 @@ const DynamicSection = ({
                     <Bind.ValidationContainer>
                         <ParentFieldProvider value={value} path={Bind.parentName}>
                             {showLabel ? (
-                                <div
-                                    className={
-                                        "relative mb-xl mt-md border-b-sm border-accent-dimmed"
-                                    }
-                                >
+                                <>
                                     <Heading
-                                        level={6}
+                                        level={5}
                                         className={
-                                            "webiny_group-label-text absolute bottom-[-10px] pr-sm text-accent-primary bg-white"
+                                            "webiny_group-label-text mt-xl mb-sm relative text-accent-primary after:absolute after:z-0 after:inset-x-0 after:top-1/2 after:-translate-y-1/2 after:block after:content-[''] after:h-px after:border-primary-300 after:border-b-1 after:flex-1 after:min-w-0"
                                         }
                                     >
-                                        {`${field.label} ${
-                                            bindFieldValue.length
-                                                ? `(${bindFieldValue.length})`
-                                                : ""
-                                        }`}
+                                        <span className="relative z-1 pr-md bg-white">
+                                            {`${field.label} ${
+                                                bindFieldValue.length
+                                                    ? `(${bindFieldValue.length})`
+                                                    : ""
+                                            }`}
+                                        </span>
                                     </Heading>
                                     {field.helpText && (
                                         <FormComponentDescription text={field.helpText} />
                                     )}
-                                </div>
+                                </>
                             ) : null}
                             <Grid className={classSet(gridClassName, style.gridContainer)}>
                                 <>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectInline.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectInline.tsx
@@ -38,25 +38,21 @@ const plugin: CmsModelFieldRendererPlugin = {
                         <Bind.ValidationContainer>
                             <ParentFieldProvider value={bindProps.value} path={Bind.parentName}>
                                 <ParentValueIndexProvider index={-1}>
-                                    <div
+                                    <Heading
+                                        level={5}
                                         className={
-                                            "relative mb-xl mt-md border-b-sm border-accent-default"
+                                            "webiny_group-label-text mt-xl mb-sm relative text-accent-primary after:absolute after:z-0 after:inset-x-0 after:top-1/2 after:-translate-y-1/2 after:block after:content-[''] after:h-px after:border-primary-300 after:border-b-1 after:flex-1 after:min-w-0"
                                         }
                                     >
-                                        <Heading
-                                            level={6}
-                                            className={
-                                                "webiny_group-label-text absolute bottom-[-10px] pr-sm text-accent-primary bg-white"
-                                            }
-                                        >
+                                        <span className="relative z-1 pr-md bg-white">
                                             {field.label}
-                                        </Heading>
-                                        {field.helpText && (
-                                            <FormComponentDescription>
-                                                {field.helpText}
-                                            </FormComponentDescription>
-                                        )}
-                                    </div>
+                                        </span>
+                                    </Heading>
+                                    {field.helpText && (
+                                        <FormComponentDescription>
+                                            {field.helpText}
+                                        </FormComponentDescription>
+                                    )}
                                     <div
                                         className={
                                             "p-md border-sm border-neutral-dimmed-darker rounded-md"

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectInline.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/object/singleObjectInline.tsx
@@ -53,11 +53,7 @@ const plugin: CmsModelFieldRendererPlugin = {
                                             {field.helpText}
                                         </FormComponentDescription>
                                     )}
-                                    <div
-                                        className={
-                                            "p-md border-sm border-neutral-dimmed-darker rounded-md"
-                                        }
-                                    >
+                                    <div className={"py-md-extra"}>
                                         <Fields
                                             gridClassName={fieldsGridStyle}
                                             Bind={Bind}


### PR DESCRIPTION
## Changes
This PR updates styling for field sections and object field wrappers in the Headless CMS UI to align with the current design system.

**Key adjustments:**
- Updated field section heading from `<h6>` to `<h5>` to improve visual hierarchy.
- Refactored the border line by moving it from the container to an `::after` pseudo-element.
- Separated the label text into its own `<span>` to enable proper `z-index` layering.
- Enhanced visual separation and spacing using updated utility classes.
- Simplified DOM structure by removing unnecessary wrapper elements.
- Removed border and padding from single inline object field wrappers, replacing them with minimal vertical padding for a cleaner, more consistent appearance.

## How Has This Been Tested?
- Verified layout and spacing updates in the Headless CMS UI.
- Checked visual hierarchy across form sections in multiple screen sizes.
- Confirmed no structural regressions or layout breaks in related components.

## Documentation
No documentation changes are required. These updates strictly refine styling to align with the existing design system and do not introduce new functionality or change user-facing behaviors.