### PR TITLE
fix(app-workflows): fix teams selector in workflow step form

### DIFF
--- a/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
+++ b/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
@@ -25,7 +25,6 @@ export const TeamsMultiAutocomplete = ({
 
     const onValuesChange = useCallback((ids: string[]) => onChange?.(ids), [onChange]);
 
-    console.log('props, props', props)
     return (
         <MultiAutoComplete
             {...props}

--- a/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
+++ b/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
@@ -25,6 +25,7 @@ export const TeamsMultiAutocomplete = ({
 
     const onValuesChange = useCallback((ids: string[]) => onChange?.(ids), [onChange]);
 
+    console.log('props, props', props)
     return (
         <MultiAutoComplete
             {...props}

--- a/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
+++ b/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
@@ -16,9 +16,7 @@ const Autocomplete = ({ bind }: IAutocompleteProps) => {
         if (!Array.isArray(bind.value) || !bind.value.length) {
             return [];
         }
-        return bind.value
-            .map((item: IInput) => item.id)
-            .filter(Boolean) as string[];
+        return bind.value.map((item: IInput) => item.id).filter(Boolean) as string[];
     }, [bind.value]);
 
     const onChange = useCallback(

--- a/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
+++ b/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
@@ -1,43 +1,37 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import type { BindComponentRenderProp } from "@webiny/form";
 import { Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { TeamsMultiAutocomplete } from "@webiny/app-admin";
 
 interface IInput {
-    id?: string;
+    id: string;
 }
-
-const mapInput = (input?: IInput[]): Required<IInput>[] => {
-    if (!input?.length) {
-        return [];
-    }
-    return input
-        .filter((item): item is Required<IInput> => {
-            return !!item.id;
-        })
-        .map(item => {
-            return {
-                id: item.id
-            };
-        });
-};
 
 interface IAutocompleteProps {
     bind: BindComponentRenderProp;
 }
 const Autocomplete = ({ bind }: IAutocompleteProps) => {
+    const values = useMemo(() => {
+        if (!Array.isArray(bind.value) || !bind.value.length) {
+            return [];
+        }
+        return bind.value
+            .map((item: IInput) => item.id)
+            .filter(Boolean) as string[];
+    }, [bind.value]);
+
     const onChange = useCallback(
-        (input?: IInput[]) => {
-            return bind.onChange(mapInput(input));
+        (ids: string[]) => {
+            return bind.onChange(ids.map(id => ({ id })));
         },
         [bind.onChange]
     );
 
     return (
         <TeamsMultiAutocomplete
-            {...bind}
             label={"Select which teams need to review and approve this workflow"}
+            values={values}
             onChange={onChange}
         />
     );

--- a/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
+++ b/packages/app-workflows/src/Components/WorkflowsEditor/Editor/Step/Form/StepFormTeams.tsx
@@ -31,6 +31,7 @@ const Autocomplete = ({ bind }: IAutocompleteProps) => {
             label={"Select which teams need to review and approve this workflow"}
             values={values}
             onChange={onChange}
+            validation={bind.validation}
         />
     );
 };


### PR DESCRIPTION
### What changed

The teams selector in the Workflow Step form was broken after migrating from `@webiny/ui` to `@webiny/admin-ui`. The new `MultiAutoComplete` component expects options as `{ label, value }` objects and selected state as `string[]` IDs, but the form binding was passing raw team objects and wiring up callbacks incorrectly — causing validation to always fail even when teams were selected, and selected teams not being pre-populated on edit.

### Changelog

**Workflows: fix teams selector not working in workflow step form**

After a recent UI library migration, the teams selector in the workflow step form stopped working — selecting a team would still show a validation error, and previously saved teams were not shown as selected when editing. Both issues are now fixed.

### Squash Merge Commit

```
fix(app-workflows): fix teams selector in workflow step form (#5285)
```
