### PR TITLE
feat: export tenant manager use cases and features from public API

### DIFF
--- a/packages/tenant-manager/src/exports/api/tenant-manager.ts
+++ b/packages/tenant-manager/src/exports/api/tenant-manager.ts
@@ -1,2 +1,44 @@
 export { TenantModelExtension } from "~/api/domain/TenantModelExtension.js";
 export type { TenantExtensions } from "~/shared/Tenant.js";
+
+export {
+    GetCurrentTenantUseCase,
+    type IGetCurrentTenantUseCase,
+    type IGetCurrentTenantUseCaseErrors
+} from "~/api/features/GetCurrentTenant/abstractions.js";
+export { GetCurrentTenantFeature } from "~/api/features/GetCurrentTenant/feature.js";
+export {
+    GetTenantByIdUseCase,
+    GetTenantByIdRepository,
+    type IGetTenantByIdUseCase,
+    type IGetTenantByIdRepository
+} from "~/api/features/GetTenantById/abstractions.js";
+export { GetTenantByIdFeature } from "~/api/features/GetTenantById/feature.js";
+export {
+    CreateTenantUseCase,
+    type ICreateTenantUseCase
+} from "~/api/features/CreateTenant/abstractions.js";
+export { CreateTenantFeature } from "~/api/features/CreateTenant/feature.js";
+export {
+    CreateAndInstallTenantUseCase,
+    type ICreateAndInstallTenantUseCase
+} from "~/api/features/CreateAndInstallTenant/abstractions.js";
+export { CreateAndInstallTenantFeature } from "~/api/features/CreateAndInstallTenant/feature.js";
+export {
+    UpdateTenantUseCase,
+    type IUpdateTenantUseCase
+} from "~/api/features/UpdateTenant/abstractions.js";
+export { UpdateTenantFeature } from "~/api/features/UpdateTenant/feature.js";
+export {
+    EnableTenantUseCase,
+    type IEnableTenantUseCase
+} from "~/api/features/EnableTenant/abstractions.js";
+export { EnableTenantFeature } from "~/api/features/EnableTenant/feature.js";
+export {
+    DisableTenantUseCase,
+    type IDisableTenantUseCase
+} from "~/api/features/DisableTenant/abstractions.js";
+export { DisableTenantFeature } from "~/api/features/DisableTenant/feature.js";
+export { default as AddCmsPermissions } from "~/api/features/AddCmsPermissions/AddCmsPermissions.js";
+export { AddCmsPermissionsFeature } from "~/api/features/AddCmsPermissions/feature.js";
+export { DeleteTenantOnEntryDeleteFeature } from "~/api/features/DeleteTenantOnEntryDelete/feature.js";

--- a/packages/tenant-manager/src/exports/api/tenant-manager.ts
+++ b/packages/tenant-manager/src/exports/api/tenant-manager.ts
@@ -1,3 +1,6 @@
+export { TenantModelExtension } from "~/api/domain/TenantModelExtension.js";
+export type { TenantExtensions } from "~/shared/Tenant.js";
+
 export { GetCurrentTenantUseCase } from "~/api/features/GetCurrentTenant/abstractions.js";
 export { GetTenantByIdUseCase } from "~/api/features/GetTenantById/abstractions.js";
 export { CreateTenantUseCase } from "~/api/features/CreateTenant/abstractions.js";

--- a/packages/tenant-manager/src/exports/api/tenant-manager.ts
+++ b/packages/tenant-manager/src/exports/api/tenant-manager.ts
@@ -1,22 +1,7 @@
-export { TenantModelExtension } from "~/api/domain/TenantModelExtension.js";
-
 export { GetCurrentTenantUseCase } from "~/api/features/GetCurrentTenant/abstractions.js";
-export { GetCurrentTenantFeature } from "~/api/features/GetCurrentTenant/feature.js";
-export {
-    GetTenantByIdUseCase,
-    GetTenantByIdRepository
-} from "~/api/features/GetTenantById/abstractions.js";
-export { GetTenantByIdFeature } from "~/api/features/GetTenantById/feature.js";
+export { GetTenantByIdUseCase } from "~/api/features/GetTenantById/abstractions.js";
 export { CreateTenantUseCase } from "~/api/features/CreateTenant/abstractions.js";
-export { CreateTenantFeature } from "~/api/features/CreateTenant/feature.js";
 export { CreateAndInstallTenantUseCase } from "~/api/features/CreateAndInstallTenant/abstractions.js";
