### PR TITLE
feat: marker-based readOnlyAccess

### DIFF
--- a/packages/api-core/__tests__/security/permissions/createPermissions.test.ts
+++ b/packages/api-core/__tests__/security/permissions/createPermissions.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect } from "vitest";
+import { createPermissions } from "~/features/security/permissions/createPermissions.js";
+import type { IIdentityContext } from "~/features/security/IdentityContext/abstractions.js";
+import type { SecurityPermission } from "~/types/security.js";
+
+const schema = {
+    prefix: "test",
+    fullAccess: true,
+    entities: [
+        {
+            id: "entry",
+            permission: "test.entry",
+            scopes: ["full", "own"],
+            actions: [{ name: "rwd" }, { name: "pw" }]
+        }
+    ]
+} as const;
+
+function createMockIdentityContext(permissions: SecurityPermission[]): IIdentityContext {
+    return {
+        hasFullAccess: async () => false,
+        getPermission: async (name: string) => {
+            return permissions.find(p => p.name === name) ?? null;
+        },
+        getPermissions: async (name: string) => {
+            return permissions.filter(p => p.name === name);
+        },
+        getIdentity: () => ({ id: "user-1", displayName: "Test User", type: "test" }),
+        listPermissions: async () => permissions,
+        setIdentity: () => {},
+        withIdentity: async (_identity: any, cb: any) => cb(),
+        withoutAuthorization: async (cb: any) => cb(),
+        isAuthorizationEnabled: () => true
+    } as unknown as IIdentityContext;
+}
+
+const { Implementation } = createPermissions(schema);
+
+describe("createPermissions", () => {
+    describe("full access", () => {
+        const identityContext = createMockIdentityContext([{ name: "test.*" }]);
+        const permissions = new (Implementation as any)(identityContext);
+
+        test("canAccess returns true", async () => {
+            expect(await permissions.canAccess("entry")).toBe(true);
+        });
+
+        test("canRead returns true", async () => {
+            expect(await permissions.canRead("entry")).toBe(true);
+        });
+
+        test("canCreate returns true", async () => {
+            expect(await permissions.canCreate("entry")).toBe(true);
+        });
+
+        test("canEdit returns true", async () => {
+            expect(await permissions.canEdit("entry")).toBe(true);
+        });
+
+        test("canDelete returns true", async () => {
+            expect(await permissions.canDelete("entry")).toBe(true);
+        });
+
+        test("canPublish returns true", async () => {
+            expect(await permissions.canPublish("entry")).toBe(true);
+        });
+
+        test("canUnpublish returns true", async () => {
+            expect(await permissions.canUnpublish("entry")).toBe(true);
+        });
+
+        test("canAction returns true", async () => {
+            expect(await permissions.canAction("someAction", "entry")).toBe(true);
+        });
+
+        test("onlyOwnRecords returns false", async () => {
+            expect(await permissions.onlyOwnRecords("entry")).toBe(false);
+        });
+    });
+
+    describe("no access", () => {
+        const identityContext = createMockIdentityContext([]);
+        const permissions = new (Implementation as any)(identityContext);
+
+        test("canAccess returns false", async () => {
+            expect(await permissions.canAccess("entry")).toBe(false);
+        });
+
+        test("canRead returns false", async () => {
+            expect(await permissions.canRead("entry")).toBe(false);
+        });
+
+        test("canCreate returns false", async () => {
+            expect(await permissions.canCreate("entry")).toBe(false);
+        });
+
+        test("canEdit returns false", async () => {
+            expect(await permissions.canEdit("entry")).toBe(false);
+        });
+
+        test("canDelete returns false", async () => {
+            expect(await permissions.canDelete("entry")).toBe(false);
+        });
+
+        test("canPublish returns false", async () => {
+            expect(await permissions.canPublish("entry")).toBe(false);
+        });
+
+        test("canUnpublish returns false", async () => {
+            expect(await permissions.canUnpublish("entry")).toBe(false);
+        });
+
+        test("canAction returns false", async () => {
+            expect(await permissions.canAction("someAction", "entry")).toBe(false);
+        });
+
+        test("onlyOwnRecords returns false", async () => {
+            expect(await permissions.onlyOwnRecords("entry")).toBe(false);
+        });
+    });
+
+    describe("entity-level read-only permissions", () => {
+        // The $-prefixed marker is inert on the backend; entity permissions are self-enforcing.
+        const identityContext = createMockIdentityContext([
+            { name: "$test.readonly" },
+            { name: "test.entry", rwd: "r" }
+        ]);
+        const permissions = new (Implementation as any)(identityContext);
+
+        test("canAccess returns true", async () => {
+            expect(await permissions.canAccess("entry")).toBe(true);
+        });
+
+        test("canRead returns true", async () => {
+            expect(await permissions.canRead("entry")).toBe(true);
+        });
+
+        test("canCreate returns false", async () => {
+            expect(await permissions.canCreate("entry")).toBe(false);
+        });
+
+        test("canEdit returns false", async () => {
+            expect(await permissions.canEdit("entry")).toBe(false);
+        });
+
+        test("canDelete returns false", async () => {
+            expect(await permissions.canDelete("entry")).toBe(false);
+        });
+
+        test("canPublish returns false", async () => {
+            expect(await permissions.canPublish("entry")).toBe(false);
+        });
+
+        test("canUnpublish returns false", async () => {
+            expect(await permissions.canUnpublish("entry")).toBe(false);
+        });
+    });
+
+    describe("wildcard with rwd flag is NOT full access", () => {
+        // { name: "test.*", rwd: "r" } has extra flags, so hasFullSchemaAccess returns false.
+        // It falls through to entity-level checks where the entity permission enforces rwd: "r".
+        const identityContext = createMockIdentityContext([{ name: "test.*", rwd: "r" }]);
+        const permissions = new (Implementation as any)(identityContext);
+
+        test("canAccess returns true", async () => {
+            expect(await permissions.canAccess("entry")).toBe(true);
+        });
+
+        test("canRead returns true", async () => {
+            expect(await permissions.canRead("entry")).toBe(true);
+        });
+
+        test("canCreate returns false", async () => {
+            expect(await permissions.canCreate("entry")).toBe(false);
+        });
+
+        test("canEdit returns false", async () => {
+            expect(await permissions.canEdit("entry")).toBe(false);
+        });
+
+        test("canDelete returns false", async () => {
+            expect(await permissions.canDelete("entry")).toBe(false);
+        });
+    });
+
+    describe("exact entity permissions checks", () => {
+        // It falls through to entity-level checks where the entity permission enforces rwd: "r".
+        const identityContext = createMockIdentityContext([{ name: "test.entry", rwd: "r" }]);
+        const permissions = new (Implementation as any)(identityContext);
+
+        test("canAccess returns true", async () => {
+            expect(await permissions.canAccess("entry")).toBe(true);
+        });
+
+        test("canRead returns true", async () => {
+            expect(await permissions.canRead("entry")).toBe(true);
+        });
+
+        test("canCreate returns false", async () => {
+            expect(await permissions.canCreate("entry")).toBe(false);
+        });
+
+        test("canEdit returns false", async () => {
+            expect(await permissions.canEdit("entry")).toBe(false);
+        });
+
+        test("canDelete returns false", async () => {
+            expect(await permissions.canDelete("entry")).toBe(false);
+        });
+    });
+});

