### PR TITLE
fix(tailwind): prevent @source directive leak into production CSS

### DIFF
--- a/packages/build-tools/bundling/admin/createRsbuildConfig.js
+++ b/packages/build-tools/bundling/admin/createRsbuildConfig.js
@@ -39,7 +39,8 @@ export const createRsbuildConfig = ({ cwd }) => {
                     ),
                     tailwindcss({
                         base: getTailwindBasePath(paths.projectRootFolder)
-                    })
+                    }),
+                    createStripTailwindSourceLeftoverPlugin()
                 ]);
             },
             rspack: {
@@ -122,6 +123,20 @@ const createInjectTailwindSourcePlugin = sourcePath => ({
     postcssPlugin: "inject-tailwind-source",
     Once(root) {
         root.prepend(`@source "${sourcePath}";`);
+    }
+});
+
+/*
+    Removes any leftover `@source` at-rule from the output. Tailwind v4 strips the
+    directive from files it processes, but `@tailwindcss/postcss` only processes
+    files containing one of its trigger at-rules; for other files (e.g., pre-bundled
+    component CSS imported through JS), the injected directive would otherwise
+    survive into the production bundle, exposing the absolute build-machine path.
+*/
+const createStripTailwindSourceLeftoverPlugin = () => ({
+    postcssPlugin: "strip-tailwind-source-leftover",
+    Once(root) {
+        root.walkAtRules("source", node => node.remove());
     }
 });
 


### PR DESCRIPTION
## Changes

The PostCSS plugin in `admin/createRsbuildConfig.js` prepended an `@source` directive — containing an absolute filesystem path — to every CSS file processed. Tailwind v4 removes that directive from CSS files it processes, but `@tailwindcss/postcss` only processes files containing one of its trigger at-rules; for other files (e.g., the pre-bundled component CSS chunk that includes the Lexical editor styles), the directive survived into the production CSS bundle, exposing the build machine's home directory in publicly-served assets.

This change adds a small PostCSS plugin that runs after `@tailwindcss/postcss` and removes any remaining `@source` at-rule from the output. The fix is independent of which at-rules trigger Tailwind processing — the leak cannot escape regardless of which files match the bail-out check.

Closes #5155

## How Has This Been Tested?

Applied the same patch in a v6.2.0 install and re-deployed the Admin app to verify the fix and check for regressions:

- Tailwind-processed bundle (`index.<hash>.css`): same hash as before the patch; utilities still present.
- Pre-bundled component CSS bundle (`234.<hash>.css`): `@source` occurrences went from 4 to 0; no absolute paths remain.

No automated tests added — `packages/build-tools/bundling/` does not currently have a test setup, and the closest precedent (#5041) modifying the same file was merged without one. Happy to add a test if there's a preferred location for it.

## Documentation

No documentation changes needed. The fix is internal to the build pipeline and does not change any public API or user-facing behavior.
