### PR TITLE
fix: scheduling on non-root tenant

### DIFF
--- a/packages/api-core/src/features/tenancy/TenantContext/TenantContext.ts
+++ b/packages/api-core/src/features/tenancy/TenantContext/TenantContext.ts
@@ -27,7 +27,7 @@ class TenantContextImpl implements Abstraction.Interface {
             return rootTenant.error as T;
         }
 
-        const tenant = rootTenant.value as Tenant;
+        const tenant = rootTenant.value;
 
         this.setTenant(tenant);
         try {

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/dataLoaders.ts
@@ -153,6 +153,6 @@ export class DataLoadersHandler implements IDataLoadersHandler {
     }
 
     public clearAll(params?: DataLoadersHandlerInterfaceClearAllParams): void {
-        this.cache.clearAll(params?.model);
+        this.cache.clearAll(params);
     }
 }

--- a/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb-es/src/operations/entry/index.ts
@@ -225,7 +225,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -346,7 +346,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -564,7 +564,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -646,7 +646,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: initialModel.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -805,7 +805,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -975,7 +975,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -1112,7 +1112,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -1238,7 +1238,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -1724,7 +1724,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -1845,7 +1845,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(

--- a/packages/api-headless-cms-ddb-es/src/types.ts
+++ b/packages/api-headless-cms-ddb-es/src/types.ts
@@ -3,7 +3,6 @@ import type {
     CmsEntry,
     CmsEntryStorageOperations as BaseCmsEntryStorageOperations,
     CmsEntryValues,
-    CmsModel,
     HeadlessCmsStorageOperations as BaseHeadlessCmsStorageOperations
 } from "@webiny/api-headless-cms/types/index.js";
 import type { DynamoDBDocument } from "@webiny/aws-sdk/client-dynamodb/index.js";
@@ -72,7 +71,7 @@ export interface CmsEntryStorageOperations extends BaseCmsEntryStorageOperations
 }
 
 export interface DataLoadersHandlerInterfaceClearAllParams {
-    model: Pick<CmsModel, "tenant">;
+    tenant: string;
 }
 export interface IDataLoadersHandler {
     clearAll: (params?: DataLoadersHandlerInterfaceClearAllParams) => void;

--- a/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/dataLoaders.ts
@@ -152,6 +152,6 @@ export class DataLoadersHandler implements IDataLoadersHandler {
     }
 
     public clearAll(params?: DataLoadersHandlerInterfaceClearAllParams): void {
-        this.cache.clearAll(params?.model);
+        this.cache.clearAll(params);
     }
 }

