### PR TITLE
feat: add command palette with DI-based command registration

### DIFF
--- a/extensions/commandPalette/CommandPalette.tsx
+++ b/extensions/commandPalette/CommandPalette.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Admin } from "webiny/extensions";
+
+export const CommandPalette = () => {
+    return (
+        <>
+            <Admin.Extension
+                src={"@/extensions/commandPalette/commands/simpleCommand/SimpleCommand.tsx"}
+            />
+            <Admin.Extension
+                src={"@/extensions/commandPalette/commands/formCommand/FormCommand.tsx"}
+            />
+        </>
+    );
+};

--- a/extensions/commandPalette/commands/formCommand/FormCommand.tsx
+++ b/extensions/commandPalette/commands/formCommand/FormCommand.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Command, RegisterFeature, createFeature } from "webiny/admin";
+import { SendMessageDetailView } from "./SendMessageDetailView.js";
+
+interface SendMessageParams {
+    recipient: string;
+    message: string;
+}
+
+class SendMessageCommand implements Command.Interface {
+    name = "send-message";
+    label = "Send Message";
+    description = "Send a message to someone";
+    category = "Demo";
+    keywords = ["send", "message", "form"];
+    shortcut = "cmd+shift+m";
+    detailView = SendMessageDetailView;
+
+    execute(params?: unknown) {
+        const { recipient, message } = params as SendMessageParams;
+        alert(`Message sent to ${recipient}: "${message}"`);
+    }
+}
+
+const SendMessageCommandImpl = Command.createImplementation({
+    implementation: SendMessageCommand,
+    dependencies: []
+});
+
+const SendMessageCommandFeature = createFeature({
+    name: "SendMessageCommand",
+    register(container) {
+        container.register(SendMessageCommandImpl);
+    }
+});
+
+export default () => {
+    return <RegisterFeature feature={SendMessageCommandFeature} />;
+};

