### PR TITLE
fix(app-headless-cms-common): exclude live field from singleton entry queries

### DIFF
--- a/packages/app-headless-cms-common/src/entries.graphql.ts
+++ b/packages/app-headless-cms-common/src/entries.graphql.ts
@@ -34,6 +34,9 @@ const createEntrySystemFields = (model: CmsModel) => {
             meta  {
                 ${CONTENT_META_FIELDS}
             }
+            live {
+                version
+            }
         `;
     }
 
@@ -113,9 +116,6 @@ const createEntrySystemFields = (model: CmsModel) => {
             displayName
         }
         ${optionalFields}
-        live {
-            version
-        }
     `;
 };
 


### PR DESCRIPTION
## What

Moved `live { version }` from the unconditional system fields into the `!isSingletonModel` conditional block in `createEntrySystemFields`.

## Why

Singleton models use `createSingularSDL` to generate their GraphQL schema, which does **not** include the `live` field. However, the client-side query builder unconditionally included `live { version }` for all models, causing:

```
Uncaught (in promise) Error: GraphQL error: Cannot query field "live" on type "AdminSettings".
```

The `wbyAco_location` and `meta` fields were already correctly excluded for singleton models, but `live` was placed outside that conditional block.

## Changes

**File:** `packages/app-headless-cms-common/src/entries.graphql.ts`

- Moved `live { version }` inside the existing `if (!isSingletonModel)` block
- Removed the standalone `live { version }` from the unconditional return template


### Before

```typescript
if (!isSingletonModel) {
    optionalFields = \`
        wbyAco_location { folderId }
        meta { ... }
    \`;                          // live was NOT here
}

return \`
    ...
    ${optionalFields}
    live { version }              // ❌ queried for ALL models
\`;
```

### After

```typescript
if (!isSingletonModel) {
    optionalFields = \`
        wbyAco_location { folderId }
        meta { ... }
        live { version }          // ✅ only for non-singleton
    \`;
}

return \`
    ...
    ${optionalFields}            // ✅ singleton models skip live
\`;
```

## How verified

- Confirmed `createSingularSDL.ts` does not include `live` in the singleton type definition
- Confirmed `wbyAco_location` and `meta` already follow the same exclusion pattern
- Non-singleton models are unaffected since `optionalFields` includes `live` for them

Fixes #5012