### PR TITLE
adrian/extensions-cmd-fixes-2026-03-16

### DIFF
--- a/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
+++ b/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
@@ -24,7 +24,6 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
 
         const flags = this.featureFlags.get();
 
-        console.log("flags", flags);
         return {
             ...project,
             package: {

--- a/packages/project/src/services/InstallExtensionService/types.ts
+++ b/packages/project/src/services/InstallExtensionService/types.ts
@@ -39,6 +39,10 @@ export interface ExtensionWebinyConfigTsx {
      * Component to render in the Extensions component.
      */
     component?: ExtensionComponent;
+    /**
+     * Multiple components to render in the Extensions component.
+     */
+    components?: ExtensionComponent[];
 }
 
 export interface ExtensionImport {

--- a/packages/project/src/services/InstallExtensionService/updateWebinyConfig.ts
+++ b/packages/project/src/services/InstallExtensionService/updateWebinyConfig.ts
@@ -18,28 +18,28 @@ const serializePropsToJsx = (props: Record<string, any>): string => {
     const attributes: string[] = [];
 
     for (const [key, value] of Object.entries(props)) {
-        // Skip undefined values
+        // Skip undefined values.
         if (value === undefined) {
             continue;
         }
 
-        // Determine the serialization based on value type
+        // Determine the serialization based on value type.
         let serializedValue: string;
 
         if (typeof value === "string") {
-            // Strings: use JSON.stringify to handle escaping, then wrap in curly braces
+            // Strings: use JSON.stringify to handle escaping, then wrap in curly braces.
             serializedValue = `{${JSON.stringify(value)}}`;
         } else if (typeof value === "number" || typeof value === "boolean") {
-            // Numbers and booleans: wrap in curly braces without quotes
+            // Numbers and booleans: wrap in curly braces without quotes.
             serializedValue = `{${value}}`;
         } else if (value === null) {
-            // Null values
+            // Null values.
             serializedValue = `{null}`;
         } else if (Array.isArray(value) || typeof value === "object") {
-            // Arrays and objects: use JSON.stringify, then wrap in curly braces
+            // Arrays and objects: use JSON.stringify, then wrap in curly braces.
             serializedValue = `{${JSON.stringify(value)}}`;
         } else {
-            // Fallback for any other types
+            // Fallback for any other types.
             serializedValue = `{${JSON.stringify(value)}}`;
         }
 
@@ -47,6 +47,62 @@ const serializePropsToJsx = (props: Record<string, any>): string => {
     }
 
     return attributes.join(" ");
+};
+
+/**
+ * Adds a component to the Extensions function in the webiny.config.tsx content.
+ */
+const addComponentToExtensions = (
+    content: string,
+    componentName: string,
+    props?: Record<string, any>
+): string => {
+    // Serialize props to JSX attributes.
+    const propsString = props ? serializePropsToJsx(props) : "";
+
+    // Generate component tag with or without props.
+    const componentTag = propsString
+        ? `<${componentName} ${propsString} />`
+        : `<${componentName} />`;
+
+    // Check if component already exists.
+    if (content.includes(componentTag)) {
+        return content;
+    }
+
+    // Find the Extensions function's return statement and add component before the final </>.
+    // Strategy: Find "export const Extensions" block, then find the last </> and insert before it.
+    const extensionsFuncRegex = /export const Extensions = \(\) => \{[\s\S]*?\};/;
+    const extensionsFuncMatch = content.match(extensionsFuncRegex);
+
+    if (!extensionsFuncMatch) {
+        return content;
+    }
+
+    const funcContent = extensionsFuncMatch[0];
+    // Find all </> in the function - the last one closes the return statement.
+    const closingTags = [...funcContent.matchAll(/<\/>/g)];
+
+    if (closingTags.length === 0) {
+        return content;
+    }
+
+    const lastClosingTag = closingTags[closingTags.length - 1];
+    const lastClosingTagIndex = lastClosingTag.index!;
+
+    // Find the indentation of the line containing the last </>.
+    const beforeClosing = funcContent.substring(0, lastClosingTagIndex);
+    const lines = beforeClosing.split("\n");
+    const lastLine = lines[lines.length - 1];
+    const indent = lastLine.match(/^(\s*)/)?.[1] || "        ";
+
+    // Insert the component before the last </>.
+    const newFuncContent =
+        funcContent.substring(0, lastClosingTagIndex) +
+        `${indent}${componentTag}\n${indent}` +
+        funcContent.substring(lastClosingTagIndex);
+
+    return content.replace(extensionsFuncRegex, newFuncContent);
 };
 
 /**
@@ -108,59 +164,19 @@ export const updateWebinyConfig = async (params: UpdateWebinyConfigParams): Prom
         }
     }
 
-    // Helper function to add a component to the Extensions function.
-    const addComponentToExtensions = (componentName: string, props?: Record<string, any>) => {
-        // Serialize props to JSX attributes.
-        const propsString = props ? serializePropsToJsx(props) : "";
-
-        // Generate component tag with or without props.
-        const componentTag = propsString
-            ? `<${componentName} ${propsString} />`
-            : `<${componentName} />`;
-
-        // Check if component already exists.
-        if (!content.includes(componentTag)) {
-            // Find the Extensions function's return statement and add component before the final </>.
-            // Strategy: Find "export const Extensions" block, then find the last </> and insert before it.
-            const extensionsFuncRegex = /export const Extensions = \(\) => \{[\s\S]*?\};/;
-            const extensionsFuncMatch = content.match(extensionsFuncRegex);
-
-            if (extensionsFuncMatch) {
-                const funcContent = extensionsFuncMatch[0];
-                // Find all </> in the function - the last one closes the return statement.
-                const closingTags = [...funcContent.matchAll(/<\/>/g)];
-
-                if (closingTags.length > 0) {
-                    const lastClosingTag = closingTags[closingTags.length - 1];
-                    const lastClosingTagIndex = lastClosingTag.index!;
-
-                    // Find the indentation of the line containing the last </>.
-                    const beforeClosing = funcContent.substring(0, lastClosingTagIndex);
-                    const lines = beforeClosing.split("\n");
-                    const lastLine = lines[lines.length - 1];
-                    const indent = lastLine.match(/^(\s*)/)?.[1] || "        ";
-
-                    // Insert the component before the last </>.
-                    const newFuncContent =
-                        funcContent.substring(0, lastClosingTagIndex) +
-                        `${indent}${componentTag}\n${indent}` +
-                        funcContent.substring(lastClosingTagIndex);
-
-                    content = content.replace(extensionsFuncRegex, newFuncContent);
-                }
-            }
-        }
-    };
-
     // Add component to the Extensions function.
     if (webinyConfigTsx.component) {
-        addComponentToExtensions(webinyConfigTsx.component.name, webinyConfigTsx.component.props);
+        content = addComponentToExtensions(
+            content,
+            webinyConfigTsx.component.name,
+            webinyConfigTsx.component.props
+        );
     }
 
     // Add multiple components to the Extensions function.
     if (webinyConfigTsx.components && webinyConfigTsx.components.length > 0) {
         for (const component of webinyConfigTsx.components) {
-            addComponentToExtensions(component.name, component.props);
+            content = addComponentToExtensions(content, component.name, component.props);
         }
     }
 

--- a/packages/project/src/services/InstallExtensionService/updateWebinyConfig.ts
+++ b/packages/project/src/services/InstallExtensionService/updateWebinyConfig.ts
@@ -63,16 +63,36 @@ export const updateWebinyConfig = async (params: UpdateWebinyConfigParams): Prom
     // Add imports at the top (after existing imports)
     if (webinyConfigTsx.imports && webinyConfigTsx.imports.length > 0) {
         for (const importStatement of webinyConfigTsx.imports) {
-            const importLine = `import { ${importStatement.specifier} } from "${importStatement.path}";`;
+            // Check if we need to add to an existing import from the same path.
+            const existingImportRegex = new RegExp(
+                `import\\s+{([^}]+)}\\s+from\\s+["']${importStatement.path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'];?`,
+                "m"
+            );
+            const existingImportMatch = content.match(existingImportRegex);
 
-            // Check if import already exists
-            if (!content.includes(importLine)) {
-                // Find the position after the last import or at the beginning
+            if (existingImportMatch) {
+                // Import from this path exists, check if specifier is already imported.
+                const existingSpecifiers = existingImportMatch[1].split(",").map(s => s.trim());
+
+                if (!existingSpecifiers.includes(importStatement.specifier)) {
+                    // Append the new specifier to the existing import.
+                    const updatedSpecifiers = [
+                        ...existingSpecifiers,
+                        importStatement.specifier
+                    ].join(", ");
+                    const updatedImportLine = `import { ${updatedSpecifiers} } from "${importStatement.path}";`;
+                    content = content.replace(existingImportRegex, updatedImportLine);
+                }
+            } else {
+                // No existing import from this path, add a new import line.
+                const importLine = `import { ${importStatement.specifier} } from "${importStatement.path}";`;
+
+                // Find the position after the last import or at the beginning.
                 const importRegex = /^import\s+.*?from\s+["'].*?["'];?\s*$/gm;
                 const matches = Array.from(content.matchAll(importRegex));
 
                 if (matches.length > 0) {
-                    // Add after the last import
+                    // Add after the last import.
                     const lastImport = matches[matches.length - 1];
                     const lastImportEnd = lastImport.index! + lastImport[0].length;
                     content =
@@ -81,49 +101,46 @@ export const updateWebinyConfig = async (params: UpdateWebinyConfigParams): Prom
                         importLine +
                         content.slice(lastImportEnd);
                 } else {
-                    // No imports found, add at the beginning
+                    // No imports found, add at the beginning.
                     content = importLine + "\n\n" + content;
                 }
             }
         }
     }
 
-    // Add component to the Extensions function
-    if (webinyConfigTsx.component) {
-        const componentName = webinyConfigTsx.component.name;
-        const props = webinyConfigTsx.component.props;
-
-        // Serialize props to JSX attributes
+    // Helper function to add a component to the Extensions function.
+    const addComponentToExtensions = (componentName: string, props?: Record<string, any>) => {
+        // Serialize props to JSX attributes.
         const propsString = props ? serializePropsToJsx(props) : "";
 
-        // Generate component tag with or without props
+        // Generate component tag with or without props.
         const componentTag = propsString
             ? `<${componentName} ${propsString} />`
             : `<${componentName} />`;
 
-        // Check if component already exists
+        // Check if component already exists.
         if (!content.includes(componentTag)) {
-            // Find the Extensions function's return statement and add component before the final </>
-            // Strategy: Find "export const Extensions" block, then find the last </> and insert before it
+            // Find the Extensions function's return statement and add component before the final </>.
+            // Strategy: Find "export const Extensions" block, then find the last </> and insert before it.
             const extensionsFuncRegex = /export const Extensions = \(\) => \{[\s\S]*?\};/;
             const extensionsFuncMatch = content.match(extensionsFuncRegex);
 
             if (extensionsFuncMatch) {
                 const funcContent = extensionsFuncMatch[0];
-                // Find all </> in the function - the last one closes the return statement
+                // Find all </> in the function - the last one closes the return statement.
                 const closingTags = [...funcContent.matchAll(/<\/>/g)];
 
                 if (closingTags.length > 0) {
                     const lastClosingTag = closingTags[closingTags.length - 1];
                     const lastClosingTagIndex = lastClosingTag.index!;
 
-                    // Find the indentation of the line containing the last </>
+                    // Find the indentation of the line containing the last </>.
                     const beforeClosing = funcContent.substring(0, lastClosingTagIndex);
                     const lines = beforeClosing.split("\n");
                     const lastLine = lines[lines.length - 1];
                     const indent = lastLine.match(/^(\s*)/)?.[1] || "        ";
 
-                    // Insert the component before the last </>
+                    // Insert the component before the last </>.
                     const newFuncContent =
                         funcContent.substring(0, lastClosingTagIndex) +
                         `${indent}${componentTag}\n${indent}` +
@@ -132,6 +149,18 @@ export const updateWebinyConfig = async (params: UpdateWebinyConfigParams): Prom
                     content = content.replace(extensionsFuncRegex, newFuncContent);
                 }
             }
+        }
+    };
+
+    // Add component to the Extensions function.
+    if (webinyConfigTsx.component) {
+        addComponentToExtensions(webinyConfigTsx.component.name, webinyConfigTsx.component.props);
+    }
+
+    // Add multiple components to the Extensions function.
+    if (webinyConfigTsx.components && webinyConfigTsx.components.length > 0) {
+        for (const component of webinyConfigTsx.components) {
+            addComponentToExtensions(component.name, component.props);
         }
     }
 


### PR DESCRIPTION
Summary
- Fix import deduplication: reuse existing imports from webiny/extensions instead of creating duplicates
- Add support for components array in extension.json to allow installing multiple components at once

Before: Installing an extension with Api would create import { Api } from "webiny/extensions"; even if that import 
already existed

After: Appends to existing import: import { Admin, Api } from "webiny/extensions";