### PR TITLE
feat: add stack output cache with destroy invalidation

### DIFF
--- a/packages/project/src/abstractions/features/DestroyApp.ts
+++ b/packages/project/src/abstractions/features/DestroyApp.ts
@@ -4,11 +4,11 @@ import { type ExecaChildProcess } from "execa";
 
 type IPulumiProcess = ExecaChildProcess<string>;
 
-interface IDestroyAppParams {
+export interface IDestroyAppParams {
     app: AppName;
 }
 
-interface IDestroyApp {
+export interface IDestroyApp {
     execute(params: IDestroyAppParams): Promise<{ pulumiProcess: IPulumiProcess }>;
 }
 

--- a/packages/project/src/abstractions/services/StackOutputCacheService.ts
+++ b/packages/project/src/abstractions/services/StackOutputCacheService.ts
@@ -1,0 +1,15 @@
+import { createAbstraction } from "~/abstractions/createAbstraction.js";
+import { type IAppModel } from "~/abstractions/models/IAppModel.js";
+
+export interface IStackOutputCacheService {
+    read(app: IAppModel): Promise<Record<string, any> | null>;
+    write(app: IAppModel, data: Record<string, any>): Promise<void>;
+    delete(app: IAppModel): Promise<void>;
+}
+
+export const StackOutputCacheService =
+    createAbstraction<IStackOutputCacheService>("StackOutputCacheService");
+
+export namespace StackOutputCacheService {
+    export type Interface = IStackOutputCacheService;
+}

--- a/packages/project/src/abstractions/services/index.ts
+++ b/packages/project/src/abstractions/services/index.ts
@@ -29,6 +29,7 @@ export { PulumiGetStackOutputService } from "./PulumiGetStackOutputService.js";
 export { PulumiLoginService } from "./PulumiLoginService.js";
 export { PulumiSelectStackService } from "./PulumiSelectStackService.js";
 export { SetProjectIdService } from "./SetProjectIdService.js";
+export { StackOutputCacheService } from "./StackOutputCacheService.js";
 export { StdioService } from "./StdioService.js";
 export { UiService } from "./UiService.js";
 export { ValidateProjectConfigService } from "./ValidateProjectConfigService.js";

--- a/packages/project/src/createProjectSdkContainer.ts
+++ b/packages/project/src/createProjectSdkContainer.ts
@@ -83,6 +83,7 @@ import {
     pulumiLoginService,
     pulumiSelectStackService,
     setProjectIdService,
+    stackOutputCacheService,
     stdioService,
     uiService,
     validateProjectConfigService,
@@ -143,6 +144,7 @@ export const createProjectSdkContainer = async (
     container.register(pulumiLoginService).inSingletonScope();
     container.register(pulumiSelectStackService).inSingletonScope();
     container.register(setProjectIdService).inSingletonScope();
+    container.register(stackOutputCacheService).inSingletonScope();
     container.register(stdioService).inSingletonScope();
     container.register(uiService).inSingletonScope();
     container.register(validateProjectConfigService).inSingletonScope();

--- a/packages/project/src/decorators/DestroyAppClearStackOutputCache.ts
+++ b/packages/project/src/decorators/DestroyAppClearStackOutputCache.ts
@@ -1,0 +1,43 @@
+import {
+    DestroyApp,
+    GetApp,
+    LoggerService,
+    StackOutputCacheService
+} from "~/abstractions/index.js";
+
+/**
+ * Decorator that clears the stack output cache when an app is destroyed.
+ *
+ * Without this, the cache file written during deploy would remain on disk after a
+ * destroy, and a subsequent deploy (or any stack output read) would use it and behave
+ * as if the stack were still deployed.
+ *
+ * The cache is cleared before the destroy runs. Since the cache is only a performance
+ * optimization, this is safe even if the destroy fails and the stack remains: the next
+ * read simply fetches fresh output from Pulumi again.
+ */
+export class DestroyAppClearStackOutputCache implements DestroyApp.Interface {
+    constructor(
+        private getApp: GetApp.Interface,
+        private logger: LoggerService.Interface,
+        private stackOutputCacheService: StackOutputCacheService.Interface,
+        private decoratee: DestroyApp.Interface
+    ) {}
+
+    async execute(params: DestroyApp.Params) {
+        try {
+            const app = this.getApp.execute(params.app);
+            await this.stackOutputCacheService.delete(app);
+        } catch (error) {
+            // Cache clearing failure shouldn't prevent the destroy from running.
+            this.logger.error("Failed to clear stack output cache before destroy.", error);
+        }
+
+        return this.decoratee.execute(params);
+    }
+}
+
+export const destroyAppClearStackOutputCache = DestroyApp.createDecorator({
+    decorator: DestroyAppClearStackOutputCache,
+    dependencies: [GetApp, LoggerService, StackOutputCacheService]
+});

--- a/packages/project/src/decorators/index.ts
+++ b/packages/project/src/decorators/index.ts
@@ -3,6 +3,7 @@ export * from "./DeployAppClearWatchedLambdaFunctions.js";
 export * from "./DeployAppRefreshStackOutputCache.js";
 export * from "./DeployAppWithHooks.js";
 export * from "./DeployAppWithWatchedLambdaReplacement.js";
+export * from "./DestroyAppClearStackOutputCache.js";
 export * from "./WatchWithHooks.js";
 export * from "./GetPulumiServiceWithDownloadInfo.js";
 export * from "./GetFeatureFlagsWithLicense.js";

--- a/packages/project/src/services/InitProjectSdkService/InitProjectSdkService.ts
+++ b/packages/project/src/services/InitProjectSdkService/InitProjectSdkService.ts
@@ -10,6 +10,7 @@ import {
     deployAppRefreshStackOutputCache,
     deployAppWithHooks,
     deployAppWithWatchedLambdaReplacement,
+    destroyAppClearStackOutputCache,
     watchWithHooks,
     getPulumiServiceWithDownloadInfo
 } from "~/decorators/index.js";
@@ -49,6 +50,7 @@ export class DefaultInitProjectSdkService implements InitProjectSdkService.Inter
         container.registerDecorator(deployAppWithWatchedLambdaReplacement);
         container.registerDecorator(deployAppClearWatchedLambdaFunctions);
         container.registerDecorator(deployAppRefreshStackOutputCache);
+        container.registerDecorator(destroyAppClearStackOutputCache);
         container.registerDecorator(deployAppWithHooks);
         container.registerDecorator(watchWithHooks);
         container.registerDecorator(getPulumiServiceWithDownloadInfo);

--- a/packages/project/src/services/PulumiGetStackOutputService/PulumiGetStackOutputService.ts
+++ b/packages/project/src/services/PulumiGetStackOutputService/PulumiGetStackOutputService.ts
@@ -1,29 +1,21 @@
 import { createImplementation } from "@webiny/di";
 import {
     GetPulumiService,
-    GetProjectService,
     LoggerService,
     PulumiGetStackOutputService,
     PulumiSelectStackService,
-    ProjectSdkParamsService
+    StackOutputCacheService
 } from "~/abstractions/index.js";
 import { type AppModel } from "~/models/index.js";
 import { createEnvConfiguration, withPulumiConfigPassphrase } from "~/utils/env/index.js";
 import { mapStackOutput } from "./mapStackOutput.js";
-import fs from "fs/promises";
-import path from "path";
 
 export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputService.Interface {
-    private static readonly DEFAULT_ENV = "dev";
-    private static readonly DEFAULT_REGION = "default";
-    private static readonly DEFAULT_VARIANT = "default";
-
     constructor(
         private getPulumiService: GetPulumiService.Interface,
         private pulumiSelectStackService: PulumiSelectStackService.Interface,
         private loggerService: LoggerService.Interface,
-        private getProjectService: GetProjectService.Interface,
-        private projectSdkParamsService: ProjectSdkParamsService.Interface
+        private stackOutputCacheService: StackOutputCacheService.Interface
     ) {}
 
     async execute<TOutput extends Record<string, any> = Record<string, any>>(
@@ -32,12 +24,8 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
     ): Promise<TOutput | null> {
         // Try to read from cache if skipCache is not true
         if (!params?.skipCache) {
-            const cachedOutput = await this.readFromCache(app);
+            const cachedOutput = await this.stackOutputCacheService.read(app);
             if (cachedOutput !== null) {
-                this.loggerService.debug(
-                    { app: app.name, cacheKey: this.getCacheKey(app) },
-                    "Stack output read from cache"
-                );
                 return this.applyMapping(cachedOutput, params?.map) as TOutput;
             }
         }
@@ -64,12 +52,7 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
                 return null;
             }
 
-            // Write to cache
-            await this.writeToCache(app, stackOutputJson);
-            this.loggerService.debug("Stack output stored to cache", {
-                app: app.name,
-                cacheKey: this.getCacheKey(app)
-            });
+            await this.stackOutputCacheService.write(app, stackOutputJson);
 
             return this.applyMapping(stackOutputJson, params?.map) as TOutput;
         } catch {
@@ -93,46 +76,6 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
         // If a mapping is provided, we map the output to the specified structure.
         return mapStackOutput(data, map);
     }
-
-    private getCacheKey(app: AppModel): string {
-        const sdkParams = this.projectSdkParamsService.get();
-        const env = sdkParams.env || DefaultPulumiGetStackOutputService.DEFAULT_ENV;
-        const region = sdkParams.region || DefaultPulumiGetStackOutputService.DEFAULT_REGION;
-        const variant = sdkParams.variant || DefaultPulumiGetStackOutputService.DEFAULT_VARIANT;
-        return `${app.name}-${env}-${region}-${variant}.json`;
-    }
-
-    private getCachePath(app: AppModel): string {
-        const project = this.getProjectService.execute();
-        const cacheDir = project.paths.dotWebinyFolder.join("caches", "stack-output").toString();
-        const cacheKey = this.getCacheKey(app);
-        return path.join(cacheDir, cacheKey);
-    }
-
-    private async readFromCache(app: AppModel): Promise<Record<string, any> | null> {
-        const cachePath = this.getCachePath(app);
-
-        try {
-            const content = await fs.readFile(cachePath, "utf-8");
-            return JSON.parse(content);
-        } catch {
-            // File doesn't exist or couldn't be read/parsed - this is expected on first run
-            return null;
-        }
-    }
-
-    private async writeToCache(app: AppModel, data: Record<string, any>): Promise<void> {
-        const cachePath = this.getCachePath(app);
-        const cacheDir = path.dirname(cachePath);
-
-        try {
-            // Create cache directory if it doesn't exist
-            await fs.mkdir(cacheDir, { recursive: true });
-            await fs.writeFile(cachePath, JSON.stringify(data, null, 2), "utf-8");
-        } catch (error) {
-            this.loggerService.error("Could not write to cache file.", cachePath, error);
-        }
-    }
 }
 
 export const pulumiGetStackOutputService = createImplementation({
@@ -142,7 +85,6 @@ export const pulumiGetStackOutputService = createImplementation({
         GetPulumiService,
         PulumiSelectStackService,
         LoggerService,
-        GetProjectService,
-        ProjectSdkParamsService
+        StackOutputCacheService
     ]
 });

--- a/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
+++ b/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
@@ -1,0 +1,92 @@
+import { createImplementation } from "@webiny/di";
+import {
+    GetProjectService,
+    LoggerService,
+    ProjectSdkParamsService,
+    StackOutputCacheService
+} from "~/abstractions/index.js";
+import { type AppModel } from "~/models/index.js";
+import fs from "fs/promises";
+import path from "path";
+
+export class DefaultStackOutputCacheService implements StackOutputCacheService.Interface {
+    private static readonly DEFAULT_ENV = "dev";
+    private static readonly DEFAULT_REGION = "default";
+    private static readonly DEFAULT_VARIANT = "default";
+
+    constructor(
+        private getProjectService: GetProjectService.Interface,
+        private projectSdkParamsService: ProjectSdkParamsService.Interface,
+        private loggerService: LoggerService.Interface
+    ) {}
+
+    async read(app: AppModel): Promise<Record<string, any> | null> {
+        const cachePath = this.getCachePath(app);
+
+        try {
+            const content = await fs.readFile(cachePath, "utf-8");
+            const data = JSON.parse(content);
+            this.loggerService.debug(
+                { app: app.name, cacheKey: this.getCacheKey(app) },
+                "Stack output read from cache"
+            );
+            return data;
+        } catch {
+            // File doesn't exist or couldn't be read/parsed - this is expected on first run.
+            return null;
+        }
+    }
+
+    async write(app: AppModel, data: Record<string, any>): Promise<void> {
+        const cachePath = this.getCachePath(app);
+        const cacheDir = path.dirname(cachePath);
+
+        try {
+            // Create cache directory if it doesn't exist.
+            await fs.mkdir(cacheDir, { recursive: true });
+            await fs.writeFile(cachePath, JSON.stringify(data, null, 2), "utf-8");
+            this.loggerService.debug("Stack output stored to cache", {
+                app: app.name,
+                cacheKey: this.getCacheKey(app)
+            });
+        } catch (error) {
+            this.loggerService.error("Could not write to cache file.", cachePath, error);
+        }
+    }
+
+    async delete(app: AppModel): Promise<void> {
+        const cachePath = this.getCachePath(app);
+
+        try {
+            // `force: true` makes this a no-op if the cache file doesn't exist.
+            await fs.rm(cachePath, { force: true });
+            this.loggerService.debug("Stack output cache deleted.", {
+                app: app.name,
+                cacheKey: this.getCacheKey(app)
+            });
+        } catch (error) {
+            this.loggerService.error("Could not delete stack output cache file.", cachePath, error);
+        }
+    }
+
+    private getCacheKey(app: AppModel): string {
+        const sdkParams = this.projectSdkParamsService.get();
+        const env = sdkParams.env || DefaultStackOutputCacheService.DEFAULT_ENV;
+        const region = sdkParams.region || DefaultStackOutputCacheService.DEFAULT_REGION;
+        const variant = sdkParams.variant || DefaultStackOutputCacheService.DEFAULT_VARIANT;
+        return `${app.name}-${env}-${region}-${variant}.json`;
+    }
+
+    private getCachePath(app: AppModel): string {
+        const project = this.getProjectService.execute();
+        const cacheDir = project.paths.dotWebinyFolder.join("caches", "stack-output").toString();
+        const cacheKey = this.getCacheKey(app);
+        return path.join(cacheDir, cacheKey);
+    }
+}
+
+export const stackOutputCacheService = createImplementation({
+    abstraction: StackOutputCacheService,
+    implementation: DefaultStackOutputCacheService,
+    dependencies: [GetProjectService, ProjectSdkParamsService, LoggerService]
+});

--- a/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
+++ b/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
@@ -7,7 +7,6 @@ import {
 } from "~/abstractions/index.js";
 import { type AppModel } from "~/models/index.js";
 import fs from "fs/promises";
-import path from "path";
 
 export class DefaultStackOutputCacheService implements StackOutputCacheService.Interface {
     private static readonly DEFAULT_ENV = "dev";
@@ -39,7 +38,7 @@ export class DefaultStackOutputCacheService implements StackOutputCacheService.I
 
     async write(app: AppModel, data: Record<string, any>): Promise<void> {
         const cachePath = this.getCachePath(app);
-        const cacheDir = path.dirname(cachePath);
+        const cacheDir = this.getCacheDir().toString();
 
         try {
             // Create cache directory if it doesn't exist.
@@ -77,11 +76,13 @@ export class DefaultStackOutputCacheService implements StackOutputCacheService.I
         return `${app.name}-${env}-${region}-${variant}.json`;
     }
 
-    private getCachePath(app: AppModel): string {
+    private getCacheDir() {
         const project = this.getProjectService.execute();
-        const cacheDir = project.paths.dotWebinyFolder.join("caches", "stack-output").toString();
-        const cacheKey = this.getCacheKey(app);
-        return path.join(cacheDir, cacheKey);
+        return project.paths.dotWebinyFolder.join("caches", "stack-output");
+    }
+
+    private getCachePath(app: AppModel): string {
+        return this.getCacheDir().join(this.getCacheKey(app)).toString();
     }
 }
 

--- a/packages/project/src/services/StackOutputCacheService/index.ts
+++ b/packages/project/src/services/StackOutputCacheService/index.ts
@@ -1,0 +1,1 @@
+export * from "./StackOutputCacheService.js";

--- a/packages/project/src/services/index.ts
+++ b/packages/project/src/services/index.ts
@@ -29,6 +29,7 @@ export * from "./PulumiGetStackOutputService/index.js";
 export * from "./PulumiLoginService/index.js";
 export * from "./PulumiSelectStackService/index.js";
 export * from "./SetProjectIdService/index.js";
+export * from "./StackOutputCacheService/index.js";
 export * from "./StdioService/index.js";
 export * from "./UiService/index.js";
 export * from "./ValidateProjectConfigService/index.js";


### PR DESCRIPTION
### What changed

Reading a Webiny app's deployed stack output no longer shells out to `pulumi stack output` every time. The first read still fetches from Pulumi, but the result is now cached to disk (under `.webiny/caches/stack-output`, keyed per app + environment + region + variant), and subsequent reads are served from that cache. This makes CLI operations that repeatedly read stack output (deploys, watch, output lookups) noticeably faster.

The cache is automatically cleared when an app is destroyed, so a destroyed stack is never mistaken for a still-deployed one on the next read or deploy. Callers that need guaranteed-fresh data can bypass the cache via a `skipCache` option. The stack-output reading service was refactored so all cache logic lives in a dedicated `StackOutputCacheService` rather than being inlined.

### Changelog

**Faster stack output reads via local caching**

Every stack output lookup previously ran a Pulumi command, which made repeated reads slow. Stack outputs are now cached locally and reused, and the cache is automatically cleared when an app is destroyed so results always stay accurate.

### Squash Merge Commit

```
perf: cache Pulumi stack output reads to disk (#5375)
feat: add stack output cache with destroy invalidation (#5375)
```
