### PR TITLE
fix(app-admin): merge permission groups by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.nx
 .webpack
 .webiny
 .artifacts

--- a/packages/app-admin/src/components/Permissions/Permissions.tsx
+++ b/packages/app-admin/src/components/Permissions/Permissions.tsx
@@ -5,6 +5,7 @@ import { useAdminConfig } from "~/config/AdminConfig.js";
 import type { PermissionRendererConfig } from "~/permissions/types.js";
 import { PermissionValueProvider } from "~/permissions/PermissionValueContext.js";
 import { PermissionRenderer } from "~/permissions/PermissionRenderer.js";
+import { mergeByName } from "./mergeByName.js";
 
 const byTitle = (a: PermissionRendererConfig, b: PermissionRendererConfig) => {
     return a.title.localeCompare(b.title);
@@ -21,7 +22,7 @@ export const Permissions = ({ id, value, onChange }: PermissionsProps) => {
         const systemRenderers: PermissionRendererConfig[] = [];
         const appRenderers: PermissionRendererConfig[] = [];
 
-        for (const renderer of permissionRenderers) {
+        for (const renderer of mergeByName(permissionRenderers)) {
             if (renderer.system) {
                 systemRenderers.push(renderer);
             } else {

--- a/packages/app-admin/src/components/Permissions/index.ts
+++ b/packages/app-admin/src/components/Permissions/index.ts
@@ -1,4 +1,5 @@
 export * from "./StyledComponents.js";
 export { Permissions } from "./Permissions.js";
+export { mergeByName } from "./mergeByName.js";
 export { CannotUseAaclAlert } from "./CannotUseAaclAlert.js";
 export * from "./PermissionsGroup.js";

--- a/packages/app-admin/src/components/Permissions/mergeByName.ts
+++ b/packages/app-admin/src/components/Permissions/mergeByName.ts
@@ -1,0 +1,50 @@
+import type { PermissionRendererConfig } from "~/permissions/types.js";
+
+/**
+ * Collapses renderers that share the same group `name` into a single renderer,
+ * concatenating their schema entities (deduped by entity id). This lets multiple
+ * apps contribute their own entities to one shared permission group (e.g. several
+ * dev tools each registering into "dev-tools") while the UI still shows one group.
+ *
+ * Group metadata (title, description, icon, system) is taken from the first
+ * registration of a given name; subsequent registrations only add entities.
+ */
+export const mergeByName = (renderers: PermissionRendererConfig[]): PermissionRendererConfig[] => {
+    const byName = new Map<string, PermissionRendererConfig>();
+
+    for (const renderer of renderers) {
+        const existing = byName.get(renderer.name);
+
+        if (!existing) {
+            // Clone the schema (and its entities) so we never mutate the registered config.
+            byName.set(
+                renderer.name,
+                renderer.schema
+                    ? {
+                          ...renderer,
+                          schema: {
+                              ...renderer.schema,
+                              entities: [...(renderer.schema.entities ?? [])]
+                          }
+                      }
+                    : { ...renderer }
+            );
+            continue;
+        }
+
+        // Merge additional entities into the already-seen group.
+        if (existing.schema && renderer.schema) {
+            const entities = existing.schema.entities ?? [];
+            const seen = new Set(entities.map(entity => entity.id));
+            for (const entity of renderer.schema.entities ?? []) {
+                if (!seen.has(entity.id)) {
+                    entities.push(entity);
+                    seen.add(entity.id);
+                }
+            }
+            existing.schema.entities = entities;
+        }
+    }
+
+    return Array.from(byName.values());
+};

--- a/packages/app-admin/src/config/AdminConfig/SecurityPermissions.tsx
+++ b/packages/app-admin/src/config/AdminConfig/SecurityPermissions.tsx
@@ -27,10 +27,18 @@ export const SecurityPermissions = ({
 }: SecurityPermissionsProps) => {
     const getId = useIdGenerator("SecurityPermissions");
 
+    // Multiple apps may contribute to the same permission group (same `name`), each
+    // declaring only its own entities. If they all registered under the same id, the
+    // last one would overwrite the others in the PropertyStore (same id => last write
+    // wins). So we append the entity ids to make each registration's id unique — e.g.
+    // "...:dev-tools:graphql-playground" vs "...:dev-tools:sdk-playground". They are
+    // merged back together by `name` at render time (see `Permissions.tsx`).
+    const entityIds = schema?.entities?.map(entity => entity.id) ?? [];
+
     return (
         <ConnectToProperties name={"AdminConfig"}>
             <Property
-                id={getId(name)}
+                id={getId(name, ...entityIds)}
                 name={"permissionRenderers"}
                 array={true}
                 value={{ name, title, description, icon, schema, element, system }}

--- a/packages/app-graphql-playground/src/PermissionsSchema.ts
+++ b/packages/app-graphql-playground/src/PermissionsSchema.ts
@@ -9,12 +9,6 @@ export const DEV_TOOLS_PERMISSIONS_SCHEMA = createPermissionSchema({
             title: "GraphQL Playground",
             permission: "dev-tools.graphql-playground.*",
             scopes: ["full"]
-        },
-        {
-            id: "sdk-playground",
-            title: "SDK Playground",
-            permission: "dev-tools.sdk-playground.*",
-            scopes: ["full"]
         }
     ]
 });

--- a/packages/app-sdk-playground/src/PermissionsSchema.ts
+++ b/packages/app-sdk-playground/src/PermissionsSchema.ts
@@ -5,12 +5,6 @@ export const DEV_TOOLS_PERMISSIONS_SCHEMA = createPermissionSchema({
     fullAccess: true,
     entities: [
         {
-            id: "graphql-playground",
-            title: "GraphQL Playground",
-            permission: "dev-tools.graphql-playground.*",
-            scopes: ["full"]
-        },
-        {
             id: "sdk-playground",
             title: "SDK Playground",
             permission: "dev-tools.sdk-playground.*",


### PR DESCRIPTION
### What changed

Previously the GraphQL Playground and SDK Playground apps each declared the *entire* "Dev Tools" permission group — including the other app's entity — because permission groups registered under the same name overwrote one another, so each app had to ship the full list to stay complete. This meant an admin could see (and toggle) a permission for an app that wasn't even installed.

Now each app declares only its own entity. The admin permissions UI merges all contributions that share a group name into a single "Dev Tools" group, combining their entities. Installing either playground (or both) shows exactly the right set of permissions, and any future dev tool can add its own entity without touching the others.

### Changelog

**Dev Tools permissions no longer duplicated across playground apps**

The GraphQL Playground and SDK Playground apps each used to register the other app's permissions as well as their own, which could show permissions for apps that weren't installed. Each app now contributes only its own permissions, and they're combined into a single "Dev Tools" group automatically.

### Squash Merge Commit

```
refactor(app-admin): merge permission groups by name (#5338)
```
