### PR TITLE
fix: include `hcmsFieldPermissions` flag in GetWcpLicense query

### DIFF
--- a/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
+++ b/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
@@ -54,9 +54,10 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
                                 ? project.package.features.advancedAccessControlLayer.options
                                       .folderLevelPermissions
                                 : false,
-                            hcmsFieldPermissions:
-                                project.package.features.advancedAccessControlLayer.options
-                                    .hcmsFieldPermissions
+                            hcmsFieldPermissions: flags.isHcmsFieldPermissionsEnabled()
+                                ? project.package.features.advancedAccessControlLayer.options
+                                      .hcmsFieldPermissions
+                                : false
                         }
                     },
                     auditLogs: {
@@ -140,7 +141,10 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
     }
 
     canUseHcmsFieldPermissions() {
-        return this.decoratee.canUseHcmsFieldPermissions();
+        return (
+            this.decoratee.canUseHcmsFieldPermissions() &&
+            this.featureFlags.get().isHcmsFieldPermissionsEnabled()
+        );
     }
 
     ensureCanUseFeature(featureId: keyof typeof WCP_FEATURE_LABEL) {

--- a/packages/feature-flags/src/FeatureFlags.ts
+++ b/packages/feature-flags/src/FeatureFlags.ts
@@ -61,6 +61,16 @@ export class FeatureFlags {
         return this.flags.recordLocking !== false;
     }
 
+    isHcmsFieldPermissionsEnabled(): boolean {
+        if (this.flags.advancedAccessControlLayer === false) {
+            return false;
+        }
+        if (typeof this.flags.advancedAccessControlLayer === "object") {
+            return this.flags.advancedAccessControlLayer.hcmsFieldPermissions !== false;
+        }
+        return true;
+    }
+
     isFileManagerThreatDetectionEnabled(): boolean {
         return this.flags.fileManager?.threatDetection !== false;
     }


### PR DESCRIPTION
## What changed

The `hcmsFieldPermissions` flag is now properly included in the `wcp/getProject` GraphQL response and correctly gated by the feature flags system, consistent with all other AACL sub-flags (`teams`, `privateFiles`, `folderLevelPermissions`).

## Why

`hcmsFieldPermissions` was missing from the `options` JSON object in the `advancedAccessControlLayer` field of the `wcp/getProject` GQL response. The value was passed through directly from the raw license without a `false` fallback — if the decrypted license didn't contain the key (e.g. when using an older `WCP_PROJECT_LICENSE` env var), the value would be `undefined` and silently dropped during JSON serialization. Additionally, `canUseHcmsFieldPermissions()` in the decorator was not ANDed with a feature flag check, unlike every other `canUse*` method.

## How

Two files were updated:

- **`packages/feature-flags/src/FeatureFlags.ts`** — added `isHcmsFieldPermissionsEnabled()` following the same pattern as `isTeamsEnabled()` and `isFolderLevelPermissionsEnabled()`: returns `false` when AACL is disabled, reads the sub-flag value when AACL is an object, and defaults to `true` otherwise.
- **`packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts`** — gated `hcmsFieldPermissions` in `getProjectWithFeatureFlags()` through `flags.isHcmsFieldPermissionsEnabled()` with an explicit `false` fallback (ensures the key is always present in the JSON response), and updated `canUseHcmsFieldPermissions()` to AND with the feature flag check.

## Changelog

#### Fixed HCMS Field Permissions Not Appearing in Project License Response

The `hcmsFieldPermissions` flag was missing from the project license data returned to the admin app when the flag was absent from the local license. This meant the admin app could not correctly determine whether HCMS field-level permissions were available. The flag is now always present in the response and is properly controlled by the feature flags system.