### PR TITLE
Fix Dialog Loading Overlay Being Clipped to Body Area

### DIFF
--- a/packages/admin-ui/src/Dialog/Dialog.tsx
+++ b/packages/admin-ui/src/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { makeDecoratable, withStaticProps } from "~/utils.js";
+import { OverlayLoader } from "~/Loader/index.js";
 import { DialogContent } from "./components/DialogContent.js";
 import { DialogHeader } from "~/Dialog/components/DialogHeader.js";
 import { DialogBody } from "~/Dialog/components/DialogBody.js";
@@ -29,6 +30,8 @@ interface DialogProps
     children: React.ReactNode;
     actions?: React.ReactNode;
     info?: React.ReactNode;
+    loading?: boolean | { text?: string };
+    overlay?: React.ReactNode;
     onClose?: () => void;
     onOpen?: () => void;
 }
@@ -73,6 +76,10 @@ const DialogBase = (props: DialogProps) => {
             actions,
             info,
 
+            // Overlay props.
+            loading,
+            overlay,
+
             // Close button props.
             showCloseButton = true,
 
@@ -111,7 +118,17 @@ const DialogBase = (props: DialogProps) => {
             bodyProps: { children, bodyPadding, scrollable, size },
             footerProps: { info, actions, size },
             closeButtonProps: { show: showCloseButton, size },
-            contentProps: { ...rest, size }
+            contentProps: {
+                ...rest,
+                size,
+                overlay:
+                    overlay ??
+                    (loading ? (
+                        <OverlayLoader
+                            text={typeof loading === "object" ? loading.text : undefined}
+                        />
+                    ) : undefined)
+            }
         };
     }, [props]);
 

--- a/packages/admin-ui/src/Dialog/Dialog.tsx
+++ b/packages/admin-ui/src/Dialog/Dialog.tsx
@@ -100,6 +100,17 @@ const DialogBase = (props: DialogProps) => {
             }
         };
 
+        const resolvedOverlay = (() => {
+            if (overlay) {
+                return overlay;
+            }
+            if (!loading) {
+                return undefined;
+            }
+            const text = typeof loading === "object" ? loading.text : undefined;
+            return <OverlayLoader text={text} />;
+        })();
+
         return {
             rootProps: {
                 defaultOpen,
@@ -118,17 +129,7 @@ const DialogBase = (props: DialogProps) => {
             bodyProps: { children, bodyPadding, scrollable, size },
             footerProps: { info, actions, size },
             closeButtonProps: { show: showCloseButton, size },
-            contentProps: {
-                ...rest,
-                size,
-                overlay:
-                    overlay ??
-                    (loading ? (
-                        <OverlayLoader
-                            text={typeof loading === "object" ? loading.text : undefined}
-                        />
-                    ) : undefined)
-            }
+            contentProps: { ...rest, size, overlay: resolvedOverlay }
         };
     }, [props]);
 

--- a/packages/admin-ui/src/Dialog/components/DialogContent.tsx
+++ b/packages/admin-ui/src/Dialog/components/DialogContent.tsx
@@ -34,45 +34,52 @@ export interface DialogContentProps
     header?: React.ReactNode;
     footer?: React.ReactNode;
     closeButton?: React.ReactNode;
+    overlay?: React.ReactNode;
 }
 
 const DialogContent = React.forwardRef<
     React.ElementRef<typeof DialogPrimitive.Content>,
     DialogContentProps