--- a/extensions/commandPalette/commands/formCommand/SendMessageDetailView.tsx
+++ b/extensions/commandPalette/commands/formCommand/SendMessageDetailView.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Form, Bind } from "webiny/admin/form";
+import { Input, Button } from "webiny/admin/ui";
+import { Command } from "webiny/admin";
+
+interface FormData {
+    recipient: string;
+    message: string;
+}
+
+export const SendMessageDetailView = ({ command, onClose }: Command.DetailProps) => {
+    return (
+        <Form<FormData>
+            data={{ recipient: "", message: "" }}
+            onSubmit={data => {
+                command.execute(data);
+                onClose();
+            }}
+        >
+            {({ submit }) => (
+                <div className="p-md space-y-md">
+                    <Bind name="recipient">
+                        <Input
+                            label="Recipient"
+                            placeholder="Enter recipient name"
+                            autoFocus={true}
+                        />
+                    </Bind>
+                    <Bind name="message">
+                        <Input label="Message" placeholder="Enter your message" />
+                    </Bind>
+                    <div className="flex justify-end gap-sm pt-sm">
+                        <Button variant="primary" onClick={submit}>
+                            Send
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </Form>
+    );
+};

--- a/extensions/commandPalette/commands/simpleCommand/SimpleCommand.tsx
+++ b/extensions/commandPalette/commands/simpleCommand/SimpleCommand.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Command, RegisterFeature, createFeature } from "webiny/admin";
+
+class SayHelloCommand implements Command.Interface {
+    name = "say-hello";
+    label = "Say Hello";
+    description = "Displays a greeting in the console";
+    category = "Demo";
+    keywords = ["hello", "greet", "demo"];
+
+    execute() {
+        alert("Hello from the Command Palette!");
+    }
+}
+
+const SayHelloCommandImpl = Command.createImplementation({
+    implementation: SayHelloCommand,
+    dependencies: []
+});
+
+const SayHelloCommandFeature = createFeature({
+    name: "SayHelloCommand",
+    register(container) {
+        container.register(SayHelloCommandImpl);
+    }
+});
+
+export default () => {
+    return <RegisterFeature feature={SayHelloCommandFeature} />;
+};

--- a/packages/admin-ui/src/CommandPalette/CommandPalette.tsx
+++ b/packages/admin-ui/src/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { ReactComponent as ArrowLeftIcon } from "@webiny/icons/arrow_back.svg";
+import { makeDecoratable, cn, withStaticProps } from "~/utils.js";
+import type { CommandPaletteProps } from "./types.js";
+import { CommandPaletteContent } from "./components/CommandPaletteContent.js";
+import { CommandPaletteSearch } from "./components/CommandPaletteSearch.js";
+import { CommandPaletteList } from "./components/CommandPaletteList.js";
+
+const CommandPaletteBase = ({
+    open,
+    onOpenChange,
+    commands,
+    detailView,
+    onSelectCommand,
+    onCancelCommand,
+    placeholder
+}: CommandPaletteProps) => {
+    const handleOpenChange = React.useCallback(
+        (nextOpen: boolean) => {
+            if (!nextOpen) {
+                onCancelCommand();
+            }
+            onOpenChange(nextOpen);
+        },
+        [onOpenChange, onCancelCommand]
+    );
+
+    return (
+        <CommandPaletteContent open={open} onOpenChange={handleOpenChange}>
+            {detailView ? (
+                <div>
+                    <div
+                        className={cn(
+                            "flex items-center gap-sm px-md py-sm border-b border-neutral-muted"
+                        )}
+                    >
+                        <button
+                            type="button"
+                            onClick={onCancelCommand}
+                            className={cn(
+                                "flex items-center justify-center w-lg h-lg rounded",
+                                "hover:bg-neutral-dimmed text-neutral-secondary",
+                                "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-default"
+                            )}
+                        >
+                            <ArrowLeftIcon className="w-md h-md fill-current" />
+                        </button>
+                        <div className="flex items-center gap-sm-extra min-w-0">
+                            {detailView.icon && (
+                                <span className="flex items-center justify-center w-md-plus h-md-plus shrink-0 fill-neutral-xstrong">
+                                    {detailView.icon}
+                                </span>
+                            )}
+                            <span className="text-md font-semibold text-neutral-primary truncate">
+                                {detailView.label}
+                            </span>
+                        </div>
+                    </div>
+                    {detailView.element}
+                </div>
+            ) : (
+                <CommandPrimitive className="flex flex-col outline-none">
+                    <CommandPaletteSearch placeholder={placeholder} />
+                    <CommandPaletteList commands={commands} onSelect={onSelectCommand} />
+                </CommandPrimitive>
+            )}
+        </CommandPaletteContent>
+    );
+};
+
+CommandPaletteBase.displayName = "CommandPalette";
+
+const DecoratableCommandPalette = makeDecoratable("CommandPalette", CommandPaletteBase);
+
+const CommandPalette = withStaticProps(DecoratableCommandPalette, {});
+
+export { CommandPalette, type CommandPaletteProps };

--- a/packages/admin-ui/src/CommandPalette/components/CommandPaletteContent.tsx
+++ b/packages/admin-ui/src/CommandPalette/components/CommandPaletteContent.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Dialog as DialogPrimitive, VisuallyHidden } from "radix-ui";
+import { cn } from "~/utils.js";
+
+interface CommandPaletteContentProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    children: React.ReactNode;
+}
+
+const CommandPaletteContent = ({ open, onOpenChange, children }: CommandPaletteContentProps) => {
+    return (
+        <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+            <DialogPrimitive.Portal>
+                <DialogPrimitive.Overlay
+                    className={cn(
+                        "z-overlay",
+                        "fixed inset-0 bg-neutral-dark/50",
+                        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+                    )}
+                />
+                <DialogPrimitive.Content
+                    className={cn(
+                        "fixed left-[50%] top-[20%] translate-x-[-50%] w-[640px]",
+                        "max-w-[calc(100vw-var(--spacing-lg))]",
+                        "bg-neutral-base rounded-xl shadow-lg border-none",
+                        "overflow-hidden focus:outline-none",
+                        "z-overlay",
+                        "duration-200",
+                        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+                        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+                    )}
+                    aria-describedby={undefined}
+                >
+                    <VisuallyHidden.Root>
+                        <DialogPrimitive.Title></DialogPrimitive.Title>
+                    </VisuallyHidden.Root>
+                    {children}
+                </DialogPrimitive.Content>
+            </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
+    );
+};
+
+export { CommandPaletteContent };

