### PR TITLE
feat: configurable element overlay actions in the editor

### DIFF
--- a/devtools/webiny-config-devtools/devtools.js
+++ b/devtools/webiny-config-devtools/devtools.js
@@ -1,1 +1,1 @@
-chrome.devtools.panels.create("Webiny Configs", "icons/icon16.png", "panel.html");
+chrome.devtools.panels.create("Webiny", "icons/icon16.png", "panel.html");

--- a/devtools/webiny-config-devtools/manifest.json
+++ b/devtools/webiny-config-devtools/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Webiny Config DevTools",
+  "name": "Webiny DevTools",
   "version": "1.0.0",
-  "description": "Inspect mounted Webiny Config components and their state",
+  "description": "Inspect Webiny app",
   "devtools_page": "devtools.html",
   "icons": {
     "16": "icons/webiny.png",

--- a/devtools/webiny-config-devtools/panel.css
+++ b/devtools/webiny-config-devtools/panel.css
@@ -1,406 +1,435 @@
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 :root {
-    --bg: #fff;
-    --bg-sidebar: #f5f5f5;
-    --bg-hover: #e8e8e8;
-    --bg-selected: #d4e4ff;
-    --bg-toolbar: #f0f0f0;
-    --border: #ddd;
-    --text: #333;
-    --text-muted: #888;
-    --text-key: #881280;
-    --text-string: #1a7f37;
-    --text-number: #0550ae;
-    --text-boolean: #cf222e;
-    --text-null: #999;
-    --text-function: #8250df;
-    --text-bracket: #666;
-    --badge-bg: #e3e3e3;
-    --tab-active: #0969da;
-    --tab-bg: transparent;
-    --tab-active-bg: #fff;
-    --scrollbar-thumb: #c1c1c1;
+  --bg: #fff;
+  --bg-sidebar: #f5f5f5;
+  --bg-hover: #e8e8e8;
+  --bg-selected: #d4e4ff;
+  --bg-toolbar: #f0f0f0;
+  --border: #ddd;
+  --text: #333;
+  --text-muted: #888;
+  --text-key: #881280;
+  --text-string: #1a7f37;
+  --text-number: #0550ae;
+  --text-boolean: #cf222e;
+  --text-null: #999;
+  --text-function: #8250df;
+  --text-bracket: #666;
+  --badge-bg: #e3e3e3;
+  --tab-active: #0969da;
+  --tab-bg: transparent;
+  --tab-active-bg: #fff;
+  --scrollbar-thumb: #c1c1c1;
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        --bg: #1e1e1e;
-        --bg-sidebar: #252526;
-        --bg-hover: #2a2d2e;
-        --bg-selected: #37373d;
-        --bg-toolbar: #2d2d2d;
-        --border: #3e3e3e;
-        --text: #d4d4d4;
-        --text-muted: #808080;
-        --text-key: #c586c0;
-        --text-string: #6aab73;
-        --text-number: #6cb6ff;
-        --text-boolean: #ff7b72;
-        --text-null: #666;
-        --text-function: #d2a8ff;
-        --text-bracket: #999;
-        --badge-bg: #3e3e3e;
-        --tab-active: #6cb6ff;
-        --tab-bg: transparent;
-        --tab-active-bg: #1e1e1e;
-        --scrollbar-thumb: #555;
-    }
+  :root {
+    --bg: #1e1e1e;
+    --bg-sidebar: #252526;
+    --bg-hover: #2a2d2e;
+    --bg-selected: #37373d;
+    --bg-toolbar: #2d2d2d;
+    --border: #3e3e3e;
+    --text: #d4d4d4;
+    --text-muted: #808080;
+    --text-key: #c586c0;
+    --text-string: #6aab73;
+    --text-number: #6cb6ff;
+    --text-boolean: #ff7b72;
+    --text-null: #666;
+    --text-function: #d2a8ff;
+    --text-bracket: #999;
+    --badge-bg: #3e3e3e;
+    --tab-active: #6cb6ff;
+    --tab-bg: transparent;
+    --tab-active-bg: #1e1e1e;
+    --scrollbar-thumb: #555;
+  }
 }
 
-html, body {
-    height: 100%;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    font-size: 12px;
-    color: var(--text);
-    background: var(--bg);
+html,
+body {
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg);
 }
 
 /* Toolbar */
 .toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 8px;