--- a/packages/api-core/src/features/security/permissions/createPermissions.ts
+++ b/packages/api-core/src/features/security/permissions/createPermissions.ts
@@ -36,6 +36,7 @@ function getEntity(entityMap: Map<string, EntityLookup>, entityId: string): Enti
 
 export function createPermissions<const S extends PermissionSchemaConfig>(schema: S) {
     const entityMap = buildEntityMap(schema);
+    const fullAccessName = `${schema.prefix}.*`;
 
     class SchemaPermissions {
         constructor(private identityContext: IdentityContext.Interface) {}
@@ -48,7 +49,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -73,7 +74,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return false;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -88,7 +89,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -108,7 +109,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -128,7 +129,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -156,7 +157,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -180,7 +181,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -197,7 +198,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -214,7 +215,7 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
                 return true;
             }
             const entity = getEntity(entityMap, entityId);
-            const permissions = await this.identityContext.getPermissions(entity.permission);
+            const permissions = await this.getEntityPermissions(entity.permission);
             if (!permissions.length) {
                 return false;
             }
@@ -223,9 +224,29 @@ export function createPermissions<const S extends PermissionSchemaConfig>(schema
             });
         }
 
+        private async getEntityPermissions(entityPermission: string): Promise<any[]> {
+            const permissions = await this.identityContext.getPermissions(entityPermission);
+            if (permissions.length) {
+                return permissions;
+            }
+            // Fall back to the schema wildcard (e.g. "test.*") — its flags apply to all entities.
+            const wildcard = await this.identityContext.getPermission(fullAccessName);
+            return wildcard ? [wildcard] : [];
+        }
+
         private async hasFullSchemaAccess(): Promise<boolean> {
-            const permission = await this.identityContext.getPermission(schema.fullAccess.name);
-            return permission !== null;
+            const permission = await this.identityContext.getPermission(fullAccessName);
+            if (!permission) {
+                return false;
+            }
+            // Only treat as full access if the permission has no `rwd` flag.
+            // A permission like { name: "wb.*", rwd: "r" } should NOT grant full access.
+            const keys = Object.keys(permission).filter(k => k !== "name");
+
+            const hasRwd = keys.includes("rwd");
+
+            // It's full-access only if there's no `rwd` flag.
+            return !hasRwd;
         }
     }
 

