### PR TITLE
feat(app-headless-cms): separator field

### DIFF
--- a/packages/admin-ui/src/Separator/Separator.stories.tsx
+++ b/packages/admin-ui/src/Separator/Separator.stories.tsx
@@ -37,7 +37,7 @@ export const Documentation: Story = {
         variant: {
             description: "The visual style variant of the separator.",
             control: "select",
-            options: ["transparent", "base", "dimmed", "muted", "strong"]
+            options: ["transparent", "base", "dimmed", "muted", "strong", "accent"]
         },
         orientation: {
             description: "The orientation of the separator.",
@@ -101,7 +101,7 @@ export const Default: Story = {
         },
         variant: {
             control: "select",
-            options: ["transparent", "base", "dimmed", "muted", "strong"]
+            options: ["transparent", "base", "dimmed", "muted", "strong", "accent"]
         }
     }
 };
@@ -208,6 +208,140 @@ export const MoreMargin: Story = {
                     <Text>{"This is text 2."}</Text>
                     <Separator orientation="vertical" margin={"xl"} />
                     <Text>{"This is text 3."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const Transparent: Story = {
+    render: () => {
+        return (
+            <div>
+                <div className="space-y-1">
+                    <Heading level={6}>{"Transparent Variant"}</Heading>
+                    <Text size="sm" className={"text-neutral-strong"}>
+                        {"This separator is transparent and not visible"}
+                    </Text>
+                </div>
+                <Separator margin={"lg"} variant="transparent" />
+                <div className="flex items-center h-6 text-sm">
+                    <Text>{"This is text 1."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const Base: Story = {
+    render: () => {
+        return (
+            <div>
+                <div className="space-y-1">
+                    <Heading level={6}>{"Base Variant"}</Heading>
+                    <Text size="sm" className={"text-neutral-strong"}>
+                        {"This separator uses bg-white"}
+                    </Text>
+                </div>
+                <Separator margin={"lg"} variant="base" />
+                <div className="flex items-center h-6 text-sm">
+                    <Text>{"This is text 1."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const Muted: Story = {
+    render: () => {
+        return (
+            <div>
+                <div className="space-y-1">
+                    <Heading level={6}>{"Muted Variant"}</Heading>
+                    <Text size="sm" className={"text-neutral-strong"}>
+                        {"This separator uses bg-neutral-muted"}
+                    </Text>
+                </div>
+                <Separator margin={"lg"} variant="muted" />
+                <div className="flex items-center h-6 text-sm">
+                    <Text>{"This is text 1."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const Strong: Story = {
+    render: () => {
+        return (
+            <div>
+                <div className="space-y-1">
+                    <Heading level={6}>{"Strong Variant"}</Heading>
+                    <Text size="sm" className={"text-neutral-strong"}>
+                        {"This separator uses bg-neutral-strong"}
+                    </Text>
+                </div>
+                <Separator margin={"lg"} variant="strong" />
+                <div className="flex items-center h-6 text-sm">
+                    <Text>{"This is text 1."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const Accent: Story = {
+    render: () => {
+        return (
+            <div>
+                <div className="space-y-1">
+                    <Heading level={6}>{"Accent Variant"}</Heading>
+                    <Text size="sm" className={"text-neutral-strong"}>
+                        {"This separator uses bg-primary"}
+                    </Text>
+                </div>
+                <Separator margin={"lg"} variant="accent" />
+                <div className="flex items-center h-6 text-sm">
+                    <Text>{"This is text 1."}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const AllVariants: Story = {
+    render: () => {
+        return (
+            <div className="space-y-8">
+                <div>
+                    <Heading level={6}>{"Transparent"}</Heading>
+                    <Separator margin={"lg"} variant="transparent" />
+                    <Text size="sm">{"Not visible"}</Text>
+                </div>
+                <div>
+                    <Heading level={6}>{"Base"}</Heading>
+                    <Separator margin={"lg"} variant="base" />
+                    <Text size="sm">{"bg-white"}</Text>
+                </div>
+                <div>
+                    <Heading level={6}>{"Dimmed (default)"}</Heading>
+                    <Separator margin={"lg"} variant="dimmed" />
+                    <Text size="sm">{"bg-neutral-dimmed"}</Text>
+                </div>
+                <div>
+                    <Heading level={6}>{"Muted"}</Heading>
+                    <Separator margin={"lg"} variant="muted" />
+                    <Text size="sm">{"bg-neutral-muted"}</Text>
+                </div>
+                <div>
+                    <Heading level={6}>{"Strong"}</Heading>
+                    <Separator margin={"lg"} variant="strong" />
+                    <Text size="sm">{"bg-neutral-strong"}</Text>
+                </div>
+                <div>
+                    <Heading level={6}>{"Accent"}</Heading>
+                    <Separator margin={"lg"} variant="accent" />
+                    <Text size="sm">{"bg-primary"}</Text>
                 </div>
             </div>
         );

--- a/packages/admin-ui/src/Separator/Separator.stories.tsx
+++ b/packages/admin-ui/src/Separator/Separator.stories.tsx
@@ -26,7 +26,9 @@ export const Documentation: Story = {
         variant: "dimmed",
         margin: "none",
         orientation: "horizontal",
-        decorative: true
+        decorative: true,
+        children: undefined,
+        labelPosition: "middle"
     },
     argTypes: {
         margin: {
@@ -48,6 +50,16 @@ export const Documentation: Story = {
             description:
                 "Whether the separator is purely decorative and should be hidden from screen readers.",
             control: "boolean"
+        },
+        children: {
+            description:
+                "Optional label text to display with the separator. Text will use text-neutral-primary text-md font-semibold styles.",
+            control: "text"
+        },
+        labelPosition: {
+            description: "Position of the label when children are provided.",
+            control: "select",
+            options: ["start", "middle", "end"]
         }
     },
     render: props => {
@@ -342,6 +354,128 @@ export const AllVariants: Story = {
                     <Heading level={6}>{"Accent"}</Heading>
                     <Separator margin={"lg"} variant="accent" />
                     <Text size="sm">{"bg-primary"}</Text>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const WithLabelMiddle: Story = {
+    render: () => {
+        return (
+            <div className="space-y-8">
+                <div>
+                    <Heading level={6}>{"Separator with label in the middle"}</Heading>
+                    <Text size="sm" className="text-neutral-strong mb-4">
+                        {"Label is positioned in the center (default)"}
+                    </Text>
+                    <Separator variant="dimmed" labelPosition="middle">
+                        {"OR"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="muted" labelPosition="middle">
+                        {"Section Title"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="accent" labelPosition="middle">
+                        {"Important"}
+                    </Separator>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const WithLabelStart: Story = {
+    render: () => {
+        return (
+            <div className="space-y-8">
+                <div>
+                    <Heading level={6}>{"Separator with label at start"}</Heading>
+                    <Text size="sm" className="text-neutral-strong mb-4">
+                        {"Label is positioned at the beginning"}
+                    </Text>
+                    <Separator variant="dimmed" labelPosition="start">
+                        {"Start"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="muted" labelPosition="start">
+                        {"Section 1"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="accent" labelPosition="start">
+                        {"New Feature"}
+                    </Separator>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const WithLabelEnd: Story = {
+    render: () => {
+        return (
+            <div className="space-y-8">
+                <div>
+                    <Heading level={6}>{"Separator with label at end"}</Heading>
+                    <Text size="sm" className="text-neutral-strong mb-4">
+                        {"Label is positioned at the end"}
+                    </Text>
+                    <Separator variant="dimmed" labelPosition="end">
+                        {"End"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="muted" labelPosition="end">
+                        {"See More"}
+                    </Separator>
+                </div>
+                <div>
+                    <Separator variant="accent" labelPosition="end">
+                        {"Continue"}
+                    </Separator>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const WithLabelVertical: Story = {
+    render: () => {
+        return (
+            <div>
+                <Heading level={6} className="mb-4">
+                    {"Vertical separator with labels"}
+                </Heading>
+                <div className="flex gap-8" style={{ height: "200px" }}>
+                    <div className="flex flex-col items-center">
+                        <Text size="sm" className="text-neutral-strong mb-2">
+                            {"Start"}
+                        </Text>
+                        <Separator orientation="vertical" variant="dimmed" labelPosition="start">
+                            {"Top"}
+                        </Separator>
+                    </div>
+                    <div className="flex flex-col items-center">
+                        <Text size="sm" className="text-neutral-strong mb-2">
+                            {"Middle"}
+                        </Text>
+                        <Separator orientation="vertical" variant="muted" labelPosition="middle">
+                            {"Center"}
+                        </Separator>
+                    </div>
+                    <div className="flex flex-col items-center">
+                        <Text size="sm" className="text-neutral-strong mb-2">
+                            {"End"}
+                        </Text>
+                        <Separator orientation="vertical" variant="accent" labelPosition="end">
+                            {"Bottom"}
+                        </Separator>
+                    </div>
                 </div>
             </div>
         );

--- a/packages/admin-ui/src/Separator/Separator.tsx
+++ b/packages/admin-ui/src/Separator/Separator.tsx
@@ -21,7 +21,8 @@ const separatorVariants = cva("shrink-0", {
             base: "bg-white",
             dimmed: "bg-neutral-dimmed",
             muted: "bg-neutral-muted",
-            strong: "bg-neutral-strong"
+            strong: "bg-neutral-strong",
+            accent: "bg-primary"
         }
     },
     compoundVariants: [

--- a/packages/admin-ui/src/Separator/Separator.tsx
+++ b/packages/admin-ui/src/Separator/Separator.tsx
@@ -44,23 +44,95 @@ const separatorVariants = cva("shrink-0", {
     }
 });
 
-type SeparatorProps = SeparatorPrimitive.SeparatorProps & VariantProps<typeof separatorVariants>;
+type SeparatorPosition = "start" | "middle" | "end";
+
+type SeparatorProps = Omit<SeparatorPrimitive.SeparatorProps, "children"> &
+    VariantProps<typeof separatorVariants> & {
+        children?: React.ReactNode;
+        labelPosition?: SeparatorPosition;
+    };
 
 const SeparatorBase = ({
     className,
-    orientation,
+    orientation = "horizontal",
     margin,
     variant,
     decorative = true,
+    children,
+    labelPosition = "middle",
     ...props
-}: SeparatorProps) => (
-    <SeparatorPrimitive.Root
-        decorative={decorative}
-        orientation={orientation}
-        className={separatorVariants({ orientation, margin, variant, className })}
-        {...props}
-    />
-);
+}: SeparatorProps) => {
+    // If no children, render simple separator
+    if (!children) {
+        return (
+            <SeparatorPrimitive.Root
+                decorative={decorative}
+                orientation={orientation}
+                className={separatorVariants({ orientation, margin, variant, className })}
+                {...props}
+            />
+        );
+    }
+
+    // With children, render separator with label
+    const isHorizontal = orientation === "horizontal";
+    const containerClass = isHorizontal
+        ? "flex items-center w-full"
+        : "flex flex-col items-center h-full";
+    const separatorClass = separatorVariants({ orientation, variant });
+    const labelClass = "text-neutral-primary text-md font-semibold px-md";
+
+    const renderContent = () => {
+        if (labelPosition === "start") {
+            return (
+                <>
+                    <span className={labelClass}>{children}</span>
+                    <SeparatorPrimitive.Root
+                        decorative={decorative}
+                        orientation={orientation}
+                        className={`${separatorClass} flex-1 ${isHorizontal ? "ml-xs" : "mt-xs"}`}
+                        {...props}
+                    />
+                </>
+            );
+        }
+
+        if (labelPosition === "end") {
+            return (
+                <>
+                    <SeparatorPrimitive.Root
+                        decorative={decorative}
+                        orientation={orientation}
+                        className={`${separatorClass} flex-1 ${isHorizontal ? "mr-xs" : "mb-xs"}`}
+                        {...props}
+                    />
+                    <span className={labelClass}>{children}</span>
+                </>
+            );
+        }
+
+        // middle (default)
+        return (
+            <>
+                <SeparatorPrimitive.Root
+                    decorative={decorative}
+                    orientation={orientation}
+                    className={`${separatorClass} flex-1 ${isHorizontal ? "mr-xs" : "mb-xs"}`}
+                    {...props}
+                />
+                <span className={labelClass}>{children}</span>
+                <SeparatorPrimitive.Root
+                    decorative={decorative}
+                    orientation={orientation}
+                    className={`${separatorClass} flex-1 ${isHorizontal ? "ml-xs" : "mt-xs"}`}
+                    {...props}
+                />
+            </>
+        );
+    };
+
+    return <div className={containerClass}>{renderContent()}</div>;
+};
 
 const Separator = makeDecoratable("Separator", SeparatorBase);
 

--- a/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/resolvers.read.test.ts
@@ -956,9 +956,9 @@ describe("READ - Resolvers", () => {
         const { listCategories } = useCategoryReadHandler(readOpts);
 
         const from = new Date(vegetables.savedOn);
-        from.setTime(from.getTime() - 10);
+        from.setTime(from.getTime() - 5);
         const to = new Date(vegetables.savedOn);
-        to.setTime(to.getTime() + 10);
+        to.setTime(to.getTime() + 5);
 
         const [result] = await listCategories({
             where: {

--- a/packages/api-headless-cms/src/graphql/schema/createFieldResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createFieldResolvers.ts
@@ -1,13 +1,7 @@
 import set from "lodash/set.js";
 import type { Resolvers } from "@webiny/handler-graphql/types.js";
 import WebinyError from "@webiny/error";
-import type {
-    ApiEndpoint,
-    CmsContext,
-    CmsFieldTypePlugins,
-    CmsModel,
-    CmsModelField
-} from "~/types/index.js";
+import type { ApiEndpoint, CmsContext, CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types/index.js";
 import { entryFieldFromStorageTransform } from "~/utils/entryStorage.js";
 import { getBaseFieldType } from "~/utils/getBaseFieldType.js";
 
@@ -53,6 +47,8 @@ export const createFieldResolversFactory = (factoryParams: CreateFieldResolversF
                         field
                     }
                 );
+            } else if (field.settings?.showInApi === false) {
+                return null;
             }
 
             const createResolver = plugin[endpointType]?.createResolver || null;

--- a/packages/api-headless-cms/src/graphql/schema/createFieldResolvers.ts
+++ b/packages/api-headless-cms/src/graphql/schema/createFieldResolvers.ts
@@ -1,7 +1,13 @@
 import set from "lodash/set.js";
 import type { Resolvers } from "@webiny/handler-graphql/types.js";
 import WebinyError from "@webiny/error";
-import type { ApiEndpoint, CmsContext, CmsFieldTypePlugins, CmsModel, CmsModelField } from "~/types/index.js";
+import type {
+    ApiEndpoint,
+    CmsContext,
+    CmsFieldTypePlugins,
+    CmsModel,
+    CmsModelField
+} from "~/types/index.js";
 import { entryFieldFromStorageTransform } from "~/utils/entryStorage.js";
 import { getBaseFieldType } from "~/utils/getBaseFieldType.js";
 

--- a/packages/api-headless-cms/src/graphqlFields/text.ts
+++ b/packages/api-headless-cms/src/graphqlFields/text.ts
@@ -2,9 +2,15 @@ import type { CmsModelField, CmsModelFieldToGraphQLPlugin } from "~/types/index.
 import { createGraphQLInputField } from "./helpers.js";
 
 interface CreateListFiltersParams {
-    field: CmsModelField;
+    field: Pick<CmsModelField, "fieldId" | "settings">;
 }
-const createListFilters = ({ field }: CreateListFiltersParams) => {
+const createListFilters = ({ field }: CreateListFiltersParams): string => {
+    /**
+     * User settings can disable showing the field in the API
+     */
+    if (field.settings?.showInApi === false) {
+        return "";
+    }
     return `
         ${field.fieldId}: String
         ${field.fieldId}_not: String
@@ -27,12 +33,18 @@ export const createTextField = (): CmsModelFieldToGraphQLPlugin => {
         fullTextSearch: true,
         read: {
             createTypeField({ field }) {
+                if (field.settings?.showInApi === false) {
+                    return "";
+                }
                 if (field.multipleValues) {
                     return `${field.fieldId}: [String]`;
                 }
                 return `${field.fieldId}: String`;
             },
             createGetFilters({ field }) {
+                if (field.settings?.showInApi === false) {
+                    return "";
+                }
                 return `${field.fieldId}: String`;
             },
             createListFilters
@@ -40,12 +52,18 @@ export const createTextField = (): CmsModelFieldToGraphQLPlugin => {
         manage: {
             createListFilters,
             createTypeField({ field }) {
+                if (field.settings?.showInApi === false) {
+                    return "";
+                }
                 if (field.multipleValues) {
                     return `${field.fieldId}: [String]`;
                 }
                 return `${field.fieldId}: String`;
             },
             createInputField({ field }) {
+                if (field.settings?.showInApi === false) {
+                    return "";
+                }
                 return createGraphQLInputField(field, "String");
             }
         }

--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -168,7 +168,10 @@ export interface CmsModelFieldInput {
     /**
      * User defined settings.
      */
-    settings?: Record<string, any>;
+    settings?: {
+        showInApi?: boolean;
+        [key: string]: any;
+    };
 }
 
 /**
@@ -303,7 +306,10 @@ export interface CmsModelFieldSettings {
      * Disable full text search explicitly on this field.
      */
     disableFullTextSearch?: boolean;
-
+    /**
+     * Should the field be exposed in the API?
+     */
+    showInApi?: boolean;
     /**
      * There are a lot of other settings that are possible to add, so we keep the type opened.
      */

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/index.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/index.tsx
@@ -1,0 +1,1 @@
+export * from "./separator.js";

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
@@ -20,18 +20,7 @@ export const createSeparatorFieldRenderer = (): CmsModelFieldRendererPlugin => {
                 return (
                     <Grid>
                         <Grid.Column span={12}>
-                            <Separator
-                                variant={"strong"}
-                                // this is the color from the figma
-                                lineColor={"backgroundColor/backgroundColor-primary-default"}
-                                alignContent={"center"}
-                                // @ts-expect-error
-                                content={
-                                    <span className={"p-l-md p-r-md p-t-sm p-b-sm bg-color-white"}>
-                                        {field.label}
-                                    </span>
-                                }
-                            />
+                            <Separator variant={"accent"}>{field.label}</Separator>
                         </Grid.Column>
                     </Grid>
                 );

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { i18n } from "@webiny/app/i18n/index.js";
+import type { CmsModelFieldRendererPlugin } from "~/types.js";
+import { Grid, Separator } from "@webiny/admin-ui";
+
+const t = i18n.ns("app-headless-cms/admin/fields/text");
+
+export const createSeparatorFieldRenderer = (): CmsModelFieldRendererPlugin => {
+    return {
+        type: "cms-editor-field-renderer",
+        name: "cms-editor-field-renderer-separator",
+        renderer: {
+            rendererName: "text-separator",
+            name: t`Separator`,
+            description: t`Renders a separator field.`,
+            canUse({ field }) {
+                return field.type === "text:separator";
+            },
+            render({ field }) {
+                return (
+                    <Grid>
+                        <Grid.Column span={12}>
+                            <Separator
+                                variant={"strong"}
+                                // this is the color from the figma
+                                lineColor={"backgroundColor/backgroundColor-primary-default"}
+                                alignContent={"center"}
+                                content={
+                                    <span className={"p-l-md p-r-md p-t-sm p-b-sm bg-color-white"}>
+                                        {field.label}
+                                    </span>
+                                }
+                            />
+                            {field.label} ------------------------------
+                        </Grid.Column>
+                    </Grid>
+                );
+            }
+        }
+    };
+};

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/separator/separator.tsx
@@ -25,13 +25,13 @@ export const createSeparatorFieldRenderer = (): CmsModelFieldRendererPlugin => {
                                 // this is the color from the figma
                                 lineColor={"backgroundColor/backgroundColor-primary-default"}
                                 alignContent={"center"}
+                                // @ts-expect-error
                                 content={
                                     <span className={"p-l-md p-r-md p-t-sm p-b-sm bg-color-white"}>
                                         {field.label}
                                     </span>
                                 }
                             />
-                            {field.label} ------------------------------
                         </Grid.Column>
                     </Grid>
                 );

--- a/packages/app-headless-cms/src/admin/plugins/fields/separator/separator.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/separator/separator.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import type { CmsModelFieldTypePlugin } from "@webiny/app-headless-cms-common/types/index.js";
+import { ReactComponent as SeparatorIcon } from "@webiny/icons/line_style.svg";
+import { i18n } from "@webiny/app/i18n/index.js";
+
+const t = i18n.ns("app-headless-cms/admin/fields");
+
+export const separatorField: CmsModelFieldTypePlugin = {
+    type: "cms-editor-field-type",
+    name: "cms-editor-field-type-text-separator",
+    field: {
+        type: "text:separator",
+        label: t`Separator`,
+        description: t`Show a separator field which is not stored in the database.`,
+        icon: <SeparatorIcon />,
+        allowLayout: false,
+        hideInAdmin: false,
+        allowMultipleValues: false,
+        allowPredefinedValues: false,
+        createField() {
+            return {
+                type: this.type,
+                renderer: {
+                    name: "text-separator"
+                }
+            };
+        }
+    }
+};

--- a/packages/app-headless-cms/src/admin/plugins/fields/separator/separator.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/separator/separator.tsx
@@ -22,6 +22,9 @@ export const separatorField: CmsModelFieldTypePlugin = {
                 type: this.type,
                 renderer: {
                     name: "text-separator"
+                },
+                settings: {
+                    showInApi: false
                 }
             };
         }

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModels.tsx
@@ -62,14 +62,14 @@ const ContentModels = () => {
                 </Grid.Column>
             </Grid>
             <NewContentModelDialog open={newContentModelDialogOpened} onClose={onClose} />
-            {cloneContentModel && (
+            {cloneContentModel ? (
                 <CloneContentModelDialog
                     contentModel={cloneContentModel}
                     onClose={onCloneClose}
                     closeModal={closeCloneModal}
                 />
-            )}
-            {importModels && <ImportContentModelsDialog onClose={closeImportModelModal} />}
+            ) : null}
+            {importModels ? <ImportContentModelsDialog onClose={closeImportModelModal} /> : null}
         </div>
     );
 };

--- a/packages/app-headless-cms/src/allPlugins.ts
+++ b/packages/app-headless-cms/src/allPlugins.ts
@@ -42,6 +42,8 @@ import editorUpperCaseSpaceFieldValidator from "~/admin/plugins/fieldValidators/
 import { dynamicZoneField } from "~/admin/plugins/fields/dynamicZone.js";
 import { dynamicZoneFieldRenderer } from "~/admin/plugins/fieldRenderers/dynamicZone/dynamicZoneRenderer.js";
 import { dynamicZoneFieldValidator } from "~/admin/plugins/fieldValidators/dynamicZone.js";
+import { createSeparatorFieldRenderer } from "~/admin/plugins/fieldRenderers/separator/index.js";
+import { separatorField } from "~/admin/plugins/fields/separator/separator.js";
 
 export default [
     headlessCmsPlugins(),
@@ -62,6 +64,8 @@ export default [
     selectFieldRenderer,
     checkboxesFieldRenderer,
     refFieldRenderer,
+    separatorField,
+    createSeparatorFieldRenderer(),
     editorGteFieldValidator,
     editorDateGteFieldValidator(),
     editorDateLteFieldValidator(),


### PR DESCRIPTION
## Changes
Separator field for the Headless CMS Content editing.

## Extra Changes

Separator component now also accepts content, to be rendered in either start, middle, or end positions.

<img width="1391" height="741" alt="image" src="https://github.com/user-attachments/assets/f11f29d6-e05f-47ad-89ad-ebb9c270dfdc" />

<img width="973" height="445" alt="image" src="https://github.com/user-attachments/assets/9a1faf48-0c65-4b38-a9ad-4b7c38723258" />

<img width="711" height="528" alt="image" src="https://github.com/user-attachments/assets/1ed52493-62cc-4ebd-8afb-e742d4d5c856" />


## How Has This Been Tested?
Manually.