### PR TITLE
feat(admin-ui): add badge prop to sidebar menu links and items

### DIFF
--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItem.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { makeDecoratable, withStaticProps } from "~/utils.js";
 import { SidebarMenuItemIcon, type SidebarMenuItemIconProps } from "./SidebarMenuItemIcon.js";
 import { SidebarMenuItemAction, type SidebarMenuItemActionProps } from "./SidebarMenuItemAction.js";
+import { SidebarMenuItemBadge, type SidebarMenuItemBadgeProps } from "./SidebarMenuItemBadge.js";
 import { SidebarMenuSubItem } from "./SidebarMenuSubItem.js";
 import { useSidebarMenu } from "./SidebarMenuProvider.js";
 import { SidebarMenuRootItem } from "~/Sidebar/components/items/SidebarMenuRootItem.js";
@@ -20,6 +21,7 @@ export interface SidebarMenuItemBaseProps {
     disabled?: boolean;
     pinnable?: boolean;
     pinnedIcon?: React.ReactNode;
+    badge?: React.ReactNode;
 }
 
 type SidebarMenuItemButtonProps = SidebarMenuItemBaseProps & {
@@ -47,7 +49,8 @@ const DecoratableSidebarMenuItem = makeDecoratable("SidebarMenuItem", SidebarMen
 
 const SidebarMenuItem = withStaticProps(DecoratableSidebarMenuItem, {
     Icon: SidebarMenuItemIcon,
-    Action: SidebarMenuItemAction
+    Action: SidebarMenuItemAction,
+    Badge: SidebarMenuItemBadge
 });
 
 export {
@@ -57,5 +60,6 @@ export {
     type SidebarMenuItemLinkProps,
     type SidebarMenuItemGroupProps,
     type SidebarMenuItemIconProps,
-    type SidebarMenuItemActionProps
+    type SidebarMenuItemActionProps,
+    type SidebarMenuItemBadgeProps
 };

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { cn } from "~/utils.js";
 
 interface SidebarMenuItemBadgeProps {
     text: React.ReactNode;

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
@@ -8,7 +8,7 @@ const SidebarMenuItemBadge = ({ text }: SidebarMenuItemBadgeProps) => {
     return (
         <span
             className={
-                "inline-flex items-center rounded-sm bg-primary px-xs text-[10px] font-semibold text-neutral-light leading-none h-[16px] shrink-0"
+                "inline-flex items-center rounded-sm bg-primary/50 px-xs text-[10px] font-semibold text-neutral-light leading-none h-md shrink-0"
             }
         >
             {text}

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuItemBadge.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { cn } from "~/utils.js";
+
+interface SidebarMenuItemBadgeProps {
+    text: React.ReactNode;
+}
+
+const SidebarMenuItemBadge = ({ text }: SidebarMenuItemBadgeProps) => {
+    return (
+        <span
+            className={
+                "inline-flex items-center rounded-sm bg-primary px-xs text-[10px] font-semibold text-neutral-light leading-none h-[16px] shrink-0"
+            }
+        >
+            {text}
+        </span>
+    );
+};
+
+export { SidebarMenuItemBadge, type SidebarMenuItemBadgeProps };

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuLink.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuLink.tsx
@@ -9,6 +9,10 @@ import {
     SidebarMenuItemAction,
     type SidebarMenuItemActionProps
 } from "~/Sidebar/components/items/SidebarMenuItemAction.js";
+import {
+    SidebarMenuItemBadge,
+    type SidebarMenuItemBadgeProps
+} from "~/Sidebar/components/items/SidebarMenuItemBadge.js";
 
 const SidebarMenuLinkBase = (props: SidebarMenuItemLinkProps) => {
     return <SidebarMenuItem {...props} />;
@@ -18,12 +22,14 @@ const DecoratableSidebarMenuLink = makeDecoratable("SidebarMenuLink", SidebarMen
 
 const SidebarMenuLink = withStaticProps(DecoratableSidebarMenuLink, {
     Icon: SidebarMenuItemIcon,
-    Action: SidebarMenuItemAction
+    Action: SidebarMenuItemAction,
+    Badge: SidebarMenuItemBadge
 });
 
 export {
     SidebarMenuLink,
     type SidebarMenuItemLinkProps,
     type SidebarMenuItemIconProps,
-    type SidebarMenuItemActionProps
+    type SidebarMenuItemActionProps,
+    type SidebarMenuItemBadgeProps
 };

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootButton.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuRootButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { cn, cva } from "~/utils.js";
 import type { SidebarMenuItemProps } from "./SidebarMenuRootItem.js";
 import { DivButton } from "./DivButton.js";
+import { SidebarMenuItemBadge } from "./SidebarMenuItemBadge.js";
 import { useAdminUi } from "~/index.js";
 
 const variants = cva(
@@ -44,6 +45,7 @@ const SidebarMenuRootButton = ({
 
     action,
     text,
+    badge,
     to,
     ...linkProps
 }: SidebarMenuButtonBaseProps) => {
@@ -60,6 +62,7 @@ const SidebarMenuRootButton = ({
         <LinkComponent {...sharedProps} to={to} {...linkProps}>
             {icon}
             {text}
+            {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </LinkComponent>
     ) : (
         <DivButton
@@ -69,6 +72,7 @@ const SidebarMenuRootButton = ({
         >
             {icon}
             {text}
+            {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </DivButton>
     );
 

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubButton.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { cva } from "~/utils.js";
 import type { SidebarMenuItemProps } from "./SidebarMenuRootItem.js";
 import { DivButton } from "./DivButton.js";
+import { SidebarMenuItemBadge } from "./SidebarMenuItemBadge.js";
 import { DistributedOmit } from "type-fest";
 import { useAdminUi } from "~/index.js";
 
@@ -47,6 +48,7 @@ const SidebarMenuSubButton = ({
 
     action,
     text,
+    badge,
     className,
     to,
     ...linkProps
@@ -64,6 +66,7 @@ const SidebarMenuSubButton = ({
         <LinkComponent {...sharedProps} to={to} {...linkProps}>
             {icon}
             {text}
+            {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </LinkComponent>
     ) : (
         // We can't use the default button element here because the content of the button
@@ -75,6 +78,7 @@ const SidebarMenuSubButton = ({
         >
             {icon}
             {text}
+            {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </DivButton>
     );
 

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItemIndentation.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItemIndentation.tsx
@@ -27,7 +27,7 @@ const SidebarMenuSubItemIndentation = ({ lvl, variant }: SidebarMenuSubItemInden
                         orientation={"vertical"}
                         margin={"none"}
                         variant={"strong"}
-                        className={separatorVariants({ variant })}
+                        className={separatorVariants({ variant, className: "!h-full" })}
                     />
                 </div>
             ))}

--- a/packages/app-admin/src/config/AdminConfig/Menu/MenuItem.tsx
+++ b/packages/app-admin/src/config/AdminConfig/Menu/MenuItem.tsx
@@ -11,7 +11,8 @@ const DecoratableMenuItem = makeDecoratable("MenuItem", MenuLinkBase);
 
 const MenuItem = Object.assign(DecoratableMenuItem, {
     Action: Sidebar.Item.Action,
-    Icon: Sidebar.Item.Icon
+    Icon: Sidebar.Item.Icon,
+    Badge: Sidebar.Item.Badge
 });
 
 export { MenuItem };

--- a/packages/app-admin/src/config/AdminConfig/Menu/MenuLink.tsx
+++ b/packages/app-admin/src/config/AdminConfig/Menu/MenuLink.tsx
@@ -20,7 +20,8 @@ const DecoratableMenuLink = makeDecoratable("MenuLink", MenuLinkBase);
 
 const MenuLink = Object.assign(DecoratableMenuLink, {
     Action: Sidebar.Link.Action,
-    Icon: Sidebar.Link.Icon
+    Icon: Sidebar.Link.Icon,
+    Badge: Sidebar.Link.Badge
 });
 
 export { MenuLink };

--- a/packages/background-tasks/src/admin/BackgroundTaskRoutes.tsx
+++ b/packages/background-tasks/src/admin/BackgroundTaskRoutes.tsx
@@ -39,6 +39,7 @@ export const BackgroundTaskRoutes = () => {
                     element={
                         <Menu.Link
                             text="Task Definitions"
+                            badge={<Menu.Link.Badge text="BETA" />}
                             to={getLink(Routes.Definitions)}
                             icon={
                                 <Menu.Link.Icon label="Task Definitions" element={<ListIcon />} />
@@ -52,6 +53,7 @@ export const BackgroundTaskRoutes = () => {
                     element={
                         <Menu.Link
                             text="Task Executions"
+                            badge={<Menu.Link.Badge text="BETA" />}
                             to={getLink(Routes.Executions)}
                             icon={<Menu.Link.Icon label="Task Executions" element={<TaskIcon />} />}
                         />


### PR DESCRIPTION
### What changed

Menu items can now show a small BETA badge next to their label. Use `badge={<Menu.Link.Badge text="BETA" />}` on any `Menu.Link` or `Menu.Item` — or just pass a string like `badge="BETA"` for simple cases. The badge renders as a compact 16px accent pill and is available via `Menu.Link.Badge` and `Menu.Item.Badge`.

### Changelog

**Add badge prop to sidebar menu items**

Menu items had no way to visually flag experimental or new features. Added a `badge` prop to `Menu.Link` and `Menu.Item` that renders a small accent badge (e.g. "BETA") next to the item text.

### Screenshots
<img width="1548" height="939" alt="image" src="https://github.com/user-attachments/assets/2557f0dc-d2c3-4f04-a7cc-9f6ce3645f67" />

### Squash Merge Commit

```
feat(admin-ui): add badge prop to sidebar menu links and items (#5250)
```

