### PR TITLE
fix: improve hover colors of vert/horiz drag indicators

### DIFF
--- a/packages/admin-ui/src/theme.css
+++ b/packages/admin-ui/src/theme.css
@@ -86,6 +86,7 @@
   --color-primary-strong: var(--color-primary-700);
   --color-primary-subtle: var(--color-primary-100);
   --color-primary-xstrong: var(--color-primary-900);
+  --color-primary-light: var(--color-primary-200);
 
   --color-secondary: var(--color-success-500);
   --color-secondary-disabled: var(--color-success-400);

--- a/packages/app-file-manager/src/modules/HeadlessCms/fileRenderer/fileFields.tsx
+++ b/packages/app-file-manager/src/modules/HeadlessCms/fileRenderer/fileFields.tsx
@@ -64,7 +64,7 @@ const FieldRenderer = ({ getBind }: CmsModelFieldRendererProps) => {
                                             onChange(dotProp.delete(values, index))
                                         }
                                         placeholder={field.placeholder}
-                                        type={"compact"}
+                                        type={"area"}
                                         data-testid={`fr.input.filefields.${field.label}`}
                                     />
                                 );

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/ContentModelEditor.tsx
@@ -180,13 +180,16 @@ export const ContentModelEditor = makeDecoratable("ContentModelEditor", () => {
                                 )}
                                 {activeTab === "preview" && (
                                     <div
-                                        className={"bg-neutral-base px-xxl py-lg"}
+                                        className={"px-xxl py-lg"}
                                         data-testid={"cms.editor.tab.preview"}
                                     >
                                         <ContentEntryEditorWithConfig>
                                             <ContentEntriesProvider contentModel={data}>
                                                 <ContentEntryProvider readonly={true}>
-                                                    <PreviewTab activeTab={true} />
+                                                    <PreviewTab
+                                                        activeTab={true}
+                                                        onSwitchToEdit={() => setActiveTab("edit")}
+                                                    />
                                                 </ContentEntryProvider>
                                             </ContentEntriesProvider>
                                         </ContentEntryEditorWithConfig>

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
@@ -1,24 +1,55 @@
 import React from "react";
 import { i18n } from "@webiny/app/i18n/index.js";
-import type { CmsEditorContentTab } from "~/types.js";
 import { useModelEditor } from "~/admin/hooks/index.js";
 import { ContentEntryFormPreview } from "../ContentEntryForm/ContentEntryFormPreview.js";
-import { Alert } from "@webiny/admin-ui";
+import { Button } from "@webiny/admin-ui";
 
 const t = i18n.ns("app-headless-cms/admin/components/editor/tabs/preview");
 
-export const PreviewTab: CmsEditorContentTab = ({ activeTab }) => {
+interface PreviewTabProps {
+    activeTab: boolean;
+    onSwitchToEdit?: () => void;
+}
+
+const LayoutIllustration = () => (
+    <svg width="90" height="72" viewBox="0 0 90 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="90" height="72" rx="4" fill="white" stroke="#DCE0E5" strokeWidth="1" />
+        <rect width="90" height="15" rx="4" fill="#F5F6F7" />
+        <rect y="11" width="90" height="4" fill="#F5F6F7" />
+        <line x1="0" y1="15" x2="90" y2="15" stroke="#DCE0E5" strokeWidth="1" />
+        <circle cx="9" cy="7.5" r="2.5" fill="#FA5723" />
+        <circle cx="17" cy="7.5" r="2.5" fill="#FA5723" fillOpacity="0.5" />
+        <circle cx="25" cy="7.5" r="2.5" fill="#FA5723" fillOpacity="0.25" />
+        <rect x="8" y="18" width="23" height="45" rx="1.5" fill="#F0F1F3" />
+        <rect x="36" y="18" width="45" height="20" rx="1.5" fill="#F0F1F3" />
+        <rect x="36" y="42" width="21" height="21" rx="1.5" fill="#F0F1F3" />
+        <rect x="61" y="42" width="20" height="21" rx="1.5" fill="#F0F1F3" />
+    </svg>
+);
+
+export const PreviewTab = ({ activeTab, onSwitchToEdit }: PreviewTabProps) => {
     const { data } = useModelEditor();
 
+    if (data.fields && data.fields.length && activeTab) {
+        return <ContentEntryFormPreview contentModel={data} />;
+    }
+
     return (
-        <>
-            {data.fields && data.fields.length && activeTab ? (
-                <ContentEntryFormPreview contentModel={data} />
-            ) : (
-                <Alert type="warning">
-                    {t`Before previewing the form, please add at least one field to the content model.`}
-                </Alert>
+        <div className={"flex flex-col gap-md items-center justify-center pb-[216px] size-full"}>
+            <LayoutIllustration />
+            <div className={"flex flex-col gap-sm items-center text-center w-full"}>
+                <p className={"text-lg font-semibold text-neutral-strong"}>
+                    {t`Nothing to see here`}
+                </p>
+                <p className={"text-sm text-neutral-strong max-w-[400px]"}>
+                    {t`It seems there was no field added to this content model. Switch to editor mode and add your very first field.`}
+                </p>
+            </div>
+            {onSwitchToEdit && (
+                <Button variant={"primary"} size={"sm"} onClick={onSwitchToEdit}>
+                    {t`Switch to edit mode`}
+                </Button>
             )}
-        </>
+        </div>
     );
 };

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/PreviewTab.tsx
@@ -42,7 +42,7 @@ export const PreviewTab = ({ activeTab, onSwitchToEdit }: PreviewTabProps) => {
                     {t`Nothing to see here`}
                 </p>
                 <p className={"text-sm text-neutral-strong max-w-[400px]"}>
-                    {t`It seems there was no field added to this content model. Switch to editor mode and add your very first field.`}
+                    {t`It looks like no field has been added to this content model yet. Switch to editor mode to add your first field.`}
                 </p>
             </div>
             {onSwitchToEdit && (

--- a/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
@@ -5,12 +5,12 @@ import { Droppable } from "./../Droppable.js";
 import { cn, cva } from "@webiny/admin-ui";
 
 const droppableContainerVariants = cva(
-    "bg-neutral-base/30 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
+    "mt-10 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
     {
         variants: {
             isOver: {
-                true: "border-neutral-muted text-accent-primary",
-                false: "border-neutral-muted text-success-primary"
+                true: "bg-primary/5 border-accent-primary/50 text-accent-primary",
+                false: "bg-neutral-base/30 border-neutral-muted text-neutral-strong"
             },
             isDroppable: {
                 false: "border-success-default text-accent-primary"
@@ -50,7 +50,7 @@ const Center = ({ onDrop, children, style, isDroppable }: CenterProps) => {
                     {...getInert(isDroppable)}
                 >
                     <div className={cn(droppableContainerVariants({ isOver, isDroppable }))}>
-                        <div className="text-sm text-neutral-strong absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
+                        <div className="text-sm absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
                             {children}
                         </div>
                     </div>

--- a/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Center.tsx
@@ -5,12 +5,12 @@ import { Droppable } from "./../Droppable.js";
 import { cn, cva } from "@webiny/admin-ui";
 
 const droppableContainerVariants = cva(
-    "bg-transparent box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed",
+    "bg-neutral-base/30 box-border h-full min-h-[120px] relative user-select-none w-full border-md border-dashed rounded-xl",
     {
         variants: {
             isOver: {
-                true: "border-accent-default text-accent-primary",
-                false: "border-success-default text-success-primary"
+                true: "border-neutral-muted text-accent-primary",
+                false: "border-neutral-muted text-success-primary"
             },
             isDroppable: {
                 false: "border-success-default text-accent-primary"
@@ -50,7 +50,7 @@ const Center = ({ onDrop, children, style, isDroppable }: CenterProps) => {
                     {...getInert(isDroppable)}
                 >
                     <div className={cn(droppableContainerVariants({ isOver, isDroppable }))}>
-                        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
+                        <div className="text-sm text-neutral-strong absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 m-0">
                             {children}
                         </div>
                     </div>

--- a/packages/app-headless-cms/src/admin/components/DropZone/Horizontal.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Horizontal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { IsVisibleCallable } from "../Droppable.js";
 import { Droppable } from "../Droppable.js";
 import type { DragSource } from "~/types.js";
-import { Icon } from "@webiny/admin-ui";
+import { cn, Icon } from "@webiny/admin-ui";
 import { ReactComponent as AddIcon } from "@webiny/icons/add.svg";
 
 interface HorizontalProps {
@@ -21,19 +21,24 @@ const Horizontal = ({ last, onDrop, isVisible, ...rest }: HorizontalProps) => {
                         drop(element);
                     }}
                     data-testid={rest["data-testid"]}
-                    className={`h-sm-extra w-full absolute left-0 ${last ? "-bottom-sm-extra" : "-top-sm-extra"} ${isDragging ? "z-[1000]" : "-z-[1]"}`}
+                    className={cn(
+                        "h-sm-extra w-full absolute left-0",
+                        last ? "-bottom-sm-extra" : "-top-sm-extra",
+                        isDragging ? "z-[1000]" : "-z-[1]"
+                    )}
                 >
                     {isDragging && (
                         <div
-                            className={
-                                "absolute w-full flex items-center " + (last ? "bottom-0" : "top-0")
-                            }
+                            className={cn(
+                                "absolute bg-primary w-full flex items-center rounded-xs",
+                                last ? "bottom-0" : "top-0"
+                            )}
                         >
                             <div
-                                className={
-                                    "w-full h-sm-extra rounded-xs p-xxs transition-colors relative flex items-center justify-center " +
-                                    (isOver ? "bg-primary" : "bg-[#fdc5b4]")
-                                }
+                                className={cn(
+                                    "w-full h-sm-extra rounded-xs p-xxs transition-colors relative flex items-center justify-center",
+                                    isOver ? "bg-primary-light/60" : "bg-primary-light"
+                                )}
                             >
                                 <Icon icon={<AddIcon />} label="Add" size="xs" color="accent" />
                             </div>

--- a/packages/app-headless-cms/src/admin/components/DropZone/Vertical.tsx
+++ b/packages/app-headless-cms/src/admin/components/DropZone/Vertical.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { IsVisibleCallable } from "../Droppable.js";
 import { Droppable } from "../Droppable.js";
 import type { DragSource } from "~/types.js";
-import { Icon } from "@webiny/admin-ui";
+import { cn, Icon } from "@webiny/admin-ui";
 import { ReactComponent as AddIcon } from "@webiny/icons/add.svg";
 
 interface VerticalProps {
@@ -20,21 +20,21 @@ const Vertical = ({ depth, last, onDrop, isVisible }: VerticalProps) => {
                     ref={element => {
                         drop(element);
                     }}
-                    className={`w-sm-extra h-full absolute top-0 ${last ? "right-0" : "left-0"}`}
+                    className={cn("w-sm-extra h-full absolute top-0", last ? "right-0" : "left-0")}
                     style={{ zIndex: isDragging ? 1000 + (depth || 0) : -1 }}
                 >
                     {isDragging && (
                         <div
-                            className={
-                                "absolute top-0 h-full flex items-center " +
-                                (last ? "right-0" : "left-0")
-                            }
+                            className={cn(
+                                "absolute top-0 h-full flex items-center rounded-xs",
+                                last ? "right-0" : "left-0"
+                            )}
                         >
                             <div
-                                className={
-                                    "h-full w-sm-extra rounded-xs p-xxs transition-colors relative flex items-center justify-center " +
-                                    (isOver ? "bg-warning-muted" : "bg-[#feebb8]")
-                                }
+                                className={cn(
+                                    "h-full w-sm-extra rounded-xs p-xxs transition-colors relative flex items-center justify-center",
+                                    isOver ? "bg-warning-muted" : "bg-warning-muted/60"
+                                )}
                             >
                                 <Icon
                                     icon={<AddIcon />}


### PR DESCRIPTION
### What changed

Updates the hover colors on the horizontal and vertical drop zone lines in the Content Model Editor to use design system tokens instead of hardcoded hex values.

https://github.com/user-attachments/assets/edb44e50-849e-46af-bee1-cd73688ef6b9

### Changelog

**Updated drop zone line hover colors to use design system tokens**

The horizontal and vertical drop zone lines in the Content Model Editor now use design token colors for their hover states instead of hardcoded hex values.

### Squash Merge Commit

```
refactor(cms): use design tokens for drop zone line hover colors (#5290)
```
