### PR TITLE
docs(container-refactor): add architecture and refactor plan

### DIFF
--- a/docs/container-refactor/01-architecture.md
+++ b/docs/container-refactor/01-architecture.md
@@ -1,0 +1,196 @@
+# 01 — Target Architecture
+
+## Goal
+
+Add a **second deployment path** for Webiny: one that runs inside a Docker container alongside `keycloak` and `mailpit` in `docker-compose`. The serverless deployment path stays exactly as it is today.
+
+Both paths share the same Webiny core (Fastify handler, plugin system, context object, DI container, GraphQL layer, all business logic). They differ only at the *edges* — where the framework meets the runtime, the database, the file system, the queue, the scheduler, the websocket transport, and the auth provider.
+
+## Two paths, one core
+
+```
+                Serverless path (unchanged)            Container path (new, additive)
+                ───────────────────────────            ──────────────────────────────
+                AWS infra                              docker-compose
+                ─────────                              ──────────────
+                  API Gateway                            api          (Node + Fastify)
+                  Lambda                                 keycloak     (OIDC IdP)
+                                                         mailpit      (SMTP catcher)
+                Edge adapter
+                ────────────
+                  @webiny/handler-aws                    @webiny/handler-node     ← NEW
+                  (@fastify/aws-lambda wrapper)          (app.listen + graceful shutdown)
+                  
+                Framework core (shared, unchanged)
+                ──────────────────────────────────
+                  @webiny/handler        (Fastify createHandler)
+                  @webiny/api            (Context, plugins, DI)
+                  @webiny/handler-graphql
+                  @webiny/api-headless-cms
+                  @webiny/api-file-manager (interface)
+                  @webiny/api-aco / api-audit-logs / api-websockets / api-scheduler / api-mailer / ...
+                  @webiny/tasks          (TaskRunner — refactored to remove ITimer leak from handler-aws)
+                
+                Storage operations (per-package; serverless picks DDB factories, container picks SQLite)
+                ─────────────────────────────────────────────────────────────────────────────────────
+                  @webiny/api-core-ddb                   @webiny/api-core-sqlite           ← NEW
+                  @webiny/api-headless-cms-ddb           @webiny/api-headless-cms-sqlite   ← NEW
+                  @webiny/api-headless-cms-ddb-es        (no -es; SQLite FTS5 is in -sqlite)
+                  @webiny/api-aco       (DDB-coupled)    @webiny/api-aco-sqlite            ← NEW
+                  @webiny/api-audit-logs (DDB-coupled)   @webiny/api-audit-logs-sqlite     ← NEW
+                  @webiny/api-websockets (DDB-coupled)   in-memory connection registry     ← NEW
+                  @webiny/api-scheduler (EventBridge)    @webiny/api-scheduler-cron        ← NEW
+                  @webiny/api-background-tasks-ddb       @webiny/api-background-tasks-sqlite ← NEW
+                  @webiny/api-file-manager-s3            @webiny/api-file-manager-fs       ← NEW
+                  @webiny/api-mailer (SES default)       @webiny/api-mailer (SMTP → mailpit, config-only)
+
+                Database / search / file storage runtime
+                ────────────────────────────────────────
+                  DynamoDB (single-table)                SQLite (single-table mirror) — file on a volume
+                  OpenSearch                             (none — SQLite FTS5 in-process)
+                  S3                                     local filesystem on a volume
+                  Cognito                                Keycloak (any OIDC provider works)
+                  EventBridge Scheduler                  node-cron
+                  SQS / SNS / EventBridge events         in-process (single container; split later)
+                  API Gateway WebSocket                  @fastify/websocket + in-memory registry
+```
+
+## What stays exactly the same
+
+- **Fastify handler core** — `packages/handler/src/fastify.ts` returns a vanilla Fastify instance. Both `handler-aws` (`@fastify/aws-lambda` wrapper) and the new `handler-node` (`app.listen()`) consume the same factory. No changes to its API surface.
+- **Plugin system, context object, DI container** — `packages/plugins`, `packages/api/src/Context.ts`, `@webiny/di`. Untouched.
+- **GraphQL layer** — `@webiny/handler-graphql`. Untouched.
+- **Business logic** — every package in `packages/` that doesn't end in `-ddb`, `-ddb-es`, or `-s3`. Untouched.
+- **Storage-operations contract** — every `*-sqlite` package implements the *same* interface as the existing `*-ddb` package. Vitest preset reuse means contract tests run against both backends with no test rewrites.
+- **JWT/OIDC validation** in `@webiny/api-core/src/idp` — already abstract over the issuer. Keycloak slots in as just another OIDC provider.
+- **Authoritative API wire-up** — `packages/project-aws/_templates/appTemplates/api/graphql/src/index.ts` continues to use `createApiCoreDdb({ documentClient })`, `createAco({ documentClient })`, etc. Existing customer projects see no diff in this template.
+
+## What is new
+
+### Runtime adapter — `@webiny/handler-node`
+
+A long-lived HTTP server companion to `@webiny/handler-aws`. It:
+
+- Calls `app.listen({ port, host })` instead of wrapping with `@fastify/aws-lambda`.
+- Handles `SIGTERM` / `SIGINT` for graceful shutdown — drains in-flight requests, closes the SQLite handle, flushes logs.
+- Exposes a `/health` endpoint suitable for container orchestrator probes.
+- Uses plain `pino` (stdout JSON) instead of `pino-lambda`.
+
+The Fastify app it returns is byte-identical to what `handler-aws` builds; only the lifecycle around it differs.
+
+### Database — `@webiny/db-sqlite`
+
+A core SQLite package, analogous to `@webiny/db-dynamodb`. Built on:
+
+- **Drizzle ORM** for schema declaration, migrations (Drizzle Kit), and type-safe queries.
+- **`node:sqlite`** preferred (Node 22+, no native compile). Fallback to `better-sqlite3` if Webiny's Node baseline doesn't allow it.
+- **Single-table schema** mirroring DynamoDB layout. One row per item:
+
+  | column | meaning |
+  |---|---|
+  | `pk` | Partition key (matches DDB) — includes tenant where applicable |
+  | `sk` | Sort key |
+  | `gsi1_pk`, `gsi1_sk` | GSI1 index columns (matches DDB) |
+  | `gsi_tenant_pk`, `gsi_tenant_sk` | GSI_TENANT index columns |
+  | `data` | JSON column with the rest of the item body |
+  | `version` | Integer for optimistic concurrency |
+  | `expires_at` | Unix timestamp; rows past this are filtered out (DDB TTL parity) |
+
+  Real indexes on `(pk, sk)`, `(gsi1_pk, gsi1_sk)`, `(gsi_tenant_pk, gsi_tenant_sk)`. Multi-tenancy is preserved automatically because tenant is part of `pk`.
+
+- **FTS5 shadow table** for full-text search. Storage-ops update it in the same transaction as the row write. SQLite's strong consistency means there's no eventual-consistency window — a meaningful behavioral upgrade over DDB-ES.
+
+- **Query helpers** that translate `dynamodb-toolbox` semantics:
+  - `begins_with(sk, "prefix")` → `WHERE sk LIKE 'prefix%'`
+  - `between(sk, "a", "z")` → `WHERE sk BETWEEN 'a' AND 'z'`
+  - `LastEvaluatedKey` cursor → `(pk, sk)` tuple cursor (validated by a stage-5 spike before any storage-ops package consumes it)
+
+The schema is intentionally a *mirror*, not a normalization. Storage-ops contract tests are written against PK/SK semantics; mirroring keeps test parity 1:1 and avoids a per-package SQL design exercise. Normalization is an option for future performance work, after parity is proven.
+
+### Storage operations — `@webiny/api-*-sqlite`
+
+One sibling package per existing `*-ddb` package. Each implements the same storage-operations interface, backed by `@webiny/db-sqlite`. The full list mirrors the authoritative inventory at `packages/project-aws/_templates/appTemplates/api/graphql/src/index.ts`:
+
+| existing | new container counterpart |
+|---|---|
+| `api-core-ddb` | `api-core-sqlite` |
+| `api-headless-cms-ddb` (and `-ddb-es`) | `api-headless-cms-sqlite` (with FTS5) |
+| `api-aco` (DDB-coupled internally) | `api-aco-sqlite` (consumed via new factory variant — see decisions doc) |
+| `api-audit-logs` (DDB-coupled internally) | `api-audit-logs-sqlite` |
+| `api-record-locking` | `api-record-locking-sqlite` |
+| `api-mailer` storage | `api-mailer-sqlite` |
+| `api-headless-cms-tasks` | `api-headless-cms-tasks-sqlite` |
+| `api-website-builder` | `api-website-builder-sqlite` |
+| `api-workflows` | `api-workflows-sqlite` |
+| `api-background-tasks-ddb` | `api-background-tasks-sqlite` |
+
+### File storage — `@webiny/api-file-manager-fs`
+
+Implements the existing `FileStorageDriver` interface. Bytes go to a directory mounted as a docker-compose volume. Sharp transforms read from this directory the same way they read from S3 today. File-manager metadata (which lives outside `api-file-manager-s3`) is stored on SQLite via `api-file-manager-sqlite` (new — file-manager doesn't have a `-ddb` package today, so this fills the gap).
+
+### Long-running runtime services
+
+- **Tasks** — `@webiny/api-background-tasks-sqlite`. In-process runner backed by a queue table in SQLite. The container has no Lambda 15-minute timeout, so resumption logic simplifies. The `ITimer` abstraction currently imported from `@webiny/handler-aws/utils` is moved into `@webiny/tasks` (or a neutral home) and given a container impl that returns `Infinity`.
+- **Scheduler** — `@webiny/api-scheduler-cron`. Implements the same `SchedulerService` interface as `EventBridgeSchedulerService` using `node-cron` in-process. Same plugin registration shape; chosen at extension level.
+- **WebSockets** — In-memory connection registry replaces the DDB-backed `api-websockets` registry, plus `@fastify/websocket` for the transport. When the topology splits to multiple containers later, this swaps to a Redis or NATS adapter without touching consumers.
+- **Mailer** — Existing `@webiny/api-mailer` already supports SMTP. Container points it at the `mailpit` service via env config. Zero code changes.
+
+### Auth — Keycloak (any OIDC IdP)
+
+Container path uses Keycloak in `docker-compose` with a seeded realm and dev user. The existing JWT/OIDC validation in `@webiny/api-core/src/idp/JwtAuthenticator.ts` works unchanged — Keycloak's JWKS URL and issuer go in via env config. The Cognito user-CRUD path (which the security flow currently calls into for admin user management) is wrapped behind a small `IdpAdmin` abstraction so the container path can satisfy it via Keycloak's Admin API or seed scripts.
+
+### Build pipeline — `createBuildServer`
+
+A second build helper in `@webiny/build-tools`, alongside `createBuildFunction`. Bundles the API as a single Node entry point (`dist/server.js`). A multi-stage Dockerfile builds via this helper and runs on `node:lts-alpine`. Existing `createBuildFunction` and the Pulumi/Lambda packaging path are untouched.
+
+### docker-compose stack
+
+```yaml
+services:
+  api:                # Webiny container — Fastify, GraphQL, WS, in-process tasks/scheduler
+  keycloak:           # OIDC IdP
+  mailpit:            # SMTP catcher (UI on :8025, SMTP on :1025)
+
+volumes:
+  webiny_data:        # SQLite + uploaded files
+```
+
+No DynamoDB Local. No OpenSearch. No MinIO. The simpler the stack, the better the DX — and SQLite + FTS5 + local filesystem cover everything the single-container POC needs.
+
+## Where the runtime split happens
+
+There is exactly **one** place in a customer project where serverless vs container is chosen: the API entry file (`apps/api/graphql/src/index.ts` in customer projects, or `extensions/api/...` in container mode). That file decides which factories to wire up:
+
+```ts
+// Serverless (existing)
+createHandler({                          // from @webiny/handler-aws
+  plugins: [
+    createApiCore({ storageOperations: createApiCoreDdb({ documentClient }) }),
+    createAco({ documentClient }),
+    // ...
+  ]
+});
+
+// Container (new)
+createServer({                           // from @webiny/handler-node
+  plugins: [
+    createApiCore({ storageOperations: createApiCoreSqlite({ db }) }),
+    createAcoWithStorageOps({ storageOperations: createAcoStorageOperationsSqlite({ db }) }),
+    // ...
+  ]
+});
+```
+
+Same plugin interface. Same context shape. Same GraphQL schema. Different runtime, different storage.
+
+## Critical files (existing) referenced throughout this folder
+
+| File | Why it matters |
+|---|---|
+| `packages/project-aws/_templates/appTemplates/api/graphql/src/index.ts` | Authoritative inventory of every plugin/factory wired into the API. The container-mode equivalent in `extensions/` mirrors this. |
+| `packages/handler/src/fastify.ts` | Fastify entry. Returns a vanilla Fastify instance. Reused unchanged by both runtime adapters. |
+| `packages/handler-aws/src/createHandler.ts` | Pattern that `@webiny/handler-node` follows, minus the Lambda adapter. |
+| `packages/api-aco/src/createAcoStorageOperations.ts` | Confirmed leaky abstraction: takes `DynamoDBDocument` in its public type. Refactor target — see decisions doc. |
+| `packages/tasks/src/runner/TaskRunner.ts` | Imports `ITimer` from `@webiny/handler-aws/utils`. Move to a neutral home; provide a container impl. |
+| `packages/api-headless-cms-ddb-es/vitest.config.ts` | Existing Vitest preset-reuse pattern that `*-sqlite` packages copy verbatim. |
+| `dynalite.cjs` | Current local DDB schema — useful reference for SQLite schema design. |

--- a/docs/container-refactor/02-decisions.md
+++ b/docs/container-refactor/02-decisions.md
@@ -1,0 +1,206 @@
+# 02 — Decisions
+
+ADR-style record of the 10 decisions that shape the container refactor. Each entry: **Context → Options → Decision → Reasoning → Consequences**.
+
+---
+
+## ADR-1 — Database for container mode
+
+**Context.** Webiny's DynamoDB single-table design is deeply baked into the `*-ddb` storage-operations packages. A container-friendly database is needed.
+
+**Options considered.**
+- (a) Run **DynamoDB Local** (or `dynalite`) as a container service. Zero schema changes.
+- (b) Add a new **SQL** backend (SQLite for local, PostgreSQL for production).
+- (c) Hybrid — DDB Local now, SQL later.
+
+**Decision.** **SQLite via Drizzle ORM**, with PostgreSQL as a future phase.
+
+**Reasoning.** SQLite gives us a single in-process database — zero extra container, zero JVM, file persisted on a volume. It's a credible signal that the storage abstraction works against a non-DDB backend, which is the real architectural test. PostgreSQL is the natural next step (same Drizzle dialect with different driver) but is out of scope for this POC.
+
+**Consequences.** Every `*-ddb` storage-operations package gets a `*-sqlite` sibling. Single-table mirror in SQL preserves storage-ops semantics 1:1. Multi-tenancy stays automatic via PK. Test divergences (eventual consistency, batch atomicity, item-size limit) are documented in `04-test-strategy.md`.
+
+---
+
+## ADR-2 — Container topology
+
+**Context.** Webiny's API does HTTP/GraphQL, websockets, scheduled jobs, and async task execution. Each is a candidate for a separate container.
+
+**Options considered.**
+- (a) **Single API container** for everything.
+- (b) Split api / worker / scheduler / websocket from day one.
+- (c) Hybrid — api+ws in one, worker+scheduler in another.
+
+**Decision.** **Single API container**. Split later if needed.
+
+**Reasoning.** The POC's job is to prove the abstractions, not the production topology. One container is dramatically simpler to build, test, and demo. The abstractions for tasks (in-process runner), scheduler (node-cron), and websocket (in-memory registry) are designed so that a Redis / message-broker variant can be added later without consumer changes — splitting is an additive future change, not a redesign.
+
+**Consequences.** No need for a message broker in the POC. Tasks run in the API event loop (acceptable for short tasks; a worker container is the natural follow-on if customers need long-running CPU-bound work).
+
+---
+
+## ADR-3 — Deployment target for POC
+
+**Context.** Container-friendly platforms include docker-compose (local dev), Kubernetes (production), AWS ECS/Fargate, GCP Cloud Run, etc.
+
+**Options considered.**
+- (a) **docker-compose for local dev only.**
+- (b) docker-compose + Kubernetes manifests / Helm charts.
+- (c) docker-compose + ECS/Fargate (still AWS).
+
+**Decision.** **docker-compose only** for this POC.
+
+**Reasoning.** We're proving the container *architecture* works. Production-grade deployment (K8s, ECS, Cloud Run) is a separate effort that depends on this one. Limiting the POC to docker-compose keeps the umbrella PR reviewable and the test surface bounded.
+
+**Consequences.** Production deployment is explicitly out of scope. We don't write Helm charts, K8s manifests, or Pulumi modules for ECS in this work. The architecture stays K8s-friendly (stateless API, externalized state on a volume) so a follow-on phase is straightforward.
+
+---
+
+## ADR-4 — Backwards compatibility with existing serverless
+
+**Context.** Webiny customers run the framework on AWS today. The user's hard requirement: no breaking changes for them.
+
+**Options considered.**
+- (a) **Serverless code path completely untouched** — new abstractions are additive.
+- (b) Refactor serverless to also flow through new runtime abstractions (cleaner long-term, but every Lambda/Pulumi piece becomes a regression risk).
+- (c) Freeze serverless at v6.x, ship container in v7.x as a hard cut.
+
+**Decision.** **Additive only.** Serverless code path is untouched.
+
+**Reasoning.** Existing customers must not have to change a line of code to upgrade. New `*-sqlite` packages, the new `@webiny/handler-node` runtime, the new factory variants for leaky packages — all live alongside the existing AWS-coupled code. The user's `apps/api/graphql/src/index.ts` template stays exactly as it is.
+
+**Consequences.** Some duplication: parallel `*-ddb` and `*-sqlite` packages. Worth it. Where DDB-coupled packages have leaky public APIs (e.g., `api-aco` exposes `DynamoDBDocument` in its types), we add new factory variants and deprecate the old ones — see ADR-9.
+
+---
+
+## ADR-5 — Search backend in container mode
+
+**Context.** Serverless uses OpenSearch via `*-ddb-es` packages because DynamoDB can't do complex filtering or full-text search. SQL databases can do most of that natively.
+
+**Options considered.**
+- (a) **SQLite FTS5 only**, no OpenSearch.
+- (b) Mirror the `-ddb-es` split: `*-sqlite-os` parallel package using a containerized OpenSearch.
+- (c) Configurable — default FTS5, opt-in OpenSearch.
+
+**Decision.** **SQLite FTS5 only.**
+
+**Reasoning.** OpenSearch is a heavyweight container (Java, ~1GB RAM) that adds complexity for marginal benefit when the database itself can search. SQLite's FTS5 covers the searchable-fields use case in `api-headless-cms`. Strong consistency is a *better* property than DDB-ES's eventual consistency. PostgreSQL (future phase) gets `pg_trgm` and `tsvector` for the same role.
+
+**Consequences.** No `*-sqlite-os` packages. Filtering and full-text logic that lives in `*-ddb-es` is re-implemented (against SQL) in `*-sqlite`. Test divergences from DDB-ES (eventual consistency settling delays become no-ops) are documented in `04-test-strategy.md`.
+
+---
+
+## ADR-6 — File storage in container mode
+
+**Context.** `api-file-manager-s3` uses the AWS SDK and S3-specific features (presigned URLs, multipart uploads).
+
+**Options considered.**
+- (a) **Local filesystem driver** (new `api-file-manager-fs` package).
+- (b) MinIO container (S3-compatible) so the existing S3 driver works unchanged.
+- (c) Both — filesystem default, MinIO opt-in.
+
+**Decision.** **New `api-file-manager-fs` driver**, no MinIO.
+
+**Reasoning.** Filesystem is the simplest possible local DX — bytes go to a directory, mounted as a docker-compose volume. No extra service, no port conflicts, no S3 API surprises. The existing `FileStorageDriver` interface is the abstraction point; FS slots in cleanly. Multi-replica deployments are a future concern — the POC is single-container, so the filesystem is plenty.
+
+**Consequences.** New package to write and test. Sharp transforms read from local FS instead of S3 (uses streams either way; no functional change). Presigned URLs are replaced with dev-time signed URLs minted by the API itself for the FS driver — a small custom signing helper.
+
+---
+
+## ADR-7 — SQL access layer
+
+**Context.** Webiny doesn't currently use any ORM or query builder.
+
+**Options considered.**
+- (a) **Drizzle ORM.**
+- (b) Kysely (type-safe query builder, no schema-first).
+- (c) Prisma (heavyweight, full ORM, Rust query engine binary).
+- (d) Raw SQL via `better-sqlite3` / `pg`.
+
+**Decision.** **Drizzle ORM.**
+
+**Reasoning.** Lightweight, schema-first, type-safe. Migration tooling (Drizzle Kit) is included and simple. Same dialect interface for SQLite and PostgreSQL — zero rework when we add Postgres. Less ergonomically opinionated than Prisma, more structured than Kysely.
+
+**Consequences.** Drizzle dependency added to `@webiny/db-sqlite`. Migration files committed to the repo. Schema is declared in TypeScript (`drizzle.schema.ts`) and codegen produces SQL migrations.
+
+---
+
+## ADR-8 — Auth provider for local container dev
+
+**Context.** Cognito doesn't run in docker-compose. JWT/OIDC validation is already abstracted in `@webiny/api-core/src/idp`.
+
+**Options considered.**
+- (a) **Pre-configured Keycloak container** with seeded realm.
+- (b) Lightweight dev-token stub authenticator (skip a real IdP).
+- (c) Both — stub default, Keycloak opt-in.
+
+**Decision.** **Keycloak.**
+
+**Reasoning.** A real OIDC provider exercises the full auth path that production deployments will use. It validates that any cloud's OIDC works (the abstraction does what we think it does). The seeded realm gives instant DX — `docker compose up` and login works.
+
+**Consequences.** `keycloak` service in docker-compose with a `realm-export.json` for the dev realm. A small `IdpAdmin` abstraction is needed because the security flow currently calls Cognito user CRUD directly; the container path satisfies it via the Keycloak Admin API (or a seed script).
+
+---
+
+## ADR-9 — Handling DDB-coupled packages with leaky public APIs
+
+**Context.** Several existing packages expose `DynamoDBDocument` in their public type signatures: `api-aco`, `api-audit-logs`, `api-websockets`, `api-scheduler` (and possibly others). To plug in SQLite, the public surface needs to change.
+
+The leak in `api-aco`:
+```ts
+// packages/api-aco/src/createAcoStorageOperations.ts
+export interface CreateAcoStorageOperationsParams {
+  cms: HeadlessCms;
+  security: Security;
+  container: Container;
+  documentClient: DynamoDBDocument;   // ← leaks AWS SDK type into the public API
+}
+```
+
+**Options considered.**
+- (a) **Add new factory variants alongside the old. Deprecate the old.**
+- (b) Refactor the public API in place — break existing customers, document migration.
+- (c) Wrap with an adapter at the extension level — build a fake `DynamoDBDocument`-shaped object that forwards to SQLite.
+
+**Decision.** **New factory variants. Old ones marked `@deprecated`.**
+
+**Reasoning.** Existing customer projects don't break. The new factory takes pre-built storage operations:
+
+```ts
+// New, container-friendly factory
+export const createAcoWithStorageOps = (params: {
+  cms: HeadlessCms;
+  security: Security;
+  container: Container;
+  storageOperations: AcoStorageOperations;
+}) => { ... };
+
+// Old, kept working, deprecated
+/** @deprecated Use createAcoWithStorageOps. */
+export const createAco = (params: { documentClient: DynamoDBDocument; ... }) => {
+  const storageOperations = await createAcoStorageOperations({ documentClient, ... });
+  return createAcoWithStorageOps({ storageOperations, ... });
+};
+```
+
+Adapter (option c) is rejected as hacky and brittle — fake document clients are a maintenance trap.
+
+**Consequences.** Each leaky package gets a refactor PR (stage 8) that introduces the new factory and reroutes the old one through it. No behavior change for existing serverless customers. The deprecation path gives a clean removal opportunity in a future major.
+
+---
+
+## ADR-10 — Out of scope for this POC
+
+**Context.** Several AWS-specific areas have no clean container equivalent and would expand the POC unreasonably.
+
+**Decisions.** Defer the following:
+
+| Area | Reason for deferral | Container POC behavior |
+|---|---|---|
+| `api-sync-system` + DDB Streams CDC | Cross-environment data sync via DDB Streams + cross-Lambda invocation. No streams in container; sync architecture needs a redesign. | Stub that no-ops in container mode. Documented as serverless-only feature. |
+| `webiny watch` via AWS IoT MQTT | The hot-reload mechanism uses AWS IoT to push code into running Lambdas. | Container DX uses `tsx watch` / `nodemon`. Two parallel watch stories — not unified. |
+| Admin UI hosting via CloudFront + S3 | Production-grade CDN hosting is a separate concern. | Fastify static plugin serves the Admin UI build from inside the API container. CDN is a follow-on phase. |
+| Email delivery via SES | The mailer abstraction already supports SMTP. | Mailpit container in docker-compose; existing SMTP transport in `api-mailer` points at it. Zero code changes. |
+
+See `06-out-of-scope.md` for the full deferral rationale.
+
+**Consequences.** Each deferred area gets a one-paragraph note in the architecture doc and an item in `06-out-of-scope.md`. The POC stays bounded.

--- a/docs/container-refactor/03-refactor-plan.md
+++ b/docs/container-refactor/03-refactor-plan.md
@@ -1,0 +1,237 @@
+# 03 — Refactor Plan
+
+This is the execution plan: how the architecture in `01-architecture.md` gets built, in what order, on which branches, and with which exit criteria per stage.
+
+## Branch convention
+
+- **Umbrella PR:** `sven/poc/container` → targets `next`
+- **Stage PRs:** `sven/poc/container-<slug>` → target `sven/poc/container`
+
+Note: git refs cannot have a name be both a leaf and a directory in the same namespace, so `sven/poc/container/<slug>` would conflict with the umbrella `sven/poc/container`. The hyphenated stage convention avoids this.
+
+## Strategy: vertical slice over breadth-first
+
+Naive plan would be: build all `*-sqlite` storage-ops packages first, then wire them up at the end. That's faster to *specify* but everything is theoretical until integration — schema decisions in one package may need to ripple across all others, and there's no demo until the very end.
+
+**Vertical slice instead.** Each stage from #5 onward produces a container that does **measurably more** than the previous stage:
+
+- After stage 5: container boots, login works.
+- After stage 6: can read/write content.
+- After stage 7: can upload files, Admin UI loads.
+- After stage 8: leaky abstractions cleaned up.
+- After stage 9: full plugin set works.
+- After stage 10: long-running services (tasks, scheduler, WS, email) wired up.
+
+Reviewer cognitive load drops because each stage is end-to-end testable. Schema decisions get validated immediately. The user sees a working demo every couple of weeks.
+
+## Each stage's PR description includes
+
+- What changed (list of files / packages added / modified).
+- What is now demonstrably working (`yarn ... && curl ...` or screenshot).
+- Test results — which suites pass; what's intentionally not yet covered.
+- Cross-links into `docs/container-refactor/`.
+
+---
+
+## Stage 1 — `sven/poc/container-docs`
+
+**Goal.** This `docs/container-refactor/` folder. Architecture locked in writing before any code refactor.
+
+**Scope.**
+- `README.md`, `01-architecture.md`, `02-decisions.md`, `03-refactor-plan.md`, `04-test-strategy.md`, `05-risks-and-mitigations.md`, `06-out-of-scope.md`. (`07-developer-guide.md` is deferred to stage 11.)
+- No code changes.
+
+**Exit criteria.** All six docs merged. User has signed off on `02-decisions.md` and this file.
+
+---
+
+## Stage 2 — `sven/poc/container-runtime`
+
+**Goal.** New `@webiny/handler-node` package — the long-lived twin of `@webiny/handler-aws`.
+
+**Scope.**
+- New package mirrors `handler-aws` structure but uses `app.listen({ port, host })` instead of `@fastify/aws-lambda`.
+- `SIGTERM` / `SIGINT` graceful shutdown — drain in-flight requests, close handles.
+- `/health` endpoint.
+- Logging via plain `pino` (stdout JSON), not `pino-lambda`.
+- Move `ITimer` from `@webiny/handler-aws/utils` to a neutral home (likely `@webiny/tasks`); add a container impl that returns `Infinity` from `getRemainingMilliseconds()`.
+- A tiny test extension that boots a hello-world server.
+
+**Exit criteria.**
+- `node dist/server.js` boots, `/health` returns 200.
+- Shuts down cleanly on `SIGTERM` (no orphaned in-flight requests).
+- Existing `handler-aws` tests still green.
+- `tasks` package no longer imports from `handler-aws`.
+
+---
+
+## Stage 3 — `sven/poc/container-build`
+
+**Goal.** Container build pipeline.
+
+**Scope.**
+- Add `createBuildServer` in `@webiny/build-tools`, alongside `createBuildFunction`. Bundles to `dist/server.js`.
+- Multi-stage `Dockerfile` (likely at `extensions/api/Dockerfile`): builder stage (`yarn install && yarn build`) → runtime stage (`node:lts-alpine`).
+- Skeleton `docker-compose.yml` with just the `api` service.
+
+**Exit criteria.**
+- `docker compose up api` builds the image, runs the hello-world server from stage 2, container exits cleanly on `docker compose down`.
+- Image size and build time captured in the PR description (baseline for future regressions).
+
+---
+
+## Stage 4 — `sven/poc/container-db-core`
+
+**Goal.** SQLite database core, no consumers yet.
+
+**Scope.**
+- New `@webiny/db-sqlite` package.
+- Drizzle ORM setup. Prefer `node:sqlite` (Node 22+) over `better-sqlite3`; document the choice in the PR.
+- Single-table schema: `pk`, `sk`, `gsi1_pk`, `gsi1_sk`, `gsi_tenant_pk`, `gsi_tenant_sk`, `data` (JSON), `version`, `expires_at`. Indexes on each GSI column pair.
+- Drizzle Kit migration runner. First migration creates the table and FTS5 shadow.
+- Storage-ops query helpers: `begins_with → LIKE`, `between → BETWEEN`, cursor encoding.
+- Unit tests for the helpers.
+- **Spike:** pagination cursor parity — DDB `LastEvaluatedKey` (compound JSON) → SQLite `(pk, sk)` tuple cursor. Tiny test asserts equivalent paging behavior on a 100-item dataset.
+
+**Exit criteria.**
+- Unit tests cover query helpers and cursor parity.
+- No storage-ops package consumes it yet — this is foundation only.
+- Migration runs cleanly on a fresh SQLite file.
+
+---
+
+## Stage 5 — `sven/poc/container-slice-alpha` (TENANCY + SECURITY + LOGIN)
+
+**Goal.** First runnable vertical slice. Container boots, authenticates against Keycloak, sets multi-tenant context per request.
+
+**Scope.**
+- New `@webiny/api-core-sqlite` mirroring `api-core-ddb` (tenancy, security, key-value, admin users).
+- Wire Keycloak into `docker-compose.yml` with a seeded realm export and a dev user.
+- Container-mode equivalent of `apps/api/graphql/src/index.ts` lives under `extensions/` (or a new entry file in the Webiny project template).
+- Storage-ops contract tests reused from `api-core` test presets, run with the new `sqlite` variant.
+- Defer leaky-factory deprecation work to stage 8 *unless* it actively blocks this slice.
+
+**Exit criteria.**
+- `docker compose up` boots Webiny container + Keycloak + Mailpit.
+- Hitting GraphQL `/cms-manage` with a Keycloak-issued JWT resolves `currentTenant`.
+- `yarn test:sqlite api-core` passes.
+- Existing `yarn test:ddb api-core` passes (no regression).
+
+---
+
+## Stage 6 — `sven/poc/container-slice-beta` (MINIMAL CMS)
+
+**Goal.** Second slice. CMS reads work end-to-end with one model and one entry.
+
+**Scope.**
+- New `@webiny/api-headless-cms-sqlite` storage operations.
+- FTS5 shadow table for entry search; integrate with `searchableFields`.
+- Storage-ops tests reused from `api-headless-cms` presets.
+- Reuse the cursor parity work from stage 4 to make pagination behave the same as DDB.
+
+**Exit criteria.**
+- Create a content model + entry via GraphQL against the container; list / read / search work.
+- CMS storage-ops contract tests green on SQLite.
+- No regression in `yarn test:ddb api-headless-cms` or `yarn test:ddb-os api-headless-cms`.
+
+---
+
+## Stage 7 — `sven/poc/container-slice-gamma` (FILES + ADMIN UI)
+
+**Goal.** Third slice. File upload/render works, Admin UI loads from the container.
+
+**Scope.**
+- New `@webiny/api-file-manager-fs` package implementing the existing `FileStorageDriver`. Bytes go to a mounted volume.
+- New `@webiny/api-file-manager-sqlite` for file metadata (no `*-ddb` package exists today; this fills the gap).
+- Sharp transforms read from the local FS instead of S3.
+- Fastify static plugin serves the Admin UI build output from inside the API container.
+- Dev-time signed-URL helper for the FS driver (replaces S3 presigned URLs).
+
+**Exit criteria.**
+- Upload a file via Admin UI; it persists on the volume.
+- Thumbnail renders.
+- Existing `FileStorageDriver` contract tests pass against the FS driver.
+
+---
+
+## Stage 8 — `sven/poc/container-abstractions`
+
+**Goal.** Refactor leaky packages so SQLite consumers don't need fake `DynamoDBDocument`s.
+
+**Scope.**
+- For each of `api-aco`, `api-audit-logs`, `api-websockets`, `api-scheduler` (and any others surfaced during stages 5–7):
+  - Add a new factory variant that takes pre-built storage operations.
+  - Deprecate the old factory; old factory keeps working by routing through the new one.
+- Migration notes added to `02-decisions.md` (Section ADR-9 references this stage).
+
+**Exit criteria.**
+- New factories proven by container-mode consumers in stage 9.
+- Existing serverless tests still green and untouched.
+- No public-API removal — only addition + deprecation marker.
+
+---
+
+## Stage 9 — `sven/poc/container-breadth`
+
+**Goal.** Fill remaining storage-ops backends so the entire plugin set in `apps/api/graphql/src/index.ts` has SQLite equivalents.
+
+**Scope.**
+- `api-aco-sqlite`, `api-audit-logs-sqlite`, `api-record-locking-sqlite`, `api-mailer-sqlite`, `api-headless-cms-tasks-sqlite`, `api-website-builder-sqlite` (and friends), `api-workflows-sqlite`, etc.
+- May land as 2–3 sub-PRs into the umbrella by package cluster, not 11 independent ones — they share schema patterns and reviewing one teaches you all of them.
+
+**Exit criteria.**
+- A complete container-mode entry file boots with no DDB factories anywhere.
+- Per-package storage-ops contract tests green for `sqlite` variant.
+
+---
+
+## Stage 10 — `sven/poc/container-runtime-services`
+
+**Goal.** Long-running runtime services that don't fit in the storage-ops layer.
+
+**Scope.**
+- `@webiny/api-background-tasks-sqlite` — in-process task runner backed by a SQLite queue table. No 15-min timeout, simpler resumption logic.
+- `@webiny/api-scheduler-cron` — `node-cron` impl behind the existing scheduler abstraction.
+- `@webiny/api-websockets` in-memory connection registry adapter + `@fastify/websocket` transport.
+- Mailer points at Mailpit via SMTP transport (config-only — `api-mailer` already supports SMTP).
+- `IdpAdmin` abstraction for admin-user CRUD; container path uses Keycloak Admin API.
+
+**Exit criteria.**
+- Tasks run in-process; cron-scheduled jobs fire; WS connect/disconnect/message works; emails land in the Mailpit UI.
+- Admin user can be created via the API in container mode.
+
+---
+
+## Stage 11 — `sven/poc/container-dx`
+
+**Goal.** Polish DX so a new contributor goes from `git clone` to logged-in Admin UI in under 5 minutes.
+
+**Scope.**
+- Final `docker-compose.yml` with seeded volumes, healthchecks, and named ports.
+- Seed scripts (root tenant, admin user via Keycloak Admin API).
+- `docs/container-refactor/07-developer-guide.md` — getting-started.
+- Sample container-mode `webiny.config.tsx`.
+
+**Exit criteria.**
+- `git clone && docker compose up && open http://localhost:8080` works on a clean machine.
+- Time-to-login measured and recorded in the PR description.
+
+---
+
+## Stage 12 — `sven/poc/container-e2e`
+
+**Goal.** CI integration — both code paths green.
+
+**Scope.**
+- New CI job that boots `docker-compose` and runs a smoke E2E suite: login, create content model, create entry, upload file, search content, scheduled job fires.
+- Existing serverless test suites stay in CI, untouched.
+
+**Exit criteria.**
+- Green CI on both serverless and container paths.
+- Smoke suite catches a deliberately-introduced regression in a manual test (sanity check that the suite is real).
+
+---
+
+## Final merge
+
+Once stages 1–12 are merged into `sven/poc/container`, open the umbrella PR `sven/poc/container → next`. Reviewers see a single combined diff but per-stage history is preserved. Squash merge optional — the per-stage PRs into the umbrella are likely the more useful unit for `git log`.

--- a/docs/container-refactor/04-test-strategy.md
+++ b/docs/container-refactor/04-test-strategy.md
@@ -1,0 +1,109 @@
+# 04 — Test Strategy
+
+The user's hard requirement: high confidence the tests are passing **and testing the correct things**. This document explains how that's achieved without rewriting the existing test corpus.
+
+## Principle: reuse contract tests, swap backends
+
+Webiny already has a Vitest preset pattern that lets the same test suite run against multiple storage backends. The DDB and DDB-ES variants of `api-headless-cms` use it today:
+
+```ts
+// packages/api-headless-cms-ddb-es/vitest.config.ts
+import { getPresets } from "@webiny/testing/vitest.preset.js";
+
+export default {
+  test: {
+    setupFiles: getPresets(["@webiny/api-headless-cms", "storage-operations"]),
+    // ...
+  }
+};
+```
+
+Both `*-ddb` and `*-ddb-es` packages reuse the *same* contract tests — a shared suite that exercises the storage-ops interface — and just point at a different backend setup. We do exactly the same for `*-sqlite`.
+
+## Three test variants going forward
+
+| Variant | Backend | What it proves |
+|---|---|---|
+| `ddb` | DynamoDB Local (dynalite) | Existing serverless behavior unchanged |
+| `ddb-os` | DynamoDB + OpenSearch | DDB-with-search behavior unchanged |
+| `sqlite` *(new)* | SQLite + FTS5 | New container behavior matches the contract |
+
+CI runs all three for every storage-ops package that has a `-sqlite` sibling. A regression in any of the three blocks merge.
+
+Per-package commands (preferred during development):
+```bash
+yarn test:ddb api-headless-cms       # existing
+yarn test:ddb-os api-headless-cms    # existing
+yarn test:sqlite api-headless-cms    # new
+```
+
+The `tester` skill (`yarn test ...`) handles all three variants; the variant flag selects backend-specific setup.
+
+## Expected behavioral divergences (documented in tests)
+
+Some tests will need backend-specific assertions because DDB and SQLite genuinely behave differently. We document each divergence at the test site rather than letting it be a silent skipped test.
+
+### 1. Eventual consistency vanishes
+
+DDB-ES tests today insert artificial settling delays after writes (`await wait(500)`) before asserting search results. SQLite is strongly consistent — these waits become no-ops, but the tests still pass because the assertion is the same. **Action:** no change needed; document the divergence in a `KNOWN_DIVERGENCES.md` next to the test files. Optional follow-up: shrink the delays to zero in the `sqlite` variant for faster runs.
+
+### 2. Batch failure semantics
+
+DynamoDB batch writes can partially succeed (some items written, others not). SQLite transactions are all-or-nothing. Tests that assert partial-success behavior will fail on SQLite. **Action:** identify them during stage 5–6 review; rewrite them as variant-conditional assertions:
+
+```ts
+test("batch write failures", () => {
+  const result = await batchWrite([...]);
+  if (variant === "sqlite") {
+    expect(result.failed).toBe(true);
+    expect(result.writtenCount).toBe(0);  // all-or-nothing
+  } else {
+    expect(result.failed).toBe(true);
+    expect(result.writtenCount).toBeGreaterThan(0);  // partial OK
+  }
+});
+```
+
+### 3. Result ordering
+
+DDB returns items in PK/SK order (effectively, the index dictates it). SQLite returns rows in implementation-defined order unless `ORDER BY` is explicit. **Action:** every storage-ops query in the SQLite implementation includes an explicit `ORDER BY (pk, sk)` (or equivalent for GSI queries). Make this a code-review checkpoint.
+
+### 4. Item-size limit
+
+DDB enforces a 400 KB item-size limit; SQLite does not. Test fixtures that happen to use oversized items pass on SQLite and fail on DDB. **Action:** note in tests that use such fixtures. Don't gate on this — the failure mode is "DDB rejects, SQLite accepts," which is graceful.
+
+### 5. Conditional writes / optimistic concurrency
+
+`dynamodb-toolbox` may emit `ConditionExpression` clauses for upserts. SQLite implements the equivalent semantics via `UNIQUE` constraints + a `version` column + `WHERE version = ?` predicates. **Action:** validate the upsert path in the cursor-parity spike (stage 4) and assert both backends behave identically for concurrent-update conflicts.
+
+### 6. Pagination cursors
+
+DDB returns a `LastEvaluatedKey` (a JSON object containing the indexed attributes). SQLite needs a `(pk, sk)` tuple cursor for equivalent paging behavior. **Action:** the cursor encoding lives in `@webiny/db-sqlite` query helpers, with a unit test that asserts a 100-item dataset paginates identically across DDB and SQLite given the same page size.
+
+## End-to-end smoke (stage 12)
+
+A short E2E suite runs against the live `docker-compose` stack in CI:
+
+| # | Operation | Asserts |
+|---|---|---|
+| 1 | Boot stack: `docker compose up -d` | All services healthy within 60 s |
+| 2 | Login via Keycloak-issued JWT | Auth succeeds; `currentTenant` resolves |
+| 3 | Create content model | `cms-manage` mutation returns the model |
+| 4 | Create entry | Entry persists; `cms-read` returns it |
+| 5 | Search entries | FTS5 returns expected match |
+| 6 | Upload file | File persists on the volume; metadata in SQLite |
+| 7 | Render thumbnail | Sharp transforms work against local FS |
+| 8 | Schedule a one-shot job | Cron fires within the expected window |
+| 9 | Tear down: `docker compose down` | No orphaned volumes; cleanup is idempotent |
+
+This is small on purpose. The goal is signal that the stack works end-to-end, not duplicate the unit/integration coverage that already exists.
+
+## Sanity check: the smoke suite must catch a real regression
+
+Before declaring stage 12 done, deliberately introduce a bug (e.g., break tenant filtering in `api-core-sqlite`) and confirm the smoke suite turns red. If it doesn't, the suite isn't testing what we think it's testing.
+
+## What this strategy does NOT do
+
+- **No new test framework, no new assertion patterns.** Vitest stays. Existing presets stay.
+- **No per-storage-ops bespoke E2E.** The contract test suite is shared. Per-backend specifics are limited to setup files and conditional assertions where divergences are real.
+- **No load testing in this POC.** The container path's performance characteristics (SQLite write throughput under concurrency, FTS5 query latency at scale) are out of scope. Add as a follow-on phase if/when a customer needs them.

--- a/docs/container-refactor/05-risks-and-mitigations.md
+++ b/docs/container-refactor/05-risks-and-mitigations.md
@@ -1,0 +1,162 @@
+# 05 — Risks and Mitigations
+
+Risks identified during the planning phase. Each one is something that could quietly derail the refactor — surface it now, mitigate it explicitly, and document it for the reviewer.
+
+---
+
+## R1 — DynamoDB Streams CDC is silently load-bearing
+
+**The risk.** Two existing systems rely on DDB streams as a change-data-capture mechanism:
+
+1. `api-dynamodb-to-elasticsearch` — tails streams to keep OpenSearch indexes in sync with DDB.
+2. `api-sync-system` — moves data between Webiny environments by tailing streams and invoking destination Lambdas.
+
+In container mode there are no streams. Anyone assuming "we just swap the storage backend" is missing this.
+
+**Mitigation.**
+- Container mode does not need (1) — search lives in the database via SQLite FTS5, updated in the same transaction as the row write. No CDC pipeline.
+- Container mode treats (2) as out of scope (see `06-out-of-scope.md`). The `api-sync-system` package is wired with a no-op stub in container mode.
+- Both behaviors are documented in the architecture doc and called out in the relevant stage PR descriptions.
+
+**Where it bites if missed.** Stage 6 storage-ops tests for `api-headless-cms-sqlite` could pass while real sync flows in customer projects silently break. The mitigation closes the gap because the sync system is explicitly stubbed.
+
+---
+
+## R2 — Public APIs that leak `DynamoDBDocument`
+
+**The risk.** Several existing packages put `DynamoDBDocument` in their public type signatures: `api-aco`, `api-audit-logs`, `api-websockets`, `api-scheduler` (and possibly more — surface during stages 5–7). To plug SQLite in, these public APIs need to change. Naively that's a breaking change for serverless customers.
+
+**Mitigation.** New factory variants alongside the old, deprecate the old. See ADR-9 in `02-decisions.md`.
+
+```ts
+// New, container-friendly
+export const createAcoWithStorageOps = (params: { storageOperations: AcoStorageOperations; ... }) => { ... };
+
+/** @deprecated Use createAcoWithStorageOps. */
+export const createAco = (params: { documentClient: DynamoDBDocument; ... }) => {
+  const storageOperations = await createAcoStorageOperations({ documentClient, ... });
+  return createAcoWithStorageOps({ storageOperations, ... });
+};
+```
+
+Existing customers don't update a line. New container-mode entry files use the new factories.
+
+**Where it bites if missed.** Forgetting a leaky package until stage 9 means re-opening stage 8 retroactively. Mitigation: stage 5–7 reviewers explicitly look for new leaks as they touch each consumer.
+
+---
+
+## R3 — `tasks` package leaks Lambda `ITimer`
+
+**The risk.** `packages/tasks/src/runner/TaskRunner.ts` imports `ITimer` from `@webiny/handler-aws/utils`. The runner asks the timer "are we close to the Lambda timeout?" to decide whether to checkpoint and re-schedule. Container mode has no timeout — but the runner branches on `isCloseToTimeout`, so a hardcoded `false` would technically work yet leaves the abstraction broken.
+
+**Mitigation.** Stage 2 moves `ITimer` out of `@webiny/handler-aws/utils` to a neutral home (likely `@webiny/tasks` itself). Two implementations:
+- `LambdaTimer` (existing, in `@webiny/handler-aws`).
+- `InfiniteTimer` (new, in `@webiny/tasks`) — `getRemainingMilliseconds()` returns `Infinity`.
+
+The runner consumes the abstraction; the runtime adapter picks the implementation.
+
+**Where it bites if missed.** Container mode would import from `@webiny/handler-aws` just to get a type — coupling that contradicts the whole point of the refactor.
+
+---
+
+## R4 — `pino-lambda` is hard-coded in `handler-aws`
+
+**The risk.** `packages/handler-aws/src/createHandler.ts` configures `pino-lambda` for log shipping. Container mode wants plain `pino` writing JSON to stdout (let the orchestrator collect logs).
+
+**Mitigation.** `@webiny/handler-node` provides its own logger setup — plain `pino`, stdout transport. The Fastify core (`@webiny/handler`) doesn't pin the logger; both adapters install their own. Zero shared change.
+
+**Where it bites if missed.** Container logs would be Lambda-formatted nonsense. Caught immediately on first stage-2 boot.
+
+---
+
+## R5 — Cognito user CRUD is wired into security flow
+
+**The risk.** Even though JWT/OIDC validation is abstract, the security flow currently calls Cognito-specific user-CRUD methods (create user, set password, etc.) — see `packages/cognito`. Replacing the IdP with Keycloak doesn't automatically replace these calls.
+
+**Mitigation.** Stage 10 introduces a small `IdpAdmin` abstraction. Cognito implementation stays in serverless; container path provides a Keycloak Admin API implementation (or relies on seed scripts for the POC and Admin API for real use).
+
+**Where it bites if missed.** Admin user creation in container mode breaks at runtime. Stage 5 will surface this for tenant/admin bootstrap; stage 10 fully resolves it.
+
+---
+
+## R6 — Conditional writes / optimistic concurrency
+
+**The risk.** `dynamodb-toolbox` may emit `ConditionExpression` clauses on writes. If SQLite doesn't enforce equivalent semantics, two concurrent writers could clobber each other in container mode but not in serverless — a subtle data-loss bug.
+
+**Mitigation.** SQLite implementation uses:
+- `UNIQUE` constraints on `(pk, sk)` so duplicate inserts fail.
+- A `version` integer column incremented on every update; updates use `WHERE version = ?` so stale writes fail.
+- Storage-ops contract tests include a concurrent-update scenario that asserts both backends behave identically.
+
+The cursor-parity spike in stage 4 also exercises this path.
+
+**Where it bites if missed.** Production data loss under concurrent admin edits. Mitigation is "tests that exercise the conflict path"; if those are missing, the bug is invisible.
+
+---
+
+## R7 — DDB 400 KB item-size limit
+
+**The risk.** DDB rejects items over 400 KB. SQLite has no such limit. Tests that happen to use oversized items would pass on SQLite and fail on DDB.
+
+**Mitigation.** Document divergence in `04-test-strategy.md`. Don't gate tests on it — the failure mode is graceful (DDB rejects, SQLite accepts; data on DDB is bounded, on SQLite is not). If a real SQLite-only feature ends up storing huge items, surface it at code review.
+
+**Where it bites if missed.** A test passes locally on SQLite, breaks in serverless CI. Caught fast because we run all three variants.
+
+---
+
+## R8 — `better-sqlite3` is a native dep
+
+**The risk.** `better-sqlite3` requires per-platform compilation. CI and developer machines may build differently; Lambda runtime (if it ever needs SQLite for any reason) would build for Linux x86_64; macOS dev machines build for darwin-arm64. Painful.
+
+**Mitigation.** Prefer **`node:sqlite`** (Node 22+, no native compile, ships with Node) if Webiny's Node baseline supports it. Falls back to `better-sqlite3` only if the baseline is older. Decision recorded in stage 4 PR.
+
+**Where it bites if missed.** Container builds break on different host platforms. Mitigation: choose `node:sqlite` if possible, document the baseline if not.
+
+---
+
+## R9 — Test divergences DDB ↔ SQLite
+
+**The risk.** Even with shared contract tests, behavior differs in real ways: eventual consistency vanishes, batch failures are all-or-nothing, result ordering is implementation-defined unless explicit, item-size limit is gone. Tests pass on one backend and fail on the other.
+
+**Mitigation.** Each divergence is enumerated and addressed in `04-test-strategy.md`:
+- Eventual consistency → no-op delays.
+- Batch failures → variant-conditional assertions.
+- Result ordering → explicit `ORDER BY` in every SQLite query.
+- Item-size limit → documented, not gated.
+
+**Where it bites if missed.** Flaky CI; reviewers waste time chasing phantom failures. Mitigation is "document the divergences upfront and write conditional assertions where they're real."
+
+---
+
+## R10 — `webiny watch` uses AWS IoT MQTT
+
+**The risk.** Webiny's hot-reload mechanism uses AWS IoT to push code into running Lambdas. Container DX needs a different mechanism. Two parallel watch stories means more code to maintain.
+
+**Mitigation.** Container DX uses `tsx watch` / `nodemon`. Documented as a separate dev-mode story; not unified with the IoT-based one. (See `06-out-of-scope.md`.)
+
+**Where it bites if missed.** Stage 11 DX feels jankier than the serverless path. Mitigation: bake `tsx watch` into the dev compose service so file changes restart the API container automatically.
+
+---
+
+## R11 — Admin UI hosting in container mode
+
+**The risk.** Admin UI today is served by CloudFront from S3. Container mode needs a different static hosting story. Wrong choice could mean a separate nginx container, more complexity than the POC justifies.
+
+**Mitigation.** Fastify static plugin serves the Admin UI build output from inside the API container. Single container, no extra service. Production-grade CDN hosting is a follow-on phase. (See `06-out-of-scope.md`.)
+
+**Where it bites if missed.** Stage 7 reviewers ask "where does Admin UI live?" and we don't have an answer. Mitigation: this doc, the architecture doc, and stage-7 PR description all say "Fastify static, follow-on phase for CDN."
+
+---
+
+## Cross-cutting: regression risk to serverless
+
+The "additive only" promise is easy to break by accident. Three classes of risk:
+
+1. **Shared interface changes.** Adding a method to `FileStorageDriver` for the FS driver requires `S3Driver` to implement it too — silently broken if missed.
+2. **Lockfile drift.** New deps (Drizzle, `node:sqlite` polyfills if any, `@fastify/websocket`) at the root may cascade into platform-specific install issues for the serverless build.
+3. **Optional fields.** New optional fields on shared types may go unset by serverless code paths; if container code assumes them present, behavior diverges.
+
+**Mitigation.**
+- Run the full DDB and DDB-ES test variants in CI for every stage PR — they catch shared interface regressions.
+- Run `yarn webiny sync-dependencies` after every dep change (per `CLAUDE.md` pre-commit checklist) to catch drift.
+- Default values for any new optional fields documented at the type level.

--- a/docs/container-refactor/06-out-of-scope.md
+++ b/docs/container-refactor/06-out-of-scope.md
@@ -1,0 +1,71 @@
+# 06 — Out of Scope
+
+The user explicitly asked for a focused POC. This document records what we're *not* doing, and why each item was deferred. The same items are summarized in ADR-10 (`02-decisions.md`).
+
+The point of an explicit out-of-scope list is to short-circuit "but what about…?" reviews and keep the umbrella PR shippable.
+
+---
+
+## OOS-1 — `api-sync-system` + DynamoDB Streams CDC
+
+**What it is.** A Webiny feature that synchronizes data between environments (e.g., dev → staging → prod) by tailing DynamoDB Streams and invoking a destination Lambda that writes the changes into the target environment. Several adjacent packages also rely on stream-based CDC: `api-dynamodb-to-elasticsearch` (DDB → OpenSearch index updates) is the most prominent.
+
+**Why deferred.** Streams don't exist outside DynamoDB. Replacing them in container mode means designing a brand-new sync architecture (write-side outbox pattern? application-level CDC? trigger-based replication?) — that's its own multi-week design effort. Doing it inside the POC would balloon scope.
+
+**Container POC behavior.** `api-sync-system` is wired with a no-op stub in container mode. Calling sync APIs in a container deployment returns "not supported in this runtime." Indexing for search is *not* affected because container mode uses SQLite FTS5 in-process — search updates happen in the same transaction as the row write, so no CDC pipeline is needed.
+
+**Future work.** When container deployments hit the customer use case for cross-environment sync, design a separate `api-sync-system-pull` (or similar) that polls or uses an outbox table.
+
+---
+
+## OOS-2 — `webiny watch` via AWS IoT MQTT
+
+**What it is.** Webiny's hot-reload mechanism uses AWS IoT MQTT to push compiled code into running Lambda functions during development. It's tightly coupled to the AWS IoT broker and the Lambda execution model.
+
+**Why deferred.** Container DX has a much simpler answer for hot-reload: `tsx watch` or `nodemon` restart the long-lived Node process when source files change. Trying to unify the two watch experiences would mean abstracting over "how do I get new code into a running runtime" — a problem that has fundamentally different shapes in serverless and container.
+
+**Container POC behavior.** `tsx watch` (or `nodemon`) is baked into the `api` service's dev command in `docker-compose.yml`. Source file changes restart the API process inside the container; the volume mount keeps state across restarts. Documented in stage 11's `07-developer-guide.md`.
+
+**Future work.** None planned. The two watch stories live separately; that's fine.
+
+---
+
+## OOS-3 — Admin UI hosting via CloudFront + S3
+
+**What it is.** In serverless production deployments, the Admin UI build output (a React SPA) is uploaded to an S3 bucket and served via CloudFront with a custom domain, edge caching, and origin failover.
+
+**Why deferred.** Production-grade static hosting is a separate concern from "does Webiny run in a container at all." Serving the SPA through a CDN matters for production performance but is not on the critical path for the POC.
+
+**Container POC behavior.** Fastify static plugin serves the Admin UI build output from inside the API container. One process, one volume mount, no extra service. Acceptable for local dev and small deployments. Not acceptable for high-traffic production.
+
+**Future work.** A separate phase introduces a static-hosting story for container production deployments — likely a sidecar nginx/Caddy container, or guidance for users to put a CDN in front of their cluster ingress. The Fastify static plugin stays as the dev/small-deployment fallback.
+
+---
+
+## OOS-4 — Email delivery via AWS SES
+
+**What it is.** Serverless deployments use SES through `@webiny/api-mailer`. The mailer abstraction supports multiple transports — SES is the default in serverless, but SMTP is also supported.
+
+**Why deferred.** Almost no work needed. Mailpit is an SMTP catcher that runs in a tiny container (~10 MB image). The existing SMTP transport in `api-mailer` points at it via env config; no code changes.
+
+**Container POC behavior.** `mailpit` container in `docker-compose.yml`. `api-mailer` configured with `SMTP_HOST=mailpit`, `SMTP_PORT=1025`. Mailpit's web UI on `:8025` shows captured emails — a great DX for testing email flows.
+
+**Future work.** Production container deployments configure their own SMTP relay (or any of the existing transports `api-mailer` supports). No abstraction work needed.
+
+---
+
+## What about Kubernetes, ECS/Fargate, Cloud Run, etc.?
+
+Production container deployment is out of scope for this POC (see ADR-3). The architecture is K8s-friendly by construction (stateless API, externalized state on a volume), so a follow-on phase that ships Helm charts, K8s manifests, or ECS/Fargate Pulumi modules is straightforward — but it's a separate effort.
+
+## What about PostgreSQL?
+
+Out of scope for this POC (see ADR-1). PostgreSQL is the natural next step after SQLite — same Drizzle dialect interface, different driver. The schema strategy (single-table mirror) is intentionally chosen so the same approach works for both. PostgreSQL is the next phase.
+
+## What about splitting api / worker / scheduler / websocket containers?
+
+Out of scope for this POC (see ADR-2). The runtime services (tasks, scheduler, WS) are abstracted such that splitting is additive — swap an in-process implementation for a Redis/NATS-backed one. Worth doing once a customer needs the scale.
+
+## What about load testing, perf benchmarks, capacity planning?
+
+Out of scope. The POC's job is correctness and DX, not throughput characterization. Benchmarks come later, when a real workload exists to measure against.

--- a/docs/container-refactor/README.md
+++ b/docs/container-refactor/README.md
@@ -1,0 +1,32 @@
+# Container Refactor
+
+This folder collects the design and execution plan for adding a **container deployment path** to Webiny.
+
+Webiny today runs exclusively on AWS serverless (Lambda + DynamoDB + S3 + OpenSearch + Cognito + EventBridge). The goal of this refactor is to make Webiny *also* runnable inside a single Docker container — alongside `keycloak` and `mailpit` services in `docker-compose` — without changing anything about the existing serverless code path. Existing customers see no behavioral changes; the container path is opt-in via the user's `webiny.config.tsx` and `extensions/`.
+
+This folder is the durable record of why we chose what we chose, and how the refactor will be sequenced. Read these in order if you're new to the work.
+
+## Reading order
+
+| # | File | What's in it |
+|---|---|---|
+| 1 | [`01-architecture.md`](./01-architecture.md) | Target architecture: serverless and container side by side. New packages, abstraction boundaries, where the runtime split happens. |
+| 2 | [`02-decisions.md`](./02-decisions.md) | ADR-style record of the 10 decisions that shaped the design (database, topology, search backend, file storage, auth, staging, etc.). |
+| 3 | [`03-refactor-plan.md`](./03-refactor-plan.md) | Stage-by-stage refactor plan. Branch naming, scope per stage, exit criteria. Vertical-slice strategy: each stage from #5 onward produces a runnable demo. |
+| 4 | [`04-test-strategy.md`](./04-test-strategy.md) | Vitest preset reuse, the new `sqlite` test variant, expected behavioral divergences between DDB and SQLite, end-to-end smoke approach. |
+| 5 | [`05-risks-and-mitigations.md`](./05-risks-and-mitigations.md) | Risks identified during planning (hidden coupling, breaking-change surfaces, perf concerns, etc.) and how each is mitigated. |
+| 6 | [`06-out-of-scope.md`](./06-out-of-scope.md) | What is intentionally deferred to a future phase and why (api-sync-system, AWS IoT watch mode, CloudFront/S3 admin UI hosting, SES). |
+| 7 | `07-developer-guide.md` *(written last)* | Getting-started guide for running Webiny locally with `docker compose up`. Added in the final stage of execution, once the stack is real. |
+
+## Status
+
+Stage 1 (this docs folder) is being written first, before any code refactor begins. The architecture is locked in writing here so the design is reviewable on its own before we ship abstraction packages.
+
+## Branches
+
+- **Umbrella PR:** `sven/poc/container` (targets `next`)
+- **Stage PRs:** `sven/poc/container-<slug>` (target `sven/poc/container`)
+
+Note on naming: git refs cannot have a name be both a leaf and a directory in the same namespace, so `sven/poc/container/<slug>` would conflict with the umbrella `sven/poc/container`. The hyphenated stage convention avoids this while keeping the intent clear.
+
+This folder lives on branch `sven/poc/container-docs`.


### PR DESCRIPTION
Add docs/container-refactor/ with the architecture, ADR-style decisions, staged refactor plan, test strategy, risks, and out-of-scope notes for adding a containerized deployment path alongside the existing AWS serverless one. No code changes — Stage 1 of the umbrella container refactor (sven/poc/container).

## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #ISSUE_NUMBER

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
