### PR TITLE
fix: update CMS scheduling resolvers

### DIFF
--- a/packages/api-headless-cms-scheduler/__tests__/actionHandlers.test.ts
+++ b/packages/api-headless-cms-scheduler/__tests__/actionHandlers.test.ts
@@ -45,7 +45,7 @@ describe("Action Handlers", () => {
             modelId: MOCK_TARGET_MODEL_ID,
             targetId: entryResult.value.id,
             actionType: "Publish",
-            scheduleOn: new Date(Date.now() + 100000)
+            scheduleOn: new Date(Date.now() + 100000).toISOString()
         });
 
         // Assert scheduled actions
@@ -73,7 +73,7 @@ describe("Action Handlers", () => {
             modelId: MOCK_TARGET_MODEL_ID,
             targetId: entryResult.value.id,
             actionType: "Unpublish",
-            scheduleOn: new Date(Date.now() + 1000000)
+            scheduleOn: new Date(Date.now() + 1000000).toISOString()
         });
 
         // Execute action handler

--- a/packages/api-headless-cms-scheduler/src/graphql/ActionMapper.ts
+++ b/packages/api-headless-cms-scheduler/src/graphql/ActionMapper.ts
@@ -1,12 +1,12 @@
 import type { IScheduledAction } from "@webiny/api-scheduler";
 
 export class ActionMapper {
-    static fromScheduledAction(modelId: string, action: IScheduledAction) {
+    static fromScheduledAction(action: IScheduledAction<{ modelId: string }>) {
         return {
             id: action.id,
             targetId: action.targetId,
             model: {
-                modelId
+                modelId: action.payload?.modelId
             },
             scheduledBy: action.scheduledBy,
             publishOn: action.actionType === "Publish" ? action.scheduledOn : null,

--- a/packages/api-headless-cms-scheduler/src/graphql/index.ts
+++ b/packages/api-headless-cms-scheduler/src/graphql/index.ts
@@ -165,9 +165,13 @@ export const createSchedulerGraphQL = () => {
                             });
                         }
 
-                        const action = actions.value.items[0];
+                        const { items } = actions.value;
 
-                        return new Response(ActionMapper.fromScheduledAction(args.modelId, action));
+                        if (!items.length) {
+                            return null;
+                        }
+
+                        return ActionMapper.fromScheduledAction(items[0]);
                     });
                 },
                 async listCmsSchedules(_, args, context) {
@@ -198,7 +202,9 @@ export const createSchedulerGraphQL = () => {
                         }
 
                         return {
-                            data: actions.value.items,
+                            data: actions.value.items.map(item =>
+                                ActionMapper.fromScheduledAction(item)
+                            ),
                             meta: actions.value.meta
                         };
                     });
@@ -227,7 +233,7 @@ export const createSchedulerGraphQL = () => {
                             throw result.error;
                         }
 
-                        return ActionMapper.fromScheduledAction(data.modelId, result.value);
+                        return ActionMapper.fromScheduledAction(result.value);
                     });
                 },
                 async updateCmsSchedule(_, args, context) {
@@ -252,7 +258,7 @@ export const createSchedulerGraphQL = () => {
                             throw result.error;
                         }
 
-                        return ActionMapper.fromScheduledAction(data.modelId, result.value);
+                        return ActionMapper.fromScheduledAction(result.value);
                     });
                 },
                 async cancelCmsSchedule(_, args, context) {

--- a/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
+++ b/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
@@ -154,8 +154,8 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
         }
 
         // Update CMS entry
-        const existingId = ScheduledActionIdWithVersion.from(existing.id);
-        const updateResult = await this.updateEntryUseCase.execute(this.model, existingId, {
+        const existingEntryId = ScheduledActionIdWithVersion.from(existing.id);
+        const updateResult = await this.updateEntryUseCase.execute(this.model, existingEntryId, {
             scheduledBy: identity,
             scheduledOn: input.scheduleOn,
             payload
@@ -170,7 +170,7 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
         // Update EventBridge schedule
         try {
             await this.schedulerService.update({
-                id: existingId,
+                id: existing.id,
                 scheduleOn: new Date(input.scheduleOn)
             });
         } catch (error) {

--- a/packages/api-scheduler/src/shared/abstractions.ts
+++ b/packages/api-scheduler/src/shared/abstractions.ts
@@ -13,7 +13,7 @@ export interface Identity {
 /**
  * Scheduled Action Record - The data stored for a scheduled action
  */
-export interface IScheduledAction {
+export interface IScheduledAction<TPayload = any> {
     id: string;
     namespace: string; // Resource scope: "Cms/Entry/Article", "Mailer/Email"
     actionType: string; // Operation: "Publish", "Unpublish", "Send", "Delete"
@@ -21,7 +21,7 @@ export interface IScheduledAction {
     scheduledBy: Identity;
     scheduledOn: string;
     title?: string;
-    payload?: any; // Action-specific data
+    payload?: TPayload; // Action-specific data
     error?: string; // Error if execution failed
 }
 


### PR DESCRIPTION
## Changes
This PR updates graphql resolvers in HCMS scheduler, and fixes an issue with incorrect ID being passed to scheduling service.

## How Has This Been Tested?
Automated tests and manually.
