### PR TITLE
feat: graphql schema abstraction and example extension

### DIFF
--- a/extensions/graphql/MyGraphQLSchema.ts
+++ b/extensions/graphql/MyGraphQLSchema.ts
@@ -1,0 +1,30 @@
+import { GraphQLSchema } from "@webiny/handler-graphql/graphql/abstractions.js";
+import { IdentityContext } from "webiny/api/security/features/IdentityContext";
+
+class Schema implements GraphQLSchema.Interface {
+    constructor(private identityContext: IdentityContext.Interface) {}
+
+    getTypeDefs() {
+        return /* GraphQL */ `
+            type Query {
+                hello: String
+            }
+        `;
+    }
+
+    getResolvers() {
+        return {
+            Query: {
+                hello: () => {
+                    const identity = this.identityContext.getIdentity();
+                    return `Hello, ${identity.displayName}!`;
+                }
+            }
+        };
+    }
+}
+
+export const MyGraphQLSchema = GraphQLSchema.createImplementation({
+    implementation: Schema,
+    dependencies: [IdentityContext]
+});

--- a/extensions/graphql/MySchemaExtension.tsx
+++ b/extensions/graphql/MySchemaExtension.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Api } from "webiny/extensions";
+
+export const MySchemaExtension = () => {
+    return (
+        <>
+            <Api.Extension src={import.meta.dirname + "/MyGraphQLSchema.ts"} />
+        </>
+    );
+};