-export { CreateAndInstallTenantFeature } from "~/api/features/CreateAndInstallTenant/feature.js";
 export { UpdateTenantUseCase } from "~/api/features/UpdateTenant/abstractions.js";
-export { UpdateTenantFeature } from "~/api/features/UpdateTenant/feature.js";
 export { EnableTenantUseCase } from "~/api/features/EnableTenant/abstractions.js";
-export { EnableTenantFeature } from "~/api/features/EnableTenant/feature.js";
 export { DisableTenantUseCase } from "~/api/features/DisableTenant/abstractions.js";
-export { DisableTenantFeature } from "~/api/features/DisableTenant/feature.js";
-export { default as AddCmsPermissions } from "~/api/features/AddCmsPermissions/AddCmsPermissions.js";
-export { AddCmsPermissionsFeature } from "~/api/features/AddCmsPermissions/feature.js";
-export { DeleteTenantOnEntryDeleteFeature } from "~/api/features/DeleteTenantOnEntryDelete/feature.js";

--- a/packages/tenant-manager/src/exports/api/tenant-manager.ts
+++ b/packages/tenant-manager/src/exports/api/tenant-manager.ts
@@ -1,43 +1,21 @@
 export { TenantModelExtension } from "~/api/domain/TenantModelExtension.js";
-export type { TenantExtensions } from "~/shared/Tenant.js";
 
-export {
-    GetCurrentTenantUseCase,
-    type IGetCurrentTenantUseCase,
-    type IGetCurrentTenantUseCaseErrors
-} from "~/api/features/GetCurrentTenant/abstractions.js";
+export { GetCurrentTenantUseCase } from "~/api/features/GetCurrentTenant/abstractions.js";
 export { GetCurrentTenantFeature } from "~/api/features/GetCurrentTenant/feature.js";
 export {
     GetTenantByIdUseCase,
-    GetTenantByIdRepository,
-    type IGetTenantByIdUseCase,
-    type IGetTenantByIdRepository
+    GetTenantByIdRepository
 } from "~/api/features/GetTenantById/abstractions.js";
 export { GetTenantByIdFeature } from "~/api/features/GetTenantById/feature.js";
-export {
-    CreateTenantUseCase,
-    type ICreateTenantUseCase
-} from "~/api/features/CreateTenant/abstractions.js";
+export { CreateTenantUseCase } from "~/api/features/CreateTenant/abstractions.js";
 export { CreateTenantFeature } from "~/api/features/CreateTenant/feature.js";
-export {
-    CreateAndInstallTenantUseCase,
-    type ICreateAndInstallTenantUseCase
-} from "~/api/features/CreateAndInstallTenant/abstractions.js";
+export { CreateAndInstallTenantUseCase } from "~/api/features/CreateAndInstallTenant/abstractions.js";
 export { CreateAndInstallTenantFeature } from "~/api/features/CreateAndInstallTenant/feature.js";
-export {
-    UpdateTenantUseCase,
-    type IUpdateTenantUseCase
-} from "~/api/features/UpdateTenant/abstractions.js";
+export { UpdateTenantUseCase } from "~/api/features/UpdateTenant/abstractions.js";
 export { UpdateTenantFeature } from "~/api/features/UpdateTenant/feature.js";
-export {
-    EnableTenantUseCase,
-    type IEnableTenantUseCase
-} from "~/api/features/EnableTenant/abstractions.js";
+export { EnableTenantUseCase } from "~/api/features/EnableTenant/abstractions.js";
 export { EnableTenantFeature } from "~/api/features/EnableTenant/feature.js";
-export {
-    DisableTenantUseCase,
-    type IDisableTenantUseCase
-} from "~/api/features/DisableTenant/abstractions.js";
+export { DisableTenantUseCase } from "~/api/features/DisableTenant/abstractions.js";
 export { DisableTenantFeature } from "~/api/features/DisableTenant/feature.js";
 export { default as AddCmsPermissions } from "~/api/features/AddCmsPermissions/AddCmsPermissions.js";
 export { AddCmsPermissionsFeature } from "~/api/features/AddCmsPermissions/feature.js";

--- a/packages/webiny/src/api/tenant-manager.ts
+++ b/packages/webiny/src/api/tenant-manager.ts
@@ -1,21 +1,7 @@
-export { TenantModelExtension } from "@webiny/tenant-manager/api/domain/TenantModelExtension.js";
 export { GetCurrentTenantUseCase } from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
