### PR TITLE
refactor: feature api types to have correct second parameter

### DIFF
--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -115,13 +115,9 @@ const setupAcoContext = async (
 
     CreateFlpOnFolderCreatedFeature.register(context.container);
 
-    UpdateFlpOnFolderUpdatedFeature.register(context.container, {
-        tasks: context.tasks
-    });
+    UpdateFlpOnFolderUpdatedFeature.register(context.container);
 
-    DeleteFlpOnFolderDeletedFeature.register(context.container, {
-        tasks: context.tasks
-    });
+    DeleteFlpOnFolderDeletedFeature.register(context.container);
 
     /**
      * Register folder event handlers

--- a/packages/api-aco/src/features/flp/GetFlp/feature.ts
+++ b/packages/api-aco/src/features/flp/GetFlp/feature.ts
@@ -3,9 +3,9 @@ import { GetFlpUseCase } from "./GetFlpUseCase.js";
 import { GetFlpUseCase as UseCaseAbstraction } from "./abstractions.js";
 import type { AcoContext } from "~/types.js";
 
-export const GetFlpFeature = createFeature({
+export const GetFlpFeature = createFeature<AcoContext["aco"]["flp"]>({
     name: "GetFlpFeature",
-    register(container, context: AcoContext["aco"]["flp"]) {
+    register(container, context) {
         container.registerFactory(UseCaseAbstraction, () => {
             return new GetFlpUseCase(context.get);
         });

--- a/packages/api-aco/src/features/flp/ListFlps/feature.ts
+++ b/packages/api-aco/src/features/flp/ListFlps/feature.ts
@@ -3,9 +3,9 @@ import { ListFlpsUseCase } from "./ListFlpsUseCase.js";
 import { ListFlpsUseCase as UseCaseAbstraction } from "./abstractions.js";
 import type { AcoContext } from "~/types.js";
 
-export const ListFlpsFeature = createFeature({
+export const ListFlpsFeature = createFeature<AcoContext["aco"]["flp"]>({
     name: "ListFlpsFeature",
-    register(container, context: AcoContext["aco"]["flp"]) {
+    register(container, context) {
         container.registerFactory(UseCaseAbstraction, () => {
             return new ListFlpsUseCase(context.list);
         });

--- a/packages/api-aco/src/features/flp/UpdateFlpOnFolderUpdated/feature.ts
+++ b/packages/api-aco/src/features/flp/UpdateFlpOnFolderUpdated/feature.ts
@@ -1,5 +1,6 @@
 import { createFeature } from "@webiny/feature/api";
 import { UpdateFlpOnFolderUpdatedHandler } from "./UpdateFlpOnFolderUpdatedHandler.js";
+import type { AcoContext } from "~/types.js";
 
 export const UpdateFlpOnFolderUpdatedFeature = createFeature({
     name: "UpdateFlpOnFolderUpdated",

--- a/packages/api-aco/src/features/flp/UpdateFlpOnFolderUpdated/feature.ts
+++ b/packages/api-aco/src/features/flp/UpdateFlpOnFolderUpdated/feature.ts
@@ -1,6 +1,5 @@
 import { createFeature } from "@webiny/feature/api";
 import { UpdateFlpOnFolderUpdatedHandler } from "./UpdateFlpOnFolderUpdatedHandler.js";
-import type { AcoContext } from "~/types.js";
 
 export const UpdateFlpOnFolderUpdatedFeature = createFeature({
     name: "UpdateFlpOnFolderUpdated",

--- a/packages/api-core/src/features/keyValueStore/feature.ts
+++ b/packages/api-core/src/features/keyValueStore/feature.ts
@@ -4,9 +4,9 @@ import { KeyValueStore } from "./KeyValueStore.js";
 import { KeyValueStoreRepository } from "./KeyValueStoreRepository.js";
 import { KeyValueStorageOperations } from "./abstractions.js";
 
-export const KeyValueStoreFeature = createFeature({
+export const KeyValueStoreFeature = createFeature<KeyValueStorageOperations.Interface>({
     name: "KeyValueStore",
-    register(container, storageOperations: KeyValueStorageOperations.Interface) {
+    register(container, storageOperations) {
         // Register legacy storage operations
         container.registerInstance(KeyValueStorageOperations, storageOperations);
 

--- a/packages/api-core/src/features/tenancy/TenancyFeature.ts
+++ b/packages/api-core/src/features/tenancy/TenancyFeature.ts
@@ -12,9 +12,9 @@ import { GetTenantByIdFeature } from "./GetTenantById/feature.js";
 import { TenantContextFeature } from "./TenantContext/feature.js";
 import { InstallTenantFeature } from "./InstallTenant/index.js";
 
-export const TenancyFeature = createFeature({
+export const TenancyFeature = createFeature<ITenancyStorageOperations>({
     name: "TenancyFeature",
-    register: (container, storageOperations: ITenancyStorageOperations) => {
+    register: (container, storageOperations) => {
         // Register storage operations abstraction (singleton)
         container.registerInstance(TenancyStorageOperations, storageOperations);
 

--- a/packages/api-core/src/features/users/AdminUsersFeature.ts
+++ b/packages/api-core/src/features/users/AdminUsersFeature.ts
@@ -10,9 +10,9 @@ import { ListUserTeamsFeature } from "./ListUserTeams/feature.js";
 import { AdminUsersStorageOperations } from "./shared/storageAbstractions.js";
 import { ExternalIdpUserSyncFeature } from "./ExternalIdpUserSync/index.js";
 
-export const AdminUsersFeature = createFeature({
+export const AdminUsersFeature = createFeature<AdminUsersStorageOperations.Interface>({
     name: "AdminUsers",
-    register(container, storageOperations: AdminUsersStorageOperations.Interface) {
+    register(container, storageOperations) {
         // Register repository in singleton scope
         container.register(AdminUsersRepository).inSingletonScope();
 

--- a/packages/api-core/src/features/wcp/WcpFeature.ts
+++ b/packages/api-core/src/features/wcp/WcpFeature.ts
@@ -3,9 +3,9 @@ import { WcpContextFeature } from "./WcpContext/feature.js";
 import { WcpContextWithFeatureFlagsDecorator } from "./WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.js";
 import type { ILicense } from "@webiny/wcp/types.js";
 
-export const WcpFeature = createFeature({
+export const WcpFeature = createFeature<ILicense>({
     name: "WebinyControlPanel",
-    register(container, license: ILicense) {
+    register(container, license) {
         WcpContextFeature.register(container, license);
         container.registerDecorator(WcpContextWithFeatureFlagsDecorator);
     }

--- a/packages/api-headless-cms-tasks/src/features/DisableModel/feature.ts
+++ b/packages/api-headless-cms-tasks/src/features/DisableModel/feature.ts
@@ -17,9 +17,9 @@ export interface LegacyDeps {
     isModelBeingDeleted: HeadlessCmsFullyDeleteModel["isModelBeingDeleted"];
 }
 
-export const DisableModelFeature = createFeature({
+export const DisableModelFeature = createFeature<LegacyDeps>({
     name: "DisableModel",
-    register(container, params: LegacyDeps) {
+    register(container, params) {
         // Register the blocking service
         container.registerInstance(
             Abstraction,

--- a/packages/api-headless-cms-workflows/src/index.ts
+++ b/packages/api-headless-cms-workflows/src/index.ts
@@ -12,7 +12,7 @@ export const createHeadlessCmsWorkflows = () => {
         }
 
         // Register features
-        EntryWorkflowsFeature.register(context.container, context);
+        EntryWorkflowsFeature.register(context.container);
         WorkflowsFeature.register(context.container);
     });
 

--- a/packages/api-record-locking/src/features/RecordLockingFeature.ts
+++ b/packages/api-record-locking/src/features/RecordLockingFeature.ts
@@ -23,9 +23,9 @@ export interface RecordLockingParams {
     model: CmsModel;
 }
 
-export const RecordLockingFeature = createFeature({
+export const RecordLockingFeature = createFeature<RecordLockingParams>({
     name: "RecordLockingManagement",
-    register(container, params: RecordLockingParams) {
+    register(container, params) {
         // Register domain abstractions
         container.registerInstance(RecordLockingConfig, { timeout: params.timeout });
         container.registerInstance(RecordLockingModel, params.model);

--- a/packages/api-website-builder-workflows/src/index.ts
+++ b/packages/api-website-builder-workflows/src/index.ts
@@ -12,7 +12,7 @@ export const createWebsiteBuilderWorkflows = () => {
         }
 
         // Register features
-        PageWorkflowsFeature.register(context.container, context);
+        PageWorkflowsFeature.register(context.container);
     });
 
     plugin.name = "website-builder-workflows.context";

--- a/packages/cognito/src/api/features/CognitoService/feature.ts
+++ b/packages/cognito/src/api/features/CognitoService/feature.ts
@@ -7,9 +7,9 @@ export type UserPoolConfig = {
     userPoolId: string;
 };
 
-export const CognitoServiceFeature = createFeature({
+export const CognitoServiceFeature = createFeature<UserPoolConfig>({
     name: "cognitoService",
-    register(container, config: UserPoolConfig) {
+    register(container, config) {
         container.register(CognitoService).inSingletonScope();
 
         container.registerInstance(CognitoConfig, config);

--- a/packages/feature/src/api/createFeature.ts
+++ b/packages/feature/src/api/createFeature.ts
@@ -1,14 +1,18 @@
 import type { Container } from "@webiny/di";
 
-export interface FeatureDefinition<TRegister> {
-    name: string;
-    register(container: Container, context?: TRegister): void;
-}
+export type FeatureDefinition<TRegister = void> = [TRegister] extends [void]
+    ? {
+          name: string;
+          register(container: Container): void;
+      }
+    : {
+          name: string;
+          register(container: Container, context: TRegister): void;
+      };
 
-export function createFeature<TRegister>(def: {
-    name: string;
-    register(container: Container, context?: TRegister): void;
-}): FeatureDefinition<TRegister> {
+export function createFeature<TRegister = void>(
+    def: FeatureDefinition<TRegister>
+): FeatureDefinition<TRegister> {
     const feature = {
         name: def.name,
         register: def.register


### PR DESCRIPTION
## Changes
Creating feature in API will now correctly populate second parameter in register method, if it was defined via generic.