### PR TITLE
feat: add a dedicated file-manager route

### DIFF
--- a/packages/app-aco/src/contexts/navigateFolder.tsx
+++ b/packages/app-aco/src/contexts/navigateFolder.tsx
@@ -75,9 +75,11 @@ export const NavigateFolderProvider = ({
         props.navigateToFolder(ROOT_FOLDER);
     };
 
+    const finalFolderId = currentFolderId || getFolderFromStorage() || ROOT_FOLDER;
+
     const context: NavigateFolderContext = {
-        currentFolderId: currentFolderId || getFolderFromStorage() || ROOT_FOLDER,
-        isRootFolder: currentFolderId === ROOT_FOLDER,
+        currentFolderId: finalFolderId,
+        isRootFolder: finalFolderId === ROOT_FOLDER,
         setFolderToStorage,
         navigateToListHome,
         navigateToFolder,

--- a/packages/app-admin/src/base/Base/Menus.tsx
+++ b/packages/app-admin/src/base/Base/Menus.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { HasPermission } from "@webiny/app-security";
-import { FileManager } from "~/base/ui/FileManager.js";
 import { WebinyVersion } from "./Menus/WebinyVersion.js";
 import { SupportMenuItems } from "./Menus/SupportMenuItems.js";
 import { AdminConfig } from "~/config/AdminConfig.js";
@@ -21,23 +20,19 @@ export const Menus = React.memo(() => {
         <AdminConfig>
             <HasPermission name={"fm.file"}>
                 <Menu
-                    name={"fm"}
+                    name={"fileManager"}
+                    pin={"start"}
                     element={
-                        <FileManager>
-                            {({ showFileManager }) => (
-                                <Menu.Item
-                                    text={"File Manager"}
-                                    icon={
-                                        <Menu.Item.Icon
-                                            label="File Manager"
-                                            element={<FileManagerIcon />}
-                                        />
-                                    }
-                                    onClick={() => showFileManager()}
-                                    data-testid={"admin-drawer-footer-menu-file-manager"}
+                        <Menu.Link
+                            text={"File Manager"}
+                            icon={
+                                <Menu.Item.Icon
+                                    label="File Manager"
+                                    element={<FileManagerIcon />}
                                 />
-                            )}
-                        </FileManager>
+                            }
+                            to={"/file-manager"}
+                        />
                     }
                 />
             </HasPermission>

--- a/packages/app-admin/src/base/Base/RoutesConfig.tsx
+++ b/packages/app-admin/src/base/Base/RoutesConfig.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Dashboard, AdminLayout, NotFound } from "~/index.js";
 import { AdminConfig } from "~/config/AdminConfig.js";
 import { Routes } from "~/routes.js";
+import { FileManagerRenderer } from "~/index.js";
+import { FileManager } from "~/index.js";
 
 const { Route } = AdminConfig;
 
@@ -13,6 +15,15 @@ export const RoutesConfig = React.memo(() => {
                 element={
                     <AdminLayout title={"Welcome!"}>
                         <Dashboard />
+                    </AdminLayout>
+                }
+            />
+
+            <Route
+                route={Routes.FileManager}
+                element={
+                    <AdminLayout title={"File Manager"}>
+                        <FileManager overlay={false} show={true}/>
                     </AdminLayout>
                 }
             />

--- a/packages/app-admin/src/base/Base/RoutesConfig.tsx
+++ b/packages/app-admin/src/base/Base/RoutesConfig.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Dashboard, AdminLayout, NotFound } from "~/index.js";
 import { AdminConfig } from "~/config/AdminConfig.js";
 import { Routes } from "~/routes.js";
-import { FileManagerRenderer } from "~/index.js";
 import { FileManager } from "~/index.js";
 
 const { Route } = AdminConfig;
@@ -23,7 +22,7 @@ export const RoutesConfig = React.memo(() => {
                 route={Routes.FileManager}
                 element={
                     <AdminLayout title={"File Manager"}>
-                        <FileManager overlay={false} show={true}/>
+                        <FileManager overlay={false} show={true} />
                     </AdminLayout>
                 }
             />

--- a/packages/app-admin/src/base/ui/FileManager.tsx
+++ b/packages/app-admin/src/base/ui/FileManager.tsx
@@ -23,12 +23,6 @@ export interface FileManagerFileItemMetaItem {
     value: any;
 }
 
-export type DeprecatedFileManagerRenderPropParams = {
-    showFileManager: (
-        onChange?: FileManagerOnChange<FileManagerFileItem | FileManagerFileItem[]>
-    ) => void;
-};
-
 export type FileManagerRenderPropParams<TValue> = {
     showFileManager: (onChange?: FileManagerOnChange<TValue>) => void;
 };
@@ -61,26 +55,19 @@ export type FileManagerProps = {
     accept?: string[];
     images?: boolean;
     maxSize?: number | string;
-    /**
-     * @deprecated This prop is no longer used. The file structure was reduced to a bare minimum so picking is no longer necessary.
-     */
-    onChangePick?: string[];
     onClose?: () => void;
     onUploadCompletion?: (files: FileManagerFileItem[]) => void;
     own?: boolean;
     scope?: string;
     tags?: string[];
     show?: boolean;
-    /**
-     * @deprecated This prop is no longer used. Use the `render` prop to get better TS autocomplete.
-     */
-    children?: (params: DeprecatedFileManagerRenderPropParams) => React.ReactNode;
+    overlay?: boolean;
 } & MultipleProps;
 
 // This jewel was taken from https://davidgomes.com/pick-omit-over-union-types-in-typescript/. Massive thanks, David!
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 
-export type FileManagerRendererProps = DistributiveOmit<FileManagerProps, "render" | "children">;
+export type FileManagerRendererProps = DistributiveOmit<FileManagerProps, "render">;
 
 export const FileManagerRenderer = makeDecoratable(
     "FileManagerRenderer",
@@ -92,7 +79,7 @@ type ShowFileManagerProps =
     | FileManagerOnChange<FileManagerFileItem[]>
     | undefined;
 
-export const FileManager = ({ children, render, onChange, ...rest }: FileManagerProps) => {
+export const FileManager = ({ render, onChange, ...rest }: FileManagerProps) => {
     const [isFileManagerVisible, setFileManagerVisible] = useState(rest.show);
     const onChangeRef = useRef(onChange);
 
@@ -116,24 +103,33 @@ export const FileManager = ({ children, render, onChange, ...rest }: FileManager
             return null;
         }
 
+        // Render as overlay
+        if (rest.overlay) {
+            return (
+                <Portal>
+                    {/*@ts-expect-error*/}
+                    <FileManagerRenderer
+                        onClose={handleCloseFileManager}
+                        onChange={onChangeRef.current}
+                        {...rest}
+                    />
+                </Portal>
+            );
+        }
+
+        // Render inline
         return (
-            <Portal>
-                {/*@ts-expect-error*/}
-                <FileManagerRenderer
-                    onClose={handleCloseFileManager}
-                    onChange={onChangeRef.current}
-                    {...rest}
-                />
-            </Portal>
+            // @ts-expect-error
+            <FileManagerRenderer
+                onClose={handleCloseFileManager}
+                onChange={onChangeRef.current}
+                {...rest}
+            />
         );
     };
 
     const renderContent = () => {
         const renderProps = { showFileManager: handleShowFileManager };
-
-        if (children) {
-            return children(renderProps);
-        }
 
         if (render) {
             return render(renderProps);

--- a/packages/app-admin/src/components/IconPicker/plugins/customPlugin.tsx
+++ b/packages/app-admin/src/components/IconPicker/plugins/customPlugin.tsx
@@ -49,8 +49,7 @@ const IconFilePicker = ({ onUpload, onChange }: IconFilePickerProps) => {
             onChange={onChange}
             scope="scope:iconPicker"
             accept={["image/svg+xml"]}
-        >
-            {({ showFileManager }) => (
+            render={({ showFileManager }) => (
                 <Button
                     variant={"primary"}
                     text={"Browse"}
@@ -59,7 +58,7 @@ const IconFilePicker = ({ onUpload, onChange }: IconFilePickerProps) => {
                     }}
                 />
             )}
-        </FileManager>
+        ></FileManager>
     );
 };
 

--- a/packages/app-admin/src/components/LexicalEditor/LexicalEditor.tsx
+++ b/packages/app-admin/src/components/LexicalEditor/LexicalEditor.tsx
@@ -22,8 +22,9 @@ export const LexicalEditor = (props: LexicalEditorProps) => {
     };
 
     return (
-        <FileManager accept={imagesOnly}>
-            {({ showFileManager }) => (
+        <FileManager
+            accept={imagesOnly}
+            render={({ showFileManager }) => (
                 <BaseEditor
                     {...props}
                     theme={editorTheme}
@@ -33,6 +34,6 @@ export const LexicalEditor = (props: LexicalEditorProps) => {
                     ]}
                 />
             )}
-        </FileManager>
+        />
     );
 };

--- a/packages/app-admin/src/components/SingleImageUpload.tsx
+++ b/packages/app-admin/src/components/SingleImageUpload.tsx
@@ -60,12 +60,6 @@ export interface SingleImageUploadProps extends FormComponentProps {
     round?: boolean;
 
     /**
-     * Define the properties that are returned on file(s) selection.
-     * @deprecated Pick the desired file attributes in the `onChange` callback, or `beforeChange` on the `<Bind>` element.
-     */
-    onChangePick?: string[];
-
-    /**
      * Render the image preview.
      */
     renderFilePreview?: FilePickerProps["renderFilePreview"];

--- a/packages/app-admin/src/routes.ts
+++ b/packages/app-admin/src/routes.ts
@@ -6,6 +6,11 @@ export const Routes = {
         path: "/"
     }),
 
+    FileManager: new Route({
+        name: "FileManager",
+        path: "/file-manager"
+    }),
+
     CatchAll: new Route({
         name: "CatchAll",
         path: "*"

--- a/packages/app-file-manager/src/components/Header/Actions.tsx
+++ b/packages/app-file-manager/src/components/Header/Actions.tsx
@@ -9,6 +9,7 @@ import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerVie
 import { useFileManagerApi } from "~/modules/FileManagerApiProvider/FileManagerApiContext/index.js";
 import type { BrowseFilesHandler, HeaderProps } from "~/components/Header/Header.js";
 import { FiltersToggle } from "@webiny/app-admin";
+import { SearchWidget } from "~/components/SearchWidget/index.js";
 
 type ActionsProps = Pick<HeaderProps, "browseFiles">;
 
@@ -110,6 +111,9 @@ const ToggleFiltersAction = () => {
 export const Actions = (props: ActionsProps) => {
     return (
         <div className={"h-full flex gap-sm items-center justify-end"}>
+            <div className={"flex justify-start w-full"}>
+                <SearchWidget />
+            </div>
             <div className={"flex gap-xs"}>
                 <ToggleFiltersAction />
                 <LayoutSwitchAction />

--- a/packages/app-file-manager/src/components/Header/Actions.tsx
+++ b/packages/app-file-manager/src/components/Header/Actions.tsx
@@ -9,7 +9,6 @@ import { useFileManagerView } from "~/modules/FileManagerRenderer/FileManagerVie
 import { useFileManagerApi } from "~/modules/FileManagerApiProvider/FileManagerApiContext/index.js";
 import type { BrowseFilesHandler, HeaderProps } from "~/components/Header/Header.js";
 import { FiltersToggle } from "@webiny/app-admin";
-import { SearchWidget } from "~/components/SearchWidget/index.js";
 
 type ActionsProps = Pick<HeaderProps, "browseFiles">;
 
@@ -111,9 +110,6 @@ const ToggleFiltersAction = () => {
 export const Actions = (props: ActionsProps) => {
     return (
         <div className={"h-full flex gap-sm items-center justify-end"}>
-            <div className={"flex justify-start w-full"}>
-                <SearchWidget />
-            </div>
             <div className={"flex gap-xs"}>
                 <ToggleFiltersAction />
                 <LayoutSwitchAction />

--- a/packages/app-file-manager/src/components/Header/Header.tsx
+++ b/packages/app-file-manager/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { FilesRenderChildren } from "react-butterfiles";
-import { Grid, Separator } from "@webiny/admin-ui";
+import { Separator } from "@webiny/admin-ui";
 
 import { Actions } from "./Actions.js";
 import { Title } from "./Title.js";
@@ -17,14 +17,9 @@ export const Header = (props: HeaderProps) => {
     return (
         <div>
             <div className={"pl-lg pr-md py-sm-extra"}>
-                <Grid>
-                    <Grid.Column span={6}>
-                        <Title />
-                    </Grid.Column>
-                    <Grid.Column span={6}>
-                        <Actions browseFiles={props.browseFiles} />
-                    </Grid.Column>
-                </Grid>
+                <Title />
+                <div className={"pb-sm"} />
+                <Actions browseFiles={props.browseFiles} />
             </div>
             <Separator />
         </div>

--- a/packages/app-file-manager/src/components/Header/Header.tsx
+++ b/packages/app-file-manager/src/components/Header/Header.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import type { FilesRenderChildren } from "react-butterfiles";
-import { Separator } from "@webiny/admin-ui";
 
 import { Actions } from "./Actions.js";
 import { Title } from "./Title.js";
+import { SearchWidget } from "~/components/SearchWidget/index.js";
 
 export interface BrowseFilesHandler {
     browseFiles: FilesRenderChildren["browseFiles"];
@@ -15,13 +15,20 @@ export interface HeaderProps {
 
 export const Header = (props: HeaderProps) => {
     return (
-        <div>
-            <div className={"pl-lg pr-md py-sm-extra"}>
-                <Title />
-                <div className={"pb-sm"} />
-                <Actions browseFiles={props.browseFiles} />
+        <div className={"flex flex-col gap-md"}>
+            <Title />
+            <div className={"px-md pb-sm"}>
+                <div className={"flex items-center gap-sm w-full"}>
+                    <div className={"flex-1"}>
+                        <SearchWidget />
+                    </div>
+                    <div>
+                        <div className={"flex gap-sm"}>
+                            <Actions browseFiles={props.browseFiles} />
+                        </div>
+                    </div>
+                </div>
             </div>
-            <Separator />
         </div>
     );
 };

--- a/packages/app-file-manager/src/components/Header/Title.tsx
+++ b/packages/app-file-manager/src/components/Header/Title.tsx
@@ -30,7 +30,7 @@ export const Title = () => {
                     {listTitle}
                 </Heading>
             </div>
-            {currentFolder && (
+            {currentFolder && !isRootFolder && (
                 <FolderProvider folder={currentFolder}>
                     <OptionsMenu
                         actions={browser.folder.actions}

--- a/packages/app-file-manager/src/components/Header/Title.tsx
+++ b/packages/app-file-manager/src/components/Header/Title.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Heading, Icon, IconButton, Skeleton } from "@webiny/admin-ui";
 import { ReactComponent as HomeIcon } from "@webiny/icons/home.svg";
 import { ReactComponent as FolderIcon } from "@webiny/icons/folder.svg";
@@ -12,39 +12,41 @@ export const Title = () => {
     const { isRootFolder, listTitle, currentFolder } = useFileManagerView();
     const { browser } = useFileManagerViewConfig();
 
-    const icon = useMemo(() => {
-        return isRootFolder ? <HomeIcon /> : <FolderIcon />;
-    }, [isRootFolder]);
+    const icon = isRootFolder ? <HomeIcon /> : <FolderIcon />;
+
+    if (!listTitle) {
+        return (
+            <div className={"flex pt-md px-md items-center"}>
+                <Skeleton size={"xl"} />
+            </div>
+        );
+    }
 
     return (
-        <>
-            {(listTitle && (
-                <div className={"flex gap-xs items-center"}>
-                    <div className={"flex gap-sm items-center truncate"}>
-                        <Icon icon={icon} label={listTitle} size={"md"} color={"neutral-strong"} />
-                        <Heading level={4} as={"h1"} className={"truncate"}>
-                            {listTitle}
-                        </Heading>
-                    </div>
-                    {currentFolder && (
-                        <FolderProvider folder={currentFolder}>
-                            <OptionsMenu
-                                actions={browser.folder.actions}
-                                data-testid={"folder.title.menu-action"}
-                                trigger={
-                                    <IconButton
-                                        icon={<MoreVerticalIcon />}
-                                        size={"sm"}
-                                        iconSize={"lg"}
-                                        variant={"ghost"}
-                                        disabled={isRootFolder}
-                                    />
-                                }
+        <div className={"flex pt-md px-lg items-center"}>
+            <div className={"flex gap-sm items-center truncate"}>
+                <Icon icon={icon} label={listTitle} size={"md"} color={"neutral-strong"} />
+                <Heading level={4} as={"h1"} className={"truncate"}>
+                    {listTitle}
+                </Heading>
+            </div>
+            {currentFolder && (
+                <FolderProvider folder={currentFolder}>
+                    <OptionsMenu
+                        actions={browser.folder.actions}
+                        data-testid={"folder.title.menu-action"}
+                        trigger={
+                            <IconButton
+                                icon={<MoreVerticalIcon />}
+                                size={"sm"}
+                                iconSize={"lg"}
+                                variant={"ghost"}
+                                disabled={isRootFolder}
                             />
-                        </FolderProvider>
-                    )}
-                </div>
-            )) || <Skeleton size={"xl"} />}
-        </>
+                        }
+                    />
+                </FolderProvider>
+            )}
+        </div>
     );
 };

--- a/packages/app-file-manager/src/components/Header/Title.tsx
+++ b/packages/app-file-manager/src/components/Header/Title.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Heading, Icon, IconButton, Skeleton, Switch } from "@webiny/admin-ui";
+import { Heading, Icon, IconButton, Skeleton } from "@webiny/admin-ui";
 import { ReactComponent as HomeIcon } from "@webiny/icons/home.svg";
 import { ReactComponent as FolderIcon } from "@webiny/icons/folder.svg";
 import { ReactComponent as MoreVerticalIcon } from "@webiny/icons/more_vert.svg";
@@ -9,14 +9,7 @@ import { OptionsMenu } from "@webiny/app-admin";
 import { useFileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.js";
 
 export const Title = () => {
-    const {
-        isRootFolder,
-        listTitle,
-        displaySubFolders,
-        setDisplaySubFolders,
-        currentFolder,
-        folders
-    } = useFileManagerView();
+    const { isRootFolder, listTitle, currentFolder } = useFileManagerView();
     const { browser } = useFileManagerViewConfig();
 
     const icon = useMemo(() => {
@@ -50,15 +43,6 @@ export const Title = () => {
                             />
                         </FolderProvider>
                     )}
-                    <div className={"flex flex-nowrap"}>
-                        <Switch
-                            label={"Display subfolders"}
-                            labelPosition={"end"}
-                            onChange={setDisplaySubFolders}
-                            checked={displaySubFolders}
-                            disabled={folders.length === 0}
-                        />
-                    </div>
                 </div>
             )) || <Skeleton size={"xl"} />}
         </>

--- a/packages/app-file-manager/src/components/SearchWidget/SearchWidget.tsx
+++ b/packages/app-file-manager/src/components/SearchWidget/SearchWidget.tsx
@@ -19,7 +19,7 @@ export const SearchWidget = () => {
                     data-testid={"file-manager.search-input"}
                     startIcon={<Icon label={"Search"} icon={<SearchIcon />} />}
                     size={"md"}
-                    variant={"secondary"}
+                    variant={"ghost"}
                 />
             )}
         </DelayedOnChange>

--- a/packages/app-file-manager/src/components/SearchWidget/SearchWidget.tsx
+++ b/packages/app-file-manager/src/components/SearchWidget/SearchWidget.tsx
@@ -19,8 +19,7 @@ export const SearchWidget = () => {
                     data-testid={"file-manager.search-input"}
                     startIcon={<Icon label={"Search"} icon={<SearchIcon />} />}
                     size={"md"}
-                    variant={"ghost-negative"}
-                    className={"max-w-full w-80"}
+                    variant={"secondary"}
                 />
             )}
         </DelayedOnChange>

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
@@ -6,7 +6,7 @@ import type { positionValues } from "react-custom-scrollbars";
 // @ts-expect-error
 import { useHotkeys } from "react-hotkeyz";
 import { observer } from "mobx-react-lite";
-import { Heading, type DataTableSorting, Scrollbar } from "@webiny/admin-ui";
+import { type DataTableSorting, Scrollbar } from "@webiny/admin-ui";
 import { i18n } from "@webiny/app/i18n/index.js";
 import { LeftPanel, RightPanel, SplitView, OverlayLayout, useSnackbar } from "@webiny/app-admin";
 import { useTenancy } from "@webiny/app-admin";
@@ -27,7 +27,6 @@ import { FileDetails } from "~/components/FileDetails/index.js";
 import { Filters } from "~/components/Filters/index.js";
 import { Grid } from "~/components/Grid/index.js";
 import { Header } from "~/components/Header/index.js";
-import { SearchWidget } from "~/components/SearchWidget/index.js";
 import type { TableProps } from "~/components/Table/index.js";
 import { Table } from "~/components/Table/index.js";
 import { TagsList } from "~/components/TagsList/index.js";

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/FileManagerView.tsx
@@ -261,6 +261,18 @@ const FileManagerView = () => {
         [view.updateFile]
     );
 
+    const withOverlay = (element: React.ReactElement) => {
+        if (view.overlay) {
+            return (
+                <OverlayLayout variant={"strong"} onExited={view.onClose}>
+                    {element}
+                </OverlayLayout>
+            );
+        }
+
+        return element;
+    };
+
     return (
         <>
             <Files
@@ -279,13 +291,8 @@ const FileManagerView = () => {
                     showSnackbar(message);
                 }}
             >
-                {({ getDropZoneProps, browseFiles }) => (
-                    <OverlayLayout
-                        variant={"strong"}
-                        onExited={view.onClose}
-                        barLeft={<Heading level={5}>{"File manager"}</Heading>}
-                        barMiddle={<SearchWidget />}
-                    >
+                {({ getDropZoneProps, browseFiles }) =>
+                    withOverlay(
                         <>
                             <FileDetails
                                 loading={drawerLoading}
@@ -355,8 +362,8 @@ const FileManagerView = () => {
                                 </RightPanel>
                             </SplitView>
                         </>
-                    </OverlayLayout>
-                )}
+                    )
+                }
             </Files>
         </>
     );

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
@@ -25,7 +25,7 @@ export const LeftSidebar = ({ currentFolder, onFolderClick, children }: LeftSide
     }, [currentFolder]);
 
     return (
-        <div className={"p-xs overflow-auto"} style={{ height: "calc(100vh - 69px)" }}>
+        <div className={"overflow-auto"} style={{ height: "calc(100vh - 69px)" }}>
             <div className={"p-sm"}>
                 <Heading level={5}>File Manager</Heading>
             </div>

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerView/LeftSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { Separator } from "@webiny/admin-ui";
 import { FolderTree, useLoadFolderHierarchy, useListFoldersByParentIds } from "@webiny/app-aco";
 import { useFileManagerViewConfig } from "~/modules/FileManagerRenderer/FileManagerView/FileManagerViewConfig.js";
+import { Heading } from "@webiny/admin-ui";
 
 interface LeftSidebarProps {
     currentFolder: string;
@@ -25,6 +26,10 @@ export const LeftSidebar = ({ currentFolder, onFolderClick, children }: LeftSide
 
     return (
         <div className={"p-xs overflow-auto"} style={{ height: "calc(100vh - 69px)" }}>
+            <div className={"p-sm"}>
+                <Heading level={5}>File Manager</Heading>
+            </div>
+            <Separator />
             <FolderTree
                 folderActions={browser.folder.actions}
                 dropConfirmation={browser.folder.dropConfirmation}

--- a/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
+++ b/packages/app-file-manager/src/modules/FileManagerRenderer/FileManagerViewProvider/FileManagerViewContext.tsx
@@ -81,6 +81,7 @@ export interface FileManagerViewContext<TFileItem extends FileItem = FileItem> e
         options?: UpdateFileOptions
     ) => Promise<void>;
     uploadFile: (file: File, options?: UploadFileOptions) => Promise<TFileItem | undefined>;
+    overlay?: boolean;
 }
 
 export const FileManagerViewContext = React.createContext<FileManagerViewContext | undefined>(
@@ -114,6 +115,7 @@ export interface FileManagerViewProviderProps {
     tags?: string[];
     scope?: string;
     own?: boolean;
+    overlay?: boolean;
     children?: React.ReactNode;
 }
 
@@ -467,6 +469,7 @@ export const FileManagerViewProvider = ({ children, ...props }: FileManagerViewP
             }
         },
         own: Boolean(props.own),
+        overlay: props.overlay ?? true,
         scope: props.scope,
         setDragging(value = true) {
             setState(state => ({

--- a/packages/app-website-builder/src/inputRenderers/LexicalInput/LexicalEditor.tsx
+++ b/packages/app-website-builder/src/inputRenderers/LexicalInput/LexicalEditor.tsx
@@ -47,8 +47,9 @@ export const LexicalEditor = (props: Omit<RichTextEditorProps, "theme">) => {
      * To use Website Builder theme, we can't use the LexicalEditor component from @webiny/app-admin.
      */
     return (
-        <FileManager accept={["image/*"]}>
-            {({ showFileManager }) => (
+        <FileManager
+            accept={["image/*"]}
+            render={({ showFileManager }) => (
                 <RichTextEditor
                     {...props}
                     onChange={onChange}
@@ -65,6 +66,6 @@ export const LexicalEditor = (props: Omit<RichTextEditorProps, "theme">) => {
                     ]}
                 />
             )}
-        </FileManager>
+        />
     );
 };


### PR DESCRIPTION
## Changes
This PR adds a dedicated route for File Manager, and renders the File Manager inline when clicking the link in the main menu.

`<FileManager/>` component now also has an `overlay={false}` prop, to render the File Manager inline. It opens as an overlay by default, because that's a more common mode.

Search widget is now rendered immediately above the files, in the same row with filters and actions.

<img width="2806" height="1746" alt="CleanShot 2025-12-14 at 11 17 53@2x" src="https://github.com/user-attachments/assets/821279cc-96d7-4fbe-a4d4-8060c7f7c61e" />

<img width="2810" height="1688" alt="CleanShot 2025-12-14 at 11 19 26@2x" src="https://github.com/user-attachments/assets/f5a30cc4-f560-44ad-9675-b194e12ca7ae" />


## How Has This Been Tested?
Manually.