### PR TITLE
feat(self-hosted-auth): self-hosted username/password identity provider

### DIFF
--- a/packages/self-hosted-auth-sql/package.json
+++ b/packages/self-hosted-auth-sql/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@webiny/self-hosted-auth-sql",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*"
+  },
+  "description": "SQL (Knex) credential storage for @webiny/self-hosted-auth.",
+  "author": "Webiny Ltd.",
+  "dependencies": {
+    "@webiny/error": "0.0.0",
+    "@webiny/feature": "0.0.0",
+    "@webiny/self-hosted-auth": "0.0.0",
+    "knex": "^3.3.0"
+  },
+  "devDependencies": {
+    "@webiny/build-tools": "0.0.0",
+    "@webiny/project-utils": "0.0.0",
+    "vitest": "^4.1.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "webiny": {
+    "publishFrom": "dist"
+  }
+}

--- a/packages/self-hosted-auth-sql/src/SelfHostedAuthSqlFeature.ts
+++ b/packages/self-hosted-auth-sql/src/SelfHostedAuthSqlFeature.ts
@@ -1,0 +1,23 @@
+import { createFeature } from "@webiny/feature/api";
+import type { Knex } from "knex";
+import { CredentialsStorageOperations } from "@webiny/self-hosted-auth";
+import { createStorageOperations } from "./credentials/index.js";
+
+export interface SelfHostedAuthSqlConfig {
+    knex: Knex;
+    tableNamePrefix?: string;
+}
+
+/**
+ * Registers the SQL implementation of `CredentialsStorageOperations`. Register
+ * this alongside `SelfHostedAuthApiFeature`, which consumes the abstraction.
+ */
+export const SelfHostedAuthSqlFeature = createFeature<SelfHostedAuthSqlConfig>({
+    name: "SelfHostedAuthSql",
+    register(container, { knex, tableNamePrefix }) {
+        container.registerInstance(
+            CredentialsStorageOperations,
+            createStorageOperations({ knex, tableNamePrefix })
+        );
+    }
+});

--- a/packages/self-hosted-auth-sql/src/credentials/index.ts
+++ b/packages/self-hosted-auth-sql/src/credentials/index.ts
@@ -1,0 +1,123 @@
+import type { Knex } from "knex";
+import WebinyError from "@webiny/error";
+import type { CredentialsStorageOperations, StorageCredential } from "@webiny/self-hosted-auth";
+
+const TABLE_NAME = "webiny_self_hosted_credentials";
+
+interface ICredentialRow {
+    tenant: string;
+    user_id: string;
+    email: string;
+    data: string;
+}
+
+const toRow = (c: StorageCredential): ICredentialRow => ({
+    tenant: c.tenant,
+    user_id: c.userId,
+    email: c.email,
+    data: JSON.stringify(c)
+});
+
+const toCredential = (row: ICredentialRow): StorageCredential =>
+    JSON.parse(row.data) as StorageCredential;
+
+interface CreateStorageOperationsParams {
+    knex: Knex;
+    tableNamePrefix?: string;
+}
+
+export const createStorageOperations = (
+    params: CreateStorageOperationsParams
+): CredentialsStorageOperations.Interface => {
+    const { knex } = params;
+    const prefix = params.tableNamePrefix ? `${params.tableNamePrefix}_` : "";
+    const table = `${prefix}${TABLE_NAME}`;
+
+    // Mirrors api-core-sql's TableManager pattern: lazily create the table on
+    // first use, then remember we did so for the process lifetime.
+    let ensured = false;
+    const ensureTable = async () => {
+        if (ensured) {
+            return;
+        }
+        const exists = await knex.schema.hasTable(table);
+        if (!exists) {
+            await knex.schema.createTable(table, t => {
+                t.text("tenant").notNullable();
+                t.text("user_id").notNullable();
+                t.text("email").notNullable();
+                t.text("data").notNullable();
+
+                t.primary(["tenant", "user_id"]);
+                // Email is the login key — unique across the store (see the v0
+                // tenancy note in LoginUseCase).
+                t.unique(["email"]);
+            });
+        }
+        ensured = true;
+    };
+
+    const query = () => knex<ICredentialRow>(table);
+
+    return {
+        async getCredentialByEmail({ email }) {
+            await ensureTable();
+            try {
+                const row = await query().where("email", email).first();
+                return row ? toCredential(row) : null;
+            } catch (err) {
+                throw WebinyError.from(err, {
+                    message: "Could not load credential by email.",
+                    code: "GET_CREDENTIAL_BY_EMAIL_ERROR"
+                });
+            }
+        },
+
+        async getCredentialByUserId({ tenant, userId }) {
+            await ensureTable();
+            try {
+                const row = await query()
+                    .where("tenant", tenant)
+                    .andWhere("user_id", userId)
+                    .first();
+                return row ? toCredential(row) : null;
+            } catch (err) {
+                throw WebinyError.from(err, {
+                    message: "Could not load credential by user id.",
+                    code: "GET_CREDENTIAL_BY_USER_ID_ERROR",
+                    data: { userId }
+                });
+            }
+        },
+
+        async saveCredential({ credential }) {
+            await ensureTable();
+            try {
+                const row = toRow(credential);
+                await query()
+                    .insert(row)
+                    .onConflict(["tenant", "user_id"])
+                    .merge({ email: row.email, data: row.data });
+            } catch (err) {
+                throw WebinyError.from(err, {
+                    message: "Could not save credential.",
+                    code: "SAVE_CREDENTIAL_ERROR",
+                    data: { userId: credential.userId }
+                });
+            }
+        },
+
+        async deleteCredential({ tenant, userId }) {
+            await ensureTable();
+            try {
+                await query().where("tenant", tenant).andWhere("user_id", userId).delete();
+            } catch (err) {
+                throw WebinyError.from(err, {
+                    message: "Could not delete credential.",
+                    code: "DELETE_CREDENTIAL_ERROR",
+                    data: { userId }
+                });
+            }
+        }
+    };
+};

--- a/packages/self-hosted-auth-sql/src/index.ts
+++ b/packages/self-hosted-auth-sql/src/index.ts
@@ -1,0 +1,5 @@
+export {
+    SelfHostedAuthSqlFeature,
+    type SelfHostedAuthSqlConfig
+} from "./SelfHostedAuthSqlFeature.js";
+export { createStorageOperations } from "./credentials/index.js";

