### PR TITLE
fix(app-website-builder): always show list revisions in rev menu

### DIFF
--- a/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryRevisionFromDataFactory/CreateEntryRevisionFromDataFactory.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryRevisionFromDataFactory/CreateEntryRevisionFromDataFactory.ts
@@ -5,7 +5,6 @@ import {
     type ICreateEntryRevisionFromDataResponse
 } from "./abstractions.js";
 import { AccessControl, CmsContext } from "~/features/shared/abstractions.js";
-import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
 import type {
     CmsEntry,
@@ -50,7 +49,6 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
     public constructor(
         private readonly cmsContext: CmsContext.Interface,
         private readonly identityContext: IdentityContext.Interface,
-        private readonly tenantContext: TenantContext.Interface,
         private readonly accessControl: AccessControl.Interface
     ) {}
 
@@ -189,6 +187,7 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
             revisionCreatedBy: getIdentity(rawInput.revisionCreatedBy, currentIdentity)!,
             revisionSavedBy: getIdentity(rawInput.revisionSavedBy, currentIdentity)!,
             revisionModifiedBy: getIdentity(rawInput.revisionModifiedBy, null),
+            revisionDescription: undefined,
             ...revisionLevelPublishingMetaFields,
             locked,
             status,
@@ -214,5 +213,5 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
 export const CreateEntryRevisionFromDataFactory = createImplementation({
     abstraction: FactoryAbstraction,
     implementation: CreateEntryRevisionFromDataFactoryImpl,
-    dependencies: [CmsContext, IdentityContext, TenantContext, AccessControl]
+    dependencies: [CmsContext, IdentityContext, AccessControl]
 });

--- a/packages/app-website-builder/src/presentation/pages/PageEditor/TopBar/RevisionsMenu.tsx
+++ b/packages/app-website-builder/src/presentation/pages/PageEditor/TopBar/RevisionsMenu.tsx
@@ -79,20 +79,17 @@ export const RevisionsMenu = () => {
                     text={<Text size={"sm"}>{revision.getLabel()}</Text>}
                 />
             ))}
-            {revisions.length > 5 ? (
-                <>
-                    <DropdownMenu.Separator />
-                    <DropdownMenu.Item
-                        key={"revisions-all"}
-                        onClick={onOpenRevisionList}
-                        text={
-                            <>
-                                <Text size={"sm"}>Show All Revisions</Text>
-                            </>
-                        }
-                    />
-                </>
-            ) : null}
+
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+                key={"revisions-all"}
+                onClick={onOpenRevisionList}
+                text={
+                    <>
+                        <Text size={"sm"}>Show All Revisions</Text>
+                    </>
+                }
+            />
         </DropdownMenu>
     );
 };

--- a/packages/app-website-builder/src/presentation/pages/PageList/hooks/usePublishPageConfirmationDialog.tsx
+++ b/packages/app-website-builder/src/presentation/pages/PageList/hooks/usePublishPageConfirmationDialog.tsx
@@ -1,7 +1,39 @@
-import React, { useCallback } from "react";
-import { usePublishPage } from "~/features/pages/index.js";
+import React, { useCallback, useRef, useState } from "react";
+import { Text, Textarea } from "@webiny/admin-ui";
+import { usePublishPage, useUpdatePageRevisionDescription } from "~/features/pages/index.js";
 import { useConfirmationDialog, useSnackbar } from "@webiny/app-admin";
 import type { PageDto } from "~/domain/Page/index.js";
+
+interface IDialogContentMessageProps {
+    title: string;
+    onDescriptionChange: (value: string) => void;
+}
+
+const DialogContentMessage = (props: IDialogContentMessageProps) => {
+    const { onDescriptionChange, title } = props;
+    const [revisionDescription, setRevisionDescription] = useState("");
+
+    const onChange = useCallback(
+        (value: string) => {
+            setRevisionDescription(value);
+            onDescriptionChange(value);
+        },
+        [onDescriptionChange]
+    );
+
+    return (
+        <>
+            <Text>
+                You are about to publish <strong>{title}</strong>. Are you sure you want to
+                continue?
+            </Text>
+            <Text size={"sm"} className={"mt-2"}>
+                Write a revision description (optional):
+            </Text>
+            <Textarea value={revisionDescription} onChange={onChange} />
+        </>
+    );
+};
 
 interface UsePublishPageConfirmationDialogProps {
     page: PageDto;
@@ -12,14 +44,20 @@ export const usePublishPageConfirmationDialog = ({
 }: UsePublishPageConfirmationDialogProps) => {
     const { publishPage } = usePublishPage();
     const { showSnackbar } = useSnackbar();
+    const revisionDescriptionRef = useRef("");
+    const { updatePageRevisionDescription } = useUpdatePageRevisionDescription();
+
+    const onDescriptionChange = useCallback((value: string) => {
+        revisionDescriptionRef.current = value;
+    }, []);
 
     const { showConfirmation } = useConfirmationDialog({
         title: "Publish page",
         message: (
-            <p>
-                You are about to publish <strong>{page.properties.title}</strong>. Are you sure you
-                want to continue?
-            </p>
+            <DialogContentMessage
+                title={page.properties.title}
+                onDescriptionChange={onDescriptionChange}
+            />
         )
     });
 
@@ -27,6 +65,10 @@ export const usePublishPageConfirmationDialog = ({
         () =>
             showConfirmation(async () => {
                 try {
+                    await updatePageRevisionDescription({
+                        id: page.id,
+                        revisionDescription: revisionDescriptionRef.current
+                    });
                     await publishPage({ id: page.id });
                     showSnackbar(`${page.properties.title} was published successfully!`);
                 } catch (ex) {


### PR DESCRIPTION
## Changes
Always show "All revisions" option in revisions menu when editing a page.
Fix for api-headless-cms to put blank revision description when creating a revision from existing revision.

## How Has This Been Tested?
Manually.