### PR TITLE
docs(sdk-skill): clarify preview mode applies only to read operations

### DIFF
--- a/skills/user-skills/webiny-sdk/SKILL.md
+++ b/skills/user-skills/webiny-sdk/SKILL.md
@@ -61,16 +61,16 @@ fields: ["id", "entryId", "values.name", "values.price", "values.description"];
 fields: ["id", "values.title", "values.author.name", "values.author.email"];
 ```
 
-## Content vs Preview Mode
+## CMS: Read vs Preview Mode
 
-The SDK uses a single GraphQL endpoint. Access mode is controlled by the `preview` parameter:
+`webiny.cms.listEntries` and `webiny.cms.getEntry` accept a `preview` parameter to control which revisions are returned:
 
 | `preview`         | Returns                              | Use For                          |
 | ----------------- | ------------------------------------ | -------------------------------- |
 | `false` (default) | Published entries only               | Public-facing apps, SSG          |
 | `true`            | Latest revision (draft or published) | Content preview, editorial tools |
 
-Write operations (`createEntry`, `updateEntryRevision`, etc.) always operate on the manage API and are not affected by `preview`.
+Write operations (`createEntry`, `updateEntryRevision`, etc.) are not affected by `preview`.
 
 ## The Result Pattern
 


### PR DESCRIPTION
## What changed

The Webiny SDK skill documentation has been updated to clarify how the `preview` parameter works on read operations. The section heading and description now more accurately reflect that `preview` only applies to `listEntries` and `getEntry`, not to write operations.

## Why

The previous wording — "The SDK uses a single GraphQL endpoint. Access mode is controlled by the `preview` parameter" — was misleading. It implied the endpoint itself changed, when in reality there is a single endpoint and only the read methods accept a `preview` flag. This caused confusion when developers were trying to understand when and how preview mode applies.

## How

Updated `skills/user-skills/webiny-sdk/SKILL.md`: renamed the section from "Content vs Preview Mode" to "CMS: Read vs Preview Mode" and rewrote the introductory sentence to explicitly name the two methods (`webiny.cms.listEntries` and `webiny.cms.getEntry`) that accept the `preview` parameter. Also simplified the note about write operations to remove the redundant "always operate on the manage API" detail.

## Changelog

**Improved SDK Skill Documentation for Preview Mode**

The description of how preview mode works in the Webiny SDK has been clarified. Developers can now more easily understand which operations are affected by the preview flag and which are not.

## Squash Merge Commit

```
docs(sdk-skill): clarify preview mode applies only to read operations
```