### PR TITLE
fix(app-website-builder-workflows): show state bar in page edit

### DIFF
--- a/packages/app-website-builder-workflows/src/Components/PageEditor/PageFormWorkflowState.tsx
+++ b/packages/app-website-builder-workflows/src/Components/PageEditor/PageFormWorkflowState.tsx
@@ -10,14 +10,16 @@ export const PageFormWorkflowState = () => {
     return (
         <WorkflowStateBar>
             {({ state, stateBar }) => {
-                return state ? (
+                return (
                     <div className={"max-w-screen bg-white p-sm"}>
                         {stateBar}
-                        <Alert className={"mb-md mt-md"} type="danger">
-                            Any changes you do on the page will not be stored!
-                        </Alert>
+                        {state ? (
+                            <Alert className={"mb-md mt-md"} type="danger">
+                                Any changes you do on the page will not be stored!
+                            </Alert>
+                        ) : null}
                     </div>
-                ) : null;
+                );
             }}
         </WorkflowStateBar>
     );


### PR DESCRIPTION
## Changes
Always show state bar in case there is a workflow for Page.

## How Has This Been Tested?
Manually.