--- a/packages/self-hosted-auth-sql/tsconfig.build.json
+++ b/packages/self-hosted-auth-sql/tsconfig.build.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../error/tsconfig.build.json" },
+    { "path": "../feature/tsconfig.build.json" },
+    { "path": "../self-hosted-auth/tsconfig.build.json" }
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
+      "@webiny/feature/*": ["../feature/src/*"],
+      "@webiny/feature": ["../feature/src"],
+      "@webiny/self-hosted-auth/*": ["../self-hosted-auth/src/*"],
+      "@webiny/self-hosted-auth": ["../self-hosted-auth/src"]
+    }
+  }
+}

--- a/packages/self-hosted-auth-sql/tsconfig.json
+++ b/packages/self-hosted-auth-sql/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [
+    { "path": "../error" },
+    { "path": "../feature" },
+    { "path": "../self-hosted-auth" }
+  ],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
+      "@webiny/feature/*": ["../feature/src/*"],
+      "@webiny/feature": ["../feature/src"],
+      "@webiny/self-hosted-auth/*": ["../self-hosted-auth/src/*"],
+      "@webiny/self-hosted-auth": ["../self-hosted-auth/src"]
+    }
+  }
+}

--- a/packages/self-hosted-auth-sql/webiny.config.js
+++ b/packages/self-hosted-auth-sql/webiny.config.js
@@ -1,0 +1,8 @@
+import { createWatchPackage, createBuildPackage } from "@webiny/build-tools";
+
+export default {
+    commands: {
+        build: createBuildPackage({ cwd: import.meta.dirname }),
+        watch: createWatchPackage({ cwd: import.meta.dirname })
+    }
+};

--- a/packages/self-hosted-auth/package.json
+++ b/packages/self-hosted-auth/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@webiny/self-hosted-auth",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*"
+  },
+  "description": "Self-hosted username/password identity provider for Webiny (no external IdP).",
+  "author": "Webiny Ltd.",
+  "dependencies": {
+    "@webiny/api-core": "0.0.0",
+    "@webiny/error": "0.0.0",
+    "@webiny/feature": "0.0.0",
+    "@webiny/handler-graphql": "0.0.0",
+    "graphql": "^16.14.2",
+    "jsonwebtoken": "^9.0.3",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.6",
+    "@webiny/build-tools": "0.0.0",
+    "@webiny/project-utils": "0.0.0",
+    "vitest": "^4.1.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "webiny": {
+    "publishFrom": "dist"
+  }
+}

--- a/packages/self-hosted-auth/src/api/SelfHostedAuthApiFeature.ts
+++ b/packages/self-hosted-auth/src/api/SelfHostedAuthApiFeature.ts
@@ -1,0 +1,49 @@
+import { createFeature } from "@webiny/feature/api";
+import { PasswordHasherFeature } from "./domain/crypto/PasswordHasher.js";
+import { TokenIssuerFeature } from "./domain/crypto/TokenIssuer.js";
+import type { TokenIssuerConfig } from "./domain/crypto/TokenIssuer.js";
+import { SelfHostedIdpFeature } from "./features/SelfHostedIdp/index.js";
+import { LoginFeature } from "./features/Login/index.js";
+import { SetPasswordFeature } from "./features/SetPassword/index.js";
+import { UserInstallerFeature } from "./features/UserInstaller/index.js";
+import { SelfHostedAuthSchema } from "./graphql/auth.gql.js";
+
+export interface SelfHostedAuthConfig {
+    /** JWT signing secret. Falls back to `WEBINY_SELF_HOSTED_AUTH_SECRET`. */
+    secret?: string;
+    /** Token lifetime in seconds. */
+    expiresIn?: number;
+}
+
+/**
+ * Wires the whole self-hosted auth module: crypto services, the JWT identity
+ * provider (validation), the login/set-password use cases, and the public
+ * GraphQL surface.
+ *
+ * The credential *storage* is NOT registered here — pull in a database package
+ * (`@webiny/self-hosted-auth-sql`, `-mdb`, …) that registers
+ * `CredentialsStorageOperations`.
+ */
+export const SelfHostedAuthApiFeature = createFeature<SelfHostedAuthConfig | undefined>({
+    name: "SelfHostedAuthApi",
+    register(container, config) {
+        const secret = config?.secret ?? process.env.WEBINY_SELF_HOSTED_AUTH_SECRET;
+        if (!secret) {
+            throw new Error(
+                "SelfHostedAuthApiFeature: a signing `secret` is required " +
+                    "(pass it in config or set WEBINY_SELF_HOSTED_AUTH_SECRET)."
+            );
+        }
+
+        const tokenIssuerConfig: TokenIssuerConfig = { secret, expiresIn: config?.expiresIn };
+
+        PasswordHasherFeature.register(container);
+        TokenIssuerFeature.register(container, tokenIssuerConfig);
+        SelfHostedIdpFeature.register(container);
+        LoginFeature.register(container);
+        SetPasswordFeature.register(container);
+        UserInstallerFeature.register(container);
+
+        container.register(SelfHostedAuthSchema);
+    }
+});

