### PR TITLE
fix(app-headless-cms): unnecessary rerendering

### DIFF
--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/FullScreenContentEntry/FullScreenContentEntry.tsx
@@ -1,20 +1,18 @@
 import React, { useState } from "react";
 import { createPortal } from "react-dom";
-import { useContentEntry } from "~/admin/views/contentEntries/hooks/index.js";
 import { RevisionListDrawer } from "./RevisionListDrawer/index.js";
 import { FullScreenContentEntryHeaderLeft } from "./FullScreenContentEntryHeaderLeft.js";
 import * as FSE from "./FullScreenContentEntry.styled.js";
 import { FullScreenContentEntryProvider } from "./useFullScreenContentEntry.js";
 import { ContentEntryEditorConfig } from "~/ContentEntryEditorConfig.js";
 import { useContentEntryEditorConfig } from "~/admin/config/contentEntries/index.js";
-import { HeaderBar, OverlayLoader } from "@webiny/admin-ui";
+import { HeaderBar } from "@webiny/admin-ui";
 
 const { ContentEntry } = ContentEntryEditorConfig;
 
 const FullScreenContentEntryDecorator = ContentEntry.createDecorator(Original => {
     return function ContentEntry() {
         const { width } = useContentEntryEditorConfig();
-        const { loading } = useContentEntry();
         const [isRevisionListOpen, openRevisionList] = useState<boolean>(false);
 
         return (
@@ -33,11 +31,10 @@ const FullScreenContentEntryDecorator = ContentEntry.createDecorator(Original =>
                             />
                         }
                     />
-                    {loading && <OverlayLoader text={"Loading entry..."} className={"z-10"} />}
                     <FSE.Content>
                         <FSE.ContentFormWrapper>
                             <FSE.ContentFormInner width={width}>
-                                {loading ? null : <Original />}
+                                <Original />
                             </FSE.ContentFormInner>
                         </FSE.ContentFormWrapper>
                     </FSE.Content>

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -3,14 +3,16 @@
  */
 import React, { useCallback, useMemo, useState } from "react";
 import { TimeAgo } from "@webiny/ui/TimeAgo/index.js";
-import { useRouter, SearchUI } from "@webiny/app-admin";
+import { SearchUI, useRouter } from "@webiny/app-admin";
 import { ReactComponent as AddIcon } from "@webiny/icons/add.svg";
-import { ReactComponent as DownloadFileIcon } from "@webiny/icons/file_download.svg";
+import {
+    ReactComponent as DownloadFileIcon,
+    ReactComponent as ExportIcon
+} from "@webiny/icons/file_download.svg";
 import { ReactComponent as UploadFileIcon } from "@webiny/icons/file_upload.svg";
 import { ReactComponent as ListIcon } from "@webiny/icons/list.svg";
 import { ReactComponent as EditIcon } from "@webiny/icons/edit.svg";
 import { ReactComponent as MoreVertIcon } from "@webiny/icons/more_vert.svg";
-import { ReactComponent as ExportIcon } from "@webiny/icons/file_download.svg";
 import { ReactComponent as DeleteIcon } from "@webiny/icons/delete.svg";
 import { ReactComponent as CloneIcon } from "@webiny/icons/flip_to_front.svg";
 import { useModels } from "../../hooks/index.js";
@@ -372,12 +374,14 @@ const ContentModelsDataList = ({
                     </UIL.List>
                 )}
             </UIL.DataList>
-            <FullyDeleteModelDialog
-                model={modelToBeDeleted}
-                onClose={() => {
-                    setModelToBeDeleted(null);
-                }}
-            />
+            {modelToBeDeleted ? (
+                <FullyDeleteModelDialog
+                    model={modelToBeDeleted}
+                    onClose={() => {
+                        setModelToBeDeleted(null);
+                    }}
+                />
+            ) : null}
         </>
     );
 };

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/FullyDeleteModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/FullyDeleteModelDialog.tsx
@@ -17,7 +17,7 @@ import { useDialogState } from "./dialog/state.js";
 import { updateModelInCache } from "~/admin/views/contentModels/cache.js";
 
 export interface FullyDeleteModelDialogProps {
-    model: CmsModel | null;
+    model: CmsModel;
     onClose: () => void;
 }
 
@@ -83,11 +83,11 @@ export const FullyDeleteModelDialog = ({
     }, [state]);
 
     const title = useMemo(() => {
-        if (model?.plugin) {
+        if (model.plugin) {
             return "Delete all entries of the model?";
         }
         return "Delete content model and all its entries?";
-    }, [model?.modelId]);
+    }, [model.modelId]);
 
     const primaryButtonText = useMemo(() => {
         if (status === FullyDeleteModelStateStatus.UNDERSTOOD) {

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/state.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/state.tsx
@@ -4,7 +4,7 @@ import { FullyDeleteModelStateStatus } from "../types.js";
 import type { CmsErrorResponse, CmsModel } from "@webiny/app-headless-cms-common/types/index.js";
 import type { IDeleteCmsModelTask } from "~/admin/viewsGraphql.js";
 
-const getDefaultState = (model: CmsModel):IFullyDeleteModelState => {
+const getDefaultState = (model: CmsModel): IFullyDeleteModelState => {
     return {
         confirmation: "",
         status: FullyDeleteModelStateStatus.NONE,

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/state.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/dialog/state.tsx
@@ -4,23 +4,27 @@ import { FullyDeleteModelStateStatus } from "../types.js";
 import type { CmsErrorResponse, CmsModel } from "@webiny/app-headless-cms-common/types/index.js";
 import type { IDeleteCmsModelTask } from "~/admin/viewsGraphql.js";
 
-const defaultState: IFullyDeleteModelState = {
-    confirmation: "",
-    status: FullyDeleteModelStateStatus.NONE,
-    model: null,
-    error: null,
-    task: null
+const getDefaultState = (model: CmsModel):IFullyDeleteModelState => {
+    return {
+        confirmation: "",
+        status: FullyDeleteModelStateStatus.NONE,
+        model,
+        error: null,
+        task: null
+    };
 };
 
-export const useDialogState = (input: CmsModel | null) => {
-    const [state, setState] = useState(defaultState);
+export const useDialogState = (input: CmsModel) => {
+    const [state, setState] = useState(() => {
+        return getDefaultState(input);
+    });
 
     const reset = useCallback(() => {
-        setState(defaultState);
-    }, [setState]);
+        setState(getDefaultState(input));
+    }, [input]);
 
     const setModel = useCallback(
-        (model: CmsModel | null) => {
+        (model: CmsModel) => {
             setState(prev => {
                 return {
                     ...prev,

--- a/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/types.ts
+++ b/packages/app-headless-cms/src/admin/views/contentModels/fullDelete/types.ts
@@ -12,7 +12,7 @@ export enum FullyDeleteModelStateStatus {
 export interface IFullyDeleteModelState {
     status: FullyDeleteModelStateStatus;
     confirmation: string;
-    model: CmsModel | null;
+    model: CmsModel;
     error: CmsErrorResponse | null;
     task: IDeleteCmsModelTask | null;
 }


### PR DESCRIPTION
## Changes
Remove unnecessary Content Entry Form rendering on entry save.
This resulted in DynamicZone and Object fields to render collapsed.

## How Has This Been Tested?
Jest and manually.