### PR TITLE
feat(extensions/api): bootstrap admin user matching Keycloak seed (Ph…

### DIFF
--- a/extensions/api/src/keycloakAuth.ts
+++ b/extensions/api/src/keycloakAuth.ts
@@ -10,9 +10,16 @@ type JwtPayload = KeycloakIdpConfig.JwtPayload;
 /**
  * Default claim → Webiny identity mapper. Reads standard OIDC claims
  * (`sub`, `email`, `preferred_username`, `name`, `given_name`,
- * `family_name`) plus Keycloak's realm roles. Customers can swap this for
- * their own implementation by registering a different `KeycloakIdpConfig`
- * before this plugin runs.
+ * `family_name`).
+ *
+ * Identity id strategy: **email** rather than `sub`. The container's
+ * boot-time bootstrap (`server.ts`) seeds a single Webiny admin-user
+ * keyed by email; using email here keeps the per-request identity in
+ * lockstep with the bootstrapped row without needing to query Keycloak's
+ * Admin API for the `sub`. POC simplification — production-grade JIT
+ * provisioning would key on `sub` and create the user record on first
+ * login. Customers wanting that behavior register a different
+ * `KeycloakIdpConfig` before this plugin runs.
  */
 class DefaultKeycloakIdpConfig implements IKeycloakIdpConfig {
     public getIdentity(token: JwtPayload): KeycloakIdentity {
@@ -24,7 +31,9 @@ class DefaultKeycloakIdpConfig implements IKeycloakIdpConfig {
         const familyName = (token["family_name"] as string | undefined) ?? "";
 
         return {
-            id: sub,
+            // Email-as-id keeps the per-request identity matched to the
+            // Webiny admin-user row bootstrapped at container start.
+            id: email || sub,
             displayName: name || preferredUsername || email || sub,
             profile: {
                 email,
@@ -42,9 +51,8 @@ class DefaultKeycloakIdpConfig implements IKeycloakIdpConfig {
  *
  * After this is wired, requests with `Authorization: Bearer <jwt>` get
  * past the JWT validator if the token was issued by the configured
- * Keycloak realm. Mapping the resulting identity into authorized GraphQL
- * operations is the next slice (Phase 2 — bootstrap a Webiny admin-user
- * row matching the Keycloak `sub`).
+ * Keycloak realm. The matching Webiny admin-user row is bootstrapped at
+ * container start in `server.ts` (Phase 2).
  */
 export const createKeycloakAuth = () => {
     return createRegisterExtensionPlugin(context => {

--- a/extensions/api/src/server.ts
+++ b/extensions/api/src/server.ts
@@ -72,6 +72,40 @@ const main = async () => {
     }
 
     // -----------------------------------------------------------------------
+    // Bootstrap — Webiny admin-user record matching the seeded Keycloak
+    // user (`admin@webiny.local`). The container's KeycloakIdpConfig
+    // returns the email as the Webiny identity id, so this row is what
+    // authorize-by-id queries match against. Without it the api validates
+    // the Keycloak token but every authorized GraphQL operation fails to
+    // find a matching user record.
+    //
+    // POC limitation: only the seeded admin works this way. A
+    // production-grade flow would JIT-provision new external users on
+    // first login (the IdentityData `external: true` flag is the hook).
+    // -----------------------------------------------------------------------
+    const ADMIN_EMAIL = "admin@webiny.local";
+    const existingAdmin = await storageOperations.usersStorageOperations.getUser({
+        where: { id: ADMIN_EMAIL, tenant: "root" }
+    });
+    if (!existingAdmin) {
+        const now = new Date().toISOString();
+        await storageOperations.usersStorageOperations.createUser({
+            user: {
+                id: ADMIN_EMAIL,
+                tenant: "root",
+                displayName: "Webiny Admin",
+                email: ADMIN_EMAIL,
+                firstName: "Webiny",
+                lastName: "Admin",
+                createdOn: now,
+                createdBy: null,
+                external: true
+            }
+        });
+        console.log(`Bootstrapped admin user ${ADMIN_EMAIL}.`);
+    }
+
+    // -----------------------------------------------------------------------
     // Server — api-core context (tenancy, security, adminUsers, KV) over the
     // SQLite storage layer, plus the GraphQL handler and a /tenants
     // diagnostic route that exercises the storage layer end-to-end. Keycloak


### PR DESCRIPTION
…ase 2)

Phase 2 of the Admin UI work. Keycloak token validation works end-to-end after Phase 1, but every authorized GraphQL operation still failed because no Webiny admin-user row matched the identity returned from the JWT. This commit closes that gap with a deterministic bootstrap that mirrors the existing root-tenant pattern.

extensions/api/src/server.ts:
- After the root-tenant bootstrap, ensure a Webiny admin-user row exists with id="admin@webiny.local", tenant="root", external=true. Idempotent.
- Adds ~25 LOC; no new deps.

extensions/api/src/keycloakAuth.ts:
- DefaultKeycloakIdpConfig.getIdentity now returns `email || sub` as the identity id (was `sub`). The bootstrapped admin row uses the email as its id, so the per-request identity matches without a Keycloak Admin API roundtrip.
- Doc comment updated to flag the POC simplification: this strategy matches one seeded user. Production-grade JIT provisioning (key on sub, create-on-first-login) is a follow-on; the existing `external: true` flag on IdentityData is the hook for that.

Verified locally: container boots clean, both bootstrap log lines fire on first start ("Bootstrapped root tenant" / "Bootstrapped admin user admin@webiny.local"); subsequent boots are no-ops because the rows exist.

End-to-end token-to-authorized-GraphQL still needs the docker-compose stack — that's the smoke for the next merge. Phase 3 (admin-side @webiny/keycloak package + Admin UI swap) lands after.

## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #ISSUE_NUMBER

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
