### PR TITLE
fix: add bottom margin to dynamic zone template gallery list

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGallery.tsx
@@ -21,7 +21,7 @@ export interface TemplateGalleryListProps {
 }
 
 const GalleryList = makeDecoratable("TemplateGalleryList", (props: TemplateGalleryListProps) => {
-    return <div className={"gap-md flex flex-wrap"}>{props.children}</div>;
+    return <div className={"gap-md flex flex-wrap mb-xs"}>{props.children}</div>;
 });
 
 export interface TemplateGalleryProps {

--- a/packages/webiny/package.json
+++ b/packages/webiny/package.json
@@ -113,7 +113,7 @@
     "./admin/form": "./admin/form.js",
     "./admin/tenancy": "./admin/tenancy.js",
     "./admin/cms/entry/editor": "./admin/cms/entry/editor.js",
-    "./admin/cms/entry/list": "./admin/cms/∞entry/list.js",
+    "./admin/cms/entry/list": "./admin/cms/entry/list.js",
     "./admin/cms/field-renderers/common": "./admin/cms/field-renderers/common.js",
     "./admin/cms/field-renderers/dynamic-zone": "./admin/cms/field-renderers/dynamic-zone.js",
     "./admin/cms/field-renderers/object": "./admin/cms/field-renderers/object.js",

--- a/packages/webiny/package.json
+++ b/packages/webiny/package.json
@@ -113,7 +113,7 @@
     "./admin/form": "./admin/form.js",
     "./admin/tenancy": "./admin/tenancy.js",
     "./admin/cms/entry/editor": "./admin/cms/entry/editor.js",
-    "./admin/cms/entry/list": "./admin/cms/entry/list.js",
+    "./admin/cms/entry/list": "./admin/cms/∞entry/list.js",
     "./admin/cms/field-renderers/common": "./admin/cms/field-renderers/common.js",
     "./admin/cms/field-renderers/dynamic-zone": "./admin/cms/field-renderers/dynamic-zone.js",
     "./admin/cms/field-renderers/object": "./admin/cms/field-renderers/object.js",


### PR DESCRIPTION
### What changed

Added a small bottom margin to the template gallery list inside the Dynamic Zone field modal. Without the spacing, the last row of templates was clipped at the bottom of the scrollable container, making it hard to see or click the last items.

### Before / After

| Before | After |
|--------|-------|
| 
<img width="1043" height="1033" alt="image" src="https://github.com/user-attachments/assets/33b67dfd-6681-4b50-a43b-80572e76758b" />
 | 
<img width="1116" height="1025" alt="image" src="https://github.com/user-attachments/assets/1b30fd20-b5a7-4d49-a5c9-1c26a1284055" />
 |

### Changelog

**Fixed Dynamic Zone Template Gallery Bottom Spacing**

The template picker modal in the Dynamic Zone field was cutting off the last row of template tiles. A missing bottom margin has been added so all templates are fully visible and accessible when scrolling.

### Squash Merge Commit

```
fix: add bottom margin to dynamic zone template gallery list (#5166)
```