--- a/packages/self-hosted-auth/src/api/domain/crypto/PasswordHasher.ts
+++ b/packages/self-hosted-auth/src/api/domain/crypto/PasswordHasher.ts
@@ -1,0 +1,94 @@
+import { randomBytes, scrypt as scryptCb, timingSafeEqual } from "node:crypto";
+import type { ScryptOptions } from "node:crypto";
+import { createAbstraction, createFeature } from "@webiny/feature/api";
+
+// `promisify(scryptCb)` resolves to the no-options overload, so we wrap by hand
+// to keep the cost parameters (N, r, p).
+const scrypt = (
+    password: string,
+    salt: Buffer,
+    keylen: number,
+    options: ScryptOptions
+): Promise<Buffer> =>
+    new Promise((resolve, reject) => {
+        scryptCb(password, salt, keylen, options, (err, derivedKey) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(derivedKey);
+            }
+        });
+    });
+
+export interface IPasswordHasher {
+    hash(password: string): Promise<string>;
+    /** Constant-time compare of `password` against a previously produced hash string. */
+    verify(password: string, storedHash: string): Promise<boolean>;
+}
+
+/** Hashes and verifies passwords. Swap the implementation to change algorithms. */
+export const PasswordHasher = createAbstraction<IPasswordHasher>("PasswordHasher");
+
+export namespace PasswordHasher {
+    export type Interface = IPasswordHasher;
+}
+
+/**
+ * Default hasher, built on Node's `crypto.scrypt` — no native dependency, so it
+ * runs anywhere Node runs. This mirrors what self-hosted CMSes (e.g. Payload)
+ * do with PBKDF2: pick a KDF that ships with the runtime.
+ *
+ * To upgrade to Argon2id later, register a different `PasswordHasher`
+ * implementation — the stored hash string is self-describing (its prefix names
+ * the algorithm), so old scrypt hashes keep verifying while new logins get the
+ * new algorithm.
+ */
+const PREFIX = "scrypt";
+const KEYLEN = 64;
+const SALT_BYTES = 16;
+
+interface ScryptCost {
+    N: number;
+    r: number;
+    p: number;
+}
+
+const DEFAULT_COST: ScryptCost = { N: 16384, r: 8, p: 1 };
+
+class ScryptPasswordHasher implements IPasswordHasher {
+    constructor(private cost: ScryptCost = DEFAULT_COST) {}
+
+    async hash(password: string): Promise<string> {
+        const { N, r, p } = this.cost;
+        const salt = randomBytes(SALT_BYTES);
+        const derived = (await scrypt(password, salt, KEYLEN, { N, r, p })) as Buffer;
+
+        return [PREFIX, N, r, p, salt.toString("base64"), derived.toString("base64")].join("$");
+    }
+
+    async verify(password: string, storedHash: string): Promise<boolean> {
+        const parts = storedHash.split("$");
+        if (parts.length !== 6 || parts[0] !== PREFIX) {
+            return false;
+        }
+
+        const [, nRaw, rRaw, pRaw, saltB64, hashB64] = parts;
+        const N = Number(nRaw);
+        const r = Number(rRaw);
+        const p = Number(pRaw);
+        const salt = Buffer.from(saltB64, "base64");
+        const expected = Buffer.from(hashB64, "base64");
+
+        const derived = (await scrypt(password, salt, expected.length, { N, r, p })) as Buffer;
+
+        // Lengths always match here, so timingSafeEqual is safe to call directly.
+        return timingSafeEqual(derived, expected);
+    }
+}
+
+export const PasswordHasherFeature = createFeature({
+    name: "PasswordHasher",
+    register(container) {
+        container.registerInstance(PasswordHasher, new ScryptPasswordHasher());
+    }
+});

--- a/packages/self-hosted-auth/src/api/domain/crypto/TokenIssuer.ts
+++ b/packages/self-hosted-auth/src/api/domain/crypto/TokenIssuer.ts
@@ -1,0 +1,98 @@
+import jwt from "jsonwebtoken";
+import type { JwtPayload } from "jsonwebtoken";
+import { createAbstraction, createFeature } from "@webiny/feature/api";
+
+/**
+ * The `iss` claim stamped onto every token we mint. The self-hosted
+ * `JwtIdentityProvider` uses it to recognise its own tokens (the same way the
+ * Cognito provider matches on the Cognito issuer URL), so this must stay stable.
+ */
+export const SELF_HOSTED_ISSUER = "webiny-self-hosted";
+
+export interface IssueTokenParams {
+    userId: string;
+    email: string;
+    tenant: string;
+    displayName?: string;
+}
+
+export interface IssuedToken {
+    token: string;
+    /** Seconds until expiry — convenient for clients to schedule a refresh. */
+    expiresIn: number;
+}
+
+export interface ITokenIssuer {
+    issue(params: IssueTokenParams): Promise<IssuedToken>;
+    /** Returns the verified payload, or `null` if the signature/claims are invalid. */
+    verify(token: string): Promise<JwtPayload | null>;
+}
+
+/** Mints and verifies the JWTs handed out on login. We are the issuer. */
+export const TokenIssuer = createAbstraction<ITokenIssuer>("TokenIssuer");
+
+export namespace TokenIssuer {
+    export type Interface = ITokenIssuer;
+    export type Payload = JwtPayload;
+}
+
+export interface TokenIssuerConfig {
+    /**
+     * Signing secret (HS256). MUST be provided in production — a self-hosted
+     * deployment sets this once and shares it between the issuer and verifier
+     * (same process here). Swap for an RS256 keypair if you ever want the
+     * verifier to hold only the public key.
+     */
+    secret: string;
+    /** Token lifetime in seconds. Defaults to 12 hours. */
+    expiresIn?: number;
+}
+
+class JwtTokenIssuer implements ITokenIssuer {
+    private readonly secret: string;
+    private readonly expiresIn: number;
+
+    constructor(config: TokenIssuerConfig) {
+        this.secret = config.secret;
+        this.expiresIn = config.expiresIn ?? 60 * 60 * 12;
+    }
+
+    async issue(params: IssueTokenParams): Promise<IssuedToken> {
+        const token = jwt.sign(
+            {
+                email: params.email,
+                tenant: params.tenant,
+                displayName: params.displayName
+            },
+            this.secret,
+            {
+                algorithm: "HS256",
+                issuer: SELF_HOSTED_ISSUER,
+                subject: params.userId,
+                expiresIn: this.expiresIn
+            }
+        );
+
+        return { token, expiresIn: this.expiresIn };
+    }
+
+    async verify(token: string): Promise<JwtPayload | null> {
+        try {
+            const decoded = jwt.verify(token, this.secret, {
+                algorithms: ["HS256"],
+                issuer: SELF_HOSTED_ISSUER
+            });
+
+            return typeof decoded === "string" ? null : decoded;
+        } catch {
+            return null;
+        }
+    }
+}
+
+export const TokenIssuerFeature = createFeature<TokenIssuerConfig>({
+    name: "TokenIssuer",
+    register(container, config) {
+        container.registerInstance(TokenIssuer, new JwtTokenIssuer(config));
+    }
+});

