### PR TITLE
feat(api-headless-cms): storage support subtypes

### DIFF
--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/CmsEntryOpenSearchFieldIndexRegistry.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/CmsEntryOpenSearchFieldIndexRegistry.ts
@@ -4,13 +4,29 @@ import { getBaseFieldType } from "@webiny/api-headless-cms/utils/getBaseFieldTyp
 import { FIELD_INDEXING_DEFAULT } from "./constants.js";
 
 class CmsEntryOpenSearchFieldIndexRegistryImpl implements Abstraction.Interface {
+    private readonly cache: Map<string, CmsEntryOpenSearchFieldIndex.Interface | undefined> =
+        new Map();
+
     public constructor(private readonly fieldIndexing: CmsEntryOpenSearchFieldIndex.Interface[]) {}
 
-    public get(type: string): CmsEntryOpenSearchFieldIndex.Interface | undefined {
-        const fieldType = getBaseFieldType({
-            type
+    public get(fieldType: string): CmsEntryOpenSearchFieldIndex.Interface | undefined {
+        if (this.cache.has(fieldType)) {
+            return this.cache.get(fieldType);
+        }
+
+        let indexing = this.fieldIndexing.find(field => {
+            return field.fieldType === fieldType;
         });
-        return this.fieldIndexing.find(field => field.fieldType === fieldType);
+        const baseType = getBaseFieldType({
+            type: fieldType
+        });
+        if (!indexing && baseType !== fieldType) {
+            indexing = this.fieldIndexing.find(field => {
+                return field.fieldType === baseType;
+            });
+        }
+        this.cache.set(fieldType, indexing);
+        return indexing;
     }
 
     public getDefault(): CmsEntryOpenSearchFieldIndex.Interface {

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/abstractions/CmsEntryOpenSearchFieldIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/abstractions/CmsEntryOpenSearchFieldIndex.ts
@@ -1,11 +1,9 @@
 import { createAbstraction } from "@webiny/feature/api";
 import type { CmsModel, CmsModelField } from "@webiny/api-headless-cms/types/index.js";
-import type { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/exports/api/cms/graphql.js";
 
 export interface ToIndexParams {
     model: CmsModel;
     field: CmsModelField;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     value: any;
     rawValue: any;
     getFieldIndex(fieldType: string): ICmsEntryOpenSearchFieldIndex;
@@ -19,7 +17,6 @@ export interface ToIndexValue {
 export interface FromIndexParams {
     model: CmsModel;
     field: CmsModelField;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     value: any;
     rawValue: any;
     getFieldIndex(fieldType: string): ICmsEntryOpenSearchFieldIndex;

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/feature.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/feature.ts
@@ -7,17 +7,21 @@ import { NumberFieldIndex } from "./fields/NumberFieldIndex.js";
 import { DefaultFieldIndex } from "./fields/DefaultFieldIndex.js";
 import { DateTimeFieldIndex } from "./fields/DateTimeFieldIndex.js";
 import { ObjectFieldIndex } from "./fields/ObjectFieldIndex.js";
+import { TextCompressedFieldIndex } from "~/features/CmsEntryOpenSearchFieldIndex/fields/TextCompressedFieldIndex.js";
 
 export const CmsEntryOpenSearchFieldIndexFeature = createFeature({
     name: "Cms/Entry/OpenSearch/FieldIndexFeature",
     register: container => {
-        container.register(RichTextFieldIndex);
-        container.register(JsonFieldIndex);
-        container.register(LongTextFieldIndex);
-        container.register(NumberFieldIndex);
-        container.register(DefaultFieldIndex);
-        container.register(DateTimeFieldIndex);
-        container.register(ObjectFieldIndex);
-        container.register(CmsEntryOpenSearchFieldIndexRegistry);
+        container.register(RichTextFieldIndex).inSingletonScope();
+        container.register(JsonFieldIndex).inSingletonScope();
+        container.register(LongTextFieldIndex).inSingletonScope();
+        container.register(NumberFieldIndex).inSingletonScope();
+        container.register(DefaultFieldIndex).inSingletonScope();
+        container.register(DateTimeFieldIndex).inSingletonScope();
+        container.register(ObjectFieldIndex).inSingletonScope();
+        container.register(TextCompressedFieldIndex).inSingletonScope();
+
+        // must be registered last
+        container.register(CmsEntryOpenSearchFieldIndexRegistry).inSingletonScope();
     }
 });

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/DefaultFieldIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/DefaultFieldIndex.ts
@@ -1,15 +1,16 @@
 import { CmsEntryOpenSearchFieldIndex } from "../abstractions/CmsEntryOpenSearchFieldIndex.js";
 import { FIELD_INDEXING_DEFAULT } from "../constants.js";
+import { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/exports/api/cms/graphql.js";
 
 class DefaultFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
     public readonly fieldType = FIELD_INDEXING_DEFAULT;
+    public constructor(private readonly fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface) {}
 
     public toIndex({
         field,
-        fieldRegistry,
         value
     }: CmsEntryOpenSearchFieldIndex.ToIndex): CmsEntryOpenSearchFieldIndex.ToValue {
-        const fieldType = fieldRegistry.get(field.type);
+        const fieldType = this.fieldRegistry.get(field.type);
 
         if (fieldType?.isSearchable === true) {
             return { value };
@@ -18,13 +19,8 @@ class DefaultFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
         return { rawValue: value };
     }
 
-    public fromIndex({
-        field,
-        fieldRegistry,
-        value,
-        rawValue
-    }: CmsEntryOpenSearchFieldIndex.FromIndex): any {
-        const fieldType = fieldRegistry.get(field.type);
+    public fromIndex({ field, value, rawValue }: CmsEntryOpenSearchFieldIndex.FromIndex): any {
+        const fieldType = this.fieldRegistry.get(field.type);
         const isSearchable = fieldType?.isSearchable ?? false;
 
         if (isSearchable) {
@@ -36,5 +32,5 @@ class DefaultFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
 
 export const DefaultFieldIndex = CmsEntryOpenSearchFieldIndex.createImplementation({
     implementation: DefaultFieldIndexImpl,
-    dependencies: []
+    dependencies: [CmsModelFieldToGraphQLRegistry]
 });

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/ObjectFieldIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/ObjectFieldIndex.ts
@@ -1,5 +1,4 @@
 import type { CmsModel, CmsModelField } from "@webiny/api-headless-cms/types/index.js";
-import type { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/exports/api/cms/graphql.js";
 import { getFieldIdentifiers } from "~/helpers/index.js";
 import { CmsEntryOpenSearchFieldIndex } from "../abstractions/CmsEntryOpenSearchFieldIndex.js";
 
@@ -8,7 +7,6 @@ interface ProcessToIndexParams {
     value: Record<string, any>;
     rawValue: Record<string, any>;
     getFieldIndex: (fieldType: string) => CmsEntryOpenSearchFieldIndex.Interface;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     model: CmsModel;
 }
 
@@ -17,100 +15,18 @@ interface ReducerValue {
     rawValue: Record<string, any>;
 }
 
-const processToIndex = (params: ProcessToIndexParams): ReducerValue => {
-    const {
-        fields,
-        value: sourceValue,
-        rawValue: sourceRawValue,
-        getFieldIndex,
-        fieldRegistry,
-        model
-    } = params;
-
-    return fields.reduce<ReducerValue>(
-        (values, field) => {
-            const plugin = getFieldIndex(field.type);
-
-            const identifiers = getFieldIdentifiers(sourceValue, sourceRawValue, field);
-            if (!identifiers) {
-                return values;
-            }
-
-            const { value, rawValue } = plugin.toIndex({
-                model,
-                field,
-                value: sourceValue[identifiers.valueIdentifier || identifiers.rawValueIdentifier],
-                rawValue:
-                    sourceRawValue[identifiers.rawValueIdentifier || identifiers.valueIdentifier],
-                getFieldIndex,
-                fieldRegistry
-            });
-
-            if (value !== undefined) {
-                values.value[identifiers.valueIdentifier || identifiers.rawValueIdentifier] = value;
-            }
-            if (rawValue !== undefined) {
-                values.rawValue[identifiers.rawValueIdentifier || identifiers.valueIdentifier] =
-                    rawValue;
-            }
-
-            return values;
-        },
-        { value: {}, rawValue: {} }
-    );
-};
-
 interface ProcessFromIndexParams {
     fields: CmsModelField[];
     value: Record<string, any>;
     rawValue?: Record<string, any> | null;
     getFieldIndex: (fieldType: string) => CmsEntryOpenSearchFieldIndex.Interface;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     model: CmsModel;
 }
-
-const processFromIndex = (params: ProcessFromIndexParams): Record<string, any> => {
-    const {
-        fields,
-        value: sourceValue,
-        rawValue: sourceRawValue,
-        getFieldIndex,
-        fieldRegistry,
-        model
-    } = params;
-
-    return fields.reduce<Record<string, any>>((values, field) => {
-        const plugin = getFieldIndex(field.type);
-
-        const identifiers = getFieldIdentifiers(sourceValue, sourceRawValue, field);
-        if (!identifiers) {
-            return values;
-        }
-
-        const value = plugin.fromIndex({
-            fieldRegistry,
-            model,
-            field,
-            value: sourceValue[identifiers.valueIdentifier || identifiers.rawValueIdentifier],
-            rawValue: sourceRawValue
-                ? sourceRawValue[identifiers.rawValueIdentifier || identifiers.valueIdentifier]
-                : null,
-            getFieldIndex
-        });
-
-        if (value !== undefined) {
-            values[identifiers.valueIdentifier || identifiers.rawValueIdentifier] = value;
-        }
-
-        return values;
-    }, {});
-};
 
 class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
     public readonly fieldType = "object";
 
     public toIndex({
-        fieldRegistry,
         model,
         field,
         value: initialValue,
@@ -129,12 +45,11 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
                 rawValue: []
             };
             for (const key in initialValue) {
-                const { value, rawValue } = processToIndex({
+                const { value, rawValue } = this.processToIndex({
                     value: initialValue[key],
                     rawValue: initialRawValue[key],
                     getFieldIndex,
                     model,
-                    fieldRegistry,
                     fields
                 });
 
@@ -148,12 +63,11 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
             };
         }
 
-        return processToIndex({
+        return this.processToIndex({
             value: initialValue,
             rawValue: initialRawValue,
             getFieldIndex,
             model,
-            fieldRegistry,
             fields
         });
     }
@@ -163,8 +77,7 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
         value,
         rawValue,
         model,
-        getFieldIndex,
-        fieldRegistry
+        getFieldIndex
     }: CmsEntryOpenSearchFieldIndex.FromIndex): any {
         if (!value) {
             return null;
@@ -176,26 +89,105 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
             const source = value || rawValue || [];
 
             return source.map((_: any, index: number) =>
-                processFromIndex({
+                this.processFromIndex({
                     value: value ? value[index] || {} : {},
                     rawValue: rawValue ? rawValue[index] || {} : {},
                     getFieldIndex,
                     model,
-                    fieldRegistry,
                     fields
                 })
             );
         }
 
-        return processFromIndex({
+        return this.processFromIndex({
             value,
             rawValue,
             getFieldIndex,
             model,
-            fieldRegistry,
             fields
         });
     }
+
+    private processToIndex(params: ProcessToIndexParams): ReducerValue {
+        const {
+            fields,
+            value: sourceValue,
+            rawValue: sourceRawValue,
+            getFieldIndex,
+            model
+        } = params;
+
+        return fields.reduce<ReducerValue>(
+            (values, field) => {
+                const plugin = getFieldIndex(field.type);
+
+                const identifiers = getFieldIdentifiers(sourceValue, sourceRawValue, field);
+                if (!identifiers) {
+                    return values;
+                }
+
+                const { value, rawValue } = plugin.toIndex({
+                    model,
+                    field,
+                    value: sourceValue[
+                        identifiers.valueIdentifier || identifiers.rawValueIdentifier
+                    ],
+                    rawValue:
+                        sourceRawValue[
+                            identifiers.rawValueIdentifier || identifiers.valueIdentifier
+                        ],
+                    getFieldIndex
+                });
+
+                if (value !== undefined) {
+                    values.value[identifiers.valueIdentifier || identifiers.rawValueIdentifier] =
+                        value;
+                }
+                if (rawValue !== undefined) {
+                    values.rawValue[identifiers.rawValueIdentifier || identifiers.valueIdentifier] =
+                        rawValue;
+                }
+
+                return values;
+            },
+            { value: {}, rawValue: {} }
+        );
+    }
+
+    private processFromIndex = (params: ProcessFromIndexParams): Record<string, any> => {
+        const {
+            fields,
+            value: sourceValue,
+            rawValue: sourceRawValue,
+            getFieldIndex,
+            model
+        } = params;
+
+        return fields.reduce<Record<string, any>>((values, field) => {
+            const plugin = getFieldIndex(field.type);
+
+            const identifiers = getFieldIdentifiers(sourceValue, sourceRawValue, field);
+            if (!identifiers) {
+                return values;
+            }
+
+            const value = plugin.fromIndex({
+                model,
+                field,
+                value: sourceValue[identifiers.valueIdentifier || identifiers.rawValueIdentifier],
+                rawValue: sourceRawValue
+                    ? sourceRawValue[identifiers.rawValueIdentifier || identifiers.valueIdentifier]
+                    : null,
+                getFieldIndex
+            });
+
+            if (value !== undefined) {
+                values[identifiers.valueIdentifier || identifiers.rawValueIdentifier] = value;
+            }
+
+            return values;
+        }, {});
+    };
 }
 
 export const ObjectFieldIndex = CmsEntryOpenSearchFieldIndex.createImplementation({

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/TextCompressedFieldIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/TextCompressedFieldIndex.ts
@@ -1,0 +1,49 @@
+import { CmsEntryOpenSearchFieldIndex } from "../abstractions/CmsEntryOpenSearchFieldIndex.js";
+import type { CmsModelField } from "@webiny/api-headless-cms/types/index.js";
+import { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/exports/api/cms/graphql.js";
+
+class TextCompressedFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
+    public readonly fieldType = "text:compressed";
+
+    public constructor(private readonly fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface) {}
+
+    public toIndex(
+        params: CmsEntryOpenSearchFieldIndex.ToIndex
+    ): CmsEntryOpenSearchFieldIndex.ToValue {
+        const { field, value } = params;
+        const isSearchable = this.isSearchable(field);
+
+        if (isSearchable) {
+            return { value };
+        }
+
+        return {
+            rawValue: value
+        };
+    }
+
+    public fromIndex(params: CmsEntryOpenSearchFieldIndex.FromIndex): any {
+        const { field, value, rawValue } = params;
+        const isSearchable = this.isSearchable(field);
+
+        if (isSearchable) {
+            return value === undefined ? rawValue : value;
+        }
+        return rawValue === undefined ? value : rawValue;
+    }
+
+    private isSearchable(field: CmsModelField): boolean {
+        const fieldType = this.fieldRegistry.get(field.type);
+        if (!fieldType?.isSearchable) {
+            return false;
+        } else if (field.settings?.disableFullTextSearch === true) {
+            return false;
+        }
+        return true;
+    }
+}
+
+export const TextCompressedFieldIndex = CmsEntryOpenSearchFieldIndex.createImplementation({
+    implementation: TextCompressedFieldIndexImpl,
+    dependencies: [CmsModelFieldToGraphQLRegistry]
+});

--- a/packages/api-headless-cms-ddb-es/src/helpers/entryIndexHelpers.ts
+++ b/packages/api-headless-cms-ddb-es/src/helpers/entryIndexHelpers.ts
@@ -20,9 +20,10 @@ interface ExtractEntriesFromIndexParams<
     entries: CmsIndexEntry<T>[];
 }
 
-interface PrepareElasticsearchDataParams<
-    T extends CmsEntryValues = CmsEntryValues
-> extends SetupEntriesIndexHelpersParams {
+interface PrepareElasticsearchDataParams<T extends CmsEntryValues = CmsEntryValues> extends Omit<
+    SetupEntriesIndexHelpersParams,
+    "fieldRegistry"
+> {
     model: CmsModel;
     entry: CmsEntry<T>;
     storageEntry: CmsEntry<T>;
@@ -31,7 +32,7 @@ interface PrepareElasticsearchDataParams<
 export const prepareEntryToIndex = <T extends CmsEntryValues = CmsEntryValues>(
     params: PrepareElasticsearchDataParams<T>
 ): CmsIndexEntry<T> => {
-    const { fieldRegistry, fieldIndexRegistry, storageEntry, entry, model } = params;
+    const { fieldIndexRegistry, storageEntry, entry, model } = params;
 
     function getFieldIndex(type: string): CmsEntryOpenSearchFieldIndex.Interface {
         const fieldIndexing = fieldIndexRegistry.get(type);
@@ -55,7 +56,6 @@ export const prepareEntryToIndex = <T extends CmsEntryValues = CmsEntryValues>(
         const fieldIndex = getFieldIndex(field.type);
 
         const { value, rawValue } = fieldIndex.toIndex({
-            fieldRegistry,
             model,
             field,
             rawValue: entry.values[identifier],
@@ -119,7 +119,6 @@ export const extractEntriesFromIndex = <T extends CmsEntryValues = CmsEntryValue
                 const key = identifiers.valueIdentifier as keyof T;
                 const rawKey = identifiers.rawValueIdentifier as keyof T;
                 indexValues[key] = fieldIndex.fromIndex({
-                    fieldRegistry,
                     model,
                     field,
                     getFieldIndex,

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -173,7 +173,6 @@ export const createEntriesStorageOperations = (
         initialStorageEntry.locked = locked;
 
         const transformer = createTransformer<T>({
-            fieldRegistry,
             fieldIndexRegistry,
             model,
             entry: initialEntry,
@@ -289,7 +288,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler,
             valuesModifiers
@@ -415,7 +413,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler
         });
@@ -741,7 +738,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler
         });
@@ -912,7 +908,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler
         });
@@ -1225,7 +1220,6 @@ export const createEntriesStorageOperations = (
                 model,
                 entry: latestEntry,
                 storageEntry: initialLatestStorageEntry,
-                fieldRegistry,
                 fieldIndexRegistry,
                 compressionHandler
             });
@@ -1476,7 +1470,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler
         });
@@ -1679,7 +1672,6 @@ export const createEntriesStorageOperations = (
                     locked: true,
                     ...updatedMetaFields
                 },
-                fieldRegistry,
                 fieldIndexRegistry,
                 compressionHandler
             });
@@ -1779,7 +1771,6 @@ export const createEntriesStorageOperations = (
             model,
             entry: initialEntry,
             storageEntry: initialStorageEntry,
-            fieldRegistry,
             fieldIndexRegistry,
             compressionHandler
         });

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/transformations/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/transformations/index.ts
@@ -14,13 +14,11 @@ import {
     createPublishedRecordType
 } from "~/operations/entry/recordType.js";
 import WebinyError from "@webiny/error";
-import type { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/features/graphql/index.js";
 import { CompressionHandler } from "@webiny/utils/features/compression/abstractions/CompressionHandler.js";
 import { CmsEntryOpenSearchFieldIndexRegistry } from "~/features/CmsEntryOpenSearchFieldIndex/index.js";
 
 interface BaseTransformerParams<T extends CmsEntryValues = CmsEntryValues> {
     model: StorageOperationsCmsModel<T>;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     fieldIndexRegistry: CmsEntryOpenSearchFieldIndexRegistry.Interface;
     compressionHandler: Pick<CompressionHandler.Interface, "compress">;
     valuesModifiers: CmsEntryOpenSearchValuesModifier.Interface[];
@@ -64,7 +62,6 @@ export const createTransformer = <T extends CmsEntryValues = CmsEntryValues>(
 ): TransformerResult<T> => {
     const {
         model,
-        fieldRegistry,
         fieldIndexRegistry,
         entry: baseEntry,
         storageEntry: baseStorageEntry,
@@ -158,7 +155,6 @@ export const createTransformer = <T extends CmsEntryValues = CmsEntryValues>(
                 model,
                 entry,
                 storageEntry,
-                fieldRegistry,
                 fieldIndexRegistry
             }));
         },

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/transformations/transformEntryToIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/transformations/transformEntryToIndex.ts
@@ -5,26 +5,23 @@ import type {
     StorageOperationsCmsModel
 } from "@webiny/api-headless-cms/types/index.js";
 import { prepareEntryToIndex } from "~/helpers/index.js";
-import type { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/features/graphql/index.js";
 import type { CmsEntryOpenSearchFieldIndexRegistry } from "~/features/CmsEntryOpenSearchFieldIndex/index.js";
 
 interface TransformEntryToIndexParams<T extends CmsEntryValues = CmsEntryValues> {
     model: StorageOperationsCmsModel<T>;
     entry: CmsEntry<T>;
     storageEntry: CmsStorageEntry<T>;
-    fieldRegistry: CmsModelFieldToGraphQLRegistry.Interface;
     fieldIndexRegistry: CmsEntryOpenSearchFieldIndexRegistry.Interface;
 }
 
 export const transformEntryToIndex = <T extends CmsEntryValues = CmsEntryValues>(
     params: TransformEntryToIndexParams<T>
 ) => {
-    const { model, entry, storageEntry, fieldRegistry, fieldIndexRegistry } = params;
+    const { model, entry, storageEntry, fieldIndexRegistry } = params;
     const result = prepareEntryToIndex<T>({
         model,
         entry: structuredClone(entry),
         storageEntry: structuredClone(storageEntry),
-        fieldRegistry,
         fieldIndexRegistry
     });
 

--- a/packages/api-headless-cms/src/features/graphql/feature.ts
+++ b/packages/api-headless-cms/src/features/graphql/feature.ts
@@ -16,18 +16,19 @@ import { RichTextFieldToGraphQL } from "./fields/base/RichTextToGraphQL.js";
 export const GraphQLFeature = createFeature({
     name: "Cms/GraphQLFeature",
     register: container => {
-        container.register(BooleanFieldToGraphQL);
-        container.register(DateTimeFieldToGraphQL);
-        container.register(DynamicZoneFieldToGraphQL);
-        container.register(FileFieldToGraphQL);
-        container.register(JsonFieldToGraphQL);
-        container.register(LongTextFieldToGraphQL);
-        container.register(NumberFieldToGraphQL);
-        container.register(ObjectFieldToGraphQL);
-        container.register(RefFieldToGraphQL);
-        container.register(RichTextFieldToGraphQL);
-        container.register(SearchableJsonFieldToGraphQL);
-        container.register(TextFieldToGraphQL);
-        container.register(CmsModelFieldToGraphQLRegistry);
+        container.register(BooleanFieldToGraphQL).inSingletonScope();
+        container.register(DateTimeFieldToGraphQL).inSingletonScope();
+        container.register(DynamicZoneFieldToGraphQL).inSingletonScope();
+        container.register(FileFieldToGraphQL).inSingletonScope();
+        container.register(JsonFieldToGraphQL).inSingletonScope();
+        container.register(LongTextFieldToGraphQL).inSingletonScope();
+        container.register(NumberFieldToGraphQL).inSingletonScope();
+        container.register(ObjectFieldToGraphQL).inSingletonScope();
+        container.register(RefFieldToGraphQL).inSingletonScope();
+        container.register(RichTextFieldToGraphQL).inSingletonScope();
+        container.register(SearchableJsonFieldToGraphQL).inSingletonScope();
+        container.register(TextFieldToGraphQL).inSingletonScope();
+
+        container.register(CmsModelFieldToGraphQLRegistry).inSingletonScope();
     }
 });

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/BaseFieldBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/BaseFieldBuilder.ts
@@ -26,7 +26,12 @@ export interface BaseFieldBuilderConfig {
  */
 export abstract class BaseFieldBuilder<TType extends string = string> {
     public readonly type: TType;
+    private _fieldSubType?: string;
     protected config: BaseFieldBuilderConfig;
+
+    public get subType(): string | undefined {
+        return this._fieldSubType;
+    }
 
     public constructor(type: TType, label?: string) {
         this.type = type;
@@ -38,28 +43,33 @@ export abstract class BaseFieldBuilder<TType extends string = string> {
         };
     }
 
-    label(text: string): this {
+    public label(text: string): this {
         this.config.label = text;
         return this;
     }
 
-    help(text: string): this {
+    public help(text: string): this {
         this.config.help = text;
         return this;
     }
 
-    description(text: string): this {
+    public description(text: string): this {
         this.config.description = text;
         return this;
     }
 
-    note(text: string): this {
+    public note(text: string): this {
         this.config.note = text;
         return this;
     }
 
-    fieldId(id: string): this {
+    public fieldId(id: string): this {
         this.config._fieldId = id;
+        return this;
+    }
+
+    protected setSubType(subType: string): this {
+        this._fieldSubType = subType;
         return this;
     }
 
@@ -67,5 +77,5 @@ export abstract class BaseFieldBuilder<TType extends string = string> {
      * Build the final field result.
      * @internal
      */
-    abstract build(): FieldBuildResult;
+    public abstract build(): FieldBuildResult;
 }

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/DataFieldBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/DataFieldBuilder.ts
@@ -386,7 +386,7 @@ export class DataFieldBuilder<TType extends string = string> extends BaseFieldBu
                 id: fieldId,
                 fieldId,
                 storageId,
-                type: this.type,
+                type: this.getFieldType(),
                 label: this.config.label,
                 validation: this.config.validation || [],
                 listValidation: this.config.listValidation || [],
@@ -404,5 +404,12 @@ export class DataFieldBuilder<TType extends string = string> extends BaseFieldBu
                 tags: this.config.tags || []
             }
         };
+    }
+
+    private getFieldType(): string {
+        if (!this.subType?.length) {
+            return this.type;
+        }
+        return `${this.type}:${this.subType}`;
     }
 }

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/TextFieldType.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/TextFieldType.ts
@@ -16,7 +16,9 @@ export interface ITextFieldBuilder
         FieldTypeValidator.UpperCase,
         FieldTypeValidator.LowerCaseSpace,
         FieldTypeValidator.UpperCaseSpace,
-        FieldTypeValidator.Unique {}
+        FieldTypeValidator.Unique {
+    compressed(): this;
+}
 
 // Module augmentation for TypeScript autocomplete
 declare module "../abstractions.js" {
@@ -144,6 +146,14 @@ class TextFieldBuilder extends DataFieldBuilder<"text"> implements ITextFieldBui
             message: message || "Value must be unique.",
             settings: {}
         });
+    }
+
+    public compressed(): this {
+        this.setSubType("compressed");
+        this.settings({
+            disableFullTextSearch: true
+        });
+        return this;
     }
 }
 

--- a/packages/api-headless-cms/src/features/storage/StorageTransformRegistry.ts
+++ b/packages/api-headless-cms/src/features/storage/StorageTransformRegistry.ts
@@ -15,16 +15,16 @@ class StorageTransformRegistryImpl implements StorageTransformRegistryAbstractio
             return this.cache.get(fieldType) as StorageTransform.Interface<T, R, F>;
         }
 
-        const baseType = getBaseFieldType({
-            type: fieldType
-        });
         let transform = this.transforms.find(
             (item): item is StorageTransform.Interface<T, R, F> => {
                 return item.fieldType === fieldType;
             }
         );
 
-        if (!transform) {
+        const baseType = getBaseFieldType({
+            type: fieldType
+        });
+        if (!transform && baseType !== fieldType) {
             transform = this.transforms.find(
                 (item): item is StorageTransform.Interface<T, R, F> => {
                     return item.fieldType === baseType;

--- a/packages/api-headless-cms/src/features/storage/StorageTransformRegistry.ts
+++ b/packages/api-headless-cms/src/features/storage/StorageTransformRegistry.ts
@@ -4,17 +4,35 @@ import type { CmsModelField } from "~/types/index.js";
 import { getBaseFieldType } from "~/utils/getBaseFieldType.js";
 
 class StorageTransformRegistryImpl implements StorageTransformRegistryAbstraction.Interface {
+    private readonly cache: Map<string, StorageTransform.Interface | undefined> = new Map();
+
     public constructor(private readonly transforms: StorageTransform.Interface[]) {}
 
     public get<T = any, R = any, F extends CmsModelField = CmsModelField>(
         fieldType: string
     ): StorageTransform.Interface<T, R, F> | undefined {
+        if (this.cache.has(fieldType)) {
+            return this.cache.get(fieldType) as StorageTransform.Interface<T, R, F>;
+        }
+
         const baseType = getBaseFieldType({
             type: fieldType
         });
-        return this.transforms.find((item): item is StorageTransform.Interface<T, R, F> => {
-            return item.fieldType === baseType;
-        });
+        let transform = this.transforms.find(
+            (item): item is StorageTransform.Interface<T, R, F> => {
+                return item.fieldType === fieldType;
+            }
+        );
+
+        if (!transform) {
+            transform = this.transforms.find(
+                (item): item is StorageTransform.Interface<T, R, F> => {
+                    return item.fieldType === baseType;
+                }
+            );
+        }
+        this.cache.set(fieldType, transform);
+        return transform;
     }
 
     public getAll(): StorageTransform.Interface[] {

--- a/packages/api-headless-cms/src/features/storage/feature.ts
+++ b/packages/api-headless-cms/src/features/storage/feature.ts
@@ -7,17 +7,21 @@ import { DynamicZoneStorageTransform } from "./fields/DynamicZoneStorageTransfor
 import { LongTextStorageTransform } from "./fields/LongTextStorageTransform.js";
 import { ObjectStorageTransform } from "./fields/ObjectStorageTransform.js";
 import { RichTextStorageTransform } from "./fields/RichTextStorageTransform.js";
+import { CompressedTextStorageTransform } from "./fields/CompressedTextStorageTransform.js";
 
 export const StorageFeature = createFeature({
     name: "Cms/StorageFeature",
     register: container => {
-        container.register(DateStorageTransform);
-        container.register(DefaultStorageTransform);
-        container.register(DynamicZoneStorageTransform);
-        container.register(JsonStorageTransform);
-        container.register(LongTextStorageTransform);
-        container.register(ObjectStorageTransform);
-        container.register(RichTextStorageTransform);
-        container.register(StorageTransformRegistry);
+        container.register(DateStorageTransform).inSingletonScope();
+        container.register(DefaultStorageTransform).inSingletonScope();
+        container.register(DynamicZoneStorageTransform).inSingletonScope();
+        container.register(JsonStorageTransform).inSingletonScope();
+        container.register(LongTextStorageTransform).inSingletonScope();
+        container.register(ObjectStorageTransform).inSingletonScope();
+        container.register(RichTextStorageTransform).inSingletonScope();
+        container.register(CompressedTextStorageTransform).inSingletonScope();
+
+        // must be last, as it depends on all other transforms being registered first
+        container.register(StorageTransformRegistry).inSingletonScope();
     }
 });

--- a/packages/api-headless-cms/src/features/storage/fields/CompressedTextStorageTransform.ts
+++ b/packages/api-headless-cms/src/features/storage/fields/CompressedTextStorageTransform.ts
@@ -1,0 +1,45 @@
+import { StorageTransform } from "../abstractions/StorageTransform.js";
+import { CompressionHandler } from "@webiny/utils/exports/api.js";
+
+class CompressedTextStorageTransformImpl implements StorageTransform.Interface<string, string> {
+    public readonly fieldType = "text:compressed";
+
+    public constructor(private readonly compressionHandler: CompressionHandler.Interface) {}
+
+    public async fromStorage(
+        params: StorageTransform.FromStorageParams<unknown, string>
+    ): StorageTransform.FromStorageResponse<string> {
+        const { value } = params;
+        if (typeof value !== "string") {
+            return value as string;
+        } else if (!value.includes("compression")) {
+            return value;
+        }
+        try {
+            const parsed = JSON.parse(value);
+            return await this.compressionHandler.decompress<string>(parsed);
+        } catch {
+            return value;
+        }
+    }
+
+    public async toStorage(
+        params: StorageTransform.ToStorageParams<unknown, string>
+    ): StorageTransform.ToStorageResponse<string> {
+        const { value } = params;
+        if (typeof value !== "string") {
+            return value as string;
+        }
+
+        try {
+            return JSON.stringify(await this.compressionHandler.compress(value));
+        } catch {
+            return value;
+        }
+    }
+}
+
+export const CompressedTextStorageTransform = StorageTransform.createImplementation({
+    implementation: CompressedTextStorageTransformImpl,
+    dependencies: [CompressionHandler]
+});

--- a/packages/utils/src/features/compression/feature.ts
+++ b/packages/utils/src/features/compression/feature.ts
@@ -6,8 +6,8 @@ import { JsonpackCompression } from "./JsonpackCompression.js";
 export const CompressionFeature = createFeature({
     name: "Api/CompressionFeature",
     register: container => {
-        container.register(GzipCompression);
-        container.register(JsonpackCompression);
-        container.register(CompressionHandler);
+        container.register(GzipCompression).inSingletonScope();
+        container.register(JsonpackCompression).inSingletonScope();
+        container.register(CompressionHandler).inSingletonScope();
     }
 });


### PR DESCRIPTION
## Changes
Support compression on the text field - will store stringified compressed value `({compresison: string, value: string})`.

Includes scoping stateless features as singletons.

## How Has This Been Tested?
Jest and manually.