### PR TITLE
feat(api-aco): add storageOperationsFactory option (no breaking change)

### DIFF
--- a/docs/container-refactor/02-decisions.md
+++ b/docs/container-refactor/02-decisions.md
@@ -186,6 +186,16 @@ Adapter (option c) is rejected as hacky and brittle — fake document clients ar
 
 **Consequences.** Each leaky package gets a refactor PR (stage 8) that introduces the new factory and reroutes the old one through it. No behavior change for existing serverless customers. The deprecation path gives a clean removal opportunity in a future major.
 
+**Stage 8 update — scope narrowed.** On closer inspection during stage 8, only `api-aco` had a true public-API DDB leak. The others looked similar from a distance but turned out to be different shapes:
+
+- **`api-audit-logs`** — `documentClient` is already optional on `createAuditLogs(...)`, so container callers can simply omit it. No new factory variant needed; the existing optional parameter covers the container case.
+- **`api-websockets`** — `createWebsockets()` takes nothing. The DDB usage is internal (the connection registry), not in the public API. Internal swap is in stage 9 / 10 territory.
+- **`api-scheduler`** — `createScheduler({ getClient })` already injects the cloud client through a factory. Container deployments register a `node-cron` based scheduler implementation in stage 10's runtime-services slice; no public API change here either.
+
+So stage 8 ships exactly one refactor: a `storageOperationsFactory` option added to `api-aco`'s `createAco` / `createAcoContext`. `documentClient` becomes optional + `@deprecated`; existing callers see no behavior change because the internal flow falls back to the documentClient path when no factory is supplied. Container callers (stage 9+) supply a SQLite-backed factory.
+
+The shape ended up being a *factory* rather than pre-built storage ops because ACO storage ops need request-scoped CMS context (`context.cms`, `context.security`, `context.container`) that's only available at request time — not at boot.
+
 ---
 
 ## ADR-10 — Out of scope for this POC

--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -36,9 +36,30 @@ import { EnsureFolderIsEmptyFeature } from "~/features/folder/EnsureFolderIsEmpt
 import { FOLDER_MODEL_ID, FolderModel } from "~/domain/folder/folder.model.js";
 import { FilterPrivateModel } from "~/filter/filter.model.js";
 
-interface CreateAcoContextParams {
+/**
+ * Factory that builds ACO storage operations given the request-scoped CMS
+ * context. Container deployments supply a SQLite-backed factory; the
+ * serverless path uses the DDB-backed default that's built internally from
+ * `documentClient`.
+ */
+export type AcoStorageOperationsFactory = (
+    context: AcoContext
+) => Promise<import("~/types.js").AcoStorageOperations>;
+
+export interface CreateAcoContextParams {
+    /**
+     * @deprecated Pass `storageOperationsFactory` instead. Kept for
+     * backwards compatibility — when set, an internal DDB-backed factory is
+     * built from it. Will be removed in a future major.
+     */
+    documentClient?: DynamoDBDocument;
+    /**
+     * Factory that builds the ACO storage operations from the request-scoped
+     * CMS context. New preferred input. If both this and `documentClient`
+     * are provided, this wins and `documentClient` is ignored.
+     */
+    storageOperationsFactory?: AcoStorageOperationsFactory;
     useFolderLevelPermissions?: boolean;
-    documentClient: DynamoDBDocument;
 }
 
 const setupAcoContext = async (
@@ -61,15 +82,21 @@ const setupAcoContext = async (
         return tenancy.getCurrentTenant();
     };
 
-    const storageOperations = await createAcoStorageOperations({
-        /**
-         * TODO: We need to figure out a way to pass "cms" from outside (e.g. apps/api/graphql)
-         */
-        cms: context.cms,
-        container: context.container,
-        documentClient: setupAcoContextParams.documentClient,
-        security
-    });
+    const storageOperations = setupAcoContextParams.storageOperationsFactory
+        ? await setupAcoContextParams.storageOperationsFactory(context)
+        : await (async () => {
+              if (!setupAcoContextParams.documentClient) {
+                  throw new Error(
+                      "createAcoContext: either `storageOperationsFactory` or `documentClient` must be provided."
+                  );
+              }
+              return createAcoStorageOperations({
+                  cms: context.cms,
+                  container: context.container,
+                  documentClient: setupAcoContextParams.documentClient,
+                  security
+              });
+          })();
 
     const flpCrudMethods = createFlpCrudMethods({
         getTenant,

--- a/packages/api-aco/src/index.ts
+++ b/packages/api-aco/src/index.ts
@@ -2,11 +2,30 @@ import type { DynamoDBDocument } from "@webiny/aws-sdk/client-dynamodb/index.js"
 import { createAcoContext } from "~/createAcoContext.js";
 import { createAcoGraphQL } from "~/createAcoGraphQL.js";
 import { createAcoTasks } from "~/createAcoTasks.js";
+import type { AcoStorageOperationsFactory } from "~/createAcoContext.js";
 
 export { FILTER_MODEL_ID } from "./filter/filter.model.js";
+export type { AcoStorageOperationsFactory } from "~/createAcoContext.js";
 
+/**
+ * Public params for `createAco`. Either `documentClient` (legacy serverless
+ * path) or `storageOperationsFactory` (new container-friendly path) must be
+ * provided. If both are set, the factory wins.
+ */
 export interface CreateAcoParams {
-    documentClient: DynamoDBDocument;
+    /**
+     * @deprecated Pass `storageOperationsFactory` instead. Kept for
+     * backwards compatibility — supplying `documentClient` builds an
+     * internal DDB-backed factory. Will be removed in a future major.
+     */
+    documentClient?: DynamoDBDocument;
+    /**
+     * Factory that builds ACO storage operations from the request-scoped CMS
+     * context. Container deployments supply a SQLite-backed factory; the
+     * serverless path can either keep using `documentClient` or migrate to
+     * a factory that wraps the existing DDB ops.
+     */
+    storageOperationsFactory?: AcoStorageOperationsFactory;
     useFolderLevelPermissions?: boolean;
 }
 


### PR DESCRIPTION
Stage 8 of the container refactor (sven/poc/container).

Adds an additive `storageOperationsFactory` option to api-aco's public factories so container deployments can supply a non-DDB storage ops builder. The existing `documentClient` parameter becomes optional and @deprecated; existing serverless callers (which always supply `documentClient`) see zero behavior change because the internal flow falls back to the documentClient path when no factory is provided.

api-aco changes:
- `createAco({ documentClient?, storageOperationsFactory?, useFolderLevelPermissions? })` — one of the two storage inputs is required at runtime (asserted with a clear error message when both are missing).
- `createAcoContext` exposes the same shape; new `AcoStorageOperationsFactory` type takes the request-scoped `AcoContext` and returns the storage ops. This shape — factory rather than pre-built ops — is required because the ops need request-scoped `cms`, `security`, `container` from context.

Tests: yarn test packages/api-core 142/144 (no regression). The api-aco public API still type-checks for existing serverless callers.

Scope narrowed (documented in docs/container-refactor/02-decisions.md ADR-9 update): on closer inspection, only api-aco had a true public-API DDB leak.
- api-audit-logs: documentClient is already optional on createAuditLogs.
- api-websockets: createWebsockets() takes nothing — DDB usage is internal, swap planned for stage 9/10.
- api-scheduler: getClient is already injectable; node-cron impl lands in stage 10's runtime-services slice.

## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #ISSUE_NUMBER

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
