### PR TITLE
fix(api-websockets): connection failure due to wrong response

### DIFF
--- a/packages/api-websockets/__tests__/handler/handler.test.ts
+++ b/packages/api-websockets/__tests__/handler/handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createHandler } from "~/handler/handler";
 import { WebsocketsEventRoute } from "~/handler/types";
 import { createMockLambdaContext } from "~tests/mocks/lambdaContext";
@@ -55,13 +55,9 @@ describe("handler", () => {
 
         expect(result).toMatchObject({
             statusCode: 200,
-            isBase64Encoded: false,
             headers: {
                 "sec-websocket-protocol": "webiny-ws-v1"
-            },
-            body: JSON.stringify({
-                statusCode: 200
-            })
+            }
         });
     });
 
@@ -98,13 +94,9 @@ describe("handler", () => {
 
         expect(result).toMatchObject({
             statusCode: 200,
-            isBase64Encoded: false,
             headers: {
                 "sec-websocket-protocol": "webiny-ws-v1"
-            },
-            body: JSON.stringify({
-                statusCode: 200
-            })
+            }
         });
 
         const connectionsAfterConnect = await context.websockets.listConnections({
@@ -148,13 +140,9 @@ describe("handler", () => {
 
         expect(connectResult).toMatchObject({
             statusCode: 200,
-            isBase64Encoded: false,
             headers: {
                 "sec-websocket-protocol": "webiny-ws-v1"
-            },
-            body: JSON.stringify({
-                statusCode: 200
-            })
+            }
         });
 
         const connectionsAfterConnect = await context.websockets.listConnections({
@@ -183,13 +171,9 @@ describe("handler", () => {
 
         expect(disconnectResult).toMatchObject({
             statusCode: 200,
-            isBase64Encoded: false,
             headers: {
                 "sec-websocket-protocol": "webiny-ws-v1"
-            },
-            body: JSON.stringify({
-                statusCode: 200
-            })
+            }
         });
 
         const connectionsAfterDisconnect = await context.websockets.listConnections({
@@ -233,26 +217,9 @@ describe("handler", () => {
 
         expect(disconnectResult).toMatchObject({
             statusCode: 200,
-            isBase64Encoded: false,
             headers: {
                 "sec-websocket-protocol": "webiny-ws-v1"
-            },
-            body: expect.any(String)
-        });
-        const bodyResult = JSON.parse(disconnectResult.body);
-
-        expect(bodyResult).toEqual({
-            error: {
-                code: "CONNECTION_NOT_FOUND",
-                data: {
-                    PK: "WS#CONNECTIONS",
-                    SK: "myConnectionId"
-                },
-                message: 'There is no connection with ID "myConnectionId".',
-                stack: expect.any(String)
-            },
-            message: 'Route "$disconnect" action failed.',
-            statusCode: 200
+            }
         });
     });
 });

--- a/packages/api-websockets/src/handler/handler.ts
+++ b/packages/api-websockets/src/handler/handler.ts
@@ -63,12 +63,14 @@ export const createHandler = (params: HandlerParams): HandlerCallable => {
 
             const result = await handler.run(event);
 
-            return reply
-                .status(result.statusCode)
-                .headers({
-                    "Sec-WebSocket-Protocol": "webiny-ws-v1"
-                })
-                .send(result);
+            app.__webiny_raw_result = {
+                statusCode: result.statusCode,
+                headers: {
+                    "sec-websocket-protocol": "webiny-ws-v1"
+                }
+            };
+
+            return reply.send();
         });
 
         const { tenant, locale, endpoint, token } = getEventValues(event);


### PR DESCRIPTION
## Changes
Websockets failed to connect to the API Gateway Websockets API.
Now, we send raw output to the Lambda response.

## How Has This Been Tested?
Manually.