### PR TITLE
fix: bump scaffolded GitHub Actions templates to Node 24

### DIFF
--- a/docs/gh-actions-workflows/pullRequest.yml
+++ b/docs/gh-actions-workflows/pullRequest.yml
@@ -12,11 +12,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4
@@ -62,11 +62,11 @@ jobs:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.DEV_AWS_REGION }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4

--- a/docs/gh-actions-workflows/pullRequestClosed.yml
+++ b/docs/gh-actions-workflows/pullRequestClosed.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.DEV_AWS_REGION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4

--- a/docs/gh-actions-workflows/pushDev.yml
+++ b/docs/gh-actions-workflows/pushDev.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.DEV_AWS_REGION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4

--- a/docs/gh-actions-workflows/pushProd.yml
+++ b/docs/gh-actions-workflows/pushProd.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.PROD_AWS_REGION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4

--- a/docs/gh-actions-workflows/pushStaging.yml
+++ b/docs/gh-actions-workflows/pushStaging.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.STAGING_AWS_ROLE_ARN }}
           aws-region: ${{ secrets.STAGING_AWS_REGION }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install and cache dependencies.
       - uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Updates the scaffolded GitHub Actions deployment workflow templates (`docs/gh-actions-workflows/*.yml`) to use **Node 24** instead of Node 20, and bumps the associated actions to their current major versions:

- `actions/setup-node@v2` → `actions/setup-node@v5`, `node-version: 20` → `24`
- `actions/checkout@v2` / `@v4` → `actions/checkout@v5`

This aligns the templates we ship to users with the Node version we use in our own CI/CD, and resolves cache-action issues reported when running these workflows on the older Node 20 setup.

## Context

Reported by a user setting up GH Actions for their Webiny instance — they had to manually bump all the actions to Node 24 to get the workflows (PR-to-dev, PR-closed, push-to-dev/staging/prod) running.

## Test plan

- [x] No remaining references to `node-version: 20`, `setup-node@v2`, `checkout@v2`, or `checkout@v4` in `docs/gh-actions-workflows/`
- Templates are documentation/scaffolding YAML; no build/test impact in the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)