### PR TITLE
Webiny CLI - Make `--env` Optional For All Commands

### DIFF
--- a/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
+++ b/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
@@ -28,7 +28,7 @@ export class BuildCommand implements CliCommand.Interface<IBuildCommandParams> {
                     required: true
                 }
             ],
-            options: [...createBaseAppOptions(projectSdk)],
+            options: createBaseAppOptions(projectSdk),
             handler: async (params: IBuildCommandParams) => {
                 const stdio = this.stdioService;
                 const ui = this.ui;

--- a/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
+++ b/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
@@ -2,6 +2,11 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
 import { BuildRunner } from "~/features/BuildCommand/buildRunners/BuildRunner.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 
 export type IBuildCommandParams = IBaseAppParams;
 
@@ -28,36 +33,13 @@ export class BuildCommand implements CliCommand.Interface<IBuildCommandParams> {
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
+                createEnvOption({
                     required: true
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to deploy",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                }
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to deploy"
+                }),
+                createRegionOption(projectSdk)
             ],
             handler: async (params: IBuildCommandParams) => {
                 const stdio = this.stdioService;

--- a/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
+++ b/packages/cli-core/src/features/BuildCommand/BuildCommand.ts
@@ -2,11 +2,7 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
 import { BuildRunner } from "~/features/BuildCommand/buildRunners/BuildRunner.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 
 export type IBuildCommandParams = IBaseAppParams;
 
@@ -32,15 +28,7 @@ export class BuildCommand implements CliCommand.Interface<IBuildCommandParams> {
                     required: true
                 }
             ],
-            options: [
-                createEnvOption({
-                    required: true
-                }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to deploy"
-                }),
-                createRegionOption(projectSdk)
-            ],
+            options: [...createBaseAppOptions(projectSdk)],
             handler: async (params: IBuildCommandParams) => {
                 const stdio = this.stdioService;
                 const ui = this.ui;

--- a/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
+++ b/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
@@ -3,11 +3,7 @@ import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abs
 import { DeployOutput } from "./deployOutputs/DeployOutput.js";
 import { AppName } from "@webiny/project";
 import { BuildRunner } from "~/features/BuildCommand/buildRunners/BuildRunner.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 import { setTimeout } from "node:timers/promises";
 import ora from "ora";
 import open from "open";
@@ -68,18 +64,18 @@ export class DeployCommand implements CliCommand.Interface<IDeployCommandParams>
                 }
             ],
             options: [
-                createEnvOption({
-                    validation: params => {
-                        if (params.apps && params.apps.length > 0 && !params.env) {
-                            throw new Error("Environment name is required when deploying an app.");
+                ...createBaseAppOptions<IDeployCommandParams>(projectSdk, {
+                    env: {
+                        validation: params => {
+                            if (params.apps && params.apps.length > 0 && !params.env) {
+                                throw new Error(
+                                    "Environment name is required when deploying an app."
+                                );
+                            }
+                            return true;
                         }
-                        return true;
                     }
                 }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to deploy"
-                }),
-                createRegionOption(projectSdk),
                 {
                     name: "build",
                     description: "Build packages before deploying",

--- a/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
+++ b/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
@@ -64,7 +64,7 @@ export class DeployCommand implements CliCommand.Interface<IDeployCommandParams>
                 }
             ],
             options: [
-                ...createBaseAppOptions<IDeployCommandParams>(projectSdk),
+                ...createBaseAppOptions(projectSdk),
                 {
                     name: "build",
                     description: "Build packages before deploying",

--- a/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
+++ b/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
@@ -64,18 +64,7 @@ export class DeployCommand implements CliCommand.Interface<IDeployCommandParams>
                 }
             ],
             options: [
-                ...createBaseAppOptions<IDeployCommandParams>(projectSdk, {
-                    env: {
-                        validation: params => {
-                            if (params.apps && params.apps.length > 0 && !params.env) {
-                                throw new Error(
-                                    "Environment name is required when deploying an app."
-                                );
-                            }
-                            return true;
-                        }
-                    }
-                }),
+                ...createBaseAppOptions<IDeployCommandParams>(projectSdk),
                 {
                     name: "build",
                     description: "Build packages before deploying",

--- a/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
+++ b/packages/cli-core/src/features/DeployCommand/DeployCommand.ts
@@ -3,6 +3,11 @@ import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abs
 import { DeployOutput } from "./deployOutputs/DeployOutput.js";
 import { AppName } from "@webiny/project";
 import { BuildRunner } from "~/features/BuildCommand/buildRunners/BuildRunner.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 import { setTimeout } from "node:timers/promises";
 import ora from "ora";
 import open from "open";
@@ -63,42 +68,18 @@ export class DeployCommand implements CliCommand.Interface<IDeployCommandParams>
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
-                    default: "dev",
+                createEnvOption({
                     validation: params => {
                         if (params.apps && params.apps.length > 0 && !params.env) {
                             throw new Error("Environment name is required when deploying an app.");
                         }
                         return true;
                     }
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to deploy",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to deploy"
+                }),
+                createRegionOption(projectSdk),
                 {
                     name: "build",
                     description: "Build packages before deploying",

--- a/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
+++ b/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
@@ -45,7 +45,7 @@ export class DestroyCommand implements CliCommand.Interface<IDestroyCommandParam
                     type: "string"
                 }
             ],
-            options: [...createBaseAppOptions<IDestroyCommandParams>(projectSdk)],
+            options: createBaseAppOptions(projectSdk),
             handler: async (params: IDestroyCommandParams) => {
                 if ("app" in params) {
                     return this.destroyApp(params);

--- a/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
+++ b/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
@@ -1,11 +1,7 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { measureDuration } from "~/features/utils/index.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 import { PulumiError } from "@webiny/pulumi-sdk";
 import { AppName } from "@webiny/project";
 
@@ -50,18 +46,18 @@ export class DestroyCommand implements CliCommand.Interface<IDestroyCommandParam
                 }
             ],
             options: [
-                createEnvOption({
-                    validation: params => {
-                        if ("app" in params && !params.env) {
-                            throw new Error("Environment name is required when destroying an app.");
+                ...createBaseAppOptions<IDestroyCommandParams>(projectSdk, {
+                    env: {
+                        validation: params => {
+                            if ("app" in params && !params.env) {
+                                throw new Error(
+                                    "Environment name is required when destroying an app."
+                                );
+                            }
+                            return true;
                         }
-                        return true;
                     }
-                }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to destroy"
-                }),
-                createRegionOption(projectSdk)
+                })
             ],
             handler: async (params: IDestroyCommandParams) => {
                 if ("app" in params) {

--- a/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
+++ b/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
@@ -1,6 +1,11 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { measureDuration } from "~/features/utils/index.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 import { PulumiError } from "@webiny/pulumi-sdk";
 import { AppName } from "@webiny/project";
 
@@ -45,42 +50,18 @@ export class DestroyCommand implements CliCommand.Interface<IDestroyCommandParam
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
-                    default: "dev",
+                createEnvOption({
                     validation: params => {
                         if ("app" in params && !params.env) {
                             throw new Error("Environment name is required when destroying an app.");
                         }
                         return true;
                     }
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to destroy",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                }
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to destroy"
+                }),
+                createRegionOption(projectSdk)
             ],
             handler: async (params: IDestroyCommandParams) => {
                 if ("app" in params) {

--- a/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
+++ b/packages/cli-core/src/features/DestroyCommand/DestroyCommand.ts
@@ -45,20 +45,7 @@ export class DestroyCommand implements CliCommand.Interface<IDestroyCommandParam
                     type: "string"
                 }
             ],
-            options: [
-                ...createBaseAppOptions<IDestroyCommandParams>(projectSdk, {
-                    env: {
-                        validation: params => {
-                            if ("app" in params && !params.env) {
-                                throw new Error(
-                                    "Environment name is required when destroying an app."
-                                );
-                            }
-                            return true;
-                        }
-                    }
-                })
-            ],
+            options: [...createBaseAppOptions<IDestroyCommandParams>(projectSdk)],
             handler: async (params: IDestroyCommandParams) => {
                 if ("app" in params) {
                     return this.destroyApp(params);

--- a/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
+++ b/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
@@ -2,7 +2,7 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
 import { PrintInfoForEnv } from "./PrintInfoForEnv.js";
-import { createEnvOption, createVariantOption } from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 
 export type IInfoCommandParams = Omit<IBaseAppParams, "app">;
 
@@ -19,10 +19,11 @@ export class InfoCommand implements CliCommand.Interface<IInfoCommandParams> {
             name: "info",
             description: "Lists relevant URLs for your Webiny project",
             options: [
-                createEnvOption(),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to watch"
-                })
+                ...createBaseAppOptions(projectSdk, {
+                    variant: {
+                        description: "Variant of the app to watch"
+                    }
+                }).filter(opt => opt.name !== "region")
             ],
 
             handler: async params => {

--- a/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
+++ b/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
@@ -2,6 +2,7 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
 import { PrintInfoForEnv } from "./PrintInfoForEnv.js";
+import { createEnvOption, createVariantOption } from "~/features/common/index.js";
 
 export type IInfoCommandParams = Omit<IBaseAppParams, "app">;
 
@@ -18,23 +19,10 @@ export class InfoCommand implements CliCommand.Interface<IInfoCommandParams> {
             name: "info",
             description: "Lists relevant URLs for your Webiny project",
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string"
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to watch",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                }
+                createEnvOption(),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to watch"
+                })
             ],
 
             handler: async params => {

--- a/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
+++ b/packages/cli-core/src/features/InfoCommand/InfoCommand.ts
@@ -18,14 +18,7 @@ export class InfoCommand implements CliCommand.Interface<IInfoCommandParams> {
         return {
             name: "info",
             description: "Lists relevant URLs for your Webiny project",
-            options: [
-                ...createBaseAppOptions(projectSdk, {
-                    variant: {
-                        description: "Variant of the app to watch"
-                    }
-                }).filter(opt => opt.name !== "region")
-            ],
-
+            options: createBaseAppOptions(projectSdk),
             handler: async params => {
                 const ui = this.uiService;
 

--- a/packages/cli-core/src/features/OpenCommand.ts
+++ b/packages/cli-core/src/features/OpenCommand.ts
@@ -1,11 +1,7 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 import open from "open";
 
 export type IOpenCommandParams = Omit<IBaseAppParams, "app">;
@@ -24,13 +20,11 @@ export class OpenCommand implements CliCommand.Interface<IOpenCommandParams> {
             name: "open",
             description: "Quickly open Admin application in your default browser",
             options: [
-                createEnvOption({
-                    required: true
+                ...createBaseAppOptions(projectSdk, {
+                    variant: {
+                        description: "Variant of the app to watch"
+                    }
                 }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to watch"
-                }),
-                createRegionOption(projectSdk),
                 {
                     name: "json",
                     description: "Emit output as JSON",

--- a/packages/cli-core/src/features/OpenCommand.ts
+++ b/packages/cli-core/src/features/OpenCommand.ts
@@ -1,6 +1,11 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 import open from "open";
 
 export type IOpenCommandParams = Omit<IBaseAppParams, "app">;
@@ -19,36 +24,13 @@ export class OpenCommand implements CliCommand.Interface<IOpenCommandParams> {
             name: "open",
             description: "Quickly open Admin application in your default browser",
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
+                createEnvOption({
                     required: true
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to watch",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to watch"
+                }),
+                createRegionOption(projectSdk),
                 {
                     name: "json",
                     description: "Emit output as JSON",
@@ -77,7 +59,7 @@ export class OpenCommand implements CliCommand.Interface<IOpenCommandParams> {
                     );
                 }
 
-                return new Promise(resolve => {
+                return new Promise<void>(resolve => {
                     setTimeout(() => {
                         ui.success(`Successfully opened %s.`, "Admin app");
                         open(appUrl);

--- a/packages/cli-core/src/features/OutputCommand.ts
+++ b/packages/cli-core/src/features/OutputCommand.ts
@@ -1,6 +1,11 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 
 export interface IOutputCommandParams extends IBaseAppParams {
     json?: boolean;
@@ -27,35 +32,11 @@ export class OutputCommand implements CliCommand.Interface<IOutputCommandParams>
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string"
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to watch",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
+                createEnvOption(),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to watch"
+                }),
+                createRegionOption(projectSdk),
                 {
                     name: "json",
                     description: "Emit output as JSON",

--- a/packages/cli-core/src/features/OutputCommand.ts
+++ b/packages/cli-core/src/features/OutputCommand.ts
@@ -1,11 +1,7 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 
 export interface IOutputCommandParams extends IBaseAppParams {
     json?: boolean;
@@ -32,11 +28,11 @@ export class OutputCommand implements CliCommand.Interface<IOutputCommandParams>
                 }
             ],
             options: [
-                createEnvOption(),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to watch"
+                ...createBaseAppOptions(projectSdk, {
+                    variant: {
+                        description: "Variant of the app to watch"
+                    }
                 }),
-                createRegionOption(projectSdk),
                 {
                     name: "json",
                     description: "Emit output as JSON",

--- a/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
+++ b/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
@@ -31,18 +31,7 @@ export class PulumiCommand implements CliCommand.Interface<IPulumiCommandParams>
                     required: true
                 }
             ],
-            options: [
-                ...createBaseAppOptions<IPulumiCommandParams>(projectSdk, {
-                    env: {
-                        validation: params => {
-                            if ("app" in params && !params.env) {
-                                throw new Error("Environment name is required.");
-                            }
-                            return true;
-                        }
-                    }
-                })
-            ],
+            options: [...createBaseAppOptions<IPulumiCommandParams>(projectSdk)],
             handler: async (params: IPulumiCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();
 

--- a/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
+++ b/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
@@ -31,7 +31,7 @@ export class PulumiCommand implements CliCommand.Interface<IPulumiCommandParams>
                     required: true
                 }
             ],
-            options: [...createBaseAppOptions<IPulumiCommandParams>(projectSdk)],
+            options: createBaseAppOptions(projectSdk),
             handler: async (params: IPulumiCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();
 

--- a/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
+++ b/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
@@ -2,6 +2,11 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { ManuallyReportedError } from "~/utils/ManuallyReportedError.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 
 export interface IPulumiCommandParams extends IBaseAppParams {
     command: string[];
@@ -31,48 +36,24 @@ export class PulumiCommand implements CliCommand.Interface<IPulumiCommandParams>
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
-                    default: "dev",
+                createEnvOption({
                     validation: params => {
                         if ("app" in params && !params.env) {
                             throw new Error("Environment name is required.");
                         }
                         return true;
                     }
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to pulumi",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                }
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to pulumi"
+                }),
+                createRegionOption(projectSdk)
             ],
             handler: async (params: IPulumiCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();
 
                 try {
-                    const [, ...command] = params._;
+                    const [, ...command] = params._ || [];
 
                     const { pulumiProcess } = await projectSdk.runPulumiCommand({
                         ...params,

--- a/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
+++ b/packages/cli-core/src/features/PulumiCommand/PulumiCommand.ts
@@ -2,11 +2,7 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { ManuallyReportedError } from "~/utils/ManuallyReportedError.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 
 export interface IPulumiCommandParams extends IBaseAppParams {
     command: string[];
@@ -36,18 +32,16 @@ export class PulumiCommand implements CliCommand.Interface<IPulumiCommandParams>
                 }
             ],
             options: [
-                createEnvOption({
-                    validation: params => {
-                        if ("app" in params && !params.env) {
-                            throw new Error("Environment name is required.");
+                ...createBaseAppOptions<IPulumiCommandParams>(projectSdk, {
+                    env: {
+                        validation: params => {
+                            if ("app" in params && !params.env) {
+                                throw new Error("Environment name is required.");
+                            }
+                            return true;
                         }
-                        return true;
                     }
-                }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to pulumi"
-                }),
-                createRegionOption(projectSdk)
+                })
             ],
             handler: async (params: IPulumiCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();

--- a/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
+++ b/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
@@ -29,7 +29,7 @@ export class RefreshCommand implements CliCommand.Interface<IRefreshCommandParam
                     required: true
                 }
             ],
-            options: [...createBaseAppOptions<IRefreshCommandParams>(projectSdk)],
+            options: createBaseAppOptions(projectSdk),
             handler: async (params: IRefreshCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();
 

--- a/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
+++ b/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
@@ -29,18 +29,7 @@ export class RefreshCommand implements CliCommand.Interface<IRefreshCommandParam
                     required: true
                 }
             ],
-            options: [
-                ...createBaseAppOptions<IRefreshCommandParams>(projectSdk, {
-                    env: {
-                        validation: params => {
-                            if ("app" in params && !params.env) {
-                                throw new Error("Environment name is required.");
-                            }
-                            return true;
-                        }
-                    }
-                })
-            ],
+            options: [...createBaseAppOptions<IRefreshCommandParams>(projectSdk)],
             handler: async (params: IRefreshCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();
 

--- a/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
+++ b/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
@@ -2,11 +2,7 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService } from "~/abstractions/index.js";
 import { ManuallyReportedError } from "~/utils/ManuallyReportedError.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 
 export interface IRefreshCommandParams extends IBaseAppParams {
     command: string[];
@@ -34,18 +30,16 @@ export class RefreshCommand implements CliCommand.Interface<IRefreshCommandParam
                 }
             ],
             options: [
-                createEnvOption({
-                    validation: params => {
-                        if ("app" in params && !params.env) {
-                            throw new Error("Environment name is required.");
+                ...createBaseAppOptions<IRefreshCommandParams>(projectSdk, {
+                    env: {
+                        validation: params => {
+                            if ("app" in params && !params.env) {
+                                throw new Error("Environment name is required.");
+                            }
+                            return true;
                         }
-                        return true;
                     }
-                }),
-                createVariantOption(projectSdk, {
-                    description: "Variant of the app to refresh"
-                }),
-                createRegionOption(projectSdk)
+                })
             ],
             handler: async (params: IRefreshCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();

--- a/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
+++ b/packages/cli-core/src/features/RefreshCommand/RefreshCommand.ts
@@ -2,6 +2,11 @@ import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService } from "~/abstractions/index.js";
 import { ManuallyReportedError } from "~/utils/ManuallyReportedError.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 
 export interface IRefreshCommandParams extends IBaseAppParams {
     command: string[];
@@ -29,42 +34,18 @@ export class RefreshCommand implements CliCommand.Interface<IRefreshCommandParam
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
-                    default: "dev",
+                createEnvOption({
                     validation: params => {
                         if ("app" in params && !params.env) {
                             throw new Error("Environment name is required.");
                         }
                         return true;
                     }
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to refresh",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    }
-                }
+                }),
+                createVariantOption(projectSdk, {
+                    description: "Variant of the app to refresh"
+                }),
+                createRegionOption(projectSdk)
             ],
             handler: async (params: IRefreshCommandParams) => {
                 const projectSdk = await this.getProjectSdkService.execute();

--- a/packages/cli-core/src/features/WatchCommand/WatchCommand.ts
+++ b/packages/cli-core/src/features/WatchCommand/WatchCommand.ts
@@ -1,6 +1,11 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
+import {
+    createEnvOption,
+    createRegionOption,
+    createVariantOption
+} from "~/features/common/index.js";
 import chalk from "chalk";
 import { getRandomColorForString } from "./getRandomColorForString.js";
 import { createPrefixer } from "./createPrefixer.js";
@@ -39,38 +44,16 @@ export class WatchCommand implements CliCommand.Interface<IWatchCommandParams> {
                 }
             ],
             options: [
-                {
-                    name: "env",
-                    description: "Environment name (dev, prod, etc.)",
-                    type: "string",
+                createEnvOption({
                     group: BASE_OPTIONS_GROUP
-                },
-                {
-                    name: "variant",
-                    description: "Variant of the app to watch",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidVariantName(params.variant);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    },
+                }),
+                createVariantOption(projectSdk, {
+                    group: BASE_OPTIONS_GROUP,
+                    description: "Variant of the app to watch"
+                }),
+                createRegionOption(projectSdk, {
                     group: BASE_OPTIONS_GROUP
-                },
-                {
-                    name: "region",
-                    description: "Region to target",
-                    type: "string",
-                    validation: params => {
-                        const isValid = projectSdk.isValidRegionName(params.region);
-                        if (isValid.isErr()) {
-                            throw isValid.error;
-                        }
-                        return true;
-                    },
-                    group: BASE_OPTIONS_GROUP
-                },
+                }),
                 {
                     name: "package",
                     alias: "p",

--- a/packages/cli-core/src/features/WatchCommand/WatchCommand.ts
+++ b/packages/cli-core/src/features/WatchCommand/WatchCommand.ts
@@ -1,11 +1,7 @@
 import { createImplementation } from "@webiny/di";
 import { CliCommand, GetProjectSdkService, StdioService, UiService } from "~/abstractions/index.js";
 import { IBaseAppParams } from "~/abstractions/features/types.js";
-import {
-    createEnvOption,
-    createRegionOption,
-    createVariantOption
-} from "~/features/common/index.js";
+import { createBaseAppOptions } from "~/features/common/index.js";
 import chalk from "chalk";
 import { getRandomColorForString } from "./getRandomColorForString.js";
 import { createPrefixer } from "./createPrefixer.js";
@@ -44,15 +40,10 @@ export class WatchCommand implements CliCommand.Interface<IWatchCommandParams> {
                 }
             ],
             options: [
-                createEnvOption({
-                    group: BASE_OPTIONS_GROUP
-                }),
-                createVariantOption(projectSdk, {
-                    group: BASE_OPTIONS_GROUP,
-                    description: "Variant of the app to watch"
-                }),
-                createRegionOption(projectSdk, {
-                    group: BASE_OPTIONS_GROUP
+                ...createBaseAppOptions(projectSdk, {
+                    env: { group: BASE_OPTIONS_GROUP },
+                    variant: { group: BASE_OPTIONS_GROUP },
+                    region: { group: BASE_OPTIONS_GROUP }
                 }),
                 {
                     name: "package",

--- a/packages/cli-core/src/features/common/index.ts
+++ b/packages/cli-core/src/features/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./options.js";

--- a/packages/cli-core/src/features/common/options.ts
+++ b/packages/cli-core/src/features/common/options.ts
@@ -1,7 +1,7 @@
 import { CliCommand } from "~/abstractions/index.js";
 import { ProjectSdk } from "@webiny/project";
 
-export const createEnvOption = <T>(
+export const createEnvOption = <T extends { env?: string }>(
     overrides: Partial<CliCommand.OptionDefinition<T>> = {}
 ): CliCommand.OptionDefinition<T> => {
     return {
@@ -9,6 +9,14 @@ export const createEnvOption = <T>(
         description: "Environment name (dev, prod, etc.)",
         type: "string",
         default: "dev",
+        validation: params => {
+            const p = params as any;
+            const hasApp = p.app || (p.apps && p.apps.length > 0);
+            if (hasApp && !p.env) {
+                throw new Error("Environment name is required.");
+            }
+            return true;
+        },
         ...overrides
     };
 };
@@ -51,7 +59,7 @@ export const createRegionOption = <T extends { region?: string }>(
     };
 };
 
-export const createBaseAppOptions = <T extends { variant?: string; region?: string }>(
+export const createBaseAppOptions = <T extends { env?: string; variant?: string; region?: string }>(
     projectSdk: ProjectSdk,
     overrides: {
         env?: Partial<CliCommand.OptionDefinition<T>>;

--- a/packages/cli-core/src/features/common/options.ts
+++ b/packages/cli-core/src/features/common/options.ts
@@ -19,7 +19,7 @@ export const createVariantOption = <T extends { variant?: string }>(
 ): CliCommand.OptionDefinition<T> => {
     return {
         name: "variant",
-        description: "Variant of the app",
+        description: "Variant name",
         type: "string",
         validation: params => {
             const isValid = projectSdk.isValidVariantName(params.variant);
@@ -49,4 +49,19 @@ export const createRegionOption = <T extends { region?: string }>(
         },
         ...overrides
     };
+};
+
+export const createBaseAppOptions = <T extends { variant?: string; region?: string }>(
+    projectSdk: ProjectSdk,
+    overrides: {
+        env?: Partial<CliCommand.OptionDefinition<T>>;
+        variant?: Partial<CliCommand.OptionDefinition<T>>;
+        region?: Partial<CliCommand.OptionDefinition<T>>;
+    } = {}
+): CliCommand.OptionDefinition<T>[] => {
+    return [
+        createEnvOption(overrides.env),
+        createVariantOption(projectSdk, overrides.variant),
+        createRegionOption(projectSdk, overrides.region)
+    ];
 };

--- a/packages/cli-core/src/features/common/options.ts
+++ b/packages/cli-core/src/features/common/options.ts
@@ -1,0 +1,52 @@
+import { CliCommand } from "~/abstractions/index.js";
+import { ProjectSdk } from "@webiny/project";
+
+export const createEnvOption = <T>(
+    overrides: Partial<CliCommand.OptionDefinition<T>> = {}
+): CliCommand.OptionDefinition<T> => {
+    return {
+        name: "env",
+        description: "Environment name (dev, prod, etc.)",
+        type: "string",
+        default: "dev",
+        ...overrides
+    };
+};
+
+export const createVariantOption = <T extends { variant?: string }>(
+    projectSdk: ProjectSdk,
+    overrides: Partial<CliCommand.OptionDefinition<T>> = {}
+): CliCommand.OptionDefinition<T> => {
+    return {
+        name: "variant",
+        description: "Variant of the app",
+        type: "string",
+        validation: params => {
+            const isValid = projectSdk.isValidVariantName(params.variant);
+            if (isValid.isErr()) {
+                throw isValid.error;
+            }
+            return true;
+        },
+        ...overrides
+    };
+};
+
+export const createRegionOption = <T extends { region?: string }>(
+    projectSdk: ProjectSdk,
+    overrides: Partial<CliCommand.OptionDefinition<T>> = {}
+): CliCommand.OptionDefinition<T> => {
+    return {
+        name: "region",
+        description: "Region to target",
+        type: "string",
+        validation: params => {
+            const isValid = projectSdk.isValidRegionName(params.region);
+            if (isValid.isErr()) {
+                throw isValid.error;
+            }
+            return true;
+        },
+        ...overrides
+    };
+};


### PR DESCRIPTION
As the title itself, we no longer require `--env` in any of the cmds to be specified. For all cmds, `--env` is by default set to `dev`. Let's test it a bit and see if it works / simplifies things as expected.

Did a couple of minor refactors in this PR as well, related to standard deployment-related opts in the CLI.