### PR TITLE
fix: add dynamodb:UpdateTimeToLive to deploy role CF template

### DIFF
--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
@@ -168,6 +168,7 @@ Resources:
               - dynamodb:DescribeTable
               - dynamodb:DescribeContinuousBackups
               - dynamodb:DescribeTimeToLive
+              - dynamodb:UpdateTimeToLive
               - dynamodb:ListTagsOfResource
               - dynamodb:TagResource
               - dynamodb:UntagResource


### PR DESCRIPTION
## Summary

Adds the missing **`dynamodb:UpdateTimeToLive`** action to the `DeployWebinyPolicy1` managed policy in the [deploy role CloudFormation template](https://www.webiny.com/docs/infrastructure/deploy-webiny-project-cf-template) (`docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml`).

The policy already granted `dynamodb:DescribeTimeToLive` but not `dynamodb:UpdateTimeToLive`. Without it, deployments using the assumed deploy role fail with an access-denied error when Pulumi configures a table's TTL.

## Context

Reported by a user setting up CI/CD for their Webiny instance who hit an assumed-role error and had to manually add this permission to `DeployWebinyPolicy1`.

> Note on `apigateway:TagResource`: the same user noted that the AWS IAM console reports "The action apigateway:TagResource does not exist." That is expected and already documented inline in the template — the action is still required for deployment, so it is intentionally left as-is.

## Test plan

- [x] `dynamodb:UpdateTimeToLive` added to the DynamoDB statement (`Resource: arn:aws:dynamodb:*:*:table/wby-*`), grouped with the other DynamoDB actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)