### PR TITLE
feat: add destructive variant to DropdownMenu.Item

### DIFF
--- a/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
+++ b/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
@@ -11,6 +11,7 @@ import { LinkComponentProps, useAdminUi } from "~/index.js";
 interface DropdownMenuItemBaseProps {
     icon?: React.ReactNode;
     readOnly?: boolean;
+    variant?: "destructive";
     text?: React.ReactNode;
     disabled?: boolean;
     onClick?: React.MouseEventHandler;
@@ -33,6 +34,9 @@ const variants = cva(
     ],
     {
         variants: {
+            variant: {
+                destructive: ["text-destructive-primary!", "[&_svg]:fill-destructive"]
+            },
             readOnly: {
                 true: "pointer-events-none"
             }
@@ -46,7 +50,7 @@ const variants = cva(
 const DropdownMenuItemBase = React.forwardRef<
     React.ElementRef<typeof DropdownMenuPrimitive.Item>,
     DropdownMenuItemProps
->(({ className, icon, text, readOnly, disabled, onClick, children, ...linkProps }, ref) => {
+>(({ className, icon, text, readOnly, variant, disabled, onClick, children, ...linkProps }, ref) => {
     const { linkComponent: LinkComponent } = useAdminUi();
 
     if (children) {
@@ -87,7 +91,7 @@ const DropdownMenuItemBase = React.forwardRef<
         <DropdownMenuPrimitive.Item
             disabled={disabled}
             ref={ref}
-            className={cn(variants({ readOnly }), className)}
+            className={cn(variants({ readOnly, variant }), className)}
         >
             {content}
         </DropdownMenuPrimitive.Item>

--- a/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
+++ b/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
@@ -50,53 +50,58 @@ const variants = cva(
 const DropdownMenuItemBase = React.forwardRef<
     React.ElementRef<typeof DropdownMenuPrimitive.Item>,
     DropdownMenuItemProps
->(({ className, icon, text, readOnly, variant, disabled, onClick, children, ...linkProps }, ref) => {
-    const { linkComponent: LinkComponent } = useAdminUi();
+>(
+    (
+        { className, icon, text, readOnly, variant, disabled, onClick, children, ...linkProps },
+        ref
+    ) => {
+        const { linkComponent: LinkComponent } = useAdminUi();
 
-    if (children) {
+        if (children) {
+            return (
+                <DropdownMenuSubRoot>
+                    <DropdownMenuSubTrigger>
+                        {icon}
+                        <span>{text}</span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuPortal>
+                        <DropdownMenuSubContent>{children}</DropdownMenuSubContent>
+                    </DropdownMenuPortal>
+                </DropdownMenuSubRoot>
+            );
+        }
+        const sharedProps = {
+            className: cn(
+                "flex px-sm py-xs-plus gap-sm-extra items-center text-md rounded-sm transition-colors group-focus:bg-neutral-dimmed",
+                {
+                    "[&_svg]:fill-neutral-disabled!": disabled
+                }
+            )
+        };
+
+        const content = linkProps.to ? (
+            <LinkComponent {...sharedProps} {...linkProps}>
+                {icon}
+                <span>{text}</span>
+            </LinkComponent>
+        ) : (
+            <div {...sharedProps} onClick={onClick}>
+                {icon}
+                <span>{text}</span>
+            </div>
+        );
+
         return (
-            <DropdownMenuSubRoot>
-                <DropdownMenuSubTrigger>
-                    {icon}
-                    <span>{text}</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                    <DropdownMenuSubContent>{children}</DropdownMenuSubContent>
-                </DropdownMenuPortal>
-            </DropdownMenuSubRoot>
+            <DropdownMenuPrimitive.Item
+                disabled={disabled}
+                ref={ref}
+                className={cn(variants({ readOnly, variant }), className)}
+            >
+                {content}
+            </DropdownMenuPrimitive.Item>
         );
     }
-    const sharedProps = {
-        className: cn(
-            "flex px-sm py-xs-plus gap-sm-extra items-center text-md rounded-sm transition-colors group-focus:bg-neutral-dimmed",
-            {
-                "[&_svg]:fill-neutral-disabled!": disabled
-            }
-        )
-    };
-
-    const content = linkProps.to ? (
-        <LinkComponent {...sharedProps} {...linkProps}>
-            {icon}
-            <span>{text}</span>
-        </LinkComponent>
-    ) : (
-        <div {...sharedProps} onClick={onClick}>
-            {icon}
-            <span>{text}</span>
-        </div>
-    );
-
-    return (
-        <DropdownMenuPrimitive.Item
-            disabled={disabled}
-            ref={ref}
-            className={cn(variants({ readOnly, variant }), className)}
-        >
-            {content}
-        </DropdownMenuPrimitive.Item>
-    );
-});
+);
 
 DropdownMenuItemBase.displayName = DropdownMenuPrimitive.Item.displayName;
 

--- a/packages/app-aco/src/components/Actions/DeleteFolder/DeleteFolder.tsx
+++ b/packages/app-aco/src/components/Actions/DeleteFolder/DeleteFolder.tsx
@@ -26,7 +26,7 @@ export const DeleteFolder = () => {
             label={"Delete"}
             onAction={onAction}
             data-testid={"aco.actions.folder.delete"}
-            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+            variant={"destructive"}
         />
     );
 };

--- a/packages/app-admin/src/components/OptionsMenu/OptionsMenuItem.tsx
+++ b/packages/app-admin/src/components/OptionsMenu/OptionsMenuItem.tsx
@@ -6,6 +6,7 @@ export interface OptionsMenuItemProps {
     disabled?: boolean;
     icon: React.ReactElement;
     label: string;
+    variant?: "destructive";
     ["data-testid"]?: string;
     className?: string;
 }
@@ -20,6 +21,7 @@ export const OptionsMenuItem = (props: OptionsMenuItemProps) => {
             data-testid={props["data-testid"]}
             icon={<DropdownMenu.Item.Icon label={props.label} element={props.icon} />}
             text={props.label}
+            variant={props.variant}
             className={props.className}
         />
     );

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/DeleteEntry.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/Table/Actions/DeleteEntry.tsx
@@ -23,7 +23,7 @@ export const DeleteEntry = () => {
             label={"Trash"}
             onAction={deleteEntry}
             data-testid={"aco.actions.entry.delete"}
-            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+            variant={"destructive"}
         />
     );
 };

--- a/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
+++ b/packages/app-headless-cms/src/admin/components/FieldEditor/Field.tsx
@@ -273,7 +273,7 @@ const Field = (props: FieldProps) => {
                                     label={t`Delete`}
                                 />
                             }
-                            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+                            variant={"destructive"}
                         />
                     </DropdownMenu>
                 </div>

--- a/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList/RevisionListItem.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentEntries/ContentEntry/RevisionsList/RevisionListItem.tsx
@@ -165,7 +165,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                                     onClick={() => deleteRevision()}
                                     icon={<DeleteIcon />}
                                     text={t` Delete revision`}
-                                    className={"text-destructive-primary! [&_svg]:fill-destructive"}
+                                    variant={"destructive"}
                                 />
                             </>
                         )}

--- a/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
+++ b/packages/app-headless-cms/src/admin/views/contentModels/ContentModelsDataList.tsx
@@ -377,9 +377,7 @@ const ContentModelsDataList = ({
                                                                 data-testid={
                                                                     "cms-delete-content-model-button"
                                                                 }
-                                                                className={
-                                                                    "text-destructive-primary! [&_svg]:fill-destructive"
-                                                                }
+                                                                variant={"destructive"}
                                                             />
                                                         )}
                                                     </DropdownMenu>

--- a/packages/app-trash-bin/src/Presentation/components/Actions/DeleteItem/DeleteItem.tsx
+++ b/packages/app-trash-bin/src/Presentation/components/Actions/DeleteItem/DeleteItem.tsx
@@ -13,7 +13,7 @@ export const DeleteItemAction = () => {
             icon={<Delete />}
             label={"Delete"}
             onAction={openDialogDeleteItem}
-            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+            variant={"destructive"}
         />
     );
 };

--- a/packages/app-website-builder/src/modules/pages/PageEditor/Revisions/RevisionListItem.tsx
+++ b/packages/app-website-builder/src/modules/pages/PageEditor/Revisions/RevisionListItem.tsx
@@ -163,9 +163,7 @@ const RevisionListItem = ({ revision }: RevisionListItemProps) => {
                                         onClick={() => deleteRevision()}
                                         icon={<DeleteIcon />}
                                         text={t`Delete revision`}
-                                        className={
-                                            "text-destructive-primary! [&_svg]:fill-destructive"
-                                        }
+                                        variant={"destructive"}
                                     />
                                 </>
                             ) : null}

--- a/packages/app-website-builder/src/modules/pages/PagesList/components/Table/Actions/Delete.tsx
+++ b/packages/app-website-builder/src/modules/pages/PagesList/components/Table/Actions/Delete.tsx
@@ -14,7 +14,7 @@ export const Delete = () => {
             icon={<DeleteIcon />}
             label={"Trash"}
             onAction={openDeletePageConfirmationDialog}
-            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+            variant={"destructive"}
         />
     );
 };

--- a/packages/app-website-builder/src/presentation/redirects/RedirectList/components/Table/Actions/Delete.tsx
+++ b/packages/app-website-builder/src/presentation/redirects/RedirectList/components/Table/Actions/Delete.tsx
@@ -15,7 +15,7 @@ export const Delete = () => {
             icon={<DeleteIcon />}
             label={"Delete"}
             onAction={openDeleteDialog}
-            className={"text-destructive-primary! [&_svg]:fill-destructive"}
+            variant={"destructive"}
         />
     );
 };

--- a/packages/tenant-manager/src/admin/TenantEntryList.tsx
+++ b/packages/tenant-manager/src/admin/TenantEntryList.tsx
@@ -28,7 +28,7 @@ const WithDisableAction = ({ children }: WithDisableActionProps) => {
                 label={"Disable"}
                 onAction={disableEntry}
                 data-testid={"aco.actions.entry.delete"}
-                className={"text-destructive-primary! [&_svg]:fill-destructive"}
+                variant={"destructive"}
             />
         );
     }

--- a/packages/webhooks/src/admin/presentation/WebhookList/components/WebhookListContent.tsx
+++ b/packages/webhooks/src/admin/presentation/WebhookList/components/WebhookListContent.tsx
@@ -158,7 +158,7 @@ export const WebhookListContent = observer(function WebhookListContent({
                         <HasPermission entity="webhook" action="delete">
                             <DropdownMenu.Separator />
                             <DropdownMenu.Item
-                                className={"text-destructive-primary! [&_svg]:fill-destructive"}
+                                variant={"destructive"}
                                 onClick={() => {
                                     showDeleteConfirmation(() => presenter.deleteWebhook(row.id));
                                 }}


### PR DESCRIPTION
### What changed

Destructive actions in dropdown menus (e.g. **Delete**, **Trash**, **Disable**) previously required authors to hand-copy a Tailwind className string (`text-destructive-primary! [&_svg]:fill-destructive`) onto every menu item to get the red styling. This was repeated across nearly every Delete button in the app and was easy to get wrong.

`DropdownMenu.Item` now exposes a first-class `variant="destructive"` prop, mirroring the variant pattern already used by `Button` and `Tag`. The shared `OptionsMenuItem` wrapper (re-exported as `EntryAction.OptionsMenuItem`, page/folder action menus, etc.) forwards the prop too, so every consumer gets it for free. All existing destructive menu items across Headless CMS, Page Builder, Tenant Manager, Trash Bin, ACO, and Webhooks were migrated from the className blob to `variant="destructive"`. There is no visual change — the rendered styling is identical.

### Changelog

**Title line:** Reusable "destructive" styling for dropdown menu items

**Body:** Adding red styling to Delete-style menu items used to require copy-pasting a long, error-prone class string onto every button. You can now mark such items as destructive with a single property, and all existing Delete actions have been updated to use it. The appearance is unchanged.

### Squash Merge Commit

```
feat: add destructive variant to DropdownMenu.Item (#5310)
```

```
refactor: use destructive menu item variant for delete actions (#5310)
```
