### PR TITLE
feat(app-headless-cms): add configurable New Entry Wizard

### DIFF
--- a/extensions/newEntryWizardDemo/Route.ts
+++ b/extensions/newEntryWizardDemo/Route.ts
@@ -1,0 +1,16 @@
+import { Route } from "webiny/admin/router";
+
+export const EntryRoute = new Route({
+    name: "Cms/ContentEntries/List",
+    path: "/cms/content-entries/:modelId",
+    params: zod => {
+        return {
+            modelId: zod.string(),
+            id: zod.string().optional(),
+            folderId: zod.string().optional(),
+            search: zod.string().optional(),
+            new: zod.boolean().optional(),
+            customFlag: zod.boolean().optional()
+        };
+    }
+});

--- a/extensions/newEntryWizardDemo/WizardForm.tsx
+++ b/extensions/newEntryWizardDemo/WizardForm.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from "react";
+import { useFeature, createReactiveComponent } from "webiny/admin";
+import { useContentEntryFormPresenter } from "webiny/admin/cms/entry/editor";
+import { FormView, FormErrors } from "webiny/admin/form";
+import { Button } from "webiny/admin/ui";
+import { WizardFormPresenterFeature } from "./WizardFormPresenter.js";
+
+export const WizardForm = createReactiveComponent(() => {
+    const { presenter } = useFeature(WizardFormPresenterFeature);
+    const formPresenter = useContentEntryFormPresenter();
+
+    const handleSubmit = useCallback(async () => {
+        const data = await presenter.submit();
+        if (data !== false) {
+            // Remap data for the actual entry form
+            formPresenter.newEntry({
+                title: data.title,
+                description: data.description,
+                settings: {
+                    internalTitle: data.title
+                }
+            });
+        }
+    }, [presenter, formPresenter]);
+
+    const { form } = presenter.vm;
+
+    return (
+        <div className="flex justify-center pt-xl">
+            <div
+                className="bg-neutral-base rounded-lg p-lg flex flex-col gap-md"
+                style={{ width: 600 }}
+            >
+                <h3 className="text-lg font-semibold">New Article Wizard</h3>
+                <p className={"text-neutral-muted"}>
+                    This is a demo extension for "article" model.
+                    <br />
+                    Disable it in webiny.config.tsx if it's getting in your way.
+                </p>
+                <FormErrors form={form} />
+                <FormView name="NewEntryWizard" form={form} />
+                <div className="flex justify-end gap-sm">
+                    <Button variant="primary" onClick={handleSubmit}>
+                        Create Entry
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+});

--- a/extensions/newEntryWizardDemo/WizardFormPresenter.ts
+++ b/extensions/newEntryWizardDemo/WizardFormPresenter.ts
@@ -1,0 +1,65 @@
+import type { FormModel } from "webiny/admin/form";
+import { makeAutoObservable, toJS } from "mobx";
+import { createAbstraction, createFeature, FormModelFactory } from "webiny/admin";
+
+export interface WizardFormVM {
+    form: FormModel.FormVM;
+    data: Record<string, unknown>;
+}
+
+class WizardFormPresenterImpl {
+    private form: FormModel.Interface;
+
+    constructor(formFactory: FormModelFactory.Interface) {
+        this.form = formFactory.create({
+            fields: fields => ({
+                title: fields.text().label("Title").required("Title is required"),
+                description: fields.text().label("Description").required("Description is required")
+            }),
+            layout: layout => [layout.row("title"), layout.row("description")]
+        });
+
+        makeAutoObservable(this);
+    }
+
+    get vm(): WizardFormVM {
+        return {
+            form: this.form.vm,
+            data: toJS(this.form.getData())
+        };
+    }
+
+    async submit(): Promise<Record<string, unknown> | false> {
+        return this.form.submit();
+    }
+
+    reset(): void {
+        this.form.reset();
+    }
+}
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, "");
+}
+
+export const WizardFormPresenter =
+    createAbstraction<WizardFormPresenterImpl>("WizardFormPresenter");
+
+export const WizardFormPresenterFeature = createFeature({
+    name: "NewEntryWizardDemo",
+    register(container) {
+        container.register(
+            WizardFormPresenter.createImplementation({
+                implementation: WizardFormPresenterImpl,
+                dependencies: [FormModelFactory]
+            })
+        );
+    },
+    resolve(container) {
+        return { presenter: container.resolve(WizardFormPresenter) };
+    }
+});

