### PR TITLE
fix(app-headless-cms-workflows): disable workflows for unpublishable models

### DIFF
--- a/packages/api-headless-cms-workflows/__tests__/__cms/models.ts
+++ b/packages/api-headless-cms-workflows/__tests__/__cms/models.ts
@@ -1,21 +1,23 @@
 import { createModelGroupPlugin, createModelPlugin } from "@webiny/api-headless-cms";
 
-export const groupPlugin = createModelGroupPlugin({
+export const group = {
     id: "default",
     name: "Default",
     description: "",
     slug: "default",
-    icon: "fa/fas"
-});
+    icon: {
+        name: "fa/fas",
+        type: "fa/fas"
+    }
+};
 
-export const group = groupPlugin.contentModelGroup;
-
-export const modelPlugin = createModelPlugin({
+export const model = {
     modelId: "author",
     name: "Author",
     group: group.slug,
     titleFieldId: "name",
     description: "",
+    icon: null,
     singularApiName: "Author",
     pluralApiName: "Authors",
     layout: [["name"]],
@@ -30,10 +32,21 @@ export const modelPlugin = createModelPlugin({
             listValidation: []
         }
     ]
-});
+};
 
-export const model = modelPlugin.contentModel;
+export interface ICreateModelsPluginsParams {
+    modifyModel?: (input: typeof model) => typeof model;
+    modifyGroup?: (input: typeof group) => typeof group;
+}
 
