### PR TITLE
fix(app-headless-cms): prefix menus

### DIFF
--- a/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
@@ -37,11 +37,10 @@ describe("import cms structure", () => {
     });
 
     it("should return error as there are no models to validate", async () => {
-        const group: CmsGroup = {
+        const group: Omit<CmsGroup, "tenant"> = {
             id: "group-1",
             name: "Group 1",
             slug: "group-1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -84,7 +83,6 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "",
             name: "Group 1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -95,7 +93,6 @@ describe("import cms structure", () => {
             id: "",
             slug: "group-2",
             name: "Group 2",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -105,7 +102,10 @@ describe("import cms structure", () => {
 
         const [result] = await validateCmsStructureMutation({
             data: {
-                groups: [group1, group2],
+                groups: [group1, group2].map(group => {
+                    const input = structuredClone(group);
+                    return input;
+                }),
                 models: []
             }
         });
@@ -156,7 +156,6 @@ describe("import cms structure", () => {
                     id: "group-1-original",
                     slug: "group-1",
                     name: "Group 1 Original",
-                    tenant: "root",
                     icon: {
                         name: "fas/star",
                         type: "fas/star",
@@ -168,7 +167,6 @@ describe("import cms structure", () => {
                     id: "group-2",
                     slug: "group-2-original",
                     name: "Group 2 Original",
-                    tenant: "root",
                     icon: {
                         name: "fas/star",
                         type: "fas/star",
@@ -183,7 +181,6 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -194,7 +191,6 @@ describe("import cms structure", () => {
             id: "group-2",
             slug: "group-2",
             name: "Group 2",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -205,7 +201,6 @@ describe("import cms structure", () => {
             id: "group-3",
             slug: "group-3",
             name: "Group 3",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -271,7 +266,6 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -282,7 +276,6 @@ describe("import cms structure", () => {
             id: "group-2",
             slug: "group-2",
             name: "Group 2",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -332,7 +325,6 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",
@@ -426,7 +418,6 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            tenant: "root",
             icon: {
                 name: "fas/star",
                 type: "fas/star",

--- a/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/import.structure.test.ts
@@ -3,7 +3,7 @@ import { useGraphQLHandler } from "~tests/testHelpers/useGraphQLHandler";
 import { CmsGroupPlugin, CmsModelPlugin, createCmsGroup } from "~/plugins";
 import { createModels, exportedGroupsAndModels } from "./mocks/exportedGroupsAndModels";
 import { CmsImportAction } from "~/export/types";
-import type { CmsModel } from "~/types";
+import type { CmsGroup, CmsModel } from "~/types";
 
 describe("import cms structure", () => {
     const {
@@ -37,11 +37,16 @@ describe("import cms structure", () => {
     });
 
     it("should return error as there are no models to validate", async () => {
-        const group = {
+        const group: CmsGroup = {
             id: "group-1",
             name: "Group 1",
             slug: "group-1",
-            icon: "fas/star",
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            },
             description: "Group 1 description"
         };
 
@@ -79,13 +84,23 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "",
             name: "Group 1",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
         const group2 = {
             id: "",
             slug: "group-2",
             name: "Group 2",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
 
         const [result] = await validateCmsStructureMutation({
@@ -141,14 +156,24 @@ describe("import cms structure", () => {
                     id: "group-1-original",
                     slug: "group-1",
                     name: "Group 1 Original",
-                    icon: "fa/fas",
+                    tenant: "root",
+                    icon: {
+                        name: "fas/star",
+                        type: "fas/star",
+                        value: "fas/star"
+                    },
                     description: ""
                 }),
                 createCmsGroup({
                     id: "group-2",
                     slug: "group-2-original",
                     name: "Group 2 Original",
-                    icon: "fa/fas",
+                    tenant: "root",
+                    icon: {
+                        name: "fas/star",
+                        type: "fas/star",
+                        value: "fas/star"
+                    },
                     description: ""
                 })
             ]
@@ -158,19 +183,34 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
         const group2 = {
             id: "group-2",
             slug: "group-2",
             name: "Group 2",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
         const group3 = {
             id: "group-3",
             slug: "group-3",
             name: "Group 3",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
 
         const [result] = await validateCmsStructureMutation({
@@ -231,13 +271,23 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
         const group2 = {
             id: "group-2",
             slug: "group-2",
             name: "Group 2",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
 
         const [result] = await validateCmsStructureMutation({
@@ -282,7 +332,12 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
 
         const model = {
@@ -351,11 +406,6 @@ describe("import cms structure", () => {
                                                 code: "too_small",
                                                 data: expect.any(Object),
                                                 message: expect.any(String)
-                                            },
-                                            layout: {
-                                                code: "too_small",
-                                                data: expect.any(Object),
-                                                message: expect.any(String)
                                             }
                                         }
                                     },
@@ -376,7 +426,12 @@ describe("import cms structure", () => {
             id: "group-1",
             slug: "group-1",
             name: "Group 1",
-            icon: "fa/fas"
+            tenant: "root",
+            icon: {
+                name: "fas/star",
+                type: "fas/star",
+                value: "fas/star"
+            }
         };
 
         const model = {
@@ -442,11 +497,6 @@ describe("import cms structure", () => {
                                                 message: expect.any(String)
                                             },
                                             fields: {
-                                                code: "too_small",
-                                                data: expect.any(Object),
-                                                message: expect.any(String)
-                                            },
-                                            layout: {
                                                 code: "too_small",
                                                 data: expect.any(Object),
                                                 message: expect.any(String)
@@ -876,7 +926,7 @@ describe("import cms structure", () => {
                 validateImportStructure: {
                     data: {
                         groups: exportedGroupsAndModels.groups.map(group => {
-                            const isCodeGroup = codeGroups.includes(group.id);
+                            const isCodeGroup = codeGroups.includes(group.id!);
                             return {
                                 action: isCodeGroup ? CmsImportAction.CODE : CmsImportAction.CREATE,
                                 error: isCodeGroup ? expect.any(Object) : null,
@@ -887,7 +937,7 @@ describe("import cms structure", () => {
                             };
                         }),
                         models: exportedGroupsAndModels.models.map(model => {
-                            const isCodeModel = codeModels.includes(model.modelId);
+                            const isCodeModel = codeModels.includes(model.modelId!);
                             return {
                                 action: isCodeModel ? CmsImportAction.CODE : CmsImportAction.CREATE,
                                 error: isCodeModel ? expect.any(Object) : null,
@@ -907,10 +957,10 @@ describe("import cms structure", () => {
 
         const importData = {
             groups: exportedGroupsAndModels.groups.filter(group => {
-                return !codeGroups.includes(group.id);
+                return !codeGroups.includes(group.id!);
             }),
             models: exportedGroupsAndModels.models.filter(model => {
-                return !codeModels.includes(model.modelId);
+                return !codeModels.includes(model.modelId!);
             })
         };
         const [importResult] = await importCmsStructureMutation({
@@ -958,7 +1008,6 @@ describe("import cms structure", () => {
                     /**
                      * Mixed types for importData and pluginGroups but it is ok for testing.
                      */
-                    // @ts-expect-error
                     data: importData.groups.concat(pluginGroups).map(group => {
                         return {
                             id: group.id
@@ -993,7 +1042,7 @@ describe("import cms structure", () => {
                 validateImportStructure: {
                     data: {
                         groups: exportedGroupsAndModels.groups.map(group => {
-                            const isCodeGroup = codeGroups.includes(group.id);
+                            const isCodeGroup = codeGroups.includes(group.id!);
                             return {
                                 action: isCodeGroup ? CmsImportAction.CODE : CmsImportAction.UPDATE,
                                 error: isCodeGroup ? expect.any(Object) : null,
@@ -1004,7 +1053,7 @@ describe("import cms structure", () => {
                             };
                         }),
                         models: exportedGroupsAndModels.models.map(model => {
-                            const isCodeModel = codeModels.includes(model.modelId);
+                            const isCodeModel = codeModels.includes(model.modelId!);
                             return {
                                 action: isCodeModel ? CmsImportAction.CODE : CmsImportAction.UPDATE,
                                 error: isCodeModel ? expect.any(Object) : null,

--- a/packages/api-headless-cms/__tests__/contentAPI/mocks/exportedGroupsAndModels.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/mocks/exportedGroupsAndModels.ts
@@ -1,20 +1,29 @@
 import { createCmsGroupPlugin, createModelPlugin } from "~/plugins";
+import type { CmsImportStructureParamsData } from "~/export/types.js";
 
-export const exportedGroupsAndModels = {
+export const exportedGroupsAndModels: CmsImportStructureParamsData = {
     groups: [
         {
             id: "64d4c105110b570008736515",
             name: "Blog",
             slug: "blog",
             description: null,
-            icon: "fab/blogger-b"
+            icon: {
+                name: "fab/blogger-b",
+                value: "fab/blogger-b",
+                type: "fab/blogger-b"
+            }
         },
         {
             id: "64d4c105110b570008736516",
             name: "Machines",
             slug: "machines",
             description: null,
-            icon: "fas/location-dot"
+            icon: {
+                name: "fas/location-dot",
+                value: "fas/location-dot",
+                type: "fas/location-dot"
+            }
         }
     ],
     models: [
@@ -22,7 +31,11 @@ export const exportedGroupsAndModels = {
             modelId: "article",
             name: "Article",
             group: "machines",
-            icon: "far/newspaper",
+            icon: {
+                name: "far/newspaper",
+                value: "far/newspaper",
+                type: "far/newspaper"
+            },
             singularApiName: "Article",
             pluralApiName: "Articles",
             fields: [
@@ -115,7 +128,11 @@ export const exportedGroupsAndModels = {
             modelId: "author",
             name: "Author",
             group: "blog",
-            icon: "fas/person",
+            icon: {
+                name: "fas/person",
+                value: "fas/person",
+                type: "fas/person"
+            },
             singularApiName: "Author",
             pluralApiName: "Authors",
             fields: [
@@ -208,7 +225,11 @@ export const exportedGroupsAndModels = {
             modelId: "category",
             name: "Category",
             group: "machines",
-            icon: "fas/location-dot",
+            icon: {
+                name: "fas/location-dot",
+                value: "fas/location-dot",
+                type: "fas/location-dot"
+            },
             singularApiName: "Category",
             pluralApiName: "Categories",
             fields: [
@@ -238,7 +259,11 @@ export const exportedGroupsAndModels = {
             modelId: "machines",
             name: "Machines",
             group: "machines",
-            icon: "fas/location-dot",
+            icon: {
+                name: "fas/location-dot",
+                value: "fas/location-dot",
+                type: "fas/location-dot"
+            },
             singularApiName: "Machine",
             pluralApiName: "Machine",
             fields: [
@@ -274,13 +299,21 @@ export const createModels = () => {
             name: "Machines",
             slug: "machines",
             description: null,
-            icon: "fas/location-dot"
+            icon: {
+                name: "fas/location-dot",
+                value: "fas/location-dot",
+                type: "fas/location-dot"
+            }
         }),
         createModelPlugin({
             modelId: "machines",
             name: "Machines",
             group: "machines",
-            icon: "fas/location-dot",
+            icon: {
+                name: "fas/location-dot",
+                value: "fas/location-dot",
+                type: "fas/location-dot"
+            },
             singularApiName: "Machine",
             pluralApiName: "Machines",
             description: "",

--- a/packages/api-headless-cms/src/crud/contentModel/validation.ts
+++ b/packages/api-headless-cms/src/crud/contentModel/validation.ts
@@ -291,7 +291,7 @@ export const createModelImportValidation = () => {
         group: shortString,
         icon,
         fields: zod.array(fieldSchema).min(1),
-        layout: zod.array(zod.array(shortString)).min(1),
+        layout: zod.array(zod.array(shortString)),
         tags: zod.array(shortString).optional(),
         titleFieldId: shortString.nullish(),
         descriptionFieldId: optionalShortString.nullish(),

--- a/packages/app-headless-cms/src/admin/hooks/usePermission.ts
+++ b/packages/app-headless-cms/src/admin/hooks/usePermission.ts
@@ -8,8 +8,8 @@ export interface CreatableItem {
 }
 
 interface CanReadEntriesCallableParams {
-    contentModelGroup: CmsGroup;
-    contentModel: CmsModel;
+    contentModelGroup: Pick<CmsGroup, "id">;
+    contentModel: Pick<CmsModel, "modelId">;
 }
 
 export const usePermission = makeDecoratable(() => {

--- a/packages/app-headless-cms/src/admin/menus/GroupContentModels.tsx
+++ b/packages/app-headless-cms/src/admin/menus/GroupContentModels.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { CmsGroup } from "~/types.js";
-import { useRouter, AdminConfig } from "@webiny/app-admin";
+import { AdminConfig, useRouter } from "@webiny/app-admin";
 import { HasContentEntryPermissions } from "./HasContentEntryPermissions.js";
 import { Routes } from "~/routes.js";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -8,19 +8,23 @@ import { normalizeIcon } from "~/utils/normalizeIcon.js";
 
 const { Menu } = AdminConfig;
 
+interface IGroupContentModelsProps {
+    group: Pick<CmsGroup, "id" | "slug" | "contentModels">;
+}
+
 /**
  * Renders menu items for all content models within a group.
  * If the group has no content models, displays a "Nothing to show" message.
  * Wraps each content model menu item with permission checks.
  */
-export const GroupContentModels = ({ group }: { group: CmsGroup }) => {
+export const GroupContentModels = ({ group }: IGroupContentModelsProps) => {
     const router = useRouter();
 
     if (group.contentModels.length === 0) {
         return (
             <Menu
                 parent="headlessCMSContent"
-                name={`${group.id}-empty`}
+                name={`cms/group/${group.slug}-empty`}
                 element={<Menu.Group text="Nothing to show" />}
             />
         );
@@ -38,8 +42,8 @@ export const GroupContentModels = ({ group }: { group: CmsGroup }) => {
                         contentModel={contentModel}
                     >
                         <Menu
-                            parent={group.id}
-                            name={contentModel.modelId}
+                            parent={`cms/group/${group.slug}`}
+                            name={`cms/model/${contentModel.modelId}`}
                             element={
                                 <Menu.Link
                                     pinnable={true}

--- a/packages/app-headless-cms/src/admin/menus/GroupMenu.tsx
+++ b/packages/app-headless-cms/src/admin/menus/GroupMenu.tsx
@@ -6,16 +6,19 @@ import { normalizeIcon } from "~/utils/normalizeIcon.js";
 
 const { Menu } = AdminConfig;
 
+interface IGroupMenuProps {
+    group: Pick<CmsGroup, "slug" | "name" | "icon">;
+}
 /**
  * Renders a menu item for a given content group.
  * Displays the group's name and icon in the menu.
  */
-export const GroupMenu = ({ group }: { group: CmsGroup }) => {
+export const GroupMenu = ({ group }: IGroupMenuProps) => {
     const icon = normalizeIcon(group.icon);
 
     return (
         <Menu
-            name={group.id}
+            name={`cms/group/${group.slug}`}
             parent="headlessCMSContent"
             element={
                 <Menu.Item

--- a/packages/app-headless-cms/src/admin/menus/HasContentEntryPermissions.ts
+++ b/packages/app-headless-cms/src/admin/menus/HasContentEntryPermissions.ts
@@ -2,8 +2,8 @@ import type { CmsGroup, CmsModel } from "~/types.js";
 import { usePermission } from "~/admin/hooks/usePermission.js";
 
 interface HasContentEntryPermissionsProps {
-    group: CmsGroup;
-    contentModel?: CmsModel;
+    group: Pick<CmsGroup, "id" | "contentModels">;
+    contentModel?: Pick<CmsModel, "modelId">;
     children: JSX.Element;
 }
 


### PR DESCRIPTION
## Changes
Prefix CMS Group and Model menus so there are no clashes with custom/autogenerated menus.

## How Has This Been Tested?
Manually.