--- a/packages/admin-ui/src/CommandPalette/components/CommandPaletteItem.tsx
+++ b/packages/admin-ui/src/CommandPalette/components/CommandPaletteItem.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "~/utils.js";
+import type { CommandPaletteCommand } from "../types.js";
+
+interface CommandPaletteItemProps {
+    command: CommandPaletteCommand;
+    onSelect: () => void;
+}
+
+const CommandPaletteItem = ({ command, onSelect }: CommandPaletteItemProps) => {
+    return (
+        <CommandPrimitive.Item
+            value={command.name}
+            keywords={command.keywords}
+            onSelect={onSelect}
+            className={cn(
+                "flex items-center gap-sm-extra px-lg py-sm-extra cursor-default select-none",
+                "text-md text-neutral-primary",
+                "data-[selected=true]:bg-neutral-dimmed",
+                "outline-none rounded-md mx-sm-extra"
+            )}
+        >
+            {command.icon && (
+                <span className="flex items-center justify-center w-lg h-lg shrink-0 fill-neutral-xstrong">
+                    {command.icon}
+                </span>
+            )}
+            <div className="flex flex-col flex-1 min-w-0">
+                <span className="truncate">{command.label}</span>
+                {command.description && (
+                    <span className="text-sm text-neutral-secondary truncate">
+                        {command.description}
+                    </span>
+                )}
+            </div>
+            {command.shortcut && (
+                <kbd
+                    className={cn(
+                        "ml-auto shrink-0 text-xs text-neutral-secondary",
+                        "bg-neutral-dimmed px-xs-plus py-xs rounded"
+                    )}
+                >
+                    {command.shortcut}
+                </kbd>
+            )}
+        </CommandPrimitive.Item>
+    );
+};
+
+export { CommandPaletteItem };

--- a/packages/admin-ui/src/CommandPalette/components/CommandPaletteList.tsx
+++ b/packages/admin-ui/src/CommandPalette/components/CommandPaletteList.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "~/utils.js";
+import type { CommandPaletteCommand } from "../types.js";
+import { CommandPaletteItem } from "./CommandPaletteItem.js";
+
+interface CommandPaletteListProps {
+    commands: CommandPaletteCommand[];
+    onSelect: (name: string) => void;
+}
+
+const CommandPaletteList = ({ commands, onSelect }: CommandPaletteListProps) => {
+    const grouped = React.useMemo(() => {
+        const groups = new Map<string, CommandPaletteCommand[]>();
+        for (const cmd of commands) {
+            const category = cmd.category ?? "";
+            const list = groups.get(category) ?? [];
+            list.push(cmd);
+            groups.set(category, list);
+        }
+        return groups;
+    }, [commands]);
+
+    return (
+        <CommandPrimitive.List
+            className={cn(
+                "max-h-[360px] overflow-y-auto overflow-x-hidden py-sm-extra",
+                "bg-neutral-base text-neutral-strong"
+            )}
+        >
+            <CommandPrimitive.Empty className="py-xl text-center text-sm text-neutral-secondary">
+                No commands found.
+            </CommandPrimitive.Empty>
+            {[...grouped.entries()].map(([category, cmds]) => {
+                if (category === "") {
+                    return cmds.map(cmd => (
+                        <CommandPaletteItem
+                            key={cmd.name}
+                            command={cmd}
+                            onSelect={() => onSelect(cmd.name)}
+                        />
+                    ));
+                }
+                return (
+                    <CommandPrimitive.Group
+                        key={category}
+                        heading={category}
+                        className={cn(
+                            "[&_[cmdk-group-heading]]:px-lg [&_[cmdk-group-heading]]:py-sm-extra",
+                            "[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold",
+                            "[&_[cmdk-group-heading]]:text-neutral-secondary [&_[cmdk-group-heading]]:uppercase",
+                            "[&_[cmdk-group-heading]]:tracking-wide"
+                        )}
+                    >
+                        {cmds.map(cmd => (
+                            <CommandPaletteItem
+                                key={cmd.name}
+                                command={cmd}
+                                onSelect={() => onSelect(cmd.name)}
+                            />
+                        ))}
+                    </CommandPrimitive.Group>
+                );
+            })}
+        </CommandPrimitive.List>
+    );
+};
+
+export { CommandPaletteList };