--- a/packages/app-admin/src/presentation/installation/components/SystemInstaller/steps/FinishSetup.tsx
+++ b/packages/app-admin/src/presentation/installation/components/SystemInstaller/steps/FinishSetup.tsx
@@ -54,7 +54,11 @@ export const FinishSetupStep = ({
                         )}
                         {isInstalled ? (
                             <Grid.Column span={12}>
-                                <Text as="div" size={"md"} className={"text-neutral-strong text-center"}>
+                                <Text
+                                    as="div"
+                                    size={"md"}
+                                    className={"text-neutral-strong text-center"}
+                                >
                                     Setup complete! Everything went smooth as a breeze!
                                 </Text>
                             </Grid.Column>

--- a/packages/handler-graphql/__tests__/mocks/booksSchema.ts
+++ b/packages/handler-graphql/__tests__/mocks/booksSchema.ts
@@ -1,6 +1,6 @@
 import { createContextPlugin } from "@webiny/handler";
 import type { Book, Context } from "~tests/types";
-import { GraphQLSchema, GraphQLResolvers } from "~/graphql/abstractions.js";
+import { GraphQLSchema } from "~/graphql/abstractions.js";
 
 export const books: Book[] = [
     {
@@ -11,7 +11,7 @@ export const books: Book[] = [
     }
 ];
 
-class BooksTypeDefsProvider implements GraphQLSchema.Interface {
+class BooksSchema implements GraphQLSchema.Interface {
     getTypeDefs() {
         return /* GraphQL */ `
             type Book {
@@ -28,14 +28,7 @@ class BooksTypeDefsProvider implements GraphQLSchema.Interface {
             }
         `;
     }
-}
 
-export const BooksTypeDefsProviderImpl = GraphQLSchema.createImplementation({
-    implementation: BooksTypeDefsProvider,
-    dependencies: []
-});
-
-class BooksResolversProvider implements GraphQLResolvers.Interface {
     getResolvers() {
         return {
             Query: {
@@ -70,8 +63,8 @@ class BooksResolversProvider implements GraphQLResolvers.Interface {
     }
 }
 
-export const BooksResolversProviderImpl = GraphQLResolvers.createImplementation({
-    implementation: BooksResolversProvider,
+export const BooksSchemaImpl = GraphQLSchema.createImplementation({
+    implementation: BooksSchema,
     dependencies: []
 });
 
@@ -85,6 +78,5 @@ export const booksCrudPlugin = createContextPlugin<Context>(async context => {
 });
 
 export const booksSchemaPlugin = createContextPlugin<Context>(context => {
-    context.container.register(BooksTypeDefsProviderImpl);
-    context.container.register(BooksResolversProviderImpl);
+    context.container.register(BooksSchemaImpl);
 });

--- a/packages/handler-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
+++ b/packages/handler-graphql/src/features/GraphQLSchemaBuilder/GraphQLSchemaBuilder.ts
@@ -1,37 +1,27 @@
 import { GraphQLSchemaBuilder as Abstraction } from "./abstractions.js";
-import {
-    GraphQLSchema,
-    GraphQLResolvers,
-    GraphQLResolverDecorators
-} from "~/graphql/abstractions.js";
-import type { TypeDefs } from "~/types.js";
+import { GraphQLSchema, GraphQLResolverDecorators } from "~/graphql/abstractions.js";
 
 class GraphQLSchemaBuilderImpl implements Abstraction.Interface {
     constructor(
         private schemas: GraphQLSchema.Interface[],
-        private resolvers: GraphQLResolvers.Interface[],
         private decorators: GraphQLResolverDecorators.Interface[]
     ) {}
 
     async build(): Promise<Abstraction.SchemaParts> {
-        const typeDefsArray: TypeDefs[] = [];
-        const resolversArray: GraphQLResolvers.Resolvers[] = [];
+        const typeDefsArray: GraphQLSchema.TypeDefs[] = [];
+        const resolversArray: GraphQLSchema.Resolvers[] = [];
         const decoratorsArray: GraphQLResolverDecorators.ResolverDecorators[] = [];
 
-        for (const schema of this.schemas) {
-            const typeDefs = await schema.getTypeDefs();
-            typeDefsArray.push(typeDefs);
-        }
-
-        for (const resolver of this.resolvers) {
-            const resolverMap = await resolver.getResolvers();
-            resolversArray.push(resolverMap);
-        }
-
-        for (const decorator of this.decorators) {
-            const decoratorMap = await decorator.getDecorators();
-            decoratorsArray.push(decoratorMap);
-        }
+        await Promise.all([
+            ...this.schemas.map(async schema => {
+                typeDefsArray.push(await schema.getTypeDefs());
+                resolversArray.push(await schema.getResolvers());
+            }),
+            // Resolver decorators
+            ...this.decorators.map(async decorators => {
+                decoratorsArray.push(await decorators.getDecorators());
+            })
+        ]);
 
         return {
             typeDefs: typeDefsArray.join("\n"),
@@ -45,7 +35,6 @@ export const GraphQLSchemaBuilder = Abstraction.createImplementation({
     implementation: GraphQLSchemaBuilderImpl,
     dependencies: [
         [GraphQLSchema, { multiple: true }],
-        [GraphQLResolvers, { multiple: true }],
         [GraphQLResolverDecorators, { multiple: true }]
     ]
 });

--- a/packages/handler-graphql/src/graphql/abstractions.ts
+++ b/packages/handler-graphql/src/graphql/abstractions.ts
@@ -1,29 +1,16 @@
 import { createAbstraction } from "@webiny/feature/api";
 import type {
     Resolvers as IResolvers,
-    TypeDefs,
+    TypeDefs as ITypeDefs,
     ResolverDecorators as IResolverDecorators
 } from "~/types.js";
 
-export interface IGraphQLSchema {
-    getTypeDefs(): Promise<TypeDefs> | TypeDefs;
-}
-
-export const GraphQLSchema = createAbstraction<IGraphQLSchema>("GraphQLSchema");
-
-export namespace GraphQLSchema {
-    export type Interface = IGraphQLSchema;
+export interface IGraphQLTypeDefs {
+    getTypeDefs(): Promise<ITypeDefs> | ITypeDefs;
 }
 
 export interface IGraphQLResolvers {
     getResolvers(): Promise<IResolvers<any>> | IResolvers<any>;
-}
-
-export const GraphQLResolvers = createAbstraction<IGraphQLResolvers>("GraphQLResolvers");
-
-export namespace GraphQLResolvers {
-    export type Interface = IGraphQLResolvers;
-    export type Resolvers = IResolvers<any>;
 }
 
 export interface IGraphQLResolverDecorators {
@@ -37,4 +24,13 @@ export const GraphQLResolverDecorators = createAbstraction<IGraphQLResolverDecor
 export namespace GraphQLResolverDecorators {
     export type Interface = IGraphQLResolverDecorators;
     export type ResolverDecorators = IResolverDecorators;
+}
+
+export interface IGraphQLSchema extends IGraphQLTypeDefs, IGraphQLResolvers {}
+
+export const GraphQLSchema = createAbstraction<IGraphQLSchema>("GraphQLSchema");
+export namespace GraphQLSchema {
+    export type Interface = IGraphQLSchema;
+    export type TypeDefs = ITypeDefs;
+    export type Resolvers = IResolvers<any>;
 }

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Cli, Infra, Project, Security } from "webiny/extensions";
+import { MySchemaExtension } from "./extensions/graphql/MySchemaExtension.js";
 
 // import { Okta } from "@webiny/okta";
 
@@ -57,6 +58,9 @@ export const Extensions = () => {
 
             {/* Project 👇 */}
             <Project.Telemetry enabled={false} />
+
+            {/* API */}
+            <MySchemaExtension />
 
             {/* Security 👇 */}
             <Security.ApiKey.AfterUpdate src={"./extensions/MyApiKeyAfterUpdate.ts"} />


### PR DESCRIPTION
## Changes
This PR makes GraphQLSchema abstraction require both `getTypeDefs` and `getResolvers` methods, to form a complete schema. This decision was made purely for DX reasons. Over time we'll collect feedback from the community and see if this is the right way to go, or if TypeDefs and Resolvers should be two separate abstractions.

<img width="1444" height="1338" alt="image" src="https://github.com/user-attachments/assets/17d17773-d9eb-4227-b4b1-652f337eb34b" />


## How Has This Been Tested?
Manually and with automated tests.