### PR TITLE
fix(website-builder): visual improvements on page editor

### DIFF
--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/PreviewContainer.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Content/Preview/PreviewContainer.tsx
@@ -11,38 +11,42 @@ export const PreviewContainer = ({ children }: PreviewContainerProps) => {
     const isDragging = useIsDragging();
 
     return (
-        <div
-            id={"preview-container"}
-            style={{ height: `calc(100vh - ${uiHeight}px)` }}
-            className={
-                "bg-neutral-subtle relative flex flex-col items-center w-full overflow-auto p-[24px]"
-            }
-        >
-            {isDragging && (
-                <>
-                    <div
-                        className={
-                            "absolute z-50 pointer-events-none animate-fade-in top-0 left-0 right-0 h-2 bg-[#f9d8ce]"
-                        }
-                    />
-                    <div
-                        className={
-                            "absolute z-50 pointer-events-none animate-fade-in bottom-0 left-0 right-0 h-2 bg-[#f9d8ce]"
-                        }
-                    />
-                    <div
-                        className={
-                            "absolute z-50 pointer-events-none animate-fade-in top-0 left-0 bottom-0 w-2 bg-[#f9d8ce]"
-                        }
-                    />
-                    <div
-                        className={
-                            "absolute z-50 pointer-events-none animate-fade-in top-0 right-0 bottom-0 w-2 bg-[#f9d8ce]"
-                        }
-                    />
-                </>
-            )}
-            {children}
-        </div>
+        <>
+            <div className={"relative"}>
+                <div
+                    id={"preview-container"}
+                    style={{ height: `calc(100vh - ${uiHeight}px)` }}
+                    className={
+                        "bg-neutral-subtle relative flex flex-col items-center w-full overflow-auto p-[24px]"
+                    }
+                >
+                    {children}
+                </div>
+                {isDragging && (
+                    <>
+                        <div
+                            className={
+                                "absolute z-50 pointer-events-none animate-fade-in top-0 left-0 right-0 h-2 bg-[#f9d8ce]"
+                            }
+                        />
+                        <div
+                            className={
+                                "absolute z-50 pointer-events-none animate-fade-in bottom-0 left-0 right-0 h-2 bg-[#f9d8ce]"
+                            }
+                        />
+                        <div
+                            className={
+                                "absolute z-50 pointer-events-none animate-fade-in top-0 left-0 bottom-0 w-2 bg-[#f9d8ce]"
+                            }
+                        />
+                        <div
+                            className={
+                                "absolute z-50 pointer-events-none animate-fade-in top-0 right-0 bottom-0 w-2 bg-[#f9d8ce]"
+                            }
+                        />
+                    </>
+                )}
+            </div>
+        </>
     );
 };

--- a/packages/app-website-builder/src/inputRenderers/FileInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/FileInput.tsx
@@ -38,6 +38,7 @@ export const FileInputRenderer = ({
             onChange={onFileChange}
             render={({ showFileManager }) => (
                 <FilePicker
+                    variant={"secondary"}
                     label={label}
                     description={input.description}
                     type="compact"

--- a/packages/app-website-builder/src/inputRenderers/FragmentSelectorInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/FragmentSelectorInput.tsx
@@ -28,6 +28,8 @@ export const FragmentSelectorInputRenderer = ({
 
     return (
         <Select
+            size={"md"}
+            variant={"secondary"}
             value={value}
             onChange={newValue => {
                 onChange(({ value }) => {

--- a/packages/app-website-builder/src/inputRenderers/NumberInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/NumberInput.tsx
@@ -27,6 +27,8 @@ export const NumberInputRenderer = ({
     return (
         <Input
             type={"number"}
+            size={"md"}
+            variant={"secondary"}
             value={value}
             onChange={localOnChange}
             label={label}

--- a/packages/app-website-builder/src/inputRenderers/SelectInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/SelectInput.tsx
@@ -12,6 +12,8 @@ export const SelectInputRenderer = ({
     const input = props.input as SelectInput;
     return (
         <Select
+            size={"md"}
+            variant={"secondary"}
             value={value}
             onChange={newValue => {
                 onChange(({ value }) => {

--- a/packages/app-website-builder/src/inputRenderers/TextareaInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/TextareaInput.tsx
@@ -23,6 +23,8 @@ export const TextareaInputRenderer = ({
 
     return (
         <Textarea
+            size={"md"}
+            variant={"secondary"}
             value={value || ""}
             onChange={previewValue}
             onBlur={e => commitValue(e.currentTarget.value)}


### PR DESCRIPTION
All inputs rendered with:

```ts
  size={"md"}
  variant={"secondary"}
```

The result:
<img width="1610" height="945" alt="image" src="https://github.com/user-attachments/assets/3f504f95-37e4-40e6-adb7-c10362f77fa3" />

Also, this orange border was cut off previously when scrolling. Now it's always stable / does not change its position.

<img width="1610" height="1300" alt="image" src="https://github.com/user-attachments/assets/9164fd59-1c53-4817-a35e-66c3ed8296bf" />
