### PR TITLE
fix(webhooks): expose stack and data fields in webhooks response

### DIFF
--- a/packages/webhooks/__tests__/graphql/webhookPersistenceError.test.ts
+++ b/packages/webhooks/__tests__/graphql/webhookPersistenceError.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { useGraphQLHandler } from "~tests/helpers/useGraphQLHandler.js";
+import { CREATE_WEBHOOK } from "./webhookQueries.js";
+import { createRegisterExtensionPlugin } from "@webiny/handler/plugins/RegisterExtensionPlugin.js";
+import { CreateWebhookRepository } from "~/api/features/CreateWebhook/abstractions.js";
+import { Result } from "@webiny/feature/api";
+import { WebhookPersistenceError } from "~/api/domain/errors.js";
+
+const VALID_INPUT = {
+    name: "Shop Sync",
+    endpointUrl: "https://example.com/hook",
+    events: ["cms.entry.product.published"],
+    signingSecret: "whsec_dGVzdHNlY3JldA=="
+};
+
+describe("Webhook persistence error in GraphQL", () => {
+    it("should return data and stack fields on WEBHOOK_PERSISTENCE_ERROR", async () => {
+        const originalDebug = process.env.DEBUG;
+        process.env.DEBUG = "true";
+
+        try {
+            const cause = new Error("Connection refused");
+            (cause as any).code = "ECONNREFUSED";
+            (cause as any).data = { host: "localhost", port: 5432 };
+
+            const handler = useGraphQLHandler({
+                plugins: [
+                    createRegisterExtensionPlugin(context => {
+                        context.container.registerInstance(CreateWebhookRepository, {
+                            execute: async () => {
+                                return Result.fail(WebhookPersistenceError.from(cause));
+                            }
+                        });
+                    })
+                ]
+            });
+
+            const [response] = await handler.invoke({
+                body: {
+                    query: CREATE_WEBHOOK,
+                    variables: { input: VALID_INPUT }
+                }
+            });
+
+            const result = response.data.webhooks.createWebhook;
+            expect(result.data).toBeNull();
+            expect(result.error.code).toBe("WEBHOOK_PERSISTENCE_ERROR");
+            expect(result.error.message).toBe("Connection refused");
+            expect(result.error.data).toMatchObject({
+                originalMessage: "Connection refused",
+                originalCode: "ECONNREFUSED",
+                originalData: { host: "localhost", port: 5432 }
+            });
+            expect(result.error.stack).toEqual(
+                expect.stringContaining("Error: Connection refused")
+            );
+        } finally {
+            process.env.DEBUG = originalDebug;
+        }
+    });
+});

--- a/packages/webhooks/__tests__/graphql/webhookQueries.ts
+++ b/packages/webhooks/__tests__/graphql/webhookQueries.ts
@@ -3,6 +3,7 @@ const ERROR = /* GraphQL */ `
         message
         code
         data
+        stack
     }
 `;
 
@@ -54,6 +55,7 @@ export const DELETE_WEBHOOK = /* GraphQL */ `
                     message
                     code
                     data
+                    stack
                 }
             }
         }

--- a/packages/webhooks/src/api/graphql/WebhookCrudSchema.ts
+++ b/packages/webhooks/src/api/graphql/WebhookCrudSchema.ts
@@ -32,6 +32,7 @@ class WebhookCrudSchema_ implements GraphQLSchemaFactory.Interface {
                 code: String
                 message: String
                 data: JSON
+                stack: String
             }
 
             type WebhookListMeta {


### PR DESCRIPTION
The WebhookError GraphQL type was missing the stack field, so persistence errors only returned code and message with no debugging context. Added stack to the schema and a test that verifies all error fields propagate.