### PR TITLE
feat: export useEnv hook from @webiny/project-aws

### DIFF
--- a/packages/project-aws/src/infra.ts
+++ b/packages/project-aws/src/infra.ts
@@ -62,6 +62,7 @@ export const Infra = {
         Tags: AwsTags
     },
     Env: {
+        useEnv,
         Is: EnvIs,
         IsNot: EnvIsNot,
         IsProd: EnvIsProd,

--- a/packages/project-aws/src/infra.ts
+++ b/packages/project-aws/src/infra.ts
@@ -42,9 +42,12 @@ import {
     EnvIsNot,
     EnvIsProd,
     EnvIsNotProd,
+    useEnv,
     CiIs,
     CiIsNot
 } from "@webiny/project/extensions/infra/index.js";
+
+export { useEnv };
 
 export const Infra = {
     Encryption,


### PR DESCRIPTION
### What changed

Added `useEnv` to the public exports of `@webiny/project-aws`. The hook was already implemented inside the package's infra extensions but was not re-exported from the AWS entry point, making it inaccessible to consumers who import from `@webiny/project-aws`.

### Changelog

**Export `useEnv` Hook from `@webiny/project-aws`**

The `useEnv` hook, which provides access to the current deployment environment context within infrastructure code, was not exported from the `@webiny/project-aws` package. It can now be imported directly from `@webiny/project-aws`.

### Squash Merge Commit

\`\`\`
feat: export useEnv hook from @webiny/project-aws (#5139)
\`\`\`