### PR TITLE
chore(di): upgrade @webiny/di to latest

### DIFF
--- a/packages/api-audit-logs/package.json
+++ b/packages/api-audit-logs/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler": "0.0.0",
     "@webiny/handler-aws": "0.0.0",

--- a/packages/api-file-manager-aco/package.json
+++ b/packages/api-file-manager-aco/package.json
@@ -32,7 +32,7 @@
     "@webiny/api-core": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler": "0.0.0",
     "@webiny/handler-aws": "0.0.0",

--- a/packages/api-file-manager/package.json
+++ b/packages/api-file-manager/package.json
@@ -27,7 +27,7 @@
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/background-tasks": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/error": "0.0.0",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/feature": "0.0.0",

--- a/packages/api-headless-cms-aco/package.json
+++ b/packages/api-headless-cms-aco/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@webiny/api-core": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/plugins": "0.0.0",

--- a/packages/api-headless-cms-bulk-actions/package.json
+++ b/packages/api-headless-cms-bulk-actions/package.json
@@ -31,7 +31,7 @@
     "@webiny/api": "0.0.0",
     "@webiny/api-core": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/plugins": "0.0.0",
     "@webiny/project-utils": "0.0.0",

--- a/packages/api-headless-cms-storage/package.json
+++ b/packages/api-headless-cms-storage/package.json
@@ -13,7 +13,7 @@
     "@webiny/api": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/db-utils": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/error": "0.0.0",
     "@webiny/plugins": "0.0.0",
     "date-fns": "^4.4.0",

--- a/packages/api-mailer/package.json
+++ b/packages/api-mailer/package.json
@@ -30,7 +30,7 @@
     "@types/nodemailer": "^8.0.1",
     "@webiny/api-core": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "*",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler": "0.0.0",
     "@webiny/handler-aws": "0.0.0",

--- a/packages/api-record-locking/package.json
+++ b/packages/api-record-locking/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@webiny/api-core": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/project-utils": "0.0.0",
     "@webiny/wcp": "0.0.0",

--- a/packages/api-scheduler-aws/package.json
+++ b/packages/api-scheduler-aws/package.json
@@ -31,7 +31,7 @@
     "@webiny/api-core": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-aws": "0.0.0",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/feature": "0.0.0",

--- a/packages/api-scheduler/package.json
+++ b/packages/api-scheduler/package.json
@@ -22,7 +22,7 @@
     "@webiny/api-core": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/aws-sdk": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-aws": "0.0.0",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/feature": "0.0.0",

--- a/packages/api-website-builder/package.json
+++ b/packages/api-website-builder/package.json
@@ -39,7 +39,7 @@
     "@webiny/api-opensearch": "0.0.0",
     "@webiny/background-tasks": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/plugins": "0.0.0",
     "@webiny/project-utils": "0.0.0",
     "@webiny/testing": "0.0.0",

--- a/packages/api-websockets-aws/package.json
+++ b/packages/api-websockets-aws/package.json
@@ -29,7 +29,7 @@
     "@webiny/api-core": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler-db": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",

--- a/packages/api-websockets/package.json
+++ b/packages/api-websockets/package.json
@@ -30,7 +30,7 @@
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/aws-sdk": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/handler-db": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/project-utils": "0.0.0",

--- a/packages/api-workflows/package.json
+++ b/packages/api-workflows/package.json
@@ -21,7 +21,7 @@
     "@webiny/api-core": "0.0.0",
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/api-mailer": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/feature": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",

--- a/packages/background-tasks/package.json
+++ b/packages/background-tasks/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/project-utils": "0.0.0",
     "@webiny/wcp": "0.0.0",
     "rimraf": "^6.1.3",

