### PR TITLE
fix(cms): "Schedule" btn breaking dropdown menu

### DIFF
--- a/packages/app-headless-cms-scheduler/src/components/Editor/MenuItem.tsx
+++ b/packages/app-headless-cms-scheduler/src/components/Editor/MenuItem.tsx
@@ -9,9 +9,14 @@ import { useScheduleDialog } from "@webiny/app-scheduler";
 import { usePermissions } from "~/hooks/usePermissions.js";
 import { createNamespace } from "~/utils/index.js";
 
-export const MenuItem = () => {
-    const { entry, loading, contentModel } = useContentEntryEditor();
-    const { canPublish, canUnpublish } = usePermissions();
+interface MenuItemWithIdProps {
+    entry: ReturnType<typeof useContentEntryEditor>["entry"];
+    contentModel: ReturnType<typeof useContentEntryEditor>["contentModel"];
+    loading: boolean;
+}
+
+/* Rendered only when entry.id exists; hooks that depend on entry.id live here. */
+const MenuItemWithId = ({ entry, contentModel, loading }: MenuItemWithIdProps) => {
     const client = useApolloClient();
 
     const { showDialog: showSchedulerDialog } = useScheduleDialog({
@@ -31,10 +36,6 @@ export const MenuItem = () => {
         showSchedulerDialog();
     }, [showSchedulerDialog]);
 
-    if (!canPublish && !canUnpublish) {
-        return null;
-    }
-
     const action = entry.meta?.status === "published" ? "unpublish" : "publish";
 
     return (
@@ -46,4 +47,32 @@ export const MenuItem = () => {
             data-testid={"cms.content-form.header.schedule"}
         />
     );
+};
+
+export const MenuItem = () => {
+    const { entry, loading, contentModel } = useContentEntryEditor();
+    const { canPublish, canUnpublish } = usePermissions();
+
+    const { OptionsMenuItem } =
+        ContentEntryEditorConfig.Actions.MenuItemAction.useOptionsMenuItem();
+
+    if (!canPublish && !canUnpublish) {
+        return null;
+    }
+
+    /* When entry.id is missing (e.g. new unsaved entry), render a disabled item
+     * without invoking hooks that require a persisted entry. */
+    if (!entry.id) {
+        return (
+            <OptionsMenuItem
+                icon={<ScheduleIcon />}
+                label={"Schedule"}
+                onAction={() => void 0}
+                disabled={true}
+                data-testid={"cms.content-form.header.schedule"}
+            />
+        );
+    }
+
+    return <MenuItemWithId entry={entry} contentModel={contentModel} loading={loading} />;
 };


### PR DESCRIPTION
## What changed

When opening a new (unsaved) content entry in the CMS editor, the Schedule menu item is now rendered as disabled instead of crashing or behaving unexpectedly.

## Why

Previously, the `MenuItem` component called hooks like `useApolloClient` and `useScheduleDialog` unconditionally — including when `entry.id` was not yet available (e.g. for a brand-new unsaved entry). This caused those hooks to run with an invalid/empty target, leading to errors.

## How

The component was split into two: an outer `MenuItem` that handles permissions and the missing-`entry.id` guard, and an inner `MenuItemWithId` (`packages/app-headless-cms-scheduler/src/components/Editor/MenuItem.tsx`) that is only rendered when `entry.id` exists and contains all hooks that depend on it (`useApolloClient`, `useScheduleDialog`). When `entry.id` is absent, a plain disabled `OptionsMenuItem` is rendered without invoking those hooks.

## Changelog

**Fixed Schedule Menu Item Crashing on New Unsaved Entries**

When creating a new content entry that had not yet been saved, the Schedule action in the editor menu would malfunction. This has been fixed — the Schedule option now appears as disabled until the entry is saved.