--- a/packages/api-core/src/features/security/permissions/types.ts
+++ b/packages/api-core/src/features/security/permissions/types.ts
@@ -44,8 +44,12 @@ export interface EntityDefinition {
 export interface PermissionSchemaConfig {
     /** Permission prefix — used to filter permissions from the array. */
     prefix: string;
-    /** Permission object emitted on "full access". All properties are spread onto the permission. */
-    fullAccess: { name: string; [key: string]: any };
+    /**
+     * Full access configuration.
+     * - `true` — emits `{ name: "${prefix}.*" }`.
+     * - `{ ...extras }` — emits `{ name: "${prefix}.*", ...extras }`.
+     */
+    fullAccess: boolean | { [key: string]: any };
     /** Entity definitions (optional — simple apps have none). */
     entities?: readonly EntityDefinition[];
 }

--- a/packages/api-file-manager/src/permissions/schema.ts
+++ b/packages/api-file-manager/src/permissions/schema.ts
@@ -3,7 +3,7 @@ import type { Permissions } from "@webiny/api-core/features/security/permissions
 
 const schema = {
     prefix: "fm",
-    fullAccess: { name: "fm.*" },
+    fullAccess: true,
     entities: [
         {
             id: "file",

--- a/packages/api-website-builder/src/domain/permissions.ts
+++ b/packages/api-website-builder/src/domain/permissions.ts
@@ -3,7 +3,7 @@ import type { Permissions } from "@webiny/api-core/features/security/permissions
 
 const schema = {
     prefix: "wb",
-    fullAccess: { name: "wb.*" },
+    fullAccess: true,
     entities: [
         {
             id: "page",

--- a/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
+++ b/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
@@ -2,7 +2,6 @@ import { AppInstaller } from "@webiny/api-core/features/InstallTenant";
 import { CreateApiKeyUseCase } from "@webiny/api-core/features/security/apiKeys/CreateApiKey/index.js";
 import { DeleteApiKeyUseCase } from "@webiny/api-core/features/security/apiKeys/DeleteApiKey/index.js";
 import type { ApiKey } from "@webiny/api-core/types/security.js";
-import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 
 class ApiKeyInstallerImpl implements AppInstaller.Interface {
     readonly alwaysRun = true;
@@ -11,21 +10,16 @@ class ApiKeyInstallerImpl implements AppInstaller.Interface {
     private apiKey: ApiKey | undefined = undefined;
 
     constructor(
-        private wcpContext: WcpContext.Interface,
         private createApiKey: CreateApiKeyUseCase.Interface,
         private deleteApiKey: DeleteApiKeyUseCase.Interface
     ) {}
 
     async install(): Promise<void> {
-        const aacl = this.wcpContext.canUseAacl();
-
-        const permissions = aacl ? [{ name: "wb.page", rwd: "r" }] : [{ name: "wb.*" }];
-
         const result = await this.createApiKey.execute({
             name: "Website Builder",
             description: "Integrate Next.js or custom frontend with Website Builder.",
             slug: "website-builder",
-            permissions
+            permissions: [{ name: "$wb.readonly" }, { name: "wb.page", rwd: "r" }]
         });
 
         if (result.isOk()) {
@@ -42,5 +36,5 @@ class ApiKeyInstallerImpl implements AppInstaller.Interface {
 
 export const ApiKeyInstaller = AppInstaller.createImplementation({
     implementation: ApiKeyInstallerImpl,
-    dependencies: [WcpContext, CreateApiKeyUseCase, DeleteApiKeyUseCase]
+    dependencies: [CreateApiKeyUseCase, DeleteApiKeyUseCase]
 });

--- a/packages/app-admin/__tests__/permissions/serializeDeserialize.test.ts
+++ b/packages/app-admin/__tests__/permissions/serializeDeserialize.test.ts
@@ -8,7 +8,7 @@ import type { Permission } from "~/permissions/types";
  */
 const fmSchema = createPermissionSchema({
     prefix: "fm",
-    fullAccess: { name: "fm.*" },
+    fullAccess: true,
     entities: [
         {
             id: "file",
@@ -31,7 +31,7 @@ const fmSchema = createPermissionSchema({
  */
 const wbSchema = createPermissionSchema({
     prefix: "wb",
-    fullAccess: { name: "wb.*" }
+    fullAccess: true
 });
 
 /**
@@ -39,7 +39,7 @@ const wbSchema = createPermissionSchema({
  */
 const rlSchema = createPermissionSchema({
     prefix: "recordLocking",
-    fullAccess: { name: "recordLocking", canForceUnlock: true }
+    fullAccess: { canForceUnlock: true }
 });
 
 /**
@@ -47,7 +47,7 @@ const rlSchema = createPermissionSchema({
  */
 const cmsSchema = createPermissionSchema({
     prefix: "cms",
-    fullAccess: { name: "cms.*" },
+    fullAccess: true,
     entities: [
         {
             id: "contentModelGroup",
@@ -80,7 +80,7 @@ const cmsSchema = createPermissionSchema({
  */
 const tmSchema = createPermissionSchema({
     prefix: "tm",
-    fullAccess: { name: "tm.*" },
+    fullAccess: true,
     entities: [
         {
             id: "tenant",
@@ -625,18 +625,21 @@ describe("custom boolean actions", () => {
 describe("fullAccess with extra properties", () => {
     it("should serialize full access with all fullAccess properties", () => {
         const result = serializePermissions(rlSchema, { accessLevel: "full" }, []);
-        expect(result).toEqual([{ name: "recordLocking", canForceUnlock: true }]);
+        expect(result).toEqual([{ name: "recordLocking.*", canForceUnlock: true }]);
     });
 
     it("should serialize full access preserving other permissions", () => {
         const existing: Permission[] = [{ name: "pb.*" }];
         const result = serializePermissions(rlSchema, { accessLevel: "full" }, existing);
-        expect(result).toEqual([{ name: "pb.*" }, { name: "recordLocking", canForceUnlock: true }]);
+        expect(result).toEqual([
+            { name: "pb.*" },
+            { name: "recordLocking.*", canForceUnlock: true }
+        ]);
     });
 
     it("should deserialize full access when matching permission exists", () => {
         const result = deserializePermissions(rlSchema, [
-            { name: "recordLocking", canForceUnlock: true }
+            { name: "recordLocking.*", canForceUnlock: true }
         ]);
         expect(result).toEqual({ accessLevel: "full" });
     });
@@ -659,7 +662,7 @@ describe("fullAccess with extra properties", () => {
     it("should strip existing permissions and rebuild on full access", () => {
         const existing: Permission[] = [
             { name: "pb.*" },
-            { name: "recordLocking", canForceUnlock: true }
+            { name: "recordLocking.*", canForceUnlock: true }
         ];
         const result = serializePermissions(rlSchema, { accessLevel: "no" }, existing);
         expect(result).toEqual([{ name: "pb.*" }]);
@@ -668,7 +671,7 @@ describe("fullAccess with extra properties", () => {
     it("should roundtrip full access with extra properties", () => {
         const original = { accessLevel: "full" };
         const permissions = serializePermissions(rlSchema, original, []);
-        expect(permissions).toEqual([{ name: "recordLocking", canForceUnlock: true }]);
+        expect(permissions).toEqual([{ name: "recordLocking.*", canForceUnlock: true }]);
         const result = deserializePermissions(rlSchema, permissions);
         expect(result).toEqual({ accessLevel: "full" });
     });

--- a/packages/app-admin/src/permissions/PermissionRenderer.tsx
+++ b/packages/app-admin/src/permissions/PermissionRenderer.tsx
@@ -19,6 +19,7 @@ export interface PermissionRendererProps {
 
 const NO_ACCESS = "no";
 const FULL_ACCESS = "full";
+const READ_ONLY_ACCESS = "read-only";
 const CUSTOM_ACCESS = "custom";
 
 const RWD_OPTIONS = [
@@ -107,7 +108,7 @@ function EntitySection({ entity, data, cannotUseAAcl, Bind, setValue }: EntitySe
 
     if (hasAction(entity, "rwd")) {
         columns.push(
-            <Grid.Column span={12} key={"pw"}>
+            <Grid.Column span={12} key={"rwd"}>
                 <Bind name={`${entity.id}RWD`}>
                     <Select
                         label={"Primary Actions"}
@@ -173,16 +174,21 @@ export const PermissionRenderer = ({ schema }: PermissionRendererProps) => {
     const entities = schema.entities || [];
     const hasEntities = entities.length > 0;
 
-    const accessLevelOptions = hasEntities
-        ? [
-              { value: NO_ACCESS, label: "No access" },
-              { value: FULL_ACCESS, label: "Full access" },
-              { value: CUSTOM_ACCESS, label: "Custom access" }
-          ]
-        : [
-              { value: NO_ACCESS, label: "No access" },
-              { value: FULL_ACCESS, label: "Full access" }
-          ];
+    const accessLevelOptions = useMemo(() => {
+        const options = [{ value: NO_ACCESS, label: "No access" }];
+
+        if (schema.readOnlyAccess) {
+            options.push({ value: READ_ONLY_ACCESS, label: "Read-only access" });
+        }
+
+        options.push({ value: FULL_ACCESS, label: "Full access" });
+
+        if (hasEntities) {
+            options.push({ value: CUSTOM_ACCESS, label: "Custom access" });
+        }
+
+        return options;
+    }, [schema, hasEntities]);
 
     return (
         <Form data={formData} onChange={onFormChange}>

--- a/packages/app-admin/src/permissions/types.ts
+++ b/packages/app-admin/src/permissions/types.ts
@@ -54,8 +54,18 @@ export interface EntityDefinition {
 export interface PermissionSchemaConfig {
     /** Permission prefix — used to filter permissions from the array */
     prefix: string;
-    /** Permission object emitted on "full access". All properties are spread onto the permission. */
-    fullAccess: { name: string; [key: string]: any };
+    /**
+     * Full access configuration.
+     * - `true` — emits `{ name: "${prefix}.*" }`.
+     * - `{ ...extras }` — emits `{ name: "${prefix}.*", ...extras }`.
+     */
+    fullAccess: boolean | { [key: string]: any };
+    /**
+     * Read-only access configuration. When defined, the schema supports a read-only tier.
+     * - `true` — emits `{ name: "${prefix}.*", rwd: "r" }`.
+     * - `Permission[]` — emits the array as-is.
+     */
+    readOnlyAccess?: boolean | Permission[];
     /** Entity definitions (optional — simple apps have none) */
     entities?: EntityDefinition[];
 }
@@ -65,8 +75,18 @@ export interface PermissionSchemaConfig {
  */
 export interface PermissionSchema {
     prefix: string;
-    /** Permission object emitted on "full access". All properties are spread onto the permission. */
-    fullAccess: { name: string; [key: string]: any };
+    /**
+     * Full access configuration.
+     * - `true` — emits `{ name: "${prefix}.*" }`.
+     * - `{ ...extras }` — emits `{ name: "${prefix}.*", ...extras }`.
+     */
+    fullAccess: boolean | { [key: string]: any };
+    /**
+     * Read-only access configuration. When defined, the schema supports a read-only tier.
+     * - `true` — emits `{ name: "${prefix}.*", rwd: "r" }`.
+     * - `Permission[]` — emits the array as-is.
+     */
+    readOnlyAccess?: boolean | Permission[];
     entities?: EntityDefinition[];
 }
 

--- a/packages/app-admin/src/permissions/usePermissionForm.ts
+++ b/packages/app-admin/src/permissions/usePermissionForm.ts
@@ -11,6 +11,26 @@ function hasAction(entity: EntityDefinition, name: string): boolean {
     return entity.actions?.some(a => a.name === name) ?? false;
 }
 
+/** Resolve fullAccess config into a concrete Permission object. */
+function resolveFullAccess(schema: PermissionSchema): Permission {
+    const name = `${schema.prefix}.*`;
+    if (schema.fullAccess === true) {
+        return { name };
+    }
+    return { name, ...schema.fullAccess };
+}
+
+/** Resolve readOnlyAccess config into a concrete Permission[]. */
+function resolveReadOnlyAccess(schema: PermissionSchema): Permission[] | undefined {
+    if (!schema.readOnlyAccess) {
+        return undefined;
+    }
+    if (schema.readOnlyAccess === true) {
+        return [{ name: `${schema.prefix}.*`, rwd: "r" }];
+    }
+    return schema.readOnlyAccess;
+}
+
 /**
  * Deserialize Permission[] into form data based on the schema.
  */
@@ -22,8 +42,14 @@ function deserializePermissions(
         return { accessLevel: "no" };
     }
 
+    // Check for read-only access by looking for the synthetic marker permission.
+    if (value.some(p => p.name === `$${schema.prefix}.readonly`)) {
+        return { accessLevel: "read-only" };
+    }
+
     // Check for full access: either wildcard or the schema's fullAccess permission.
-    const hasFullAccess = value.some(p => p.name === "*" || p.name === schema.fullAccess.name);
+    const fullAccessName = `${schema.prefix}.*`;
+    const hasFullAccess = value.some(p => p.name === "*" || p.name === fullAccessName);
     if (hasFullAccess) {
         return { accessLevel: "full" };
     }
@@ -77,7 +103,9 @@ function serializePermissions(
 ): Permission[] {
     // Start by filtering out all permissions belonging to this schema's prefix.
     const filtered = Array.isArray(currentValue)
-        ? currentValue.filter(p => !p.name.startsWith(schema.prefix))
+        ? currentValue.filter(
+              p => !p.name.startsWith(schema.prefix) && !p.name.startsWith(`$${schema.prefix}`)
+          )
         : [];
 
     if (formData.accessLevel === "no" || !formData.accessLevel) {
@@ -85,7 +113,12 @@ function serializePermissions(
     }
 
     if (formData.accessLevel === "full") {
-        return [...filtered, { ...schema.fullAccess }];
+        return [...filtered, resolveFullAccess(schema)];
+    }
+
+    const readOnlyPermissions = resolveReadOnlyAccess(schema);
+    if (formData.accessLevel === "read-only" && readOnlyPermissions) {
+        return [...filtered, { name: `$${schema.prefix}.readonly` }, ...readOnlyPermissions];
     }
 
     const entities = schema.entities || [];
@@ -227,7 +260,11 @@ export function usePermissionForm(
                 );
                 // Re-add non-schema permissions that were filtered out.
                 const nonSchemaPermissions = Array.isArray(value)
-                    ? value.filter(p => !p.name.startsWith(schema.prefix))
+                    ? value.filter(
+                          p =>
+                              !p.name.startsWith(schema.prefix) &&
+                              !p.name.startsWith(`$${schema.prefix}`)
+                      )
                     : [];
                 result = [...nonSchemaPermissions, ...result];
             }

--- a/packages/app-admin/src/permissions/usePermissions.ts
+++ b/packages/app-admin/src/permissions/usePermissions.ts
@@ -41,7 +41,8 @@ function buildResult<S extends PermissionSchemaConfig>(
     schema: S,
     identity: Identity
 ): UsePermissionsResult<S> {
-    const hasFullAccess = !!identity.getPermission(schema.fullAccess.name);
+    const fullAccessName = `${schema.prefix}.*`;
+    const hasFullAccess = !!identity.getPermission(fullAccessName);
     const entityMap = buildEntityMap(schema);
 
     const canAccess = (entityId: string): boolean => {

--- a/packages/app-audit-logs/src/SecurityPermission.tsx
+++ b/packages/app-audit-logs/src/SecurityPermission.tsx
@@ -14,7 +14,7 @@ export const SecurityPermission = () => {
                 icon={<PermissionsIcon />}
                 schema={{
                     prefix: "al",
-                    fullAccess: { name: "al.*" }
+                    fullAccess: true
                 }}
             />
         </AdminConfig>

--- a/packages/app-file-manager/src/modules/SecurityPermissions.tsx
+++ b/packages/app-file-manager/src/modules/SecurityPermissions.tsx
@@ -14,7 +14,7 @@ export const SecurityPermissions = () => {
                 icon={<PermissionsIcon />}
                 schema={{
                     prefix: "fm",
-                    fullAccess: { name: "fm.*" },
+                    fullAccess: true,
                     entities: [
                         {
                             id: "file",

--- a/packages/app-record-locking/src/components/SecurityPermissions.tsx
+++ b/packages/app-record-locking/src/components/SecurityPermissions.tsx
@@ -14,7 +14,7 @@ export const SecurityPermissions = () => {
                 icon={<LockIcon />}
                 schema={{
                     prefix: "recordLocking",
-                    fullAccess: { name: "recordLocking", canForceUnlock: true }
+                    fullAccess: { canForceUnlock: true }
                 }}
             />
         </AdminConfig>

--- a/packages/app-security-access-management/src/SecurityPermissions.tsx
+++ b/packages/app-security-access-management/src/SecurityPermissions.tsx
@@ -36,7 +36,7 @@ export const SecurityPermissions = () => {
 
         return {
             prefix: "security",
-            fullAccess: { name: "security.*" },
+            fullAccess: true,
             entities
         };
     }, [teams]);

--- a/packages/app-website-builder/src/constants.ts
+++ b/packages/app-website-builder/src/constants.ts
@@ -33,7 +33,8 @@ export const WB_REDIRECT_LATEST_VISITED_FOLDER = "wb/redirect/list/last-folder";
 
 export const WB_PERMISSIONS_SCHEMA = createPermissionSchema({
     prefix: "wb",
-    fullAccess: { name: "wb.*" },
+    fullAccess: true,
+    readOnlyAccess: true,
     entities: [
         {
             id: "page",

--- a/packages/app-workflows/src/Components/WorkflowsPermissions/SecurityPermissions.tsx
+++ b/packages/app-workflows/src/Components/WorkflowsPermissions/SecurityPermissions.tsx
@@ -14,7 +14,7 @@ export const SecurityPermissions = () => {
                 icon={<PermissionsIcon />}
                 schema={{
                     prefix: "workflows",
-                    fullAccess: { name: "workflows", editor: true }
+                    fullAccess: { editor: true }
                 }}
             />
         </AdminConfig>

--- a/packages/cognito/src/admin/SecurityPermission.tsx
+++ b/packages/cognito/src/admin/SecurityPermission.tsx
@@ -14,7 +14,7 @@ export const SecurityPermission = () => {
                 icon={<PermissionsIcon />}
                 schema={{
                     prefix: "adminUsers",
-                    fullAccess: { name: "adminUsers.*" },
+                    fullAccess: true,
                     entities: [
                         {
                             id: "user",

--- a/packages/tenant-manager/src/admin/SecurityPermission.tsx
+++ b/packages/tenant-manager/src/admin/SecurityPermission.tsx
@@ -14,7 +14,7 @@ export const SecurityPermission = () => {
                 icon={<PermissionsIcon />}
                 schema={{
                     prefix: "tm",
-                    fullAccess: { name: "tm.*" }
+                    fullAccess: true
                 }}
             />
         </AdminConfig>


### PR DESCRIPTION
## Summary

- **`fullAccess`** is now `true | { ...extras }` — name is auto-derived as `${prefix}.*`. Removes redundant `name` field from all schema declarations.
- **`readOnlyAccess`** uses a marker-based approach: `true` (emits `{ name: "${prefix}.*", rwd: "r" }`) or `Permission[]` (developer-defined entity permissions). A synthetic `$prefix.readonly` marker permission is emitted for frontend detection.
- **Backend `createPermissions`**: removed `hasReadOnlySchemaAccess()` — entity-level `rwd: "r"` is self-enforcing. `hasFullSchemaAccess()` now only returns `true` for bare wildcards (no `rwd` flag). Added wildcard fallback in `getEntityPermissions()`.
- Updated all 12 schema declarations across the codebase.
- Website Builder API Key created with a strict read-only access to pages only

🤖 Generated with [Claude Code](https://claude.com/claude-code)