--- a/packages/self-hosted-auth/src/api/domain/errors.ts
+++ b/packages/self-hosted-auth/src/api/domain/errors.ts
@@ -1,0 +1,37 @@
+import { BaseError } from "@webiny/feature/api";
+
+/**
+ * Deliberately generic: we never reveal whether it was the email or the
+ * password that was wrong, to avoid leaking which accounts exist.
+ */
+export class InvalidCredentialsError extends BaseError {
+    override readonly code = "INVALID_CREDENTIALS" as const;
+
+    constructor() {
+        super({ message: "Invalid credentials." });
+    }
+}
+
+export class CredentialNotFoundError extends BaseError<{ userId: string }> {
+    override readonly code = "CREDENTIAL_NOT_FOUND" as const;
+
+    constructor(userId: string) {
+        super({ message: "Credential not found.", data: { userId } });
+    }
+}
+
+export class NotAuthorizedError extends BaseError {
+    override readonly code = "NOT_AUTHORIZED" as const;
+
+    constructor() {
+        super({ message: "Not authorized." });
+    }
+}
+
+export class WeakPasswordError extends BaseError {
+    override readonly code = "WEAK_PASSWORD" as const;
+
+    constructor(message: string) {
+        super({ message });
+    }
+}

--- a/packages/self-hosted-auth/src/api/features/Login/LoginUseCase.ts
+++ b/packages/self-hosted-auth/src/api/features/Login/LoginUseCase.ts
@@ -1,0 +1,65 @@
+import { Result } from "@webiny/feature/api";
+import { LoginUseCase as UseCaseAbstraction } from "./abstractions.js";
+import type { LoginInput, LoginOutput } from "./abstractions.js";
+import { loginValidation } from "./schema.js";
+import { InvalidCredentialsError } from "~/api/domain/errors.js";
+import { CredentialsStorageOperations } from "~/api/storage/abstractions.js";
+import { PasswordHasher } from "~/api/domain/crypto/PasswordHasher.js";
+import { TokenIssuer } from "~/api/domain/crypto/TokenIssuer.js";
+
+class LoginUseCaseImpl implements UseCaseAbstraction.Interface {
+    constructor(
+        private credentials: CredentialsStorageOperations.Interface,
+        private passwordHasher: PasswordHasher.Interface,
+        private tokenIssuer: TokenIssuer.Interface
+    ) {}
+
+    async execute(input: LoginInput): Promise<Result<LoginOutput, UseCaseAbstraction.Error>> {
+        // Shape-validate only. Every failure past this point returns the same
+        // generic error so we never disclose whether the account exists.
+        const validation = loginValidation.safeParse(input);
+        if (!validation.success) {
+            return Result.fail(new InvalidCredentialsError());
+        }
+
+        const { email, password } = validation.data;
+
+        // TENANCY DECISION (v0): the credential is resolved by email alone and
+        // the identity is issued for its stored `tenant`. This treats email as a
+        // global admin-login key. If a single email must map to per-tenant
+        // credentials, add `tenant` to this lookup and to the GraphQL input.
+        const credential = await this.credentials.getCredentialByEmail({ email });
+        if (!credential) {
+            // Still hash to keep the timing of "no such user" ~ "wrong password".
+            await this.passwordHasher.verify(password, DUMMY_HASH);
+            return Result.fail(new InvalidCredentialsError());
+        }
+
+        const ok = await this.passwordHasher.verify(password, credential.passwordHash);
+        if (!ok) {
+            return Result.fail(new InvalidCredentialsError());
+        }
+
+        const issued = await this.tokenIssuer.issue({
+            userId: credential.userId,
+            email: credential.email,
+            tenant: credential.tenant
+        });
+
+        return Result.ok(issued);
+    }
+}
+
+/**
+ * A syntactically valid scrypt hash of a random value. Verifying against it when
+ * the account is missing keeps login timing roughly constant, mitigating user
+ * enumeration via response time.
+ */
+const DUMMY_HASH =
+    "scrypt$16384$8$1$AAAAAAAAAAAAAAAAAAAAAA==$" +
+    "Y2xhdWRlLWR1bW15LWhhc2gtcGxhY2Vob2xkZXItbm90LWEtcmVhbC1zZWNyZXQtdmFsdWU=";
+
+export const LoginUseCase = UseCaseAbstraction.createImplementation({
+    implementation: LoginUseCaseImpl,
+    dependencies: [CredentialsStorageOperations, PasswordHasher, TokenIssuer]
+});

--- a/packages/self-hosted-auth/src/api/features/Login/abstractions.ts
+++ b/packages/self-hosted-auth/src/api/features/Login/abstractions.ts
@@ -1,0 +1,29 @@
+import { createAbstraction } from "@webiny/feature/api";
+import type { Result } from "@webiny/feature/api";
+import type { InvalidCredentialsError } from "~/api/domain/errors.js";
+
+export interface LoginInput {
+    email: string;
+    password: string;
+}
+
+export interface LoginOutput {
+    token: string;
+    expiresIn: number;
+}
+
+export type LoginError = InvalidCredentialsError;
+
+export interface ILoginUseCase {
+    execute(input: LoginInput): Promise<Result<LoginOutput, LoginError>>;
+}
+
+/** Verifies a username/password pair and mints a signed JWT. */
+export const LoginUseCase = createAbstraction<ILoginUseCase>("LoginUseCase");
+
+export namespace LoginUseCase {
+    export type Interface = ILoginUseCase;
+    export type Input = LoginInput;
+    export type Output = LoginOutput;
+    export type Error = LoginError;
+}

--- a/packages/self-hosted-auth/src/api/features/Login/feature.ts
+++ b/packages/self-hosted-auth/src/api/features/Login/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import { LoginUseCase } from "./LoginUseCase.js";
+
+export const LoginFeature = createFeature({
+    name: "LoginFeature",
+    register(container) {
+        container.register(LoginUseCase);
+    }
+});

--- a/packages/self-hosted-auth/src/api/features/Login/index.ts
+++ b/packages/self-hosted-auth/src/api/features/Login/index.ts
@@ -1,0 +1,2 @@
+export * from "./abstractions.js";
+export * from "./feature.js";