->(({ className, dismissible, size, header, footer, closeButton, children, ...props }, ref) => {
-    const dismissibleProps = React.useMemo<
-        Pick<DialogPrimitive.DialogContentProps, "onInteractOutside" | "onEscapeKeyDown">
-    >(() => {
-        if (dismissible === false) {
-            return {
-                onInteractOutside: event => event.preventDefault(),
-                onEscapeKeyDown: event => event.preventDefault()
-            };
-        }
+>(
+    (
+        { className, dismissible, size, header, footer, closeButton, overlay, children, ...props },
+        ref
+    ) => {
+        const dismissibleProps = React.useMemo<
+            Pick<DialogPrimitive.DialogContentProps, "onInteractOutside" | "onEscapeKeyDown">
+        >(() => {
+            if (dismissible === false) {
+                return {
+                    onInteractOutside: event => event.preventDefault(),
+                    onEscapeKeyDown: event => event.preventDefault()
+                };
+            }
 
-        return {};
-    }, [dismissible]);
+            return {};
+        }, [dismissible]);
 
-    return (
-        <DialogPrimitive.Content
-            {...dismissibleProps}
-            {...props}
-            ref={ref}
-            className={cn(dialogContentVariants({ size }), className)}
-            // TODO: An optional accessible description to be announced when the dialog is opened. At the moment we skip this.
-            aria-describedby={undefined}
-        >
-            {(header || closeButton) && (
-                <div className="row-start-1 relative">
-                    {header}
-                    {closeButton}
-                </div>
-            )}
-            <div className="row-start-2 min-h-0 overflow-hidden pr-xs">{children}</div>
-            {footer && <div className="row-start-3">{footer}</div>}
-        </DialogPrimitive.Content>
-    );
-});
+        return (
+            <DialogPrimitive.Content
+                {...dismissibleProps}
+                {...props}
+                ref={ref}
+                className={cn(dialogContentVariants({ size }), className)}
+                // TODO: An optional accessible description to be announced when the dialog is opened. At the moment we skip this.
+                aria-describedby={undefined}
+            >
+                {(header || closeButton) && (
+                    <div className="row-start-1 relative">
+                        {header}
+                        {closeButton}
+                    </div>
+                )}
+                <div className="row-start-2 min-h-0 overflow-hidden pr-xs">{children}</div>
+                {footer && <div className="row-start-3">{footer}</div>}
+                {overlay}
+            </DialogPrimitive.Content>
+        );
+    }
+);
 
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 

--- a/packages/app-aco/src/dialogs/useMoveToFolderDialog.tsx
+++ b/packages/app-aco/src/dialogs/useMoveToFolderDialog.tsx
@@ -14,7 +14,7 @@ interface ShowDialogParams {
     message?: ReactNode;
     acceptLabel?: ReactNode;
     cancelLabel?: ReactNode;
-    loadingLabel?: ReactNode;
+    loadingLabel?: string;
     focusedFolderId: string;
     onAccept: (data: GenericFormData) => void;
     onClose?: () => void;

--- a/packages/app-admin-ui/src/Dialog/DialogContainer.tsx
+++ b/packages/app-admin-ui/src/Dialog/DialogContainer.tsx
@@ -74,8 +74,8 @@ export const DialogContainer = () => {
                     </>
                 )
             }
+            loading={isLoading ? loading : false}
         >
-            {isLoading ? loading : null}
             {message}
         </Dialog>
     );