-export const createModelsPlugins = () => {
+export const createModelsPlugins = (params?: ICreateModelsPluginsParams) => {
+    if (!params) {
+        return [createModelPlugin(model), createModelGroupPlugin(group)];
+    }
+    const modifiedModel = params.modifyModel ? params.modifyModel(model) : model;
+    const modifiedGroup = params.modifyGroup ? params.modifyGroup(group) : group;
+
+    const modelPlugin = createModelPlugin(modifiedModel);
+    const groupPlugin = createModelGroupPlugin(modifiedGroup);
     return [modelPlugin, groupPlugin];
 };

--- a/packages/api-headless-cms-workflows/__tests__/__handler/context.ts
+++ b/packages/api-headless-cms-workflows/__tests__/__handler/context.ts
@@ -1,16 +1,18 @@
 import { createWorkflows } from "@webiny/api-workflows";
 import { useContextHandler, type UseContextHandlerParams } from "@webiny/testing";
 import { createTestWcpLicense } from "@webiny/wcp/testing/createTestWcpLicense.js";
-import { createModelsPlugins } from "../__cms/models.js";
+import { createModelsPlugins, type ICreateModelsPluginsParams } from "../__cms/models.js";
 import { createHeadlessCmsWorkflows } from "~/index.js";
 
-export const createContextHandler = (params?: UseContextHandlerParams) => {
+export const createContextHandler = (
+    params?: UseContextHandlerParams & ICreateModelsPluginsParams
+) => {
     const testLicence = createTestWcpLicense();
 
     return useContextHandler({
         ...params,
         bottomPlugins: [
-            ...createModelsPlugins(),
+            ...createModelsPlugins(params),
             createWorkflows(),
             createHeadlessCmsWorkflows(),
             params?.plugins || []

--- a/packages/api-headless-cms-workflows/__tests__/__workflows/workflow.ts
+++ b/packages/api-headless-cms-workflows/__tests__/__workflows/workflow.ts
@@ -1,6 +1,7 @@
 import type { Context } from "@webiny/api";
 import { StoreWorkflowUseCase } from "@webiny/api-workflows/features/workflow/StoreWorkflow/index.js";
 import { FULL_ACCESS_TEAM_ID } from "@webiny/testing";
+import { model } from "~tests/__cms/models.js";
 
 export const createWorkflow = async (context: Context) => {
     const id = `workflow-1`;
@@ -8,7 +9,7 @@ export const createWorkflow = async (context: Context) => {
     const storeWorkflow = context.container.resolve(StoreWorkflowUseCase);
 
     const workflow = await storeWorkflow.execute({
-        app: "test",
+        app: `cms.${model.modelId}`,
         id,
         name: "Test Workflow",
         steps: [

--- a/packages/api-headless-cms-workflows/__tests__/workflows/disallowUnpublishableModels.test.ts
+++ b/packages/api-headless-cms-workflows/__tests__/workflows/disallowUnpublishableModels.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createContextHandler } from "~tests/__handler/context.js";
+import { model as modelDefinition } from "~tests/__cms/models.js";
+import { createWorkflow } from "~tests/__workflows/workflow.js";
+
+describe("Disallow unpublishable models", () => {
+    it("should not allow creating workflows for unpublishable models", async () => {
+        expect.assertions(1);
+        const { context: createContext } = createContextHandler({
+            modifyModel: model => {
+                return {
+                    ...model,
+                    tags: ["$publishing:false"]
+                };
+            }
+        });
+        const context = await createContext();
+        try {
+            await createWorkflow(context);
+        } catch (ex) {
+            expect((ex as Error).message).toBe(
+                `Cannot create a workflow for the model "${modelDefinition.modelId}" because it is marked as unpublishable.`
+            );
+        }
+    });
+});

--- a/packages/api-headless-cms-workflows/src/features/Workflows/feature.ts
+++ b/packages/api-headless-cms-workflows/src/features/Workflows/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import { DisallowUnpublishableModelsOnBeforeCreate } from "./handlers/DisallowUnpublishableModelsOnBeforeCreate.js";
+
+export const WorkflowsFeature = createFeature({
+    name: "CmsWorkflows",
+    register(container) {
+        container.register(DisallowUnpublishableModelsOnBeforeCreate);
+    }
+});

--- a/packages/api-headless-cms-workflows/src/features/Workflows/handlers/DisallowUnpublishableModelsOnBeforeCreate.ts
+++ b/packages/api-headless-cms-workflows/src/features/Workflows/handlers/DisallowUnpublishableModelsOnBeforeCreate.ts
@@ -1,0 +1,34 @@
+import { WorkflowBeforeCreateHandler } from "@webiny/api-workflows/features/workflow/CreateWorkflow/events.js";
+import { getModelIdFromAppName } from "~/utils/appName.js";
+import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
+
+class DisallowUnpublishableModelsOnBeforeCreateImpl
+    implements WorkflowBeforeCreateHandler.Interface
+{
+    public constructor(private getModelUseCase: GetModelUseCase.Interface) {}
+
+    public async handle(event: WorkflowBeforeCreateHandler.Event): Promise<void> {
+        const { workflow } = event.payload;
+        const modelId = getModelIdFromAppName(workflow.app);
+        if (!modelId) {
+            return;
+        }
+        const model = await this.getModelUseCase.execute(modelId);
+        if (model.isFail()) {
+            return;
+        }
+        const tags = model.value.tags || [];
+        if (tags.includes("$publishing:false") === false) {
+            return;
+        }
+        throw new Error(
+            `Cannot create a workflow for the model "${modelId}" because it is marked as unpublishable.`
+        );
+    }
+}
+
+export const DisallowUnpublishableModelsOnBeforeCreate =
+    WorkflowBeforeCreateHandler.createImplementation({
+        implementation: DisallowUnpublishableModelsOnBeforeCreateImpl,
+        dependencies: [GetModelUseCase]
+    });

--- a/packages/api-headless-cms-workflows/src/features/Workflows/index.ts
+++ b/packages/api-headless-cms-workflows/src/features/Workflows/index.ts
@@ -1,0 +1,1 @@
+export { WorkflowsFeature } from "./feature.js";

--- a/packages/api-headless-cms-workflows/src/index.ts
+++ b/packages/api-headless-cms-workflows/src/index.ts
@@ -1,6 +1,7 @@
 import { createContextPlugin } from "@webiny/api";
 import { EntryWorkflowsFeature } from "./features/EntryWorkflows/feature.js";
 import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
+import { WorkflowsFeature } from "~/features/Workflows/index.js";
 
 export const createHeadlessCmsWorkflows = () => {
     const plugin = createContextPlugin(async context => {
@@ -12,6 +13,7 @@ export const createHeadlessCmsWorkflows = () => {
 
         // Register features
         EntryWorkflowsFeature.register(context.container, context);
+        WorkflowsFeature.register(context.container);
     });
 
     plugin.name = "headless-cms-workflows.context";

--- a/packages/app-headless-cms-workflows/src/Components/CmsWorkflows/CmsWorkflowsEditorView.tsx
+++ b/packages/app-headless-cms-workflows/src/Components/CmsWorkflows/CmsWorkflowsEditorView.tsx
@@ -74,7 +74,12 @@ export const CmsWorkflowsEditorView = () => {
 
     const apps = useMemo<IWorkflowApplication[]>(() => {
         return models
-            .filter(model => canEdit(model, "cms.contentModel"))
+            .filter(model => {
+                if (model.tags.includes("$publishing:false")) {
+                    return false;
+                }
+                return canEdit(model, "cms.contentModel");
+            })
             .map(model => {
                 return {
                     id: createAppName(model),


### PR DESCRIPTION
## Changes
Disable Workflows for models with tag `$publishing:false`.

## How Has This Been Tested?
Manually.