### PR TITLE
fix: remove revision from folder id

### DIFF
--- a/packages/api-aco/src/features/flp/UpdateFlp/UpdateFlpUseCase.ts
+++ b/packages/api-aco/src/features/flp/UpdateFlp/UpdateFlpUseCase.ts
@@ -5,6 +5,7 @@ import type { UpdateFlpParams, UpdateFlpUseCase as UseCaseAbstraction } from "./
 import type { AcoContext, Folder, FolderLevelPermission, FolderPermission } from "~/types.js";
 import { ListFoldersUseCase } from "~/features/folder/ListFolders/index.js";
 import { FolderModel } from "~/domain/folder/abstractions.js";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 
 interface FlpUpdateData {
     parentId: string;
@@ -148,7 +149,8 @@ export class UpdateFlpUseCase implements UseCaseAbstraction.Interface {
             for (const item of items) {
                 const { id, data } = item;
                 // Directly update the folder in CMS storage to bypass any folder update event triggers.
-                await this.context.cms.updateEntry(folderModel, id, {
+                const entryId = EntryId.from(id);
+                await this.context.cms.updateEntry(folderModel, entryId.toString(), {
                     values: {
                         path: data.path
                     }

--- a/packages/api-aco/src/features/folder/CreateFolder/CreateFolderRepository.ts
+++ b/packages/api-aco/src/features/folder/CreateFolder/CreateFolderRepository.ts
@@ -11,6 +11,7 @@ import type { CmsEntryFolder, CreateFolderParams, Folder } from "~/folder/folder
 import { EntryToFolderMapper } from "../shared/EntryToFolderMapper.js";
 import { FolderPersistenceError, FolderValidationError } from "~/domain/folder/errors.js";
 import { Path } from "~/utils/Path.js";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 
 class CreateFolderRepositoryImpl implements ICreateFolderRepository {
     constructor(
@@ -78,7 +79,7 @@ class CreateFolderRepositoryImpl implements ICreateFolderRepository {
                     slug,
                     parentId
                 },
-                ...(excludeId ? { id_not: excludeId } : {})
+                ...(excludeId ? { entryId_not: excludeId } : {})
             },
             limit: 1
         });
@@ -112,7 +113,7 @@ class CreateFolderRepositoryImpl implements ICreateFolderRepository {
 
         const parentResult = await this.getEntryById.execute<CmsEntryFolder>(
             this.folderModel,
-            parentId
+            EntryId.from(parentId).toString()
         );
 
         if (parentResult.isFail()) {

--- a/packages/api-aco/src/features/folder/GetFolder/GetFolderRepository.ts
+++ b/packages/api-aco/src/features/folder/GetFolder/GetFolderRepository.ts
@@ -8,6 +8,7 @@ import { FolderModel } from "~/domain/folder/abstractions.js";
 import type { CmsEntryFolder, Folder } from "~/folder/folder.types.js";
 import { EntryToFolderMapper } from "../shared/EntryToFolderMapper.js";
 import { FolderNotFoundError, FolderPersistenceError } from "~/domain/folder/errors.js";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 
 class GetFolderRepositoryImpl implements IGetFolderRepository {
     constructor(
@@ -16,7 +17,11 @@ class GetFolderRepositoryImpl implements IGetFolderRepository {
     ) {}
 
     async execute(id: string): Promise<Result<Folder, RepositoryAbstraction.Error>> {
-        const result = await this.getEntryById.execute<CmsEntryFolder>(this.folderModel, id);
+        const entryId = EntryId.from(id);
+        const result = await this.getEntryById.execute<CmsEntryFolder>(
+            this.folderModel,
+            entryId.toString()
+        );
 
         if (result.isFail()) {
             if (result.error.code === "Cms/Entry/NotFound") {

--- a/packages/api-aco/src/features/folder/GetFolderHierarchy/GetFolderHierarchyRepository.ts
+++ b/packages/api-aco/src/features/folder/GetFolderHierarchy/GetFolderHierarchyRepository.ts
@@ -5,6 +5,7 @@ import {
 } from "./abstractions.js";
 import { GetEntryByIdUseCase } from "@webiny/api-headless-cms/features/contentEntry/GetEntryById";
 import { ListLatestEntriesUseCase } from "@webiny/api-headless-cms/features/contentEntry/ListEntries";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 import { FolderModel } from "~/domain/folder/abstractions.js";
 import type {
     CmsEntryFolder,
@@ -60,9 +61,10 @@ class GetFolderHierarchyRepositoryImpl implements IGetFolderHierarchyRepository 
         }
 
         // Get the folder by id
+        const entryId = EntryId.from(params.id);
         const folderResult = await this.getEntryById.execute<CmsEntryFolder>(
             this.folderModel,
-            params.id
+            entryId.toString()
         );
 
         if (folderResult.isFail()) {
@@ -85,7 +87,7 @@ class GetFolderHierarchyRepositoryImpl implements IGetFolderHierarchyRepository 
             this.folderModel,
             {
                 where: {
-                    id_not_in: parentIds,
+                    entryId_not_in: parentIds,
                     values: {
                         type: folder.type,
                         parentId_in: parentIds
@@ -117,7 +119,7 @@ class GetFolderHierarchyRepositoryImpl implements IGetFolderHierarchyRepository 
         while (currentFolder.parentId) {
             const parentResult = await this.getEntryById.execute<CmsEntryFolder>(
                 this.folderModel,
-                currentFolder.parentId
+                EntryId.from(currentFolder.parentId).toString()
             );
 
             if (parentResult.isFail()) {

--- a/packages/api-aco/src/features/folder/UpdateFolder/UpdateFolderRepository.ts
+++ b/packages/api-aco/src/features/folder/UpdateFolder/UpdateFolderRepository.ts
@@ -11,6 +11,7 @@ import type { CmsEntryFolder, Folder, UpdateFolderParams } from "~/folder/folder
 import { EntryToFolderMapper } from "../shared/EntryToFolderMapper.js";
 import { FolderPersistenceError, FolderValidationError } from "~/domain/folder/errors.js";
 import { Path } from "~/utils/Path.js";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 
 class UpdateFolderRepositoryImpl implements IUpdateFolderRepository {
     constructor(
@@ -24,10 +25,12 @@ class UpdateFolderRepositoryImpl implements IUpdateFolderRepository {
         id: string,
         data: UpdateFolderParams
     ): Promise<Result<Folder, RepositoryAbstraction.Error>> {
+        const entryId = EntryId.from(id);
+
         // Get the original folder
         const originalResult = await this.getEntryById.execute<CmsEntryFolder>(
             this.folderModel,
-            id
+            entryId.toString()
         );
 
         if (originalResult.isFail()) {
@@ -58,12 +61,16 @@ class UpdateFolderRepositoryImpl implements IUpdateFolderRepository {
             return Result.fail(pathResult.error);
         }
 
-        const result = await this.updateEntry.execute<CmsEntryFolder>(this.folderModel, id, {
-            values: {
-                ...data,
-                path: pathResult.value
+        const result = await this.updateEntry.execute<CmsEntryFolder>(
+            this.folderModel,
+            entryId.toString(),
+            {
+                values: {
+                    ...data,
+                    path: pathResult.value
+                }
             }
-        });
+        );
 
         if (result.isFail()) {
             return Result.fail(new FolderPersistenceError(result.error));
@@ -84,7 +91,7 @@ class UpdateFolderRepositoryImpl implements IUpdateFolderRepository {
         const result = await this.listLatestEntries.execute<CmsEntryFolder>(this.folderModel, {
             where: {
                 latest: true,
-                id_not: id,
+                entryId_not: id,
                 values: {
                     type,
                     slug,
@@ -123,7 +130,7 @@ class UpdateFolderRepositoryImpl implements IUpdateFolderRepository {
 
         const parentResult = await this.getEntryById.execute<CmsEntryFolder>(
             this.folderModel,
-            parentId
+            EntryId.from(parentId).toString()
         );
 
         if (parentResult.isFail()) {

--- a/packages/api-aco/src/features/folder/shared/EntryToFolderMapper.ts
+++ b/packages/api-aco/src/features/folder/shared/EntryToFolderMapper.ts
@@ -4,8 +4,7 @@ import type { CmsEntryFolder, Folder } from "~/folder/folder.types.js";
 export class EntryToFolderMapper {
     static toFolder(entry: CmsEntry<CmsEntryFolder>): Folder {
         return {
-            id: entry.id,
-            entryId: entry.entryId,
+            id: entry.entryId,
             createdOn: entry.createdOn,
             modifiedOn: entry.modifiedOn ?? null,
             savedOn: entry.savedOn,

--- a/packages/api-aco/src/flp/flp.crud.ts
+++ b/packages/api-aco/src/flp/flp.crud.ts
@@ -6,6 +6,7 @@ import {
     type UpdateFlpParams
 } from "~/types.js";
 import type { Tenant } from "@webiny/api-core/types/tenancy.js";
+import { EntryId } from "@webiny/api-headless-cms/exports/api/cms/entry.js";
 
 export interface CreateFlpCrudMethodsParams {
     getTenant: () => Tenant;
@@ -92,8 +93,9 @@ export const createFlpCrudMethods = ({
             return true;
         },
         async get(id: string) {
+            const entryId = EntryId.from(id);
             return await storageOperations.flp.get({
-                id,
+                id: entryId.id,
                 tenant: getTenant().id
             });
         },

--- a/packages/api-aco/src/folder/folder.types.ts
+++ b/packages/api-aco/src/folder/folder.types.ts
@@ -13,7 +13,6 @@ export interface CmsEntryFolder {
 
 export interface Folder extends CmsEntryFolder {
     id: string;
-    entryId: string;
     createdOn: string;
     modifiedOn: string | null;
     savedOn: string;

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/SidebarHeader/SidebarHeader.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/SidebarHeader/SidebarHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Heading, Link, Separator, Text, Tooltip } from "@webiny/admin-ui";
 import { useModel } from "@webiny/app-headless-cms-common";
+import { IsModelPublishable } from "~/admin/components/IsModelPublishable.js";
 
 export const SidebarHeader = () => {
     const { model } = useModel();
@@ -8,31 +9,33 @@ export const SidebarHeader = () => {
     return (
         <div>
             <div className={"p-md pl-lg"}>
-                <Heading level={5}>{model.name}</Heading>
-                <Text size={"sm"} className={"text-neutral-muted"}>
-                    Model ID:{" "}
-                    {model.plugin ? (
-                        <Tooltip
-                            side={"top"}
-                            content={"Content model is registered via a plugin."}
-                            trigger={model.modelId}
-                        />
-                    ) : (
-                        <Tooltip
-                            content={"Edit content model"}
-                            side={"top"}
-                            trigger={
-                                <Link
-                                    to={`/cms/content-models/${model.modelId}`}
-                                    variant={"secondary"}
-                                    className={"text-neutral-muted hover:text-neutral-strong"}
-                                >
-                                    {model.modelId}
-                                </Link>
-                            }
-                        />
-                    )}
-                </Text>
+                <Heading level={5}>{model.pluralApiName}</Heading>
+                <IsModelPublishable>
+                    <Text size={"sm"} className={"text-neutral-muted"}>
+                        Model ID:{" "}
+                        {model.plugin ? (
+                            <Tooltip
+                                side={"top"}
+                                content={"Content model is registered via a plugin."}
+                                trigger={model.modelId}
+                            />
+                        ) : (
+                            <Tooltip
+                                content={"Edit content model"}
+                                side={"top"}
+                                trigger={
+                                    <Link
+                                        to={`/cms/content-models/${model.modelId}`}
+                                        variant={"secondary"}
+                                        className={"text-neutral-muted hover:text-neutral-strong"}
+                                    >
+                                        {model.modelId}
+                                    </Link>
+                                }
+                            />
+                        )}
+                    </Text>
+                </IsModelPublishable>
             </div>
             <Separator />
         </div>

--- a/packages/tenant-manager/src/admin/Extension.tsx
+++ b/packages/tenant-manager/src/admin/Extension.tsx
@@ -32,7 +32,9 @@ export const Extension = () => {
                                     icon={
                                         <Menu.Link.Icon element={<TenantIcon />} label={"Tenant"} />
                                     }
-                                    to={getLink(Routes.ContentEntries.List, { modelId: "tenant" })}
+                                    to={getLink(Routes.ContentEntries.List, {
+                                        modelId: "wbyTenant"
+                                    })}
                                 />
                             }
                         />

--- a/packages/website-builder-sdk/src/dataProviders/GET_PAGE_BY_ID.ts
+++ b/packages/website-builder-sdk/src/dataProviders/GET_PAGE_BY_ID.ts
@@ -7,6 +7,7 @@ export const GET_PAGE_BY_ID = /* GraphQL*/ `
                     properties
                     elements
                     bindings
+                    extensions
                 }
                 error {
                     code

--- a/packages/website-builder-sdk/src/dataProviders/GET_PAGE_BY_PATH.ts
+++ b/packages/website-builder-sdk/src/dataProviders/GET_PAGE_BY_PATH.ts
@@ -7,6 +7,7 @@ export const GET_PAGE_BY_PATH = /* GraphQL*/ `
                     properties
                     elements
                     bindings
+                    extensions
                 }
                 error {
                     code

--- a/packages/website-builder-sdk/src/dataProviders/LIST_PUBLISHED_PAGES.ts
+++ b/packages/website-builder-sdk/src/dataProviders/LIST_PUBLISHED_PAGES.ts
@@ -7,6 +7,7 @@ export const LIST_PUBLISHED_PAGES = /* GraphQL*/ `
                     properties
                     elements
                     bindings
+                    extensions
                 }
                 error {
                     code

--- a/packages/website-builder-sdk/src/types.ts
+++ b/packages/website-builder-sdk/src/types.ts
@@ -161,7 +161,7 @@ export type Document = {
 
 export type PublicPage = Pick<
     Page,
-    "id" | "version" | "properties" | "bindings" | "elements" | "state"
+    "id" | "version" | "properties" | "bindings" | "elements" | "extensions" | "state"
 >;
 
 export type PublicRedirect = {
@@ -214,6 +214,7 @@ export type Page = Document & {
             metaTags: Array<{ property: string; content: string }>;
         };
     };
+    extensions: Record<string, any>;
 };
 
 export type Box = {


### PR DESCRIPTION
## Changes
This PR removes entry revision from folder IDs in the ACO app.  Folders are not versioned, so this revision ID is only creating noise, but serves no purpose.

Before (URL params):
```
folderId=697fadeef45ab3000209c632#0001
```

After (URL params):
```
folderId=697fadeef45ab3000209c632
```

## How Has This Been Tested?
Automated tests and manually.
