### PR TITLE
refactor(app-headless-cms): publish only on unpublished

### DIFF
--- a/packages/app-headless-cms/src/ContentEntriesModule.tsx
+++ b/packages/app-headless-cms/src/ContentEntriesModule.tsx
@@ -49,6 +49,7 @@ import { SaveAndPublishButton } from "~/presentation/contentEntries/views/action
 import { DeleteEntryMenuItem } from "~/presentation/contentEntries/views/actions/DeleteEntryMenuItem.js";
 import { ShowRevisionListMenuItem } from "~/presentation/contentEntries/views/actions/ShowRevisionListMenuItem.js";
 import { CreateNewRevisionButton } from "~/presentation/contentEntries/views/actions/CreateNewRevisionButton.js";
+import { PublishOnlyButton } from "~/presentation/contentEntries/views/actions/PublishOnlyButton.js";
 
 const { Browser } = InternalContentEntryListConfig;
 const { Actions } = ContentEntryEditorConfig;
@@ -154,6 +155,7 @@ export const ContentEntriesModule = () => {
                         element={<CreateNewRevisionButton />}
                     />
                     <Actions.ButtonAction name={"publish"} element={<SaveAndPublishButton />} />
+                    <Actions.ButtonAction name={"publishOnly"} element={<PublishOnlyButton />} />
                 </IsModelPublishable>
                 <Actions.MenuItemAction
                     name={"delete"}

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
@@ -105,6 +105,7 @@ class ContentEntryFormPresenterImpl implements Abstraction.Interface {
             entry: toJS(this.entry),
             form: this.form?.vm ?? null,
             canSave,
+            status,
             canCreateNewRevision:
                 !!status && canSave && ["published", "unpublished"].includes(status),
             canPublish: this.entry !== null && status !== "published",

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
@@ -1,7 +1,7 @@
 import { createAbstraction } from "@webiny/feature/admin";
 import { FormModel } from "@webiny/app-admin";
 import type { IFormModel } from "@webiny/app-admin/features/formModel/abstractions.js";
-import type { CmsContentEntry } from "~/types.js";
+import type { CmsContentEntry, CmsContentEntryStatusType } from "~/types.js";
 import type { CmsModel } from "~/types.js";
 
 export interface IContentEntryFormViewModel {
@@ -10,6 +10,7 @@ export interface IContentEntryFormViewModel {
     canCreateNewRevision: boolean;
     model: CmsModel;
     form: FormModel.FormVM | null;
+    status: CmsContentEntryStatusType | undefined;
     canSave: boolean;
     canPublish: boolean;
     canUnpublish: boolean;

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/CreateNewRevisionButton.tsx
@@ -33,7 +33,7 @@ export const CreateNewRevisionButton = observer(() => {
 
     return (
         <Button
-            variant="primary"
+            variant={"secondary"}
             text={"New Revision"}
             onClick={handleSave}
             icon={<NewRevisionIcon />}

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/actions/PublishOnlyButton.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/actions/PublishOnlyButton.tsx
@@ -4,35 +4,31 @@ import { ContentEntryEditorConfig } from "~/admin/config/contentEntries/index.js
 import { usePermission } from "~/admin/hooks/usePermission.js";
 import { useContentEntryFormPresenter } from "~/presentation/contentEntries/form/useContentEntryFormPresenter.js";
 
-export const SaveAndPublishButton = observer(() => {
+export const PublishOnlyButton = observer(() => {
     const presenter = useContentEntryFormPresenter();
     const { ButtonPrimary } = ContentEntryEditorConfig.Actions.ButtonAction.useButtons();
-    const { canEdit, canPublish } = usePermission();
+    const { canPublish } = usePermission();
 
     if (
         !presenter.vm.canPublish ||
-        (presenter.vm.status === "unpublished" && !presenter.vm.isDirty) ||
-        (presenter.vm.entry && !canEdit(presenter.vm.entry, "cms.contentEntry")) ||
+        presenter.vm.isDirty ||
+        presenter.vm.status !== "unpublished" ||
         !canPublish("cms.contentEntry")
     ) {
         return null;
     }
 
-    const saveAndPublish = async () => {
-        const saved = await presenter.saveRevision({ skipValidation: false });
-        if (!saved) {
-            return;
-        }
+    const publish = async () => {
         await presenter.publishRevision();
     };
 
     return (
         <ButtonPrimary
-            onAction={saveAndPublish}
+            onAction={publish}
             disabled={presenter.vm.loading !== null}
-            data-testid="cms-content-save-publish-content-button"
+            data-testid="cms-content-publish-content-button"
         >
-            {"Save & Publish"}
+            {"Publish"}
         </ButtonPrimary>
     );
 });


### PR DESCRIPTION
## Changes
When entry was published and then unpublished, now there is a `New Revision` and `Publish`buttons.

## How Has This Been Tested?
Manually.