### PR TITLE
adrian/custom-domains-for-api-2026-04-02

### DIFF
--- a/packages/project-aws/src/infra.ts
+++ b/packages/project-aws/src/infra.ts
@@ -26,6 +26,7 @@ import {
 
 import {
     AdminCustomDomains,
+    ApiCustomDomains,
     AwsTags,
     BlueGreenDeployments,
     Vpc
@@ -73,6 +74,7 @@ export const Infra = {
         AfterBuild: ApiAfterBuild,
         AfterDeploy: ApiAfterDeploy,
         Pulumi: ApiPulumi,
+        CustomDomains: ApiCustomDomains,
         StackOutputValue: ApiStackOutputValue,
         LambdaFunction: ApiLambdaFunction
     },

--- a/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
@@ -25,6 +25,8 @@ import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfig
 import { getOsConfigFromExtension } from "~/pulumi/apps/extensions/getOsConfigFromExtension.js";
 import { handleGuardDutyEvents } from "./handleGuardDutyEvents.js";
 import { ApiPulumi } from "@webiny/project/abstractions/index.js";
+import { ApiCustomDomains as apiCustomDomainsExt } from "~/pulumi/extensions/ApiCustomDomains.js";
+import { applyCustomDomain } from "~/pulumi/apps/customDomain.js";
 
 export type ApiPulumiApp = ReturnType<typeof createApiPulumiApp>;
 
@@ -227,10 +229,15 @@ export const createApiPulumiApp = () => {
             const backgroundTask = app.addModule(ApiBackgroundTask);
             const scheduler = app.addModule(ApiScheduler);
 
-            // const domains = app.getParam(projectAppParams.domains);
-            // if (domains) {
-            //     applyCustomDomain(cloudfront, domains);
-            // }
+            const [apiCustomDomains] = projectConfig.extensionsByType(apiCustomDomainsExt);
+            if (apiCustomDomains) {
+                const { domains, sslMethod, certificateArn } = apiCustomDomains.params;
+                applyCustomDomain(cloudfront, {
+                    domains,
+                    sslSupportMethod: sslMethod,
+                    acmCertificateArn: certificateArn
+                });
+            }
 
             app.addOutputs({
                 awsAccountId: getAwsAccountId(app),

--- a/packages/project-aws/src/pulumi/extensions/ApiCustomDomains.ts
+++ b/packages/project-aws/src/pulumi/extensions/ApiCustomDomains.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { defineExtension } from "@webiny/project/defineExtension/index.js";
+
+export const ApiCustomDomains = defineExtension({
+    type: "Infra/Api/CustomDomains",
+    tags: { runtimeContext: "project" },
+    description: "Configure custom domains for the API.",
+    paramsSchema: z.object({
+        domains: z.array(z.string()).describe("List of custom domains.").min(1),
+        sslMethod: z
+            .enum(["sni-only", "vip"])
+            .describe("The method to use for SSL/TLS certificate validation.")
+            .default("sni-only"),
+        certificateArn: z
+            .string()
+            .describe("The ARN of the SSL/TLS certificate to use for the custom domains.")
+    })
+});

--- a/packages/project-aws/src/pulumi/extensions/BlueGreenDeployments.ts
+++ b/packages/project-aws/src/pulumi/extensions/BlueGreenDeployments.ts
@@ -14,9 +14,7 @@ const domainsSchema = z.object({
     sslSupportMethod: z.enum(["sni-only", "vip"]),
     domains: z.object({
         api: nonEmptyStringArray,
-        admin: nonEmptyStringArray,
-        website: nonEmptyStringArray,
-        preview: nonEmptyStringArray
+        admin: nonEmptyStringArray
     })
 });
 

--- a/packages/project-aws/src/pulumi/extensions/index.ts
+++ b/packages/project-aws/src/pulumi/extensions/index.ts
@@ -2,12 +2,14 @@ import { AwsTags } from "./AwsTags.js";
 import { OpenSearch } from "./OpenSearch.js";
 import { Vpc } from "./Vpc.js";
 import { AdminCustomDomains } from "./AdminCustomDomains.js";
+import { ApiCustomDomains } from "./ApiCustomDomains.js";
 import { BlueGreenDeployments } from "~/pulumi/extensions/BlueGreenDeployments.js";
 
 export { AwsTags };
 export { Vpc };
 export { OpenSearch };
 export { AdminCustomDomains };
+export { ApiCustomDomains };
 export { BlueGreenDeployments };
 
 export const definitions = [
@@ -15,5 +17,6 @@ export const definitions = [
     Vpc.def,
     OpenSearch.def,
     AdminCustomDomains.def,
+    ApiCustomDomains.def,
     BlueGreenDeployments.def
 ];

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -73,7 +73,7 @@ export const Extensions = () => {
                         "arn:aws:acm:us-east-1:636962863878:certificate/3baf9092-fb27-4efb-9409-XXXXXXXX",
                     sslSupportMethod: "sni-only",
                     domains: {
-                        aƒpi: ["api.bg.webiny.com"],
+                        api: ["api.bg.webiny.com"],
                         admin: ["admin.bg.webiny.com"],
                         website: ["website.bg.webiny.com"],
                         preview: ["preview.bg.webiny.com"]


### PR DESCRIPTION
## What changed

Users can now configure custom domains for the API CloudFront distribution using `<Infra.Api.CustomDomains>` in `webiny.config.tsx`, the same way custom domains are already supported for the Admin app via `<Infra.Admin.CustomDomains>`. The blue/green deployments extension schema was also cleaned up by removing unused `website` and `preview` domain fields.

## Why

There was no built-in way to attach a custom domain and ACM certificate to the API CloudFront distribution. Users had to resort to manual Pulumi overrides. The `Infra.Admin.CustomDomains` extension already solved this for the Admin app, and the API needed the same treatment.

## How

A new `ApiCustomDomains` extension was added in `packages/project-aws/src/pulumi/extensions/ApiCustomDomains.ts`, mirroring `AdminCustomDomains.ts` with type `"Infra/Api/CustomDomains"`. It is registered in the extensions `index.ts` definitions array and exposed as `Infra.Api.CustomDomains` in `infra.ts`. In `createApiPulumiApp.ts`, the extension is read from `projectConfig.extensionsByType()` and applied to the API CloudFront distribution via the existing `applyCustomDomain()` utility, replacing the old commented-out dead code. The `BlueGreenDeployments` extension schema had `website` and `preview` removed from its domains object as those apps do not exist.

## Changelog

#### Added Custom Domain Support for the API CloudFront Distribution

It is now possible to configure custom domains and an ACM SSL certificate for the API directly in `webiny.config.tsx` using the new `Infra.Api.CustomDomains` extension, consistent with how custom domains are already configured for the Admin app.