--- a/packages/admin-ui/src/CommandPalette/components/CommandPaletteSearch.tsx
+++ b/packages/admin-ui/src/CommandPalette/components/CommandPaletteSearch.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "~/utils.js";
+
+interface CommandPaletteSearchProps {
+    placeholder?: string;
+    value?: string;
+    onValueChange?: (value: string) => void;
+}
+
+const CommandPaletteSearch = ({
+    placeholder = "Search commands…",
+    ...props
+}: CommandPaletteSearchProps) => {
+    return (
+        <div className={cn("flex items-center gap-sm px-lg border-b border-neutral-muted")}>
+            <CommandPrimitive.Input
+                autoFocus={true}
+                className={cn(
+                    "flex w-full py-md bg-transparent text-md",
+                    "placeholder:text-neutral-disabled",
+                    "outline-none border-none"
+                )}
+                placeholder={placeholder}
+                {...props}
+            />
+        </div>
+    );
+};
+
+export { CommandPaletteSearch };

--- a/packages/admin-ui/src/CommandPalette/components/index.ts
+++ b/packages/admin-ui/src/CommandPalette/components/index.ts
@@ -1,0 +1,4 @@
+export { CommandPaletteContent } from "./CommandPaletteContent.js";
+export { CommandPaletteSearch } from "./CommandPaletteSearch.js";
+export { CommandPaletteList } from "./CommandPaletteList.js";
+export { CommandPaletteItem } from "./CommandPaletteItem.js";

--- a/packages/admin-ui/src/CommandPalette/index.ts
+++ b/packages/admin-ui/src/CommandPalette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPalette, type CommandPaletteProps } from "./CommandPalette.js";
+export type { CommandPaletteCommand } from "./types.js";

--- a/packages/admin-ui/src/CommandPalette/types.ts
+++ b/packages/admin-ui/src/CommandPalette/types.ts
@@ -1,0 +1,28 @@
+import type React from "react";
+
+export interface CommandPaletteCommand {
+    name: string;
+    label: string;
+    description?: string;
+    icon?: React.ReactNode;
+    category?: string;
+    keywords?: string[];
+    shortcut?: string;
+    hasDetailView: boolean;
+}
+
+export interface CommandPaletteDetailView {
+    label: string;
+    icon?: React.ReactNode;
+    element: React.ReactNode;
+}
+
+export interface CommandPaletteProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    commands: CommandPaletteCommand[];
+    detailView?: CommandPaletteDetailView;
+    onSelectCommand: (name: string) => void;
+    onCancelCommand: () => void;
+    placeholder?: string;
+}

--- a/packages/admin-ui/src/index.ts
+++ b/packages/admin-ui/src/index.ts
@@ -8,6 +8,7 @@ export * from "./Checkbox/index.js";
 export * from "./CheckboxGroup/index.js";
 export * from "./CodeEditor/index.js";
 export * from "./ColorPicker/index.js";
