### PR TITLE
fix(api-headless-cms): various

### DIFF
--- a/packages/api-aco/src/domain/folder/folder.model.ts
+++ b/packages/api-aco/src/domain/folder/folder.model.ts
@@ -6,9 +6,10 @@ class FolderPrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(FOLDER_MODEL_ID)
-                .name("ACO - Folder")
+                .private({
+                    modelId: FOLDER_MODEL_ID,
+                    name: "ACO - Folder"
+                })
                 .fields(fields => ({
                     title: fields.text().label("Title").required("Value is required."),
                     slug: fields

--- a/packages/api-aco/src/filter/filter.model.ts
+++ b/packages/api-aco/src/filter/filter.model.ts
@@ -6,9 +6,10 @@ class FilterPrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(FILTER_MODEL_ID)
-                .name("ACO - Filter")
+                .private({
+                    modelId: FILTER_MODEL_ID,
+                    name: "ACO - Filter"
+                })
                 .fields(fields => ({
                     name: fields.text().label("Name").required(),
                     description: fields.text().label("Description"),

--- a/packages/api-aco/src/flp/tasks/createFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/createFlp.task.ts
@@ -8,7 +8,7 @@ class CreateFlpTaskImpl implements TaskDefinition.Interface<ICreateFlpTaskInput>
     title = "ACO - Create FLP record";
     description =
         "Synchronizes the FLP catalog by creating the FLP record based on the provided folder.";
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(private createFlp: CreateFlpUseCase.Interface) {}
 

--- a/packages/api-aco/src/flp/tasks/createFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/createFlp.task.ts
@@ -8,7 +8,7 @@ class CreateFlpTaskImpl implements TaskDefinition.Interface<ICreateFlpTaskInput>
     title = "ACO - Create FLP record";
     description =
         "Synchronizes the FLP catalog by creating the FLP record based on the provided folder.";
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(private createFlp: CreateFlpUseCase.Interface) {}
 

--- a/packages/api-aco/src/flp/tasks/deleteFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/deleteFlp.task.ts
@@ -8,7 +8,7 @@ class DeleteFlpTaskImpl implements TaskDefinition.Interface<IDeleteFlpTaskInput>
     title = "ACO - Delete FLP record";
     description =
         "Synchronizes the FLP catalog by deleting the FLP record based on the provided folder.";
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(private deleteFlp: DeleteFlpUseCase.Interface) {}
 

--- a/packages/api-aco/src/flp/tasks/deleteFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/deleteFlp.task.ts
@@ -8,7 +8,7 @@ class DeleteFlpTaskImpl implements TaskDefinition.Interface<IDeleteFlpTaskInput>
     title = "ACO - Delete FLP record";
     description =
         "Synchronizes the FLP catalog by deleting the FLP record based on the provided folder.";
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(private deleteFlp: DeleteFlpUseCase.Interface) {}
 

--- a/packages/api-aco/src/flp/tasks/syncFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/syncFlp.task.ts
@@ -10,7 +10,7 @@ class SyncFlpTaskImpl implements TaskDefinition.Interface<ISyncFlpTaskInput> {
     id = SYNC_FLP_TASK_ID;
     title = "ACO - Sync FLP record";
     description = "Synchronizes the FLP catalog by updating the FLP record and its descendants.";
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(
         private getFolder: GetFolderUseCase.Interface,

--- a/packages/api-aco/src/flp/tasks/syncFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/syncFlp.task.ts
@@ -10,7 +10,7 @@ class SyncFlpTaskImpl implements TaskDefinition.Interface<ISyncFlpTaskInput> {
     id = SYNC_FLP_TASK_ID;
     title = "ACO - Sync FLP record";
     description = "Synchronizes the FLP catalog by updating the FLP record and its descendants.";
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(
         private getFolder: GetFolderUseCase.Interface,

--- a/packages/api-aco/src/flp/tasks/updateFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/updateFlp.task.ts
@@ -8,7 +8,7 @@ class UpdateFlpTaskImpl implements TaskDefinition.Interface<IUpdateFlpTaskInput>
     title = "ACO - Update FLP record";
     description =
         "Synchronizes the FLP catalog by updating the FLP record and its descendants based on the provided folder.";
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(private updateFlp: UpdateFlpUseCase.Interface) {}
 

--- a/packages/api-aco/src/flp/tasks/updateFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/updateFlp.task.ts
@@ -8,7 +8,7 @@ class UpdateFlpTaskImpl implements TaskDefinition.Interface<IUpdateFlpTaskInput>
     title = "ACO - Update FLP record";
     description =
         "Synchronizes the FLP catalog by updating the FLP record and its descendants based on the provided folder.";
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(private updateFlp: UpdateFlpUseCase.Interface) {}
 

--- a/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
+++ b/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
@@ -103,7 +103,7 @@ export interface ITaskDefinition<
     title: string;
     description?: string;
     maxIterations?: number;
-    disableDatabaseLogs?: boolean;
+    enableDatabaseLogs?: boolean;
     isPrivate?: boolean;
 
     /**
@@ -146,7 +146,7 @@ export interface IRunnableTaskDefinition<
 > extends ITaskDefinition<I, O> {
     // Override optional properties to be required with guaranteed values
     isPrivate: boolean;
-    disableDatabaseLogs: boolean;
+    enableDatabaseLogs: boolean;
     maxIterations: number;
 }
 

--- a/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
+++ b/packages/api-core/src/features/task/TaskDefinition/abstractions.ts
@@ -103,7 +103,7 @@ export interface ITaskDefinition<
     title: string;
     description?: string;
     maxIterations?: number;
-    enableDatabaseLogs?: boolean;
+    databaseLogs?: boolean;
     isPrivate?: boolean;
 
     /**
@@ -146,7 +146,7 @@ export interface IRunnableTaskDefinition<
 > extends ITaskDefinition<I, O> {
     // Override optional properties to be required with guaranteed values
     isPrivate: boolean;
-    enableDatabaseLogs: boolean;
+    databaseLogs: boolean;
     maxIterations: number;
 }
 

--- a/packages/api-elasticsearch-tasks/src/tasks/dataSynchronization/DataSynchronizationTask.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/dataSynchronization/DataSynchronizationTask.ts
@@ -16,7 +16,7 @@ export class DataSynchronizationTask
     description = "Synchronize data between Elasticsearch and DynamoDB";
     isPrivate = false;
     maxIterations = 100;
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(
         private elasticsearchClient: IElasticsearchTaskConfig["elasticsearchClient"],

--- a/packages/api-elasticsearch-tasks/src/tasks/dataSynchronization/DataSynchronizationTask.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/dataSynchronization/DataSynchronizationTask.ts
@@ -16,7 +16,7 @@ export class DataSynchronizationTask
     description = "Synchronize data between Elasticsearch and DynamoDB";
     isPrivate = false;
     maxIterations = 100;
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(
         private elasticsearchClient: IElasticsearchTaskConfig["elasticsearchClient"],

--- a/packages/api-file-manager-s3/src/features/ExtractMetadata/ExtractMetadataTask.ts
+++ b/packages/api-file-manager-s3/src/features/ExtractMetadata/ExtractMetadataTask.ts
@@ -15,7 +15,7 @@ class ExtractMetadataTask implements TaskDefinition.Interface<ExtractMetadataInp
     description = "A task to extract metadata from uploaded image files";
     maxIterations = 1;
     isPrivate = true;
-    enableDatabaseLogs = false;
+    databaseLogs = false;
 
     constructor(
         private keyValueStore: GlobalKeyValueStore.Interface,

--- a/packages/api-file-manager-s3/src/features/ExtractMetadata/ExtractMetadataTask.ts
+++ b/packages/api-file-manager-s3/src/features/ExtractMetadata/ExtractMetadataTask.ts
@@ -15,7 +15,7 @@ class ExtractMetadataTask implements TaskDefinition.Interface<ExtractMetadataInp
     description = "A task to extract metadata from uploaded image files";
     maxIterations = 1;
     isPrivate = true;
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
 
     constructor(
         private keyValueStore: GlobalKeyValueStore.Interface,

--- a/packages/api-file-manager/src/domain/file/file.model.ts
+++ b/packages/api-file-manager/src/domain/file/file.model.ts
@@ -9,7 +9,7 @@ class FilePrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         const model = builder.private({
             modelId: FILE_MODEL_ID,
-            name: "File"
+            name: "FmFile"
         });
         const privateFiles = this.wcp.canUsePrivateFiles();
 

--- a/packages/api-file-manager/src/domain/file/file.model.ts
+++ b/packages/api-file-manager/src/domain/file/file.model.ts
@@ -7,7 +7,10 @@ class FilePrivateModelImpl implements ModelFactory.Interface {
     public constructor(private wcp: WcpContext.Interface) {}
 
     public async execute(builder: ModelFactory.Builder) {
-        const model = builder.private().modelId(FILE_MODEL_ID).name("FmFile");
+        const model = builder.private({
+            modelId: FILE_MODEL_ID,
+            name: "File"
+        });
         const privateFiles = this.wcp.canUsePrivateFiles();
 
         model.fields(fields => ({

--- a/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
@@ -42,7 +42,7 @@ export const createBulkActionTasks = (
         public readonly id = listTaskId;
         public readonly title = `Headless CMS: list "${bulkActionName}" entries by model`;
         public readonly maxIterations = 500;
-        public readonly enableDatabaseLogs = false;
+        public readonly databaseLogs = false;
         public readonly isPrivate = true;
         public readonly context: BulkActionContext.Interface;
         public readonly getModel: GetModelUseCase.Interface;
@@ -130,7 +130,7 @@ export const createBulkActionTasks = (
         public readonly id = processTaskId;
         public readonly title = `Headless CMS: process "${bulkActionName}" entries`;
         public readonly maxIterations = 2;
-        public readonly enableDatabaseLogs = false;
+        public readonly databaseLogs = false;
         public readonly isPrivate = true;
         public readonly getModel: GetModelUseCase.Interface;
 

--- a/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
@@ -42,7 +42,7 @@ export const createBulkActionTasks = (
         public readonly id = listTaskId;
         public readonly title = `Headless CMS: list "${bulkActionName}" entries by model`;
         public readonly maxIterations = 500;
-        public readonly disableDatabaseLogs = true;
+        public readonly enableDatabaseLogs = false;
         public readonly isPrivate = true;
         public readonly context: BulkActionContext.Interface;
         public readonly getModel: GetModelUseCase.Interface;
@@ -130,7 +130,7 @@ export const createBulkActionTasks = (
         public readonly id = processTaskId;
         public readonly title = `Headless CMS: process "${bulkActionName}" entries`;
         public readonly maxIterations = 2;
-        public readonly disableDatabaseLogs = true;
+        public readonly enableDatabaseLogs = false;
         public readonly isPrivate = true;
         public readonly getModel: GetModelUseCase.Interface;
 

--- a/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
@@ -32,7 +32,7 @@ class EmptyTrashBinTask
     public readonly description =
         "Delete all entries in the trash bin for each model in the system.";
     public readonly maxIterations = 120;
-    public readonly disableDatabaseLogs = true;
+    public readonly enableDatabaseLogs = false;
 
     constructor(
         private tenantContext: TenantContext.Interface,

--- a/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
@@ -32,7 +32,7 @@ class EmptyTrashBinTask
     public readonly description =
         "Delete all entries in the trash bin for each model in the system.";
     public readonly maxIterations = 120;
-    public readonly enableDatabaseLogs = false;
+    public readonly databaseLogs = false;
 
     constructor(
         private tenantContext: TenantContext.Interface,

--- a/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModelTask.ts
+++ b/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModelTask.ts
@@ -13,7 +13,7 @@ class DeleteModelTaskDefinition
     title = "Delete model and all of the entries";
     maxIterations = 50;
     isPrivate = true;
-    enableDatabaseLogs = false;
+    databaseLogs = false;
     description = "Delete a content model and all associated entries.";
 
     constructor(private context: CmsContext.Interface) {}

--- a/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModelTask.ts
+++ b/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModelTask.ts
@@ -13,7 +13,7 @@ class DeleteModelTaskDefinition
     title = "Delete model and all of the entries";
     maxIterations = 50;
     isPrivate = true;
-    disableDatabaseLogs = true;
+    enableDatabaseLogs = false;
     description = "Delete a content model and all associated entries.";
 
     constructor(private context: CmsContext.Interface) {}

--- a/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
@@ -17,11 +17,10 @@ describe("All Field Types Model", () => {
                 return [
                     builder
                         .private({
-                            modelId: "allFieldsModel"
+                            modelId: "allFieldsModel",
+                            name: "All Fields Model"
                         })
-                        .name("All Fields Model")
                         .fields(fields => ({
-                            location: fields.location(),
                             // Text field - basic
                             title: fields.text().label("Title").required("Title is required."),
 
@@ -393,9 +392,9 @@ describe("All Field Types Model", () => {
                 return [
                     builder
                         .private({
-                            modelId: "duplicateTagsPrivate"
+                            modelId: "duplicateTagsPrivate",
+                            name: "Duplicate Tags Private"
                         })
-                        .name("Duplicate Tags Private")
                         .tags(["type:model", "custom:tag", "type:model", "custom:tag"])
                         .fields(fields => ({
                             title: fields.text().label("Title")

--- a/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
@@ -209,8 +209,8 @@ describe("All Field Types Model", () => {
         expect(fieldTypes).toContain("dynamicZone");
 
         // Verify specific fields
-        const locationField = model!.fields.find(f => f.fieldId === "location");
-        expect(locationField?.type).toBe("object");
+        // const locationField = model!.fields.find(f => f.fieldId === "location");
+        // expect(locationField?.type).toBe("object");
 
         const titleField = model!.fields.find(f => f.fieldId === "title");
         expect(titleField?.type).toBe("text");

--- a/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/allFieldsModel.test.ts
@@ -16,8 +16,9 @@ describe("All Field Types Model", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .private()
-                        .modelId("allFieldsModel")
+                        .private({
+                            modelId: "allFieldsModel"
+                        })
                         .name("All Fields Model")
                         .fields(fields => ({
                             location: fields.location(),
@@ -286,12 +287,13 @@ describe("All Field Types Model", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .public()
-                        .modelId("fullPublicModel")
-                        .name("Full Public Model")
-                        .singularApiName("FullPublicModel")
-                        .pluralApiName("FullPublicModels")
-                        .group("test")
+                        .public({
+                            modelId: "fullPublicModel",
+                            name: "Full Public Model",
+                            singularApiName: "FullPublicModel",
+                            pluralApiName: "FullPublicModels",
+                            group: "test"
+                        })
                         .icon("fas/database")
                         .description("A complete public model with all fields")
                         .titleFieldId("title")
@@ -362,10 +364,11 @@ describe("All Field Types Model", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .public()
-                        .modelId("duplicateTagsPublic")
-                        .name("Duplicate Tags Public")
-                        .group("test")
+                        .public({
+                            name: "Duplicate Tags Public",
+                            modelId: "duplicateTagsPublic",
+                            group: "test"
+                        })
                         .tags(["type:model", "custom:tag", "type:model", "custom:tag"])
                         .fields(fields => ({
                             title: fields.text().label("Title")
@@ -389,8 +392,9 @@ describe("All Field Types Model", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .private()
-                        .modelId("duplicateTagsPrivate")
+                        .private({
+                            modelId: "duplicateTagsPrivate"
+                        })
                         .name("Duplicate Tags Private")
                         .tags(["type:model", "custom:tag", "type:model", "custom:tag"])
                         .fields(fields => ({
@@ -416,10 +420,11 @@ describe("All Field Types Model", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .public()
-                        .modelId("noTagsModel")
-                        .name("No Tags Model")
-                        .group("test")
+                        .public({
+                            modelId: "noTagsModel",
+                            name: "No Tags Model",
+                            group: "test"
+                        })
                         .fields(fields => ({
                             title: fields.text().label("Title")
                         }))

--- a/packages/api-headless-cms/__tests__/modelBuilder/modelBuilderComparison.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/modelBuilderComparison.test.ts
@@ -74,9 +74,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                 public async execute(builder: ModelFactory.Builder) {
                     return [
                         builder
-                            .private()
-                            .modelId("testModel")
-                            .name("TestModel")
+                            .private({
+                                modelId: "testModel",
+                                name: "TestModel"
+                            })
                             .fields(fields => ({
                                 name: fields.text().label("Name").required("Value is required."),
                                 description: fields.text().label("Description"),
@@ -167,9 +168,10 @@ describe("Model Builder Comparison - Old vs New API", () => {
                 public async execute(builder: ModelFactory.Builder) {
                     return [
                         builder
-                            .private()
-                            .modelId("article")
-                            .name("Article")
+                            .private({
+                                modelId: "article",
+                                name: "Article"
+                            })
                             .fields(fields => ({
                                 title: fields.text().storageId("text@title").label("Title"),
                                 body: fields.richText().storageId("rich-text@body").label("Body"),

--- a/packages/api-headless-cms/__tests__/modelBuilder/multipleFieldsCalls.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/multipleFieldsCalls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@webiny/di";
 import { ModelBuilderFeature } from "~/features/modelBuilder/feature.js";
 import { ModelFactory, ModelsProvider } from "~/features/modelBuilder/index.js";
@@ -16,9 +16,10 @@ describe("Private Models", () => {
             public async execute(builder: ModelFactory.Builder) {
                 // First call - add base fields
                 const model = builder
-                    .private()
-                    .modelId("testModel")
-                    .name("Test Model")
+                    .private({
+                        modelId: "testModel",
+                        name: "Test Model"
+                    })
                     .fields(fields => ({
                         name: fields.text().label("Name").required(),
                         email: fields.text().label("Email").email()
@@ -63,9 +64,10 @@ describe("Private Models", () => {
             public async execute(builder: ModelFactory.Builder) {
                 // Always add base fields
                 const model = builder
-                    .private()
-                    .modelId("conditionalModel")
-                    .name("Conditional Model")
+                    .private({
+                        modelId: "conditionalModel",
+                        name: "Conditional Model"
+                    })
                     .fields(fields => ({
                         title: fields.text().label("Title").required()
                     }));
@@ -123,10 +125,11 @@ describe("Public Models", () => {
             public async execute(builder: ModelFactory.Builder) {
                 // First call - add base fields
                 const model = builder
-                    .public()
-                    .modelId("publicTestModel")
-                    .name("Public Test Model")
-                    .group("test")
+                    .public({
+                        modelId: "publicTestModel",
+                        name: "Public Test Model",
+                        group: "test"
+                    })
                     .fields(fields => ({
                         title: fields.text().label("Title").required("Title is required."),
                         description: fields.longText().label("Description")
@@ -174,10 +177,11 @@ describe("Public Models", () => {
             public async execute(builder: ModelFactory.Builder) {
                 // Always add base fields
                 const model = builder
-                    .public()
-                    .modelId("conditionalPublicModel")
-                    .name("Conditional Public Model")
-                    .group("test")
+                    .public({
+                        modelId: "conditionalPublicModel",
+                        name: "Conditional Public Model",
+                        group: "test"
+                    })
                     .fields(fields => ({
                         title: fields.text().label("Title").required("Title is required.")
                     }));

--- a/packages/api-headless-cms/__tests__/modelBuilder/objectFieldExtension.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/objectFieldExtension.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@webiny/di";
 import { ModelBuilderFeature } from "~/features/modelBuilder/feature";
-import { FieldBuilderRegistry } from "~/features/modelBuilder/abstractions";
+import { FieldBuilderRegistry } from "~/features/modelBuilder/fieldBuilder/abstractions";
 import { ModelBuilder } from "~/features/modelBuilder/models/ModelBuilder";
 
 describe("Object Field Extension", () => {
@@ -15,7 +15,11 @@ describe("Object Field Extension", () => {
     const createModel = () => {
         const registry = container.resolve(FieldBuilderRegistry);
         const builder = new ModelBuilder(registry);
-        return builder.public();
+        return builder.public({
+            modelId: "testModel",
+            name: "Test Model",
+            group: "test"
+        });
     };
 
     describe("extend() method", () => {
@@ -23,20 +27,16 @@ describe("Object Field Extension", () => {
             const model = createModel();
 
             // Initial model with theme object
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color"),
-                            font: fields.text().label("Font")
-                        }))
-                        .layout([["primaryColor"], ["font"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color"),
+                        font: fields.text().label("Font")
+                    }))
+                    .layout([["primaryColor"], ["font"]])
+            }));
 
             // Extend the theme object
             model.fields(fields => ({
@@ -65,19 +65,15 @@ describe("Object Field Extension", () => {
         it("should replace field when redefining without .extend() flag", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color")
-                        }))
-                        .layout([["primaryColor"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color")
+                    }))
+                    .layout([["primaryColor"]])
+            }));
 
             // Redefine theme without .extend() - should replace entirely
             model.fields(fields => ({
@@ -103,13 +99,9 @@ describe("Object Field Extension", () => {
         it("should throw error when redefining with wrong field type", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    name: fields.text().label("Name")
-                }));
+            model.fields(fields => ({
+                name: fields.text().label("Name")
+            }));
 
             expect(() => {
                 model.fields(fields => ({
@@ -126,19 +118,15 @@ describe("Object Field Extension", () => {
         it("should support multiple extensions of the same object field", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color")
-                        }))
-                        .layout([["primaryColor"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color")
+                    }))
+                    .layout([["primaryColor"]])
+            }));
 
             // First extension
             model.fields(fields => ({
@@ -180,26 +168,22 @@ describe("Object Field Extension", () => {
         it("should correctly extend second object field when multiple exist", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color")
-                        }))
-                        .layout([["primaryColor"]]),
-                    settings: fields
-                        .object()
-                        .label("Settings")
-                        .fields(fields => ({
-                            enableNotifications: fields.text().label("Enable Notifications")
-                        }))
-                        .layout([["enableNotifications"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color")
+                    }))
+                    .layout([["primaryColor"]]),
+                settings: fields
+                    .object()
+                    .label("Settings")
+                    .fields(fields => ({
+                        enableNotifications: fields.text().label("Enable Notifications")
+                    }))
+                    .layout([["enableNotifications"]])
+            }));
 
             // Extend the SECOND object field (settings, not theme)
             model.fields(fields => ({
@@ -236,20 +220,16 @@ describe("Object Field Extension", () => {
         it("should allow extending object field layout without adding new fields", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color"),
-                            secondaryColor: fields.text().label("Secondary Color")
-                        }))
-                        .layout([["primaryColor"], ["secondaryColor"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color"),
+                        secondaryColor: fields.text().label("Secondary Color")
+                    }))
+                    .layout([["primaryColor"], ["secondaryColor"]])
+            }));
 
             // Just modify layout
             model.fields(fields => ({
@@ -270,20 +250,16 @@ describe("Object Field Extension", () => {
         it("should support array layout replacement", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color"),
-                            font: fields.text().label("Font")
-                        }))
-                        .layout([["primaryColor"], ["font"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color"),
+                        font: fields.text().label("Font")
+                    }))
+                    .layout([["primaryColor"], ["font"]])
+            }));
 
             // Replace entire layout
             model.fields(fields => ({
@@ -305,20 +281,16 @@ describe("Object Field Extension", () => {
         it("should support builder callback for incremental layout changes", () => {
             const model = createModel();
 
-            model
-                .modelId("testModel")
-                .name("Test Model")
-                .group("test")
-                .fields(fields => ({
-                    theme: fields
-                        .object()
-                        .label("Theme")
-                        .fields(fields => ({
-                            primaryColor: fields.text().label("Primary Color"),
-                            font: fields.text().label("Font")
-                        }))
-                        .layout([["primaryColor"], ["font"]])
-                }));
+            model.fields(fields => ({
+                theme: fields
+                    .object()
+                    .label("Theme")
+                    .fields(fields => ({
+                        primaryColor: fields.text().label("Primary Color"),
+                        font: fields.text().label("Font")
+                    }))
+                    .layout([["primaryColor"], ["font"]])
+            }));
 
             // Use builder for incremental changes
             model.fields(fields => ({

--- a/packages/api-headless-cms/__tests__/modelBuilder/objectFieldExtension.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/objectFieldExtension.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@webiny/di";
 import { ModelBuilderFeature } from "~/features/modelBuilder/feature";
-import { FieldBuilderRegistry } from "~/features/modelBuilder/fieldBuilder/abstractions";
+import { FieldBuilderRegistry } from "~/features/modelBuilder/abstractions";
 import { ModelBuilder } from "~/features/modelBuilder/models/ModelBuilder";
 
 describe("Object Field Extension", () => {

--- a/packages/api-headless-cms/__tests__/modelBuilder/objectFieldMultipleCalls.test.ts
+++ b/packages/api-headless-cms/__tests__/modelBuilder/objectFieldMultipleCalls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Container } from "@webiny/di";
 import { ModelBuilderFeature } from "~/features/modelBuilder/feature.js";
 import { ModelFactory, ModelsProvider } from "~/features/modelBuilder/index.js";
@@ -16,9 +16,10 @@ describe("Object Field Multiple .fields() Calls", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .private()
-                        .modelId("testObjectMultipleFields")
-                        .name("Test Object Multiple Fields")
+                        .private({
+                            modelId: "testObjectMultipleFields",
+                            name: "Test Object Multiple Fields"
+                        })
                         .fields(fields => ({
                             metadata: fields
                                 .object()
@@ -92,9 +93,10 @@ describe("Object Field Multiple .fields() Calls", () => {
 
                 return [
                     builder
-                        .private()
-                        .modelId("conditionalObjectModel")
-                        .name("Conditional Object Model")
+                        .private({
+                            modelId: "conditionalObjectModel",
+                            name: "Conditional Object Model"
+                        })
                         .fields(fields => ({
                             metadata: metadataBuilder(fields)
                         }))
@@ -140,9 +142,10 @@ describe("Object Field Multiple .fields() Calls", () => {
             public async execute(builder: ModelFactory.Builder) {
                 return [
                     builder
-                        .private()
-                        .modelId("nestedObjectModel")
-                        .name("Nested Object Model")
+                        .private({
+                            modelId: "nestedObjectModel",
+                            name: "Nested Object Model"
+                        })
                         .fields(fields => ({
                             section: fields
                                 .object()

--- a/packages/api-headless-cms/src/features/modelBuilder/abstractions.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/abstractions.ts
@@ -1,6 +1,7 @@
 import { createAbstraction } from "@webiny/feature/api";
 import type { PrivateModelBuilder } from "./models/PrivateModelBuilder.js";
 import type { PublicModelBuilder } from "./models/PublicModelBuilder.js";
+import type { IModelBuilderPrivateInput, IModelBuilderPublicInput } from "./models/ModelBuilder.js";
 
 /**
  * Field Builder Registry
@@ -31,15 +32,15 @@ export namespace FieldBuilderRegistry {
  */
 
 export interface IModelBuilder {
-    private(): PrivateModelBuilder;
-    public(): PublicModelBuilder;
+    private(input: IModelBuilderPrivateInput): PrivateModelBuilder;
+    public(input: IModelBuilderPublicInput): PublicModelBuilder;
 }
 
 export interface IModelFactory {
     execute(builder: IModelBuilder): Promise<PrivateModelBuilder[] | PublicModelBuilder[]>;
 }
 
-export const ModelFactory = createAbstraction<IModelFactory>("ModelFactory");
+export const ModelFactory = createAbstraction<IModelFactory>("Cms/ModelFactory");
 export namespace ModelFactory {
     export type Interface = IModelFactory;
     export type Return = Promise<PrivateModelBuilder[] | PublicModelBuilder[]>;

--- a/packages/api-headless-cms/src/features/modelBuilder/feature.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/feature.ts
@@ -12,7 +12,7 @@ import { FileFieldType } from "./fields/FileFieldType.js";
 import { DateTimeFieldType } from "./fields/DateTimeFieldType.js";
 import { JsonFieldType } from "./fields/JsonFieldType.js";
 import { SearchableJsonFieldType } from "./fields/SearchableJsonFieldType.js";
-import { LocationFieldType } from "./fields/LocationFieldType.js";
+// import { LocationFieldType } from "./fields/LocationFieldType.js";
 import { FieldBuilderRegistry as FieldsRegistryAbstraction, ModelFactory } from "./abstractions.js";
 import { AccessControl } from "~/features/shared/abstractions.js";
 import { ModelsProvider as ModelsProviderAbstraction } from "./models/abstractions.js";
@@ -34,7 +34,7 @@ export const ModelBuilderFeature = createFeature({
         container.register(DateTimeFieldType);
         container.register(JsonFieldType);
         container.register(SearchableJsonFieldType);
-        container.register(LocationFieldType);
+        // container.register(LocationFieldType);
 
         // Register field builder registry (will automatically get all FieldType implementations)
         container.register(FieldBuilderRegistry).inSingletonScope();

--- a/packages/api-headless-cms/src/features/modelBuilder/feature.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/feature.ts
@@ -12,13 +12,10 @@ import { FileFieldType } from "./fields/FileFieldType.js";
 import { DateTimeFieldType } from "./fields/DateTimeFieldType.js";
 import { JsonFieldType } from "./fields/JsonFieldType.js";
 import { SearchableJsonFieldType } from "./fields/SearchableJsonFieldType.js";
-import { LocationFieldType } from "~/features/modelBuilder/fields/LocationFieldType.js";
-import {
-    ModelFactory,
-    FieldBuilderRegistry as FieldsRegistryAbstraction
-} from "~/features/modelBuilder/abstractions.js";
+import { LocationFieldType } from "./fields/LocationFieldType.js";
+import { FieldBuilderRegistry as FieldsRegistryAbstraction, ModelFactory } from "./abstractions.js";
 import { AccessControl } from "~/features/shared/abstractions.js";
-import { ModelsProvider as ModelsProviderAbstraction } from "~/features/modelBuilder/models/abstractions.js";
+import { ModelsProvider as ModelsProviderAbstraction } from "./models/abstractions.js";
 import { ModelsProvider } from "./models/ModelsProvider.js";
 
 export const ModelBuilderFeature = createFeature({

--- a/packages/api-headless-cms/src/features/modelBuilder/index.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/index.ts
@@ -20,6 +20,6 @@ import "./fields/DateTimeFieldType.js";
 import "./fields/ObjectFieldType.js";
 import "./fields/RefFieldType.js";
 import "./fields/DynamicZoneFieldType.js";
-import "./fields/LocationFieldType.js";
+// import "./fields/LocationFieldType.js";
 import "./fields/JsonFieldType.js";
 import "./fields/SearchableJsonFieldType.js";

--- a/packages/api-headless-cms/src/features/modelBuilder/index.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/index.ts
@@ -1,4 +1,4 @@
-export * from "./abstractions.js";
+export { ModelFactory } from "./abstractions.js";
 export * from "./models/BaseModelBuilder.js";
 export * from "./models/ModelBuilder.js";
 export * from "./models/PrivateModelBuilder.js";

--- a/packages/api-headless-cms/src/features/modelBuilder/models/BaseModelBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/models/BaseModelBuilder.ts
@@ -1,5 +1,6 @@
-import { FieldBuilder, FieldBuilderRegistry } from "~/features/modelBuilder/index.js";
+import { FieldBuilder } from "~/features/modelBuilder/index.js";
 import { CmsModelPlugin } from "~/plugins/index.js";
+import { FieldBuilderRegistry } from "../abstractions.js";
 
 /**
  * Base class for all model builders, containing shared logic.

--- a/packages/api-headless-cms/src/features/modelBuilder/models/ModelBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/models/ModelBuilder.ts
@@ -1,6 +1,19 @@
-import { FieldBuilderRegistry } from "~/features/modelBuilder/index.js";
+import { FieldBuilderRegistry } from "../abstractions.js";
 import { PrivateModelBuilder } from "./PrivateModelBuilder.js";
 import { PublicModelBuilder } from "./PublicModelBuilder.js";
+
+export interface IModelBuilderPrivateInput {
+    modelId: string;
+    name: string;
+}
+
+export interface IModelBuilderPublicInput {
+    name: string;
+    modelId: string;
+    group: string;
+    singularApiName?: string;
+    pluralApiName?: string;
+}
 
 /**
  * Entry point builder that allows selecting model type.
@@ -12,14 +25,27 @@ export class ModelBuilder {
     /**
      * Create a private model (internal models, no GraphQL API).
      */
-    private(): PrivateModelBuilder {
-        return new PrivateModelBuilder(this.registry);
+    public private(input: IModelBuilderPrivateInput): PrivateModelBuilder {
+        const model = new PrivateModelBuilder(this.registry);
+        model.modelId(input.modelId);
+        model.name(input.name);
+        return model;
     }
 
     /**
      * Create a public model (with GraphQL API).
      */
-    public(): PublicModelBuilder {
-        return new PublicModelBuilder(this.registry);
+    public public(input: IModelBuilderPublicInput): PublicModelBuilder {
+        const model = new PublicModelBuilder(this.registry);
+        model.name(input.name);
+        model.modelId(input.modelId);
+        model.group(input.group);
+        if (input.singularApiName) {
+            model.singularApiName(input.singularApiName);
+        }
+        if (input.pluralApiName) {
+            model.pluralApiName(input.pluralApiName);
+        }
+        return model;
     }
 }

--- a/packages/api-headless-cms/src/features/modelBuilder/models/ModelsProvider.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/models/ModelsProvider.ts
@@ -1,6 +1,7 @@
 import { ModelsProvider as ProviderAbstraction } from "./abstractions.js";
 import { AccessControl } from "~/features/shared/abstractions.js";
-import { ModelFactory, FieldBuilderRegistry } from "~/features/modelBuilder/index.js";
+import { ModelFactory } from "../abstractions.js";
+import { FieldBuilderRegistry } from "../abstractions.js";
 import type { CmsModel } from "~/types/index.js";
 import { filterAsync } from "~/utils/filterAsync.js";
 import { ModelBuilder } from "./ModelBuilder.js";

--- a/packages/api-headless-cms/src/features/modelBuilder/models/PublicModelBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/models/PublicModelBuilder.ts
@@ -79,7 +79,10 @@ export class PublicModelBuilder extends BaseModelBuilder {
         this.publicConfig.imageFieldId = fieldId;
         return this;
     }
-
+    /**
+     * It just creates problems if we import the FieldBuilderRegistry.
+     * TODO: figure out
+     */
     constructor(registry: any) {
         super(registry);
         this.layoutBuilder = new LayoutBuilder();

--- a/packages/api-headless-cms/src/features/modelBuilder/models/PublicModelBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/models/PublicModelBuilder.ts
@@ -3,7 +3,7 @@ import camelCase from "lodash/camelCase.js";
 import pluralize from "pluralize";
 import { createModelPlugin } from "~/plugins/CmsModelPlugin.js";
 import { BaseModelBuilder } from "./BaseModelBuilder.js";
-import type { CmsIcon } from "~/types/index.js";
+import type { CmsIcon, CmsModelField } from "~/types/index.js";
 import { LayoutBuilder } from "../LayoutBuilder.js";
 
 const createApiName = (name: string) => {
@@ -124,7 +124,8 @@ export class PublicModelBuilder extends BaseModelBuilder {
                 group: this.publicConfig.group,
                 icon: this.publicConfig.icon ?? null,
                 description: this.publicConfig.description || null,
-                titleFieldId: this.publicConfig.titleFieldId ?? "",
+                titleFieldId:
+                    this.publicConfig.titleFieldId ?? this.findFirstFieldId(fields, "text"),
                 descriptionFieldId: this.publicConfig.descriptionFieldId,
                 imageFieldId: this.publicConfig.imageFieldId,
                 layout: this.layoutBuilder.build(),
@@ -133,5 +134,14 @@ export class PublicModelBuilder extends BaseModelBuilder {
             },
             { validateLayout: false }
         );
+    }
+
+    private findFirstFieldId(fields: CmsModelField[], type: string): string {
+        for (const field of fields) {
+            if (field.type === type) {
+                return field.fieldId;
+            }
+        }
+        return fields.find(field => field.type === "text")?.fieldId || "";
     }
 }

--- a/packages/api-record-locking/src/domain/RecordLockingModel.ts
+++ b/packages/api-record-locking/src/domain/RecordLockingModel.ts
@@ -6,9 +6,10 @@ class RecordLockingPrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(RECORD_LOCKING_MODEL_ID)
-                .name("Record Lock Tracking")
+                .private({
+                    modelId: RECORD_LOCKING_MODEL_ID,
+                    name: "Record Lock Tracking"
+                })
                 .fields(fields => ({
                     targetId: fields.text().label("Target ID").required("Target ID is required."),
                     type: fields.text().label("Record Type").required("Record type is required."),

--- a/packages/api-scheduler/src/domain/SchedulePrivateModel.ts
+++ b/packages/api-scheduler/src/domain/SchedulePrivateModel.ts
@@ -5,9 +5,10 @@ class SchedulePrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(SCHEDULE_MODEL_ID)
-                .name("Webiny CMS Schedule")
+                .private({
+                    modelId: SCHEDULE_MODEL_ID,
+                    name: "Webiny CMS Schedule"
+                })
                 .fields(fields => ({
                     namespace: fields.text().label("Namespace"),
                     actionType: fields.text().label("Action Type"),

--- a/packages/api-website-builder/src/features/redirects/ListRedirects/abstractions.ts
+++ b/packages/api-website-builder/src/features/redirects/ListRedirects/abstractions.ts
@@ -29,10 +29,10 @@ export interface IListWbRedirectsWhere {
 }
 
 export interface ListWbRedirectsParams {
-    where: IListWbRedirectsWhere;
-    sort: CmsEntryListSort;
-    limit: number;
-    after: string | null;
+    where?: IListWbRedirectsWhere;
+    sort?: CmsEntryListSort;
+    limit?: number;
+    after?: string | null;
     search?: string;
 }
 

--- a/packages/api-workflows/src/domain/workflow/workflowModel.ts
+++ b/packages/api-workflows/src/domain/workflow/workflowModel.ts
@@ -7,9 +7,10 @@ class WorkflowModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(WORKFLOW_MODEL_ID)
-                .name("Workflow")
+                .private({
+                    modelId: WORKFLOW_MODEL_ID,
+                    name: "Workflow"
+                })
                 .fields(fields => ({
                     name: fields.text().label("Name").required("Workflow name is required."),
                     app: fields.text().label("App").required("App is required."),

--- a/packages/api-workflows/src/domain/workflowState/stateModel.ts
+++ b/packages/api-workflows/src/domain/workflowState/stateModel.ts
@@ -26,9 +26,10 @@ class WorkflowStateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(WORKFLOW_STATE_MODEL_ID)
-                .name("RecordWorkflow State")
+                .private({
+                    modelId: WORKFLOW_STATE_MODEL_ID,
+                    name: "Workflow State"
+                })
                 .fields(fields => ({
                     workflowId: fields.text().label("Workflow ID"),
                     app: fields.text().label("App").required("App is required."),

--- a/packages/api-workflows/src/domain/workflowState/stateModel.ts
+++ b/packages/api-workflows/src/domain/workflowState/stateModel.ts
@@ -28,7 +28,7 @@ class WorkflowStateModelImpl implements ModelFactory.Interface {
             builder
                 .private({
                     modelId: WORKFLOW_STATE_MODEL_ID,
-                    name: "Workflow State"
+                    name: "RecordWorkflow State"
                 })
                 .fields(fields => ({
                     workflowId: fields.text().label("Workflow ID"),

--- a/packages/app-headless-cms-common/src/Fields/FieldElement.tsx
+++ b/packages/app-headless-cms-common/src/Fields/FieldElement.tsx
@@ -36,12 +36,19 @@ const RenderField = (props: RenderFieldProps) => {
         return <>{field.renderer({ field, getBind, Label, contentModel })}</>;
     }
 
+    const fieldRendererName = get(field, "renderer.name");
+    if (!fieldRendererName) {
+        return t`Cannot render "{fieldName}" field - field renderer not defined.`({
+            fieldName: <strong>{field.fieldId}</strong>
+        });
+    }
+
     const renderPlugin = renderPlugins.find(
-        plugin => plugin.renderer.rendererName === get(field, "renderer.name")
+        plugin => plugin.renderer.rendererName === fieldRendererName
     );
 
     if (!renderPlugin) {
-        return t`Cannot render "{fieldName}" field - field renderer missing.`({
+        return t`Cannot render "{fieldName}" field - field renderer missing in Admin UI plugins.`({
             fieldName: <strong>{field.fieldId}</strong>
         });
     }

--- a/packages/tasks/__tests__/runner/taskDefinition.ts
+++ b/packages/tasks/__tests__/runner/taskDefinition.ts
@@ -8,7 +8,7 @@ class TestingRunTask implements TaskDefinition.Interface {
     id = TASK_ID;
     title = "Task Runner Task";
     maxIterations = 2;
-    enableDatabaseLogs = true;
+    databaseLogs = true;
     constructor(private controller: TaskController.Interface) {}
 
     async run({ input }: TaskDefinition.RunParams) {

--- a/packages/tasks/__tests__/runner/taskDefinition.ts
+++ b/packages/tasks/__tests__/runner/taskDefinition.ts
@@ -8,6 +8,7 @@ class TestingRunTask implements TaskDefinition.Interface {
     id = TASK_ID;
     title = "Task Runner Task";
     maxIterations = 2;
+    enableDatabaseLogs = true;
     constructor(private controller: TaskController.Interface) {}
 
     async run({ input }: TaskDefinition.RunParams) {

--- a/packages/tasks/src/crud/TaskLogPrivateModel.ts
+++ b/packages/tasks/src/crud/TaskLogPrivateModel.ts
@@ -7,9 +7,10 @@ class TaskLogPrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(WEBINY_TASK_LOG_MODEL_ID)
-                .name("Webiny Task Log")
+                .private({
+                    modelId: WEBINY_TASK_LOG_MODEL_ID,
+                    name: "Webiny Task Log"
+                })
                 .fields(fields => ({
                     executionName: fields.text().label("Execution Name"),
                     task: fields.text().label("Task").required("Task is required."),

--- a/packages/tasks/src/crud/TaskPrivateModel.ts
+++ b/packages/tasks/src/crud/TaskPrivateModel.ts
@@ -7,9 +7,10 @@ class TaskPrivateModelImpl implements ModelFactory.Interface {
     public async execute(builder: ModelFactory.Builder) {
         return [
             builder
-                .private()
-                .modelId(WEBINY_TASK_MODEL_ID)
-                .name("Webiny Task")
+                .private({
+                    modelId: WEBINY_TASK_MODEL_ID,
+                    name: "Webiny Task"
+                })
                 .fields(fields => ({
                     name: fields.text().label("Name").required("Name is required."),
                     definitionId: fields

--- a/packages/tasks/src/decorators/RunnableTaskDecorator.ts
+++ b/packages/tasks/src/decorators/RunnableTaskDecorator.ts
@@ -7,7 +7,7 @@ const DEFAULT_MAX_ITERATIONS = 50;
 
 /**
  * RunnableTaskDecorator adds runtime behavior to TaskDefinition:
- * - Applies default values (maxIterations, isPrivate, enableDatabaseLogs, fields)
+ * - Applies default values (maxIterations, isPrivate, databaseLogs, fields)
  * - Validates task ID (must be camelCase)
  * - Provides field management methods
  */
@@ -34,8 +34,8 @@ class RunnableTaskDecoratorImpl implements TaskDefinition.Interface {
         return this.decoratee.isPrivate ?? false;
     }
 
-    get enableDatabaseLogs() {
-        return this.decoratee.enableDatabaseLogs ?? false;
+    get databaseLogs() {
+        return this.decoratee.databaseLogs ?? false;
     }
 
     get maxIterations() {

--- a/packages/tasks/src/decorators/RunnableTaskDecorator.ts
+++ b/packages/tasks/src/decorators/RunnableTaskDecorator.ts
@@ -7,7 +7,7 @@ const DEFAULT_MAX_ITERATIONS = 50;
 
 /**
  * RunnableTaskDecorator adds runtime behavior to TaskDefinition:
- * - Applies default values (maxIterations, isPrivate, disableDatabaseLogs, fields)
+ * - Applies default values (maxIterations, isPrivate, enableDatabaseLogs, fields)
  * - Validates task ID (must be camelCase)
  * - Provides field management methods
  */
@@ -34,8 +34,8 @@ class RunnableTaskDecoratorImpl implements TaskDefinition.Interface {
         return this.decoratee.isPrivate ?? false;
     }
 
-    get disableDatabaseLogs() {
-        return this.decoratee.disableDatabaseLogs ?? false;
+    get enableDatabaseLogs() {
+        return this.decoratee.enableDatabaseLogs ?? false;
     }
 
     get maxIterations() {

--- a/packages/tasks/src/runner/TaskControl.ts
+++ b/packages/tasks/src/runner/TaskControl.ts
@@ -70,7 +70,10 @@ export class TaskControl implements ITaskControl {
                 }
             });
         }
-        const disableDatabaseLogs = !!definition.disableDatabaseLogs;
+        /**
+         * Only enable logs if definition explicitly allows them.
+         */
+        const disableDatabaseLogs = definition.disableDatabaseLogs === false ? false : true;
 
         /**
          * As this as a run of the task, we need to create a new log entry.

--- a/packages/tasks/src/runner/TaskControl.ts
+++ b/packages/tasks/src/runner/TaskControl.ts
@@ -16,7 +16,7 @@ import {
 
 interface IGetTaskLogParams {
     task: ITask;
-    enableDatabaseLogs: boolean;
+    databaseLogs: boolean;
 }
 
 export class TaskControl implements ITaskControl {
@@ -78,7 +78,7 @@ export class TaskControl implements ITaskControl {
         /**
          * Only enable logs if definition explicitly allows them.
          */
-        const enableDatabaseLogs = definition.enableDatabaseLogs === true;
+        const databaseLogs = definition.databaseLogs === true;
 
         /**
          * As this as a run of the task, we need to create a new log entry.
@@ -87,7 +87,7 @@ export class TaskControl implements ITaskControl {
         try {
             taskLog = await this.getTaskLog({
                 task,
-                enableDatabaseLogs
+                databaseLogs
             });
         } catch (error) {
             return this.response.error({
@@ -128,7 +128,7 @@ export class TaskControl implements ITaskControl {
             context: this.context,
             task,
             log: taskLog,
-            enableDatabaseLogs
+            databaseLogs
         });
 
         // Populate TaskExecutionContext BEFORE executing task
@@ -225,11 +225,11 @@ export class TaskControl implements ITaskControl {
     }
 
     private async getTaskLog(params: IGetTaskLogParams): Promise<ITaskLog> {
-        const { task, enableDatabaseLogs } = params;
+        const { task, databaseLogs } = params;
         /**
          * If logs are disabled, let's return a mocked one.
          */
-        if (!enableDatabaseLogs) {
+        if (!databaseLogs) {
             return {
                 id: `${task.id}-log`,
                 createdOn: task.createdOn,

--- a/packages/tasks/src/runner/TaskControl.ts
+++ b/packages/tasks/src/runner/TaskControl.ts
@@ -14,6 +14,11 @@ import {
     TaskResultStatus
 } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 
+interface IGetTaskLogParams {
+    task: ITask;
+    enableDatabaseLogs: boolean;
+}
+
 export class TaskControl implements ITaskControl {
     public readonly runner: ITaskRunner;
     public readonly response: IResponse;
@@ -73,14 +78,17 @@ export class TaskControl implements ITaskControl {
         /**
          * Only enable logs if definition explicitly allows them.
          */
-        const disableDatabaseLogs = definition.disableDatabaseLogs === false ? false : true;
+        const enableDatabaseLogs = definition.enableDatabaseLogs === true;
 
         /**
          * As this as a run of the task, we need to create a new log entry.
          */
         let taskLog: ITaskLog;
         try {
-            taskLog = await this.getTaskLog(task, disableDatabaseLogs);
+            taskLog = await this.getTaskLog({
+                task,
+                enableDatabaseLogs
+            });
         } catch (error) {
             return this.response.error({
                 error
@@ -120,7 +128,7 @@ export class TaskControl implements ITaskControl {
             context: this.context,
             task,
             log: taskLog,
-            disableDatabaseLogs
+            enableDatabaseLogs
         });
 
         // Populate TaskExecutionContext BEFORE executing task
@@ -216,11 +224,12 @@ export class TaskControl implements ITaskControl {
         });
     }
 
-    private async getTaskLog(task: ITask, disableDatabaseLogs: boolean): Promise<ITaskLog> {
+    private async getTaskLog(params: IGetTaskLogParams): Promise<ITaskLog> {
+        const { task, enableDatabaseLogs } = params;
         /**
          * If logs are disabled, let's return a mocked one.
          */
-        if (disableDatabaseLogs) {
+        if (!enableDatabaseLogs) {
             return {
                 id: `${task.id}-log`,
                 createdOn: task.createdOn,

--- a/packages/tasks/src/runner/TaskManagerStore.ts
+++ b/packages/tasks/src/runner/TaskManagerStore.ts
@@ -47,7 +47,7 @@ export interface ITaskManagerStoreParams {
     context: TaskManagerStoreContext;
     task: ITask;
     log: ITaskLog;
-    disableDatabaseLogs?: boolean;
+    disableDatabaseLogs: boolean;
 }
 
 export class TaskManagerStore<

--- a/packages/tasks/src/runner/TaskManagerStore.ts
+++ b/packages/tasks/src/runner/TaskManagerStore.ts
@@ -47,7 +47,7 @@ export interface ITaskManagerStoreParams {
     context: TaskManagerStoreContext;
     task: ITask;
     log: ITaskLog;
-    disableDatabaseLogs: boolean;
+    enableDatabaseLogs: boolean;
 }
 
 export class TaskManagerStore<
@@ -58,7 +58,7 @@ export class TaskManagerStore<
     private readonly context: TaskManagerStoreContext;
     private task: ITask<T, O>;
     private taskLog: ITaskLog;
-    private readonly disableDatabaseLogs: boolean;
+    private readonly enableDatabaseLogs: boolean;
 
     private readonly taskUpdater = new ObjectUpdater<ITask<T, O>>();
     private readonly taskLogUpdater = new ObjectUpdater<ITaskLog>();
@@ -67,7 +67,7 @@ export class TaskManagerStore<
         this.context = params.context;
         this.task = params.task as ITask<T, O>;
         this.taskLog = params.log;
-        this.disableDatabaseLogs = !!params.disableDatabaseLogs;
+        this.enableDatabaseLogs = params.enableDatabaseLogs === true;
     }
 
     public getStatus(): TaskDataStatus {
@@ -166,7 +166,7 @@ export class TaskManagerStore<
         log: ITaskManagerStoreInfoLog,
         options?: ITaskManagerStoreAddLogOptions
     ): Promise<void> {
-        if (this.disableDatabaseLogs) {
+        if (!this.enableDatabaseLogs) {
             return;
         }
         this.taskLogUpdater.update({
@@ -193,7 +193,7 @@ export class TaskManagerStore<
         log: ITaskManagerStoreErrorLog,
         options?: ITaskManagerStoreAddLogOptions
     ): Promise<void> {
-        if (this.disableDatabaseLogs) {
+        if (!this.enableDatabaseLogs) {
             return;
         }
         /**
@@ -229,7 +229,7 @@ export class TaskManagerStore<
                 this.taskUpdater.fetch()
             );
         }
-        if (this.disableDatabaseLogs) {
+        if (!this.enableDatabaseLogs) {
             return;
         }
         if (this.taskLogUpdater.isDirty()) {

--- a/packages/tasks/src/runner/TaskManagerStore.ts
+++ b/packages/tasks/src/runner/TaskManagerStore.ts
@@ -47,7 +47,7 @@ export interface ITaskManagerStoreParams {
     context: TaskManagerStoreContext;
     task: ITask;
     log: ITaskLog;
-    enableDatabaseLogs: boolean;
+    databaseLogs: boolean;
 }
 
 export class TaskManagerStore<
@@ -58,7 +58,7 @@ export class TaskManagerStore<
     private readonly context: TaskManagerStoreContext;
     private task: ITask<T, O>;
     private taskLog: ITaskLog;
-    private readonly enableDatabaseLogs: boolean;
+    private readonly databaseLogs: boolean;
 
     private readonly taskUpdater = new ObjectUpdater<ITask<T, O>>();
     private readonly taskLogUpdater = new ObjectUpdater<ITaskLog>();
@@ -67,7 +67,7 @@ export class TaskManagerStore<
         this.context = params.context;
         this.task = params.task as ITask<T, O>;
         this.taskLog = params.log;
-        this.enableDatabaseLogs = params.enableDatabaseLogs === true;
+        this.databaseLogs = params.databaseLogs === true;
     }
 
     public getStatus(): TaskDataStatus {
@@ -166,7 +166,7 @@ export class TaskManagerStore<
         log: ITaskManagerStoreInfoLog,
         options?: ITaskManagerStoreAddLogOptions
     ): Promise<void> {
-        if (!this.enableDatabaseLogs) {
+        if (!this.databaseLogs) {
             return;
         }
         this.taskLogUpdater.update({
@@ -193,7 +193,7 @@ export class TaskManagerStore<
         log: ITaskManagerStoreErrorLog,
         options?: ITaskManagerStoreAddLogOptions
     ): Promise<void> {
-        if (!this.enableDatabaseLogs) {
+        if (!this.databaseLogs) {
             return;
         }
         /**
@@ -229,7 +229,7 @@ export class TaskManagerStore<
                 this.taskUpdater.fetch()
             );
         }
-        if (!this.enableDatabaseLogs) {
+        if (!this.databaseLogs) {
             return;
         }
         if (this.taskLogUpdater.isDirty()) {

--- a/packages/tenant-manager/src/api/domain/TenantModel.ts
+++ b/packages/tenant-manager/src/api/domain/TenantModel.ts
@@ -7,12 +7,13 @@ class TenantModelFactory implements ModelFactory.Interface {
 
     async execute(builder: ModelFactory.Builder) {
         const model = builder
-            .public()
-            .modelId(TENANT_MODEL_ID)
-            .name("Tenant")
+            .public({
+                modelId: TENANT_MODEL_ID,
+                name: "Tenant",
+                group: "hidden"
+            })
             .description("Manage system tenants.")
             .titleFieldId("name")
-            .group("hidden")
             .icon("fas/building")
             .singularApiName("Tenant")
             .pluralApiName("Tenants")


### PR DESCRIPTION
## Changes
Add input params when creating private or public models. Models should not be created without some initial values, as they cannot function without those (modelId, name, etc...).
Add function to take first possible text field as titleFieldId, if none is defined.
A bit more informative UI error when model field renderer is not set.
Must strictly enable database logs for tasks - was strict disable before.

## How Has This Been Tested?
Jest and manually.