### PR TITLE
fix: ref field responsiveness, sidebar footer and expand arrow

### DIFF
--- a/packages/admin-ui/src/Sidebar/Sidebar.tsx
+++ b/packages/admin-ui/src/Sidebar/Sidebar.tsx
@@ -58,9 +58,11 @@ const SidebarBase = (props: SidebarProps) => {
             <SidebarContent {...contentProps}>
                 <SidebarMenuRoot showPinnedItems={true}>{props.children}</SidebarMenuRoot>
             </SidebarContent>
-            <SidebarFooter>
-                <SidebarMenuRoot showPinnedItems={false}>{footerProps.footer}</SidebarMenuRoot>
-            </SidebarFooter>
+            {footerProps.footer && (
+                <SidebarFooter>
+                    <SidebarMenuRoot showPinnedItems={false}>{footerProps.footer}</SidebarMenuRoot>
+                </SidebarFooter>
+            )}
         </SidebarRoot>
     );
 };

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootItem.tsx
@@ -138,6 +138,7 @@ const SidebarMenuItemBase = ({
                 color={"neutral-strong"}
                 data-sidebar={"menu-item-expanded-indicator"}
                 icon={<KeyboardArrowRightIcon />}
+                onClick={toggleSectionExpanded}
             />
         ) : null;
 

--- a/packages/app-admin-ui/src/Navigation/Navigation.tsx
+++ b/packages/app-admin-ui/src/Navigation/Navigation.tsx
@@ -15,11 +15,17 @@ export const Navigation = NavigationRenderer.createDecorator(() => {
             </SimpleLink>
         );
 
+        const hasFooterMenus = menus.some(m => (m.tags || []).includes("footer"));
+
         return (
             <Sidebar
                 title={titleElement}
                 icon={icon}
-                footer={<SidebarMenuItems menus={menus} where={{ tags: ["footer"] }} />}
+                footer={
+                    hasFooterMenus ? (
+                        <SidebarMenuItems menus={menus} where={{ tags: ["footer"] }} />
+                    ) : undefined
+                }
             >
                 <SidebarMenuItems menus={menus} />
             </Sidebar>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedMultipleReferenceField.tsx
@@ -199,7 +199,7 @@ export const AdvancedMultipleReferenceField = (props: AdvancedMultipleReferenceF
     const invalid = useMemo(() => validationIsValid === false, [validationIsValid]);
 
     return (
-        <>
+        <div className={"@container"}>
             <div className={"flex items-center justify-between"}>
                 <FormComponentLabel text={field.label} invalid={invalid} disabled={disabled} />
             </div>
@@ -264,6 +264,6 @@ export const AdvancedMultipleReferenceField = (props: AdvancedMultipleReferenceF
                     onDialogClose={onLinkEntryDialogClose}
                 />
             )}
-        </>
+        </div>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/AdvancedSingleReferenceField.tsx
@@ -173,7 +173,7 @@ export const AdvancedSingleReferenceField = (props: AdvancedSingleReferenceField
     const disabled = !rules.canEdit || rules.disabled;
 
     return (
-        <>
+        <div className={"@container"}>
             <FormComponentLabel text={field.label} invalid={invalid} disabled={disabled} />
             <div className={"webiny_ref-field-container"}>
                 {loading && <OverlayLoader size={"md"} />}
@@ -219,6 +219,6 @@ export const AdvancedSingleReferenceField = (props: AdvancedSingleReferenceField
                     onDialogClose={onLinkEntryDialogClose}
                 />
             )}
-        </>
+        </div>
     );
 };

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entry.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Entry.tsx
@@ -123,50 +123,49 @@ export const Entry = ({
             ) : null}
             <div
                 className={
-                    "grid grid-cols-[auto_1fr_auto] items-center gap-lg text-sm text-neutral-muted w-full min-w-0"
+                    "grid grid-cols-[auto_1fr] items-start @lg:items-center gap-lg text-sm text-neutral-muted w-full min-w-0"
                 }
             >
                 <Image title={entry.title} src={entry.image} />
-                <div className={"overflow-hidden"}>
-                    <div>{entry.model.name}</div>
+                <div
+                    className={
+                        "flex flex-col @lg:flex-row @lg:items-center @lg:justify-between gap-sm min-w-0"
+                    }
+                >
+                    <div className={"min-w-0"}>
+                        <div className={"truncate"}>{entry.model.name}</div>
 
-                    <div
-                        title={entry.title}
-                        className={
-                            "text-md text-neutral-primary font-semibold mb-sm text-ellipsis overflow-hidden whitespace-nowrap block"
-                        }
-                    >
-                        {entry.title}
+                        <div
+                            title={entry.title}
+                            className={
+                                "text-md text-neutral-primary font-semibold mb-sm text-ellipsis overflow-hidden whitespace-nowrap block"
+                            }
+                        >
+                            {entry.title}
+                        </div>
+
+                        <div>
+                            <span className={"w-[60px] inline-block"}>Created:</span>
+                            <span>
+                                {entry.createdBy.displayName},{" "}
+                                <TimeAgo datetime={entry.createdOn} />
+                            </span>
+                        </div>
                     </div>
+                    <div className={"flex items-center gap-sm shrink-0"}>
+                        <Tag
+                            content={
+                                <>
+                                    {entryStatusLabel}&nbsp;
+                                    <Text size={"sm"} className={"text-neutral-muted"}>
+                                        ({entryRevision})
+                                    </Text>
+                                </>
+                            }
+                            variant={"neutral-base-outline"}
+                        />
 
-                    <div>
-                        <span className={"w-[60px] inline-block"}>Created:</span>
-                        <span>
-                            {entry.createdBy.displayName}, <TimeAgo datetime={entry.createdOn} />
-                        </span>
-                    </div>
-                    {/* <div>
-                        <span className={"w-[60px] inline-block"}>Location:</span>
-                        <span>
-                            Home / Content / Preview / ... / Manage / Retail / Local / Products
-                        </span>
-                    </div>*/}
-                </div>
-                <div className={"flex items-center gap-sm"}>
-                    <Tag
-                        content={
-                            <>
-                                {entryStatusLabel}&nbsp;
-                                <Text size={"sm"} className={"text-neutral-muted"}>
-                                    ({entryRevision})
-                                </Text>
-                            </>
-                        }
-                        variant={"neutral-base-outline"}
-                    />
-
-                    {!disabled && placement == "multiRef" ? (
-                        <>
+                        {!disabled && placement == "multiRef" ? (
                             <div className={"flex gap-xs"}>
                                 <IconButton
                                     disabled={!onMoveUpClick}
@@ -183,31 +182,37 @@ export const Entry = ({
                                     onClick={onMoveDown}
                                 />
                             </div>
-                        </>
-                    ) : null}
+                        ) : null}
 
-                    {!disabled ? (
-                        <DropdownMenu
-                            trigger={
-                                <IconButton variant={"ghost"} size={"sm"} icon={<MoreVertIcon />} />
-                            }
-                        >
-                            <DropdownMenu.Link
-                                icon={<OpenInNewIcon />}
-                                text={"Open in new tab"}
-                                to={link}
-                                target={"_blank"}
-                            />
-
-                            {onRemove && (
-                                <DropdownMenu.Item
-                                    icon={<RemoveIcon />}
-                                    text={placement === "multiRef" ? "Remove from list" : "Remove"}
-                                    onClick={() => onRemove(entry.id)}
+                        {!disabled ? (
+                            <DropdownMenu
+                                trigger={
+                                    <IconButton
+                                        variant={"ghost"}
+                                        size={"sm"}
+                                        icon={<MoreVertIcon />}
+                                    />
+                                }
+                            >
+                                <DropdownMenu.Link
+                                    icon={<OpenInNewIcon />}
+                                    text={"Open in new tab"}
+                                    to={link}
+                                    target={"_blank"}
                                 />
-                            )}
-                        </DropdownMenu>
-                    ) : null}
+
+                                {onRemove && (
+                                    <DropdownMenu.Item
+                                        icon={<RemoveIcon />}
+                                        text={
+                                            placement === "multiRef" ? "Remove from list" : "Remove"
+                                        }
+                                        onClick={() => onRemove(entry.id)}
+                                    />
+                                )}
+                            </DropdownMenu>
+                        ) : null}
+                    </div>
                 </div>
             </div>
         </div>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Options.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/ref/advanced/components/Options.tsx
@@ -43,7 +43,7 @@ export const Options = ({ models, onNewRecord, onLinkExistingRecord }: OptionsPr
 
     if (hasMultipleModels) {
         return (
-            <div className={"flex gap-sm"}>
+            <div className={"flex flex-wrap gap-sm"}>
                 <DropdownMenu
                     trigger={
                         <Button
@@ -71,9 +71,8 @@ export const Options = ({ models, onNewRecord, onLinkExistingRecord }: OptionsPr
     }
 
     return (
-        <div>
+        <div className={"flex flex-wrap gap-sm"}>
             <CreateNewRecordButton onClick={onSingleNewRecord} />
-            &nbsp;
             <LinkExistingRecordButton onClick={onSingleExistingRecord} />
         </div>
     );

--- a/packages/app-sdk-playground/src/plugins/defaultCode.ts
+++ b/packages/app-sdk-playground/src/plugins/defaultCode.ts
@@ -11,9 +11,9 @@ async function run() {
 
     // Handle the result
     if (result.isOk()) {
-        console.log("Entries:", result.value);
+        console.log(result.value);
     } else {
-        console.error("Error:", result.error);
+        console.error(result.error);
     }
 }
 


### PR DESCRIPTION
### What changed

This PR includes three UI fixes:

1. **Ref field responsive layout** — Reference field entry cards now adapt to the available container width. In narrow panels, cards stack metadata and action buttons vertically; in wider views they return to the original single-row layout. The "Create" and "Select" buttons below the list also wrap cleanly at narrow widths.

<img width="2276" height="1044" alt="image" src="https://github.com/user-attachments/assets/7eb41f8f-c9a6-46f6-9ea3-19263eec72a0" />

2. **Sidebar footer hidden when empty** — The sidebar footer section (including its separator) is now hidden when there are no footer menu items, instead of rendering an empty section.

3. **Sidebar section expand arrow is clickable** — The right-arrow indicator on collapsible sidebar sections now correctly toggles the section when clicked.

<img width="654" height="1141" alt="image" src="https://github.com/user-attachments/assets/7bee79ab-6d1d-4c63-bba2-ec16eb3d2423" />

### Changelog

**Responsive Layout for Reference Field Entry Cards**

When a reference field was rendered in a narrow panel, entry cards squished text into a few characters and action buttons overlapped the content. Cards now stack into multiple rows at narrow widths and return to the side-by-side layout when there is enough space.

**Sidebar Footer No Longer Shown When Empty**

When no footer menu items were registered, the sidebar still rendered an empty footer section with a visible separator. The footer is now hidden entirely when there is nothing to show.

**Sidebar Section Expand Arrow Now Toggles Section**

Clicking the expand/collapse arrow icon on a sidebar section did not toggle the section. The click handler is now correctly wired up to the arrow button.

### Squash Merge Commit

```
fix: ref field responsiveness, sidebar footer and expand arrow (#5144)
```