### PR TITLE
Fix Dev Tools Playground Permissions Scoping

### DIFF
--- a/packages/app-graphql-playground/src/PermissionsSchema.ts
+++ b/packages/app-graphql-playground/src/PermissionsSchema.ts
@@ -7,13 +7,13 @@ export const DEV_TOOLS_PERMISSIONS_SCHEMA = createPermissionSchema({
         {
             id: "graphql-playground",
             title: "GraphQL Playground",
-            permission: "graphql-playground.*",
+            permission: "dev-tools.graphql-playground.*",
             scopes: ["full"]
         },
         {
             id: "sdk-playground",
             title: "SDK Playground",
-            permission: "sdk-playground.*",
+            permission: "dev-tools.sdk-playground.*",
             scopes: ["full"]
         }
     ]

--- a/packages/app-graphql-playground/src/index.tsx
+++ b/packages/app-graphql-playground/src/index.tsx
@@ -38,7 +38,7 @@ const GraphQLPlaygroundExtension = ({ createApolloClient }: GraphQLPlaygroundPro
                         />
                     }
                 />
-                <HasPermission any={["dev-tools.*", "graphql-playground.*"]}>
+                <HasPermission any={["dev-tools.*", "dev-tools.graphql-playground.*"]}>
                     <Menu
                         name={"dev-tools.graphql"}
                         parent={"dev-tools"}

--- a/packages/app-sdk-playground/src/PermissionsSchema.ts
+++ b/packages/app-sdk-playground/src/PermissionsSchema.ts
@@ -7,13 +7,13 @@ export const DEV_TOOLS_PERMISSIONS_SCHEMA = createPermissionSchema({
         {
             id: "graphql-playground",
             title: "GraphQL Playground",
-            permission: "graphql-playground.*",
+            permission: "dev-tools.graphql-playground.*",
             scopes: ["full"]
         },
         {
             id: "sdk-playground",
             title: "SDK Playground",
-            permission: "sdk-playground.*",
+            permission: "dev-tools.sdk-playground.*",
             scopes: ["full"]
         }
     ]

--- a/packages/app-sdk-playground/src/index.tsx
+++ b/packages/app-sdk-playground/src/index.tsx
@@ -26,7 +26,7 @@ const SdkPlaygroundExtension = () => {
                         />
                     }
                 />
-                <HasPermission any={["dev-tools.*", "sdk-playground.*"]}>
+                <HasPermission any={["dev-tools.*", "dev-tools.sdk-playground.*"]}>
                     <Menu
                         name={"dev-tools.sdk"}
                         parent={"dev-tools"}


### PR DESCRIPTION
### What changed

Dev Tools permission strings for the GraphQL Playground and SDK Playground are now correctly scoped under the `dev-tools` namespace. Previously, permissions were stored as `graphql-playground.*` and `sdk-playground.*`, which meant revoking `dev-tools.*` access had no effect on sidebar visibility for those tools. They are now `dev-tools.graphql-playground.*` and `dev-tools.sdk-playground.*`, so access control behaves consistently with the rest of the Dev Tools section.

### Changelog

**Fixed Dev Tools Permissions Not Respecting Access Revocation**

The GraphQL Playground and SDK Playground used unscoped permission strings that sat outside the `dev-tools` namespace. As a result, removing Dev Tools access from a security group did not hide these items from the sidebar. Permissions are now correctly namespaced under `dev-tools`, so revoking Dev Tools access works as expected.

### Squash Merge Commit

```
fix: scope dev-tools playground permissions under dev-tools namespace (#5162)
```