--- a/packages/event-handler-aws/package.json
+++ b/packages/event-handler-aws/package.json
@@ -31,11 +31,11 @@
     "@webiny/feature": "0.0.0"
   },
   "peerDependencies": {
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": "^1.0.2"
   },
   "devDependencies": {
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "rimraf": "^6.1.3",
     "typescript": "6.0.3",
     "vitest": "^4.1.9"

--- a/packages/event-handler-core/package.json
+++ b/packages/event-handler-core/package.json
@@ -21,11 +21,11 @@
     "@webiny/feature": "0.0.0"
   },
   "peerDependencies": {
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": "^1.0.2"
   },
   "devDependencies": {
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "rimraf": "^6.1.3",
     "typescript": "6.0.3",
     "vitest": "^4.1.9"

--- a/packages/event-handler-server/package.json
+++ b/packages/event-handler-server/package.json
@@ -21,11 +21,11 @@
     "@webiny/event-handler-core": "0.0.0"
   },
   "peerDependencies": {
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": "^1.0.2"
   },
   "devDependencies": {
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "rimraf": "^6.1.3",
     "typescript": "6.0.3",
     "vitest": "^4.1.9"

--- a/packages/handler-db/package.json
+++ b/packages/handler-db/package.json
@@ -20,7 +20,7 @@
     "@webiny/db": "0.0.0",
     "@webiny/db-dynamodb": "0.0.0",
     "@webiny/db-utils": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/feature": "0.0.0",
     "@webiny/handler": "0.0.0",
     "@webiny/handler-graphql": "0.0.0"

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@webiny/build-tools": "0.0.0",
     "@webiny/db-dynamodb": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -27,7 +27,7 @@
     "@webiny/aws-sdk": "0.0.0",
     "@webiny/background-tasks": "0.0.0",
     "@webiny/build-tools": "0.0.0",
-    "@webiny/di": "^1.0.1",
+    "@webiny/di": "^1.0.2",
     "@webiny/error": "0.0.0",
     "@webiny/event-handler-core": "0.0.0",
     "@webiny/handler": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10506,7 +10506,7 @@ __metadata:
     "@webiny/api-website-builder": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
     "@webiny/common-audit-logs": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
@@ -10682,7 +10682,7 @@ __metadata:
     "@webiny/api-file-manager": "npm:0.0.0"
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
@@ -10765,7 +10765,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
@@ -10797,7 +10797,7 @@ __metadata:
     "@webiny/api-core": "npm:0.0.0"
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -10821,7 +10821,7 @@ __metadata:
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-aws": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
@@ -10968,7 +10968,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
     "@webiny/db-utils": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/plugins": "npm:0.0.0"
     "@webiny/project-utils": "npm:0.0.0"
@@ -11097,7 +11097,7 @@ __metadata:
     "@webiny/api": "npm:0.0.0"
     "@webiny/api-core": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:*"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -11147,7 +11147,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/api-websockets": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -11173,7 +11173,7 @@ __metadata:
     "@webiny/api-scheduler": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-aws": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
@@ -11217,7 +11217,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-aws": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
@@ -11320,7 +11320,7 @@ __metadata:
     "@webiny/api-opensearch": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -11350,7 +11350,7 @@ __metadata:
     "@webiny/api-websockets": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -11434,7 +11434,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-aws": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
@@ -11461,7 +11461,7 @@ __metadata:
     "@webiny/api-headless-cms": "npm:0.0.0"
     "@webiny/api-mailer": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler-graphql": "npm:0.0.0"
@@ -12241,7 +12241,7 @@ __metadata:
     "@webiny/app-admin": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-aws": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
@@ -12459,7 +12459,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webiny/di@npm:*, @webiny/di@npm:^1.0.1, @webiny/di@npm:^1.0.2":
+"@webiny/di@npm:^1.0.2":
   version: 1.0.2
   resolution: "@webiny/di@npm:1.0.2"
   dependencies:
@@ -12485,14 +12485,14 @@ __metadata:
     "@webiny/api-core": "npm:0.0.0"
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     rimraf: "npm:^6.1.3"
     typescript: "npm:6.0.3"
     vitest: "npm:^4.1.9"
   peerDependencies:
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": ^1.0.2
   languageName: unknown
   linkType: soft
 
@@ -12501,13 +12501,13 @@ __metadata:
   resolution: "@webiny/event-handler-core@workspace:packages/event-handler-core"
   dependencies:
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/feature": "npm:0.0.0"
     rimraf: "npm:^6.1.3"
     typescript: "npm:6.0.3"
     vitest: "npm:^4.1.9"
   peerDependencies:
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": ^1.0.2
   languageName: unknown
   linkType: soft
 
@@ -12516,13 +12516,13 @@ __metadata:
   resolution: "@webiny/event-handler-server@workspace:packages/event-handler-server"
   dependencies:
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     rimraf: "npm:^6.1.3"
     typescript: "npm:6.0.3"
     vitest: "npm:^4.1.9"
   peerDependencies:
-    "@webiny/di": ">=0.2.3"
+    "@webiny/di": ^1.0.2
   languageName: unknown
   linkType: soft
 
@@ -12606,7 +12606,7 @@ __metadata:
     "@webiny/db": "npm:0.0.0"
     "@webiny/db-dynamodb": "npm:0.0.0"
     "@webiny/db-utils": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
     "@webiny/handler-graphql": "npm:0.0.0"
@@ -12711,7 +12711,7 @@ __metadata:
     "@webiny/app-headless-cms": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
     "@webiny/db-dynamodb": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"
@@ -13244,7 +13244,7 @@ __metadata:
     "@webiny/aws-sdk": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.1"
+    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/handler": "npm:0.0.0"


### PR DESCRIPTION
### What changed

Upgraded `@webiny/di` to the latest version (`^1.0.2`) across all packages.

### Changelog

**Upgrade `@webiny/di` to latest**

Upgraded the internal dependency-injection package to its latest version.

### Squash Merge Commit

```
chore(di): upgrade @webiny/di to latest (#5362)
```
