### PR TITLE
fix(sdk): remove standalone entity type exports

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,15 +8,6 @@ export * from "./types.js";
 export { Result } from "./Result.js";
 export { HttpError, ApiError, NetworkError, ValidationError } from "./errors.js";
 
-// Export shared CMS types.
-export type {
-    CmsEntryValues,
-    CmsEntryStatus,
-    CmsIdentity,
-    IEntryState,
-    CmsEntryData
-} from "./methods/cms/cmsTypes.js";
-
 // Export types from methods.
 export type { CreateCmsEntryData, CreateEntryParams } from "./methods/cms/createEntry.js";
 
@@ -49,11 +40,6 @@ export type { EnableTenantParams } from "./methods/tenantManager/enableTenant.js
 
 // Export FileManager types.
 export type {
-    FmIdentity,
-    FmLocation,
-    FmFile,
-    FmTag,
-    FmListMeta,
     FmLocationInput,
     FmLocationWhereInput,
     FmFileListWhereInput,
@@ -90,18 +76,6 @@ export type {
 } from "./methods/fileManager/createMultiPartUpload.js";
 
 export type { CompleteMultiPartUploadParams } from "./methods/fileManager/completeMultiPartUpload.js";
-
-// Export Languages types.
-export type { Language } from "./methods/languages/listLanguages.js";
-
-// Export Tasks types.
-export type {
-    TaskStatus,
-    TaskDefinition,
-    TaskRun,
-    TaskLog,
-    TaskLogItem
-} from "./methods/tasks/taskTypes.js";
 
 // Export types from tasks methods.
 export type { ListLogsParams } from "./methods/tasks/listLogs.js";


### PR DESCRIPTION
### What changed

Standalone domain entity types are no longer exported from `@webiny/sdk`. Types such as `FmFile`, `FmIdentity`, `FmLocation`, `FmTag`, `FmListMeta`, `CmsEntryData`, `CmsEntryValues`, `CmsEntryStatus`, `CmsIdentity`, `IEntryState`, `Language`, `TaskStatus`, `TaskDefinition`, `TaskRun`, `TaskLog`, and `TaskLogItem` have been removed from the package's public API. Method parameter types, result wrapper types, and input/filter types remain exported as before. Consumers should use TypeScript inference to obtain entity shapes from method return types.

### Changelog

**Removed Standalone Entity Type Exports from the SDK Package**

The SDK no longer exports raw domain entity types like file, entry, language, and task objects. These types were not intended as part of the public API — the SDK methods already return fully typed results, so consumers can rely on TypeScript inference instead.

### Squash Merge Commit

```
chore(sdk): remove standalone entity type exports (#5152)
```