--- a/packages/self-hosted-auth/src/api/features/Login/schema.ts
+++ b/packages/self-hosted-auth/src/api/features/Login/schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const loginValidation = z.object({
+    email: z.string().email(),
+    password: z.string().min(1)
+});

--- a/packages/self-hosted-auth/src/api/features/SelfHostedIdp/SelfHostedJwtIdentityProvider.ts
+++ b/packages/self-hosted-auth/src/api/features/SelfHostedIdp/SelfHostedJwtIdentityProvider.ts
@@ -1,0 +1,52 @@
+import { JwtIdentityProvider } from "@webiny/api-core/idp";
+import { TokenIssuer, SELF_HOSTED_ISSUER } from "~/api/domain/crypto/TokenIssuer.js";
+
+/**
+ * Validation half of the self-hosted IdP. Registered as one of the many
+ * `JwtIdentityProvider`s the `JwtAuthenticator` fans out to, so it coexists with
+ * Cognito/Auth0/etc. with zero special-casing.
+ *
+ * We are the issuer, so there is no remote JWKS to fetch — we verify the
+ * signature in-process with the same secret we signed with. That is why we
+ * implement `JwtIdentityProvider` directly instead of `OidcIdentityProvider`.
+ */
+class SelfHostedJwtIdentityProviderImpl implements JwtIdentityProvider.Interface {
+    constructor(private tokenIssuer: TokenIssuer.Interface) {}
+
+    isApplicable(payload: JwtIdentityProvider.JwtPayload): boolean {
+        return payload.iss === SELF_HOSTED_ISSUER;
+    }
+
+    async getIdentity(
+        token: string,
+        _jwt: JwtIdentityProvider.Jwt
+    ): Promise<JwtIdentityProvider.IdentityData | null> {
+        const payload = await this.tokenIssuer.verify(token);
+        if (!payload || !payload.sub) {
+            return null;
+        }
+
+        const email = (payload.email as string | undefined) ?? "";
+        const tenant = (payload.tenant as string | undefined) ?? "root";
+        const displayName = (payload.displayName as string | undefined) ?? email;
+
+        return {
+            id: payload.sub,
+            displayName: displayName || "Unknown User",
+            type: "admin",
+            profile: {
+                email,
+                external: false
+            },
+            context: {
+                defaultTenantId: tenant,
+                canAccessTenant: true
+            }
+        };
+    }
+}
+
+export const SelfHostedJwtIdentityProvider = JwtIdentityProvider.createImplementation({
+    implementation: SelfHostedJwtIdentityProviderImpl,
+    dependencies: [TokenIssuer]
+});

--- a/packages/self-hosted-auth/src/api/features/SelfHostedIdp/feature.ts
+++ b/packages/self-hosted-auth/src/api/features/SelfHostedIdp/feature.ts
@@ -1,0 +1,11 @@
+import { createFeature } from "@webiny/feature/api";
+import { SelfHostedJwtIdentityProvider } from "./SelfHostedJwtIdentityProvider.js";
+
+export const SelfHostedIdpFeature = createFeature({
+    name: "SelfHostedIdp",
+    register(container) {
+        // Registered alongside any other JwtIdentityProvider (Cognito, Auth0, …);
+        // the JwtAuthenticator tries each until one claims the token.
+        container.register(SelfHostedJwtIdentityProvider).inSingletonScope();
+    }
+});

--- a/packages/self-hosted-auth/src/api/features/SelfHostedIdp/index.ts
+++ b/packages/self-hosted-auth/src/api/features/SelfHostedIdp/index.ts
@@ -1,0 +1,1 @@
+export * from "./feature.js";

--- a/packages/self-hosted-auth/src/api/features/SetPassword/SetPasswordUseCase.ts
+++ b/packages/self-hosted-auth/src/api/features/SetPassword/SetPasswordUseCase.ts
@@ -1,0 +1,57 @@
+import { Result } from "@webiny/feature/api";
+import { z } from "zod";
+import { SetPasswordUseCase as UseCaseAbstraction } from "./abstractions.js";
+import type { SetPasswordInput } from "./abstractions.js";
+import { WeakPasswordError } from "~/api/domain/errors.js";
+import { CredentialsStorageOperations } from "~/api/storage/abstractions.js";
+import type { StorageCredential } from "~/api/storage/abstractions.js";
+import { PasswordHasher } from "~/api/domain/crypto/PasswordHasher.js";
+
+const passwordPolicy = z.string().min(8);
+
+class SetPasswordUseCaseImpl implements UseCaseAbstraction.Interface {
+    constructor(
+        private credentials: CredentialsStorageOperations.Interface,
+        private passwordHasher: PasswordHasher.Interface
+    ) {}
+
+    async execute(input: SetPasswordInput): Promise<Result<true, UseCaseAbstraction.Error>> {
+        // TODO(authz): when called from a "change password" flow, assert the
+        // caller is `input.userId` (self-service) or holds `adminUsers.user`
+        // (admin reset). The bootstrap/installer path intentionally skips this.
+
+        const policy = passwordPolicy.safeParse(input.password);
+        if (!policy.success) {
+            return Result.fail(new WeakPasswordError("Password must be at least 8 characters."));
+        }
+
+        const passwordHash = await this.passwordHasher.hash(input.password);
+
+        const existing = await this.credentials.getCredentialByUserId({
+            tenant: input.tenant,
+            userId: input.userId
+        });
+
+        const now = nowIso();
+        const credential: StorageCredential = {
+            tenant: input.tenant,
+            userId: input.userId,
+            email: input.email,
+            passwordHash,
+            createdOn: existing?.createdOn ?? now,
+            updatedOn: now
+        };
+
+        await this.credentials.saveCredential({ credential });
+
+        return Result.ok(true);
+    }
+}
+
+// `new Date()` is used at call time (runtime), not in a workflow context.
+const nowIso = () => new Date().toISOString();
+
+export const SetPasswordUseCase = UseCaseAbstraction.createImplementation({
+    implementation: SetPasswordUseCaseImpl,
+    dependencies: [CredentialsStorageOperations, PasswordHasher]
+});

