### PR TITLE
fix: stamp CLI telemetry with the canonical global-config machine id

### DIFF
--- a/packages/telemetry/cli.js
+++ b/packages/telemetry/cli.js
@@ -11,9 +11,14 @@ export const sendEvent = async ({ event, version, properties }) => {
         return;
     }
 
-    // The WTS client reads the machine id from `~/.webiny/config` (user.id field)
-    // via the same path globalConfig writes to. No need to pass user explicitly.
-    const wts = new WTS({ source: "cli" });
+    // Use the canonical Webiny machine id — the top-level `id` field in
+    // `~/.webiny/config`, owned by @webiny/global-config. The admin app
+    // (REACT_APP_WEBINY_TELEMETRY_USER_ID) and the website install/finish alias
+    // both key off this same id, so passing it here keeps CLI, admin, and
+    // website events on a single PostHog person. Without it, the WTS client
+    // falls back to its own `user.id` field, which is a different UUID and
+    // fragments funnels across surfaces.
+    const wts = new WTS({ source: "cli", distinctId: globalConfig.get("id") });
 
     const wcpProperties = {};
     const [wcpOrgId, wcpProjectId] = getWcpOrgProjectId();


### PR DESCRIPTION
CLI events used the WTS client's own `user.id` field while admin events and the website install/finish alias use @webiny/global-config's top-level `id`. Those are different UUIDs, so CLI events landed on a separate PostHog person and never linked in funnels (docs pageview -> cli-create-webiny-project-start showed 0%).

Pass distinctId: globalConfig.get("id") so CLI, admin, and website events share one identity. Requires @webiny/wts-client with Node distinctId support.

## Changes
<!--- Please describe the changes you're making. Why are they here? How they are solved? -->
<!--- If your changes include something of a visual nature, it's useful to include screenshots or even short GIFs. -->
<!--- If solving an existing issue, make sure to link it. -->
Closes #ISSUE_NUMBER

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Documentation
<!-- 
If needed, make sure that the introduced changes are properly documented on our documentation website (https://www.webiny.com/docs)*. Ask yourself the following questions:
- Do I need to create an additional documentation page, explaining the changes I made and how to use them?
- Do I need to update existing documentation pages?
- Are these changes important for Webiny users? If so, they should be mentioned on the Changelog page**.

* Webiny documentation repository: https://github.com/webiny/docs.webiny.com
** For example https://www.webiny.com/docs/changelog/5.3.0.
-->
