### PR TITLE
fix: export useBuildParams from main webiny/admin entry point

### DIFF
--- a/packages/app-admin/src/exports/admin.ts
+++ b/packages/app-admin/src/exports/admin.ts
@@ -1,6 +1,7 @@
 export { DevToolsSection } from "~/components/index.js";
 export { RegisterFeature } from "~/components/RegisterFeature.js";
 export { BuildParam, BuildParams } from "~/features/buildParams/index.js";
+export { useBuildParams } from "~/presentation/buildParams/useBuildParams.js";
 export { Tool, ToolPipelineRunner, LexicalContext } from "~/features/tools/index.js";
 export { ToolsFeature } from "~/features/tools/index.js";
 export { AdminConfig } from "~/config/AdminConfig.js";

--- a/packages/app-admin/src/exports/admin/build-params.ts
+++ b/packages/app-admin/src/exports/admin/build-params.ts
@@ -1,2 +1,5 @@
+/** @deprecated Import from "webiny/admin" instead. */
 export { useBuildParams } from "~/presentation/buildParams/useBuildParams.js";
+
+/** @deprecated Import from "webiny/admin" instead. */
 export { BuildParam, BuildParams } from "~/features/buildParams/index.js";

--- a/packages/webiny/src/admin.ts
+++ b/packages/webiny/src/admin.ts
@@ -8,6 +8,7 @@ export { Plugin } from "@webiny/app/core/Plugin.js";
 export { DevToolsSection } from "@webiny/app-admin/components/index.js";
 export { RegisterFeature } from "@webiny/app-admin/components/RegisterFeature.js";
 export { BuildParam, BuildParams } from "@webiny/app-admin/features/buildParams/index.js";
+export { useBuildParams } from "@webiny/app-admin/presentation/buildParams/useBuildParams.js";
 export {
     Tool,
     ToolPipelineRunner,

--- a/packages/webiny/src/admin/build-params.ts
+++ b/packages/webiny/src/admin/build-params.ts
@@ -1,2 +1,4 @@
+/** @deprecated Import from "webiny/admin" instead. */
 export { useBuildParams } from "@webiny/app-admin/presentation/buildParams/useBuildParams.js";
+/** @deprecated Import from "webiny/admin" instead. */
 export { BuildParam, BuildParams } from "@webiny/app-admin/features/buildParams/index.js";


### PR DESCRIPTION
### What changed

`useBuildParams` is now exported from the main `webiny/admin` entry point. Previously it was only accessible via the sub-path `webiny/admin/build-params`. The sub-path export is now marked as deprecated in favour of the main entry point.

### Why

Consumers needed to import `useBuildParams` from a non-standard sub-path (`webiny/admin/build-params`), which was inconsistent with how other admin hooks and components are imported. Moving it to the primary `webiny/admin` export makes the API surface consistent and removes the need to know about internal sub-path structure.

### How

Added `useBuildParams` to the re-export list in `packages/app-admin/src/exports/admin.ts` and `packages/webiny/src/admin.ts`. Annotated the existing sub-path export files (`webiny/admin/build-params` and `@webiny/app-admin/admin/build-params`) with `@deprecated` JSDoc pointing consumers to the main entry point.

### Changelog

#### Exported useBuildParams from Main Admin Entry Point

The `useBuildParams` hook was previously only importable from a sub-path and was missing from the main admin package exports. It is now available from the standard `webiny/admin` import path, consistent with all other admin hooks.

### Squash Merge Commit

```
fix: export useBuildParams from main webiny/admin entry point (#5136)
```