--- a/packages/self-hosted-auth/src/api/features/SetPassword/abstractions.ts
+++ b/packages/self-hosted-auth/src/api/features/SetPassword/abstractions.ts
@@ -1,0 +1,29 @@
+import { createAbstraction } from "@webiny/feature/api";
+import type { Result } from "@webiny/feature/api";
+import type { WeakPasswordError, NotAuthorizedError } from "~/api/domain/errors.js";
+
+export interface SetPasswordInput {
+    tenant: string;
+    userId: string;
+    email: string;
+    password: string;
+}
+
+export type SetPasswordError = WeakPasswordError | NotAuthorizedError;
+
+export interface ISetPasswordUseCase {
+    execute(input: SetPasswordInput): Promise<Result<true, SetPasswordError>>;
+}
+
+/**
+ * Creates or replaces a user's credential. Used to seed the first admin and to
+ * change passwords. Authorization is the caller's responsibility (see the TODO
+ * in the implementation).
+ */
+export const SetPasswordUseCase = createAbstraction<ISetPasswordUseCase>("SetPasswordUseCase");
+
+export namespace SetPasswordUseCase {
+    export type Interface = ISetPasswordUseCase;
+    export type Input = SetPasswordInput;
+    export type Error = SetPasswordError;
+}

--- a/packages/self-hosted-auth/src/api/features/SetPassword/feature.ts
+++ b/packages/self-hosted-auth/src/api/features/SetPassword/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import { SetPasswordUseCase } from "./SetPasswordUseCase.js";
+
+export const SetPasswordFeature = createFeature({
+    name: "SetPasswordFeature",
+    register(container) {
+        container.register(SetPasswordUseCase);
+    }
+});

--- a/packages/self-hosted-auth/src/api/features/SetPassword/index.ts
+++ b/packages/self-hosted-auth/src/api/features/SetPassword/index.ts
@@ -1,0 +1,2 @@
+export * from "./abstractions.js";
+export * from "./feature.js";

--- a/packages/self-hosted-auth/src/api/features/UserInstaller/UserInstaller.ts
+++ b/packages/self-hosted-auth/src/api/features/UserInstaller/UserInstaller.ts
@@ -1,0 +1,99 @@
+import type { Tenant } from "@webiny/api-core/types/tenancy.js";
+import type { AdminUser } from "@webiny/api-core/types/users.js";
+import { AppInstaller } from "@webiny/api-core/features/tenancy/InstallTenant/index.js";
+import { GetRoleUseCase } from "@webiny/api-core/features/security/roles/GetRole/index.js";
+import { CreateUserUseCase } from "@webiny/api-core/features/users/CreateUser/index.js";
+import { DeleteUserUseCase } from "@webiny/api-core/features/users/DeleteUser/index.js";
+import { SetPasswordUseCase } from "~/api/features/SetPassword/index.js";
+import { CredentialsStorageOperations } from "~/api/storage/abstractions.js";
+
+interface UserInstallationData {
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
+}
+
+/**
+ * Seeds the first admin user for the self-hosted IdP. Unlike Cognito (which
+ * pushes the user into an external pool), we compose two local steps:
+ *   1. create the admin user via api-core's `CreateUserUseCase`;
+ *   2. store its password via our own `SetPasswordUseCase`.
+ *
+ * If step 2 fails, step 1 is rolled back so a half-installed user never lingers.
+ */
+class UserInstallerImpl implements AppInstaller.Interface<UserInstallationData> {
+    readonly alwaysRun = false;
+    readonly appName = "SelfHostedAuth";
+    readonly dependsOn = ["Security"];
+    private createdUser: AdminUser | undefined;
+
+    constructor(
+        private getRole: GetRoleUseCase.Interface,
+        private createUserUseCase: CreateUserUseCase.Interface,
+        private setPasswordUseCase: SetPasswordUseCase.Interface,
+        private deleteUserUseCase: DeleteUserUseCase.Interface,
+        private credentials: CredentialsStorageOperations.Interface
+    ) {}
+
+    async install(tenant: Tenant, data: UserInstallationData): Promise<void> {
+        const roleResult = await this.getRole.execute({ slug: "full-access" });
+        if (roleResult.isFail()) {
+            throw new Error(`Failed to get full-access role: ${roleResult.error.message}`);
+        }
+
+        const role = roleResult.value;
+
+        const createResult = await this.createUserUseCase.execute({
+            email: data.email,
+            firstName: data.firstName,
+            lastName: data.lastName,
+            displayName: `${data.firstName} ${data.lastName}`,
+            roles: [role.id],
+            teams: []
+        });
+        if (createResult.isFail()) {
+            throw new Error(`Failed to create admin user: ${createResult.error.message}`);
+        }
+
+        this.createdUser = createResult.value;
+
+        const passwordResult = await this.setPasswordUseCase.execute({
+            tenant: tenant.id,
+            userId: this.createdUser.id,
+            email: this.createdUser.email,
+            password: data.password
+        });
+        if (passwordResult.isFail()) {
+            // Roll back the user we just created before surfacing the failure.
+            await this.deleteUserUseCase.execute(this.createdUser.id);
+            this.createdUser = undefined;
+            throw new Error(`Failed to set admin password: ${passwordResult.error.message}`);
+        }
+    }
+
+    async uninstall(tenant: Tenant): Promise<void> {
+        if (!this.createdUser) {
+            return;
+        }
+
+        // Deleting the user does not cascade to credentials, so remove both.
+        await this.credentials.deleteCredential({
+            tenant: tenant.id,
+            userId: this.createdUser.id
+        });
+        await this.deleteUserUseCase.execute(this.createdUser.id);
+        this.createdUser = undefined;
+    }
+}
+
+export const UserInstaller = AppInstaller.createImplementation({
+    implementation: UserInstallerImpl,
+    dependencies: [
+        GetRoleUseCase,
+        CreateUserUseCase,
+        SetPasswordUseCase,
+        DeleteUserUseCase,
+        CredentialsStorageOperations
+    ]
+});

--- a/packages/self-hosted-auth/src/api/features/UserInstaller/feature.ts
+++ b/packages/self-hosted-auth/src/api/features/UserInstaller/feature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/api";
+import { UserInstaller } from "./UserInstaller.js";
+
+export const UserInstallerFeature = createFeature({
+    name: "UserInstallerFeature",
+    register(container) {
+        container.register(UserInstaller);
+    }
+});

