### PR TITLE
feat: support environment-specific .env files

### DIFF
--- a/packages/project/src/services/LoadEnvVarsService/LoadEnvVarsService.ts
+++ b/packages/project/src/services/LoadEnvVarsService/LoadEnvVarsService.ts
@@ -1,24 +1,39 @@
 import { createImplementation } from "@webiny/di";
-import { GetProjectService, LoadEnvVarsService, LoggerService } from "~/abstractions/index.js";
+import {
+    GetProjectService,
+    LoadEnvVarsService,
+    LoggerService,
+    ProjectSdkParamsService
+} from "~/abstractions/index.js";
 import dotenv from "dotenv";
 
 export class DefaultLoadEnvVarsService implements LoadEnvVarsService.Interface {
     constructor(
         private getProjectService: GetProjectService.Interface,
-        private loggerService: LoggerService.Interface
+        private loggerService: LoggerService.Interface,
+        private projectSdkParamsService: ProjectSdkParamsService.Interface
     ) {}
 
     async execute() {
         const project = this.getProjectService.execute();
-
         const logger = this.loggerService;
 
-        const dotEnvFilePath = project.paths.rootFolder.join(".env").toString();
-        const { error } = dotenv.config({ path: dotEnvFilePath, quiet: true });
-        if (error) {
-            logger.warn({ err: error, dotEnvFilePath }, `No environment variables file found.`);
-        } else {
-            logger.trace({ dotEnvFilePath }, `Successfully loaded environment variables.`);
+        const loadEnvFile = (filePath: string, override = false) => {
+            const { error } = dotenv.config({ path: filePath, quiet: true, override });
+            if (error) {
+                logger.trace({ err: error, filePath }, `No environment variables file found.`);
+            } else {
+                logger.trace({ filePath }, `Successfully loaded environment variables.`);
+            }
+        };
+
+        const rootFolder = project.paths.rootFolder;
+
+        loadEnvFile(rootFolder.join(".env").toString());
+
+        const { env } = this.projectSdkParamsService.get();
+        if (env) {
+            loadEnvFile(rootFolder.join(`.env.${env}`).toString(), true);
         }
     }
 }
@@ -26,5 +41,5 @@ export class DefaultLoadEnvVarsService implements LoadEnvVarsService.Interface {
 export const loadEnvVarsService = createImplementation({
     abstraction: LoadEnvVarsService,
     implementation: DefaultLoadEnvVarsService,
-    dependencies: [GetProjectService, LoggerService]
+    dependencies: [GetProjectService, LoggerService, ProjectSdkParamsService]
 });


### PR DESCRIPTION
### What changed

Webiny now loads environment-specific `.env` files in addition to the base `.env`. When deploying with a given environment name (e.g. `production`), the SDK first loads `.env` for shared defaults, then loads `.env.production` (if it exists) with override priority — so environment-specific values always win.

### Changelog

**Support for Environment-Specific `.env` Files**

Previously, Webiny only read the root `.env` file when loading environment variables. You can now create environment-specific files like `.env.production` or `.env.dev` alongside your base `.env` — values in the environment-specific file take precedence over the base file.

### Squash Merge Commit

```
feat: support environment-specific .env files (#5237)
feat: load .env.[env] overrides in DefaultLoadEnvVarsService (#5237)
```
