### PR TITLE
feat(cli-core): add install version to upgrade cmd

### DIFF
--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
@@ -14,6 +14,7 @@ interface UpgradeCommandParams {
     version?: string;
     registry?: string;
     packageManager?: string;
+    installVersion?: string;
     skipDependencyGuard?: boolean;
 }
 
@@ -82,6 +83,13 @@ class UpgradeCommandImpl implements CliCommandFactory.Interface<UpgradeCommandPa
                     default: false,
                     description: `Skip the dependency guard that checks for incompatible dependencies before performing the upgrade.`,
                     type: "boolean"
+                },
+                {
+                    name: "install-version",
+                    type: "string",
+                    default: "",
+                    description:
+                        "Install a specific version of Webiny, no matter the version upgrade script is running for. Eg. upgrade script is for 6.5.0 but you want to install 6.5.0-rc.0"
                 }
             ],
             handler: async params => {
@@ -97,6 +105,7 @@ class UpgradeCommandImpl implements CliCommandFactory.Interface<UpgradeCommandPa
                     debug: params.debug || false,
                     packageManager: params.packageManager || undefined,
                     registry: params.registry || undefined,
+                    installVersion: params.installVersion || undefined,
                     skipDependencyGuard: params.skipDependencyGuard || false,
                     version
                 });

--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
@@ -25,7 +25,8 @@ export class UpgradeCommandHandlerImpl implements UpgradeCommandHandlerAbstracti
     public constructor(private ui: UiService.Interface) {}
 
     public async handle(params: UpgradeCommandHandlerAbstraction.Params): Promise<void> {
-        const { version, skipChecks, debug, logLevel, showLogs, showStackTrace } = params;
+        const { version, skipChecks, debug, logLevel, showLogs, showStackTrace, installVersion } =
+            params;
 
         if (!skipChecks) {
             /**
@@ -67,6 +68,7 @@ export class UpgradeCommandHandlerImpl implements UpgradeCommandHandlerAbstracti
             showLogs ? `--showLogs=${showLogs}` : "",
             showStackTrace ? `--showStackTrace=${showStackTrace}` : "",
             logLevel ? `--logLevel=${logLevel}` : "",
+            installVersion ? `--installVersion=${installVersion}` : "",
             "--json"
         ].filter(Boolean);
 

--- a/packages/cli-core/src/features/UpgradeCommand/abstraction.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/abstraction.ts
@@ -12,6 +12,7 @@ export interface IUpgradeCommandHandlerHandleParams {
     packageManager?: string;
     registry?: string;
     skipDependencyGuard?: boolean;
+    installVersion?: string;
 }
 
 export interface IUpgradeCommandHandler {


### PR DESCRIPTION
## Changes
Users can now add `--install-version=0.0.0-unstable.abc` (or any version they like) to install during the upgrade process.
This is mostly for testing, but if a user wants to upgrade to an unstable version, for which upgrade does not exist, this is the way.

For example, user is on `6.2.0` and we release a `6.3.0-unstable.abc`, user wont be run automatic upgrade process because a upgrade for `6.3.0` requires `6.3.0` to be released. This way, they can use the unstable, but still run the upgrade process for `6.3.0`.


## How Has This Been Tested?
Manually.