### PR TITLE
fix: detect remote Pulumi backend for configured production environments

### DIFF
--- a/packages/project/src/extensions/Project/ValidateProductionPulumiState.ts
+++ b/packages/project/src/extensions/Project/ValidateProductionPulumiState.ts
@@ -1,5 +1,6 @@
 import {
     CoreBeforeDeploy,
+    GetProductionEnvironments,
     IsRemotePulumiBackendService,
     ProjectSdkParamsService
 } from "~/abstractions/index.js";
@@ -8,7 +9,8 @@ import { GracefulError } from "~/index.js";
 class ValidateProductionPulumiStateImpl implements CoreBeforeDeploy.Interface {
     constructor(
         private isRemotePulumiBackendService: IsRemotePulumiBackendService.Interface,
-        private projectSdkParamsService: ProjectSdkParamsService.Interface
+        private projectSdkParamsService: ProjectSdkParamsService.Interface,
+        private getProductionEnvironments: GetProductionEnvironments.Interface
     ) {}
 
     async execute(params: CoreBeforeDeploy.Params) {
@@ -16,7 +18,7 @@ class ValidateProductionPulumiStateImpl implements CoreBeforeDeploy.Interface {
         const { env } = sdkParams;
         const { allowLocalStateFiles } = params;
 
-        const prodEnvs = ["prod", "production"];
+        const prodEnvs = await this.getProductionEnvironments.execute();
         const isProdEnv = prodEnvs.includes(env);
 
         if (!isProdEnv) {
@@ -45,5 +47,5 @@ class ValidateProductionPulumiStateImpl implements CoreBeforeDeploy.Interface {
 
 export const ValidateProductionPulumiState = CoreBeforeDeploy.createImplementation({
     implementation: ValidateProductionPulumiStateImpl,
-    dependencies: [IsRemotePulumiBackendService, ProjectSdkParamsService]
+    dependencies: [IsRemotePulumiBackendService, ProjectSdkParamsService, GetProductionEnvironments]
 });

--- a/packages/project/src/services/IsRemotePulumiBackendService/IsRemotePulumiBackendService.ts
+++ b/packages/project/src/services/IsRemotePulumiBackendService/IsRemotePulumiBackendService.ts
@@ -4,9 +4,10 @@ import { IsRemotePulumiBackendService } from "~/abstractions/index.js";
 /**
  * Service to check if a remote Pulumi backend is configured via environment variables.
  *
- * Checks for the following environment variables in order:
- * - WEBINY_CLI_PULUMI_BACKEND
+ * Checks for the following environment variables:
+ * - WEBINY_CLI_PULUMI_BACKEND (canonical)
  * - WEBINY_CLI_PULUMI_BACKEND_URL
+ * - WEBINY_PULUMI_BACKEND (legacy, kept for backwards compatibility)
  * - PULUMI_LOGIN (fallback for standard Pulumi configuration)
  */
 export class DefaultIsRemotePulumiBackendService implements IsRemotePulumiBackendService.Interface {
@@ -14,6 +15,7 @@ export class DefaultIsRemotePulumiBackendService implements IsRemotePulumiBacken
         return !!(
             process.env.WEBINY_CLI_PULUMI_BACKEND ||
             process.env.WEBINY_CLI_PULUMI_BACKEND_URL ||
+            process.env.WEBINY_PULUMI_BACKEND ||
             process.env.PULUMI_LOGIN
         );
     }

--- a/packages/project/src/services/PulumiLoginService/PulumiLoginService.ts
+++ b/packages/project/src/services/PulumiLoginService/PulumiLoginService.ts
@@ -15,8 +15,9 @@ export class DefaultPulumiLoginService implements PulumiLoginService.Interface {
 
         const projectAppRelativePath = path.join("apps", app.name);
 
-        // A couple of variations here, just to preserve backwards compatibility.
-        let loginUrl = process.env.WEBINY_PULUMI_BACKEND;
+        // `WEBINY_CLI_PULUMI_BACKEND` is the canonical variable. We still read the legacy
+        // `WEBINY_PULUMI_BACKEND` as a fallback, to preserve backwards compatibility.
+        let loginUrl = process.env.WEBINY_CLI_PULUMI_BACKEND || process.env.WEBINY_PULUMI_BACKEND;
 
         if (loginUrl) {
             // If the user passed `s3://my-bucket`, we want to store files in `s3://my-bucket/{project-application-path}`


### PR DESCRIPTION
> 🎯 Targets `release/6.4.3` — intended to ship in the upcoming **6.4.3 patch**.

## Summary

Fixes two related issues that made deploying to a **custom production environment** (e.g. `staging` registered via `Infra.ProductionEnvironments`) fail with `Cannot deploy to production with local state files.` even when a remote Pulumi backend was correctly configured (state was visibly being written to S3).

### 1. Hard-coded production environments
`ValidateProductionPulumiState` hard-coded the production env list as `["prod", "production"]`, ignoring environments registered via `Infra.ProductionEnvironments`. It now reads the configured list through the existing `GetProductionEnvironments` feature (which already merges the defaults with the user-registered environments).

This is why `prod` triggered the check but `staging` silently skipped it — they behaved inconsistently.

### 2. Inconsistent Pulumi backend env var
`PulumiLoginService` reads `WEBINY_PULUMI_BACKEND` (what actually configures the backend and writes state to S3), but `IsRemotePulumiBackendService` (the validation gate) only checked `WEBINY_CLI_PULUMI_BACKEND` / `WEBINY_CLI_PULUMI_BACKEND_URL` / `PULUMI_LOGIN` — none of which the templates or docs ever set. So the gate always concluded "no remote backend" and threw.

`WEBINY_CLI_PULUMI_BACKEND` is now the **canonical** variable across both services, with `WEBINY_PULUMI_BACKEND` kept as a **legacy fallback** for backwards compatibility:
- `PulumiLoginService`: `WEBINY_CLI_PULUMI_BACKEND || WEBINY_PULUMI_BACKEND`
- `IsRemotePulumiBackendService`: now also detects `WEBINY_PULUMI_BACKEND`

> Note: this PR contains **only the code fix**. The scaffolded GitHub Actions template updates (Node 24 + the `WEBINY_CLI_PULUMI_BACKEND` rename) are handled separately against `next` and will converge later. Because `WEBINY_PULUMI_BACKEND` remains supported as a legacy fallback, existing projects keep working without any template/secret changes.

## Context

Reported by a user (Webiny v6.4.2) whose `prod` push deploy failed while `staging` worked, despite both being declared production envs and a remote backend being configured. They traced both root causes in `node_modules`.

## Follow-up (not in this PR)
- The public docs (webiny.com/docs) still reference `WEBINY_PULUMI_BACKEND` and should be updated to the canonical name.
- The error message links to `https://webiny.link/state-files-production`, which is currently dead.

## Test plan

- [x] `yarn build -p @webiny/project` passes (typecheck + build) on `release/6.4.3`
- [x] `oxlint --deny-warnings` clean on changed files
- [x] `getProductionEnvironments` is registered in `createProjectSdkContainer`; no tests construct `ValidateProductionPulumiStateImpl` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)