### PR TITLE
feat(sdk): allow dyn tokens

### DIFF
--- a/packages/app-sdk-playground/src/plugins/useCodeExecution.ts
+++ b/packages/app-sdk-playground/src/plugins/useCodeExecution.ts
@@ -1,11 +1,13 @@
-import { useCallback, useState } from "react";
-import type { MutableRefObject } from "react";
-import type { editor } from "monaco-editor";
 import { useSnackbar, useTenantContext } from "@webiny/app-admin";
+import { AuthenticationContextFeature } from "@webiny/app-admin/features/security/AuthenticationContext/feature.js";
+import { useFeature } from "@webiny/app";
 import { config as appConfig } from "@webiny/app/config.js";
 import { Webiny } from "@webiny/sdk";
-import type { ConsoleMessage } from "./types.js";
+import type { editor } from "monaco-editor";
+import type { MutableRefObject } from "react";
+import { useCallback, useState } from "react";
 import { createCustomConsole } from "./consoleCapture.js";
+import type { ConsoleMessage } from "./types.js";
 
 export function useCodeExecution(
     code: string,
@@ -15,6 +17,7 @@ export function useCodeExecution(
     const [isRunning, setIsRunning] = useState(false);
     const { showSnackbar } = useSnackbar();
     const { tenant } = useTenantContext();
+    const { authenticationContext } = useFeature(AuthenticationContextFeature);
 
     const handleRun = useCallback(async () => {
         const apiUrl = appConfig.getKey("API_URL", process.env.REACT_APP_API_URL) as string;
@@ -33,17 +36,10 @@ export function useCodeExecution(
         const customConsole = createCustomConsole(messages, setOutput);
 
         try {
-            // Create SDK instance with current tenant and API endpoint.
-            // Note: The SDK will use cookie-based authentication (credentials: "include")
-            // when running in the browser, as the admin app sets up the necessary cookies.
             const sdk = new Webiny({
                 endpoint: apiUrl,
                 tenant: tenant || undefined,
-                headers: {
-                    // Add any additional headers if needed.
-                    // The Authorization header with Bearer token is handled via cookies
-                    // when running within the admin app context.
-                }
+                token: () => authenticationContext.getIdToken() as Promise<string>
             });
 
             // Wrap code in async function to allow top-level await.
@@ -73,7 +69,7 @@ export function useCodeExecution(
         } finally {
             setIsRunning(false);
         }
-    }, [code, editorRef, showSnackbar, tenant]);
+    }, [code, editorRef, showSnackbar, tenant, authenticationContext]);
 
     return {
         output,

--- a/packages/sdk/src/methods/executeGraphQL.ts
+++ b/packages/sdk/src/methods/executeGraphQL.ts
@@ -23,7 +23,8 @@ export async function executeGraphQL(
 
         // Only add Authorization header if token is provided and not already set in custom headers.
         if (config.token && !headers.Authorization) {
-            headers.Authorization = `Bearer ${config.token}`;
+            const token = typeof config.token === "function" ? await config.token() : config.token;
+            headers.Authorization = `Bearer ${token}`;
         }
 
         response = await fetchFn(url, {

--- a/packages/sdk/src/methods/executeGraphQL.ts
+++ b/packages/sdk/src/methods/executeGraphQL.ts
@@ -30,8 +30,7 @@ export async function executeGraphQL(
         response = await fetchFn(url, {
             method: "POST",
             headers,
-            body,
-            credentials: "include"
+            body
         });
     } catch (error) {
         return Result.fail(

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,5 +1,7 @@
+export type TokenProvider = string | (() => string | Promise<string>);
+
 export interface WebinyConfig {
-    token?: string;
+    token?: TokenProvider;
     endpoint: string;
     tenant?: string;
     headers?: Record<string, string>;


### PR DESCRIPTION
## What changed

The SDK's `token` parameter now accepts either a plain string or an async function that returns a string. The SDK playground in the admin app now uses a live token provider instead of cookie-based authentication.

## Why

The admin app's identity tokens expire and need to be refreshed. Passing a static string token to the SDK meant it would use a stale token after expiry. By accepting a token provider function, the SDK always fetches a fresh token on each request — which is required when using the SDK inside the admin app.

## How

- `packages/sdk/src/types.ts`: Added a `TokenProvider` type (`string | (() => string | Promise<string>)`) and updated `WebinyConfig.token` to use it.
- `packages/sdk/src/methods/executeGraphQL.ts`: Before setting the `Authorization` header, the token is resolved — called if it's a function, used directly if it's a string. Also removed the hardcoded `credentials: "include"` from the fetch call.
- `packages/app-sdk-playground/src/plugins/useCodeExecution.ts`: Uses `useFeature(AuthenticationContextFeature)` to get `authenticationContext`, then passes `() => authenticationContext.getIdToken()` as the `token` provider when instantiating the SDK.

## Changelog

**SDK Token Parameter Now Supports Async Token Providers**

The SDK's token parameter previously only accepted a plain string. It now also accepts an async function that returns a token string, allowing the token to be refreshed on every request. This enables the SDK to be used in contexts where tokens expire, such as inside the admin app.