### PR TITLE
fix(app-admin): prevent duplicate team selections

### DIFF
--- a/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
+++ b/packages/app-admin/src/components/TeamsMultiAutocomplete/index.tsx
@@ -27,6 +27,7 @@ export const TeamsMultiAutocomplete = ({
 
     return (
         <MultiAutoComplete
+            uniqueValues
             {...props}
             options={options}
             values={loading ? undefined : (values as string[] | undefined)}


### PR DESCRIPTION
### What changed

`TeamsMultiAutocomplete` now enforces unique selections — users can no longer pick the same team more than once in a workflow step.

### Changelog

**Teams multi-autocomplete: prevent duplicate team selections**

Users could previously select the same team more than once when configuring a workflow step. This is now prevented.

### Squash Merge Commit

```
fix(app-admin): prevent duplicate team selections (#5286)
```