--- a/extensions/newEntryWizardDemo/index.tsx
+++ b/extensions/newEntryWizardDemo/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { RegisterFeature } from "webiny/admin";
+import { ContentEntryEditorConfig } from "webiny/admin/cms/entry/editor";
+import { WizardFormPresenterFeature } from "./WizardFormPresenter.js";
+import { WizardForm } from "./WizardForm.js";
+
+const NewEntryWizardDemo = () => {
+    return (
+        <>
+            <RegisterFeature feature={WizardFormPresenterFeature} />
+            <ContentEntryEditorConfig>
+                <ContentEntryEditorConfig.NewEntryWizard
+                    element={<WizardForm />}
+                    modelIds={["article"]}
+                />
+            </ContentEntryEditorConfig>
+        </>
+    );
+};
+
+export default NewEntryWizardDemo;

--- a/packages/app-admin/src/exports/admin/form.ts
+++ b/packages/app-admin/src/exports/admin/form.ts
@@ -1,4 +1,6 @@
 // New Form Model
+export { FormView, FormErrors } from "~/features/formModel/index.js";
+export type { FormModel } from "~/features/formModel/index.js";
 export type {
     IFieldRendererRegistry,
     IFieldBuilderRegistry,

--- a/packages/app-admin/src/features/formModel/FormModel.ts
+++ b/packages/app-admin/src/features/formModel/FormModel.ts
@@ -254,14 +254,16 @@ export class FormModel implements IFormModel {
         return data;
     }
 
-    setData(data: Record<string, unknown>): void {
+    setData(data: Record<string, unknown>, options?: { dirty?: boolean }): void {
         for (const [name, value] of Object.entries(data)) {
             const field = this._fields.get(name);
             if (field) {
                 field.setValueSilent(value);
             }
         }
-        this._snapshotBaseline();
+        if (!options?.dirty) {
+            this._snapshotBaseline();
+        }
         this._resetAllValidation();
         this._submitted = false;
         this._submitCount = 0;
@@ -434,7 +436,8 @@ export class FormModel implements IFormModel {
             submitCount: this._submitCount,
             focusField: (path: string) => this.focusField(path),
             getData: () => this.getData() as Record<string, unknown>,
-            setData: (data: Record<string, unknown>) => this.setData(data)
+            setData: (data: Record<string, unknown>, options?: { dirty?: boolean }) =>
+                this.setData(data, options)
         };
     }
 

--- a/packages/app-admin/src/features/formModel/abstractions.ts
+++ b/packages/app-admin/src/features/formModel/abstractions.ts
@@ -701,7 +701,7 @@ export interface IFormVM {
     submitCount: number;
     focusField(path: string): void;
     getData(): Record<string, unknown>;
-    setData(data: Record<string, unknown>): void;
+    setData(data: Record<string, unknown>, options?: { dirty?: boolean }): void;
 }
 
 /**
@@ -739,7 +739,7 @@ export interface IFormModel<T = Record<string, any>> {
      */
     addRule(rule: FormRule): void;
     getData(): T;
-    setData(data: T): void;
+    setData(data: T, options?: { dirty?: boolean }): void;
     reset(): void;
     validate(): Promise<boolean>;
     submit<T = Record<string, unknown>>(options?: { skipValidation?: boolean }): Promise<T | false>;

--- a/packages/app-admin/src/features/formModel/index.ts
+++ b/packages/app-admin/src/features/formModel/index.ts
@@ -7,12 +7,12 @@ import "./renderers.js";
 // Abstractions (types + DI tokens)
 export {
     FormModelFactory,
-    FormModel,
     RuleEvaluator,
     FieldType,
     FieldBuilderRegistry
 } from "./abstractions.js";
 export type {
+    FormModel,
     IFieldRendererRegistry,
     FieldRendererName,
     FieldRendererSettings,
@@ -88,11 +88,10 @@ export type {
 } from "./abstractions.js";
 
 // Implementations
-export { FormModel as FormModelImpl } from "./FormModel.js";
 export { Field } from "./Field.js";
 export { FieldBuilder, createFieldBuilderRegistry } from "./FieldBuilder.js";
 
-// Field type augmentations (side-effect imports ensure declare module blocks are included)
+// Field type augmentations (side effect imports ensure declare module blocks are included)
 import "./fieldTypes/TextFieldType.js";
 import "./fieldTypes/NumberFieldType.js";
 import "./fieldTypes/BooleanFieldType.js";

--- a/packages/app-headless-cms-workflows/src/presentation/ContentEntryFormPresenterWorkflowDecorator.ts
+++ b/packages/app-headless-cms-workflows/src/presentation/ContentEntryFormPresenterWorkflowDecorator.ts
@@ -71,8 +71,8 @@ class ContentEntryFormPresenterWithWorkflow implements IContentEntryFormPresente
         this.original.setFolderId(folderId);
     }
 
-    newEntry(): void {
-        return this.original.newEntry();
+    newEntry(initialValues?: Record<string, unknown>): void {
+        return this.original.newEntry(initialValues);
     }
 
     reset(): void {

--- a/packages/app-headless-cms/src/admin/config/contentEntries/editor/ContentEntryEditorConfig.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/editor/ContentEntryEditorConfig.tsx
@@ -1,14 +1,16 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { createConfigurableComponent } from "@webiny/react-properties";
 import type { ActionsConfig } from "./Actions/index.js";
 import { Actions } from "./Actions/index.js";
 import { Width } from "./Width.js";
+import { NewEntryWizard } from "./NewEntryWizard.js";
 
 const base = createConfigurableComponent<ContentEntryEditorConfig>("ContentEntryEditorConfig");
 
 export const ContentEntryEditorConfig = Object.assign(base.Config, {
     Actions,
-    Width
+    Width,
+    NewEntryWizard
 });
 
 export const ContentEntryEditorWithConfig = base.WithConfig;
@@ -16,6 +18,7 @@ export const ContentEntryEditorWithConfig = base.WithConfig;
 interface ContentEntryEditorConfig {
     actions: ActionsConfig;
     width: string;
+    newEntryWizard: React.ReactElement | null;
 }
 
 export function useContentEntryEditorConfig() {
@@ -29,7 +32,8 @@ export function useContentEntryEditorConfig() {
             menuItemActions: [
                 ...(actions.filter(action => action.$type === "menu-item-action") || [])
             ],
-            width: config.width || "1020px"
+            width: config.width || "1020px",
+            newEntryWizard: (config.newEntryWizard as React.ReactElement) ?? null
         }),
         [config]
     );

--- a/packages/app-headless-cms/src/admin/config/contentEntries/editor/NewEntryWizard.tsx
+++ b/packages/app-headless-cms/src/admin/config/contentEntries/editor/NewEntryWizard.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Property } from "@webiny/react-properties";
+import { IsApplicableToCurrentModel } from "~/admin/config/IsApplicableToCurrentModel.js";
+
+export interface NewEntryWizardProps {
+    modelIds?: string[];
+    element: React.ReactElement;
+}
+
+export const NewEntryWizard = ({ element, modelIds = [] }: NewEntryWizardProps) => {
+    return (
+        <IsApplicableToCurrentModel modelIds={modelIds}>
+            <Property id="contentEntryForm:newEntryWizard" name="newEntryWizard" value={element} />
+        </IsApplicableToCurrentModel>
+    );
+};

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/ContentEntryFormPresenter.ts
@@ -303,9 +303,12 @@ class ContentEntryFormPresenterImpl implements Abstraction.Interface {
         this.folderId = folderId;
     }
 
-    newEntry(): void {
+    newEntry(initialValues?: Record<string, unknown>): void {
         this.entry = null;
         this.form = this.buildForm();
+        if (initialValues) {
+            this.form.setData(initialValues, { dirty: true });
+        }
     }
 
     reset(): void {

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/abstractions.ts
@@ -25,7 +25,7 @@ export interface IContentEntryFormPresenter {
     unpublishRevision(): Promise<boolean>;
     deleteEntry(): Promise<boolean>;
     setFolderId(folderId: string | null): void;
-    newEntry(): void;
+    newEntry(initialValues?: Record<string, unknown>): void;
     reset(): void;
 }
 

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/ContentEntryFormView.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/ContentEntryFormView.tsx
@@ -23,16 +23,22 @@ export const ContentEntryFormView = observer(() => {
     const listPresenter = useContentEntriesPresenter();
     const formPresenter = useContentEntryFormPresenter();
     const { presenter: revisionsPresenter } = useFeature(RevisionsListFeature);
-    const { width } = useContentEntryEditorConfig();
+    const { width, newEntryWizard } = useContentEntryEditorConfig();
     const router = useRouter();
     const dialogs = useDialogs();
     const { route } = useRoute(Routes.ContentEntries.List);
 
     const entryId = listPresenter.vm.selectedEntryId;
+    const { vm } = formPresenter;
+
+    const hasWizard = entryId === "new" && newEntryWizard !== null;
+    const showWizard = hasWizard && vm.form === null;
 
     useEffect(() => {
         if (entryId === "new") {
-            formPresenter.newEntry();
+            if (!newEntryWizard) {
+                formPresenter.newEntry();
+            }
         } else if (entryId) {
             formPresenter.loadRevision(entryId);
             revisionsPresenter.init(entryId);
@@ -65,8 +71,6 @@ export const ContentEntryFormView = observer(() => {
         });
     }, []);
 
-    const { vm } = formPresenter;
-
     const handleBack = () => {
         const { modelId, folderId } = route.params;
         router.goToRoute(Routes.ContentEntries.List, { modelId, folderId });
@@ -89,11 +93,15 @@ export const ContentEntryFormView = observer(() => {
             />
             <ScrollArea>
                 {vm.loading ? <OverlayLoader text={vm.loading} /> : null}
-                <ContentEntryFormContent>
-                    <div className={"bg-neutral-base rounded-lg p-lg"} style={{ width }}>
-                        <ContentEntryForm />
-                    </div>
-                </ContentEntryFormContent>
+                {showWizard ? (
+                    newEntryWizard
+                ) : (
+                    <ContentEntryFormContent>
+                        <div className={"bg-neutral-base rounded-lg p-lg"} style={{ width }}>
+                            <ContentEntryForm />
+                        </div>
+                    </ContentEntryFormContent>
+                )}
             </ScrollArea>
             <RevisionDrawer />
         </Container>

--- a/packages/app-record-locking/src/presentation/entryLocking/ContentEntryFormPresenterDecorator.ts
+++ b/packages/app-record-locking/src/presentation/entryLocking/ContentEntryFormPresenterDecorator.ts
@@ -69,8 +69,8 @@ class ContentEntryFormPresenterWithLocking implements IContentEntryFormPresenter
         this.original.setFolderId(folderId);
     }
 
-    newEntry(): void {
-        return this.original.newEntry();
+    newEntry(initialValues?: Record<string, unknown>): void {
+        return this.original.newEntry(initialValues);
     }
 
     reset(): void {

--- a/packages/webiny/package.json
+++ b/packages/webiny/package.json
@@ -143,7 +143,7 @@
     "./extensions": "./extensions.js",
     "./api/tenant-manager": "./api/tenant-manager.js"
   },
-  "exportGenerationHash": "f1a4f6a770d3182c859c7b604e6b4e2ce46b9b3a02b24aba53a9210aa040b306",
+  "exportGenerationHash": "f12b3234bd92f61e43b780a0f3eeff5f4a01afd9416d4086057700bc850a6c42",
   "webiny": {
     "publishFrom": "dist"
   }

--- a/packages/webiny/src/admin/form.ts
+++ b/packages/webiny/src/admin/form.ts
@@ -1,3 +1,5 @@
+export { FormView, FormErrors } from "@webiny/app-admin/features/formModel/index.js";
+export type { FormModel } from "@webiny/app-admin/features/formModel/index.js";
 export type {
     IFieldRendererRegistry,
     IFieldBuilderRegistry,

--- a/skills/user-skills/admin/new-entry-wizard/SKILL.md
+++ b/skills/user-skills/admin/new-entry-wizard/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: webiny-new-entry-wizard
+context: webiny-admin
+description: >
+  Building a New Entry Wizard for the Headless CMS. Use this skill when the developer wants to
+  show a custom wizard UI before the entry form when creating new CMS entries -- collecting
+  fields like title, slug, or category upfront, then pre-filling the entry form. Covers
+  ContentEntryEditorConfig.NewEntryWizard, createFeature, FormModelFactory, createReactiveComponent,
+  useContentEntryFormPresenter, and the dirty-flag on setData.
+---
+
+# New Entry Wizard
+
+## TL;DR
+
+A New Entry Wizard intercepts the "create new entry" flow in the Headless CMS and shows a custom form before the full entry editor. The wizard collects initial values (title, slug, category, etc.), then calls `formPresenter.newEntry(initialValues)` to pre-fill the entry form and transition to the editor. The form is automatically marked as dirty so the user sees unsaved changes.
+
+A wizard extension has five files:
+1. **`abstractions.ts`** -- DI token and presenter interface (ALWAYS a standalone file)
+2. **`feature.ts`** -- `createFeature` wiring (ALWAYS a standalone file)
+3. **Presenter** -- owns the wizard form (fields, layout, validation) via `FormModelFactory`
+4. **View** -- renders the wizard UI using `FormView` and `FormErrors`
+5. **Registration** -- plugs the wizard into specific content models via `ContentEntryEditorConfig.NewEntryWizard`
+
+## Registration
+
+```tsx
+// extensions/myWizard/index.tsx
+import React from "react";
+import { RegisterFeature } from "webiny/admin";
+import { ContentEntryEditorConfig } from "webiny/admin/cms/entry/editor";
+import { MyWizardFeature } from "./feature.js";
+import { MyWizardForm } from "./MyWizardForm.js";
+
+const MyWizardExtension = () => {
+    return (
+        <>
+            <RegisterFeature feature={MyWizardFeature} />
+            <ContentEntryEditorConfig>
+                <ContentEntryEditorConfig.NewEntryWizard
+                    element={<MyWizardForm />}
+                    modelIds={["article", "blogPost"]}
+                />
+            </ContentEntryEditorConfig>
+        </>
+    );
+};
+
+export default MyWizardExtension;
+```
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `element` | `React.ReactElement` | The wizard component to render |
+| `modelIds` | `string[]` | Content model IDs this wizard applies to. Omit or pass `[]` to apply to all models. |
+
+### Enabling the extension
+
+```tsx
+// webiny.config.tsx
+<Admin.Extension src={"@/extensions/myWizard/index.tsx"} />
+```
+
+## Abstractions
+
+Abstractions MUST live in a dedicated `abstractions.ts` file. This file defines the DI token for the presenter. It is imported by both the feature and the view.
+
+```typescript
+// extensions/myWizard/abstractions.ts
+import { createAbstraction } from "webiny/admin";
+import type { FormModel } from "webiny/admin/form";
+
+export interface MyWizardVM {
+    form: FormModel.FormVM;
+    data: Record<string, unknown>;
+}
+
+export interface IMyWizardPresenter {
+    vm: MyWizardVM;
+    submit(): Promise<Record<string, unknown> | false>;
+    reset(): void;
+}
+
+export const MyWizardPresenter =
+    createAbstraction<IMyWizardPresenter>("MyWizardPresenter");
+```
+
+## Feature
+
+The feature MUST live in a dedicated `feature.ts` file. It wires the presenter implementation to the abstraction and defines how the feature is resolved from the DI container.
+
+```typescript
+// extensions/myWizard/feature.ts
+import { createFeature, FormModelFactory } from "webiny/admin";
+import { MyWizardPresenter } from "./abstractions.js";
+import { MyWizardPresenterImpl } from "./MyWizardPresenter.js";
+
+export const MyWizardFeature = createFeature({
+    name: "MyWizard",
+    register(container) {
+        container.register(
+            MyWizardPresenter.createImplementation({
+                implementation: MyWizardPresenterImpl,
+                dependencies: [FormModelFactory]
+            })
+        );
+    },
+    resolve(container) {
+        return { presenter: container.resolve(MyWizardPresenter) };
+    }
+});
+```
+
+## Presenter
+
+The presenter owns a `FormModel` for the wizard's own fields. It is a plain class -- the DI token lives in `abstractions.ts` and the feature wiring lives in `feature.ts`.
+
+```typescript
+// extensions/myWizard/MyWizardPresenter.ts
+import type { FormModel } from "webiny/admin/form";
+import { makeAutoObservable, toJS } from "mobx";
+import { FormModelFactory } from "webiny/admin";
+import type { IMyWizardPresenter, MyWizardVM } from "./abstractions.js";
+
+export class MyWizardPresenterImpl implements IMyWizardPresenter {
+    private form: FormModel.Interface;
+
+    constructor(formFactory: FormModelFactory.Interface) {
+        this.form = formFactory.create({
+            fields: fields => ({
+                title: fields.text().label("Title").required("Title is required"),
+                slug: fields.text().label("Slug").required("Slug is required"),
+                category: fields.text().label("Category").options([
+                    { label: "News", value: "news" },
+                    { label: "Tutorial", value: "tutorial" }
+                ])
+            }),
+            layout: layout => [
+                layout.row("title"),
+                layout.row("slug"),
+                layout.row("category")
+            ]
+        });
+
+        makeAutoObservable(this);
+    }
+
+    get vm(): MyWizardVM {
+        return {
+            form: this.form.vm,
+            data: toJS(this.form.getData())
+        };
+    }
+
+    async submit(): Promise<Record<string, unknown> | false> {
+        return this.form.submit();
+    }
+
+    reset(): void {
+        this.form.reset();
+    }
+}
+```
+
+The presenter uses the same `FormModel` system as all Webiny forms. See the `webiny-form-model` skill for field types, renderers, layout options, and validation.
+
+## View
+
+The view renders the wizard form and handles submission. On submit, it calls `formPresenter.newEntry(initialValues)` to transition from the wizard to the entry editor with pre-filled values.
+
+```tsx
+// extensions/myWizard/MyWizardForm.tsx
+import React, { useCallback } from "react";
+import { useFeature, createReactiveComponent } from "webiny/admin";
+import { useContentEntryFormPresenter } from "webiny/admin/cms/entry/editor";
+import { FormView, FormErrors } from "webiny/admin/form";
+import { Button } from "webiny/admin/ui";
+import { MyWizardFeature } from "./feature.js";
+
+export const MyWizardForm = createReactiveComponent(() => {
+    const { presenter } = useFeature(MyWizardFeature);
+    const formPresenter = useContentEntryFormPresenter();
+
+    const handleSubmit = useCallback(async () => {
+        const data = await presenter.submit();
+        if (data !== false) {
+            formPresenter.newEntry({
+                title: data.title,
+                settings: {
+                    general: {
+                        slug: data.slug
+                    }
+                }
+            });
+        }
+    }, [presenter, formPresenter]);
+
+    const { form } = presenter.vm;
+
+    return (
+        <div className="flex justify-center pt-xl">
+            <div
+                className="bg-neutral-base rounded-lg p-lg flex flex-col gap-md"
+                style={{ width: 600 }}
+            >
+                <h3 className="text-lg font-semibold">Create New Article</h3>
+                <FormErrors form={form} />
+                <FormView name="MyWizard" form={form} />
+                <div className="flex justify-end gap-sm">
+                    <Button variant="primary" onClick={handleSubmit}>
+                        Create
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+});
+```
+
+## Key APIs
+
+### `formPresenter.newEntry(initialValues?)`
+
+Called from the wizard view to transition to the entry editor. When `initialValues` is provided, the entry form is pre-filled and marked as dirty (unsaved changes). The values map to the content model's field structure.
+
+```typescript
+formPresenter.newEntry({
+    title: "My Article",
+    description: "A short description",
+    settings: {
+        general: {
+            slug: "my-article"
+        }
+    }
+});
+```
+
+### `createReactiveComponent`
+
+Wraps a component so it re-renders when MobX observables (like `presenter.vm`) change. Always use this for wizard views that read from a presenter.
+
+### `useContentEntryFormPresenter()`
+
+Returns the content entry form presenter. Used inside the wizard to call `newEntry()` after the wizard form is submitted.
+
+### `useFeature(feature)`
+
+Resolves the feature from the DI container. Returns the object produced by the feature's `resolve()` callback.
+
+## How It Works
+
+1. User clicks "New Entry" -- the route sets `id=new`
+2. If a `NewEntryWizard` is configured for the current model, the wizard element renders instead of the entry form
+3. The wizard collects data via its own `FormModel` and validates on submit
+4. On successful submit, the wizard calls `formPresenter.newEntry(initialValues)`
+5. This creates the entry form, pre-fills it with `setData(initialValues, { dirty: true })`, and the view switches from the wizard to the entry editor
+6. The entry form shows as dirty -- the user can review and save
+
+## File Structure
+
+```
+extensions/myWizard/
+  index.tsx              -- registration (NewEntryWizard config + RegisterFeature)
+  abstractions.ts        -- DI token + presenter interface (ALWAYS a standalone file)
+  feature.ts             -- createFeature wiring (ALWAYS a standalone file)
+  MyWizardPresenter.ts   -- presenter implementation (FormModel, business logic)
+  MyWizardForm.tsx       -- view (createReactiveComponent, FormView, submit handler)
+```
+
+**Iron rule:** `abstractions.ts` and `feature.ts` are ALWAYS separate, standalone files. Never inline abstractions or feature definitions into the presenter or view.

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -15,6 +15,7 @@ export const Extensions = () => {
             <Admin.Extension src={"@/extensions/customPageTypes/index.tsx"} />
             <Admin.Extension src={"@/extensions/customPageSettings/index.tsx"} />
             <Admin.Extension src={"@/extensions/customFormFieldType/index.tsx"} />
+            <Admin.Extension src={"@/extensions/newEntryWizardDemo/index.tsx"} />
 
             {/*<Admin.Extension src={"@/extensions/AdminTitleLogo/AdminTitleLogo.tsx"} />*/}
             {/*<Admin.Extension src={"/extensions/AdminTheme/AdminTheme.tsx"} />*/}


### PR DESCRIPTION
## Summary

<img width="1510" height="938" alt="CleanShot 2026-07-02 at 14 54 38@2x" src="https://github.com/user-attachments/assets/c80b2469-0493-444b-9e1a-3ffdd47b59d5" />


- Adds a `NewEntryWizard` config component to `ContentEntryEditorConfig`, allowing extensions to inject a custom wizard UI before the entry form opens.
- Extends `FormModel.setData()` with an optional `{ dirty: true }` flag to skip baseline snapshotting, so pre-filled forms are correctly marked as dirty.
- Updates `newEntry(initialValues?)` on the content entry form presenter to accept initial values from a wizard and forward them with the dirty flag.
- Propagates the `initialValues` parameter through workflow and record-locking decorators.

## Usage

```tsx
import React from "react";
import { RegisterFeature } from "webiny/admin";
import { ContentEntryEditorConfig } from "webiny/admin/cms/entry/editor";
import { WizardFormPresenterFeature } from "./WizardFormPresenter.js";
import { WizardForm } from "./WizardForm.js";

const NewEntryWizardDemo = () => {
    return (
        <>
            <RegisterFeature feature={WizardFormPresenterFeature} />
            <ContentEntryEditorConfig>
                <ContentEntryEditorConfig.NewEntryWizard
                    element={<WizardForm />}
                    modelIds={["article"]}
                />
            </ContentEntryEditorConfig>
        </>
    );
};
```

## Test plan

- [x] Create new entry without a wizard configured — behaves as before
- [x] Create new entry with a wizard configured — wizard renders, submit pre-fills the form, form is marked dirty
- [x] Verify `modelIds` filtering: wizard only shows for specified models
- [x] Verify existing tests pass (`FormModel` — 255 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)