### PR TITLE
fix(headless-cms): improve empty states in model editor

### DIFF
--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
@@ -180,13 +180,16 @@ export const ContentModelEditor = makeDecoratable("ContentModelEditor", () => {
                                 )}
                                 {activeTab === "preview" && (
                                     <div
-                                        className={"bg-neutral-base px-xxl py-lg"}
+                                        className={"px-xxl py-lg"}
                                         data-testid={"cms.editor.tab.preview"}
                                     >
                                         <ContentEntryEditorWithConfig>
                                             <ContentEntriesProvider contentModel={data}>
                                                 <ContentEntryProvider readonly={true}>
-                                                    <PreviewTab activeTab={true} />
+                                                    <PreviewTab
+                                                        activeTab={true}
+                                                        onSwitchToEdit={() => setActiveTab("edit")}
+                                                    />
                                                 </ContentEntryProvider>
                                             </ContentEntriesProvider>
                                         </ContentEntryEditorWithConfig>

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
@@ -1,24 +1,55 @@
 import React from "react";
 import { i18n } from "@webiny/app/i18n/index.js";
-import type { CmsEditorContentTab } from "~/types.js";
 import { useModelEditor } from "~/admin/hooks/index.js";
 import { ContentEntryFormPreview } from "../ContentEntryForm/ContentEntryFormPreview.js";
-import { Alert } from "@webiny/admin-ui";
+import { Button } from "@webiny/admin-ui";
 
 const t = i18n.ns("app-headless-cms/admin/components/editor/tabs/preview");
 
-export const PreviewTab: CmsEditorContentTab = ({ activeTab }) => {
+interface PreviewTabProps {
+    activeTab: boolean;
+    onSwitchToEdit?: () => void;
+}
+
+const LayoutIllustration = () => (
+    <svg width="90" height="72" viewBox="0 0 90 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="90" height="72" rx="4" fill="white" stroke="#DCE0E5" strokeWidth="1" />
+        <rect width="90" height="15" rx="4" fill="#F5F6F7" />
+        <rect y="11" width="90" height="4" fill="#F5F6F7" />
+        <line x1="0" y1="15" x2="90" y2="15" stroke="#DCE0E5" strokeWidth="1" />
+        <circle cx="9" cy="7.5" r="2.5" fill="#FA5723" />
+        <circle cx="17" cy="7.5" r="2.5" fill="#FA5723" fillOpacity="0.5" />
+        <circle cx="25" cy="7.5" r="2.5" fill="#FA5723" fillOpacity="0.25" />
+        <rect x="8" y="18" width="23" height="45" rx="1.5" fill="#F0F1F3" />
+        <rect x="36" y="18" width="45" height="20" rx="1.5" fill="#F0F1F3" />
+        <rect x="36" y="42" width="21" height="21" rx="1.5" fill="#F0F1F3" />
+        <rect x="61" y="42" width="20" height="21" rx="1.5" fill="#F0F1F3" />
+    </svg>
+);
+
+export const PreviewTab = ({ activeTab, onSwitchToEdit }: PreviewTabProps) => {
     const { data } = useModelEditor();
 
+    if (data.fields && data.fields.length && activeTab) {
+        return <ContentEntryFormPreview contentModel={data} />;
+    }
+
     return (
-        <>
-            {data.fields && data.fields.length && activeTab ? (
-                <ContentEntryFormPreview contentModel={data} />
-            ) : (
-                <Alert type="warning">
-                    {t`Before previewing the form, please add at least one field to the content model.`}
-                </Alert>
+        <div className={"flex flex-col gap-md items-center justify-center pb-[216px] size-full"}>
+            <LayoutIllustration />
+            <div className={"flex flex-col gap-sm items-center text-center w-full"}>
+                <p className={"text-lg font-semibold text-neutral-strong"}>
+                    {t`Nothing to see here`}
+                </p>
+                <p className={"text-sm text-neutral-strong max-w-[400px]"}>
+                    {t`It seems there was no field added to this content model. Switch to editor mode and add your very first field.`}
+                </p>
+            </div>
+            {onSwitchToEdit && (
+                <Button variant={"primary"} size={"sm"} onClick={onSwitchToEdit}>
+                    {t`Switch to edit mode`}
+                </Button>
             )}
-        </>
+        </div>
     );
 };

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
@@ -42,7 +42,7 @@ export const PreviewTab = ({ activeTab, onSwitchToEdit }: PreviewTabProps) => {
                     {t`Nothing to see here`}
                 </p>
                 <p className={"text-sm text-neutral-strong max-w-[400px]"}>
-                    {t`It seems there was no field added to this content model. Switch to editor mode and add your very first field.`}
+                    {t`It looks like no field has been added to this content model yet. Switch to editor mode to add your first field.`}
                 </p>
             </div>
             {onSwitchToEdit && (

--- a/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
@@ -5,12 +5,12 @@ import { Droppable } from "./../Droppable.js";
 import { cn, cva } from "@webiny/admin-ui";
 
 const droppableContainerVariants = cva(
-    "bg-neutral-base/30 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
+    "mt-10 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
     {
         variants: {
             isOver: {
-                true: "border-neutral-muted text-accent-primary",
-                false: "border-neutral-muted text-success-primary"
+                true: "bg-primary/5 border-accent-primary/50 text-accent-primary",
+                false: "bg-neutral-base/30 border-neutral-muted text-neutral-strong"
             },
             isDroppable: {
                 false: "border-success-default text-accent-primary"
@@ -50,7 +50,7 @@ const Center = ({ onDrop, children, style, isDroppable }: CenterProps) => {
                     {...getInert(isDroppable)}
                 >
                     <div className={cn(droppableContainerVariants({ isOver, isDroppable }))}>
-                        <div className="text-sm text-neutral-strong absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
+                        <div className="text-sm absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
                             {children}
                         </div>
                     </div>

--- a/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
@@ -5,12 +5,12 @@ import { Droppable } from "./../Droppable.js";
 import { cn, cva } from "@webiny/admin-ui";
 
 const droppableContainerVariants = cva(
-    "bg-transparent box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed",
+    "bg-neutral-base/30 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
     {
         variants: {
             isOver: {
-                true: "border-accent-default text-accent-primary",
-                false: "border-success-default text-success-primary"
+                true: "border-neutral-muted text-accent-primary",
+                false: "border-neutral-muted text-success-primary"
             },
             isDroppable: {
                 false: "border-success-default text-accent-primary"
@@ -50,7 +50,7 @@ const Center = ({ onDrop, children, style, isDroppable }: CenterProps) => {
                     {...getInert(isDroppable)}
                 >
                     <div className={cn(droppableContainerVariants({ isOver, isDroppable }))}>
-                        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
+                        <div className="text-sm text-neutral-strong absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
                             {children}
                         </div>
                     </div>


### PR DESCRIPTION
### What changed

The preview tab in the content model editor now shows a proper empty state when no fields have been added to the model. Previously it displayed a yellow warning alert — it now shows a centered illustration, a "Nothing to see here" heading, a short description, and a "Switch to edit mode" button that takes the user directly back to the editor tab. The drop zone area in the field editor also received visual polish: rounded corners, a softer neutral border color, and consistent text styling.

<img width="1248" height="910" alt="image" src="https://github.com/user-attachments/assets/027bc77e-2d1f-496a-92c7-eda0b6998445" />

<img width="1248" height="885" alt="image" src="https://github.com/user-attachments/assets/b175e2c3-3bb0-4b68-8ce3-fc390bd427df" />

---

### Changelog

**Improve empty state in content model editor preview tab**

When opening the Preview tab on a content model with no fields, users now see a friendly empty state with an illustration and a direct call-to-action button instead of a plain warning message. The drop zone in the field editor was also given rounded corners and a more neutral border style.

---

### Squash Merge Commit

```
fix(admin-ui): replace alert with empty state in model editor preview tab (#5289)
```

```
fix(headless-cms): improve empty states in model editor (#5289)
```