--- a/packages/api-headless-cms-ddb/src/operations/entry/index.ts
+++ b/packages/api-headless-cms-ddb/src/operations/entry/index.ts
@@ -199,7 +199,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -283,7 +283,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -392,7 +392,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
             return initialStorageEntry;
         } catch (ex) {
@@ -531,7 +531,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -587,7 +587,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(
@@ -672,7 +672,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
 
             return initialStorageEntry;
@@ -748,7 +748,7 @@ export const createEntriesStorageOperations = (
             await entityBatch.execute();
 
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
         } catch (ex) {
             throw new WebinyError(ex.message, ex.code, {
@@ -1272,7 +1272,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
             return initialStorageEntry;
         } catch (ex) {
@@ -1377,7 +1377,7 @@ export const createEntriesStorageOperations = (
         try {
             await entityBatch.execute();
             dataLoaders.clearAll({
-                model
+                tenant: entry.tenant
             });
             return initialStorageEntry;
         } catch (ex) {

--- a/packages/api-headless-cms-ddb/src/types.ts
+++ b/packages/api-headless-cms-ddb/src/types.ts
@@ -2,7 +2,6 @@ import { type Plugin, PluginsContainer } from "@webiny/plugins/types.js";
 import type {
     CmsContext,
     CmsEntryStorageOperations as BaseCmsEntryStorageOperations,
-    CmsModel,
     CmsModelField,
     HeadlessCmsStorageOperations as BaseHeadlessCmsStorageOperations
 } from "@webiny/api-headless-cms/types/index.js";
@@ -71,7 +70,7 @@ export interface CmsEntryStorageOperations extends BaseCmsEntryStorageOperations
 }
 
 export interface DataLoadersHandlerInterfaceClearAllParams {
-    model: Pick<CmsModel, "tenant">;
+    tenant: string;
 }
 export interface IDataLoadersHandler {
     clearAll: (params?: DataLoadersHandlerInterfaceClearAllParams) => void;

--- a/packages/api-headless-cms-scheduler/__tests__/actionHandlers.test.ts
+++ b/packages/api-headless-cms-scheduler/__tests__/actionHandlers.test.ts
@@ -54,6 +54,7 @@ describe("Action Handlers", () => {
         const publishActionResult = await schedulePublish.execute({
             id: entryResult.value.id,
             model: modelResult.value,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 100000)
         });
 
@@ -71,6 +72,7 @@ describe("Action Handlers", () => {
         const scheduledAction = publishActionResult.value;
         await executeScheduledAction.execute({
             id: scheduledAction.scheduledAction.id,
+            tenant: "root",
             namespace: scheduledAction.scheduledAction.namespace
         });
 
@@ -86,12 +88,14 @@ describe("Action Handlers", () => {
         const unpublishActionResult = await scheduleUnpublish.execute({
             id: entryResult.value.id,
             model: modelResult.value,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 1000000)
         });
 
         // Execute action handler
         await executeScheduledAction.execute({
             id: unpublishActionResult.value.scheduledAction.id,
+            tenant: "root",
             namespace: unpublishActionResult.value.scheduledAction.namespace
         });
 

--- a/packages/api-headless-cms-scheduler/src/features/SchedulePublishEntryUseCase/SchedulePublishEntryUseCase.ts
+++ b/packages/api-headless-cms-scheduler/src/features/SchedulePublishEntryUseCase/SchedulePublishEntryUseCase.ts
@@ -17,7 +17,7 @@ class SchedulePublishEntryUseCaseImpl implements UseCaseAbstraction.Interface {
     ) {}
 
     public async execute(params: UseCaseAbstraction.Params): UseCaseAbstraction.Result {
-        const { model: initialModel, scheduleFor, id } = params;
+        const { model: initialModel, tenant, scheduleFor, id } = params;
 
         const modelResult = await this.getModelUseCase.execute(initialModel.modelId);
         if (modelResult.isFail()) {
@@ -34,6 +34,7 @@ class SchedulePublishEntryUseCaseImpl implements UseCaseAbstraction.Interface {
             namespace: createNamespace(model),
             actionType: ScheduledActionTypePublish,
             scheduleFor,
+            tenant,
             targetId: id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-headless-cms-scheduler/src/features/SchedulePublishEntryUseCase/abstractions.ts
+++ b/packages/api-headless-cms-scheduler/src/features/SchedulePublishEntryUseCase/abstractions.ts
@@ -8,6 +8,7 @@ import type { CmsModel } from "@webiny/api-headless-cms/types/index.js";
 export interface ISchedulePublishEntryUseCaseParams {
     id: string;
     model: Pick<CmsModel, "modelId">;
+    tenant: string;
     scheduleFor: Date;
 }
 

--- a/packages/api-headless-cms-scheduler/src/features/ScheduleUnpublishEntryUseCase/ScheduleUnpublishEntryUseCase.ts
+++ b/packages/api-headless-cms-scheduler/src/features/ScheduleUnpublishEntryUseCase/ScheduleUnpublishEntryUseCase.ts
@@ -17,7 +17,7 @@ class ScheduleUnpublishEntryUseCaseImpl implements UseCaseAbstraction.Interface 
     ) {}
 
     public async execute(params: UseCaseAbstraction.Params): UseCaseAbstraction.Result {
-        const { model: initialModel, scheduleFor, id } = params;
+        const { model: initialModel, scheduleFor, tenant, id } = params;
 
         const modelResult = await this.getModelUseCase.execute(initialModel.modelId);
         if (modelResult.isFail()) {
@@ -34,6 +34,7 @@ class ScheduleUnpublishEntryUseCaseImpl implements UseCaseAbstraction.Interface 
             namespace: createNamespace(model),
             actionType: ScheduledActionTypeUnpublish,
             scheduleFor,
+            tenant,
             targetId: id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-headless-cms-scheduler/src/features/ScheduleUnpublishEntryUseCase/abstractions.ts
+++ b/packages/api-headless-cms-scheduler/src/features/ScheduleUnpublishEntryUseCase/abstractions.ts
@@ -8,6 +8,7 @@ import type { CmsModel } from "@webiny/api-headless-cms/types/index.js";
 export interface IScheduleUnpublishEntryUseCaseParams {
     id: string;
     model: Pick<CmsModel, "modelId">;
+    tenant: string;
     scheduleFor: Date;
 }
 

--- a/packages/api-scheduler/__tests__/SchedulerService.test.ts
+++ b/packages/api-scheduler/__tests__/SchedulerService.test.ts
@@ -22,6 +22,8 @@ describe("SchedulerService", () => {
     };
     const namespace = "test:something";
 
+    const tenant = "root";
+
     it("creates a schedule successfully", async () => {
         const client = mockClient(SchedulerClient);
         client.on(CreateScheduleCommand).resolves({
@@ -34,13 +36,12 @@ describe("SchedulerService", () => {
 
         const input: SchedulerServiceCreateInput = {
             id: "schedule-1",
+            tenant,
             namespace,
             scheduleFor: new Date(Date.now() + 1000000)
         };
 
         await service.create(input);
-        // We are simply testing if running the service succeeds.
-        // The service returns `void`, so there's no value to expect.
     });
 
     it("throws if creating a schedule in the past", async () => {
@@ -49,6 +50,7 @@ describe("SchedulerService", () => {
 
         const input: SchedulerServiceCreateInput = {
             id: "schedule-1",
+            tenant,
             namespace,
             scheduleFor: new Date(Date.now() - 100000)
         };
@@ -81,13 +83,12 @@ describe("SchedulerService", () => {
 
         const input: SchedulerServiceCreateInput = {
             id: "schedule-1",
+            tenant,
             namespace,
             scheduleFor: new Date(Date.now() + 1000000)
         };
 
         await service.update(input);
-        // We are simply testing if running the service succeeds.
-        // The service returns `void`, so there's no value to expect.
     });
 
     it("throws if updating a schedule in the past", async () => {
@@ -96,6 +97,7 @@ describe("SchedulerService", () => {
 
         const input: SchedulerServiceCreateInput = {
             id: "schedule-1",
+            tenant,
             namespace,
             scheduleFor: new Date(Date.now())
         };
@@ -122,10 +124,11 @@ describe("SchedulerService", () => {
         const service = new EventBridgeSchedulerService(() => client, config);
         vi.spyOn(service, "exists").mockResolvedValue(true);
 
-        await service.delete("schedule-1");
-
-        // We are simply testing if running the service succeeds.
-        // The service returns `void`, so there's no value to expect.
+        await service.delete({
+            id: "schedule-1",
+            tenant,
+            namespace
+        });
     });
 
     it("does not delete a schedule if it does not exist", async () => {
@@ -134,12 +137,16 @@ describe("SchedulerService", () => {
         vi.spyOn(service, "exists").mockResolvedValue(false);
 
         try {
-            const result = await service.delete("schedule-1");
+            const result = await service.delete({
+                id: "schedule-1",
+                tenant,
+                namespace
+            });
             expect(result).toEqual("SHOULD NOT REACH HERE");
         } catch (ex) {
             expect(ex).toBeInstanceOf(WebinyError);
             expect(ex.message).toContain(
-                `Cannot delete schedule "schedule-1" because it does not exist.`
+                `Cannot delete schedule "schedule-1", tenant "${tenant}", because it does not exist.`
             );
         }
     });
@@ -154,7 +161,11 @@ describe("SchedulerService", () => {
 
         const service = new EventBridgeSchedulerService(() => client, config);
 
-        const result = await service.exists("schedule-1");
+        const result = await service.exists({
+            id: "schedule-1",
+            tenant,
+            namespace
+        });
 
         expect(result).toEqual(true);
     });
@@ -169,7 +180,11 @@ describe("SchedulerService", () => {
 
         const service = new EventBridgeSchedulerService(() => client, config);
 
-        const result = await service.exists("schedule-1");
+        const result = await service.exists({
+            id: "schedule-1",
+            tenant,
+            namespace
+        });
         expect(result).toBe(false);
     });
 
@@ -181,6 +196,12 @@ describe("SchedulerService", () => {
 
         const service = new EventBridgeSchedulerService(() => client, config);
 
-        await expect(() => service.exists("schedule-1")).rejects.toThrow();
+        await expect(() =>
+            service.exists({
+                id: "schedule-1",
+                tenant,
+                namespace
+            })
+        ).rejects.toThrow();
     });
 });

--- a/packages/api-scheduler/__tests__/eventHandler.test.ts
+++ b/packages/api-scheduler/__tests__/eventHandler.test.ts
@@ -20,6 +20,8 @@ import {
 } from "~tests/__mocks/PublishTestEntryActionHandler.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
 import { NamespaceHandler } from "~tests/__mocks/NamespaceHandler.js";
+import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
+import { GetTenantByIdUseCase } from "@webiny/api-core/exports/api/tenancy.js";
 
 describe("Scheduler Event Handler", () => {
     const lambdaContext = {} as LambdaContext;
@@ -125,5 +127,79 @@ describe("Scheduler Event Handler", () => {
         expect(result).toEqual({
             success: true
         });
+    });
+
+    it("should execute a scheduled action created on a non-root tenant", async () => {
+        const tenantContext = context.container.resolve(TenantContext);
+        const getTenantById = context.container.resolve(GetTenantByIdUseCase);
+
+        const tenantResult = await getTenantById.execute("webiny");
+        expect(tenantResult.isOk()).toBeTrue();
+        const webinyTenant = tenantResult.value;
+
+        /* Schedule action while on the "webiny" tenant. */
+        const scheduleFor = new Date(Date.now() + 5 * 60 * 1000);
+        const createResult = await tenantContext.withTenant(webinyTenant, async () => {
+            const scheduleActionUseCase = context.container.resolve(ScheduleActionUseCase);
+            return scheduleActionUseCase.execute({
+                namespace: PublishTestEntryActionHandlerImpl.name,
+                actionType: SCHEDULED_ACTION_PUBLISH,
+                targetId: "target-id#0002",
+                scheduleFor,
+                immediately: false
+            });
+        });
+
+        expect(createResult.isOk()).toBeTrue();
+        expect(createResult.value.tenant).toBe("webiny");
+
+        /*
+         * Create a fresh context for the event handler execution.
+         * In production, the EventBridge event triggers a separate Lambda invocation
+         * with its own context and fresh DataLoader caches. We simulate that here.
+         */
+        const executionHandler = useHandler({
+            getScheduleClient: () => {
+                return createMockScheduleClient();
+            }
+        });
+        const executionContext = await executionHandler.handler();
+        executionContext.container.register(PublishTestEntryActionHandler);
+        executionContext.container.register(NamespaceHandler);
+        executionContext.container.registerInstance(SchedulerService, new VoidSchedulerService());
+
+        const executionTenantContext = executionContext.container.resolve(TenantContext);
+        expect(executionTenantContext.getTenant().id).toBe("root");
+
+        const identityContext = executionContext.container.resolve(IdentityContext);
+        identityContext.setIdentity(undefined);
+
+        const eventHandler = createScheduledActionEventHandler();
+
+        /*
+         * Fire the event with tenant in the payload.
+         * Without the tenant-aware handler this would fail with "ScheduledAction/NotFound"
+         * because the CMS entry lives under the "webiny" tenant.
+         */
+        const result = await eventHandler.cb({
+            payload: {
+                [SCHEDULED_ACTION_EVENT_IDENTIFIER]: {
+                    id: createResult.value.id,
+                    namespace: PublishTestEntryActionHandlerImpl.name,
+                    tenant: "webiny",
+                    scheduleFor: new Date(Date.now() + 3 * 60 * 1000).toISOString()
+                }
+            },
+            context: executionContext,
+            request: executionContext.request,
+            reply: executionContext.reply
+        });
+
+        expect(result).toEqual({
+            success: true
+        });
+
+        /* Tenant context should be restored to root after execution. */
+        expect(executionTenantContext.getTenant().id).toBe("root");
     });
 });

--- a/packages/api-scheduler/__tests__/eventHandler.test.ts
+++ b/packages/api-scheduler/__tests__/eventHandler.test.ts
@@ -80,6 +80,7 @@ describe("Scheduler Event Handler", () => {
         expect(createResult.isOk()).toBeTrue();
         expect(createResult.value).toEqual({
             actionType: SCHEDULED_ACTION_PUBLISH,
+            error: undefined,
             id: expect.stringMatching("wby-schedule-"),
             namespace: PublishTestEntryActionHandlerImpl.name,
             payload: {
@@ -97,6 +98,7 @@ describe("Scheduler Event Handler", () => {
             },
             scheduledFor: scheduleFor,
             targetId: "target-id#0001",
+            tenant: "root",
             title: "Fetched title from handler"
         });
         /**

--- a/packages/api-scheduler/__tests__/eventHandler.test.ts
+++ b/packages/api-scheduler/__tests__/eventHandler.test.ts
@@ -54,6 +54,7 @@ describe("Scheduler Event Handler", () => {
                     actionType: SCHEDULED_ACTION_PUBLISH,
                     targetId: "target-id#0001"
                 }),
+                tenant: "root",
                 namespace,
                 scheduleFor: new Date().toISOString()
             }
@@ -76,7 +77,8 @@ describe("Scheduler Event Handler", () => {
             actionType: SCHEDULED_ACTION_PUBLISH,
             targetId: "target-id#0001",
             scheduleFor,
-            immediately: false
+            immediately: false,
+            tenant: "root"
         });
 
         expect(createResult.isOk()).toBeTrue();
@@ -117,6 +119,7 @@ describe("Scheduler Event Handler", () => {
                 [SCHEDULED_ACTION_EVENT_IDENTIFIER]: {
                     id,
                     namespace,
+                    tenant: "root",
                     scheduleFor: new Date(new Date().getTime() + 3 * 60 * 1000).toISOString()
                 }
             },
@@ -146,6 +149,7 @@ describe("Scheduler Event Handler", () => {
                 actionType: SCHEDULED_ACTION_PUBLISH,
                 targetId: "target-id#0002",
                 scheduleFor,
+                tenant: "root",
                 immediately: false
             });
         });
@@ -153,25 +157,10 @@ describe("Scheduler Event Handler", () => {
         expect(createResult.isOk()).toBeTrue();
         expect(createResult.value.tenant).toBe("webiny");
 
-        /*
-         * Create a fresh context for the event handler execution.
-         * In production, the EventBridge event triggers a separate Lambda invocation
-         * with its own context and fresh DataLoader caches. We simulate that here.
-         */
-        const executionHandler = useHandler({
-            getScheduleClient: () => {
-                return createMockScheduleClient();
-            }
-        });
-        const executionContext = await executionHandler.handler();
-        executionContext.container.register(PublishTestEntryActionHandler);
-        executionContext.container.register(NamespaceHandler);
-        executionContext.container.registerInstance(SchedulerService, new VoidSchedulerService());
+        /* We are back on root — simulating a separate Lambda invocation. */
+        expect(tenantContext.getTenant().id).toBe("root");
 
-        const executionTenantContext = executionContext.container.resolve(TenantContext);
-        expect(executionTenantContext.getTenant().id).toBe("root");
-
-        const identityContext = executionContext.container.resolve(IdentityContext);
+        const identityContext = context.container.resolve(IdentityContext);
         identityContext.setIdentity(undefined);
 
         const eventHandler = createScheduledActionEventHandler();
@@ -190,9 +179,9 @@ describe("Scheduler Event Handler", () => {
                     scheduleFor: new Date(Date.now() + 3 * 60 * 1000).toISOString()
                 }
             },
-            context: executionContext,
-            request: executionContext.request,
-            reply: executionContext.reply
+            context,
+            request: context.request,
+            reply: context.reply
         });
 
         expect(result).toEqual({
@@ -200,6 +189,6 @@ describe("Scheduler Event Handler", () => {
         });
 
         /* Tenant context should be restored to root after execution. */
-        expect(executionTenantContext.getTenant().id).toBe("root");
+        expect(tenantContext.getTenant().id).toBe("root");
     });
 });

--- a/packages/api-scheduler/__tests__/features/useCases.test.ts
+++ b/packages/api-scheduler/__tests__/features/useCases.test.ts
@@ -86,6 +86,7 @@ describe("Combined Use Cases", () => {
             },
             scheduledFor: createResult.value.scheduledFor,
             targetId: "target-id#0001",
+            tenant: "root",
             title: "Fetched title from handler"
         };
         expect(getResult.value).toEqual({

--- a/packages/api-scheduler/src/createEventHandler.ts
+++ b/packages/api-scheduler/src/createEventHandler.ts
@@ -4,11 +4,14 @@ import { createSourceHandler } from "@webiny/handler-aws/sourceHandler.js";
 import { createEventHandler, createHandler } from "@webiny/handler-aws/raw/index.js";
 import { SCHEDULED_ACTION_EVENT_IDENTIFIER } from "~/constants.js";
 import { ExecuteScheduledActionUseCase } from "~/features/ExecuteScheduledAction/index.js";
+import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
+import { GetTenantByIdUseCase } from "@webiny/api-core/exports/api/tenancy.js";
 
 export interface IScheduledActionEventPayload {
     namespace: string;
     id: string;
     scheduleFor: string;
+    tenant: string;
 }
 
 export interface IScheduledActionEvent {
@@ -47,17 +50,36 @@ export const createScheduledActionEventHandler = () => {
             const { payload, context } = params;
             const input = payload[SCHEDULED_ACTION_EVENT_IDENTIFIER];
 
-            const executeScheduledAction = context.container.resolve(ExecuteScheduledActionUseCase);
-            const result = await executeScheduledAction.execute(input);
-
-            if (result.isFail()) {
-                const error = result.error;
-                console.error(error.code, error.message);
-                throw error;
+            const tenantContext = context.container.resolve(TenantContext);
+            /**
+             * Use default tenant if tenant is not provided in the payload.
+             * This allows backward compatibility with existing scheduled actions that do not have tenant information in their payload.
+             */
+            if (!input.tenant) {
+                input.tenant = tenantContext.getTenant().id;
             }
-            return {
-                success: true
-            };
+            const getTenantByIdUseCase = context.container.resolve(GetTenantByIdUseCase);
+            const tenantResult = await getTenantByIdUseCase.execute(input.tenant);
+            if (tenantResult.isFail()) {
+                throw tenantResult.error;
+            }
+            const tenant = tenantResult.value;
+
+            return tenantContext.withTenant(tenant, async () => {
+                const executeScheduledAction = context.container.resolve(
+                    ExecuteScheduledActionUseCase
+                );
+                const result = await executeScheduledAction.execute(input);
+
+                if (result.isFail()) {
+                    const error = result.error;
+                    console.error(error.code, error.message);
+                    throw error;
+                }
+                return {
+                    success: true
+                };
+            });
         }
     });
 };

--- a/packages/api-scheduler/src/domain/ScheduledActionMapper.ts
+++ b/packages/api-scheduler/src/domain/ScheduledActionMapper.ts
@@ -17,7 +17,8 @@ export class ScheduledActionMapper {
             actionType: action.values.actionType,
             title: action.values.title,
             payload: action.values.payload,
-            error: action.values.error
+            error: action.values.error,
+            tenant: action.tenant
         };
     }
 

--- a/packages/api-scheduler/src/features/CancelScheduledAction/CancelScheduledActionUseCase.ts
+++ b/packages/api-scheduler/src/features/CancelScheduledAction/CancelScheduledActionUseCase.ts
@@ -56,16 +56,16 @@ class CancelScheduledActionUseCaseImpl implements UseCaseAbstraction.Interface {
         // Delete EventBridge schedule
         // Note: We continue even if this fails, as the schedule might already be executed/deleted
         try {
-            const eventBridgeSchedule = await this.schedulerService.exists(id);
+            const eventBridgeSchedule = await this.schedulerService.exists(params);
             /**
              * No point to even try deleting if it doesn't exist.
              */
             if (eventBridgeSchedule) {
-                await this.schedulerService.delete(id);
+                await this.schedulerService.delete(params);
             }
         } catch (error) {
             console.warn(
-                `Failed to delete EventBridge schedule: ${scheduleId}. Continuing with CMS entry deletion.`,
+                `Failed to delete EventBridge schedule: ${scheduleId}, tenant "${params.tenant}". Continuing with CMS entry deletion.`,
                 error
             );
         }

--- a/packages/api-scheduler/src/features/CancelScheduledAction/abstractions.ts
+++ b/packages/api-scheduler/src/features/CancelScheduledAction/abstractions.ts
@@ -25,6 +25,7 @@ type CancelScheduledActionError = ICancelScheduledActionErrors[keyof ICancelSche
 export interface ICancelScheduledActionUseCaseParams {
     namespace: string;
     id: string;
+    tenant: string;
 }
 export interface ICancelScheduledActionUseCase {
     execute(

--- a/packages/api-scheduler/src/features/ExecuteScheduledAction/abstractions.ts
+++ b/packages/api-scheduler/src/features/ExecuteScheduledAction/abstractions.ts
@@ -33,6 +33,7 @@ type ExecuteScheduledActionError =
 
 export interface IExecuteScheduledActionUseCaseParams {
     namespace: string;
+    tenant: string;
     id: string;
 }
 

--- a/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
+++ b/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
@@ -147,20 +147,10 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
         } = params;
         const { id: scheduleId } = parseIdentifier(initialId);
 
-        const scheduledAction: IScheduledAction<T> = {
-            id: scheduleId,
-            title,
-            namespace,
-            actionType,
-            targetId,
-            scheduledBy: {
-                id: identity.id,
-                type: identity.type,
-                displayName: identity.displayName
-            },
-            scheduledFor: scheduleFor,
-            payload,
-            error: undefined
+        const scheduledBy: Identity = {
+            id: identity.id,
+            type: identity.type,
+            displayName: identity.displayName
         };
 
         // Create CMS entry
@@ -170,7 +160,7 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
                 id: scheduleId,
                 values: {
                     scheduledFor: scheduleFor.toISOString(),
-                    scheduledBy: scheduledAction.scheduledBy,
+                    scheduledBy,
                     namespace,
                     title,
                     actionType,
@@ -187,10 +177,24 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
             );
         }
 
+        const scheduledAction: IScheduledAction<T> = {
+            id: scheduleId,
+            tenant: createResult.value.tenant,
+            title,
+            namespace,
+            actionType,
+            targetId,
+            scheduledBy,
+            scheduledFor: scheduleFor,
+            payload,
+            error: undefined
+        };
+
         // Create EventBridge schedule
         try {
             await this.schedulerService.create({
                 id: scheduleId,
+                tenant: createResult.value.tenant,
                 namespace,
                 scheduleFor: new Date(scheduleFor)
             });
@@ -251,6 +255,7 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
         try {
             await this.schedulerService.update({
                 id: existing.id,
+                tenant: existing.tenant,
                 namespace: existing.namespace,
                 scheduleFor: new Date(scheduleFor)
             });

--- a/packages/api-scheduler/src/features/ScheduleAction/abstractions.ts
+++ b/packages/api-scheduler/src/features/ScheduleAction/abstractions.ts
@@ -26,6 +26,7 @@ export interface IScheduleActionErrors {
 export type ScheduleActionError = IScheduleActionErrors[keyof IScheduleActionErrors];
 
 export interface IScheduleActionParams {
+    tenant: string;
     namespace: string;
     targetId: string;
     actionType: ScheduledActionType;

--- a/packages/api-scheduler/src/features/SchedulerService/EventBridgeSchedulerService.ts
+++ b/packages/api-scheduler/src/features/SchedulerService/EventBridgeSchedulerService.ts
@@ -33,8 +33,8 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
         private config: ISchedulerConfig
     ) {}
 
-    public async create(params: ISchedulerServiceCreateParams): Promise<void> {
-        const { id, scheduleFor } = params;
+    public async create(params: SchedulerService.CreateParams): Promise<void> {
+        const { id, scheduleFor, tenant } = params;
 
         // Validate date is in future
         if (scheduleFor <= new Date()) {
@@ -43,6 +43,7 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
                 "INVALID_SCHEDULE_DATE",
                 {
                     scheduleFor,
+                    tenant,
                     id
                 }
             );
@@ -51,7 +52,7 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
         const client = this.getClient();
 
         // Check if schedule already exists (for auto-update logic)
-        const exists = await this.exists(id);
+        const exists = await this.exists(params);
         if (exists) {
             return this.update(params);
         }
@@ -73,7 +74,7 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
         );
     }
 
-    public async update(params: ISchedulerServiceUpdateParams): Promise<void> {
+    public async update(params: SchedulerService.UpdateParams): Promise<void> {
         const { id, scheduleFor } = params;
 
         // Validate date is in future
@@ -107,16 +108,20 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
         );
     }
 
-    public async delete(id: string): Promise<void> {
+    public async delete(params: SchedulerService.DeleteParams): Promise<void> {
         const client = this.getClient();
 
-        const exists = await this.exists(id);
+        const exists = await this.exists(params);
         if (!exists) {
-            throw new WebinyError(`Cannot delete schedule "${id}" because it does not exist.`);
+            throw new WebinyError(
+                `Cannot delete schedule "${params.id}", tenant "${params.tenant}", because it does not exist.`
+            );
         }
 
+        const name = this.createScheduleName(params);
+
         try {
-            await client.send(new DeleteScheduleCommand({ Name: id }));
+            await client.send(new DeleteScheduleCommand({ Name: name }));
         } catch (ex) {
             if (ex.name === "ResourceNotFoundException") {
                 return;
@@ -125,11 +130,13 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
         }
     }
 
-    public async exists(id: string): Promise<boolean> {
+    public async exists(params: SchedulerService.ExistsParams): Promise<boolean> {
         const client = this.getClient();
 
+        const name = this.createScheduleName(params);
+
         try {
-            await client.send(new GetScheduleCommand({ Name: id }));
+            await client.send(new GetScheduleCommand({ Name: name }));
             return true;
         } catch (ex) {
             if (ex.name === "ResourceNotFoundException") {
@@ -153,14 +160,19 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
     }
 
     private createScheduledActionEventPayload(
-        params: ISchedulerServiceCreateParams | ISchedulerServiceUpdateParams
+        params: SchedulerService.CreateParams | SchedulerService.UpdateParams
     ): IScheduledActionEventPayload {
-        const { id, scheduleFor, namespace } = params;
+        const { id, scheduleFor, tenant, namespace } = params;
 
         return {
             id,
+            tenant,
             namespace,
             scheduleFor: scheduleFor.toISOString()
         };
+    }
+
+    private createScheduleName(params: SchedulerService.ExistsParams): string {
+        return `schedule_${params.tenant}-${params.namespace}-${params.id}`;
     }
 }

--- a/packages/api-scheduler/src/features/SchedulerService/VoidSchedulerService.ts
+++ b/packages/api-scheduler/src/features/SchedulerService/VoidSchedulerService.ts
@@ -1,14 +1,10 @@
-import {
-    type ISchedulerServiceCreateParams,
-    type ISchedulerServiceUpdateParams,
-    SchedulerService
-} from "~/shared/abstractions.js";
+import type { SchedulerService } from "~/shared/abstractions.js";
 
 export interface IVoidSchedulerServiceParams {
-    create?: (params: ISchedulerServiceCreateParams) => Promise<void>;
-    update?: (params: ISchedulerServiceUpdateParams) => Promise<void>;
-    delete?: (id: string) => Promise<void>;
-    exists?: (id: string) => Promise<boolean>;
+    create?: (params: SchedulerService.CreateParams) => Promise<void>;
+    update?: (params: SchedulerService.UpdateParams) => Promise<void>;
+    delete?: (params: SchedulerService.DeleteParams) => Promise<void>;
+    exists?: (params: SchedulerService.ExistsParams) => Promise<boolean>;
 }
 
 export class VoidSchedulerService implements SchedulerService.Interface {
@@ -18,31 +14,31 @@ export class VoidSchedulerService implements SchedulerService.Interface {
         this.callbacks = callbacks;
     }
 
-    public async create(params: ISchedulerServiceCreateParams): Promise<void> {
+    public async create(params: SchedulerService.CreateParams): Promise<void> {
         if (!this.callbacks?.create) {
             return;
         }
         return this.callbacks?.create(params);
     }
 
-    public async update(params: ISchedulerServiceUpdateParams): Promise<void> {
+    public async update(params: SchedulerService.UpdateParams): Promise<void> {
         if (!this.callbacks?.update) {
             return;
         }
         return this.callbacks?.update(params);
     }
 
-    public async delete(id: string): Promise<void> {
+    public async delete(params: SchedulerService.DeleteParams): Promise<void> {
         if (!this.callbacks?.delete) {
             return;
         }
-        return this.callbacks?.delete(id);
+        return this.callbacks.delete(params);
     }
 
-    public async exists(id: string): Promise<boolean> {
+    public async exists(params: SchedulerService.ExistsParams): Promise<boolean> {
         if (!this.callbacks?.exists) {
             return false;
         }
-        return this.callbacks?.exists(id);
+        return this.callbacks.exists(params);
     }
 }

--- a/packages/api-scheduler/src/shared/abstractions.ts
+++ b/packages/api-scheduler/src/shared/abstractions.ts
@@ -40,6 +40,7 @@ export interface IScheduledAction<T extends GenericRecord = GenericRecord> exten
     "scheduledFor"
 > {
     id: string;
+    tenant: string;
     scheduledFor: Date;
 }
 
@@ -80,20 +81,34 @@ export namespace ScheduledActionHandler {
 
 export interface ISchedulerServiceCreateParams {
     id: string;
+    tenant: string;
     namespace: string;
     scheduleFor: Date;
 }
 export interface ISchedulerServiceUpdateParams {
     id: string;
+    tenant: string;
     namespace: string;
     scheduleFor: Date;
+}
+
+export interface ISchedulerServiceDeleteParams {
+    id: string;
+    namespace: string;
+    tenant: string;
+}
+
+export interface ISchedulerServiceExistsParams {
+    id: string;
+    namespace: string;
+    tenant: string;
 }
 
 export interface ISchedulerService {
     create(params: ISchedulerServiceCreateParams): Promise<void>;
     update(params: ISchedulerServiceUpdateParams): Promise<void>;
-    delete(id: string): Promise<void>;
-    exists(id: string): Promise<boolean>;
+    delete(params: ISchedulerServiceDeleteParams): Promise<void>;
+    exists(params: ISchedulerServiceExistsParams): Promise<boolean>;
 }
 
 /** Core service for managing scheduled actions. */
@@ -101,6 +116,10 @@ export const SchedulerService = createAbstraction<ISchedulerService>("SchedulerS
 
 export namespace SchedulerService {
     export type Interface = ISchedulerService;
+    export type CreateParams = ISchedulerServiceCreateParams;
+    export type UpdateParams = ISchedulerServiceUpdateParams;
+    export type DeleteParams = ISchedulerServiceDeleteParams;
+    export type ExistsParams = ISchedulerServiceExistsParams;
 }
 
 /**

--- a/packages/api-website-builder-scheduler/__tests__/pageActionHandlers.test.ts
+++ b/packages/api-website-builder-scheduler/__tests__/pageActionHandlers.test.ts
@@ -52,6 +52,7 @@ describe("Page Action Handlers", () => {
 
         const publishActionResult = await schedulePublishPage.execute({
             id: page.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 100000)
         });
 
@@ -66,6 +67,7 @@ describe("Page Action Handlers", () => {
 
         await executeScheduledAction.execute({
             id: publishActionResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: publishActionResult.value!.scheduledAction.namespace
         });
 
@@ -94,10 +96,12 @@ describe("Page Action Handlers", () => {
 
         const publishResult = await schedulePublishPage.execute({
             id: page.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 100000)
         });
         await executeScheduledAction.execute({
             id: publishResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: publishResult.value!.scheduledAction.namespace
         });
 
@@ -106,10 +110,12 @@ describe("Page Action Handlers", () => {
 
         const unpublishResult = await scheduleUnpublishPage.execute({
             id: page.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 1000000)
         });
         await executeScheduledAction.execute({
             id: unpublishResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: unpublishResult.value!.scheduledAction.namespace
         });
 

--- a/packages/api-website-builder-scheduler/__tests__/redirectActionHandlers.test.ts
+++ b/packages/api-website-builder-scheduler/__tests__/redirectActionHandlers.test.ts
@@ -53,6 +53,7 @@ describe("Redirect Action Handlers", () => {
 
         const publishActionResult = await schedulePublishRedirect.execute({
             id: redirect.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 100000)
         });
 
@@ -65,6 +66,7 @@ describe("Redirect Action Handlers", () => {
 
         await executeScheduledAction.execute({
             id: publishActionResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: publishActionResult.value!.scheduledAction.namespace
         });
 
@@ -93,10 +95,12 @@ describe("Redirect Action Handlers", () => {
 
         const publishResult = await schedulePublishRedirect.execute({
             id: redirect.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 100000)
         });
         await executeScheduledAction.execute({
             id: publishResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: publishResult.value!.scheduledAction.namespace
         });
 
@@ -105,10 +109,12 @@ describe("Redirect Action Handlers", () => {
 
         const unpublishResult = await scheduleUnpublishRedirect.execute({
             id: redirect.id,
+            tenant: "root",
             scheduleFor: new Date(Date.now() + 1000000)
         });
         await executeScheduledAction.execute({
             id: unpublishResult.value!.scheduledAction.id,
+            tenant: "root",
             namespace: unpublishResult.value!.scheduledAction.namespace
         });
 

--- a/packages/api-website-builder-scheduler/src/features/SchedulePublishPageUseCase/SchedulePublishPageUseCase.ts
+++ b/packages/api-website-builder-scheduler/src/features/SchedulePublishPageUseCase/SchedulePublishPageUseCase.ts
@@ -15,6 +15,7 @@ class SchedulePublishPageUseCaseImpl implements UseCaseAbstraction.Interface {
             namespace: createNamespace(SCHEDULED_ACTION_TYPE_PAGE),
             actionType: ScheduledActionTypePublish,
             scheduleFor: params.scheduleFor,
+            tenant: params.tenant,
             targetId: params.id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-website-builder-scheduler/src/features/SchedulePublishPageUseCase/abstractions.ts
+++ b/packages/api-website-builder-scheduler/src/features/SchedulePublishPageUseCase/abstractions.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface ISchedulePublishPageUseCaseParams {
     id: string;
+    tenant: string;
     scheduleFor: Date;
 }
 

--- a/packages/api-website-builder-scheduler/src/features/SchedulePublishRedirectUseCase/SchedulePublishRedirectUseCase.ts
+++ b/packages/api-website-builder-scheduler/src/features/SchedulePublishRedirectUseCase/SchedulePublishRedirectUseCase.ts
@@ -15,6 +15,7 @@ class SchedulePublishRedirectUseCaseImpl implements UseCaseAbstraction.Interface
             namespace: createNamespace(SCHEDULED_ACTION_TYPE_REDIRECT),
             actionType: ScheduledActionTypePublish,
             scheduleFor: params.scheduleFor,
+            tenant: params.tenant,
             targetId: params.id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-website-builder-scheduler/src/features/SchedulePublishRedirectUseCase/abstractions.ts
+++ b/packages/api-website-builder-scheduler/src/features/SchedulePublishRedirectUseCase/abstractions.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface ISchedulePublishRedirectUseCaseParams {
     id: string;
+    tenant: string;
     scheduleFor: Date;
 }
 

--- a/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishPageUseCase/ScheduleUnpublishPageUseCase.ts
+++ b/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishPageUseCase/ScheduleUnpublishPageUseCase.ts
@@ -15,6 +15,7 @@ class ScheduleUnpublishPageUseCaseImpl implements UseCaseAbstraction.Interface {
             namespace: createNamespace(SCHEDULED_ACTION_TYPE_PAGE),
             actionType: ScheduledActionTypeUnpublish,
             scheduleFor: params.scheduleFor,
+            tenant: params.tenant,
             targetId: params.id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishPageUseCase/abstractions.ts
+++ b/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishPageUseCase/abstractions.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface IScheduleUnpublishPageUseCaseParams {
     id: string;
+    tenant: string;
     scheduleFor: Date;
 }
 

--- a/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishRedirectUseCase/ScheduleUnpublishRedirectUseCase.ts
+++ b/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishRedirectUseCase/ScheduleUnpublishRedirectUseCase.ts
@@ -15,6 +15,7 @@ class ScheduleUnpublishRedirectUseCaseImpl implements UseCaseAbstraction.Interfa
             namespace: createNamespace(SCHEDULED_ACTION_TYPE_REDIRECT),
             actionType: ScheduledActionTypeUnpublish,
             scheduleFor: params.scheduleFor,
+            tenant: params.tenant,
             targetId: params.id
         });
         if (scheduleResult.isFail()) {

--- a/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishRedirectUseCase/abstractions.ts
+++ b/packages/api-website-builder-scheduler/src/features/ScheduleUnpublishRedirectUseCase/abstractions.ts
@@ -6,6 +6,7 @@ import type {
 
 export interface IScheduleUnpublishRedirectUseCaseParams {
     id: string;
+    tenant: string;
     scheduleFor: Date;
 }
 


### PR DESCRIPTION
## Summary

  Scheduled actions created on non-root tenants failed to execute because the event handler ran in the root tenant context and couldn't find the CMS entry stored under the originating
  tenant's partition.

  ### Root cause

  1. **Missing tenant in scheduling pipeline** — the `tenant` was never threaded through the scheduler interfaces, so EventBridge payloads and schedule names had no tenant awareness,
  causing cross-tenant collisions and incorrect execution context.
  2. **DataLoader cache invalidation scoped to wrong tenant** — after CMS entry writes, `dataLoaders.clearAll({ model })` used `model.tenant` (always `"root"` for singleton models like
  `ScheduledActionModel`). Entries created under non-root tenants left stale empty results in the DataLoader cache.

  ### Changes

  **`api-scheduler`** — Thread `tenant: string` through the entire pipeline:
  - Added `tenant` to all use case param interfaces (`ScheduleAction`, `CancelScheduledAction`, `ExecuteScheduledAction`) and to `IScheduledAction`.
  - `EventBridgeSchedulerService` now generates tenant-scoped schedule names (`schedule_${tenant}-${namespace}-${id}`) and includes `tenant` in the EventBridge payload.
  - `createEventHandler` resolves the tenant from the payload, falls back to the current tenant for backward compatibility, and wraps execution in `tenantContext.withTenant()`.
  - `ScheduledActionMapper` maps `action.tenant` into the domain object.
  - `SchedulerService` `delete`/`exists` now take param objects (with tenant) instead of bare `id`.

  **`api-headless-cms-ddb` / `api-headless-cms-ddb-es`** — Fix DataLoader cache invalidation:
  - `DataLoadersHandlerInterfaceClearAllParams` changed from `{ model: Pick<CmsModel, "tenant"> }` to `{ tenant: string }`.
  - All `dataLoaders.clearAll()` call sites now pass `{ tenant: entry.tenant }` instead of `{ model }`, ensuring the correct tenant's cache is invalidated after writes.

  **`api-headless-cms-scheduler` / `api-website-builder-scheduler`** — Added `tenant` to all schedule/unschedule use case params and forwarded it downstream.

  ### Backward compatibility

  - If `tenant` is missing from an EventBridge payload (pre-existing scheduled actions), the handler falls back to the current tenant context.

  ## Test plan

  - [x] `api-scheduler` — 30 tests passing (8 files), including new cross-tenant execution test
  - [x] `api-headless-cms-scheduler` — 1 test passing
  - [x] `api-website-builder-scheduler` — 4 tests passing
  - [ ] Manual: schedule a publish on a non-root tenant, verify it executes correctly when triggered