### PR TITLE
feat(api-core-sql): add table name prefix support for test isolation

### DIFF
--- a/packages/api-core-sql/__tests__/__api__/setupFile.js
+++ b/packages/api-core-sql/__tests__/__api__/setupFile.js
@@ -1,5 +1,6 @@
 import { setStorageOps } from "@webiny/project-utils/testing/environment/index.js";
 import { createApiCoreSql } from "~/createApiCoreSql.js";
+import { getSqlTablePrefix } from "~/getSqlTablePrefix.js";
 import knexLib from "knex";
 
 const knex = knexLib({
@@ -12,9 +13,11 @@ const knex = knexLib({
 
 global.__testKnex = knex;
 
+const tableNamePrefix = getSqlTablePrefix();
+
 setStorageOps("apiCore", () => {
     return {
-        storageOperations: createApiCoreSql({ knex }),
+        storageOperations: createApiCoreSql({ knex, tableNamePrefix }),
         plugins: []
     };
 });

--- a/packages/api-core-sql/src/TableManager.ts
+++ b/packages/api-core-sql/src/TableManager.ts
@@ -2,15 +2,18 @@ import type { Knex } from "knex";
 
 interface ITableManager {
     reset(): void;
+    resolve(tableName: string): string;
     ensure(tableName: string, creator: (table: Knex.CreateTableBuilder) => void): Promise<void>;
 }
 
 export class TableManager implements ITableManager {
     private readonly knex: Knex;
+    private readonly prefix: string;
     private readonly verified = new Set<string>();
 
-    constructor(knex: Knex) {
+    constructor(knex: Knex, prefix: string = "") {
         this.knex = knex;
+        this.prefix = prefix ? `${prefix}_` : "";
 
         const g = globalThis as Record<string, unknown>;
         const managers = (g.__sqlTableManagers ??= []) as ITableManager[];
@@ -21,20 +24,26 @@ export class TableManager implements ITableManager {
         this.verified.clear();
     }
 
+    public resolve(tableName: string): string {
+        return `${this.prefix}${tableName}`;
+    }
+
     public async ensure(
         tableName: string,
         creator: (table: Knex.CreateTableBuilder) => void
     ): Promise<void> {
-        if (this.verified.has(tableName)) {
+        const resolved = this.resolve(tableName);
+
+        if (this.verified.has(resolved)) {
             return;
         }
 
-        const exists = await this.knex.schema.hasTable(tableName);
+        const exists = await this.knex.schema.hasTable(resolved);
 
         if (!exists) {
-            await this.knex.schema.createTable(tableName, creator);
+            await this.knex.schema.createTable(resolved, creator);
         }
 
-        this.verified.add(tableName);
+        this.verified.add(resolved);
     }
 }

--- a/packages/api-core-sql/src/adminUsers/index.ts
+++ b/packages/api-core-sql/src/adminUsers/index.ts
@@ -54,7 +54,7 @@ export const createStorageOperations = (
     };
 
     const query = () => {
-        return knex<IAdminUserRow>(TABLE_NAME);
+        return knex<IAdminUserRow>(tableManager.resolve(TABLE_NAME));
     };
 
     return {

--- a/packages/api-core-sql/src/createApiCoreSql.ts
+++ b/packages/api-core-sql/src/createApiCoreSql.ts
@@ -8,10 +8,14 @@ import { TableManager } from "./TableManager.js";
 
 interface CreateApiCoreSqlParams {
     knex: Knex;
+    tableNamePrefix?: string;
 }
 
-export const createApiCoreSql = ({ knex }: CreateApiCoreSqlParams): ApiCoreStorageOperations => {
-    const tableManager = new TableManager(knex);
+export const createApiCoreSql = ({
+    knex,
+    tableNamePrefix
+}: CreateApiCoreSqlParams): ApiCoreStorageOperations => {
+    const tableManager = new TableManager(knex, tableNamePrefix);
 
     return {
         usersStorageOperations: createUsersStorageOperations({

--- a/packages/api-core-sql/src/getSqlTablePrefix.ts
+++ b/packages/api-core-sql/src/getSqlTablePrefix.ts
@@ -1,0 +1,3 @@
+export const getSqlTablePrefix = (): string => {
+    return process.env.SQL_TABLE_PREFIX || process.env.WEBINY_SQL_TABLE_PREFIX || "";
+};

--- a/packages/api-core-sql/src/index.ts
+++ b/packages/api-core-sql/src/index.ts
@@ -1,1 +1,2 @@
 export { createApiCoreSql } from "./createApiCoreSql.js";
+export { getSqlTablePrefix } from "./getSqlTablePrefix.js";

--- a/packages/api-core-sql/src/keyValueStore/index.ts
+++ b/packages/api-core-sql/src/keyValueStore/index.ts
@@ -37,7 +37,7 @@ export const createStorageOperations = (
     };
 
     const query = () => {
-        return knex<IKeyValueRow>(TABLE_NAME);
+        return knex<IKeyValueRow>(tableManager.resolve(TABLE_NAME));
     };
 
     const createScopedKey = (key: string, scope: string): string => {

--- a/packages/api-core-sql/src/security/index.ts
+++ b/packages/api-core-sql/src/security/index.ts
@@ -83,9 +83,9 @@ export const createStorageOperations = (
         });
     };
 
-    const rolesQuery = () => knex<IRoleRow>(ROLES_TABLE);
-    const teamsQuery = () => knex<ITeamRow>(TEAMS_TABLE);
-    const apiKeysQuery = () => knex<IApiKeyRow>(API_KEYS_TABLE);
+    const rolesQuery = () => knex<IRoleRow>(tableManager.resolve(ROLES_TABLE));
+    const teamsQuery = () => knex<ITeamRow>(tableManager.resolve(TEAMS_TABLE));
+    const apiKeysQuery = () => knex<IApiKeyRow>(tableManager.resolve(API_KEYS_TABLE));
 
     return {
         /* Roles */

--- a/packages/api-core-sql/src/tenancy/index.ts
+++ b/packages/api-core-sql/src/tenancy/index.ts
@@ -61,7 +61,7 @@ export const createStorageOperations = (
     };
 
     const query = () => {
-        return knex<ITenantRow>(TABLE_NAME);
+        return knex<ITenantRow>(tableManager.resolve(TABLE_NAME));
     };
 
     return {

--- a/packages/api-headless-cms-sql/__tests__/__api__/setupFile.js
+++ b/packages/api-headless-cms-sql/__tests__/__api__/setupFile.js
@@ -14,9 +14,11 @@ const knex = knexLib({
 
 global.__testKnex = knex;
 
+const tableNamePrefix = process.env.SQL_TABLE_PREFIX || process.env.WEBINY_SQL_TABLE_PREFIX || "";
+
 setStorageOps("cms", () => {
     const plugins = [
-        ...registerSqlStorageOperations({ knex }),
+        ...registerSqlStorageOperations({ knex, tableNamePrefix }),
         createCmsEntryFieldSortingPlugin({
             canUse: params => {
                 const { fieldId } = params;


### PR DESCRIPTION
Add prefix support to TableManager (matching the OpenSearch index prefix pattern) so SQL table names can be namespaced per test suite in CI.