### PR TITLE
refactor(app-headless-cms): new revision button

### DIFF
--- a/packages/app-headless-cms/src/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/ContentEntriesModule.tsx
@@ -147,12 +147,12 @@ export const ContentEntriesModule = () => {
                     />
                 </IsModelPublishable>
                 <Actions.ButtonAction name={"optionsMenu"} element={<ContentFormOptionsMenu />} />
-                <Actions.ButtonAction
-                    name={"createNewRevision"}
-                    element={<CreateNewRevisionButton />}
-                />
                 <Actions.ButtonAction name={"save"} element={<SaveContentButton />} />
                 <IsModelPublishable>
+                    <Actions.ButtonAction
+                        name={"createNewRevision"}
+                        element={<CreateNewRevisionButton />}
+                    />
                     <Actions.ButtonAction name={"publish"} element={<SaveAndPublishButton />} />
                 </IsModelPublishable>
                 <Actions.MenuItemAction

--- a/packages/app-headless-cms/src/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/ContentEntriesModule.tsx
@@ -48,6 +48,7 @@ import { SaveContentButton } from "~/presentation/contentEntries/views/actions/S
 import { SaveAndPublishButton } from "~/presentation/contentEntries/views/actions/SaveAndPublishButton.js";
 import { DeleteEntryMenuItem } from "~/presentation/contentEntries/views/actions/DeleteEntryMenuItem.js";
 import { ShowRevisionListMenuItem } from "~/presentation/contentEntries/views/actions/ShowRevisionListMenuItem.js";
+import { CreateNewRevisionButton } from "~/presentation/contentEntries/views/actions/CreateNewRevisionButton.js";
 
 const { Browser } = InternalContentEntryListConfig;
 const { Actions } = ContentEntryEditorConfig;
@@ -146,6 +147,10 @@ export const ContentEntriesModule = () => {
                     />
                 </IsModelPublishable>
                 <Actions.ButtonAction name={"optionsMenu"} element={<ContentFormOptionsMenu />} />
+                <Actions.ButtonAction
+                    name={"createNewRevision"}
+                    element={<CreateNewRevisionButton />}
+                />
                 <Actions.ButtonAction name={"save"} element={<SaveContentButton />} />
                 <IsModelPublishable>
                     <Actions.ButtonAction name={"publish"} element={<SaveAndPublishButton />} />

--- a/packages/app-headless-cms/src/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/ContentEntriesModule.tsx
@@ -150,7 +150,7 @@ export const ContentEntriesModule = () => {
                 <Actions.ButtonAction name={"save"} element={<SaveContentButton />} />
                 <IsModelPublishable>
                     <Actions.ButtonAction
-                        name={"createNewRevision"}
+                        name={"cms/createNewRevision"}
                         element={<CreateNewRevisionButton />}
                     />
                     <Actions.ButtonAction name={"publish"} element={<SaveAndPublishButton />} />

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
@@ -105,6 +105,8 @@ class ContentEntryFormPresenterImpl implements Abstraction.Interface {
             entry: toJS(this.entry),
             form: this.form?.vm ?? null,
             canSave,
+            canCreateNewRevision:
+                !!status && canSave && ["published", "unpublished"].includes(status),
             canPublish: this.entry !== null && status !== "published",
             canUnpublish: this.entry !== null && status === "published",
             canDelete: this.entry !== null,

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
@@ -7,6 +7,7 @@ import type { CmsModel } from "~/types.js";
 export interface IContentEntryFormViewModel {
     loading: string | null;
     entry: CmsContentEntry | null;
+    canCreateNewRevision: boolean;
     model: CmsModel;
     form: FormModel.FormVM | null;
     canSave: boolean;

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
@@ -3,19 +3,25 @@ import { observer } from "mobx-react-lite";
 import { Button, useToast } from "@webiny/admin-ui";
 import { usePermission } from "~/admin/hooks/usePermission.js";
 import { useContentEntryFormPresenter } from "~/presentation/contentEntries/form/useContentEntryFormPresenter.js";
-import { useContentEntriesPresenter } from "~/presentation/contentEntries/list/useContentEntriesPresenter.js";
+import { ReactComponent as NewRevisionIcon } from "@webiny/icons/add.svg";
 
-export const SaveContentButton = observer(() => {
+export const CreateNewRevisionButton = observer(() => {
     const { canEdit } = usePermission();
     const presenter = useContentEntryFormPresenter();
-    const listPresenter = useContentEntriesPresenter();
     const { showSuccessToast } = useToast();
-
+    
+    console.log({
+        entry: presenter.vm.entry,
+        canCreateNewRevision: presenter.vm.canCreateNewRevision,
+        canEdit: canEdit(presenter.vm.entry!, "cms.contentEntry")
+    });
+    
     if (
-        presenter.vm.canCreateNewRevision ||
-        !presenter.vm.canSave ||
-        (presenter.vm.entry && !canEdit(presenter.vm.entry, "cms.contentEntry"))
+        !presenter.vm.entry ||
+        !presenter.vm.canCreateNewRevision ||
+        !canEdit(presenter.vm.entry, "cms.contentEntry")
     ) {
+
         return null;
     }
 
@@ -23,24 +29,21 @@ export const SaveContentButton = observer(() => {
         const model = presenter.vm.model;
         const isPublishable = !model.tags.includes("$publishing:false");
 
-        const isNew = presenter.vm.isNewEntry;
         const saved = await presenter.saveRevision({ skipValidation: isPublishable });
-        if (saved) {
-            if (isNew && presenter.vm.entry) {
-                listPresenter.selectEntry(presenter.vm.entry.id);
-            }
-            showSuccessToast({
-                title: `${presenter.vm.entry?.meta?.title || "Entry"} saved successfully!`
-            });
+        if (!saved) {
+            return;
         }
+        showSuccessToast({
+            title: `A new revision of "${presenter.vm.entry?.meta?.title || "Entry"}" was created!`
+        });
     };
 
     return (
         <Button
-            variant={"secondary"}
-            data-testid={"cms-content-save-content-button"}
+            variant="primary"
+            text={"New Revision"}
             onClick={handleSave}
-            text={"Save"}
+            icon={<NewRevisionIcon />}
         />
     );
 });

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
@@ -9,20 +9,12 @@ export const CreateNewRevisionButton = observer(() => {
     const { canEdit } = usePermission();
     const presenter = useContentEntryFormPresenter();
     const { showSuccessToast } = useToast();
-    
-    console.log({
-        CreateNewRevisionButton: true,
-        entry: presenter.vm.entry,
-        canCreateNewRevision: presenter.vm.canCreateNewRevision,
-        canEdit: canEdit(presenter.vm.entry!, "cms.contentEntry")
-    });
-    
+
     if (
         !presenter.vm.entry ||
         !presenter.vm.canCreateNewRevision ||
         !canEdit(presenter.vm.entry, "cms.contentEntry")
     ) {
-
         return null;
     }
 

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
@@ -11,6 +11,7 @@ export const CreateNewRevisionButton = observer(() => {
     const { showSuccessToast } = useToast();
     
     console.log({
+        CreateNewRevisionButton: true,
         entry: presenter.vm.entry,
         canCreateNewRevision: presenter.vm.canCreateNewRevision,
         canEdit: canEdit(presenter.vm.entry!, "cms.contentEntry")

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/SaveContentButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/SaveContentButton.tsx
@@ -10,7 +10,14 @@ export const SaveContentButton = observer(() => {
     const presenter = useContentEntryFormPresenter();
     const listPresenter = useContentEntriesPresenter();
     const { showSuccessToast } = useToast();
-
+    
+    console.log({
+        SaveContentButton: true,
+        entry: presenter.vm.entry,
+        canCreateNewRevision: presenter.vm.canCreateNewRevision,
+        canEdit: canEdit(presenter.vm.entry!, "cms.contentEntry")
+    });
+    
     if (
         presenter.vm.canCreateNewRevision ||
         !presenter.vm.canSave ||

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/SaveContentButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/SaveContentButton.tsx
@@ -10,14 +10,7 @@ export const SaveContentButton = observer(() => {
     const presenter = useContentEntryFormPresenter();
     const listPresenter = useContentEntriesPresenter();
     const { showSuccessToast } = useToast();
-    
-    console.log({
-        SaveContentButton: true,
-        entry: presenter.vm.entry,
-        canCreateNewRevision: presenter.vm.canCreateNewRevision,
-        canEdit: canEdit(presenter.vm.entry!, "cms.contentEntry")
-    });
-    
+
     if (
         presenter.vm.canCreateNewRevision ||
         !presenter.vm.canSave ||

--- a/packages/app-website-builder/src/presentation/pages/PageEditor/TopBar/NewRevisionButton.tsx
+++ b/packages/app-website-builder/src/presentation/pages/PageEditor/TopBar/NewRevisionButton.tsx
@@ -14,7 +14,7 @@ export const NewRevisionButton = () => {
 
     const id = useSelectFromDocument(document => document.id);
 
-    const publish = () => {
+    const createNewRevision = () => {
         showDialog({
             title: "Create a new page revision",
             icon: <NewRevisionIcon />,
@@ -40,7 +40,7 @@ export const NewRevisionButton = () => {
         <Button
             variant="primary"
             text={"New Revision"}
-            onClick={publish}
+            onClick={createNewRevision}
             icon={<NewRevisionIcon />}
         />
     );


### PR DESCRIPTION
## Changes
Add a `New Revision` button when editing an entry - if entry is published or unpublished.


## How Has This Been Tested?
Manually.