--- a/packages/app-admin-ui/src/Dialog/DialogContainer.tsx
+++ b/packages/app-admin-ui/src/Dialog/DialogContainer.tsx
@@ -55,6 +55,7 @@ export const DialogContainer = () => {
             style={style}
             showCloseButton={showCloseButton}
             title={title}
+            loading={isLoading ? loading : false}
             actions={
                 !actions.cancel && !actions.accept ? null : (
                     <>
@@ -74,7 +75,6 @@ export const DialogContainer = () => {
                     </>
                 )
             }
-            loading={isLoading ? loading : false}
         >
             {message}
         </Dialog>

--- a/packages/app-admin/src/components/Dialogs/Dialog.tsx
+++ b/packages/app-admin/src/components/Dialogs/Dialog.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import React, { useEffect, useState } from "react";
-import { Dialog as AdminDialog, OverlayLoader } from "@webiny/admin-ui";
+import { Dialog as AdminDialog } from "@webiny/admin-ui";
 import type { FormOnSubmit, GenericFormData } from "@webiny/form";
 import { Form } from "@webiny/form";
 
@@ -13,8 +13,8 @@ export interface DialogProps {
     icon: ReactNode;
     acceptLabel?: ReactNode;
     cancelLabel?: ReactNode;
-    loadingLabel?: ReactNode;
-    dataLoadingLabel?: ReactNode;
+    loadingLabel?: string;
+    dataLoadingLabel?: string;
     onSubmit: (data: GenericFormData) => void;
     closeDialog: () => void;
     loading: boolean;
@@ -69,6 +69,13 @@ export const Dialog = ({
                     icon={<AdminDialog.Icon icon={props.icon} label={""} />}
                     dismissible={props.dismissible}
                     info={props.info}
+                    loading={
+                        loading
+                            ? { text: loadingLabel }
+                            : dataIsLoading
+                              ? { text: dataLoadingLabel }
+                              : false
+                    }
                     actions={
                         <>
                             {cancelLabel ? (
@@ -83,13 +90,7 @@ export const Dialog = ({
                         </>
                     }
                 >
-                    {open ? (
-                        <>
-                            {loading && <OverlayLoader text={loadingLabel} />}
-                            {dataIsLoading && <OverlayLoader text={dataLoadingLabel} />}
-                            {content}
-                        </>
-                    ) : null}
+                    {open ? content : null}
                 </AdminDialog>
             )}
         </Form>

--- a/packages/app-admin/src/components/Dialogs/DialogsContext.tsx
+++ b/packages/app-admin/src/components/Dialogs/DialogsContext.tsx
@@ -18,8 +18,8 @@ interface ShowDialogParams {
     info?: ReactNode;
     acceptLabel?: ReactNode;
     cancelLabel?: ReactNode;
-    loadingLabel?: ReactNode;
-    dataLoadingLabel?: ReactNode;
+    loadingLabel?: string;
+    dataLoadingLabel?: string;
     onAccept?: (data: GenericFormData) => void;
     onClose?: () => void;
     formData?: DialogProps["formData"];

--- a/packages/app-admin/src/hooks/useConfirmationDialog.tsx
+++ b/packages/app-admin/src/hooks/useConfirmationDialog.tsx
@@ -9,7 +9,7 @@ interface Params {
     message?: React.ReactNode;
     acceptLabel?: React.ReactNode;
     cancelLabel?: React.ReactNode;
-    loading?: boolean | { text?: string };
+    loading?: boolean | string;
     [key: string]: any;
 }
 
@@ -40,7 +40,7 @@ const useConfirmationDialog = ({
                         options: {
                             ...options,
                             title,
-                            loading,
+                            loading: typeof loading === "string" ? { text: loading } : loading,
                             actions: {
                                 accept: {
                                     label: acceptLabel,

--- a/packages/app-admin/src/hooks/useConfirmationDialog.tsx
+++ b/packages/app-admin/src/hooks/useConfirmationDialog.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useUi } from "@webiny/app/hooks/useUi.js";
 import { i18n } from "@webiny/app/i18n/index.js";
-import { CircularProgress } from "@webiny/ui/Progress/index.js";
 
 const t = i18n.ns("app-admin/hooks/use-confirmation-dialog");
 
@@ -10,7 +9,7 @@ interface Params {
     message?: React.ReactNode;
     acceptLabel?: React.ReactNode;
     cancelLabel?: React.ReactNode;
-    loading?: React.ReactNode;
+    loading?: boolean | { text?: string };
     [key: string]: any;
 }
 
@@ -25,7 +24,7 @@ const useConfirmationDialog = ({
     message,
     acceptLabel = t`Confirm`,
     cancelLabel = t`Cancel`,
-    loading = <CircularProgress />,
+    loading = true,
     ...options
 }: Params = {}): UseConfirmationDialogResponse => {
     const ui = useUi();
@@ -36,6 +35,7 @@ const useConfirmationDialog = ({
                 return {
                     ...ui,
                     dialog: {
+                        loading: true,
                         message: message || t`Are you sure you want to continue?`,
                         options: {
                             ...options,

--- a/packages/app-file-manager/src/hooks/useDeleteFile.tsx
+++ b/packages/app-file-manager/src/hooks/useDeleteFile.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { i18n } from "@webiny/app/i18n/index.js";
-import { OverlayLoader, Text } from "@webiny/admin-ui";
+import { Text } from "@webiny/admin-ui";
 import { useConfirmationDialog, useSnackbar } from "@webiny/app-admin";
 import type { FileItem } from "~/types.js";
 import { useFileManagerView } from "~/index.js";
@@ -18,7 +18,7 @@ export const useDeleteFile = ({ onDelete, file }: UseDeleteFileParams) => {
 
     const { showConfirmation } = useConfirmationDialog({
         title: t`Delete file`,
-        loading: <OverlayLoader text={"Deleting file..."} />,
+        loading: { text: "Deleting file..." },
         message: file && (
             <>
                 <Text>

--- a/packages/app-file-manager/src/hooks/useDeleteFile.tsx
+++ b/packages/app-file-manager/src/hooks/useDeleteFile.tsx
@@ -18,7 +18,7 @@ export const useDeleteFile = ({ onDelete, file }: UseDeleteFileParams) => {
 
     const { showConfirmation } = useConfirmationDialog({
         title: t`Delete file`,
-        loading: { text: "Deleting file..." },
+        loading: "Deleting file...",
         message: file && (
             <>
                 <Text>

--- a/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/NewContentModelDialog.tsx
@@ -3,7 +3,6 @@ import { useRouter, useSnackbar } from "@webiny/app-admin";
 import { Form } from "@webiny/form";
 import { Input } from "@webiny/ui/Input/index.js";
 import { Select } from "@webiny/ui/Select/index.js";
-import { CircularProgress } from "@webiny/ui/Progress/index.js";
 import { validation } from "@webiny/validation";
 import { useApolloClient, useMutation, useQuery } from "../../hooks/index.js";
 import { i18n } from "@webiny/app/i18n/index.js";
@@ -167,6 +166,7 @@ const NewContentModelDialog = ({ open, onClose }: NewContentModelDialogProps) =>
                         onClose={onClose}
                         data-testid="cms-new-content-model-modal"
                         title={t`New Content Model`}
+                        loading={loading ? { text: "Creating content model..." } : false}
                         actions={
                             <Dialog.ConfirmAction onClick={submit}>
                                 + {t`Create Model`}
@@ -174,7 +174,6 @@ const NewContentModelDialog = ({ open, onClose }: NewContentModelDialogProps) =>
                         }
                     >
                         <>
-                            {loading && <CircularProgress label={"Creating content model..."} />}
                             <Grid>
                                 <Grid.Column span={12}>
                                     <Bind

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,15 @@ export * from "./types.js";
 export { Result } from "./Result.js";
 export { HttpError, ApiError, NetworkError, ValidationError } from "./errors.js";
 
+// Export shared CMS types.
+export type {
+    CmsEntryValues,
+    CmsEntryStatus,
+    CmsIdentity,
+    IEntryState,
+    CmsEntryData
+} from "./methods/cms/cmsTypes.js";
+
 // Export types from methods.
 export type { CreateCmsEntryData, CreateEntryParams } from "./methods/cms/createEntry.js";
 
@@ -40,6 +49,11 @@ export type { EnableTenantParams } from "./methods/tenantManager/enableTenant.js
 
 // Export FileManager types.
 export type {
+    FmIdentity,
+    FmLocation,
+    FmFile,
+    FmTag,
+    FmListMeta,
     FmLocationInput,
     FmLocationWhereInput,
     FmFileListWhereInput,
@@ -76,6 +90,18 @@ export type {
 } from "./methods/fileManager/createMultiPartUpload.js";
 
 export type { CompleteMultiPartUploadParams } from "./methods/fileManager/completeMultiPartUpload.js";
+
+// Export Languages types.
+export type { Language } from "./methods/languages/listLanguages.js";
+
+// Export Tasks types.
+export type {
+    TaskStatus,
+    TaskDefinition,
+    TaskRun,
+    TaskLog,
+    TaskLogItem
+} from "./methods/tasks/taskTypes.js";
 
 // Export types from tasks methods.
 export type { ListLogsParams } from "./methods/tasks/listLogs.js";


### PR DESCRIPTION
### What changed

The loading overlay shown during dialog async actions (e.g. confirming a deletion, moving a file, creating a content model) was previously rendered inside the dialog body, causing it to be clipped by the body's scroll container. It now renders over the entire dialog — header, body, and footer — so nothing is cut off.

The `Dialog` component gains a first-class `loading` prop (`boolean | { text?: string }`) that handles overlay rendering internally. Passing `true` shows a spinner with no label; passing `{ text: "..." }` adds a label. The lower-level `overlay` prop remains available as an escape hatch for custom overlay content.

### Screenshots

<img width="839" height="501" alt="image" src="https://github.com/user-attachments/assets/a877fade-e48d-41cb-9346-6733384f556b" />

<img width="950" height="754" alt="image" src="https://github.com/user-attachments/assets/9f0bd065-50c3-4724-90c7-96b70a05d1d3" />

<img width="943" height="1139" alt="image" src="https://github.com/user-attachments/assets/4c7504ba-948a-494b-a063-c09691e43957" />


### Changelog

**Dialog Loading Overlay Now Covers the Entire Dialog**

The loading spinner shown while a dialog action was in progress was being clipped, appearing only over the dialog body and cutting off at the footer. It now covers the full dialog surface, including the header and footer.

### Squash Merge Commit

```
fix: dialog loading overlay now covers the full dialog surface (#5168)
```
