### PR TITLE
fix(validation): throw ValidationError not RangeError on invalid date comparison

### DIFF
--- a/packages/validation/__tests__/dateGte.test.js
+++ b/packages/validation/__tests__/dateGte.test.js
@@ -43,4 +43,10 @@ describe("date gte test", () => {
             );
         }
     );
+
+    test("should throw a ValidationError (not RangeError) when the comparison date is invalid", async () => {
+        await expect(validation.validate("2020-06-06", "dateGte:garbage")).rejects.toThrow(
+            `Value "garbage" is not a valid date to compare against.`
+        );
+    });
 });

--- a/packages/validation/__tests__/dateLte.test.js
+++ b/packages/validation/__tests__/dateLte.test.js
@@ -44,4 +44,10 @@ describe("date lte test", () => {
             );
         }
     );
+
+    test("should throw a ValidationError (not RangeError) when the comparison date is invalid", async () => {
+        await expect(validation.validate("2030-06-06", "dateLte:garbage")).rejects.toThrow(
+            `Value "garbage" is not a valid date to compare against.`
+        );
+    });
 });

--- a/packages/validation/src/validators/dateGte.ts
+++ b/packages/validation/src/validators/dateGte.ts
@@ -16,6 +16,10 @@ export default (value: string, params?: string[]) => {
     const date = new Date(value);
     const gteDate = new Date(gteValue);
 
+    if (isNaN(gteDate.getTime())) {
+        throw new ValidationError(`Value "${gteValue}" is not a valid date to compare against.`);
+    }
+
     if (date >= gteDate) {
         return;
     }

--- a/packages/validation/src/validators/dateLte.ts
+++ b/packages/validation/src/validators/dateLte.ts
@@ -16,6 +16,10 @@ export default (value: string, params?: string[]) => {
     const date = new Date(value);
     const lteDate = new Date(lteValue);
 
+    if (isNaN(lteDate.getTime())) {
+        throw new ValidationError(`Value "${lteValue}" is not a valid date to compare against.`);
+    }
+
     if (date <= lteDate) {
         return;
     }


### PR DESCRIPTION
## What's broken

The `dateGte` / `dateLte` validators throw an uncaught `RangeError: Invalid time value` instead of a `ValidationError` when the configured comparison date is unparseable. A validator should only ever throw `ValidationError`, so this leaks a raw `RangeError` up the stack. Hit it by configuring a field with a malformed rule like `dateGte:garbage` (e.g. a typo in the Headless CMS model editor) — every submission to that field then 500s.

## Why it happens

When the comparison value can't be parsed, `new Date(value)` is an Invalid Date. The comparison is `false`, so control enters the error branch, which builds the message with `gteDate.toISOString()` — and `toISOString()` on an Invalid Date throws `RangeError`. The validator crashes while trying to report a validation failure.

## Fix

Guard with `isNaN(date.getTime())` and throw a clear `ValidationError` when the comparison date is invalid.

## Test

Added a case to each validator asserting a `ValidationError` (not `RangeError`) on a malformed comparison date; valid in-range/out-of-range behavior is unchanged.
