### PR TITLE
fix(cli-core): upgrade command force and debug

### DIFF
--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
@@ -56,7 +56,7 @@ class UpgradeCommandImpl implements CliCommandFactory.Interface<UpgradeCommandPa
                 },
                 {
                     name: "log-level",
-                    default: "info",
+                    default: "debug",
                     description: `Set log level for the upgrade process executed by npx. Possible values are "debug", "info", "warning", and "error".`,
                     type: "string"
                 },

--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommand.ts
@@ -7,6 +7,7 @@ interface UpgradeCommandParams {
     disableSemver?: boolean;
     debug?: boolean;
     _: string[];
+    force?: boolean;
     target?: string;
     logLevel?: string;
     showLogs?: boolean;
@@ -41,6 +42,12 @@ class UpgradeCommandImpl implements CliCommandFactory.Interface<UpgradeCommandPa
                 }
             ],
             options: [
+                {
+                    name: "force",
+                    description: "Force an upgrade for a version, even if it was ran before.",
+                    type: "boolean",
+                    default: false
+                },
                 {
                     name: "skip-checks",
                     description: "Do not perform CLI version and Git tree checks.",
@@ -98,11 +105,12 @@ class UpgradeCommandImpl implements CliCommandFactory.Interface<UpgradeCommandPa
                  */
                 const version = this.getVersion(params);
                 return this.upgradeCommandHandler.handle({
+                    force: params.force || false,
                     logLevel: params.logLevel || "info",
                     showLogs: params.showLogs || false,
                     showStackTrace: params.showStackTrace || false,
                     skipChecks: params.skipChecks || false,
-                    debug: params.debug || false,
+                    debug: true,
                     packageManager: params.packageManager || undefined,
                     registry: params.registry || undefined,
                     installVersion: params.installVersion || undefined,

--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
@@ -70,7 +70,7 @@ export class UpgradeCommandHandlerImpl implements UpgradeCommandHandlerAbstracti
             debug ? "--debug" : "",
             showLogs ? `--showLogs=${showLogs}` : "",
             showStackTrace ? `--showStackTrace=${showStackTrace}` : "",
-            logLevel ? `--logLevel=${logLevel}` : "",
+            logLevel ? `--logLevel=${logLevel}` : "--logLevel=debug",
             installVersion ? `--installVersion=${installVersion}` : "",
             force ? "--force" : "",
             "--json"

--- a/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/UpgradeCommandHandler.ts
@@ -20,8 +20,16 @@ export class UpgradeCommandHandlerImpl implements UpgradeCommandHandlerAbstracti
     public constructor(private ui: UiService.Interface) {}
 
     public async handle(params: UpgradeCommandHandlerAbstraction.Params): Promise<void> {
-        const { version, skipChecks, debug, logLevel, showLogs, showStackTrace, installVersion } =
-            params;
+        const {
+            version,
+            skipChecks,
+            debug,
+            logLevel,
+            showLogs,
+            showStackTrace,
+            installVersion,
+            force
+        } = params;
 
         if (!skipChecks) {
             /**
@@ -64,6 +72,7 @@ export class UpgradeCommandHandlerImpl implements UpgradeCommandHandlerAbstracti
             showStackTrace ? `--showStackTrace=${showStackTrace}` : "",
             logLevel ? `--logLevel=${logLevel}` : "",
             installVersion ? `--installVersion=${installVersion}` : "",
+            force ? "--force" : "",
             "--json"
         ].filter(Boolean);
 

--- a/packages/cli-core/src/features/UpgradeCommand/abstraction.ts
+++ b/packages/cli-core/src/features/UpgradeCommand/abstraction.ts
@@ -3,6 +3,7 @@ import { createAbstraction } from "~/abstractions/createAbstraction.js";
 export type UpgradeCommandPackageVersion = `${number}.${number}.${number}` | "latest";
 
 export interface IUpgradeCommandHandlerHandleParams {
+    force: boolean;
     showLogs: boolean;
     logLevel: string;
     showStackTrace: boolean;


### PR DESCRIPTION
## Changes
Adds force parameter to webiny upgrade.
Also, debug is turned on by default for the upgrade script (not in Webiny project - thats set before runtime).