### PR TITLE
fix(api-form-builder): validate submission meta and use it afterwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .artifacts
 .env*
 .npmrc
+.run/
 htpasswd
 lerna-debug.log
 npm-debug.log

--- a/packages/api-form-builder/__tests__/formSubmissionSecurity.test.ts
+++ b/packages/api-form-builder/__tests__/formSubmissionSecurity.test.ts
@@ -16,6 +16,11 @@ interface MockSubmissionData {
 }
 interface MockSubmissionMeta {
     ip: string;
+    submittedOn: string;
+    url: {
+        location: string;
+        query: Record<string, string>;
+    };
 }
 class MockSubmission {
     public data: MockSubmissionData;
@@ -28,7 +33,15 @@ class MockSubmission {
             email: `${prefix}email@gmail.com`
         };
         this.meta = {
-            ip: "150.129.183.18"
+            ip: "150.129.183.18",
+            submittedOn: new Date("2020-01-01").toISOString(),
+            url: {
+                location: "https://example.com",
+                query: {
+                    param1: "value1",
+                    param2: "value2"
+                }
+            }
         };
     }
 }
@@ -256,11 +269,13 @@ describe("Forms Submission Security Test", () => {
                 ...new MockSubmission(`B${b}-`)
             });
 
-            expect(createFormSubmissionResponse).toEqual({
+            expect(createFormSubmissionResponse).toMatchObject({
                 data: {
                     formBuilder: {
                         createFormSubmission: {
-                            data: expect.any(Object),
+                            data: {
+                                ...new MockSubmission(`B${b}-`)
+                            },
                             error: null
                         }
                     }

--- a/packages/api-form-builder/__tests__/graphql/formSubmission.ts
+++ b/packages/api-form-builder/__tests__/graphql/formSubmission.ts
@@ -5,6 +5,10 @@ export const DATA_FIELD = /* GraphQL */ `
         meta {
             ip
             submittedOn
+            url {
+                location
+                query
+            }
         }
         form {
             id

--- a/packages/api-form-builder/src/plugins/crud/forms.models.ts
+++ b/packages/api-form-builder/src/plugins/crud/forms.models.ts
@@ -92,7 +92,17 @@ export const FormSubmissionCreateDataModel = zod.object({
     meta: zod
         .object({
             ip: zod.string().optional().default(""),
-            submittedOn: zod.string().optional().default(new Date().toISOString()),
+            submittedOn: zod
+                .string()
+                .optional()
+                .transform(value => {
+                    if (!!value) {
+                        try {
+                            return new Date(value).toISOString();
+                        } catch (ex) {}
+                    }
+                    return new Date().toISOString();
+                }),
             url: zod
                 .object({
                     location: zod.string().optional(),

--- a/packages/api-form-builder/src/plugins/crud/submissions.crud.ts
+++ b/packages/api-form-builder/src/plugins/crud/submissions.crud.ts
@@ -358,7 +358,7 @@ export const createSubmissionsCrud = (params: CreateSubmissionsCrudParams): Subm
                                     submission.logs.push(log);
                                 },
                                 data: sanitizeFormSubmissionData(form.fields, data),
-                                meta,
+                                meta: validation.data.meta,
                                 trigger: form.triggers[plugin.trigger]
                             });
                         }

--- a/packages/api-form-builder/src/plugins/triggers/webhook.ts
+++ b/packages/api-form-builder/src/plugins/triggers/webhook.ts
@@ -17,13 +17,25 @@ const plugin: FbFormTriggerHandlerPlugin = {
              * work in Lambda, so for now, let's await the result of the request, and update form submission
              * logs accordingly.
              */
+            let submittedOn = format(new Date(), "yyyy-MM-dd HH:mm:ss");
+            try {
+                submittedOn = format(new Date(meta.submittedOn || data), "yyyy-MM-dd HH:mm:ss");
+            } catch {
+                console.warn({
+                    message:
+                        "Failed to parse `submittedOn` date from meta. Using current date instead.",
+                    metaSubmittedOn: meta.submittedOn,
+                    data,
+                    meta
+                });
+            }
             try {
                 const response = await fetch(url, {
                     method: "POST",
                     body: JSON.stringify({
                         ...data,
                         meta: {
-                            submittedOn: format(new Date(meta.submittedOn), "yyyy-MM-dd HH:mm:ss"),
+                            submittedOn,
                             // We don't spread the full `meta` object in order to ensure sensitive data
                             // doesn't end up being included (at the moment, that's IP address).
                             url: meta.url


### PR DESCRIPTION
## Changes
When submitting a form, meta information is validated but not correctly used when triggering defined hooks.
This resulted in new Date() parsing wrong type of value and it threw an exception.

Test for meta.submittedOn was added.

## How Has This Been Tested?
Jest and manually.