-    background: var(--bg-toolbar);
-    border-bottom: 1px solid var(--border);
-    height: 28px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background: var(--bg-toolbar);
+  border-bottom: 1px solid var(--border);
+  height: 28px;
 }
 
 .toolbar-title {
-    font-weight: 600;
-    font-size: 12px;
+  font-weight: 600;
+  font-size: 12px;
 }
 
 .toolbar-count {
-    color: var(--text-muted);
-    font-size: 11px;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .toolbar-btn {
-    margin-left: auto;
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    background: var(--bg);
-    color: var(--text);
-    font-size: 11px;
-    cursor: pointer;
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 11px;
+  cursor: pointer;
 }
 
 .toolbar-btn:hover {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 
 /* Main layout */
 .main {
-    display: flex;
-    height: calc(100% - 28px);
+  display: flex;
+  height: calc(100% - 28px);
 }
 
 /* Sidebar */
 .sidebar {
-    width: 220px;
-    min-width: 160px;
-    border-right: 1px solid var(--border);
-    background: var(--bg-sidebar);
-    overflow-y: auto;
+  width: 220px;
+  min-width: 160px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-sidebar);
+  overflow-y: auto;
 }
 
 .sidebar-empty {
-    padding: 16px 12px;
-    color: var(--text-muted);
-    text-align: center;
-    line-height: 1.5;
-    font-size: 11px;
+  padding: 16px 12px;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.5;
+  font-size: 11px;
 }
 
 .sidebar-group-header {
-    padding: 6px 10px 4px;
-    font-size: 10px;
-    font-weight: 600;
-    color: var(--text-muted);
-    letter-spacing: 0.5px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-toolbar);
+  padding: 6px 10px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-toolbar);
 }
 
 .sidebar-item {
-    padding: 5px 10px;
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    border-bottom: 1px solid var(--border);
-    font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
 }
 
 .sidebar-item:hover {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 
 .sidebar-item.selected {
-    background: var(--bg-selected);
-    font-weight: 600;
+  background: var(--bg-selected);
+  font-weight: 600;
 }
 
 .sidebar-item .badge {
-    display: inline-block;
-    margin-left: 6px;
-    padding: 0 5px;
-    border-radius: 8px;
-    background: var(--badge-bg);
-    color: var(--text-muted);
-    font-size: 10px;
-    font-weight: 400;
-    vertical-align: middle;
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 8px;
+  background: var(--badge-bg);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 400;
+  vertical-align: middle;
 }
 
 /* Detail pane */
 .detail {
-    flex: 1;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .detail-empty {
-    padding: 32px 16px;
-    color: var(--text-muted);
-    text-align: center;
+  padding: 32px 16px;
+  color: var(--text-muted);
+  text-align: center;
 }
 
 /* Tabs */
 .tabs {
-    display: flex;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-toolbar);
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-toolbar);
 }
 
 .tab {
-    padding: 5px 14px;
-    cursor: pointer;
-    font-size: 12px;
-    color: var(--text-muted);
-    border-bottom: 2px solid transparent;
-    background: var(--tab-bg);
+  padding: 5px 14px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  background: var(--tab-bg);
 }
 
 .tab:hover {
-    color: var(--text);
+  color: var(--text);
 }
 
 .tab.active {
-    color: var(--tab-active);
-    border-bottom-color: var(--tab-active);
-    background: var(--tab-active-bg);
+  color: var(--tab-active);
+  border-bottom-color: var(--tab-active);
+  background: var(--tab-active-bg);
 }
 
 /* Tab content */
 .tab-content {
-    flex: 1;
-    overflow: auto;
-    padding: 8px 12px;
+  flex: 1;
+  overflow: auto;
+  padding: 8px 12px;
 }
 
 .tab-content.hidden {
-    display: none;
+  display: none;
 }
 
 /* Browse tab */
 .tab-content-browse {
-    display: flex;
-    padding: 0;
+  display: flex;
+  padding: 0;
 }
 
 .tab-content-browse.hidden {
-    display: none;
+  display: none;
 }
 
 .browse-keys {
-    width: 200px;
-    min-width: 140px;
-    border-right: 1px solid var(--border);
-    overflow-y: auto;
-    background: var(--bg-sidebar);
-    flex-shrink: 0;
+  width: 200px;
+  min-width: 140px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: var(--bg-sidebar);
+  flex-shrink: 0;
 }
 
 .browse-key-item {
-    padding: 6px 10px;
-    cursor: pointer;
-    border-bottom: 1px solid var(--border);
+  padding: 6px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
 }
 
 .browse-key-item:hover {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 
 .browse-key-item.selected {
-    background: var(--bg-selected);
+  background: var(--bg-selected);
 }
 
 .browse-key-name {
-    font-weight: 600;
-    font-size: 12px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .browse-key-type {
-    font-size: 10px;
-    color: var(--text-muted);
-    margin-top: 1px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .browse-value {
-    flex: 1;
-    overflow: auto;
-    padding: 8px 12px;
+  flex: 1;
+  overflow: auto;
+  padding: 8px 12px;
 }
 
 .browse-value-empty {
-    color: var(--text-muted);
-    padding: 16px;
-    text-align: center;
+  color: var(--text-muted);
+  padding: 16px;
+  text-align: center;
 }
 
 /* Tree toolbar (Expand All / Collapse) */
 .tree-toolbar {
-    display: flex;
-    gap: 6px;
-    padding: 4px 0 6px;
-    border-bottom: 1px solid var(--border);
-    margin-bottom: 6px;
+  display: flex;
+  gap: 6px;
+  padding: 4px 0 6px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
 }
 
 .tree-toolbar-btn {
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    background: var(--bg);
-    color: var(--text-muted);
-    font-size: 10px;
-    cursor: pointer;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 10px;
+  cursor: pointer;
 }
 
 .tree-toolbar-btn:hover {
-    color: var(--text);
-    background: var(--bg-hover);
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+.tree-search-input {
+  margin-left: 8px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 11px;
+  font-family: inherit;
+  width: 180px;
+  outline: none;
+}
+
+.tree-search-input:focus {
+  border-color: var(--tab-active);
+}
+
+.tree-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.tree-search-info {
+  color: var(--text-muted);
+  font-size: 10px;
+  margin-left: 6px;
+  align-self: center;
 }
 
 /* JSON tree */
 .json-tree {
-    font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;
-    font-size: 11px;
-    line-height: 1.6;
+  font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.6;
 }
 
 .json-node {
-    padding-left: 16px;
+  padding-left: 16px;
 }
 
 .json-toggle {
-    display: inline-block;
-    width: 14px;
-    cursor: pointer;
-    user-select: none;
-    color: var(--text-muted);
+  display: inline-block;
+  width: 14px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-muted);
 }
 
 .json-toggle:hover {
-    color: var(--text);
+  color: var(--text);
 }
 
 .json-key {
-    color: var(--text-key);
+  color: var(--text-key);
 }
 
 .json-string {
-    color: var(--text-string);
+  color: var(--text-string);
 }
 
 .json-number {
-    color: var(--text-number);
+  color: var(--text-number);
 }
 
 .json-boolean {
-    color: var(--text-boolean);
+  color: var(--text-boolean);
 }
 
 .json-null {
-    color: var(--text-null);
-    font-style: italic;
+  color: var(--text-null);
+  font-style: italic;
 }
 
 .json-function {
-    color: var(--text-function);
-    font-style: italic;
+  color: var(--text-function);
+  font-style: italic;
 }
 
 .json-bracket {
-    color: var(--text-bracket);
+  color: var(--text-bracket);
 }
 
 .json-collapsed-preview {
-    color: var(--text-muted);
-    font-size: 10px;
+  color: var(--text-muted);
+  font-size: 10px;
 }
 
 /* Properties table */
 .props-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;
-    font-size: 11px;
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;
+  font-size: 11px;
 }
 
 .props-table th {
-    text-align: left;
-    padding: 4px 8px;
-    border-bottom: 2px solid var(--border);
-    font-weight: 600;
-    color: var(--text-muted);
-    position: sticky;
-    top: 0;
-    background: var(--bg);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 2px solid var(--border);
+  font-weight: 600;
+  color: var(--text-muted);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .props-table td {
-    padding: 3px 8px;
-    border-bottom: 1px solid var(--border);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 300px;
+  padding: 3px 8px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
 }
 
 .props-table tr:hover td {
-    background: var(--bg-hover);
+  background: var(--bg-hover);
 }
 
 /* Scrollbar */
 ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
-    border-radius: 4px;
+  background: var(--scrollbar-thumb);
+  border-radius: 4px;
 }

--- a/devtools/webiny-config-devtools/panel.html
+++ b/devtools/webiny-config-devtools/panel.html
@@ -1,23 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
+  <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="panel.css" />
-</head>
-<body>
+  </head>
+  <body>
     <div class="toolbar">
-        <span class="toolbar-title">Webiny Configs</span>
-        <span class="toolbar-count" id="configCount">0 configs</span>
-        <button class="toolbar-btn" id="refreshBtn" title="Refresh">Refresh</button>
+      <span class="toolbar-title">Webiny</span>
+      <span class="toolbar-count" id="configCount">0 configs</span>
+      <button class="toolbar-btn" id="refreshBtn" title="Refresh">Refresh</button>
     </div>
     <div class="main">
-        <div class="sidebar" id="sidebar">
-            <div class="sidebar-empty">No configs detected.<br />Make sure the app is running in development mode.</div>
+      <div class="sidebar" id="sidebar">
+        <div class="sidebar-empty">
+          No configs detected.<br />Make sure the app is running in development mode.
         </div>
-        <div class="detail" id="detail">
-            <div class="detail-empty">Select a config from the sidebar.</div>
-        </div>
+      </div>
+      <div class="detail" id="detail">
+        <div class="detail-empty">Select a config from the sidebar.</div>
+      </div>
     </div>
     <script src="panel.js"></script>
-</body>
+  </body>
 </html>

--- a/devtools/webiny-config-devtools/panel.js
+++ b/devtools/webiny-config-devtools/panel.js
@@ -230,7 +230,7 @@
                 valueTree.className = "json-tree";
                 buildJsonTree(configObj[selectedKey], valueTree, 0, browseNodes);
                 if (browseNodes.length > 0) {
-                    buildTreeToolbar(browseValue, browseNodes);
+                    buildTreeToolbar(browseValue, browseNodes, valueTree, configObj[selectedKey]);
                 }
                 browseValue.appendChild(valueTree);
             } else {
@@ -259,7 +259,7 @@
         tree.className = "json-tree";
         buildJsonTree(data.config, tree, 0, configNodes);
         if (configNodes.length > 0) {
-            buildTreeToolbar(configContent, configNodes);
+            buildTreeToolbar(configContent, configNodes, tree, data.config);
         }
         configContent.appendChild(tree);
         detail.appendChild(configContent);
@@ -342,7 +342,7 @@
                 valueTree.className = "json-tree";
                 buildJsonTree(sectionData[selectedKey], valueTree, 0, nodes);
                 if (nodes.length > 0) {
-                    buildTreeToolbar(valuePane, nodes);
+                    buildTreeToolbar(valuePane, nodes, valueTree, sectionData[selectedKey]);
                 }
                 valuePane.appendChild(valueTree);
             } else {
@@ -362,7 +362,7 @@
             tree.className = "json-tree";
             buildJsonTree(sectionData, tree, 0, nodes);
             if (nodes.length > 0) {
-                buildTreeToolbar(content, nodes);
+                buildTreeToolbar(content, nodes, tree, sectionData);
             }
             content.appendChild(tree);
         }
@@ -383,7 +383,62 @@
 
     // ── JSON tree builder ──────────────────────────────────────────
 
-    function buildTreeToolbar(targetContainer, nodeList) {
+    // Search: recursively check if a value (or any descendant) contains the query
+    function valueContains(value, query) {
+        if (value === null || value === undefined) return false;
+        if (typeof value === "string") return value.toLowerCase().indexOf(query) !== -1;
+        if (typeof value === "number" || typeof value === "boolean") {
+            return String(value).toLowerCase().indexOf(query) !== -1;
+        }
+        if (Array.isArray(value)) {
+            for (var i = 0; i < value.length; i++) {
+                if (valueContains(value[i], query)) return true;
+            }
+            return false;
+        }
+        if (typeof value === "object") {
+            var keys = Object.keys(value);
+            for (var j = 0; j < keys.length; j++) {
+                if (keys[j].toLowerCase().indexOf(query) !== -1) return true;
+                if (valueContains(value[keys[j]], query)) return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    // Filter: return a new value keeping only matching branches
+    function filterValue(value, query) {
+        if (value === null || value === undefined) return undefined;
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+            return valueContains(value, query) ? value : undefined;
+        }
+        if (Array.isArray(value)) {
+            var filtered = [];
+            for (var i = 0; i < value.length; i++) {
+                if (valueContains(value[i], query)) {
+                    filtered.push(value[i]);
+                }
+            }
+            return filtered.length > 0 ? filtered : undefined;
+        }
+        if (typeof value === "object") {
+            var result = {};
+            var hasMatch = false;
+            var keys = Object.keys(value);
+            for (var j = 0; j < keys.length; j++) {
+                var k = keys[j];
+                if (k.toLowerCase().indexOf(query) !== -1 || valueContains(value[k], query)) {
+                    result[k] = value[k];
+                    hasMatch = true;
+                }
+            }
+            return hasMatch ? result : undefined;
+        }
+        return undefined;
+    }
+
+    function buildTreeToolbar(targetContainer, nodeList, treeContainer, originalData) {
         var bar = document.createElement("div");
         bar.className = "tree-toolbar";
         var expandBtn = document.createElement("button");
@@ -402,8 +457,47 @@
                 nodeList[i].setExpanded(nodeList[i].depth < 2);
             }
         });
+
+        var searchInput = document.createElement("input");
+        searchInput.type = "text";
+        searchInput.className = "tree-search-input";
+        searchInput.placeholder = "Filter...";
+
+        var searchInfo = document.createElement("span");
+        searchInfo.className = "tree-search-info";
+
+        var debounceTimer = null;
+        searchInput.addEventListener("input", function () {
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(function () {
+                var query = searchInput.value.trim().toLowerCase();
+                // Clear and rebuild tree
+                nodeList.length = 0;
+                treeContainer.innerHTML = "";
+
+                if (!query) {
+                    searchInfo.textContent = "";
+                    buildJsonTree(originalData, treeContainer, 0, nodeList);
+                } else {
+                    var filtered = filterValue(originalData, query);
+                    if (filtered !== undefined) {
+                        buildJsonTree(filtered, treeContainer, 0, nodeList);
+                        // Expand all when searching
+                        for (var i = 0; i < nodeList.length; i++) {
+                            nodeList[i].setExpanded(true);
+                        }
+                        searchInfo.textContent = "";
+                    } else {
+                        searchInfo.textContent = "No matches";
+                    }
+                }
+            }, 200);
+        });
+
         bar.appendChild(expandBtn);
         bar.appendChild(collapseBtn);
+        bar.appendChild(searchInput);
+        bar.appendChild(searchInfo);
         targetContainer.appendChild(bar);
     }
 

--- a/extensions/funnelBuilder/pageEditor/pageSettings/index.tsx
+++ b/extensions/funnelBuilder/pageEditor/pageSettings/index.tsx
@@ -1,12 +1,38 @@
 import React from "react";
-import { PageEditorConfig } from "webiny/admin/website-builder/page/editor";
+import { PageEditorConfig, useElementOverlay } from "webiny/admin/website-builder/page/editor";
 import { ReactComponent as StarIcon } from "webiny/admin/icons/star.svg";
+import { ReactComponent as EditIcon } from "webiny/admin/icons/edit.svg";
+import { IconButton } from "webiny/admin/ui";
 
-const { PageSettings } = PageEditorConfig;
+const { PageSettings, ElementOverlay } = PageEditorConfig;
+
+const CustomOverlayAction = () => {
+    const { elementId, componentManifest, isHighlighted } = useElementOverlay();
+
+    if (!isHighlighted) {
+        return null;
+    }
+
+    if (!componentManifest.name.startsWith("FunnelBuilder/")) {
+        return null;
+    }
+
+    return (
+        /* Add 32px which is the size of an IconButton. */
+        <ElementOverlay.Element.Container position={{ top: 5, right: 5 + 32 }}>
+            <IconButton
+                icon={<EditIcon />}
+                variant={"secondary"}
+                onClick={() => console.log("edit", elementId)}
+            />
+        </ElementOverlay.Element.Container>
+    );
+};
 
 export const FubPageSettings = () => {
     return (
         <PageEditorConfig>
+            <ElementOverlay.Element name="editAction" element={<CustomOverlayAction />} />
             <PageSettings.ViewMode.Drawer />
             <PageSettings.Group
                 name={"custom"}

--- a/packages/app-website-builder/src/BaseEditor/config/EditorConfig.tsx
+++ b/packages/app-website-builder/src/BaseEditor/config/EditorConfig.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { createConfigurableComponent } from "@webiny/react-properties";
 import type { ElementConfig } from "./Element.js";
 import { Element } from "./Element.js";
@@ -16,29 +15,11 @@ import type { ElementInputConfig } from "./ElementInput.js";
 import { ElementInput } from "./ElementInput.js";
 import { IsNotReadOnly } from "~/BaseEditor/config/IsNotReadOnly.js";
 import { IsReadOnly } from "~/BaseEditor/config/IsReadOnly.js";
-
-export interface PageSettingsElementConfig {
-    name: string;
-    element: JSX.Element;
-}
-
-export interface PageSettingsGroupConfig {
-    name: string;
-    title?: string;
-    description?: string;
-    icon?: React.ReactNode;
-    elements: PageSettingsElementConfig[];
-}
-
-export interface EditorPageSettings {
-    groups: PageSettingsGroupConfig[];
-    viewMode: "dialog" | "drawer";
-}
+import { ElementOverlay } from "./ElementOverlay.js";
 
 interface EditorConfig {
     elements: ElementConfig[];
     inputRenderers: ElementInputConfig[];
-    pageSettings: EditorPageSettings;
 }
 
 const base = createConfigurableComponent<EditorConfig>("DocumentEditor");
@@ -78,6 +59,10 @@ export const EditorConfigComponents = {
      */
     ElementActions,
     /**
+     * Customize ElementOverlay
+     */
+    ElementOverlay,
+    /**
      * Access full editor config. WARNING: very low-level, we don't recommend using this directly!
      */
     useEditorConfig
@@ -87,15 +72,12 @@ export const EditorConfig = Object.assign(base.Config, EditorConfigComponents);
 
 export const EditorWithConfig = Object.assign(base.WithConfig, { displayName: "EditorWithConfig" });
 
-export function useEditorConfig() {
-    const config = base.useConfig();
+export function useEditorConfig<TConfig = EditorConfig>() {
+    const { elements, inputRenderers, ...rest } = base.useConfig<TConfig & EditorConfig>();
 
     return {
-        elements: config.elements || [],
-        inputRenderers: config.inputRenderers || [],
-        pageSettings: {
-            groups: config.pageSettings.groups ?? [],
-            viewMode: config.pageSettings.viewMode ?? "dialog"
-        }
+        elements: elements || [],
+        inputRenderers: inputRenderers || [],
+        ...rest
     };
 }

--- a/packages/app-website-builder/src/BaseEditor/config/ElementOverlay.tsx
+++ b/packages/app-website-builder/src/BaseEditor/config/ElementOverlay.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Element as BaseElement, type ElementProps as BaseElementProps } from "./Element.js";
+import { Elements as BaseElements } from "./Elements.js";
+import { useElementOverlay } from "~/BaseEditor/hooks/useElementOverlay.js";
+
+export type ElementProps = Pick<BaseElementProps, "name" | "element">;
+
+const Element = ({ name, element }: ElementProps) => {
+    return <BaseElement name={name} element={element} scope={"elementOverlay"} />;
+};
+
+const Elements = () => {
+    return <BaseElements scope={"elementOverlay"} />;
+};
+
+export interface ElementOverlayContainerProps {
+    position: {
+        top?: number;
+        left?: number;
+        bottom?: number;
+        right?: number;
+    };
+    children: React.ReactNode;
+}
+
+const empty = undefined;
+
+const Container = ({ position, children }: ElementOverlayContainerProps) => {
+    const { box } = useElementOverlay();
+
+    const top = position.top !== empty ? box.top + position.top : empty;
+    const left = position.left !== empty ? box.left + position.left : empty;
+    const bottom = position.bottom !== empty ? box.top + box.height - position.bottom : empty;
+    const right = position.right !== empty ? box.left + box.width - position.right : empty;
+
+    return (
+        <div
+            data-role={"element-overlay"}
+            className={"absolute pointer-events-auto"}
+            style={{ top: top ?? bottom, left: left ?? right, zIndex: 100 + box.depth + 100 }}
+        >
+            {children}
+        </div>
+    );
+};
+
+export const ElementOverlay = {
+    Element: Object.assign(Element, { Container }),
+    Elements
+};

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlay.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlay.tsx
@@ -5,121 +5,117 @@ import type { Box } from "../Box.js";
 import { $highlightElement, $selectElement } from "~/editorSdk/utils/index.js";
 import { Draggable } from "~/BaseEditor/components/Draggable.js";
 import { useIsDragging } from "~/BaseEditor/defaultConfig/Content/Preview/useIsDragging.js";
-import { useElementComponentManifest } from "~/BaseEditor/defaultConfig/Content/Preview/useElementComponentManifest.js";
 import { useStyles } from "~/BaseEditor/defaultConfig/Sidebar/StyleSettings/useStyles.js";
+import { useElementOverlay } from "./ElementOverlayProvider.js";
 
-interface ElementOverlayProps {
-    elementId: string;
-    isSelected: boolean;
-    isHighlighted: boolean;
-    previewBox: Box;
-    editorBox: Box;
-}
+export const ElementOverlay = React.memo(() => {
+    const editor = useDocumentEditor();
+    const {
+        elementId,
+        isSelected,
+        isHighlighted,
+        componentManifest,
+        box: previewBox
+    } = useElementOverlay();
 
-export const ElementOverlay = React.memo(
-    ({ previewBox, elementId, isSelected, isHighlighted }: ElementOverlayProps) => {
-        const editor = useDocumentEditor();
-        const componentManifest = useElementComponentManifest(previewBox.id);
+    const onClick = useCallback((event: React.MouseEvent) => {
+        event.stopPropagation();
+        $selectElement(editor, elementId);
+    }, []);
 
-        const onClick = useCallback((event: React.MouseEvent) => {
-            event.stopPropagation();
-            $selectElement(editor, elementId);
-        }, []);
+    const setHighlighted = useCallback((event: React.MouseEvent) => {
+        event.stopPropagation();
+        $highlightElement(editor, elementId);
+    }, []);
 
-        const setHighlighted = useCallback((event: React.MouseEvent) => {
-            event.stopPropagation();
-            $highlightElement(editor, elementId);
-        }, []);
-
-        const unsetHighlighted = useCallback((event: React.MouseEvent) => {
-            event.stopPropagation();
-            $highlightElement(editor, null);
-        }, []);
-
-        const dnd = useIsDragging();
-
-        if (!componentManifest) {
-            return null;
+    const unsetHighlighted = useCallback((event: React.MouseEvent) => {
+        if ((event.relatedTarget as Element)?.closest('[data-role="element-overlay"]')) {
+            return;
         }
+        event.stopPropagation();
+        $highlightElement(editor, null);
+    }, []);
 
-        const pointerEvents = "auto";
-        const componentName = componentManifest.label ?? componentManifest.name;
-        const boxState = isSelected ? "active" : isHighlighted && !dnd ? "hover" : null;
+    const dnd = useIsDragging();
 
-        return (
-            <Draggable
-                type="ELEMENT"
-                item={{ id: elementId, componentName: componentManifest.name }}
-                canDrag={componentManifest.canDrag !== false}
-            >
-                {({ isDragging, dragRef }) =>
-                    dragRef(
+    if (!componentManifest) {
+        return null;
+    }
+
+    const pointerEvents = "auto";
+    const componentName = componentManifest.label ?? componentManifest.name;
+    const boxState = isSelected ? "active" : isHighlighted && !dnd ? "hover" : null;
+
+    return (
+        <Draggable
+            type="ELEMENT"
+            item={{ id: elementId, componentName: componentManifest.name }}
+            canDrag={componentManifest.canDrag !== false}
+        >
+            {({ isDragging, dragRef }) =>
+                dragRef(
+                    <div
+                        data-element-id={elementId}
+                        onMouseEnter={setHighlighted}
+                        onMouseLeave={unsetHighlighted}
+                        style={{
+                            position: "absolute",
+                            pointerEvents,
+                            zIndex: 100 + previewBox.depth,
+                            top: previewBox.top,
+                            left: previewBox.left,
+                            width: previewBox.width,
+                            height: previewBox.height,
+                            opacity: isDragging ? 0.7 : 1
+                        }}
+                    >
                         <div
+                            className={cn(
+                                "absolute box-border text-right top-0 left-0 w-full h-full",
+                                "data-[state=hover]:border-md data-[state=hover]:border-success-default",
+                                "data-[state=active]:border-md data-[state=active]:border-accent-default"
+                            )}
+                            onClick={onClick}
+                            data-state={boxState}
                             data-element-id={elementId}
-                            onMouseEnter={setHighlighted}
-                            onMouseLeave={unsetHighlighted}
+                            data-role={"element-overlay"}
+                            data-depth={previewBox.depth}
+                        >
+                            {isSelected ? (
+                                <AllMarginStripes elementId={elementId} previewBox={previewBox} />
+                            ) : null}
+                        </div>
+                        <div
+                            data-role={"opacity-overlay"}
+                            className={"pointer-events-none absolute top-0 left-0 bg-white"}
                             style={{
-                                position: "absolute",
-                                pointerEvents,
                                 zIndex: 100 + previewBox.depth,
-                                top: previewBox.top,
-                                left: previewBox.left,
                                 width: previewBox.width,
                                 height: previewBox.height,
-                                opacity: isDragging ? 0.7 : 1
+                                opacity: isDragging ? 0.7 : 0
                             }}
+                        ></div>
+                        <div
+                            data-role={"element-overlay-label"}
+                            data-label-for={previewBox.id}
+                            data-state={isDragging ? "dragging" : boxState}
+                            onClick={onClick}
+                            className={cn(
+                                "absolute text-sm text-neutral-light p-xs opacity-0 pointer-events-auto",
+                                "data-[state=hover]:bg-success data-[state=hover]:opacity-100",
+                                "data-[state=active]:bg-primary data-[state=active]:opacity-100",
+                                "data-[state=dragging]:opacity-30"
+                            )}
+                            style={{ top: -24 }}
                         >
-                            <div
-                                className={cn(
-                                    "absolute box-border text-right top-0 left-0 w-full h-full",
-                                    "data-[state=hover]:border-md data-[state=hover]:border-success-default",
-                                    "data-[state=active]:border-md data-[state=active]:border-accent-default"
-                                )}
-                                onClick={onClick}
-                                data-state={boxState}
-                                data-element-id={elementId}
-                                data-role={"element-overlay"}
-                                data-depth={previewBox.depth}
-                            >
-                                {isSelected ? (
-                                    <AllMarginStripes
-                                        elementId={elementId}
-                                        previewBox={previewBox}
-                                    />
-                                ) : null}
-                            </div>
-                            <div
-                                data-role={"opacity-overlay"}
-                                className={"pointer-events-none absolute top-0 left-0 bg-white"}
-                                style={{
-                                    zIndex: 100 + previewBox.depth,
-                                    width: previewBox.width,
-                                    height: previewBox.height,
-                                    opacity: isDragging ? 0.7 : 0
-                                }}
-                            ></div>
-                            <div
-                                data-role={"element-overlay-label"}
-                                data-label-for={previewBox.id}
-                                data-state={isDragging ? "dragging" : boxState}
-                                onClick={onClick}
-                                className={cn(
-                                    "absolute text-sm text-neutral-light p-xs opacity-0 pointer-events-auto",
-                                    "data-[state=hover]:bg-success data-[state=hover]:opacity-100",
-                                    "data-[state=active]:bg-primary data-[state=active]:opacity-100",
-                                    "data-[state=dragging]:opacity-30"
-                                )}
-                                style={{ top: -24 }}
-                            >
-                                {componentName}
-                            </div>
+                            {componentName}
                         </div>
-                    )
-                }
-            </Draggable>
-        );
-    }
-);
+                    </div>
+                )
+            }
+        </Draggable>
+    );
+});
 
 ElementOverlay.displayName = "ElementOverlay";
 

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlayProvider.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlayProvider.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { createGenericContext } from "@webiny/app";
+import type { ComponentManifest } from "@webiny/website-builder-sdk";
+import { useElementComponentManifest } from "~/BaseEditor/defaultConfig/Content/Preview/useElementComponentManifest.js";
+import type { Box } from "../Box.js";
+
+interface ElementOverlayContext {
+    elementId: string;
+    isSelected: boolean;
+    isHighlighted: boolean;
+    box: Box;
+    componentManifest: ComponentManifest;
+}
+
+export type ElementOverlayProviderProps = Pick<
+    ElementOverlayContext,
+    "elementId" | "isSelected" | "isHighlighted" | "box"
+> & {
+    children: React.ReactNode;
+};
+
+const context = createGenericContext<ElementOverlayContext>("ElementOverlayProvider");
+
+export const ElementOverlayProvider = (props: ElementOverlayProviderProps) => {
+    const { children } = props;
+    const componentManifest = useElementComponentManifest(props.elementId);
+
+    if (!componentManifest) {
+        return null;
+    }
+
+    return (
+        <context.Provider {...props} componentManifest={componentManifest}>
+            {children}
+        </context.Provider>
+    );
+};
+export const useElementOverlay = context.useHook;

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlays.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlays.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useRef } from "react";
+import React, { useCallback, useRef } from "react";
 import { observer } from "mobx-react-lite";
 import { useDrop } from "react-dnd";
 import styled from "@emotion/styled";

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlays.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlays.tsx
@@ -18,8 +18,9 @@ import { ElementDropLines } from "./ElementDropLines.js";
 import { DropBox } from "./DropBox.js";
 import { useDropZoneManager } from "../DropZoneManagerProvider.js";
 import { mergeRefs } from "../mergeRefs.js";
-import { Commands } from "~/BaseEditor/index.js";
+import { Commands, EditorConfig } from "~/BaseEditor/index.js";
 import type { Editor } from "~/editorSdk/Editor.js";
+import { ElementOverlayProvider } from "~/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlayProvider.js";
 
 const OverlayContainer = styled("div")({
     overflow: "hidden",
@@ -128,20 +129,21 @@ export const ElementOverlays = observer(() => {
     return (
         <OverlayContainer ref={mergeRefs(dropRef)} style={viewportContainer}>
             {boxes.preview.filter(filterElements).map(box => (
-                <Fragment key={box.id}>
-                    <ElementOverlay
-                        elementId={box.id}
-                        isSelected={selectedElement === box.id}
-                        isHighlighted={highlightedElement === box.id}
-                        previewBox={box}
-                        editorBox={boxes.editor.get(box.id)!}
-                    />
+                <ElementOverlayProvider
+                    key={box.id}
+                    elementId={box.id}
+                    isSelected={selectedElement === box.id}
+                    isHighlighted={highlightedElement === box.id}
+                    box={box}
+                >
+                    <ElementOverlay />
                     <ElementDropLines
                         isFirst={box.parentIndex === 0}
                         previewBox={box}
                         editorBox={boxes.editor.get(box.id)!}
                     />
-                </Fragment>
+                    <EditorConfig.ElementOverlay.Elements />
+                </ElementOverlayProvider>
             ))}
             {slots.map(slot => (
                 <DropBox key={slot.id} box={slot} onDrop={onDrop} />

--- a/packages/app-website-builder/src/BaseEditor/hooks/useElementOverlay.ts
+++ b/packages/app-website-builder/src/BaseEditor/hooks/useElementOverlay.ts
@@ -1,0 +1,1 @@
+export { useElementOverlay } from "~/BaseEditor/defaultConfig/Content/Preview/Overlays/ElementOverlayProvider.js";

--- a/packages/app-website-builder/src/BaseEditor/hooks/useHighlightedElement.ts
+++ b/packages/app-website-builder/src/BaseEditor/hooks/useHighlightedElement.ts
@@ -1,0 +1,30 @@
+import { autorun, toJS } from "mobx";
+import { useEffect, useState } from "react";
+import { useDocumentEditor } from "~/DocumentEditor/index.js";
+import type { DocumentElement } from "@webiny/website-builder-sdk";
+import deepEqual from "deep-equal";
+
+export const useHighlightedElement = () => {
+    const [highlightedElement, setHighlightedElement] = useState<DocumentElement | null>(null);
+    const editor = useDocumentEditor();
+
+    useEffect(() => {
+        return autorun(() => {
+            const editorState = editor.getEditorState().read();
+            const documentState = editor.getDocumentState().read();
+
+            const elementId = editorState.highlightedElement;
+
+            if (elementId) {
+                const newElement = toJS(documentState.elements[elementId]);
+                if (!deepEqual(newElement, highlightedElement)) {
+                    setHighlightedElement(newElement);
+                }
+            } else {
+                setHighlightedElement(null);
+            }
+        });
+    }, [highlightedElement]);
+
+    return highlightedElement;
+};

--- a/packages/app-website-builder/src/exports/admin/website-builder/page/editor.ts
+++ b/packages/app-website-builder/src/exports/admin/website-builder/page/editor.ts
@@ -1,3 +1,4 @@
+export { usePageEditorConfig } from "~/modules/pages/PageEditor/usePageEditorConfig.js";
 export { PageEditorConfig } from "~/modules/pages/PageEditor/PageEditorConfig.js";
 export { createCommand } from "~/editorSdk/createCommand.js";
 export { Commands } from "~/BaseEditor/index.js";
@@ -5,11 +6,13 @@ export { useSelectFromEditor } from "~/BaseEditor/hooks/useSelectFromEditor.js";
 export { useSelectFromDocument } from "~/BaseEditor/hooks/useSelectFromDocument.js";
 export { useDocumentEditor } from "~/DocumentEditor/index.js";
 export { useActiveElement } from "~/BaseEditor/hooks/useActiveElement.js";
+export { useHighlightedElement } from "~/BaseEditor/hooks/useHighlightedElement.js";
 export { useComponent } from "~/BaseEditor/hooks/useComponent.js";
 export { useElementInputs } from "~/BaseEditor/hooks/useElementInputs.js";
 export { useCreateElement } from "~/BaseEditor/hooks/useCreateElement.js";
 export { useDeleteElement } from "~/BaseEditor/hooks/useDeleteElement.js";
 export { useUpdateElement } from "~/BaseEditor/hooks/useUpdateElement.js";
+export { useElementOverlay } from "~/BaseEditor/hooks/useElementOverlay.js";
 export { ElementInputs } from "~/BaseEditor/defaultConfig/Sidebar/ElementSettings/ElementInputs.js";
 
 export { $selectElement } from "~/editorSdk/utils/index.js";

--- a/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/PageSettingsDialog.tsx
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/PageSettingsDialog.tsx
@@ -2,11 +2,11 @@ import React, { useEffect } from "react";
 import { useDialogs } from "@webiny/app-admin";
 import { SettingsDialogBody } from "./SettingsDialogBody.js";
 import type { PageSettingsOverlayProps } from "~/modules/pages/PageEditor/TopBar/SettingsButton.js";
-import { useEditorConfig } from "~/BaseEditor/index.js";
+import { usePageEditorConfig } from "~/modules/pages/PageEditor/usePageEditorConfig.js";
 
 export const PageSettingsDialog = ({ open, data, onClose, onSave }: PageSettingsOverlayProps) => {
     const dialogs = useDialogs();
-    const { pageSettings } = useEditorConfig();
+    const { pageSettings } = usePageEditorConfig();
 
     const showDialog = () => {
         dialogs.showDialog({

--- a/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/PageSettingsDrawer.tsx
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/PageSettingsDrawer.tsx
@@ -1,12 +1,12 @@
 import React, { Fragment, useRef, useState } from "react";
 import { Form, type FormAPI } from "@webiny/form";
 import { Drawer, Heading, Text, List, Grid } from "@webiny/admin-ui";
-import { useEditorConfig } from "~/BaseEditor/index.js";
 import type { PageSettingsOverlayProps } from "~/modules/pages/PageEditor/TopBar/SettingsButton.js";
+import { usePageEditorConfig } from "~/modules/pages/PageEditor/usePageEditorConfig.js";
 
 export const PageSettingsDrawer = ({ open, data, onSave, onClose }: PageSettingsOverlayProps) => {
     const formRef = useRef<FormAPI | undefined>();
-    const { pageSettings } = useEditorConfig();
+    const { pageSettings } = usePageEditorConfig();
 
     const groups = pageSettings.groups;
 

--- a/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/SettingsDialogBody.tsx
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/Settings/SettingsDialogBody.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tabs, Grid } from "@webiny/admin-ui";
-import type { EditorPageSettings } from "~/BaseEditor/index.js";
+import type { EditorPageSettings } from "~/modules/pages/PageEditor/usePageEditorConfig.js";
 
 export interface SettingsDialogBodyProps {
     pageSettings: EditorPageSettings;

--- a/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/SettingsButton.tsx
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/TopBar/SettingsButton.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as SettingsIcon } from "@webiny/icons/settings.svg";
 import type { GenericFormData } from "@webiny/form";
 import { useDocumentEditor } from "~/DocumentEditor/index.js";
 import { useSelectFromDocument } from "~/BaseEditor/hooks/useSelectFromDocument.js";
-import { useEditorConfig } from "~/BaseEditor/index.js";
+import { usePageEditorConfig } from "~/modules/pages/PageEditor/usePageEditorConfig.js";
 import { PageSettingsDrawer } from "./Settings/PageSettingsDrawer.js";
 import { PageSettingsDialog } from "./Settings/PageSettingsDialog.js";
 
@@ -19,7 +19,7 @@ export interface PageSettingsOverlayProps {
 
 export const SettingsButton = () => {
     const editor = useDocumentEditor();
-    const { pageSettings } = useEditorConfig();
+    const { pageSettings } = usePageEditorConfig();
     const [isOverlayOpen, setOverlayOpen] = useState(false);
 
     const openOverlay = useCallback(() => {

--- a/packages/app-website-builder/src/modules/pages/PageEditor/usePageEditorConfig.ts
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/usePageEditorConfig.ts
@@ -1,0 +1,35 @@
+import { useEditorConfig } from "~/BaseEditor/index.js";
+
+export interface PageSettingsElementConfig {
+    name: string;
+    element: JSX.Element;
+}
+
+export interface PageSettingsGroupConfig {
+    name: string;
+    title?: string;
+    description?: string;
+    icon?: React.ReactNode;
+    elements: PageSettingsElementConfig[];
+}
+
+export interface EditorPageSettings {
+    groups: PageSettingsGroupConfig[];
+    viewMode: "dialog" | "drawer";
+}
+
+interface PageEditorConfig {
+    pageSettings: EditorPageSettings;
+}
+
+export const usePageEditorConfig = (): PageEditorConfig => {
+    const config = useEditorConfig<PageEditorConfig>();
+
+    return {
+        ...config,
+        pageSettings: {
+            groups: config.pageSettings.groups ?? [],
+            viewMode: config.pageSettings.viewMode ?? "dialog"
+        }
+    };
+};

--- a/packages/webiny/src/admin/website-builder/page/editor.ts
+++ b/packages/webiny/src/admin/website-builder/page/editor.ts
@@ -1,3 +1,4 @@
+export { usePageEditorConfig } from "@webiny/app-website-builder/modules/pages/PageEditor/usePageEditorConfig.js";
 export { PageEditorConfig } from "@webiny/app-website-builder/modules/pages/PageEditor/PageEditorConfig.js";
 export { createCommand } from "@webiny/app-website-builder/editorSdk/createCommand.js";
 export { Commands } from "@webiny/app-website-builder/BaseEditor/index.js";
@@ -5,11 +6,13 @@ export { useSelectFromEditor } from "@webiny/app-website-builder/BaseEditor/hook
 export { useSelectFromDocument } from "@webiny/app-website-builder/BaseEditor/hooks/useSelectFromDocument.js";
 export { useDocumentEditor } from "@webiny/app-website-builder/DocumentEditor/index.js";
 export { useActiveElement } from "@webiny/app-website-builder/BaseEditor/hooks/useActiveElement.js";
+export { useHighlightedElement } from "@webiny/app-website-builder/BaseEditor/hooks/useHighlightedElement.js";
 export { useComponent } from "@webiny/app-website-builder/BaseEditor/hooks/useComponent.js";
 export { useElementInputs } from "@webiny/app-website-builder/BaseEditor/hooks/useElementInputs.js";
 export { useCreateElement } from "@webiny/app-website-builder/BaseEditor/hooks/useCreateElement.js";
 export { useDeleteElement } from "@webiny/app-website-builder/BaseEditor/hooks/useDeleteElement.js";
 export { useUpdateElement } from "@webiny/app-website-builder/BaseEditor/hooks/useUpdateElement.js";
+export { useElementOverlay } from "@webiny/app-website-builder/BaseEditor/hooks/useElementOverlay.js";
 export { ElementInputs } from "@webiny/app-website-builder/BaseEditor/defaultConfig/Sidebar/ElementSettings/ElementInputs.js";
 export { $selectElement } from "@webiny/app-website-builder/editorSdk/utils/index.js";
 export { $deselectElement } from "@webiny/app-website-builder/editorSdk/utils/index.js";


### PR DESCRIPTION
## Summary

- Add `ElementOverlay` config component to `EditorConfig`, allowing extensions to inject custom actions into element overlays (e.g., edit buttons positioned relative to the element box)
- Extract `ElementOverlayProvider` context so overlay state (`elementId`, `isHighlighted`, `isSelected`, `box`, `componentManifest`) is available to custom overlay elements
- Move `pageSettings` config out of the base `EditorConfig` into a dedicated `usePageEditorConfig` hook, keeping the base editor generic
- Export new hooks: `useElementOverlay`, `useHighlightedElement`, `usePageEditorConfig`
- Add search/filter to Webiny DevTools panel and rename plugin to "Webiny DevTools"

<img width="936" height="775" alt="image" src="https://github.com/user-attachments/assets/1f363b6e-6ba9-4791-a40f-a6604d609ad3" />

