### PR TITLE
refactor(project-aws): pulumi deprecations

### DIFF
--- a/packages/project-aws/src/pulumi/apps/core/CoreAuditLogsDynamo.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreAuditLogsDynamo.ts
@@ -39,61 +39,138 @@ export const CoreAuditLogsDynamo = createAppModule({
                 globalSecondaryIndexes: [
                     {
                         name: "GSI_TENANT",
-                        hashKey: "GSI_TENANT",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI_TENANT",
+                                keyType: "HASH"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI1",
-                        hashKey: "GSI1_PK",
-                        rangeKey: "GSI1_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI1_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI1_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI2",
-                        hashKey: "GSI2_PK",
-                        rangeKey: "GSI2_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI2_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI2_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI3",
-                        hashKey: "GSI3_PK",
-                        rangeKey: "GSI3_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI3_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI3_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI4",
-                        hashKey: "GSI4_PK",
-                        rangeKey: "GSI4_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI4_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI4_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI5",
-                        hashKey: "GSI5_PK",
-                        rangeKey: "GSI5_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI5_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI5_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI6",
-                        hashKey: "GSI6_PK",
-                        rangeKey: "GSI6_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI6_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI6_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI7",
-                        hashKey: "GSI7_PK",
-                        rangeKey: "GSI7_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI7_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI7_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI8",
-                        hashKey: "GSI8_PK",
-                        rangeKey: "GSI8_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI8_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI8_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI9",
-                        hashKey: "GSI9_PK",
-                        rangeKey: "GSI9_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI9_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI9_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     }
                 ],

--- a/packages/project-aws/src/pulumi/apps/core/CoreDynamo.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreDynamo.ts
@@ -24,19 +24,40 @@ export const CoreDynamo = createAppModule({
                 globalSecondaryIndexes: [
                     {
                         name: "GSI_TENANT",
-                        hashKey: "GSI_TENANT",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI_TENANT",
+                                keyType: "HASH"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI1",
-                        hashKey: "GSI1_PK",
-                        rangeKey: "GSI1_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI1_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI1_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     },
                     {
                         name: "GSI2",
-                        hashKey: "GSI2_PK",
-                        rangeKey: "GSI2_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI2_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI2_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     }
                 ],

--- a/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
@@ -21,7 +21,7 @@ export const CoreFileManger = createAppModule({
         });
 
         // We need these rules to be able to upload to this bucket from the browser.
-        const bucketCorsConfiguration = app.addResource(aws.s3.BucketCorsConfigurationV2, {
+        const bucketCorsConfiguration = app.addResource(aws.s3.BucketCorsConfiguration, {
             name: `${name}-cors`,
             config: {
                 bucket: bucket.output.id,

--- a/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
@@ -11,12 +11,19 @@ export const CoreFileManger = createAppModule({
         const bucket = app.addResource(aws.s3.Bucket, {
             name,
             config: {
-                acl: aws.s3.CannedAcl.Private,
                 // We definitely don't want to force-destroy if "protected" flag is true.
                 forceDestroy: !params.protect
             },
             opts: {
                 protect: params.protect
+            }
+        });
+
+        const bucketAcl = app.addResource(aws.s3.BucketAclV2, {
+            name: `${name}-acl`,
+            config: {
+                bucket: bucket.output.id,
+                acl: aws.s3.CannedAcl.Private
             }
         });
 
@@ -50,6 +57,7 @@ export const CoreFileManger = createAppModule({
 
         return {
             bucket,
+            bucketAcl,
             blockPublicAccessBlock,
             bucketCorsConfiguration
         };

--- a/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
@@ -13,8 +13,18 @@ export const CoreFileManger = createAppModule({
             config: {
                 acl: aws.s3.CannedAcl.Private,
                 // We definitely don't want to force-destroy if "protected" flag is true.
-                forceDestroy: !params.protect,
-                // We need these rules to be able to upload to this bucket from the browser.
+                forceDestroy: !params.protect
+            },
+            opts: {
+                protect: params.protect
+            }
+        });
+
+        // We need these rules to be able to upload to this bucket from the browser.
+        const bucketCorsConfiguration = app.addResource(aws.s3.BucketCorsConfigurationV2, {
+            name: `${name}-cors`,
+            config: {
+                bucket: bucket.output.id,
                 corsRules: [
                     {
                         allowedHeaders: ["*"],
@@ -23,9 +33,6 @@ export const CoreFileManger = createAppModule({
                         maxAgeSeconds: 3000
                     }
                 ]
-            },
-            opts: {
-                protect: params.protect
             }
         });
 
@@ -43,7 +50,8 @@ export const CoreFileManger = createAppModule({
 
         return {
             bucket,
-            blockPublicAccessBlock
+            blockPublicAccessBlock,
+            bucketCorsConfiguration
         };
     }
 });

--- a/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
@@ -19,11 +19,24 @@ export const CoreFileManger = createAppModule({
             }
         });
 
+        const bucketOwnershipControls = app.addResource(aws.s3.BucketOwnershipControls, {
+            name: `${name}-ownership-controls`,
+            config: {
+                bucket: bucket.output.id,
+                rule: {
+                    objectOwnership: "BucketOwnerPreferred"
+                }
+            }
+        });
+
         const bucketAcl = app.addResource(aws.s3.BucketAcl, {
             name: `${name}-acl`,
             config: {
                 bucket: bucket.output.id,
                 acl: aws.s3.CannedAcl.Private
+            },
+            opts: {
+                dependsOn: [bucketOwnershipControls.output]
             }
         });
 
@@ -57,6 +70,7 @@ export const CoreFileManger = createAppModule({
 
         return {
             bucket,
+            bucketOwnershipControls,
             bucketAcl,
             blockPublicAccessBlock,
             bucketCorsConfiguration

--- a/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreFileManager.ts
@@ -19,7 +19,7 @@ export const CoreFileManger = createAppModule({
             }
         });
 
-        const bucketAcl = app.addResource(aws.s3.BucketAclV2, {
+        const bucketAcl = app.addResource(aws.s3.BucketAcl, {
             name: `${name}-acl`,
             config: {
                 bucket: bucket.output.id,

--- a/packages/project-aws/src/pulumi/apps/core/LogDynamo.ts
+++ b/packages/project-aws/src/pulumi/apps/core/LogDynamo.ts
@@ -30,37 +30,82 @@ export const LogDynamo = createAppModule({
                 globalSecondaryIndexes: [
                     {
                         name: "GSI_TENANT",
-                        hashKey: "GSI_TENANT",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI_TENANT",
+                                keyType: "HASH"
+                            }
+                        ],
                         projectionType: "KEYS_ONLY"
                     },
                     {
                         name: "GSI1",
-                        hashKey: "GSI1_PK",
-                        rangeKey: "GSI1_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI1_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI1_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     },
                     {
                         name: "GSI2",
-                        hashKey: "GSI2_PK",
-                        rangeKey: "GSI2_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI2_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI2_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     },
                     {
                         name: "GSI3",
-                        hashKey: "GSI3_PK",
-                        rangeKey: "GSI3_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI3_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI3_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     },
                     {
                         name: "GSI4",
-                        hashKey: "GSI4_PK",
-                        rangeKey: "GSI4_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI4_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI4_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     },
                     {
                         name: "GSI5",
-                        hashKey: "GSI5_PK",
-                        rangeKey: "GSI5_SK",
+                        keySchemas: [
+                            {
+                                attributeName: "GSI5_PK",
+                                keyType: "HASH"
+                            },
+                            {
+                                attributeName: "GSI5_SK",
+                                keyType: "RANGE"
+                            }
+                        ],
                         projectionType: "ALL"
                     }
                 ],

--- a/packages/project-aws/src/pulumi/apps/createAppBucket.ts
+++ b/packages/project-aws/src/pulumi/apps/createAppBucket.ts
@@ -7,12 +7,19 @@ export function createPublicAppBucket(app: PulumiApp, name: string) {
     const bucket = app.addResource(aws.s3.Bucket, {
         name: name,
         config: {
-            acl: aws.s3.CannedAcl.PublicRead,
             forceDestroy: true,
             website: {
                 indexDocument: "index.html",
                 errorDocument: "_NOT_FOUND_PAGE_/index.html"
             }
+        }
+    });
+
+    const bucketAcl = app.addResource(aws.s3.BucketAcl, {
+        name: `${name}-acl`,
+        config: {
+            bucket: bucket.output.id,
+            acl: aws.s3.CannedAcl.PublicRead
         }
     });
 
@@ -29,6 +36,7 @@ export function createPublicAppBucket(app: PulumiApp, name: string) {
 
     return {
         bucket,
+        bucketAcl,
         origin
     };
 }
@@ -41,8 +49,15 @@ export function createPrivateAppBucket(app: PulumiApp, name: string) {
     const bucket = app.addResource(aws.s3.Bucket, {
         name: name,
         config: {
-            acl: aws.s3.CannedAcl.Private,
             forceDestroy: true
+        }
+    });
+
+    const bucketAcl = app.addResource(aws.s3.BucketAcl, {
+        name: `${name}-acl`,
+        config: {
+            bucket: bucket.output.id,
+            acl: aws.s3.CannedAcl.Private
         }
     });
 
@@ -119,6 +134,7 @@ export function createPrivateAppBucket(app: PulumiApp, name: string) {
 
     return {
         bucket,
+        bucketAcl,
         originIdentity,
         origin,
         bucketPublicAccessBlock,

--- a/packages/project-aws/src/pulumi/apps/createAppBucket.ts
+++ b/packages/project-aws/src/pulumi/apps/createAppBucket.ts
@@ -15,11 +15,24 @@ export function createPublicAppBucket(app: PulumiApp, name: string) {
         }
     });
 
+    const bucketOwnershipControls = app.addResource(aws.s3.BucketOwnershipControls, {
+        name: `${name}-ownership-controls`,
+        config: {
+            bucket: bucket.output.id,
+            rule: {
+                objectOwnership: "BucketOwnerPreferred"
+            }
+        }
+    });
+
     const bucketAcl = app.addResource(aws.s3.BucketAcl, {
         name: `${name}-acl`,
         config: {
             bucket: bucket.output.id,
             acl: aws.s3.CannedAcl.PublicRead
+        },
+        opts: {
+            dependsOn: [bucketOwnershipControls.output]
         }
     });
 
@@ -37,6 +50,7 @@ export function createPublicAppBucket(app: PulumiApp, name: string) {
     return {
         bucket,
         bucketAcl,
+        bucketOwnershipControls,
         origin
     };
 }
@@ -53,11 +67,24 @@ export function createPrivateAppBucket(app: PulumiApp, name: string) {
         }
     });
 
+    const bucketOwnershipControls = app.addResource(aws.s3.BucketOwnershipControls, {
+        name: `${name}-ownership-controls`,
+        config: {
+            bucket: bucket.output.id,
+            rule: {
+                objectOwnership: "BucketOwnerPreferred"
+            }
+        }
+    });
+
     const bucketAcl = app.addResource(aws.s3.BucketAcl, {
         name: `${name}-acl`,
         config: {
             bucket: bucket.output.id,
             acl: aws.s3.CannedAcl.Private
+        },
+        opts: {
+            dependsOn: [bucketOwnershipControls.output]
         }
     });
 
@@ -134,6 +161,7 @@ export function createPrivateAppBucket(app: PulumiApp, name: string) {
 
     return {
         bucket,
+        bucketOwnershipControls,
         bucketAcl,
         originIdentity,
         origin,


### PR DESCRIPTION
## Changes
Replace deprecated pulumi variables with new ones in DynamoDB and Bucket deployments.

## How Has This Been Tested?
Manually by previewing the deployment and making sure there are no changes in deployed infrastructure, which would break something.
There are deployed infrastructure changes because we added new resources for Buckets (acl and cors configs).