--- a/packages/self-hosted-auth/src/api/features/UserInstaller/index.ts
+++ b/packages/self-hosted-auth/src/api/features/UserInstaller/index.ts
@@ -1,0 +1,1 @@
+export * from "./feature.js";

--- a/packages/self-hosted-auth/src/api/graphql/auth.gql.ts
+++ b/packages/self-hosted-auth/src/api/graphql/auth.gql.ts
@@ -1,0 +1,68 @@
+import { ErrorResponse, Response } from "@webiny/handler-graphql/responses.js";
+import { CoreGraphQLSchemaFactory } from "@webiny/handler-graphql/graphql/abstractions.js";
+import { LoginUseCase } from "~/api/features/Login/index.js";
+
+/**
+ * Public auth surface for the self-hosted IdP. `login` is intentionally
+ * unauthenticated — it is how an identity is obtained in the first place.
+ */
+class SelfHostedAuthSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
+    async execute(
+        builder: CoreGraphQLSchemaFactory.SchemaBuilder
+    ): CoreGraphQLSchemaFactory.Return {
+        builder.addTypeDefs(/* GraphQL */ `
+            type SelfHostedAuthLoginData {
+                token: String!
+                expiresIn: Int!
+            }
+
+            type SelfHostedAuthLoginResponse {
+                data: SelfHostedAuthLoginData
+                error: SelfHostedAuthError
+            }
+
+            type SelfHostedAuthError {
+                code: String
+                message: String
+                data: JSON
+            }
+
+            extend type Mutation {
+                """
+                Exchange a username/password pair for a signed JWT.
+                """
+                selfHostedAuthLogin(email: String!, password: String!): SelfHostedAuthLoginResponse
+            }
+        `);
+
+        builder.addResolver({
+            path: "Mutation.selfHostedAuthLogin",
+            dependencies: [LoginUseCase],
+            resolver: (loginUseCase: LoginUseCase.Interface) => {
+                return async ({ args }) => {
+                    const result = await loginUseCase.execute({
+                        email: args.email,
+                        password: args.password
+                    });
+
+                    if (result.isFail()) {
+                        return new ErrorResponse({
+                            message: result.error.message,
+                            code: result.error.code,
+                            data: result.error.data
+                        });
+                    }
+
+                    return new Response(result.value);
+                };
+            }
+        });
+
+        return builder;
+    }
+}
+
+export const SelfHostedAuthSchema = CoreGraphQLSchemaFactory.createImplementation({
+    implementation: SelfHostedAuthSchemaImpl,
+    dependencies: []
+});

--- a/packages/self-hosted-auth/src/api/storage/abstractions.ts
+++ b/packages/self-hosted-auth/src/api/storage/abstractions.ts
@@ -1,0 +1,52 @@
+import { createAbstraction } from "@webiny/feature/api";
+
+/**
+ * A single stored credential. Kept in a table separate from admin users so that
+ * password material never rides along on user reads.
+ *
+ * `email` is the login key. See the tenancy note in `LoginUseCase` for why the
+ * credential is currently resolved by email alone.
+ */
+export interface StorageCredential {
+    tenant: string;
+    userId: string;
+    email: string;
+    /**
+     * Opaque, self-describing hash string produced by a `PasswordHasher`
+     * (e.g. `scrypt$16384$8$1$<salt>$<hash>`). The algorithm is encoded in the
+     * value, so swapping hashers later does not require a migration.
+     */
+    passwordHash: string;
+    createdOn: string;
+    updatedOn: string;
+}
+
+export interface GetCredentialByEmailParams {
+    email: string;
+}
+
+export interface GetCredentialByUserIdParams {
+    tenant: string;
+    userId: string;
+}
+
+export interface ICredentialsStorageOperations {
+    getCredentialByEmail(params: GetCredentialByEmailParams): Promise<StorageCredential | null>;
+    getCredentialByUserId(params: GetCredentialByUserIdParams): Promise<StorageCredential | null>;
+    /** Upsert — create if absent, replace otherwise. */
+    saveCredential(params: { credential: StorageCredential }): Promise<void>;
+    deleteCredential(params: GetCredentialByUserIdParams): Promise<void>;
+}
+
+/**
+ * Persistence seam for credentials. Database-agnostic on purpose: each database
+ * ships a thin implementation (`@webiny/self-hosted-auth-sql`, `-mdb`, …).
+ */
+export const CredentialsStorageOperations = createAbstraction<ICredentialsStorageOperations>(
+    "CredentialsStorageOperations"
+);
+
+export namespace CredentialsStorageOperations {
+    export type Interface = ICredentialsStorageOperations;
+    export type Credential = StorageCredential;
+}

--- a/packages/self-hosted-auth/src/index.ts
+++ b/packages/self-hosted-auth/src/index.ts
@@ -1,0 +1,18 @@
+export {
+    SelfHostedAuthApiFeature,
+    type SelfHostedAuthConfig
+} from "./api/SelfHostedAuthApiFeature.js";
+
+// Storage seam — implemented by database packages (`-sql`, `-mdb`, …).
+export {
+    CredentialsStorageOperations,
+    type StorageCredential
+} from "./api/storage/abstractions.js";
+
+// Crypto seams — override to swap the KDF (e.g. Argon2id) or token strategy.
+export { PasswordHasher } from "./api/domain/crypto/PasswordHasher.js";
+export { TokenIssuer, SELF_HOSTED_ISSUER } from "./api/domain/crypto/TokenIssuer.js";
+
+// Use cases — handy for installers/seeding scripts.
+export { LoginUseCase } from "./api/features/Login/index.js";
+export { SetPasswordUseCase } from "./api/features/SetPassword/index.js";

--- a/packages/self-hosted-auth/tsconfig.build.json
+++ b/packages/self-hosted-auth/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../api-core/tsconfig.build.json" },
+    { "path": "../error/tsconfig.build.json" },
+    { "path": "../feature/tsconfig.build.json" },
+    { "path": "../handler-graphql/tsconfig.build.json" }
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"],
+      "@webiny/api-core/*": ["../api-core/src/*"],
+      "@webiny/api-core": ["../api-core/src"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
+      "@webiny/feature/*": ["../feature/src/*"],
+      "@webiny/feature": ["../feature/src"],
+      "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],
+      "@webiny/handler-graphql": ["../handler-graphql/src"]
+    }
+  }
+}