+export * from "./CommandPalette/index.js";
 export * from "./DataList/index.js";
 export * from "./DataTable/index.js";
 export * from "./DelayedOnChange/index.js";

--- a/packages/app-admin/src/base/Base.tsx
+++ b/packages/app-admin/src/base/Base.tsx
@@ -4,6 +4,7 @@ import { RoutesConfig } from "./Base/RoutesConfig.js";
 import { Tenant } from "./Base/Tenant.js";
 import { UserMenu } from "./Base/UserMenu.js";
 import { LexicalPreset } from "./Base/LexicalPreset.js";
+import { CommandPaletteExtension } from "~/presentation/commandPalette/CommandPaletteExtension.js";
 
 const BaseExtension = () => {
     return (
@@ -13,6 +14,7 @@ const BaseExtension = () => {
             <UserMenu />
             <RoutesConfig />
             <LexicalPreset />
+            <CommandPaletteExtension />
         </>
     );
 };

--- a/packages/app-admin/src/exports/admin.ts
+++ b/packages/app-admin/src/exports/admin.ts
@@ -1,3 +1,4 @@
+export { Command } from "~/presentation/commandPalette/index.js";
 export { DevToolsSection } from "~/components/index.js";
 export { createPermissionSchema } from "~/permissions/index.js";
 export { createHasPermission } from "~/permissions/index.js";

--- a/packages/app-admin/src/hooks/useHotkeys.ts
+++ b/packages/app-admin/src/hooks/useHotkeys.ts
@@ -88,21 +88,24 @@ export function useHotkeys(props: HookProps) {
     const prevPropsRef = useRef<HookProps | undefined>();
     const firstRenderRef = useRef(true);
 
-    useEffect(function () {
-        if (firstRenderRef.current || prevPropsRef.current?.disabled !== disabled) {
-            firstRenderRef.current = false;
-            if (disabled) {
-                unregisterZIndex(props);
-            } else {
-                registerZIndex(props);
+    useEffect(
+        function () {
+            if (firstRenderRef.current || prevPropsRef.current?.disabled !== disabled) {
+                firstRenderRef.current = false;
+                if (disabled) {
+                    unregisterZIndex(props);
+                } else {
+                    registerZIndex(props);
+                }
             }
-        }
 
-        if (!disabled && typeof keys === "object") {
-            Object.assign(state.handlers[zIndex], keys);
-        }
-        prevPropsRef.current = { ...props };
-    });
+            if (!disabled && typeof keys === "object") {
+                Object.assign(state.handlers[zIndex], keys);
+            }
+            prevPropsRef.current = { ...props };
+        },
+        [keys]
+    );
 
     useEffect(function () {
         return function () {

--- a/packages/app-admin/src/index.ts
+++ b/packages/app-admin/src/index.ts
@@ -47,6 +47,9 @@ export type { AaclPermission } from "./features/wcp/types.js";
 export type { Tenant } from "./features/tenancy/types.js";
 
 export { BuildParamsFeature } from "./features/buildParams/feature.js";
+export { CommandPaletteFeature } from "./presentation/commandPalette/feature.js";
+export { Command } from "./presentation/commandPalette/abstractions.js";
+export type { ICommand, CommandDetailProps } from "./presentation/commandPalette/abstractions.js";
 
 // Hooks
 export * from "./hooks/index.js";

--- a/packages/app-admin/src/presentation/commandPalette/CommandPalette.tsx
+++ b/packages/app-admin/src/presentation/commandPalette/CommandPalette.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useEffect, useMemo } from "react";
+import { observer } from "mobx-react-lite";
+import { useFeature } from "@webiny/app";
+import { CommandPalette as CommandPaletteUi } from "@webiny/admin-ui";
+import { useHotkeys } from "~/hooks/useHotkeys.js";
+import { CommandPaletteFeature } from "~/presentation/commandPalette/feature.js";
+
+export const CommandPalette = observer(() => {
+    const { presenter } = useFeature(CommandPaletteFeature);
+    const { vm } = presenter;
+
+    useEffect(() => {
+        presenter.init();
+    }, [presenter]);
+
+    const keys = useMemo(() => {
+        return {
+            "mod+k": (e: KeyboardEvent) => {
+                e.preventDefault();
+                presenter.toggle();
+            },
+            backspace: (e: KeyboardEvent) => {
+                if (e.target instanceof HTMLInputElement) {
+                    return;
+                }
+                e.preventDefault();
+                presenter.cancelCommand();
+            },
+            ...presenter.shortcutKeys
+        };
+    }, [presenter, presenter.shortcutKeys]);
+
+    useHotkeys({
+        zIndex: 100,
+        keys
+    });
+
+    const handleOpenChange = useCallback(
+        (nextOpen: boolean) => {
+            if (nextOpen) {
+                presenter.open();
+            } else {
+                presenter.close();
+            }
+        },
+        [presenter]
+    );
+
+    const activeCommand = vm.activeCommand;
+    const detailView = activeCommand
+        ? {
+              label: activeCommand.command.label,
+              icon: activeCommand.command.icon,
+              element: (
+                  <activeCommand.DetailView
+                      command={activeCommand.command}
+                      onClose={() => presenter.close()}
+                      onBack={() => presenter.cancelCommand()}
+                  />
+              )
+          }
+        : undefined;
+
+    return (
+        <CommandPaletteUi
+            open={vm.isOpen}
+            onOpenChange={handleOpenChange}
+            commands={vm.commands}
+            detailView={detailView}
+            onSelectCommand={name => presenter.useCommand(name)}
+            onCancelCommand={() => presenter.cancelCommand()}
+        />
+    );
+});

--- a/packages/app-admin/src/presentation/commandPalette/CommandPaletteExtension.tsx
+++ b/packages/app-admin/src/presentation/commandPalette/CommandPaletteExtension.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Plugins } from "@webiny/app";
+import { CommandPalette } from "./CommandPalette.js";
+import { RegisterFeature } from "~/components/index.js";
+import { CommandPaletteFeature } from "~/presentation/commandPalette/feature.js";
+import { DeveloperMode } from "~/components/index.js";
+
+export const CommandPaletteExtension = () => {
+    return (
+        <DeveloperMode>
+            <RegisterFeature feature={CommandPaletteFeature} />
+            <Plugins>
+                <CommandPalette />
+            </Plugins>
+        </DeveloperMode>
+    );
+};

--- a/packages/app-admin/src/presentation/commandPalette/CommandPalettePresenter.ts
+++ b/packages/app-admin/src/presentation/commandPalette/CommandPalettePresenter.ts
@@ -1,0 +1,99 @@
+import { makeAutoObservable } from "mobx";
+import {
+    Command,
+    CommandPalettePresenter as Abstraction,
+    type CommandPaletteViewModel
+} from "./abstractions.js";
+
+export class CommandPalettePresenter implements Abstraction.Interface {
+    private isOpen = false;
+    private activeCommandName: string | null = null;
+    private resolvedCommands: Command.Interface[] = [];
+
+    constructor(private getCommands: () => Command.Interface[]) {
+        makeAutoObservable(this);
+    }
+
+    init(): void {
+        this.resolvedCommands = this.getCommands();
+    }
+
+    get shortcutKeys(): Record<string, (e: KeyboardEvent) => void> {
+        const keys: Record<string, (e: KeyboardEvent) => void> = {};
+        for (const cmd of this.resolvedCommands) {
+            if (cmd.shortcut) {
+                keys[cmd.shortcut] = (e: KeyboardEvent) => {
+                    e.preventDefault();
+                    this.useCommand(cmd.name);
+                };
+            }
+        }
+        return keys;
+    }
+
+    get vm(): CommandPaletteViewModel {
+        const activeCmd =
+            this.activeCommandName !== null
+                ? this.resolvedCommands.find(c => c.name === this.activeCommandName)
+                : null;
+
+        return {
+            isOpen: this.isOpen,
+            commands: this.resolvedCommands.map(cmd => ({
+                name: cmd.name,
+                label: cmd.label,
+                description: cmd.description,
+                icon: cmd.icon,
+                category: cmd.category,
+                keywords: cmd.keywords,
+                shortcut: cmd.shortcut,
+                hasDetailView: Boolean(cmd.detailView)
+            })),
+            activeCommand:
+                activeCmd && activeCmd.detailView
+                    ? {
+                          command: activeCmd,
+                          DetailView: activeCmd.detailView
+                      }
+                    : null
+        };
+    }
+
+    open(): void {
+        this.resolvedCommands = this.getCommands();
+        this.activeCommandName = null;
+        this.isOpen = true;
+    }
+
+    close(): void {
+        this.isOpen = false;
+        this.activeCommandName = null;
+    }
+
+    toggle(): void {
+        if (this.isOpen) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+
+    useCommand(name: string): void {
+        const cmd = this.resolvedCommands.find(c => c.name === name);
+        if (!cmd) {
+            return;
+        }
+
+        if (cmd.detailView) {
+            this.activeCommandName = name;
+            this.isOpen = true;
+        } else {
+            cmd.execute();
+            this.close();
+        }
+    }
+
+    cancelCommand(): void {
+        this.activeCommandName = null;
+    }
+}

--- a/packages/app-admin/src/presentation/commandPalette/abstractions.ts
+++ b/packages/app-admin/src/presentation/commandPalette/abstractions.ts
@@ -1,0 +1,70 @@
+import type React from "react";
+import { createAbstraction } from "@webiny/feature/admin";
+import { Abstraction } from "@webiny/di";
+
+export interface CommandDetailProps {
+    command: ICommand;
+    onClose: () => void;
+    onBack: () => void;
+}
+
+export interface ICommand {
+    name: string;
+    label: string;
+    description?: string;
+    icon?: React.ReactNode;
+    category?: string;
+    keywords?: string[];
+    shortcut?: string;
+    execute(params?: unknown): void | Promise<void>;
+    detailView?: React.ComponentType<CommandDetailProps>;
+}
+
+export const Command = createAbstraction<ICommand>("Command");
+
+export namespace Command {
+    export type Interface = ICommand;
+    export type DetailProps = CommandDetailProps;
+}
+
+export interface CommandItemVm {
+    name: string;
+    label: string;
+    description?: string;
+    icon?: React.ReactNode;
+    category?: string;
+    keywords?: string[];
+    shortcut?: string;
+    hasDetailView: boolean;
+}
+
+export interface ActiveCommandVm {
+    command: ICommand;
+    DetailView: React.ComponentType<CommandDetailProps>;
+}
+
+export interface CommandPaletteViewModel {
+    isOpen: boolean;
+    commands: CommandItemVm[];
+    activeCommand: ActiveCommandVm | null;
+}
+
+export interface ICommandPalettePresenter {
+    vm: CommandPaletteViewModel;
+    shortcutKeys: Record<string, (e: KeyboardEvent) => void>;
+    init(): void;
+    open(): void;
+    close(): void;
+    toggle(): void;
+    useCommand(name: string): void;
+    cancelCommand(): void;
+}
+
+export const CommandPalettePresenter = new Abstraction<ICommandPalettePresenter>(
+    "CommandPalettePresenter"
+);
+
+export namespace CommandPalettePresenter {
+    export type Interface = ICommandPalettePresenter;
+    export type ViewModel = CommandPaletteViewModel;
+}

--- a/packages/app-admin/src/presentation/commandPalette/feature.ts
+++ b/packages/app-admin/src/presentation/commandPalette/feature.ts
@@ -1,0 +1,21 @@
+import { createFeature } from "@webiny/feature/admin";
+import { Container } from "@webiny/di";
+import { CommandPalettePresenter as Abstraction } from "./abstractions.js";
+import { CommandPalettePresenter } from "./CommandPalettePresenter.js";
+import { Command } from "./abstractions.js";
+
+export const CommandPaletteFeature = createFeature({
+    name: "CommandPalette",
+    register(container: Container) {
+        container.registerFactory(Abstraction, () => {
+            return new CommandPalettePresenter(() => {
+                return container.resolveAll(Command);
+            });
+        });
+    },
+    resolve(container: Container) {
+        return {
+            presenter: container.resolve(Abstraction)
+        };
+    }
+});

--- a/packages/app-admin/src/presentation/commandPalette/index.ts
+++ b/packages/app-admin/src/presentation/commandPalette/index.ts
@@ -1,0 +1,3 @@
+export { Command, CommandPalettePresenter } from "./abstractions.js";
+export type { ICommand, CommandDetailProps, CommandPaletteViewModel } from "./abstractions.js";
+export { CommandPaletteFeature } from "./feature.js";

--- a/packages/webiny/src/admin.ts
+++ b/packages/webiny/src/admin.ts
@@ -4,6 +4,7 @@ export { createProviderPlugin } from "@webiny/app/core/createProviderPlugin.js";
 export { createProvider } from "@webiny/app/core/createProvider.js";
 export { Provider } from "@webiny/app/core/Provider.js";
 export { Plugin } from "@webiny/app/core/Plugin.js";
+export { Command } from "@webiny/app-admin/presentation/commandPalette/index.js";
 export { DevToolsSection } from "@webiny/app-admin/components/index.js";
 export { createPermissionSchema } from "@webiny/app-admin/permissions/index.js";
 export { createHasPermission } from "@webiny/app-admin/permissions/index.js";

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Admin, Api, Cli, Infra, Project } from "webiny/extensions";
 import { Cognito } from "@webiny/cognito";
 import { MyFeature } from "@/extensions/myFeature/Extension.js";
+import { CommandPalette } from "@/extensions/commandPalette/CommandPalette.js";
 // import { MyIdpExtension } from "./extensions/idp/okta/MyIdpExtension.js";
 
 export const Extensions = () => {
@@ -14,6 +15,7 @@ export const Extensions = () => {
             {/*<Admin.Extension src={"/extensions/AdminTheme/AdminTheme.tsx"} />*/}
             <Admin.Extension src={"@/extensions/LexicalPlugin.tsx"} />
             <MyFeature />
+            <CommandPalette />
 
             {/* Infra 👇 */}
             <Infra.PulumiResourceNamePrefix prefix={"myproj-"} />


### PR DESCRIPTION
## Summary

> [!CAUTION]
> This feature is hidden from users for the time being. You can enable it using the Developer Mode.

- Add `Command` DI abstraction for registering commands with full dependency injection support
- Add `CommandPalettePresenter` (MobX) that lazily resolves commands from the container, manages open/close state, active command selection, and global keyboard shortcuts
- Add `CommandPalette` UI component (`@webiny/admin-ui`) using `cmdk` + Radix Dialog — supports command list with search, grouped categories, and pluggable detail views
- Commands can optionally provide a `detailView` React component (e.g., a form) that renders inside the palette when selected
- Global shortcuts: commands with a `shortcut` property register global hotkeys that trigger the command directly
- Demo extensions: simple command (`SayHello`) and form-based command (`SendMessage`) in `extensions/commandPalette/`

<img width="969" height="465" alt="CleanShot 2026-04-02 at 14 52 02" src="https://github.com/user-attachments/assets/b750e352-52ea-430d-a971-3c167179bcb9" />
