### PR TITLE
feat: add Infra.Env.IsProd and IsNotProd components

### DIFF
--- a/packages/project-aws-template/template/webiny.config.base.tsx
+++ b/packages/project-aws-template/template/webiny.config.base.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ProjectAws } from "@webiny/project-aws/extensions/ProjectAws.js";
+import { Infra } from "@webiny/project-aws";
 import { TenantManager } from "@webiny/tenant-manager";
 import { Languages } from "@webiny/languages";
 import { AiPowerups } from "@webiny/ai-powerups";
@@ -8,6 +9,7 @@ import { Extensions as WebinyConfigTsx } from "../../webiny.config.js";
 export const Extensions = () => {
     return (
         <>
+            <Infra.ProductionEnvironments environments={["prod", "production"]} />
             <ProjectAws />
             <Languages />
             <TenantManager />

--- a/packages/project-aws/src/infra.ts
+++ b/packages/project-aws/src/infra.ts
@@ -37,7 +37,14 @@ import { AwsDefaultRegion } from "./extensions/AwsDefaultRegion.js";
 import { Encryption } from "./extensions/Encryption.js";
 import { ApiLambdaFunction } from "./extensions/ApiLambdaFunction.js";
 import { EnvVar } from "@webiny/project/extensions/index.js";
-import { EnvIs, EnvIsNot, CiIs, CiIsNot } from "@webiny/project/extensions/infra/index.js";
+import {
+    EnvIs,
+    EnvIsNot,
+    EnvIsProd,
+    EnvIsNotProd,
+    CiIs,
+    CiIsNot
+} from "@webiny/project/extensions/infra/index.js";
 
 export const Infra = {
     Encryption,
@@ -53,7 +60,9 @@ export const Infra = {
     },
     Env: {
         Is: EnvIs,
-        IsNot: EnvIsNot
+        IsNot: EnvIsNot,
+        IsProd: EnvIsProd,
+        IsNotProd: EnvIsNotProd
     },
     Ci: {
         Is: CiIs,

--- a/packages/project/src/extensions/infra/Env.tsx
+++ b/packages/project/src/extensions/infra/Env.tsx
@@ -5,6 +5,7 @@ import {
     useRegion,
     useEnvContext
 } from "~/services/GetProjectConfigService/EnvContext.js";
+import { useProductionEnvironments } from "~/services/GetProjectConfigService/ProductionEnvironmentsContext.js";
 
 export interface EnvIsProps {
     env?: string | string[];
@@ -75,6 +76,20 @@ export const EnvIsNot: React.FC<EnvIsProps> = ({ env, variant, region, children 
         return null;
     }
 
+    return <>{children}</>;
+};
+
+export const EnvIsProd: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const env = useEnv();
+    const prodEnvs = useProductionEnvironments();
+    if (!prodEnvs.includes(env)) return null;
+    return <>{children}</>;
+};
+
+export const EnvIsNotProd: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const env = useEnv();
+    const prodEnvs = useProductionEnvironments();
+    if (prodEnvs.includes(env)) return null;
     return <>{children}</>;
 };
 

--- a/packages/project/src/extensions/infra/Env.tsx
+++ b/packages/project/src/extensions/infra/Env.tsx
@@ -82,14 +82,18 @@ export const EnvIsNot: React.FC<EnvIsProps> = ({ env, variant, region, children 
 export const EnvIsProd: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const env = useEnv();
     const prodEnvs = useProductionEnvironments();
-    if (!prodEnvs.includes(env)) return null;
+    if (!prodEnvs.includes(env)) {
+        return null;
+    }
     return <>{children}</>;
 };
 
 export const EnvIsNotProd: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const env = useEnv();
     const prodEnvs = useProductionEnvironments();
-    if (prodEnvs.includes(env)) return null;
+    if (prodEnvs.includes(env)) {
+        return null;
+    }
     return <>{children}</>;
 };
 

--- a/packages/project/src/extensions/pulumi/ProductionEnvironments.ts
+++ b/packages/project/src/extensions/pulumi/ProductionEnvironments.ts
@@ -1,11 +1,26 @@
+import React, { useEffect } from "react";
 import { z } from "zod";
 import { defineExtension } from "~/defineExtension/index.js";
+import { useRegisterProductionEnvironments } from "~/services/GetProjectConfigService/ProductionEnvironmentsContext.js";
+
+interface RegistrarProps {
+    environments: string[];
+}
+
+const Registrar: React.FC<RegistrarProps> = ({ environments }) => {
+    const setProdEnvs = useRegisterProductionEnvironments();
+    useEffect(() => {
+        if (setProdEnvs) {
+            setProdEnvs(environments);
+        }
+    }, []);
+    return null;
+};
 
 export const ProductionEnvironments = defineExtension({
     type: "Infra/ProductionEnvironments",
     tags: { runtimeContext: "project" },
     description: "Provide names for environments that are considered production environments.",
-    multiple: true,
     paramsSchema: z.object({
         environments: z.array(
             z.string().superRefine((value, ctx) => {
@@ -27,5 +42,6 @@ export const ProductionEnvironments = defineExtension({
                 }
             })
         )
-    })
+    }),
+    render: props => React.createElement(Registrar, { environments: props.environments })
 });

--- a/packages/project/src/services/GetProjectConfigService/ProductionEnvironmentsContext.tsx
+++ b/packages/project/src/services/GetProjectConfigService/ProductionEnvironmentsContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface ProductionEnvironmentsContextValue {
+    prodEnvs: string[];
+    setProdEnvs: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const ProductionEnvironmentsContext = createContext<ProductionEnvironmentsContextValue | null>(
+    null
+);
+
+export const ProductionEnvironmentsCollector: React.FC<{ children: React.ReactNode }> = ({
+    children
+}) => {
+    const [prodEnvs, setProdEnvs] = useState<string[]>([]);
+    return (
+        <ProductionEnvironmentsContext.Provider value={{ prodEnvs, setProdEnvs }}>
+            {children}
+        </ProductionEnvironmentsContext.Provider>
+    );
+};
+
+export const useProductionEnvironments = (): string[] => {
+    return useContext(ProductionEnvironmentsContext)?.prodEnvs ?? [];
+};
+
+export const useRegisterProductionEnvironments = () => {
+    return useContext(ProductionEnvironmentsContext)?.setProdEnvs ?? null;
+};

--- a/packages/project/src/services/GetProjectConfigService/renderConfigWorker.tsx
+++ b/packages/project/src/services/GetProjectConfigService/renderConfigWorker.tsx
@@ -10,6 +10,7 @@ import { ProjectModel } from "~/models/ProjectModel.js";
 import { toImportSpecifier } from "~/utils/index.js";
 import { EnvProvider } from "./EnvContext.js";
 import { WcpProjectLicenseProvider } from "./WcpProjectLicenseContext.js";
+import { ProductionEnvironmentsCollector } from "./ProductionEnvironmentsContext.js";
 
 const sendError = (err: Error) => {
     const message: RenderConfigWorkerMessageDto = {
@@ -75,9 +76,11 @@ const reactRoot = createRoot(root);
 reactRoot.render(
     <WcpProjectLicenseProvider>
         <EnvProvider>
-            <Properties onChange={onChange}>
-                <Extensions />
-            </Properties>
+            <ProductionEnvironmentsCollector>
+                <Properties onChange={onChange}>
+                    <Extensions />
+                </Properties>
+            </ProductionEnvironmentsCollector>
         </EnvProvider>
     </WcpProjectLicenseProvider>
 );

--- a/packages/pulumi-sdk/src/Pulumi.ts
+++ b/packages/pulumi-sdk/src/Pulumi.ts
@@ -230,7 +230,6 @@ export class Pulumi {
                 // lock file are matched by the same prefix check.
                 const baseName = entry.endsWith(".lock") ? entry.slice(0, -5) : entry;
                 if (baseName !== requiredPluginDir) {
-                    console.log("DERI", entry);
                     fs.removeSync(path.join(pluginsDir, entry));
                 }
             }


### PR DESCRIPTION
### What changed

Two new components, `Infra.Env.IsProd` and `Infra.Env.IsNotProd`, are now available for conditionally rendering config based on whether the current environment is a production environment. `Infra.ProductionEnvironments` is now mounted in the base project template with `prod` and `production` as the default production environment names.

### Why

Users with multiple production environments (e.g. `prod-eu`, `prod-us`) previously had to repeat the full list of environment names at every `Infra.Env.Is` usage site. There was no single place to declare "these are my production environments" and then reference that intent semantically throughout the config.

### How

A new `ProductionEnvironmentsContext` holds a `prodEnvs` string array in React state. `ProductionEnvironmentsCollector` (a state-owning provider) is added to the render tree in `renderConfigWorker.tsx`, wrapping the `Extensions` component. `Infra.ProductionEnvironments` gains a `render` function with a `Registrar` child component that calls `useEffect` to push its `environments` prop into the context on mount — triggering a re-render before the debounced `onChange` fires. `EnvIsProd` and `EnvIsNotProd` read from this context via `useProductionEnvironments()`. The `multiple: true` flag was removed from `ProductionEnvironments` so a user-declared instance fully replaces the template default rather than merging with it.

### Changelog

**Added `Infra.Env.IsProd` and `Infra.Env.IsNotProd` Components**

Projects with multiple production environments (e.g. `prod-eu`, `prod-us`) previously required repeating the full list of environment names everywhere in the config. The new `Infra.Env.IsProd` and `Infra.Env.IsNotProd` components let you declare which environments are production once via `Infra.ProductionEnvironments`, then reference that intent throughout your config without repetition.

### Squash Merge Commit

```
feat: add Infra.Env.IsProd and IsNotProd components (#5129)
```