--- a/packages/self-hosted-auth/tsconfig.json
+++ b/packages/self-hosted-auth/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "__tests__"],
+  "references": [
+    { "path": "../api-core" },
+    { "path": "../error" },
+    { "path": "../feature" },
+    { "path": "../handler-graphql" }
+  ],
+  "compilerOptions": {
+    "rootDirs": ["./src", "./__tests__"],
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"],
+      "~tests/*": ["./__tests__/*"],
+      "@webiny/api-core/*": ["../api-core/src/*"],
+      "@webiny/api-core": ["../api-core/src"],
+      "@webiny/error/*": ["../error/src/*"],
+      "@webiny/error": ["../error/src"],
+      "@webiny/feature/*": ["../feature/src/*"],
+      "@webiny/feature": ["../feature/src"],
+      "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],
+      "@webiny/handler-graphql": ["../handler-graphql/src"]
+    }
+  }
+}

--- a/packages/self-hosted-auth/webiny.config.js
+++ b/packages/self-hosted-auth/webiny.config.js
@@ -1,0 +1,8 @@
+import { createWatchPackage, createBuildPackage } from "@webiny/build-tools";
+
+export default {
+    commands: {
+        build: createBuildPackage({ cwd: import.meta.dirname }),
+        watch: createWatchPackage({ cwd: import.meta.dirname })
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9136,7 +9136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:^9.0.10":
+"@types/jsonwebtoken@npm:^9.0.10, @types/jsonwebtoken@npm:^9.0.6":
   version: 9.0.10
   resolution: "@types/jsonwebtoken@npm:9.0.10"
   dependencies:
@@ -13146,6 +13146,38 @@ __metadata:
     p-retry: "npm:^8.0.0"
     standardwebhooks: "npm:^1.0.0"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.9"
+    zod: "npm:4.4.3"
+  languageName: unknown
+  linkType: soft
+
+"@webiny/self-hosted-auth-sql@workspace:packages/self-hosted-auth-sql":
+  version: 0.0.0-use.local
+  resolution: "@webiny/self-hosted-auth-sql@workspace:packages/self-hosted-auth-sql"
+  dependencies:
+    "@webiny/build-tools": "npm:0.0.0"
+    "@webiny/error": "npm:0.0.0"
+    "@webiny/feature": "npm:0.0.0"
+    "@webiny/project-utils": "npm:0.0.0"
+    "@webiny/self-hosted-auth": "npm:0.0.0"
+    knex: "npm:^3.3.0"
+    vitest: "npm:^4.1.9"
+  languageName: unknown
+  linkType: soft
+
+"@webiny/self-hosted-auth@npm:0.0.0, @webiny/self-hosted-auth@workspace:packages/self-hosted-auth":
+  version: 0.0.0-use.local
+  resolution: "@webiny/self-hosted-auth@workspace:packages/self-hosted-auth"
+  dependencies:
+    "@types/jsonwebtoken": "npm:^9.0.6"
+    "@webiny/api-core": "npm:0.0.0"
+    "@webiny/build-tools": "npm:0.0.0"
+    "@webiny/error": "npm:0.0.0"
+    "@webiny/feature": "npm:0.0.0"
+    "@webiny/handler-graphql": "npm:0.0.0"
+    "@webiny/project-utils": "npm:0.0.0"
+    graphql: "npm:^16.14.2"
+    jsonwebtoken: "npm:^9.0.3"
     vitest: "npm:^4.1.9"
     zod: "npm:4.4.3"
   languageName: unknown


### PR DESCRIPTION
## What changed

Adds a **self-hosted username/password identity provider** for the pure-Node (`-server`) flavour of Webiny — a first-party alternative to Cognito/Auth0 that needs no external auth service.

It plugs into Webiny's existing IdP interface exactly like Cognito does: it registers a `JwtIdentityProvider` that recognises and verifies its own tokens (matching on the `webiny-self-hosted` issuer), so it coexists with any other provider with zero core changes. The half that Cognito delegates to an external service — **issuing** tokens — is implemented here as a public `selfHostedAuthLogin(email, password)` GraphQL mutation that verifies the credential and mints a signed JWT.

Two packages, mirroring the `cognito`/`auth0` sibling pattern:

- **`@webiny/self-hosted-auth`** — database-agnostic auth logic:
  - **scrypt** password hashing via `node:crypto` (zero native dependencies). Hashes are self-describing (`scrypt$N$r$p$salt$hash`), so a future Argon2id hasher can be dropped in without a migration.
  - HS256 JWT issue/verify (`jsonwebtoken`), with the signing secret injected via config or `WEBINY_SELF_HOSTED_AUTH_SECRET`.
  - `LoginUseCase`, `SetPasswordUseCase`, and a `UserInstaller` that seeds the first admin (creates the user via api-core, then sets its password, with rollback on failure).
  - A `CredentialsStorageOperations` seam so credential storage stays pluggable per database.
- **`@webiny/self-hosted-auth-sql`** — the thin Knex implementation of `CredentialsStorageOperations`, following the repo's existing storage-ops pattern (lazy table `ensure`, JSON `data` column). Credentials live in their own table, never on the admin-user record.

Security niceties: login returns a single generic error and runs a dummy hash on missing accounts to keep timing roughly constant, mitigating user enumeration.

**Scope / follow-ups (not in this PR):** no automated tests yet; no Mongo (`-mdb`) storage package yet; no admin-side login UI; and `SetPasswordUseCase` carries a `TODO(authz)` for self-service-vs-admin-reset enforcement. There is also a v0 tenancy decision (credentials resolved by email alone) documented in `LoginUseCase`.

## Changelog

**Self-hosted username & password login**

Webiny can now run with its own built-in username-and-password sign-in, so a self-hosted deployment no longer needs an external login service. Administrators get a first account set up automatically during installation.

## Squash merge commit

```
feat(self-hosted-auth): add username/password identity provider (#5367)
feat(self-hosted-auth): self-hosted auth with scrypt + JWT (#5367)
```
