### PR TITLE
refactor: remove sync methods where async is also present

### DIFF
--- a/packages/api-aco/src/domain/folder/folder.model.ts
+++ b/packages/api-aco/src/domain/folder/folder.model.ts
@@ -3,7 +3,7 @@ import { ModelFactory } from "@webiny/api-headless-cms/features/modelBuilder/ind
 export const FOLDER_MODEL_ID = process.env.WEBINY_API_LEGACY_MODELS ? "acoFolder" : "wbyAcoFolder";
 
 class FolderPrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/api-aco/src/filter/filter.model.ts
+++ b/packages/api-aco/src/filter/filter.model.ts
@@ -3,7 +3,7 @@ import { ModelFactory } from "@webiny/api-headless-cms/features/modelBuilder/ind
 export const FILTER_MODEL_ID = process.env.WEBINY_API_LEGACY_MODELS ? "acoFilter" : "wbyAcoFilter";
 
 class FilterPrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/api-file-manager/src/domain/file/file.model.ts
+++ b/packages/api-file-manager/src/domain/file/file.model.ts
@@ -4,9 +4,9 @@ import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 export const FILE_MODEL_ID = process.env.WEBINY_API_LEGACY_MODELS ? "fmFile" : "wbyFmFile";
 
 class FilePrivateModelImpl implements ModelFactory.Interface {
-    constructor(private wcp: WcpContext.Interface) {}
+    public constructor(private wcp: WcpContext.Interface) {}
 
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         const model = builder.private().modelId(FILE_MODEL_ID).name("FmFile");
         const privateFiles = this.wcp.canUsePrivateFiles();
 

--- a/packages/api-headless-cms-import-export/src/tasks/utils/entryAssets/EntryAssets.ts
+++ b/packages/api-headless-cms-import-export/src/tasks/utils/entryAssets/EntryAssets.ts
@@ -33,7 +33,7 @@ export class EntryAssets implements IEntryAssets {
             if (!entry?.values) {
                 continue;
             }
-            await this.traverser.traverse(entry.values, ({ field, value }) => {
+            await this.traverser.traverse(entry.values, async ({ field, value }) => {
                 if (!value || fileTypes.includes(field.type) === false) {
                     return;
                 }

--- a/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
@@ -13,7 +13,7 @@ describe("All Field Types Model", () => {
 
     it("should support all field types with various configurations", async () => {
         class AllFieldsModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .private()
@@ -283,7 +283,7 @@ describe("All Field Types Model", () => {
 
     it("should support all public-model-specific methods", async () => {
         class FullPublicModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .public()
@@ -359,7 +359,7 @@ describe("All Field Types Model", () => {
     it("should ensure tags are unique and always include type:model", async () => {
         // Test public model with duplicate tags including "type:model"
         class DuplicateTagsPublicModel implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .public()
@@ -386,7 +386,7 @@ describe("All Field Types Model", () => {
 
         // Test private model with duplicate tags
         class DuplicateTagsPrivateModel implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .private()
@@ -413,7 +413,7 @@ describe("All Field Types Model", () => {
 
         // Test model without tags still gets type:model
         class NoTagsModel implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .public()

--- a/packages/api-headless-cms/__tests__/modelBuilder/modelBuilderComparison.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/modelBuilderComparison.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@webiny/di";
 import { ModelBuilderFeature } from "~/features/modelBuilder/feature.js";
 import { ModelFactory, ModelsProvider } from "~/features/modelBuilder/index.js";
-import { createPrivateModelPlugin, createModelField } from "~/index.js";
+import { createModelField, createPrivateModelPlugin } from "~/index.js";
 import { articleModel } from "~tests/contentTraverser/mocks/article.model.js";
 
 describe("Model Builder Comparison - Old vs New API", () => {
@@ -71,7 +71,7 @@ describe("Model Builder Comparison - Old vs New API", () => {
             // NEW WAY - Using builder API via DI
             // ============================================
             class TestModelImpl implements ModelFactory.Interface {
-                execute(builder: ModelFactory.Builder) {
+                public async execute(builder: ModelFactory.Builder) {
                     return [
                         builder
                             .private()
@@ -164,7 +164,7 @@ describe("Model Builder Comparison - Old vs New API", () => {
             // NEW WAY - Using builder API via DI
             // ============================================
             class ArticleModelImpl implements ModelFactory.Interface {
-                execute(builder: ModelFactory.Builder) {
+                public async execute(builder: ModelFactory.Builder) {
                     return [
                         builder
                             .private()
@@ -187,7 +187,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                                     .template("cv2zf965v324ivdc7e1vt", {
                                         name: "Hero #1",
                                         gqlTypeName: "Hero",
-                                        icon: "fas/flag",
+                                        icon: {
+                                            type: "fas/flag",
+                                            name: "fas/flag"
+                                        },
                                         description: "The top piece of content on every page.",
                                         fields: f => ({
                                             title: f.text().label("Title")
@@ -196,7 +199,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                                     .template("81qiz2v453wx9uque0gox", {
                                         name: "Simple Text #1",
                                         gqlTypeName: "SimpleText",
-                                        icon: "fas/file-text",
+                                        icon: {
+                                            name: "fas/file-text",
+                                            type: "fas/file-text"
+                                        },
                                         description: "Simple paragraph of text.",
                                         fields: f => ({
                                             text: f.longText().label("Text")
@@ -205,7 +211,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                                     .template("9ht43gurhegkbdfsaafyads", {
                                         name: "Settings",
                                         gqlTypeName: "Settings",
-                                        icon: "fas/file-text",
+                                        icon: {
+                                            name: "fas/file-text",
+                                            type: "fas/file-text"
+                                        },
                                         description: "Settings",
                                         fields: f => ({
                                             settings: f
@@ -227,7 +236,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                                                 .template("0emukbsvmzpozx2lzk883", {
                                                     name: "Ad",
                                                     gqlTypeName: "Ad",
-                                                    icon: "fab/buysellads",
+                                                    icon: {
+                                                        name: "fab/buysellads",
+                                                        type: "fab/buysellads"
+                                                    },
                                                     description: "Ad",
                                                     fields: adFields => ({
                                                         authors: adFields

--- a/packages/api-headless-cms/__tests__/modelBuilder/multipleFieldsCalls.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/multipleFieldsCalls.test.ts
@@ -13,7 +13,7 @@ describe("Private Models", () => {
 
     it("should append fields when .fields() is called multiple times", async () => {
         class TestModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 // First call - add base fields
                 const model = builder
                     .private()
@@ -60,7 +60,7 @@ describe("Private Models", () => {
         class ConditionalModelImpl implements ModelFactory.Interface {
             constructor(private includeOptionalFields: boolean) {}
 
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 // Always add base fields
                 const model = builder
                     .private()
@@ -120,7 +120,7 @@ describe("Public Models", () => {
 
     it("should append fields when .fields() is called multiple times on public models", async () => {
         class TestPublicModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 // First call - add base fields
                 const model = builder
                     .public()
@@ -171,7 +171,7 @@ describe("Public Models", () => {
         class ConditionalPublicModelImpl implements ModelFactory.Interface {
             constructor(private includeValidators: boolean) {}
 
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 // Always add base fields
                 const model = builder
                     .public()

--- a/packages/api-headless-cms/__tests__/modelBuilder/objectFieldMultipleCalls.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/objectFieldMultipleCalls.test.ts
@@ -13,7 +13,7 @@ describe("Object Field Multiple .fields() Calls", () => {
 
     it("should append fields when .fields() is called multiple times on object field", async () => {
         class TestModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .private()
@@ -69,7 +69,7 @@ describe("Object Field Multiple .fields() Calls", () => {
         class ConditionalObjectModelImpl implements ModelFactory.Interface {
             constructor(private includeExtendedMetadata: boolean) {}
 
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 // Create object field with base fields
                 const metadataBuilder = (fields: ModelFactory.FieldBuilder) => {
                     const objField = fields
@@ -137,7 +137,7 @@ describe("Object Field Multiple .fields() Calls", () => {
 
     it("should support nested object fields with multiple .fields() calls", async () => {
         class NestedObjectModelImpl implements ModelFactory.Interface {
-            execute(builder: ModelFactory.Builder) {
+            public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
                         .private()

--- a/packages/api-headless-cms/src/abstractions/entryHooks/OnEntryBeforeCreate.ts
+++ b/packages/api-headless-cms/src/abstractions/entryHooks/OnEntryBeforeCreate.ts
@@ -1,7 +1,7 @@
 import { Abstraction } from "@webiny/di";
 
 export interface IOnEntryBeforeCreate {
-    execute(): void | Promise<void>;
+    execute(): Promise<void>;
 }
 
 export const OnEntryBeforeCreate = new Abstraction<IOnEntryBeforeCreate>("OnEntryBeforeCreate");

--- a/packages/api-headless-cms/src/context.ts
+++ b/packages/api-headless-cms/src/context.ts
@@ -106,7 +106,7 @@ export const createContextPlugin = ({ storageOperations }: CrudParams) => {
         await storageOperations.beforeInit(context);
 
         const accessControl = new AccessControl({
-            getIdentity: () => context.security.getIdentity(),
+            getIdentity: async () => context.security.getIdentity(),
             getGroupsPermissions: () => context.security.getPermissions("cms.contentModelGroup"),
             getModelsPermissions: () => context.security.getPermissions("cms.contentModel"),
             getEntriesPermissions: () => context.security.getPermissions("cms.contentEntry"),

--- a/packages/api-headless-cms/src/crud/AccessControl/AccessControl.ts
+++ b/packages/api-headless-cms/src/crud/AccessControl/AccessControl.ts
@@ -10,10 +10,10 @@ import type { SecurityIdentity } from "@webiny/api-core/types/security.js";
 import { NotAuthorizedError } from "~/utils/errors.js";
 
 export interface AccessControlParams {
-    getIdentity: () => SecurityIdentity | Promise<SecurityIdentity>;
-    getGroupsPermissions: () => CmsGroupPermission[] | Promise<CmsGroupPermission[]>;
-    getModelsPermissions: () => CmsModelPermission[] | Promise<CmsModelPermission[]>;
-    getEntriesPermissions: () => CmsEntryPermission[] | Promise<CmsEntryPermission[]>;
+    getIdentity: () => Promise<SecurityIdentity>;
+    getGroupsPermissions: () => Promise<CmsGroupPermission[]>;
+    getModelsPermissions: () => Promise<CmsModelPermission[]>;
+    getEntriesPermissions: () => Promise<CmsEntryPermission[]>;
     listAllGroups: () => Promise<CmsGroup[]>;
 }
 
@@ -69,7 +69,7 @@ export class AccessControl {
     listAllGroupsCallback: AccessControlParams["listAllGroups"];
 
     private fullAccessPermissions: string[];
-    private allGroups: null | CmsGroup[] | Promise<CmsGroup[]>;
+    private allGroups: null | Promise<CmsGroup[]>;
 
     constructor({
         getIdentity,

--- a/packages/api-headless-cms/src/features/modelBuilder/abstractions.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/abstractions.ts
@@ -36,21 +36,13 @@ export interface IModelBuilder {
 }
 
 export interface IModelFactory {
-    execute(
-        builder: IModelBuilder
-    ):
-        | Promise<PrivateModelBuilder[] | PublicModelBuilder[]>
-        | PrivateModelBuilder[]
-        | PublicModelBuilder[];
+    execute(builder: IModelBuilder): Promise<PrivateModelBuilder[] | PublicModelBuilder[]>;
 }
 
 export const ModelFactory = createAbstraction<IModelFactory>("ModelFactory");
 export namespace ModelFactory {
     export type Interface = IModelFactory;
-    export type Return =
-        | Promise<PrivateModelBuilder[] | PublicModelBuilder[]>
-        | PrivateModelBuilder[]
-        | PublicModelBuilder[];
+    export type Return = Promise<PrivateModelBuilder[] | PublicModelBuilder[]>;
     export type Builder = IModelBuilder;
     export type FieldBuilder = FieldBuilderRegistry.Interface;
 }

--- a/packages/api-headless-cms/src/htmlRenderer/createLexicalHTMLRenderer.ts
+++ b/packages/api-headless-cms/src/htmlRenderer/createLexicalHTMLRenderer.ts
@@ -7,7 +7,7 @@ const isLexicalContents = (contents: RichTextContents): contents is SerializedEd
 };
 
 export const createLexicalHTMLRenderer = () => {
-    return new CmsRichTextRendererPlugin("html", contents => {
+    return new CmsRichTextRendererPlugin("html", async contents => {
         if (!isLexicalContents(contents)) {
             return undefined;
         }

--- a/packages/api-headless-cms/src/plugins/CmsRichTextRendererPlugin.ts
+++ b/packages/api-headless-cms/src/plugins/CmsRichTextRendererPlugin.ts
@@ -9,7 +9,7 @@ export interface CmsRichTextRenderer<T> {
 }
 
 export interface RichTextRendererMiddleware<T> {
-    (contents: RichTextContents, next: CmsRichTextRenderer<T>): Promise<T> | T;
+    (contents: RichTextContents, next: CmsRichTextRenderer<T>): Promise<T>;
 }
 
 interface CmsRichTextRendererConstructorParams<T> {

--- a/packages/api-headless-cms/src/types/modelAst.ts
+++ b/packages/api-headless-cms/src/types/modelAst.ts
@@ -44,8 +44,5 @@ export interface ContentEntryNodeContext {
 }
 
 export interface ContentEntryValueVisitor {
-    (
-        params: ContentEntryNode,
-        context: ContentEntryNodeContext
-    ): Promise<void | unknown> | void | unknown;
+    (params: ContentEntryNode, context: ContentEntryNodeContext): Promise<void | unknown>;
 }

--- a/packages/api-record-locking/src/domain/RecordLockingModel.ts
+++ b/packages/api-record-locking/src/domain/RecordLockingModel.ts
@@ -3,7 +3,7 @@ import { ModelFactory } from "@webiny/api-headless-cms/features/modelBuilder/ind
 export const RECORD_LOCKING_MODEL_ID = "wbyRecordLock";
 
 class RecordLockingPrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/api-scheduler/src/domain/SchedulePrivateModel.ts
+++ b/packages/api-scheduler/src/domain/SchedulePrivateModel.ts
@@ -2,7 +2,7 @@ import { ModelFactory } from "@webiny/api-headless-cms/features/modelBuilder/ind
 import { SCHEDULE_MODEL_ID } from "~/constants.js";
 
 class SchedulePrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/api-workflows/src/domain/workflow/workflowModel.ts
+++ b/packages/api-workflows/src/domain/workflow/workflowModel.ts
@@ -4,7 +4,7 @@ import { WORKFLOW_MODEL_ID } from "~/constants.js";
 export { WORKFLOW_MODEL_ID };
 
 class WorkflowModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/api-workflows/src/domain/workflowState/stateModel.ts
+++ b/packages/api-workflows/src/domain/workflowState/stateModel.ts
@@ -23,7 +23,7 @@ const states = [
 ];
 
 class WorkflowStateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
+++ b/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
@@ -52,8 +52,8 @@ export class VerifyDepsCommand implements CliCommandFactory.Interface<unknown> {
                                 if (JSON.stringify(refDep) !== JSON.stringify(fileDep)) {
                                     console.log("Mismatch in dependency:", refDep.name, "in", type);
                                     console.log({
-                                        refDep,
-                                        fileDep
+                                        refDep: JSON.stringify(refDep),
+                                        fileDep: JSON.stringify(fileDep)
                                     });
                                 }
                             }

--- a/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
+++ b/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
@@ -4,6 +4,7 @@ import loadJsonFile from "load-json-file";
 import { getDuplicatesFilePath, getReferencesFilePath } from "../paths.js";
 import fs from "fs";
 import { createDependencyTree } from "../createDependencyTree.js";
+import type { IDependencyCollection } from "~/features/DepsSync/types.js";
 
 export class VerifyDepsCommand implements CliCommandFactory.Interface<unknown> {
     constructor(
@@ -25,7 +26,7 @@ export class VerifyDepsCommand implements CliCommandFactory.Interface<unknown> {
 
                 const tree = createDependencyTree(project);
 
-                const references = {
+                const references: IDependencyCollection = {
                     dependencies: tree.dependencies,
                     devDependencies: tree.devDependencies,
                     peerDependencies: tree.peerDependencies,
@@ -36,8 +37,27 @@ export class VerifyDepsCommand implements CliCommandFactory.Interface<unknown> {
                 ui.info("Checking references file...");
 
                 if (fs.existsSync(referencesFile)) {
-                    const json = loadJsonFile.sync(referencesFile);
+                    const json = loadJsonFile.sync<IDependencyCollection>(referencesFile)!;
                     if (JSON.stringify(references) !== JSON.stringify(json)) {
+                        for (const type in references) {
+                            const refDependencies = references[type as keyof typeof references];
+                            const fileDependencies = json[type as keyof typeof json];
+                            for (const dep in refDependencies) {
+                                const refDep = refDependencies[dep];
+                                const fileDep = fileDependencies[dep];
+                                if (!fileDep) {
+                                    console.log("Missing dependency:", dep, "in", type);
+                                    continue;
+                                }
+                                if (JSON.stringify(refDep) !== JSON.stringify(fileDep)) {
+                                    console.log("Mismatch in dependency:", dep, "in", type);
+                                    console.log({
+                                        refDep,
+                                        fileDep
+                                    });
+                                }
+                            }
+                        }
                         throw new Error(
                             "References are not in sync. Please run `yarn webiny sync-dependencies` command."
                         );

--- a/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
+++ b/packages/cli-core/src/features/DepsSync/commands/VerifyDepsCommand.ts
@@ -46,11 +46,11 @@ export class VerifyDepsCommand implements CliCommandFactory.Interface<unknown> {
                                 const refDep = refDependencies[dep];
                                 const fileDep = fileDependencies[dep];
                                 if (!fileDep) {
-                                    console.log("Missing dependency:", dep, "in", type);
+                                    console.log("Missing dependency:", refDep.name, "in", type);
                                     continue;
                                 }
                                 if (JSON.stringify(refDep) !== JSON.stringify(fileDep)) {
-                                    console.log("Mismatch in dependency:", dep, "in", type);
+                                    console.log("Mismatch in dependency:", refDep.name, "in", type);
                                     console.log({
                                         refDep,
                                         fileDep

--- a/packages/cli-core/src/features/DepsSync/createReferenceFile.ts
+++ b/packages/cli-core/src/features/DepsSync/createReferenceFile.ts
@@ -2,7 +2,7 @@ import writeJsonFile from "write-json-file";
 import { IProjectModel } from "@webiny/project";
 import { UiService } from "~/abstractions/services/index.js";
 import { getDuplicatesFilePath, getReferencesFilePath } from "./paths.js";
-import type { IDependencyTree } from "./types.js";
+import type { IDependencyCollection, IDependencyTree } from "./types.js";
 
 export interface ICreateReferenceFileDi {
     uiService: UiService.Interface;
@@ -21,21 +21,19 @@ export const createReferenceFile = (
         ui.info("No references found.");
         return;
     }
+    
+    const json: IDependencyCollection = {
+        dependencies: tree.dependencies,
+        devDependencies: tree.devDependencies,
+        peerDependencies: tree.peerDependencies,
+        resolutions: tree.resolutions,
+        references: tree.references
+    };
 
     ui.info(`Creating %s...`, refsFilePath);
-    writeJsonFile.sync(
-        refsFilePath,
-        {
-            dependencies: tree.dependencies,
-            devDependencies: tree.devDependencies,
-            peerDependencies: tree.peerDependencies,
-            resolutions: tree.resolutions,
-            references: tree.references
-        },
-        {
-            indent: 0
-        }
-    );
+    writeJsonFile.sync(refsFilePath, json, {
+        indent: 0
+    });
 
     ui.info(`Creating %s...`, dupesFilePath);
 

--- a/packages/cli-core/src/features/DepsSync/createReferenceFile.ts
+++ b/packages/cli-core/src/features/DepsSync/createReferenceFile.ts
@@ -21,7 +21,7 @@ export const createReferenceFile = (
         ui.info("No references found.");
         return;
     }
-    
+
     const json: IDependencyCollection = {
         dependencies: tree.dependencies,
         devDependencies: tree.devDependencies,

--- a/packages/cli-core/src/features/DepsSync/types.ts
+++ b/packages/cli-core/src/features/DepsSync/types.ts
@@ -34,6 +34,14 @@ export interface IDependencyTreePushParams {
     ignore?: RegExp;
 }
 
+export interface IDependencyCollection {
+    dependencies: IDependency[];
+    devDependencies: IDependency[];
+    peerDependencies: IDependency[];
+    resolutions: IDependency[];
+    references: IReference[];
+}
+
 export interface IDependencyTree {
     dependencies: IDependency[];
     devDependencies: IDependency[];

--- a/packages/tasks/src/crud/TaskLogPrivateModel.ts
+++ b/packages/tasks/src/crud/TaskLogPrivateModel.ts
@@ -4,7 +4,7 @@ import { TaskLogItemType } from "~/types.js";
 export const WEBINY_TASK_LOG_MODEL_ID = "wbyTaskLog";
 
 class TaskLogPrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()

--- a/packages/tasks/src/crud/TaskPrivateModel.ts
+++ b/packages/tasks/src/crud/TaskPrivateModel.ts
@@ -4,7 +4,7 @@ import { TaskDataStatus } from "~/types.js";
 export const WEBINY_TASK_MODEL_ID = "wbyTask";
 
 class TaskPrivateModelImpl implements ModelFactory.Interface {
-    execute(builder: ModelFactory.Builder) {
+    public async execute(builder: ModelFactory.Builder) {
         return [
             builder
                 .private()


### PR DESCRIPTION
## Changes
Remove sync methods in favor of async ones where both exist. It creates unnecessary overhead + adding issues with return types in user projects.

Example
```typescript 
interface MyReturn {
 key: string;
....
}
interface MyInterface {
   execute(): Promise<MyReturn> | MyReturn;
}
```

## How Has This Been Tested?
Jest and manually.