### PR TITLE
fix(website-builder): resolve DataCloneError when cloning MobX observables

### DIFF
--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/StylesStore.ts
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/StylesStore.ts
@@ -110,7 +110,7 @@ export class StylesStore {
             return;
         }
 
-        const styles = new StylesValueObject(toJS(this.devFriendlyStyles));
+        const styles = new StylesValueObject(structuredClone(toJS(this.devFriendlyStyles)));
 
         cb({ styles, metadata: this.elementMetadata });
 

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/StylesStore.ts
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/StylesStore.ts
@@ -9,7 +9,7 @@ import {
 } from "~/BaseEditor/metadata/index.js";
 import { Commands } from "~/BaseEditor/index.js";
 import type { Editor } from "~/editorSdk/Editor.js";
-import { autorun, makeAutoObservable, runInAction } from "mobx";
+import { autorun, makeAutoObservable, runInAction, toJS } from "mobx";
 import { type InheritanceInfo, InheritanceProcessor } from "@webiny/website-builder-sdk";
 import {
     BindingsProcessor,
@@ -110,7 +110,7 @@ export class StylesStore {
             return;
         }
 
-        const styles = new StylesValueObject(structuredClone(this.devFriendlyStyles));
+        const styles = new StylesValueObject(toJS(this.devFriendlyStyles));
 
         cb({ styles, metadata: this.elementMetadata });
 

--- a/packages/website-builder-sdk/src/StylesBindingsProcessor.ts
+++ b/packages/website-builder-sdk/src/StylesBindingsProcessor.ts
@@ -1,5 +1,6 @@
 import set from "lodash/set.js";
 import unset from "lodash/unset.js";
+import { toJS } from "mobx";
 import type { DocumentElementBindings, DocumentElementStyleBindings } from "~/types.js";
 import { InheritedValueResolver } from "~/InheritedValueResolver.js";
 import { StylesUpdater } from "./StylesUpdater.js";
@@ -93,7 +94,7 @@ export class StylesBindingsProcessor {
 
     private getBaseStyles(): ElementStylesBindings {
         const baseStyles: ElementStylesBindings = {
-            styles: structuredClone(this.rawBindings.styles) ?? {},
+            styles: structuredClone(toJS(this.rawBindings.styles)) ?? {},
             overrides: {}
         };
 
@@ -104,7 +105,7 @@ export class StylesBindingsProcessor {
                     set(
                         baseStyles,
                         `overrides.${bp}.styles`,
-                        structuredClone(this.rawBindings.overrides[bp].styles)
+                        structuredClone(toJS(this.rawBindings.overrides[bp].styles))
                     );
                 }
             }


### PR DESCRIPTION
### What changed

Fixed a crash in the Website Builder style editor that occurred when interacting with style inputs (e.g. padding, margin, unit pickers). The root cause was `structuredClone` being called on MobX observable objects (Proxy instances), which the browser cannot clone. The fix unwraps the observables with MobX's `toJS()` before cloning.

### Changelog

**Fix: style editor inputs crashing with DataCloneError**

When editing styles in the Website Builder sidebar, changing or previewing input values (such as padding or margin) would throw a `DataCloneError` and fail silently. This has been fixed and style inputs now work correctly.

### Squash Merge Commit

```
fix(website-builder): resolve DataCloneError when cloning MobX observables (#5248)
```
