### PR TITLE
adrian/ui-fixes

### DIFF
--- a/packages/admin-ui/src/SegmentedControl/primitives/SegmentedControlPrimitive.tsx
+++ b/packages/admin-ui/src/SegmentedControl/primitives/SegmentedControlPrimitive.tsx
@@ -12,7 +12,7 @@ import { Icon } from "~/Icon/index.js";
  */
 const segmentedControlItemVariants = cva(
     [
-        "inline-flex items-center justify-center whitespace-nowrap transition-colors cursor-pointer relative z-10 rounded-md",
+        "inline-flex items-center justify-center whitespace-nowrap transition-colors cursor-pointer relative rounded-md",
         "text-md px-sm-extra py-xs [&>svg]:size-md gap-xs",
         "focus-visible:outline-none focus-visible:ring-md focus-visible:ring-primary-dimmed focus-visible:ring-offset-0",
         "disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed"

--- a/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
@@ -34,7 +34,7 @@ const SidebarHeader = ({ title, icon }: SidebarHeaderProps) => {
                     </div>
 
                     {expanded && transition === null && (
-                        <div className={"size-md animate-in fade-in-0 duration-200"}>
+                        <div className={"size-md animate-in fade-in-0 duration-100"}>
                             <Tooltip
                                 side={"right"}
                                 trigger={

--- a/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
@@ -12,7 +12,7 @@ interface SidebarHeaderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
 }
 
 const SidebarHeader = ({ title, icon }: SidebarHeaderProps) => {
-    const { togglePinned, expanded, pinned } = useSidebar();
+    const { togglePinned, expanded, transition, pinned } = useSidebar();
 
     return (
         <>
@@ -33,8 +33,8 @@ const SidebarHeader = ({ title, icon }: SidebarHeaderProps) => {
                         <span className={"text-md font-semibold truncate"}>{title}</span>
                     </div>
 
-                    {expanded && (
-                        <div className={"size-md"}>
+                    {expanded && transition === null && (
+                        <div className={"size-md animate-in fade-in-0 duration-200"}>
                             <Tooltip
                                 side={"right"}
                                 trigger={

--- a/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Separator } from "~/Separator/index.js";
 import { IconButton } from "~/Button/index.js";
 import { useSidebar } from "./SidebarProvider.js";
@@ -12,7 +12,19 @@ interface SidebarHeaderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
 }
 
 const SidebarHeader = ({ title, icon }: SidebarHeaderProps) => {
-    const { togglePinned, expanded, transition, pinned } = useSidebar();
+    const { togglePinned, expanded, pinned } = useSidebar();
+    const [showButton, setShowButton] = useState(false);
+
+    useEffect(() => {
+        if (expanded) {
+            const timer = setTimeout(() => {
+                setShowButton(true);
+            }, 100);
+            return () => clearTimeout(timer);
+        }
+        setShowButton(false);
+        return undefined;
+    }, [expanded]);
 
     return (
         <>
@@ -33,8 +45,8 @@ const SidebarHeader = ({ title, icon }: SidebarHeaderProps) => {
                         <span className={"text-md font-semibold truncate"}>{title}</span>
                     </div>
 
-                    {expanded && transition === null && (
-                        <div className={"size-md animate-in fade-in-0 duration-100"}>
+                    {showButton && (
+                        <div className={"size-md"}>
                             <Tooltip
                                 side={"right"}
                                 trigger={

--- a/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
@@ -15,7 +15,7 @@ const variants = cva("group peer block border-r-sm border-neutral-dimmed bg-neut
 });
 
 const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRootProps) => {
-    const { state, setExpanded, pinned } = useSidebar();
+    const { state, setExpanded, pinned, expanded } = useSidebar();
 
     const elementRef = useRef<HTMLDivElement>(null);
 
@@ -35,14 +35,22 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
 
         // Add delay before opening to prevent accidental openings
         timeoutRef.current = window.setTimeout(() => {
-            setExpanded(true);
+            // Only set expanded if it's not already expanded
+            if (!expanded) {
+                setExpanded(true);
+            }
         }, 300);
-    }, [pinned, setExpanded]);
+    }, [pinned, setExpanded, expanded]);
 
     const onMouseLeave = useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
         // If the sidebar is pinned, we don't want to close the sidebar on mouse leave.
         if (pinned) {
             return;
+        }
+
+        if (timeoutRef.current) {
+            window.clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
         }
 
         // With this timeout, we prevent the sidebar glitching (quickly opening/closing) during mouse enter/leave events.

--- a/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
@@ -48,7 +48,7 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
         // With this timeout, we prevent the sidebar glitching (quickly opening/closing) during mouse enter/leave events.
         timeoutRef.current = window.setTimeout(() => {
             setExpanded(false);
-        }, 200);
+        }, 300);
     }, [pinned, setExpanded]);
 
     return (

--- a/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
@@ -33,7 +33,10 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
             timeoutRef.current = null;
         }
 
-        setExpanded(true);
+        // Add delay before opening to prevent accidental openings
+        timeoutRef.current = window.setTimeout(() => {
+            setExpanded(true);
+        }, 300);
     }, [pinned, setExpanded]);
 
     const onMouseLeave = useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
@@ -45,7 +48,7 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
         // With this timeout, we prevent the sidebar glitching (quickly opening/closing) during mouse enter/leave events.
         timeoutRef.current = window.setTimeout(() => {
             setExpanded(false);
-        }, 50);
+        }, 200);
     }, [pinned, setExpanded]);
 
     return (
@@ -78,6 +81,13 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
                     {children}
                 </div>
             </div>
+
+            <div
+                data-sidebar={"extra-hover-area"}
+                className={
+                    "absolute top-0 left-[theme(spacing.sidebar-collapsed)] h-full w-sm hidden group-data-[state=collapsed]:block"
+                }
+            />
         </div>
     );
 };

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemAction.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemAction.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { IconButton, type IconButtonProps } from "~/Button/IconButton.js";
 import { useSidebar } from "~/Sidebar/index.js";
 
@@ -7,9 +7,21 @@ interface SidebarMenuItemActionProps extends Omit<IconButtonProps, "icon"> {
 }
 
 const SidebarMenuItemAction = ({ element, ...props }: SidebarMenuItemActionProps) => {
-    const { expanded, transition } = useSidebar();
+    const { expanded } = useSidebar();
+    const [showAction, setShowAction] = useState(false);
 
-    if (!expanded || transition !== null) {
+    useEffect(() => {
+        if (expanded) {
+            const timer = setTimeout(() => {
+                setShowAction(true);
+            }, 100);
+            return () => clearTimeout(timer);
+        }
+        setShowAction(false);
+        return undefined;
+    }, [expanded]);
+
+    if (!showAction) {
         return null;
     }
 
@@ -18,7 +30,7 @@ const SidebarMenuItemAction = ({ element, ...props }: SidebarMenuItemActionProps
             icon={element}
             size={"xs"}
             variant={"ghost"}
-            className={"ml-auto group-data-[state=collapsed]:hidden animate-in fade-in-0 duration-100"}
+            className={"ml-auto group-data-[state=collapsed]:hidden"}
             {...props}
         />
     );

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemAction.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemAction.tsx
@@ -1,17 +1,24 @@
 import React from "react";
 import { IconButton, type IconButtonProps } from "~/Button/IconButton.js";
+import { useSidebar } from "~/Sidebar/index.js";
 
 interface SidebarMenuItemActionProps extends Omit<IconButtonProps, "icon"> {
     element?: React.ReactNode;
 }
 
 const SidebarMenuItemAction = ({ element, ...props }: SidebarMenuItemActionProps) => {
+    const { expanded, transition } = useSidebar();
+
+    if (!expanded || transition !== null) {
+        return null;
+    }
+
     return (
         <IconButton
             icon={element}
             size={"xs"}
             variant={"ghost"}
-            className={"ml-auto group-data-[state=collapsed]:hidden"}
+            className={"ml-auto group-data-[state=collapsed]:hidden animate-in fade-in-0 duration-100"}
             {...props}
         />
     );

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
@@ -32,18 +32,18 @@ const SidebarMenuItemBase = ({ children, className, ...buttonProps }: SidebarMen
             return <SidebarMenuRootButton {...buttonProps} />;
         }
 
-        const chevron = (
+        const chevron = sidebar.expanded && sidebar.transition === null ? (
             <Icon
                 label={"Expand / Collapse"}
                 size={"sm"}
                 className={
-                    "ml-auto transition-transform duration-175 group-data-[state=open]/menu-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden"
+                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden animate-in fade-in-0"
                 }
                 color={"neutral-strong"}
                 data-sidebar={"menu-item-expanded-indicator"}
                 icon={<KeyboardArrowRightIcon />}
             />
-        );
+        ) : null;
 
         return (
             <Collapsible.Root

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
@@ -36,6 +36,7 @@ const SidebarMenuItemBase = ({ children, className, ...buttonProps }: SidebarMen
             return () => clearTimeout(timer);
         }
         setShowChevron(false);
+        return undefined;
     }, [sidebar.expanded]);
 
     const sidebarMenuButton = useMemo(() => {

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { cn, makeDecoratable, withStaticProps } from "~/utils.js";
 import { SidebarMenuRootButton } from "./SidebarMenuRootButton.js";
 import { SidebarMenuItemIcon } from "./SidebarMenuItemIcon.js";
@@ -14,6 +14,7 @@ import { useSidebar } from "~/Sidebar/index.js";
 const SidebarMenuItemBase = ({ children, className, ...buttonProps }: SidebarMenuItemProps) => {
     const { currentLevel } = useSidebarMenu();
     const sidebar = useSidebar();
+    const [showChevron, setShowChevron] = useState(false);
 
     const menuItemId = useMemo(() => {
         return btoa(`sidebar-item-${currentLevel}-${buttonProps.text}`);
@@ -27,17 +28,27 @@ const SidebarMenuItemBase = ({ children, className, ...buttonProps }: SidebarMen
         sidebar.toggleSectionExpanded(menuItemId);
     }, [isSectionExpanded]);
 
+    useEffect(() => {
+        if (sidebar.expanded) {
+            const timer = setTimeout(() => {
+                setShowChevron(true);
+            }, 100);
+            return () => clearTimeout(timer);
+        }
+        setShowChevron(false);
+    }, [sidebar.expanded]);
+
     const sidebarMenuButton = useMemo(() => {
         if (!children) {
             return <SidebarMenuRootButton {...buttonProps} />;
         }
 
-        const chevron = sidebar.expanded && sidebar.transition === null ? (
+        const chevron = showChevron ? (
             <Icon
                 label={"Expand / Collapse"}
                 size={"sm"}
                 className={
-                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden animate-in fade-in-0"
+                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden"
                 }
                 color={"neutral-strong"}
                 data-sidebar={"menu-item-expanded-indicator"}
@@ -59,7 +70,7 @@ const SidebarMenuItemBase = ({ children, className, ...buttonProps }: SidebarMen
                 </Collapsible.Content>
             </Collapsible.Root>
         );
-    }, [children, buttonProps, menuItemId, isSectionExpanded, toggleSectionExpanded]);
+    }, [children, buttonProps, menuItemId, isSectionExpanded, toggleSectionExpanded, showChevron]);
 
     return (
         <li

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "~/utils.js";
 import { Collapsible } from "radix-ui";
 import { SidebarMenuSubButton } from "./SidebarMenuSubButton.js";
@@ -13,6 +13,7 @@ import { useSidebar } from "~/Sidebar/index.js";
 const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenuItemProps) => {
     const { currentLevel } = useSidebarMenu();
     const sidebar = useSidebar();
+    const [showChevron, setShowChevron] = useState(false);
 
     const menuItemId = useMemo(() => {
         return btoa(`sidebar-item-${currentLevel}-${buttonProps.text}`);
@@ -25,6 +26,17 @@ const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenu
     const toggleSectionExpanded = useCallback(() => {
         sidebar.toggleSectionExpanded(menuItemId);
     }, [isSectionExpanded]);
+
+    useEffect(() => {
+        if (sidebar.expanded) {
+            const timer = setTimeout(() => {
+                setShowChevron(true);
+            }, 100);
+            return () => clearTimeout(timer);
+        }
+        setShowChevron(false);
+        return undefined;
+    }, [sidebar.expanded]);
 
     const sidebarMenuSubButton = useMemo(() => {
         if (!children) {
@@ -39,12 +51,12 @@ const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenu
             );
         }
 
-        const chevron = sidebar.expanded && sidebar.transition === null ? (
+        const chevron = showChevron ? (
             <Icon
                 label={"Expand / Collapse"}
                 size={"sm"}
                 className={
-                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-sub-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden animate-in fade-in-0"
+                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-sub-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden"
                 }
                 color={"neutral-strong"}
                 data-sidebar={"menu-item-expanded-indicator"}
@@ -68,7 +80,7 @@ const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenu
                 </Collapsible.Content>
             </Collapsible.Root>
         );
-    }, [children, buttonProps, currentLevel, menuItemId, isSectionExpanded, toggleSectionExpanded]);
+    }, [children, buttonProps, currentLevel, menuItemId, isSectionExpanded, toggleSectionExpanded, showChevron]);
 
     return (
         <li

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
@@ -39,18 +39,18 @@ const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenu
             );
         }
 
-        const chevron = (
+        const chevron = sidebar.expanded && sidebar.transition === null ? (
             <Icon
                 label={"Expand / Collapse"}
                 size={"sm"}
                 className={
-                    "ml-auto transition-transform duration-175 group-data-[state=open]/menu-sub-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden"
+                    "ml-auto transition-transform duration-100 group-data-[state=open]/menu-sub-item-collapsible:rotate-180 group-data-[state=collapsed]:hidden animate-in fade-in-0"
                 }
                 color={"neutral-strong"}
                 data-sidebar={"menu-item-expanded-indicator"}
                 icon={<KeyboardArrowRightIcon />}
             />
-        );
+        ) : null;
 
         return (
             <Collapsible.Root className="w-full group/menu-sub-item-collapsible">

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
@@ -80,7 +80,15 @@ const SidebarMenuSubItem = ({ children, className, ...buttonProps }: SidebarMenu
                 </Collapsible.Content>
             </Collapsible.Root>
         );
-    }, [children, buttonProps, currentLevel, menuItemId, isSectionExpanded, toggleSectionExpanded, showChevron]);
+    }, [
+        children,
+        buttonProps,
+        currentLevel,
+        menuItemId,
+        isSectionExpanded,
+        toggleSectionExpanded,
+        showChevron
+    ]);
 
     return (
         <li

--- a/packages/admin-ui/src/Tooltip/components/TooltipContent.tsx
+++ b/packages/admin-ui/src/Tooltip/components/TooltipContent.tsx
@@ -4,7 +4,7 @@ import { cn, cva, type VariantProps } from "~/utils.js";
 
 const tooltipContentVariants = cva(
     [
-        "px-sm-extra py-sm max-w-64 rounded-md text-sm font-normal animate-in fade-in-0 zoom-in-95",
+        "z-[var(--z-index-tooltip)] px-sm-extra py-sm max-w-64 rounded-md text-sm font-normal animate-in fade-in-0 zoom-in-95",
         "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
         "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
     ],

--- a/packages/api-headless-cms-ddb/src/definitions/model.ts
+++ b/packages/api-headless-cms-ddb/src/definitions/model.ts
@@ -24,10 +24,6 @@ export const createModelEntity = (params: Params): Entity<any> => {
                 type: "string",
                 required: true
             },
-            webinyVersion: {
-                type: "string",
-                required: true
-            },
             name: {
                 type: "string",
                 required: true

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntryHeaderLeft.tsx
@@ -29,7 +29,7 @@ export const ContentEntryFormTitle = makeDecoratable("ContentEntryFormTitle", ()
     return (
         <Heading
             level={5}
-            className={cn("text-neutral-primary max-w-lg truncate", {
+            className={cn("text-neutral-primary", {
                 "opacity-50": isNewEntry
             })}
         >

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -7,7 +7,7 @@ export const Extensions = () => {
     return (
         <>
             {/* Admin 👇 */}
-            <Admin.Extension src={"./extensions/AdminLogo.tsx"} />
+            {/*<Admin.Extension src={"./extensions/AdminLogo.tsx"} />*/}
 
             {/* Infra 👇 */}
             <Infra.PulumiResourceNamePrefix prefix={"myproj-"} />


### PR DESCRIPTION
Multiple UI fixes.

1. Sidebar (main menu) now opens and closes with a short delay after a mouse hover. This should help with accidentally opens of the menu.

2. Previously, once the menu started to expand (on mouse hover), for a micro amount of time, you'd see the chevron / header icon over the app icons. This is now handled.

3. CMS Editor - Fixed Top-Left Section (screenshot below)
<img width="754" height="283" alt="image" src="https://github.com/user-attachments/assets/da702e8c-7d69-47a4-96d2-386e7332e5f1" />

4. Segmented control buttons are not rendered over the sidebar any more (reported by @m0nikaza )
<img width="716" height="403" alt="image" src="https://github.com/user-attachments/assets/15b68987-fe22-4960-8451-953a60a6076b" />