-export { GetCurrentTenantFeature } from "@webiny/tenant-manager/api/features/GetCurrentTenant/feature.js";
-export {
-    GetTenantByIdUseCase,
-    GetTenantByIdRepository
-} from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
-export { GetTenantByIdFeature } from "@webiny/tenant-manager/api/features/GetTenantById/feature.js";
+export { GetTenantByIdUseCase } from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
 export { CreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";
-export { CreateTenantFeature } from "@webiny/tenant-manager/api/features/CreateTenant/feature.js";
 export { CreateAndInstallTenantUseCase } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/abstractions.js";
-export { CreateAndInstallTenantFeature } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/feature.js";
 export { UpdateTenantUseCase } from "@webiny/tenant-manager/api/features/UpdateTenant/abstractions.js";
-export { UpdateTenantFeature } from "@webiny/tenant-manager/api/features/UpdateTenant/feature.js";
 export { EnableTenantUseCase } from "@webiny/tenant-manager/api/features/EnableTenant/abstractions.js";
-export { EnableTenantFeature } from "@webiny/tenant-manager/api/features/EnableTenant/feature.js";
 export { DisableTenantUseCase } from "@webiny/tenant-manager/api/features/DisableTenant/abstractions.js";
-export { DisableTenantFeature } from "@webiny/tenant-manager/api/features/DisableTenant/feature.js";
-export { default as AddCmsPermissions } from "@webiny/tenant-manager/api/features/AddCmsPermissions/AddCmsPermissions.js";
-export { AddCmsPermissionsFeature } from "@webiny/tenant-manager/api/features/AddCmsPermissions/feature.js";
-export { DeleteTenantOnEntryDeleteFeature } from "@webiny/tenant-manager/api/features/DeleteTenantOnEntryDelete/feature.js";

--- a/packages/webiny/src/api/tenant-manager.ts
+++ b/packages/webiny/src/api/tenant-manager.ts
@@ -1,34 +1,20 @@
 export { TenantModelExtension } from "@webiny/tenant-manager/api/domain/TenantModelExtension.js";
-export type { TenantExtensions } from "@webiny/tenant-manager/shared/Tenant.js";
 export { GetCurrentTenantUseCase } from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
-export {
-    type IGetCurrentTenantUseCase,
-    IGetCurrentTenantUseCaseErrors
-} from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
 export { GetCurrentTenantFeature } from "@webiny/tenant-manager/api/features/GetCurrentTenant/feature.js";
 export {
     GetTenantByIdUseCase,
     GetTenantByIdRepository
 } from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
-export {
-    type IGetTenantByIdUseCase,
-    IGetTenantByIdRepository
-} from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
 export { GetTenantByIdFeature } from "@webiny/tenant-manager/api/features/GetTenantById/feature.js";
 export { CreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";
-export { type ICreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";
 export { CreateTenantFeature } from "@webiny/tenant-manager/api/features/CreateTenant/feature.js";
 export { CreateAndInstallTenantUseCase } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/abstractions.js";
-export { type ICreateAndInstallTenantUseCase } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/abstractions.js";
 export { CreateAndInstallTenantFeature } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/feature.js";
 export { UpdateTenantUseCase } from "@webiny/tenant-manager/api/features/UpdateTenant/abstractions.js";
-export { type IUpdateTenantUseCase } from "@webiny/tenant-manager/api/features/UpdateTenant/abstractions.js";
 export { UpdateTenantFeature } from "@webiny/tenant-manager/api/features/UpdateTenant/feature.js";
 export { EnableTenantUseCase } from "@webiny/tenant-manager/api/features/EnableTenant/abstractions.js";
-export { type IEnableTenantUseCase } from "@webiny/tenant-manager/api/features/EnableTenant/abstractions.js";
 export { EnableTenantFeature } from "@webiny/tenant-manager/api/features/EnableTenant/feature.js";
 export { DisableTenantUseCase } from "@webiny/tenant-manager/api/features/DisableTenant/abstractions.js";
-export { type IDisableTenantUseCase } from "@webiny/tenant-manager/api/features/DisableTenant/abstractions.js";
 export { DisableTenantFeature } from "@webiny/tenant-manager/api/features/DisableTenant/feature.js";
 export { default as AddCmsPermissions } from "@webiny/tenant-manager/api/features/AddCmsPermissions/AddCmsPermissions.js";
 export { AddCmsPermissionsFeature } from "@webiny/tenant-manager/api/features/AddCmsPermissions/feature.js";

--- a/packages/webiny/src/api/tenant-manager.ts
+++ b/packages/webiny/src/api/tenant-manager.ts
@@ -1,2 +1,35 @@
 export { TenantModelExtension } from "@webiny/tenant-manager/api/domain/TenantModelExtension.js";
 export type { TenantExtensions } from "@webiny/tenant-manager/shared/Tenant.js";
+export { GetCurrentTenantUseCase } from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
+export {
+    type IGetCurrentTenantUseCase,
+    IGetCurrentTenantUseCaseErrors
+} from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
+export { GetCurrentTenantFeature } from "@webiny/tenant-manager/api/features/GetCurrentTenant/feature.js";
+export {
+    GetTenantByIdUseCase,
+    GetTenantByIdRepository
+} from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
+export {
+    type IGetTenantByIdUseCase,
+    IGetTenantByIdRepository
+} from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
+export { GetTenantByIdFeature } from "@webiny/tenant-manager/api/features/GetTenantById/feature.js";
+export { CreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";
+export { type ICreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";
+export { CreateTenantFeature } from "@webiny/tenant-manager/api/features/CreateTenant/feature.js";
+export { CreateAndInstallTenantUseCase } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/abstractions.js";
+export { type ICreateAndInstallTenantUseCase } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/abstractions.js";
+export { CreateAndInstallTenantFeature } from "@webiny/tenant-manager/api/features/CreateAndInstallTenant/feature.js";
+export { UpdateTenantUseCase } from "@webiny/tenant-manager/api/features/UpdateTenant/abstractions.js";
+export { type IUpdateTenantUseCase } from "@webiny/tenant-manager/api/features/UpdateTenant/abstractions.js";
+export { UpdateTenantFeature } from "@webiny/tenant-manager/api/features/UpdateTenant/feature.js";
+export { EnableTenantUseCase } from "@webiny/tenant-manager/api/features/EnableTenant/abstractions.js";
+export { type IEnableTenantUseCase } from "@webiny/tenant-manager/api/features/EnableTenant/abstractions.js";
+export { EnableTenantFeature } from "@webiny/tenant-manager/api/features/EnableTenant/feature.js";
+export { DisableTenantUseCase } from "@webiny/tenant-manager/api/features/DisableTenant/abstractions.js";
+export { type IDisableTenantUseCase } from "@webiny/tenant-manager/api/features/DisableTenant/abstractions.js";
+export { DisableTenantFeature } from "@webiny/tenant-manager/api/features/DisableTenant/feature.js";
+export { default as AddCmsPermissions } from "@webiny/tenant-manager/api/features/AddCmsPermissions/AddCmsPermissions.js";
+export { AddCmsPermissionsFeature } from "@webiny/tenant-manager/api/features/AddCmsPermissions/feature.js";
+export { DeleteTenantOnEntryDeleteFeature } from "@webiny/tenant-manager/api/features/DeleteTenantOnEntryDelete/feature.js";

--- a/packages/webiny/src/api/tenant-manager.ts
+++ b/packages/webiny/src/api/tenant-manager.ts
@@ -1,3 +1,5 @@
+export { TenantModelExtension } from "@webiny/tenant-manager/api/domain/TenantModelExtension.js";
+export type { TenantExtensions } from "@webiny/tenant-manager/shared/Tenant.js";
 export { GetCurrentTenantUseCase } from "@webiny/tenant-manager/api/features/GetCurrentTenant/abstractions.js";
 export { GetTenantByIdUseCase } from "@webiny/tenant-manager/api/features/GetTenantById/abstractions.js";
 export { CreateTenantUseCase } from "@webiny/tenant-manager/api/features/CreateTenant/abstractions.js";


### PR DESCRIPTION
### What changed

This PR exposes the tenant manager's use case and feature classes through the public API exports. Previously, only `TenantModelExtension` and `TenantExtensions` were exported from both the `@webiny/tenant-manager` package and the main `@webiny/api` entry point. Now, all tenant lifecycle operations — getting the current tenant, fetching by ID, creating, updating, enabling, disabling, and installing tenants — are available as named exports, along with their corresponding feature wrappers and TypeScript interfaces.

### Changelog

**Tenant Manager Use Cases and Features Now Exported from Public API**

The tenant manager's use case classes, feature plugins, and TypeScript interfaces were not accessible through the package's public entry point, making it difficult to extend or override tenant management behavior. They are now exported from both `@webiny/tenant-manager` and the main `@webiny/webiny` package, enabling developers to consume and build on top of these abstractions directly.

### Squash Merge Commit

```
feat: export tenant manager use cases and features from public API (#5140)
```