### PR TITLE
feat: make IEncryption encrypt/decrypt methods async

### DIFF
--- a/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
+++ b/packages/ai-powerups/src/api/features/AiImageEnrichment/AiImageEnrichmentTask.ts
@@ -98,7 +98,7 @@ class AiImageEnrichmentTaskImpl implements TaskDefinition.Interface<IAiImageEnri
                 output: aiOutputSchema,
                 connection: {
                     sdkName: firstProvider.model.split("/")[0],
-                    apiKey: this.encryption.decrypt(firstProvider.apiKeyEncrypted)
+                    apiKey: await this.encryption.decrypt(firstProvider.apiKeyEncrypted)
                 },
                 messages: [
                     {

--- a/packages/ai-powerups/src/api/features/Providers/ProvidersHandler.ts
+++ b/packages/ai-powerups/src/api/features/Providers/ProvidersHandler.ts
@@ -61,7 +61,7 @@ class ProvidersHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
                     apiKeyMasked = existingMatch?.apiKeyMasked ?? "";
                 } else {
                     // New plaintext key — encrypt and mask
-                    apiKeyEncrypted = this.encryption.encrypt(preset.apiKey);
+                    apiKeyEncrypted = await this.encryption.encrypt(preset.apiKey);
                     apiKeyMasked = this.masker.mask(preset.apiKey, [8, 4]);
                 }
 

--- a/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/WbGeneratePageContent/WbGeneratePageContentUseCase.ts
@@ -47,7 +47,7 @@ class WbGeneratePageContentUseCaseImpl implements WbGeneratePageContentUseCase.I
             );
         }
 
-        const apiKey = this.encryption.decrypt(firstProvider.apiKeyEncrypted);
+        const apiKey = await this.encryption.decrypt(firstProvider.apiKeyEncrypted);
 
         const sdkTools = this.aiSdkTools.getToolSet();
 

--- a/packages/api-core/src/features/encryption/EncryptionService.ts
+++ b/packages/api-core/src/features/encryption/EncryptionService.ts
@@ -34,7 +34,7 @@ export class EncryptionImpl implements EncryptionAbstraction.Interface {
         }
     }
 
-    encrypt(value: string): string {
+    async encrypt(value: string): Promise<string> {
         if (!this.key) {
             return value;
         }
@@ -45,7 +45,7 @@ export class EncryptionImpl implements EncryptionAbstraction.Interface {
         return Buffer.concat([iv, authTag, encrypted]).toString("base64");
     }
 
-    decrypt(value: string): string {
+    async decrypt(value: string): Promise<string> {
         if (!this.key) {
             return value;
         }

--- a/packages/api-core/src/features/encryption/abstractions.ts
+++ b/packages/api-core/src/features/encryption/abstractions.ts
@@ -1,8 +1,8 @@
 import { createAbstraction } from "@webiny/feature/api";
 
 export interface IEncryption {
-    encrypt(value: string): string;
-    decrypt(value: string): string;
+    encrypt(value: string): Promise<string>;
+    decrypt(value: string): Promise<string>;
 }
 
 /** Symmetric encryption and decryption using a configured secret key. */

--- a/packages/api-mailer/src/features/GetSettings/GetSettingsRepository.ts
+++ b/packages/api-mailer/src/features/GetSettings/GetSettingsRepository.ts
@@ -36,7 +36,7 @@ class GetSettingsRepositoryImpl implements GetSettingsRepository.Interface {
 
         // Decrypt password if present.
         const password = settings.password
-            ? this.encryption.decrypt(String(settings.password))
+            ? await this.encryption.decrypt(String(settings.password))
             : "";
 
         const transportSettings: TransportSettings = {

--- a/packages/api-mailer/src/features/SaveSettings/SaveSettingsRepository.ts
+++ b/packages/api-mailer/src/features/SaveSettings/SaveSettingsRepository.ts
@@ -24,11 +24,11 @@ class SaveSettingsRepositoryImpl implements SaveSettingsRepository.Interface {
         // If updating and no password provided, keep the existing password
         let passwordToStore = input.password || "";
         if (!input.password && existingSettings) {
-            passwordToStore = this.encryption.decrypt(transportSettings.password || "");
+            passwordToStore = await this.encryption.decrypt(transportSettings.password || "");
         }
 
         // Encrypt password
-        const encryptedPassword = this.encryption.encrypt(passwordToStore);
+        const encryptedPassword = await this.encryption.encrypt(passwordToStore);
 
         // Prepare data
         const data = {

--- a/packages/webhooks/__tests__/useCases/settingsEncryption.test.ts
+++ b/packages/webhooks/__tests__/useCases/settingsEncryption.test.ts
@@ -47,7 +47,7 @@ describe("Webhook settings signingSecret is encrypted in storage", () => {
         expect(rawSigningSecret).not.toBe(SECRET);
 
         /* Decrypting the raw value must recover the original secret. */
-        const decrypted = encryption.decrypt(rawSigningSecret);
+        const decrypted = await encryption.decrypt(rawSigningSecret);
         expect(decrypted).toBe(SECRET);
     });
 


### PR DESCRIPTION
### What changed

The `IEncryption` interface's `encrypt` and `decrypt` methods now return `Promise<string>` instead of `string`. The concrete implementation (`EncryptionImpl`) was updated to be `async`, and all call sites across the AI Power-Ups, Mailer, and Webhooks packages were updated to `await` the results.

### Changelog

**Make Encryption Interface Methods Async**

The `encrypt` and `decrypt` methods on the encryption abstraction now return promises, making the interface compatible with async encryption backends (e.g. KMS, HSM) in the future. All existing call sites have been updated accordingly.

### Squash Merge Commit

```
feat: make IEncryption encrypt/decrypt methods async (#5233)
refactor: make encryption interface methods return Promise (#5233)
```
