### PR TITLE
feat: add support for Cognito Federation and MFA

### DIFF
--- a/extensions/idp/entraid/EntraIdApiConfig.ts
+++ b/extensions/idp/entraid/EntraIdApiConfig.ts
@@ -1,4 +1,4 @@
-import { CognitoIdpConfig } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito/api";
 
 class EntraIdConfig implements CognitoIdpConfig.Interface {
     getIdentity(_token: CognitoIdpConfig.JwtPayload) {

--- a/extensions/idp/entraid/EntraIdApiConfig.ts
+++ b/extensions/idp/entraid/EntraIdApiConfig.ts
@@ -1,0 +1,15 @@
+import { CognitoIdpConfig } from "@webiny/cognito";
+
+class EntraIdConfig implements CognitoIdpConfig.Interface {
+    getIdentity(_token: CognitoIdpConfig.JwtPayload) {
+        return {
+            roles: ["full-access"],
+            teams: []
+        };
+    }
+}
+
+export default CognitoIdpConfig.createImplementation({
+    implementation: EntraIdConfig,
+    dependencies: []
+});

--- a/extensions/idp/entraid/Extension.tsx
+++ b/extensions/idp/entraid/Extension.tsx
@@ -24,6 +24,7 @@ export const CognitoFederation = () => {
                             oidc_issuer: process.env.ENTRA_OIDC_ISSUER
                         },
                         attributeMapping: {
+                            "custom:id": "sub",
                             username: "sub",
                             email: "email",
                             given_name: "given_name",

--- a/extensions/idp/entraid/Extension.tsx
+++ b/extensions/idp/entraid/Extension.tsx
@@ -4,12 +4,13 @@ import { Cognito } from "@webiny/cognito";
 export const CognitoFederation = () => {
     return (
         <Cognito
+            mfa={true}
             apiConfig={"@/extensions/idp/entraid/EntraIdApiConfig.ts"}
             federation={{
                 domain: "myproj-webiny-with-entraid",
                 callbackUrls: ["https://webiny-6.4.x.localhost"],
                 responseType: "code",
-                allowCredentialsLogin: false,
+                allowCredentialsLogin: true,
                 identityProviders: [
                     {
                         name: "EntraID",

--- a/extensions/idp/entraid/Extension.tsx
+++ b/extensions/idp/entraid/Extension.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Cognito } from "@webiny/cognito";
+
+export const CognitoFederation = () => {
+    return (
+        <Cognito
+            apiConfig={"@/extensions/idp/entraid/EntraIdApiConfig.ts"}
+            federation={{
+                domain: "myproj-webiny-with-entraid",
+                callbackUrls: ["https://webiny-6.4.x.localhost"],
+                responseType: "code",
+                allowCredentialsLogin: false,
+                identityProviders: [
+                    {
+                        name: "EntraID",
+                        type: "oidc",
+                        label: "Sign in with Microsoft",
+                        providerDetails: {
+                            attributes_request_method: "POST",
+                            authorize_scopes: "email profile openid",
+                            client_id: process.env.ENTRA_CLIENT_ID,
+                            client_secret: process.env.ENTRA_CLIENT_SECRET,
+                            oidc_issuer: process.env.ENTRA_OIDC_ISSUER
+                        },
+                        attributeMapping: {
+                            username: "sub",
+                            email: "email",
+                            given_name: "given_name",
+                            family_name: "family_name",
+                            preferred_username: "email"
+                        }
+                    }
+                ]
+            }}
+        />
+    );
+};

--- a/packages/app-security-access-management/src/ui/views/Teams/TeamsForm.tsx
+++ b/packages/app-security-access-management/src/ui/views/Teams/TeamsForm.tsx
@@ -124,8 +124,10 @@ export const TeamsForm = ({ newEntry, id }: TeamsFormProps) => {
         );
     }
 
+    const team = { ...data, roles: (data.roles ?? []).map((r: any) => r.id) };
+
     return (
-        <Form data={data} onSubmit={onSubmit}>
+        <Form data={team} onSubmit={onSubmit}>
             {({ data, form }) => {
                 return (
                     <SimpleForm>
@@ -233,11 +235,16 @@ const FormContent = (props: FormContentProps) => {
             </Grid.Column>
             <Grid.Column span={12}>
                 <Bind name="roles" validators={validation.create("required")}>
-                    <RolesMultiAutocomplete
-                        disabled={!canModifyTeam}
-                        label={t`Roles`}
-                        data-testid="admin.am.team.new.roles"
-                    />
+                    {({ value, onChange, validation }) => (
+                        <RolesMultiAutocomplete
+                            values={value}
+                            onChange={onChange}
+                            validation={validation}
+                            disabled={!canModifyTeam}
+                            label={t`Roles`}
+                            data-testid="admin.am.team.new.roles"
+                        />
+                    )}
                 </Bind>
             </Grid.Column>
         </Grid>

--- a/packages/cognito/package.json
+++ b/packages/cognito/package.json
@@ -6,7 +6,8 @@
   "sideEffects": false,
   "exports": {
     ".": "./index.js",
-    "./*": "./*"
+    "./api": "./api/index.js",
+    "./admin": "./admin/index.js"
   },
   "description": "Security plugins for Cognito",
   "author": "Webiny Ltd.",

--- a/packages/cognito/src/Cognito.tsx
+++ b/packages/cognito/src/Cognito.tsx
@@ -3,25 +3,90 @@ import { defineExtension } from "@webiny/project/defineExtension/index.js";
 import { Api, Admin, Infra } from "@webiny/project-aws";
 import { z } from "zod";
 
+const identityProviderSchema = z.object({
+    type: z.enum(["google", "facebook", "amazon", "apple", "oidc"]),
+    name: z.string().optional(),
+    label: z.string(),
+    providerDetails: z.record(z.string(), z.any()),
+    idpIdentifiers: z.array(z.string()).optional(),
+    attributeMapping: z.record(z.string(), z.string()).optional()
+});
+
+const federationSchema = z.object({
+    domain: z.string().describe("Cognito User Pool domain prefix."),
+    callbackUrls: z.array(z.string()).describe("OAuth callback URLs."),
+    logoutUrls: z.array(z.string()).optional(),
+    responseType: z.enum(["code", "token"]).default("code"),
+    allowCredentialsLogin: z.boolean().default(true),
+    identityProviders: z.array(identityProviderSchema)
+});
+
 export const Cognito = defineExtension({
     type: "Project/Cognito",
     tags: { runtimeContext: "project" },
     description: "Enable and configure Cognito authentication.",
     paramsSchema: z.object({
-        apiConfig: z.string().describe("Path to API configuration.").optional()
+        apiConfig: z.string().describe("Path to API configuration.").optional(),
+        adminConfig: z.string().describe("Path to Admin configuration.").optional(),
+        federation: federationSchema.optional()
     }),
     render: props => {
+        const federation = props.federation;
+
         return (
             <>
                 <Infra.EnvVar varName={"REACT_APP_IDP_TYPE"} value={"cognito"} />
+
                 {/* Api extensions */}
                 <Api.Extension
                     src={import.meta.dirname + "/api/CognitoApiFeature.js"}
                     exportName={"CognitoApiFeature"}
                 />
                 {props.apiConfig ? <Api.Extension src={props.apiConfig} /> : null}
+
                 {/* Admin extensions */}
                 <Admin.Extension src={import.meta.dirname + "/admin/Extension.js"} />
+                {props.adminConfig ? <Admin.Extension src={props.adminConfig} /> : null}
+
+                {/* Federation infra + admin config */}
+                {federation ? (
+                    <>
+                        {/* Pulumi: create User Pool Domain, IdP resources, OAuth client */}
+                        <Infra.EnvVar
+                            varName={"COGNITO_FEDERATION_INFRA_CONFIG"}
+                            value={JSON.stringify({
+                                domain: federation.domain,
+                                callbackUrls: federation.callbackUrls,
+                                logoutUrls: federation.logoutUrls,
+                                identityProviders: federation.identityProviders.map(idp => ({
+                                    type: idp.type,
+                                    name: idp.name,
+                                    providerDetails: idp.providerDetails,
+                                    idpIdentifiers: idp.idpIdentifiers,
+                                    attributeMapping: idp.attributeMapping
+                                }))
+                            })}
+                        />
+                        <Infra.Core.Pulumi
+                            src={import.meta.dirname + "/infra/CognitoFederationPulumi.js"}
+                        />
+
+                        {/* Admin: pass federation config as build param */}
+                        <Admin.BuildParam
+                            paramName={"cognitoFederation"}
+                            value={{
+                                callbackUrls: federation.callbackUrls,
+                                logoutUrls: federation.logoutUrls || federation.callbackUrls,
+                                responseType: federation.responseType,
+                                allowCredentialsLogin: federation.allowCredentialsLogin,
+                                providers: federation.identityProviders.map(idp => ({
+                                    name: idp.name || idp.type,
+                                    label: idp.label
+                                }))
+                            }}
+                        />
+                    </>
+                ) : null}
             </>
         );
     }

--- a/packages/cognito/src/Cognito.tsx
+++ b/packages/cognito/src/Cognito.tsx
@@ -28,7 +28,8 @@ export const Cognito = defineExtension({
     paramsSchema: z.object({
         apiConfig: z.string().describe("Path to API configuration.").optional(),
         adminConfig: z.string().describe("Path to Admin configuration.").optional(),
-        federation: federationSchema.optional()
+        federation: federationSchema.optional(),
+        mfa: z.boolean().describe("Enable TOTP MFA for all users.").default(false)
     }),
     render: props => {
         const federation = props.federation;
@@ -36,6 +37,7 @@ export const Cognito = defineExtension({
         return (
             <>
                 <Infra.EnvVar varName={"REACT_APP_IDP_TYPE"} value={"cognito"} />
+                {props.mfa ? <Infra.EnvVar varName={"COGNITO_MFA"} value={"true"} /> : null}
 
                 {/* Api extensions */}
                 <Api.Extension

--- a/packages/cognito/src/admin/DefaultCognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/DefaultCognitoSignInConfig.ts
@@ -1,0 +1,50 @@
+import { BuildParams } from "@webiny/app-admin/features/buildParams/index.js";
+import {
+    CognitoSignInConfig,
+    type ICognitoSignInConfig
+} from "./presentation/Cognito/CognitoSignInConfig.js";
+
+interface FederationBuildParam {
+    callbackUrls: string[];
+    logoutUrls: string[];
+    responseType: "code" | "token";
+    allowCredentialsLogin: boolean;
+    providers: { name: string; label: string }[];
+}
+
+class DefaultCognitoSignInConfigImpl implements ICognitoSignInConfig {
+    constructor(private buildParams: BuildParams.Interface) {}
+
+    async getConfig() {
+        const config = this.buildParams.get<FederationBuildParam>("cognitoFederation");
+
+        if (!config) {
+            return {
+                oauth: {
+                    scopes: ["profile", "email", "openid"],
+                    redirectSignIn: [window.location.origin],
+                    redirectSignOut: [window.location.origin],
+                    responseType: "code" as const
+                },
+                allowCredentialsLogin: true,
+                providers: []
+            };
+        }
+
+        return {
+            oauth: {
+                scopes: ["profile", "email", "openid"],
+                redirectSignIn: config.callbackUrls,
+                redirectSignOut: config.logoutUrls,
+                responseType: config.responseType
+            },
+            allowCredentialsLogin: config.allowCredentialsLogin,
+            providers: config.providers
+        };
+    }
+}
+
+export const DefaultCognitoSignInConfig = CognitoSignInConfig.createImplementation({
+    implementation: DefaultCognitoSignInConfigImpl,
+    dependencies: [BuildParams]
+});

--- a/packages/cognito/src/admin/Extension.tsx
+++ b/packages/cognito/src/admin/Extension.tsx
@@ -3,6 +3,7 @@ import { RegisterFeature } from "@webiny/app-admin";
 import { CognitoFeature } from "./presentation/Cognito/feature.js";
 import { CognitoAdmin } from "./Cognito.js";
 import { CognitoPermissionsFeature } from "./features/permissions/feature.js";
+import { CognitoSignInFeature } from "./presentation/Cognito/signInFeature.js";
 
 export const Extension = () => {
     const region = process.env.REACT_APP_USER_POOL_REGION || "";
@@ -13,13 +14,8 @@ export const Extension = () => {
         <>
             <RegisterFeature feature={CognitoFeature} />
             <RegisterFeature feature={CognitoPermissionsFeature} />
-            <CognitoAdmin
-                login={{
-                    region,
-                    userPoolId,
-                    clientId
-                }}
-            />
+            <RegisterFeature feature={CognitoSignInFeature} />
+            <CognitoAdmin login={{ region, userPoolId, clientId }} />
         </>
     );
 };

--- a/packages/cognito/src/admin/index.ts
+++ b/packages/cognito/src/admin/index.ts
@@ -3,3 +3,5 @@ export {
     type FederatedProvider,
     type SignInProps
 } from "./presentation/Cognito/CognitoSignInConfig.js";
+
+export { Components } from "./presentation/Cognito/components/index.js";

--- a/packages/cognito/src/admin/index.ts
+++ b/packages/cognito/src/admin/index.ts
@@ -1,7 +1,2 @@
-export {
-    CognitoSignInConfig,
-    type FederatedProvider,
-    type SignInProps
-} from "./presentation/Cognito/CognitoSignInConfig.js";
-
-export { Components } from "./presentation/Cognito/components/index.js";
+export { CognitoSignInConfig } from "./presentation/Cognito/CognitoSignInConfig.js";
+export { Components as CognitoComponents } from "./presentation/Cognito/components/index.js";

--- a/packages/cognito/src/admin/index.ts
+++ b/packages/cognito/src/admin/index.ts
@@ -1,0 +1,5 @@
+export {
+    CognitoSignInConfig,
+    type FederatedProvider,
+    type SignInProps
+} from "./presentation/Cognito/CognitoSignInConfig.js";

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoLoginScreen.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoLoginScreen.tsx
@@ -8,6 +8,8 @@ import { RequireNewPassword } from "./components/RequireNewPassword.js";
 import { RequestPasswordResetCode } from "./components/RequestPasswordResetCode.js";
 import { SetNewPassword } from "./components/SetNewPassword.js";
 import { PasswordResetCodeSent } from "~/admin/presentation/Cognito/components/PasswordResetCodeSent.js";
+import { ConfirmTotpCode } from "./components/ConfirmTotpCode.js";
+import { SetupTotp } from "./components/SetupTotp.js";
 
 export interface CognitoLoginScreenProps {
     region: string;
@@ -74,6 +76,21 @@ export const CognitoLoginScreen = observer((props: CognitoLoginScreenProps) => {
                                 presenter.confirmPasswordReset(code, password)
                             }
                             onCancel={() => presenter.showSignIn()}
+                        />
+                    )}
+
+                    {vm.authState === "confirmTotpCode" && (
+                        <ConfirmTotpCode
+                            vm={vm.confirmTotpCode}
+                            onSubmit={code => presenter.confirmTotpCode(code)}
+                            onCancel={() => presenter.showSignIn()}
+                        />
+                    )}
+
+                    {vm.authState === "setupTotp" && (
+                        <SetupTotp
+                            vm={vm.setupTotp}
+                            onSubmit={code => presenter.verifyTotpSetup(code)}
                         />
                     )}
 

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
@@ -17,7 +17,7 @@ import {
 } from "./abstractions.js";
 import { LogInUseCase } from "@webiny/app-admin/features/security/LogIn/index.js";
 import { IdentityContext } from "@webiny/app-admin/features/security/IdentityContext/index.js";
-import { CognitoSignInConfig, type FederatedProvider } from "./CognitoSignInConfig.js";
+import { CognitoSignInConfig } from "./CognitoSignInConfig.js";
 
 const federatedDescription =
     "You will be taken to an external service to complete the sign-in process.";
@@ -34,7 +34,7 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private signInTitle = "Sign in";
     private signInDescription: string | undefined = undefined;
     private allowCredentialsLogin = true;
-    private federatedProviders: FederatedProvider[] = [];
+    private federatedProviders: CognitoSignInConfig.FederatedProvider[] = [];
 
     private totpSharedSecret = "";
     private totpQrCodeUri = "";

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
@@ -17,6 +17,10 @@ import {
 } from "./abstractions.js";
 import { LogInUseCase } from "@webiny/app-admin/features/security/LogIn/index.js";
 import { IdentityContext } from "@webiny/app-admin/features/security/IdentityContext/index.js";
+import { CognitoSignInConfig, type FederatedProvider } from "./CognitoSignInConfig.js";
+
+const federatedDescription =
+    "You will be taken to an external service to complete the sign-in process.";
 
 class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private authState: AuthState = "signIn";
@@ -27,9 +31,15 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private formLoading = false;
     private initialized = false;
 
+    private signInTitle = "Sign in";
+    private signInDescription: string | undefined = undefined;
+    private allowCredentialsLogin = true;
+    private federatedProviders: FederatedProvider[] = [];
+
     constructor(
         private identity: IdentityContext.Interface,
-        private logInUseCase: LogInUseCase.Interface
+        private logInUseCase: LogInUseCase.Interface,
+        private signInConfig: CognitoSignInConfig.Interface | undefined
     ) {
         makeAutoObservable(this);
     }
@@ -46,7 +56,11 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             // View-specific VMs
             signIn: {
                 isLoading: this.formLoading,
-                message: this.message
+                message: this.message,
+                title: this.signInTitle,
+                description: this.signInDescription,
+                allowCredentialsLogin: this.allowCredentialsLogin,
+                federatedProviders: this.federatedProviders
             },
             requestPasswordResetCode: {
                 isLoading: this.formLoading,
@@ -72,8 +86,47 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             return;
         }
 
+        let oauthConfig:
+            | { Cognito: { userPoolId: string; userPoolClientId: string; loginWith: any } }
+            | undefined;
+
+        if (this.signInConfig) {
+            const config = await this.signInConfig.getConfig();
+
+            runInAction(() => {
+                this.signInTitle = config.title ?? "Sign in";
+                this.signInDescription = config.description;
+
+                if (!config.description && !config.allowCredentialsLogin) {
+                    this.signInDescription = federatedDescription;
+                }
+
+                this.allowCredentialsLogin = config.allowCredentialsLogin;
+                this.federatedProviders = config.providers;
+            });
+
+            const domain = process.env.REACT_APP_USER_POOL_DOMAIN;
+            if (domain) {
+                oauthConfig = {
+                    Cognito: {
+                        userPoolId: params.userPoolId,
+                        userPoolClientId: params.clientId,
+                        loginWith: {
+                            oauth: {
+                                domain,
+                                redirectSignIn: config.oauth.redirectSignIn,
+                                redirectSignOut: config.oauth.redirectSignOut,
+                                scopes: config.oauth.scopes,
+                                responseType: config.oauth.responseType
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
         Amplify.configure({
-            Auth: {
+            Auth: oauthConfig ?? {
                 Cognito: {
                     userPoolId: params.userPoolId,
                     userPoolClientId: params.clientId
@@ -290,16 +343,6 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     }
 
     private async checkUrl(): Promise<void> {
-        const query = new URLSearchParams(window.location.search);
-        const queryData: Record<string, string> = {};
-        query.forEach((value, key) => (queryData[key] = value));
-        const { state } = queryData;
-
-        if (state) {
-            // Handle state from URL if needed
-            return;
-        }
-
         return this.checkSession();
     }
 
@@ -326,5 +369,5 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
 
 export const CognitoPresenter = CognitoPresenterAbstraction.createImplementation({
     implementation: CognitoPresenterImpl,
-    dependencies: [IdentityContext, LogInUseCase]
+    dependencies: [IdentityContext, LogInUseCase, [CognitoSignInConfig, { optional: true }]]
 });

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
@@ -36,6 +36,9 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private allowCredentialsLogin = true;
     private federatedProviders: FederatedProvider[] = [];
 
+    private totpSharedSecret = "";
+    private totpQrCodeUri = "";
+
     constructor(
         private identity: IdentityContext.Interface,
         private logInUseCase: LogInUseCase.Interface,
@@ -77,6 +80,16 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             requireNewPassword: {
                 isLoading: this.formLoading,
                 requiredAttributes: (this.authData && this.authData.requiredAttributes) || []
+            },
+            confirmTotpCode: {
+                isLoading: this.formLoading,
+                message: this.message
+            },
+            setupTotp: {
+                isLoading: this.formLoading,
+                sharedSecret: this.totpSharedSecret,
+                qrCodeUri: this.totpQrCodeUri,
+                message: this.message
             }
         };
     }
@@ -157,6 +170,20 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
                     this.authData = {
                         requiredAttributes: nextStep.missingAttributes || []
                     };
+                    this.formLoading = false;
+                });
+            } else if (nextStep.signInStep === "CONFIRM_SIGN_IN_WITH_TOTP_CODE") {
+                runInAction(() => {
+                    this.authState = "confirmTotpCode";
+                    this.formLoading = false;
+                });
+            } else if (nextStep.signInStep === "CONTINUE_SIGN_IN_WITH_TOTP_SETUP") {
+                const totpSetup = nextStep.totpSetupDetails;
+                const uri = totpSetup.getSetupUri("Webiny").toString();
+                runInAction(() => {
+                    this.totpSharedSecret = totpSetup.sharedSecret;
+                    this.totpQrCodeUri = uri;
+                    this.authState = "setupTotp";
                     this.formLoading = false;
                 });
             } else {
@@ -275,6 +302,54 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             runInAction(() => {
                 this.message = {
                     title: "Error",
+                    text: error.message,
+                    type: "danger"
+                };
+            });
+        } finally {
+            runInAction(() => {
+                this.formLoading = false;
+            });
+        }
+    }
+
+    async confirmTotpCode(code: string): Promise<void> {
+        runInAction(() => {
+            this.formLoading = true;
+            this.message = null;
+        });
+
+        try {
+            await confirmSignIn({ challengeResponse: code });
+            await this.handleSignedIn();
+        } catch (error) {
+            runInAction(() => {
+                this.message = {
+                    title: "Verification Failed",
+                    text: error.message,
+                    type: "danger"
+                };
+            });
+        } finally {
+            runInAction(() => {
+                this.formLoading = false;
+            });
+        }
+    }
+
+    async verifyTotpSetup(code: string): Promise<void> {
+        runInAction(() => {
+            this.formLoading = true;
+            this.message = null;
+        });
+
+        try {
+            await confirmSignIn({ challengeResponse: code });
+            await this.handleSignedIn();
+        } catch (error) {
+            runInAction(() => {
+                this.message = {
+                    title: "Setup Failed",
                     text: error.message,
                     type: "danger"
                 };

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
@@ -24,8 +24,7 @@ export interface ICognitoSignInConfig {
     }>;
 }
 
-export const CognitoSignInConfig =
-    createAbstraction<ICognitoSignInConfig>("CognitoSignInConfig");
+export const CognitoSignInConfig = createAbstraction<ICognitoSignInConfig>("CognitoSignInConfig");
 
 export namespace CognitoSignInConfig {
     export type Interface = ICognitoSignInConfig;

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
@@ -5,7 +5,7 @@ export interface SignInProps {
     signIn: () => void;
 }
 
-export type FederatedProvider =
+export type IFederatedProvider =
     | { name: string; label: string }
     | { name: string; component: React.FC<SignInProps> };
 
@@ -18,7 +18,7 @@ export interface ICognitoSignInConfig {
             responseType: "code" | "token";
         };
         allowCredentialsLogin: boolean;
-        providers: FederatedProvider[];
+        providers: IFederatedProvider[];
         title?: string;
         description?: string;
     }>;
@@ -29,4 +29,5 @@ export const CognitoSignInConfig = createAbstraction<ICognitoSignInConfig>("Cogn
 export namespace CognitoSignInConfig {
     export type Interface = ICognitoSignInConfig;
     export type Config = Awaited<ReturnType<ICognitoSignInConfig["getConfig"]>>;
+    export type FederatedProvider = IFederatedProvider;
 }

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
@@ -1,0 +1,33 @@
+import type React from "react";
+import { createAbstraction } from "@webiny/feature/admin";
+
+export interface SignInProps {
+    signIn: () => void;
+}
+
+export type FederatedProvider =
+    | { name: string; label: string }
+    | { name: string; component: React.FC<SignInProps> };
+
+export interface ICognitoSignInConfig {
+    getConfig(): Promise<{
+        oauth: {
+            scopes: string[];
+            redirectSignIn: string[];
+            redirectSignOut: string[];
+            responseType: "code" | "token";
+        };
+        allowCredentialsLogin: boolean;
+        providers: FederatedProvider[];
+        title?: string;
+        description?: string;
+    }>;
+}
+
+export const CognitoSignInConfig =
+    createAbstraction<ICognitoSignInConfig>("CognitoSignInConfig");
+
+export namespace CognitoSignInConfig {
+    export type Interface = ICognitoSignInConfig;
+    export type Config = Awaited<ReturnType<ICognitoSignInConfig["getConfig"]>>;
+}

--- a/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
@@ -8,7 +8,9 @@ export type AuthState =
     | "requestPasswordResetCode"
     | "passwordResetCodeSent"
     | "setNewPassword"
-    | "requireNewPassword";
+    | "requireNewPassword"
+    | "confirmTotpCode"
+    | "setupTotp";
 
 export interface AuthDataVerified {
     email?: string;
@@ -76,6 +78,18 @@ export interface SetNewPasswordVM {
     message: AuthMessage | null;
 }
 
+export interface ConfirmTotpCodeVM {
+    isLoading: boolean;
+    message: AuthMessage | null;
+}
+
+export interface SetupTotpVM {
+    isLoading: boolean;
+    sharedSecret: string;
+    qrCodeUri: string;
+    message: AuthMessage | null;
+}
+
 export interface ICognitoPresenter {
     vm: {
         authState: AuthState;
@@ -87,6 +101,8 @@ export interface ICognitoPresenter {
         requestPasswordResetCode: RequestPasswordResetCodeVM;
         passwordResetCodeSent: PasswordResetCodeSentVM;
         setNewPassword: SetNewPasswordVM;
+        confirmTotpCode: ConfirmTotpCodeVM;
+        setupTotp: SetupTotpVM;
     };
 
     // Lifecycle
@@ -98,6 +114,8 @@ export interface ICognitoPresenter {
     requestPasswordReset(username: string): Promise<void>;
     resendPasswordResetCode(): Promise<void>;
     confirmPasswordReset(code: string, password: string): Promise<void>;
+    confirmTotpCode(code: string): Promise<void>;
+    verifyTotpSetup(code: string): Promise<void>;
 
     // Navigation actions
     showSignIn(): void;

--- a/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
@@ -1,5 +1,5 @@
 import { createAbstraction } from "@webiny/feature/admin";
-import type { FederatedProvider } from "./CognitoSignInConfig.js";
+import type { IFederatedProvider } from "./CognitoSignInConfig.js";
 
 export type AuthState =
     | "signIn"
@@ -55,7 +55,7 @@ export interface SignInVM {
     title: string;
     description: string | undefined;
     allowCredentialsLogin: boolean;
-    federatedProviders: FederatedProvider[];
+    federatedProviders: IFederatedProvider[];
 }
 
 export interface RequireNewPasswordVM {

--- a/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
@@ -1,4 +1,5 @@
 import { createAbstraction } from "@webiny/feature/admin";
+import type { FederatedProvider } from "./CognitoSignInConfig.js";
 
 export type AuthState =
     | "signIn"
@@ -49,6 +50,10 @@ export interface ICognitoInitParams {
 export interface SignInVM {
     isLoading: boolean;
     message: AuthMessage | null;
+    title: string;
+    description: string | undefined;
+    allowCredentialsLogin: boolean;
+    federatedProviders: FederatedProvider[];
 }
 
 export interface RequireNewPasswordVM {

--- a/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { Form, Bind } from "@webiny/form";
+import { validation } from "@webiny/validation";
+import { View } from "./View.js";
+import type { ConfirmTotpCodeVM } from "~/admin/presentation/Cognito/abstractions.js";
+import { FooterSignIn } from "~/admin/presentation/Cognito/components/FooterSignIn.js";
+
+export interface ConfirmTotpCodeProps {
+    vm: ConfirmTotpCodeVM;
+    onSubmit: (code: string) => void;
+    onCancel: () => void;
+}
+
+export const ConfirmTotpCode = (props: ConfirmTotpCodeProps) => {
+    const { vm, onSubmit, onCancel } = props;
+
+    return (
+        <View.Container>
+            <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
+                {({ submit }) => (
+                    <View.Content>
+                        <View.Title
+                            title={"Two-factor authentication"}
+                            description={"Enter the 6-digit code from your authenticator app."}
+                        />
+
+                        {vm.message && (
+                            <div className={"mb-lg"}>
+                                <Alert title={vm.message.title} type={vm.message.type}>
+                                    {vm.message.text}
+                                </Alert>
+                            </div>
+                        )}
+
+                        <Grid>
+                            <Grid.Column span={12}>
+                                <Bind name="code" validators={validation.create("required")}>
+                                    <Input
+                                        label={"Verification Code"}
+                                        autoComplete={"one-time-code"}
+                                        inputMode={"numeric"}
+                                    />
+                                </Bind>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <div className={"flex items-center justify-between"}>
+                                    <FooterSignIn onSignIn={onCancel} />
+                                    <Button
+                                        text={"Verify"}
+                                        onClick={submit}
+                                        containerClassName={"ml-auto"}
+                                        disabled={vm.isLoading}
+                                    />
+                                </div>
+                            </Grid.Column>
+                        </Grid>
+                    </View.Content>
+                )}
+            </Form>
+        </View.Container>
+    );
+};

--- a/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -12,52 +13,55 @@ export interface ConfirmTotpCodeProps {
     onCancel: () => void;
 }
 
-export const ConfirmTotpCode = (props: ConfirmTotpCodeProps) => {
-    const { vm, onSubmit, onCancel } = props;
+export const ConfirmTotpCode = makeDecoratable(
+    "CognitoConfirmTotpCode",
+    (props: ConfirmTotpCodeProps) => {
+        const { vm, onSubmit, onCancel } = props;
 
-    return (
-        <View.Container>
-            <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title
-                            title={"Two-factor authentication"}
-                            description={"Enter the 6-digit code from your authenticator app."}
-                        />
+        return (
+            <View.Container>
+                <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title
+                                title={"Two-factor authentication"}
+                                description={"Enter the 6-digit code from your authenticator app."}
+                            />
 
-                        {vm.message && (
-                            <div className={"mb-lg"}>
-                                <Alert title={vm.message.title} type={vm.message.type}>
-                                    {vm.message.text}
-                                </Alert>
-                            </div>
-                        )}
-
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind name="code" validators={validation.create("required")}>
-                                    <Input
-                                        label={"Verification Code"}
-                                        autoComplete={"one-time-code"}
-                                        inputMode={"numeric"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div className={"flex items-center justify-between"}>
-                                    <FooterSignIn onSignIn={onCancel} />
-                                    <Button
-                                        text={"Verify"}
-                                        onClick={submit}
-                                        containerClassName={"ml-auto"}
-                                        disabled={vm.isLoading}
-                                    />
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
                                 </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind name="code" validators={validation.create("required")}>
+                                        <Input
+                                            label={"Verification Code"}
+                                            autoComplete={"one-time-code"}
+                                            inputMode={"numeric"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div className={"flex items-center justify-between"}>
+                                        <FooterSignIn onSignIn={onCancel} />
+                                        <Button
+                                            text={"Verify"}
+                                            onClick={submit}
+                                            containerClassName={"ml-auto"}
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/Divider.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/Divider.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Separator, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 
-export const Divider = () => {
+export const Divider = makeDecoratable("CognitoDivider", () => {
     return (
         <div className={"relative my-lg"}>
             <div className={"absolute inset-0 flex items-center"}>
@@ -14,4 +15,4 @@ export const Divider = () => {
             </div>
         </div>
     );
-};
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { signInWithRedirect } from "aws-amplify/auth";
 import { Button } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import type { FederatedProvider } from "~/admin/presentation/Cognito/CognitoSignInConfig.js";
 import { federatedIdentityProviders } from "~/admin/federatedIdentityProviders.js";
 import { FederatedProviders } from "./FederatedProviders.js";
@@ -9,44 +10,47 @@ type AuthProvider = "Amazon" | "Apple" | "Facebook" | "Google";
 
 const builtInProviders = new Set<string>(["Amazon", "Apple", "Facebook", "Google"]);
 
-interface FederatedLoginProps {
+export interface FederatedLoginProps {
     providers: FederatedProvider[];
 }
 
-export const FederatedLogin = ({ providers }: FederatedLoginProps) => {
-    return (
-        <FederatedProviders.Container>
-            {providers.map(provider => {
-                const cognitoProviderName =
-                    federatedIdentityProviders[provider.name] ?? provider.name;
-                const isBuiltIn = builtInProviders.has(cognitoProviderName);
+export const FederatedLogin = makeDecoratable(
+    "CognitoFederatedLogin",
+    ({ providers }: FederatedLoginProps) => {
+        return (
+            <FederatedProviders.Container>
+                {providers.map(provider => {
+                    const cognitoProviderName =
+                        federatedIdentityProviders[provider.name] ?? provider.name;
+                    const isBuiltIn = builtInProviders.has(cognitoProviderName);
 
-                const signIn = () => {
-                    if (isBuiltIn) {
-                        signInWithRedirect({
-                            provider: cognitoProviderName as AuthProvider
-                        });
-                    } else {
-                        signInWithRedirect({
-                            provider: { custom: cognitoProviderName }
-                        });
+                    const signIn = () => {
+                        if (isBuiltIn) {
+                            signInWithRedirect({
+                                provider: cognitoProviderName as AuthProvider
+                            });
+                        } else {
+                            signInWithRedirect({
+                                provider: { custom: cognitoProviderName }
+                            });
+                        }
+                    };
+
+                    if ("component" in provider) {
+                        const Component = provider.component;
+                        return <Component key={provider.name} signIn={signIn} />;
                     }
-                };
 
-                if ("component" in provider) {
-                    const Component = provider.component;
-                    return <Component key={provider.name} signIn={signIn} />;
-                }
-
-                return (
-                    <Button
-                        key={provider.name}
-                        text={provider.label}
-                        onClick={signIn}
-                        style={{ width: "100%" }}
-                    />
-                );
-            })}
-        </FederatedProviders.Container>
-    );
-};
+                    return (
+                        <Button
+                            key={provider.name}
+                            text={provider.label}
+                            onClick={signIn}
+                            style={{ width: "100%" }}
+                        />
+                    );
+                })}
+            </FederatedProviders.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { signInWithRedirect } from "aws-amplify/auth";
-import type { FederatedIdentityProvider } from "~/admin/federatedIdentityProviders.js";
+import { Button } from "@webiny/admin-ui";
+import type { FederatedProvider } from "~/admin/presentation/Cognito/CognitoSignInConfig.js";
 import { federatedIdentityProviders } from "~/admin/federatedIdentityProviders.js";
 import { FederatedProviders } from "./FederatedProviders.js";
 
@@ -9,14 +10,15 @@ type AuthProvider = "Amazon" | "Apple" | "Facebook" | "Google";
 const builtInProviders = new Set<string>(["Amazon", "Apple", "Facebook", "Google"]);
 
 interface FederatedLoginProps {
-    providers: FederatedIdentityProvider[];
+    providers: FederatedProvider[];
 }
 
 export const FederatedLogin = ({ providers }: FederatedLoginProps) => {
     return (
         <FederatedProviders.Container>
-            {providers.map(({ name, component: Component }) => {
-                const cognitoProviderName = federatedIdentityProviders[name] ?? name;
+            {providers.map(provider => {
+                const cognitoProviderName =
+                    federatedIdentityProviders[provider.name] ?? provider.name;
                 const isBuiltIn = builtInProviders.has(cognitoProviderName);
 
                 const signIn = () => {
@@ -31,7 +33,19 @@ export const FederatedLogin = ({ providers }: FederatedLoginProps) => {
                     }
                 };
 
-                return <Component key={name} signIn={signIn} />;
+                if ("component" in provider) {
+                    const Component = provider.component;
+                    return <Component key={provider.name} signIn={signIn} />;
+                }
+
+                return (
+                    <Button
+                        key={provider.name}
+                        text={provider.label}
+                        onClick={signIn}
+                        style={{ width: "100%" }}
+                    />
+                );
             })}
         </FederatedProviders.Container>
     );

--- a/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
@@ -2,16 +2,16 @@ import React from "react";
 import { signInWithRedirect } from "aws-amplify/auth";
 import { Button } from "@webiny/admin-ui";
 import { makeDecoratable } from "@webiny/app-admin";
-import type { FederatedProvider } from "~/admin/presentation/Cognito/CognitoSignInConfig.js";
 import { federatedIdentityProviders } from "~/admin/federatedIdentityProviders.js";
 import { FederatedProviders } from "./FederatedProviders.js";
+import { CognitoSignInConfig } from "~/admin/index.js";
 
 type AuthProvider = "Amazon" | "Apple" | "Facebook" | "Google";
 
 const builtInProviders = new Set<string>(["Amazon", "Apple", "Facebook", "Google"]);
 
 export interface FederatedLoginProps {
-    providers: FederatedProvider[];
+    providers: CognitoSignInConfig.FederatedProvider[];
 }
 
 export const FederatedLogin = makeDecoratable(

--- a/packages/cognito/src/admin/presentation/Cognito/components/FooterSignIn.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FooterSignIn.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { Link, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 
-interface FooterSignInProps {
+export interface FooterSignInProps {
     onSignIn: () => void;
 }
 
-export const FooterSignIn = ({ onSignIn }: FooterSignInProps) => {
-    return (
-        <Text as={"div"} size={"sm"}>
-            Want to sign in?&nbsp;
-            <Link to="#" onClick={onSignIn}>
-                Sign in
-            </Link>
-            .
-        </Text>
-    );
-};
+export const FooterSignIn = makeDecoratable(
+    "CognitoFooterSignIn",
+    ({ onSignIn }: FooterSignInProps) => {
+        return (
+            <Text as={"div"} size={"sm"}>
+                Want to sign in?&nbsp;
+                <Link to="#" onClick={onSignIn}>
+                    Sign in
+                </Link>
+                .
+            </Text>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/PasswordResetCodeSent.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/PasswordResetCodeSent.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert, Button, Grid, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { View } from "./View.js";
 import type { PasswordResetCodeSentVM } from "~/admin/presentation/Cognito/abstractions.js";
 import { FooterSignIn } from "~/admin/presentation/Cognito/components/FooterSignIn.js";
@@ -11,55 +12,58 @@ export interface PasswordResetCodeSentProps {
     onCancel: () => void;
 }
 
-export const PasswordResetCodeSent = (props: PasswordResetCodeSentProps) => {
-    const { vm, onResendCode, onCodeAcquired, onCancel } = props;
+export const PasswordResetCodeSent = makeDecoratable(
+    "CognitoPasswordResetCodeSent",
+    (props: PasswordResetCodeSentProps) => {
+        const { vm, onResendCode, onCodeAcquired, onCancel } = props;
 
-    return (
-        <View.Container>
-            <View.Content>
-                <View.Title
-                    title={"Password recovery"}
-                    description={"Request a password reset code."}
-                />
+        return (
+            <View.Container>
+                <View.Content>
+                    <View.Title
+                        title={"Password recovery"}
+                        description={"Request a password reset code."}
+                    />
 
-                {vm.message && (
-                    <div className={"mb-lg"}>
-                        <Alert title={vm.message.title} type={vm.message.type}>
-                            {vm.message.text}
-                        </Alert>
-                    </div>
-                )}
-
-                <Grid>
-                    <Grid.Column span={12}>
-                        <Text>We have sent you a code to reset your password.</Text>
-                    </Grid.Column>
-                    <Grid.Column span={12}>
-                        <Text>
-                            Click the &quot;Resend code&quot; button below to resend the code in
-                            case you haven&apos;t received it the first time.
-                        </Text>
-                    </Grid.Column>
-
-                    <Grid.Column span={12}>
-                        <div className={"flex items-center justify-between"}>
-                            <FooterSignIn onSignIn={onCancel} />
-                            <div className={"flex gap-x-sm"}>
-                                <Button
-                                    variant={"secondary"}
-                                    text={"Resend code"}
-                                    onClick={onResendCode}
-                                />
-                                <Button
-                                    variant={"primary"}
-                                    text={"I got the code!"}
-                                    onClick={onCodeAcquired}
-                                />
-                            </div>
+                    {vm.message && (
+                        <div className={"mb-lg"}>
+                            <Alert title={vm.message.title} type={vm.message.type}>
+                                {vm.message.text}
+                            </Alert>
                         </div>
-                    </Grid.Column>
-                </Grid>
-            </View.Content>
-        </View.Container>
-    );
-};
+                    )}
+
+                    <Grid>
+                        <Grid.Column span={12}>
+                            <Text>We have sent you a code to reset your password.</Text>
+                        </Grid.Column>
+                        <Grid.Column span={12}>
+                            <Text>
+                                Click the &quot;Resend code&quot; button below to resend the code in
+                                case you haven&apos;t received it the first time.
+                            </Text>
+                        </Grid.Column>
+
+                        <Grid.Column span={12}>
+                            <div className={"flex items-center justify-between"}>
+                                <FooterSignIn onSignIn={onCancel} />
+                                <div className={"flex gap-x-sm"}>
+                                    <Button
+                                        variant={"secondary"}
+                                        text={"Resend code"}
+                                        onClick={onResendCode}
+                                    />
+                                    <Button
+                                        variant={"primary"}
+                                        text={"I got the code!"}
+                                        onClick={onCodeAcquired}
+                                    />
+                                </div>
+                            </div>
+                        </Grid.Column>
+                    </Grid>
+                </View.Content>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/RequestPasswordResetCode.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/RequestPasswordResetCode.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -12,52 +13,57 @@ export interface ForgotPasswordProps {
     onCancel: () => void;
 }
 
-export const RequestPasswordResetCode = (props: ForgotPasswordProps) => {
-    const { vm, ...actions } = props;
+export const RequestPasswordResetCode = makeDecoratable(
+    "CognitoRequestPasswordResetCode",
+    (props: ForgotPasswordProps) => {
+        const { vm, ...actions } = props;
 
-    return (
-        <View.Container>
-            <Form onSubmit={(data: any) => actions.onRequestCode(data.username)} submitOnEnter>
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title
-                            title={"Password recovery"}
-                            description={"Request a password reset code."}
-                        />
+        return (
+            <View.Container>
+                <Form onSubmit={(data: any) => actions.onRequestCode(data.username)} submitOnEnter>
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title
+                                title={"Password recovery"}
+                                description={"Request a password reset code."}
+                            />
 
-                        {vm.message && (
-                            <div className={"mb-lg"}>
-                                <Alert title={vm.message.title} type={vm.message.type}>
-                                    {vm.message.text}
-                                </Alert>
-                            </div>
-                        )}
-
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="username"
-                                    validators={validation.create("required,email")}
-                                >
-                                    <Input label={"Email"} />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Send me the code"}
-                                        onClick={submit}
-                                        disabled={vm.isLoading}
-                                    />
-                                    <FooterSignIn onSignIn={actions.onCancel} />
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
                                 </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="username"
+                                        validators={validation.create("required,email")}
+                                    >
+                                        <Input label={"Email"} />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Send me the code"}
+                                            onClick={submit}
+                                            disabled={vm.isLoading}
+                                        />
+                                        <FooterSignIn onSignIn={actions.onCancel} />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/RequireNewPassword.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/RequireNewPassword.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Heading, Input } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -21,64 +22,72 @@ type FormData = {
     requiredAttributes: Record<string, string>;
 };
 
-export const RequireNewPassword = (props: RequireNewPasswordProps) => {
-    const { vm, onSubmit } = props;
+export const RequireNewPassword = makeDecoratable(
+    "CognitoRequireNewPassword",
+    (props: RequireNewPasswordProps) => {
+        const { vm, onSubmit } = props;
 
-    return (
-        <View.Container>
-            <Form<FormData>
-                onSubmit={data => onSubmit(data.password, data.requiredAttributes)}
-                submitOnEnter
-            >
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title title={"Set new password"} />
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind name="password" validators={validation.create("required")}>
-                                    <Input
-                                        type={"password"}
-                                        label={"New password"}
-                                        autoComplete={"off"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
+        return (
+            <View.Container>
+                <Form<FormData>
+                    onSubmit={data => onSubmit(data.password, data.requiredAttributes)}
+                    submitOnEnter
+                >
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title title={"Set new password"} />
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={validation.create("required")}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"New password"}
+                                            autoComplete={"off"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
 
-                            {vm.requiredAttributes.length > 0 ? (
-                                <>
-                                    <Grid.Column span={12}>
-                                        <Heading level={6} className={"text-center"}>
-                                            Please enter additional information
-                                        </Heading>
-                                    </Grid.Column>
-                                    {vm.requiredAttributes.map(attr => (
-                                        <Grid.Column key={attr} span={12}>
-                                            <Bind name={`requiredAttributes.${attr}`}>
-                                                <Input label={sentenceCase(attr)} />
-                                            </Bind>
+                                {vm.requiredAttributes.length > 0 ? (
+                                    <>
+                                        <Grid.Column span={12}>
+                                            <Heading level={6} className={"text-center"}>
+                                                Please enter additional information
+                                            </Heading>
                                         </Grid.Column>
-                                    ))}
-                                </>
-                            ) : (
-                                <></>
-                            )}
+                                        {vm.requiredAttributes.map(attr => (
+                                            <Grid.Column key={attr} span={12}>
+                                                <Bind name={`requiredAttributes.${attr}`}>
+                                                    <Input label={sentenceCase(attr)} />
+                                                </Bind>
+                                            </Grid.Column>
+                                        ))}
+                                    </>
+                                ) : (
+                                    <></>
+                                )}
 
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Confirm"}
-                                        onClick={submit}
-                                        size="lg"
-                                        disabled={vm.isLoading}
-                                    />
-                                </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Confirm"}
+                                            onClick={submit}
+                                            size="lg"
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/SetNewPassword.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SetNewPassword.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind, useForm } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -13,72 +14,78 @@ export interface SetNewPasswordProps {
     onCancel: () => void;
 }
 
-export const SetNewPassword = (props: SetNewPasswordProps) => {
-    const { vm, onSetNewPassword, onCancel } = props;
-    const passwordValidator = usePasswordValidator();
+export const SetNewPassword = makeDecoratable(
+    "CognitoSetNewPassword",
+    (props: SetNewPasswordProps) => {
+        const { vm, onSetNewPassword, onCancel } = props;
+        const passwordValidator = usePasswordValidator();
 
-    return (
-        <View.Container>
-            <Form
-                onSubmit={(data: any) => onSetNewPassword(data.code, data.password)}
-                submitOnEnter
-            >
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title title={"Set new password"} />
+        return (
+            <View.Container>
+                <Form
+                    onSubmit={(data: any) => onSetNewPassword(data.code, data.password)}
+                    submitOnEnter
+                >
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title title={"Set new password"} />
 
-                        {vm.message && (
-                            <div className={"mb-lg"}>
-                                <Alert title={vm.message.title} type={vm.message.type}>
-                                    {vm.message.text}
-                                </Alert>
-                            </div>
-                        )}
-
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind name="code" validators={validation.create("required")}>
-                                    <Input
-                                        label={"Verification Code"}
-                                        description={"Enter the code we sent to your email."}
-                                        autoComplete={"new-password"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="password"
-                                    validators={[validation.create("required"), passwordValidator]}
-                                >
-                                    <Input
-                                        type={"password"}
-                                        label={"New Password"}
-                                        description={"Enter your new password."}
-                                        autoComplete={"new-password"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <RetypePassword />
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div className={"flex items-center justify-between"}>
-                                    <FooterSignIn onSignIn={onCancel} />
-                                    <Button
-                                        text={"Reset Password"}
-                                        onClick={submit}
-                                        containerClassName={"ml-auto"}
-                                        disabled={vm.isLoading}
-                                    />
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
                                 </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind name="code" validators={validation.create("required")}>
+                                        <Input
+                                            label={"Verification Code"}
+                                            description={"Enter the code we sent to your email."}
+                                            autoComplete={"new-password"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={[
+                                            validation.create("required"),
+                                            passwordValidator
+                                        ]}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"New Password"}
+                                            description={"Enter your new password."}
+                                            autoComplete={"new-password"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <RetypePassword />
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div className={"flex items-center justify-between"}>
+                                        <FooterSignIn onSignIn={onCancel} />
+                                        <Button
+                                            text={"Reset Password"}
+                                            onClick={submit}
+                                            containerClassName={"ml-auto"}
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);
 
 const RetypePassword = () => {
     const form = useForm();

--- a/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Button, Grid, Input, Alert, Text } from "@webiny/admin-ui";
+import { Form, Bind } from "@webiny/form";
+import { validation } from "@webiny/validation";
+import { View } from "./View.js";
+import type { SetupTotpVM } from "~/admin/presentation/Cognito/abstractions.js";
+
+export interface SetupTotpProps {
+    vm: SetupTotpVM;
+    onSubmit: (code: string) => void;
+}
+
+export const SetupTotp = (props: SetupTotpProps) => {
+    const { vm, onSubmit } = props;
+
+    return (
+        <View.Container>
+            <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
+                {({ submit }) => (
+                    <View.Content>
+                        <View.Title
+                            title={"Set up two-factor authentication"}
+                            description={
+                                "Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.), then enter the 6-digit code to verify."
+                            }
+                        />
+
+                        {vm.message && (
+                            <div className={"mb-lg"}>
+                                <Alert title={vm.message.title} type={vm.message.type}>
+                                    {vm.message.text}
+                                </Alert>
+                            </div>
+                        )}
+
+                        <Grid>
+                            <Grid.Column span={12}>
+                                <div className={"flex justify-center my-md"}>
+                                    <img
+                                        src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(vm.qrCodeUri)}`}
+                                        alt={"TOTP QR Code"}
+                                        width={200}
+                                        height={200}
+                                    />
+                                </div>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <Text size={"sm"} className={"text-neutral-strong"}>
+                                    {"Can't scan the code? Enter this key manually:"}
+                                </Text>
+                                <Text
+                                    as={"div"}
+                                    size={"sm"}
+                                    className={"font-mono mt-xs select-all break-all"}
+                                >
+                                    {vm.sharedSecret}
+                                </Text>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <Bind name="code" validators={validation.create("required")}>
+                                    <Input
+                                        label={"Verification Code"}
+                                        description={
+                                            "Enter the 6-digit code from your authenticator app."
+                                        }
+                                        autoComplete={"one-time-code"}
+                                        inputMode={"numeric"}
+                                    />
+                                </Bind>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <div className={"flex justify-end"}>
+                                    <Button
+                                        text={"Verify & Enable"}
+                                        onClick={submit}
+                                        disabled={vm.isLoading}
+                                    />
+                                </div>
+                            </Grid.Column>
+                        </Grid>
+                    </View.Content>
+                )}
+            </Form>
+        </View.Container>
+    );
+};

--- a/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -10,7 +11,7 @@ export interface SetupTotpProps {
     onSubmit: (code: string) => void;
 }
 
-export const SetupTotp = (props: SetupTotpProps) => {
+export const SetupTotp = makeDecoratable("CognitoSetupTotp", (props: SetupTotpProps) => {
     const { vm, onSubmit } = props;
 
     return (
@@ -83,4 +84,4 @@ export const SetupTotp = (props: SetupTotpProps) => {
             </Form>
         </View.Container>
     );
-};
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/SignIn.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SignIn.tsx
@@ -2,19 +2,22 @@ import React from "react";
 import { Grid, Input, Alert, Link, Button, Text, OverlayLoader } from "@webiny/admin-ui";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
+import { makeDecoratable } from "@webiny/app-admin";
 import { View } from "./View.js";
+import { FederatedLogin } from "./FederatedLogin.js";
+import { Divider } from "./Divider.js";
 import type { SignInVM } from "~/admin/presentation/Cognito/abstractions.js";
 
 export interface SignInProps {
     vm: SignInVM;
     onSubmit: (username: string, password: string) => void;
     onForgotPassword: () => void;
-    title?: string;
-    description?: React.ReactNode;
 }
 
-export const SignIn = (props: SignInProps) => {
-    const { vm, onSubmit, onForgotPassword, title = "Sign in", description } = props;
+export const SignIn = makeDecoratable("CognitoSignIn", (props: SignInProps) => {
+    const { vm, onSubmit, onForgotPassword } = props;
+    const showCredentials = vm.allowCredentialsLogin;
+    const showFederated = vm.federatedProviders.length > 0;
 
     return (
         <View.Container>
@@ -22,7 +25,7 @@ export const SignIn = (props: SignInProps) => {
                 {({ submit }) => (
                     <View.Content>
                         {vm.isLoading ? <OverlayLoader text={"Authenticating..."} /> : null}
-                        <View.Title title={title} description={description} />
+                        <View.Title title={vm.title} description={vm.description} />
 
                         {vm.message && (
                             <div className={"mb-lg"}>
@@ -32,48 +35,59 @@ export const SignIn = (props: SignInProps) => {
                             </div>
                         )}
 
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="username"
-                                    validators={validation.create("required,email")}
-                                    beforeChange={(val: string, cb: (value: string) => void) =>
-                                        cb(val.toLowerCase())
-                                    }
-                                >
-                                    <Input label={"Email"} />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <Bind name="password" validators={validation.create("required")}>
-                                    <Input
-                                        type={"password"}
-                                        label={"Password"}
-                                        autoComplete={"off"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Submit"}
-                                        data-testid="submit-sign-in-form-button"
-                                        onClick={submit}
-                                        disabled={vm.isLoading}
-                                    />
-                                    <Text as={"div"} size={"sm"}>
-                                        <Link to="#" onClick={onForgotPassword}>
-                                            Forgot password?
-                                        </Link>
-                                    </Text>
-                                </div>
-                            </Grid.Column>
-                        </Grid>
+                        {showCredentials && (
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="username"
+                                        validators={validation.create("required,email")}
+                                        beforeChange={(val: string, cb: (value: string) => void) =>
+                                            cb(val.toLowerCase())
+                                        }
+                                    >
+                                        <Input label={"Email"} />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={validation.create("required")}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"Password"}
+                                            autoComplete={"off"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Submit"}
+                                            data-testid="submit-sign-in-form-button"
+                                            onClick={submit}
+                                            disabled={vm.isLoading}
+                                        />
+                                        <Text as={"div"} size={"sm"}>
+                                            <Link to="#" onClick={onForgotPassword}>
+                                                Forgot password?
+                                            </Link>
+                                        </Text>
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        )}
+
+                        {showCredentials && showFederated && <Divider />}
+
+                        {showFederated && <FederatedLogin providers={vm.federatedProviders} />}
                     </View.Content>
                 )}
             </Form>
         </View.Container>
     );
-};
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/index.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/components/index.ts
@@ -1,0 +1,27 @@
+import { SignIn } from "./SignIn.js";
+import { ConfirmTotpCode } from "./ConfirmTotpCode.js";
+import { SetupTotp } from "./SetupTotp.js";
+import { RequireNewPassword } from "./RequireNewPassword.js";
+import { RequestPasswordResetCode } from "./RequestPasswordResetCode.js";
+import { PasswordResetCodeSent } from "./PasswordResetCodeSent.js";
+import { SetNewPassword } from "./SetNewPassword.js";
+import { FederatedLogin } from "./FederatedLogin.js";
+import { FederatedProviders } from "./FederatedProviders.js";
+import { Divider } from "./Divider.js";
+import { FooterSignIn } from "./FooterSignIn.js";
+import { View } from "./View.js";
+
+export const Components = {
+    SignIn,
+    ConfirmTotpCode,
+    SetupTotp,
+    RequireNewPassword,
+    RequestPasswordResetCode,
+    PasswordResetCodeSent,
+    SetNewPassword,
+    FederatedLogin,
+    FederatedProviders,
+    Divider,
+    FooterSignIn,
+    View
+};

--- a/packages/cognito/src/admin/presentation/Cognito/signInFeature.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/signInFeature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/admin";
+import { DefaultCognitoSignInConfig } from "~/admin/DefaultCognitoSignInConfig.js";
+
+export const CognitoSignInFeature = createFeature({
+    name: "CognitoSignIn",
+    register(container) {
+        container.register(DefaultCognitoSignInConfig).inSingletonScope();
+    }
+});

--- a/packages/cognito/src/admin/ui/views/Users/UsersForm.tsx
+++ b/packages/cognito/src/admin/ui/views/Users/UsersForm.tsx
@@ -176,11 +176,16 @@ export const UserForm = ({ teams }: UserFormProps) => {
                                 <Grid>
                                     <Grid.Column span={12}>
                                         <Bind name={"roles"} validators={groupValidators}>
-                                            <RolesMultiAutocomplete
-                                                label={"Roles"}
-                                                data-testid="roles-autocomplete"
-                                                disabled={isDisabled}
-                                            />
+                                            {({ value, onChange, validation }) => (
+                                                <RolesMultiAutocomplete
+                                                    values={value}
+                                                    onChange={onChange}
+                                                    validation={validation}
+                                                    label={"Roles"}
+                                                    data-testid="roles-autocomplete"
+                                                    disabled={isDisabled}
+                                                />
+                                            )}
                                         </Bind>
                                     </Grid.Column>
                                 </Grid>
@@ -194,11 +199,16 @@ export const UserForm = ({ teams }: UserFormProps) => {
                                     <Grid>
                                         <Grid.Column span={12}>
                                             <Bind name={"teams"}>
-                                                <TeamsMultiAutocomplete
-                                                    label={"Teams"}
-                                                    data-testid="teams-autocomplete"
-                                                    disabled={isDisabled}
-                                                />
+                                                {({ value, onChange, validation }) => (
+                                                    <TeamsMultiAutocomplete
+                                                        values={value}
+                                                        onChange={onChange}
+                                                        validation={validation}
+                                                        label={"Teams"}
+                                                        data-testid="teams-autocomplete"
+                                                        disabled={isDisabled}
+                                                    />
+                                                )}
                                             </Bind>
                                         </Grid.Column>
                                     </Grid>

--- a/packages/cognito/src/admin/ui/views/Users/hooks/useUserForm.ts
+++ b/packages/cognito/src/admin/ui/views/Users/hooks/useUserForm.ts
@@ -106,7 +106,9 @@ export function useUserForm() {
         user: {
             ...user,
             group: user.group ? user.group.id : undefined,
-            team: user.team ? user.team.id : undefined
+            team: user.team ? user.team.id : undefined,
+            roles: user.roles ? user.roles.map((r: any) => r.id) : [],
+            teams: user.teams ? user.teams.map((t: any) => t.id) : []
         },
         onSubmit,
         isNewUser: newUser,

--- a/packages/cognito/src/api/features/CognitoIdp/CognitoIdentityProvider.ts
+++ b/packages/cognito/src/api/features/CognitoIdp/CognitoIdentityProvider.ts
@@ -24,26 +24,14 @@ class CognitoIdentityProviderImpl implements OidcIdentityProvider.Interface {
     async getIdentity(
         token: OidcIdentityProvider.JwtPayload
     ): Promise<OidcIdentityProvider.IdentityData> {
-        const customIdentity = this.config ? await this.config.getIdentity(token) : null;
+        const isFederated = Array.isArray(token.identities) && token.identities.length > 0;
 
-        if (customIdentity) {
-            return {
-                ...customIdentity,
-                type: "admin",
-                profile: {
-                    ...customIdentity,
-                    external: false
-                }
-            };
-        }
-
-        // Default identity
         const customId = token["custom:id"] as string | undefined;
         const givenName = token["given_name"] as string | undefined;
         const familyName = token["family_name"] as string | undefined;
         const email = token["email"] as string | undefined;
 
-        return {
+        const defaultIdentity: OidcIdentityProvider.IdentityData = {
             id: customId || token.sub || "",
             displayName: `${givenName || ""} ${familyName || ""}`.trim() || email || "Unknown User",
             type: "admin",
@@ -51,7 +39,24 @@ class CognitoIdentityProviderImpl implements OidcIdentityProvider.Interface {
                 email: email || "",
                 firstName: givenName || "",
                 lastName: familyName || "",
-                external: false
+                external: isFederated
+            }
+        };
+
+        const customIdentity = this.config ? await this.config.getIdentity(token) : null;
+
+        if (!customIdentity) {
+            return defaultIdentity;
+        }
+
+        return {
+            ...defaultIdentity,
+            ...customIdentity,
+            type: "admin",
+            profile: {
+                ...defaultIdentity.profile,
+                ...customIdentity.profile,
+                external: isFederated
             }
         };
     }

--- a/packages/cognito/src/api/features/CognitoIdp/abstractions.ts
+++ b/packages/cognito/src/api/features/CognitoIdp/abstractions.ts
@@ -3,7 +3,7 @@ import type jwt from "jsonwebtoken";
 import type { IdentityData } from "@webiny/api-core/idp";
 
 export type CognitoIdentity = Omit<IdentityData, "type"> & {
-    profile: Omit<IdentityData["profile"], "external">;
+    profile?: Omit<IdentityData["profile"], "external">;
 };
 
 export interface ICognitoIdpConfig {

--- a/packages/cognito/src/api/index.ts
+++ b/packages/cognito/src/api/index.ts
@@ -1,0 +1,1 @@
+export { CognitoIdpConfig } from "./features/CognitoIdp/index.js";

--- a/packages/cognito/src/index.ts
+++ b/packages/cognito/src/index.ts
@@ -1,3 +1,4 @@
 export { Cognito } from "./Cognito.js";
 export { CognitoIdpConfig } from "./api/features/CognitoIdp/index.js";
 export { CognitoSignInConfig } from "./admin/index.js";
+export { Components as CognitoComponents } from "./admin/index.js";

--- a/packages/cognito/src/index.ts
+++ b/packages/cognito/src/index.ts
@@ -1,4 +1,1 @@
 export { Cognito } from "./Cognito.js";
-export { CognitoIdpConfig } from "./api/features/CognitoIdp/index.js";
-export { CognitoSignInConfig } from "./admin/index.js";
-export { Components as CognitoComponents } from "./admin/index.js";

--- a/packages/cognito/src/index.ts
+++ b/packages/cognito/src/index.ts
@@ -1,2 +1,3 @@
 export { Cognito } from "./Cognito.js";
 export { CognitoIdpConfig } from "./api/features/CognitoIdp/index.js";
+export { CognitoSignInConfig } from "./admin/index.js";

--- a/packages/cognito/src/infra/CognitoFederationPulumi.ts
+++ b/packages/cognito/src/infra/CognitoFederationPulumi.ts
@@ -1,0 +1,22 @@
+import { CorePulumi } from "@webiny/project-aws/exports/infra/core.js";
+import {
+    configureAdminCognitoFederation,
+    type CognitoIdentityProvidersConfig
+} from "@webiny/project-aws/pulumi/apps/core/cognitoIdentityProviders/configure.js";
+
+class CognitoFederationPulumiImpl implements CorePulumi.Interface {
+    execute(app: CorePulumi.Params): void {
+        const raw = process.env.COGNITO_FEDERATION_INFRA_CONFIG;
+        if (!raw) {
+            return;
+        }
+
+        const config: CognitoIdentityProvidersConfig = JSON.parse(raw);
+        configureAdminCognitoFederation(app, config);
+    }
+}
+
+export default CorePulumi.createImplementation({
+    implementation: CognitoFederationPulumiImpl,
+    dependencies: []
+});

--- a/packages/project-aws/src/pulumi/apps/core/CoreCognito.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreCognito.ts
@@ -4,6 +4,7 @@ import { createAppModule, type PulumiApp, type PulumiAppModule } from "@webiny/p
 export interface CoreCognitoParams {
     protect: boolean;
     useEmailAsUsername: boolean;
+    mfa?: boolean;
 }
 
 export type CoreCognito = PulumiAppModule<typeof CoreCognito>;
@@ -35,7 +36,8 @@ export const CoreCognito = createAppModule({
                 usernameAttributes: params.useEmailAsUsername ? ["email"] : undefined,
                 aliasAttributes: params.useEmailAsUsername ? undefined : ["preferred_username"],
                 lambdaConfig: {},
-                mfaConfiguration: "OFF",
+                mfaConfiguration: params.mfa ? "ON" : "OFF",
+                softwareTokenMfaConfiguration: params.mfa ? { enabled: true } : undefined,
                 userPoolAddOns: {
                     advancedSecurityMode: "OFF" /* required */
                 },

--- a/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
@@ -75,6 +75,7 @@ export const configureAdminCognitoFederation = (
     );
 
     const idpConfigs: aws.cognito.IdentityProviderArgs[] = [];
+    const idpOutputs: pulumi.Output<aws.cognito.IdentityProvider>[] = [];
 
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
@@ -87,10 +88,16 @@ export const configureAdminCognitoFederation = (
         // names to be all lowercase anyway.
         const name = config.providerName.toString().toLowerCase();
 
-        app.addResource(aws.cognito.IdentityProvider, { name, config });
+        const idpResource = app.addResource(aws.cognito.IdentityProvider, { name, config });
+        idpOutputs.push(idpResource.output);
 
         idpConfigs.push(config);
     }
+
+    appClient.opts.dependsOn = [
+        ...(appClient.opts.dependsOn ? (Array.isArray(appClient.opts.dependsOn) ? appClient.opts.dependsOn : [appClient.opts.dependsOn]) : []),
+        ...idpOutputs
+    ] as pulumi.Input<pulumi.Resource>[];
 
     appClient.config.supportedIdentityProviders([
         "COGNITO",

--- a/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
@@ -95,7 +95,11 @@ export const configureAdminCognitoFederation = (
     }
 
     appClient.opts.dependsOn = [
-        ...(appClient.opts.dependsOn ? (Array.isArray(appClient.opts.dependsOn) ? appClient.opts.dependsOn : [appClient.opts.dependsOn]) : []),
+        ...(appClient.opts.dependsOn
+            ? Array.isArray(appClient.opts.dependsOn)
+                ? appClient.opts.dependsOn
+                : [appClient.opts.dependsOn]
+            : []),
         ...idpOutputs
     ] as pulumi.Input<pulumi.Resource>[];
 

--- a/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
@@ -249,6 +249,28 @@ export function createCorePulumiApp() {
                 useEmailAsUsername: false
             });
 
+            // Cognito custom:id was originally set to maxLength 36 (UUID). Federated OIDC
+            // providers (e.g., Entra ID) can produce sub values longer than 36 chars. Since
+            // Cognito doesn't allow changing custom attribute constraints after pool creation,
+            // we only increase it for new deployments. Existing pools keep their original limit.
+            const isNewDeployment = !coreStackOutput || Object.keys(coreStackOutput).length === 0;
+            if (isNewDeployment) {
+                cognito.userPool.config.schemas(schemas => {
+                    return schemas?.map(schema => {
+                        if (schema.name === "id") {
+                            return {
+                                ...schema,
+                                stringAttributeConstraints: {
+                                    ...schema.stringAttributeConstraints,
+                                    maxLength: "256"
+                                }
+                            };
+                        }
+                        return schema;
+                    });
+                });
+            }
+
             // Setup event bus
             const eventBus = app.addModule(CoreEventBus);
 

--- a/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
@@ -246,7 +246,8 @@ export function createCorePulumiApp() {
             // Setup Cognito
             const cognito = app.addModule(CoreCognito, {
                 protect,
-                useEmailAsUsername: false
+                useEmailAsUsername: false,
+                mfa: process.env.COGNITO_MFA === "true"
             });
 
             // Cognito custom:id was originally set to maxLength 36 (UUID). Federated OIDC
@@ -269,6 +270,11 @@ export function createCorePulumiApp() {
                         return schema;
                     });
                 });
+            } else {
+                cognito.userPool.opts.ignoreChanges = [
+                    ...(cognito.userPool.opts.ignoreChanges || []),
+                    "schemas"
+                ];
             }
 
             // Setup event bus

--- a/skills/user-skills/cognito-federation/SKILL.md
+++ b/skills/user-skills/cognito-federation/SKILL.md
@@ -221,7 +221,7 @@ Map Cognito groups to Webiny roles/teams:
 
 ```ts
 // extensions/cognito/api.ts
-import { CognitoIdpConfig } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito/api";
 
 class MyConfig implements CognitoIdpConfig.Interface {
   getIdentity(token: CognitoIdpConfig.JwtPayload) {
@@ -258,7 +258,7 @@ export default CognitoIdpConfig.createImplementation({
 
 ```tsx
 // extensions/cognito/admin.tsx
-import { CognitoSignInConfig } from "@webiny/cognito";
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
 
 const ALLOWED_IPS = ["1.2.3.4", "5.6.7.8"];
 
@@ -301,7 +301,7 @@ export default CognitoSignInConfig.createImplementation({
 
 ```tsx
 // extensions/cognito/admin.tsx
-import { CognitoSignInConfig } from "@webiny/cognito";
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
 import { GoogleLoginButton } from "react-social-login-buttons";
 
 class MyFederationConfig implements CognitoSignInConfig.Interface {
@@ -350,7 +350,9 @@ class MyFederationConfig implements CognitoSignInConfig.Interface {
 
 ### Example 6: Custom Attribute Mapping
 
-Override the default OIDC attribute mapping:
+Override the default OIDC attribute mapping when your IdP uses non-standard claim names.
+
+The `custom:id` mapping is important — Webiny uses it as the primary user identifier. It's mapped to the IdP's `sub` claim by default. Always include it in custom mappings unless the IdP's `sub` value exceeds 36 characters on an existing Cognito pool (deployed prior to Webiny 6.4.4). New pools support up to 256 characters.
 
 ```tsx
 <Cognito
@@ -369,6 +371,7 @@ Override the default OIDC attribute mapping:
           oidc_issuer: "..."
         },
         attributeMapping: {
+          "custom:id": "sub",
           username: "sub",
           email: "email",
           given_name: "first_name",
@@ -426,20 +429,20 @@ When MFA is enabled:
 import { Cognito } from "@webiny/cognito";
 
 // API identity mapping
-import { CognitoIdpConfig } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito/api";
 
 // Admin login customization
-import { CognitoSignInConfig } from "@webiny/cognito";
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
 ```
 
 ### Key Interfaces
 
-| Interface                       | Package           | Purpose                                   |
-| ------------------------------- | ----------------- | ----------------------------------------- |
-| `CognitoIdpConfig.Interface`    | `@webiny/cognito` | API-side JWT-to-identity mapping          |
-| `CognitoIdpConfig.JwtPayload`   | `@webiny/cognito` | JWT token payload type                    |
-| `CognitoSignInConfig.Interface` | `@webiny/cognito` | Admin login screen customization          |
-| `FederatedProvider`             | `@webiny/cognito` | Provider button type (label or component) |
+| Interface                               | Package                 | Purpose                                   |
+| --------------------------------------- | ----------------------- | ----------------------------------------- |
+| `CognitoIdpConfig.Interface`            | `@webiny/cognito/api`   | API-side JWT-to-identity mapping          |
+| `CognitoIdpConfig.JwtPayload`           | `@webiny/cognito/api`   | JWT token payload type                    |
+| `CognitoSignInConfig.Interface`         | `@webiny/cognito/admin` | Admin login screen customization          |
+| `CognitoSignInConfig.FederatedProvider` | `@webiny/cognito/admin` | Provider button type (label or component) |
 
 ### File Structure (Advanced)
 

--- a/skills/user-skills/cognito-federation/SKILL.md
+++ b/skills/user-skills/cognito-federation/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: webiny-cognito-federation
+description: >
+  Configuring Cognito Federation for Webiny projects — federated sign-in via
+  external identity providers (Google, Facebook, Apple, Amazon, OIDC/Entra ID)
+  while keeping Cognito as the user pool. Use this skill when the developer asks
+  about Cognito federation, SSO with Cognito, adding Google/Microsoft/OIDC login
+  to Cognito, federated identity providers, CognitoSignInConfig, CognitoIdpConfig, external
+  users, signInWithRedirect, OAuth redirect URLs, hiding the password form,
+  allowCredentialsLogin, or customizing the federated login screen.
+---
+
+# Cognito Federation
+
+## TL;DR
+
+Webiny supports federated sign-in through Cognito — users authenticate via external identity providers (Google, Entra ID, etc.) while Cognito remains the user pool. Configure it by adding a `federation` prop to `<Cognito />` in `webiny.config.tsx`. This handles both infrastructure (Cognito User Pool Domain, IdP resources, OAuth client) and the admin login screen (provider buttons, OAuth for Amplify). Federated users are auto-detected and synced into Webiny. For advanced use cases, provide `apiConfig` (custom identity mapping) and/or `adminConfig` (custom login screen behavior).
+
+## Pattern / Core Concept
+
+Cognito Federation has three layers:
+
+1. **Infrastructure** — The `federation` prop on `<Cognito />`, under the hood, creates the Cognito User Pool Domain, Identity Provider resources, and configures OAuth on the User Pool Client.
+
+2. **Admin Login Screen** — The federation config is passed as an `Admin.BuildParam` to the admin app. A `CognitoSignInConfig` abstraction provides the login screen with provider buttons, OAuth settings for Amplify, and credentials visibility. By default, this is auto-generated from the `federation` prop. For advanced customization (IP whitelists, async logic), provide an `adminConfig` extension.
+
+3. **API Identity** — Federated tokens are auto-detected via the `identities` JWT claim and marked `external: true`. The `ExternalIdpUserSyncHandler` auto-creates/updates users on login. For custom role/team mapping, provide an `apiConfig` extension implementing `CognitoIdpConfig`.
+
+### How Federated Login Works
+
+1. User clicks a provider button on the login screen
+2. `signInWithRedirect()` redirects to Cognito Hosted UI
+3. Cognito redirects to the external IdP (Google, Entra ID, etc.)
+4. After authentication, Cognito creates an `idToken` with an `identities` claim
+5. The admin app picks up the session via `fetchAuthSession()`
+6. The API detects `identities` in the token, sets `external: true`
+7. `ExternalIdpUserSyncHandler` creates/updates the Webiny user with roles/teams
+
+## Reference Tables
+
+### `<Cognito />` Federation Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `federation` | `object` | Federation config (see below) |
+| `apiConfig` | `string` | Path to API identity mapping extension |
+| `adminConfig` | `string` | Path to Admin login customization extension |
+
+### `federation` Object
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `domain` | `string` | Yes | — | Cognito User Pool domain prefix |
+| `callbackUrls` | `string[]` | Yes | — | OAuth callback/redirect URLs |
+| `logoutUrls` | `string[]` | No | `callbackUrls` | OAuth logout redirect URLs |
+| `responseType` | `"code" \| "token"` | No | `"code"` | OAuth response type |
+| `allowCredentialsLogin` | `boolean` | No | `true` | Show email/password form |
+| `identityProviders` | `array` | Yes | — | List of federated IdPs |
+
+### `identityProviders[]` Items
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"google" \| "facebook" \| "amazon" \| "apple" \| "oidc"` | Yes | Provider type |
+| `name` | `string` | No | Custom provider name (required for OIDC) |
+| `label` | `string` | Yes | Button text on the login screen |
+| `providerDetails` | `object` | Yes | AWS Cognito provider details (client_id, client_secret, etc.) |
+| `attributeMapping` | `object` | No | Custom attribute mapping (overrides defaults) |
+
+### `CognitoSignInConfig.Interface` (Admin Customization)
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `getConfig()` | `() => Promise<Config>` | Returns federation config for the login screen |
+
+### `CognitoSignInConfig.Config` (Return Type)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oauth` | `{ scopes, redirectSignIn, redirectSignOut, responseType }` | Yes | Amplify OAuth config |
+| `allowCredentialsLogin` | `boolean` | Yes | Show email/password form |
+| `providers` | `FederatedProvider[]` | Yes | Provider buttons |
+| `title` | `string` | No | Login screen title (default: "Sign in") |
+| `description` | `string` | No | Login screen description |
+
+### `FederatedProvider` (Union Type)
+
+```ts
+type FederatedProvider =
+    | { name: string; label: string }        // Auto-rendered button
+    | { name: string; component: React.FC<{ signIn: () => void }> }  // Custom button
+```
+
+### `CognitoIdpConfig.Interface` (API Identity Mapping)
+
+| Method | Signature | Required | Description |
+|--------|-----------|----------|-------------|
+| `getIdentity` | `(token: JwtPayload) => CognitoIdentity \| Promise<CognitoIdentity>` | Yes | Maps JWT claims to Webiny identity |
+| `verifyTokenClaims` | `(token: JwtPayload) => void \| Promise<void>` | No | Custom claim verification |
+
+### Identity Return Type
+
+Default identity fields (`id`, `displayName`, `profile`) are auto-populated from standard Cognito claims (`custom:id`, `given_name`, `family_name`, `email`). The custom `getIdentity` only needs to return fields it wants to **override** — typically `roles` and `teams`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | User ID (default: `custom:id` or `sub`) |
+| `displayName` | `string` | Display name (default: from name claims) |
+| `roles` | `string[]` | Webiny roles by slug |
+| `teams` | `string[]` | Webiny teams by slug |
+| `profile` | `{ email, firstName, lastName }` | User profile (defaults from claims) |
+
+## Full Examples
+
+### Example 1: Simple Federation (No Extension Files)
+
+```tsx
+// webiny.config.tsx
+import { Cognito } from "@webiny/cognito";
+
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001", "https://admin.example.com"],
+    responseType: "code",
+    identityProviders: [
+      {
+        type: "google",
+        label: "Sign in with Google",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.GOOGLE_CLIENT_ID),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET),
+        }
+      }
+    ]
+  }}
+/>
+```
+
+This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Google" button, and auto-syncs federated users.
+
+### Example 2: OIDC Provider (Entra ID / Custom)
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER),
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 3: Multiple Providers
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    responseType: "code",
+    identityProviders: [
+      {
+        type: "google",
+        label: "Sign in with Google",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.GOOGLE_CLIENT_ID),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET),
+        }
+      },
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER),
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 4: Custom Identity Mapping (apiConfig)
+
+Map Cognito groups to Webiny roles/teams:
+
+```tsx
+// webiny.config.tsx
+<Cognito
+  federation={{ /* ... */ }}
+  apiConfig={"/extensions/cognito/api.ts"}
+/>
+```
+
+```ts
+// extensions/cognito/api.ts
+import { CognitoIdpConfig } from "@webiny/cognito";
+
+class MyConfig implements CognitoIdpConfig.Interface {
+    getIdentity(token: CognitoIdpConfig.JwtPayload) {
+        const cognitoGroups: string[] = (token["cognito:groups"] as string[]) || [];
+
+        return {
+            roles: cognitoGroups.includes("admins") ? ["full-access"] : ["content-editor"],
+            teams: cognitoGroups.filter(g => g.startsWith("team-")),
+        };
+    }
+}
+
+export default CognitoIdpConfig.createImplementation({
+    implementation: MyConfig,
+    dependencies: []
+});
+```
+
+### Example 5: Custom Admin Login Screen (adminConfig)
+
+#### IP-based credentials whitelist
+
+```tsx
+// webiny.config.tsx
+<Cognito
+  federation={{ /* ... */ }}
+  adminConfig={"/extensions/cognito/admin.tsx"}
+/>
+```
+
+```tsx
+// extensions/cognito/admin.tsx
+import { CognitoSignInConfig } from "@webiny/cognito";
+
+const ALLOWED_IPS = ["1.2.3.4", "5.6.7.8"];
+
+async function fetchUserIP(): Promise<string> {
+    const response = await fetch("https://api64.ipify.org?format=json");
+    const data = await response.json();
+    return data.ip;
+}
+
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+    async getConfig() {
+        let allowCredentials = false;
+
+        if (process.env.REACT_APP_STAGE !== "prod") {
+            const ip = await fetchUserIP();
+            allowCredentials = ALLOWED_IPS.includes(ip);
+        }
+
+        return {
+            oauth: {
+                scopes: ["profile", "email", "openid"],
+                redirectSignIn: [window.location.origin],
+                redirectSignOut: [window.location.origin],
+                responseType: "code" as const,
+            },
+            allowCredentialsLogin: allowCredentials,
+            providers: [
+                { name: "EntraID", label: "Sign in with Microsoft" }
+            ],
+            title: "Welcome",
+        };
+    }
+}
+
+export default CognitoSignInConfig.createImplementation({
+    implementation: MyFederationConfig,
+    dependencies: []
+});
+```
+
+#### Custom button component
+
+```tsx
+// extensions/cognito/admin.tsx
+import { CognitoSignInConfig } from "@webiny/cognito";
+import { GoogleLoginButton } from "react-social-login-buttons";
+
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+    async getConfig() {
+        return {
+            oauth: {
+                scopes: ["profile", "email", "openid"],
+                redirectSignIn: [window.location.origin],
+                redirectSignOut: [window.location.origin],
+                responseType: "code" as const,
+            },
+            allowCredentialsLogin: true,
+            providers: [
+                {
+                    name: "google",
+                    component: ({ signIn }) => <GoogleLoginButton onClick={signIn} />
+                }
+            ],
+        };
+    }
+}
+
+export default CognitoSignInConfig.createImplementation({
+    implementation: MyFederationConfig,
+    dependencies: []
+});
+```
+
+#### Custom title and description
+
+```tsx
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+    async getConfig() {
+        return {
+            oauth: { /* ... */ },
+            allowCredentialsLogin: false,
+            providers: [
+                { name: "EntraID", label: "Sign In" }
+            ],
+            title: "Company Portal",
+            description: "Use your corporate credentials to sign in.",
+        };
+    }
+}
+```
+
+### Example 6: Custom Attribute Mapping
+
+Override the default OIDC attribute mapping:
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "MyIDP",
+        type: "oidc",
+        label: "Sign in with MyIDP",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: "...",
+          client_secret: "...",
+          oidc_issuer: "...",
+        },
+        attributeMapping: {
+          username: "sub",
+          email: "email",
+          given_name: "first_name",
+          family_name: "last_name",
+        }
+      }
+    ]
+  }}
+/>
+```
+
+## Quick Reference
+
+### Imports
+
+```typescript
+// Extension component
+import { Cognito } from "@webiny/cognito";
+
+// API identity mapping
+import { CognitoIdpConfig } from "@webiny/cognito";
+
+// Admin login customization
+import { CognitoSignInConfig } from "@webiny/cognito";
+```
+
+### Key Interfaces
+
+| Interface | Package | Purpose |
+|-----------|---------|---------|
+| `CognitoIdpConfig.Interface` | `@webiny/cognito` | API-side JWT-to-identity mapping |
+| `CognitoIdpConfig.JwtPayload` | `@webiny/cognito` | JWT token payload type |
+| `CognitoSignInConfig.Interface` | `@webiny/cognito` | Admin login screen customization |
+| `FederatedProvider` | `@webiny/cognito` | Provider button type (label or component) |
+
+### File Structure (Advanced)
+
+```
+extensions/cognito/
+├── api.ts       # API config (identity mapping) — optional
+└── admin.tsx    # Admin config (login customization) — optional
+```
+
+### Deploy
+
+```bash
+yarn webiny deploy        # Deploy all (Core + API + Admin)
+```
+
+Core must be deployed first (creates IdP resources), then API + Admin.
+
+## Related Skills
+
+- **webiny-configure-entraid** — Specific guide for Microsoft Entra ID federation
+- **webiny-configure-okta** — Alternative: Okta replaces Cognito entirely
+- **webiny-configure-auth0** — Alternative: Auth0 replaces Cognito entirely
+- **webiny-dependency-injection** — The DI pattern used by `createImplementation()`

--- a/skills/user-skills/cognito-federation/SKILL.md
+++ b/skills/user-skills/cognito-federation/SKILL.md
@@ -40,75 +40,75 @@ Cognito Federation has three layers:
 
 ### `<Cognito />` Federation Props
 
-| Prop | Type | Description |
-|------|------|-------------|
-| `federation` | `object` | Federation config (see below) |
-| `apiConfig` | `string` | Path to API identity mapping extension |
+| Prop          | Type     | Description                                 |
+| ------------- | -------- | ------------------------------------------- |
+| `federation`  | `object` | Federation config (see below)               |
+| `apiConfig`   | `string` | Path to API identity mapping extension      |
 | `adminConfig` | `string` | Path to Admin login customization extension |
 
 ### `federation` Object
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `domain` | `string` | Yes | — | Cognito User Pool domain prefix |
-| `callbackUrls` | `string[]` | Yes | — | OAuth callback/redirect URLs |
-| `logoutUrls` | `string[]` | No | `callbackUrls` | OAuth logout redirect URLs |
-| `responseType` | `"code" \| "token"` | No | `"code"` | OAuth response type |
-| `allowCredentialsLogin` | `boolean` | No | `true` | Show email/password form |
-| `identityProviders` | `array` | Yes | — | List of federated IdPs |
+| Field                   | Type                | Required | Default        | Description                     |
+| ----------------------- | ------------------- | -------- | -------------- | ------------------------------- |
+| `domain`                | `string`            | Yes      | —              | Cognito User Pool domain prefix |
+| `callbackUrls`          | `string[]`          | Yes      | —              | OAuth callback/redirect URLs    |
+| `logoutUrls`            | `string[]`          | No       | `callbackUrls` | OAuth logout redirect URLs      |
+| `responseType`          | `"code" \| "token"` | No       | `"code"`       | OAuth response type             |
+| `allowCredentialsLogin` | `boolean`           | No       | `true`         | Show email/password form        |
+| `identityProviders`     | `array`             | Yes      | —              | List of federated IdPs          |
 
 ### `identityProviders[]` Items
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | `"google" \| "facebook" \| "amazon" \| "apple" \| "oidc"` | Yes | Provider type |
-| `name` | `string` | No | Custom provider name (required for OIDC) |
-| `label` | `string` | Yes | Button text on the login screen |
-| `providerDetails` | `object` | Yes | AWS Cognito provider details (client_id, client_secret, etc.) |
-| `attributeMapping` | `object` | No | Custom attribute mapping (overrides defaults) |
+| Field              | Type                                                      | Required | Description                                                   |
+| ------------------ | --------------------------------------------------------- | -------- | ------------------------------------------------------------- |
+| `type`             | `"google" \| "facebook" \| "amazon" \| "apple" \| "oidc"` | Yes      | Provider type                                                 |
+| `name`             | `string`                                                  | No       | Custom provider name (required for OIDC)                      |
+| `label`            | `string`                                                  | Yes      | Button text on the login screen                               |
+| `providerDetails`  | `object`                                                  | Yes      | AWS Cognito provider details (client_id, client_secret, etc.) |
+| `attributeMapping` | `object`                                                  | No       | Custom attribute mapping (overrides defaults)                 |
 
 ### `CognitoSignInConfig.Interface` (Admin Customization)
 
-| Method | Signature | Description |
-|--------|-----------|-------------|
+| Method        | Signature               | Description                                    |
+| ------------- | ----------------------- | ---------------------------------------------- |
 | `getConfig()` | `() => Promise<Config>` | Returns federation config for the login screen |
 
 ### `CognitoSignInConfig.Config` (Return Type)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `oauth` | `{ scopes, redirectSignIn, redirectSignOut, responseType }` | Yes | Amplify OAuth config |
-| `allowCredentialsLogin` | `boolean` | Yes | Show email/password form |
-| `providers` | `FederatedProvider[]` | Yes | Provider buttons |
-| `title` | `string` | No | Login screen title (default: "Sign in") |
-| `description` | `string` | No | Login screen description |
+| Field                   | Type                                                        | Required | Description                             |
+| ----------------------- | ----------------------------------------------------------- | -------- | --------------------------------------- |
+| `oauth`                 | `{ scopes, redirectSignIn, redirectSignOut, responseType }` | Yes      | Amplify OAuth config                    |
+| `allowCredentialsLogin` | `boolean`                                                   | Yes      | Show email/password form                |
+| `providers`             | `FederatedProvider[]`                                       | Yes      | Provider buttons                        |
+| `title`                 | `string`                                                    | No       | Login screen title (default: "Sign in") |
+| `description`           | `string`                                                    | No       | Login screen description                |
 
 ### `FederatedProvider` (Union Type)
 
 ```ts
 type FederatedProvider =
-    | { name: string; label: string }        // Auto-rendered button
-    | { name: string; component: React.FC<{ signIn: () => void }> }  // Custom button
+  | { name: string; label: string } // Auto-rendered button
+  | { name: string; component: React.FC<{ signIn: () => void }> }; // Custom button
 ```
 
 ### `CognitoIdpConfig.Interface` (API Identity Mapping)
 
-| Method | Signature | Required | Description |
-|--------|-----------|----------|-------------|
-| `getIdentity` | `(token: JwtPayload) => CognitoIdentity \| Promise<CognitoIdentity>` | Yes | Maps JWT claims to Webiny identity |
-| `verifyTokenClaims` | `(token: JwtPayload) => void \| Promise<void>` | No | Custom claim verification |
+| Method              | Signature                                                            | Required | Description                        |
+| ------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------- |
+| `getIdentity`       | `(token: JwtPayload) => CognitoIdentity \| Promise<CognitoIdentity>` | Yes      | Maps JWT claims to Webiny identity |
+| `verifyTokenClaims` | `(token: JwtPayload) => void \| Promise<void>`                       | No       | Custom claim verification          |
 
 ### Identity Return Type
 
 Default identity fields (`id`, `displayName`, `profile`) are auto-populated from standard Cognito claims (`custom:id`, `given_name`, `family_name`, `email`). The custom `getIdentity` only needs to return fields it wants to **override** — typically `roles` and `teams`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | `string` | User ID (default: `custom:id` or `sub`) |
-| `displayName` | `string` | Display name (default: from name claims) |
-| `roles` | `string[]` | Webiny roles by slug |
-| `teams` | `string[]` | Webiny teams by slug |
-| `profile` | `{ email, firstName, lastName }` | User profile (defaults from claims) |
+| Field         | Type                             | Description                              |
+| ------------- | -------------------------------- | ---------------------------------------- |
+| `id`          | `string`                         | User ID (default: `custom:id` or `sub`)  |
+| `displayName` | `string`                         | Display name (default: from name claims) |
+| `roles`       | `string[]`                       | Webiny roles by slug                     |
+| `teams`       | `string[]`                       | Webiny teams by slug                     |
+| `profile`     | `{ email, firstName, lastName }` | User profile (defaults from claims)      |
 
 ## Full Examples
 
@@ -130,12 +130,12 @@ import { Cognito } from "@webiny/cognito";
         providerDetails: {
           authorize_scopes: "email profile openid",
           client_id: String(process.env.GOOGLE_CLIENT_ID),
-          client_secret: String(process.env.GOOGLE_CLIENT_SECRET),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET)
         }
       }
     ]
   }}
-/>
+/>;
 ```
 
 This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Google" button, and auto-syncs federated users.
@@ -159,7 +159,7 @@ This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Goog
           authorize_scopes: "email profile openid",
           client_id: String(process.env.ENTRA_CLIENT_ID),
           client_secret: String(process.env.ENTRA_CLIENT_SECRET),
-          oidc_issuer: String(process.env.ENTRA_ISSUER),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
         }
       }
     ]
@@ -182,7 +182,7 @@ This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Goog
         providerDetails: {
           authorize_scopes: "email profile openid",
           client_id: String(process.env.GOOGLE_CLIENT_ID),
-          client_secret: String(process.env.GOOGLE_CLIENT_SECRET),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET)
         }
       },
       {
@@ -194,7 +194,7 @@ This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Goog
           authorize_scopes: "email profile openid",
           client_id: String(process.env.ENTRA_CLIENT_ID),
           client_secret: String(process.env.ENTRA_CLIENT_SECRET),
-          oidc_issuer: String(process.env.ENTRA_ISSUER),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
         }
       }
     ]
@@ -209,7 +209,11 @@ Map Cognito groups to Webiny roles/teams:
 ```tsx
 // webiny.config.tsx
 <Cognito
-  federation={{ /* ... */ }}
+  federation={
+    {
+      /* ... */
+    }
+  }
   apiConfig={"/extensions/cognito/api.ts"}
 />
 ```
@@ -219,19 +223,19 @@ Map Cognito groups to Webiny roles/teams:
 import { CognitoIdpConfig } from "@webiny/cognito";
 
 class MyConfig implements CognitoIdpConfig.Interface {
-    getIdentity(token: CognitoIdpConfig.JwtPayload) {
-        const cognitoGroups: string[] = (token["cognito:groups"] as string[]) || [];
+  getIdentity(token: CognitoIdpConfig.JwtPayload) {
+    const cognitoGroups: string[] = (token["cognito:groups"] as string[]) || [];
 
-        return {
-            roles: cognitoGroups.includes("admins") ? ["full-access"] : ["content-editor"],
-            teams: cognitoGroups.filter(g => g.startsWith("team-")),
-        };
-    }
+    return {
+      roles: cognitoGroups.includes("admins") ? ["full-access"] : ["content-editor"],
+      teams: cognitoGroups.filter(g => g.startsWith("team-"))
+    };
+  }
 }
 
 export default CognitoIdpConfig.createImplementation({
-    implementation: MyConfig,
-    dependencies: []
+  implementation: MyConfig,
+  dependencies: []
 });
 ```
 
@@ -242,7 +246,11 @@ export default CognitoIdpConfig.createImplementation({
 ```tsx
 // webiny.config.tsx
 <Cognito
-  federation={{ /* ... */ }}
+  federation={
+    {
+      /* ... */
+    }
+  }
   adminConfig={"/extensions/cognito/admin.tsx"}
 />
 ```
@@ -254,39 +262,37 @@ import { CognitoSignInConfig } from "@webiny/cognito";
 const ALLOWED_IPS = ["1.2.3.4", "5.6.7.8"];
 
 async function fetchUserIP(): Promise<string> {
-    const response = await fetch("https://api64.ipify.org?format=json");
-    const data = await response.json();
-    return data.ip;
+  const response = await fetch("https://api64.ipify.org?format=json");
+  const data = await response.json();
+  return data.ip;
 }
 
 class MyFederationConfig implements CognitoSignInConfig.Interface {
-    async getConfig() {
-        let allowCredentials = false;
+  async getConfig() {
+    let allowCredentials = false;
 
-        if (process.env.REACT_APP_STAGE !== "prod") {
-            const ip = await fetchUserIP();
-            allowCredentials = ALLOWED_IPS.includes(ip);
-        }
-
-        return {
-            oauth: {
-                scopes: ["profile", "email", "openid"],
-                redirectSignIn: [window.location.origin],
-                redirectSignOut: [window.location.origin],
-                responseType: "code" as const,
-            },
-            allowCredentialsLogin: allowCredentials,
-            providers: [
-                { name: "EntraID", label: "Sign in with Microsoft" }
-            ],
-            title: "Welcome",
-        };
+    if (process.env.REACT_APP_STAGE !== "prod") {
+      const ip = await fetchUserIP();
+      allowCredentials = ALLOWED_IPS.includes(ip);
     }
+
+    return {
+      oauth: {
+        scopes: ["profile", "email", "openid"],
+        redirectSignIn: [window.location.origin],
+        redirectSignOut: [window.location.origin],
+        responseType: "code" as const
+      },
+      allowCredentialsLogin: allowCredentials,
+      providers: [{ name: "EntraID", label: "Sign in with Microsoft" }],
+      title: "Welcome"
+    };
+  }
 }
 
 export default CognitoSignInConfig.createImplementation({
-    implementation: MyFederationConfig,
-    dependencies: []
+  implementation: MyFederationConfig,
+  dependencies: []
 });
 ```
 
@@ -298,28 +304,28 @@ import { CognitoSignInConfig } from "@webiny/cognito";
 import { GoogleLoginButton } from "react-social-login-buttons";
 
 class MyFederationConfig implements CognitoSignInConfig.Interface {
-    async getConfig() {
-        return {
-            oauth: {
-                scopes: ["profile", "email", "openid"],
-                redirectSignIn: [window.location.origin],
-                redirectSignOut: [window.location.origin],
-                responseType: "code" as const,
-            },
-            allowCredentialsLogin: true,
-            providers: [
-                {
-                    name: "google",
-                    component: ({ signIn }) => <GoogleLoginButton onClick={signIn} />
-                }
-            ],
-        };
-    }
+  async getConfig() {
+    return {
+      oauth: {
+        scopes: ["profile", "email", "openid"],
+        redirectSignIn: [window.location.origin],
+        redirectSignOut: [window.location.origin],
+        responseType: "code" as const
+      },
+      allowCredentialsLogin: true,
+      providers: [
+        {
+          name: "google",
+          component: ({ signIn }) => <GoogleLoginButton onClick={signIn} />
+        }
+      ]
+    };
+  }
 }
 
 export default CognitoSignInConfig.createImplementation({
-    implementation: MyFederationConfig,
-    dependencies: []
+  implementation: MyFederationConfig,
+  dependencies: []
 });
 ```
 
@@ -327,17 +333,17 @@ export default CognitoSignInConfig.createImplementation({
 
 ```tsx
 class MyFederationConfig implements CognitoSignInConfig.Interface {
-    async getConfig() {
-        return {
-            oauth: { /* ... */ },
-            allowCredentialsLogin: false,
-            providers: [
-                { name: "EntraID", label: "Sign In" }
-            ],
-            title: "Company Portal",
-            description: "Use your corporate credentials to sign in.",
-        };
-    }
+  async getConfig() {
+    return {
+      oauth: {
+        /* ... */
+      },
+      allowCredentialsLogin: false,
+      providers: [{ name: "EntraID", label: "Sign In" }],
+      title: "Company Portal",
+      description: "Use your corporate credentials to sign in."
+    };
+  }
 }
 ```
 
@@ -359,13 +365,13 @@ Override the default OIDC attribute mapping:
           authorize_scopes: "email profile openid",
           client_id: "...",
           client_secret: "...",
-          oidc_issuer: "...",
+          oidc_issuer: "..."
         },
         attributeMapping: {
           username: "sub",
           email: "email",
           given_name: "first_name",
-          family_name: "last_name",
+          family_name: "last_name"
         }
       }
     ]
@@ -390,12 +396,12 @@ import { CognitoSignInConfig } from "@webiny/cognito";
 
 ### Key Interfaces
 
-| Interface | Package | Purpose |
-|-----------|---------|---------|
-| `CognitoIdpConfig.Interface` | `@webiny/cognito` | API-side JWT-to-identity mapping |
-| `CognitoIdpConfig.JwtPayload` | `@webiny/cognito` | JWT token payload type |
-| `CognitoSignInConfig.Interface` | `@webiny/cognito` | Admin login screen customization |
-| `FederatedProvider` | `@webiny/cognito` | Provider button type (label or component) |
+| Interface                       | Package           | Purpose                                   |
+| ------------------------------- | ----------------- | ----------------------------------------- |
+| `CognitoIdpConfig.Interface`    | `@webiny/cognito` | API-side JWT-to-identity mapping          |
+| `CognitoIdpConfig.JwtPayload`   | `@webiny/cognito` | JWT token payload type                    |
+| `CognitoSignInConfig.Interface` | `@webiny/cognito` | Admin login screen customization          |
+| `FederatedProvider`             | `@webiny/cognito` | Provider button type (label or component) |
 
 ### File Structure (Advanced)
 

--- a/skills/user-skills/cognito-federation/SKILL.md
+++ b/skills/user-skills/cognito-federation/SKILL.md
@@ -38,13 +38,14 @@ Cognito Federation has three layers:
 
 ## Reference Tables
 
-### `<Cognito />` Federation Props
+### `<Cognito />` Props
 
-| Prop          | Type     | Description                                 |
-| ------------- | -------- | ------------------------------------------- |
-| `federation`  | `object` | Federation config (see below)               |
-| `apiConfig`   | `string` | Path to API identity mapping extension      |
-| `adminConfig` | `string` | Path to Admin login customization extension |
+| Prop          | Type      | Description                                      |
+| ------------- | --------- | ------------------------------------------------ |
+| `federation`  | `object`  | Federation config (see below)                    |
+| `mfa`         | `boolean` | Enable TOTP MFA for all users (default: `false`) |
+| `apiConfig`   | `string`  | Path to API identity mapping extension           |
+| `adminConfig` | `string`  | Path to Admin login customization extension      |
 
 ### `federation` Object
 
@@ -378,6 +379,43 @@ Override the default OIDC attribute mapping:
   }}
 />
 ```
+
+## MFA (Multi-Factor Authentication)
+
+Enable TOTP-based MFA for all admin users with `mfa={true}`:
+
+```tsx
+<Cognito mfa={true} />
+```
+
+Or combine with federation:
+
+```tsx
+<Cognito
+  mfa={true}
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          /* ... */
+        }
+      }
+    ]
+  }}
+/>
+```
+
+When MFA is enabled:
+
+- The Cognito User Pool requires TOTP for all users (`mfaConfiguration: "ON"`)
+- On first login, users see a TOTP setup screen with a QR code to scan with their authenticator app (Google Authenticator, Authy, etc.)
+- On subsequent logins, users enter a 6-digit code from their authenticator app
+- MFA applies to password-based logins only — federated IdP logins are handled by the external provider
 
 ## Quick Reference
 

--- a/skills/user-skills/configure-entraid/SKILL.md
+++ b/skills/user-skills/configure-entraid/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: webiny-configure-entraid
+description: >
+  Configuring Microsoft Entra ID (formerly Azure AD) as a federated identity
+  provider for Webiny projects using Cognito Federation. Use this skill when the
+  developer asks about Entra ID, Azure AD, Microsoft SSO, OIDC with Microsoft,
+  Microsoft login for Webiny, or configuring login.microsoftonline.com as an
+  identity provider. Also relevant for tenant IDs, Entra application registration,
+  or connecting Microsoft 365 accounts to Webiny.
+---
+
+# Configure Microsoft Entra ID Authentication
+
+## TL;DR
+
+Webiny supports Microsoft Entra ID (formerly Azure AD) as a federated identity provider through Cognito Federation. Unlike Okta or Auth0 which replace Cognito entirely, Entra ID works **alongside** Cognito — users authenticate via Microsoft, but Cognito remains the user pool. Configure it by adding `federation` to the `<Cognito />` extension in `webiny.config.tsx` with your Entra ID application's client ID, client secret, and issuer URL.
+
+## Prerequisites
+
+Before configuring Webiny, you need to register an application in the Microsoft Entra ID portal:
+
+1. Go to [Microsoft Entra admin center](https://entra.microsoft.com) > **App registrations** > **New registration**
+2. Set a name (e.g., "Webiny Admin")
+3. Set **Supported account types** (typically "Accounts in this organizational directory only")
+4. Set **Redirect URI**: Web — use your Cognito domain callback URL (you'll get this after the first deploy: `https://{domain}.auth.{region}.amazoncognito.com/oauth2/idpresponse`)
+5. After registration, note:
+   - **Application (client) ID** — this is your `client_id`
+   - **Directory (tenant) ID** — part of your issuer URL
+6. Go to **Certificates & secrets** > **New client secret** — note the **Value** (this is your `client_secret`)
+7. The **Issuer URL** is: `https://login.microsoftonline.com/{tenant-id}/v2.0`
+
+## Reference Tables
+
+### Required Entra ID Values
+
+| Value                   | Where to find it                          | Used as                              |
+| ----------------------- | ----------------------------------------- | ------------------------------------ |
+| Application (client) ID | App registration > Overview               | `client_id` in `providerDetails`     |
+| Client secret value     | App registration > Certificates & secrets | `client_secret` in `providerDetails` |
+| Directory (tenant) ID   | App registration > Overview               | Part of `oidc_issuer` URL            |
+
+### Environment Variables
+
+| Variable              | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `ENTRA_CLIENT_ID`     | Entra ID Application (client) ID                     |
+| `ENTRA_CLIENT_SECRET` | Entra ID client secret value                         |
+| `ENTRA_ISSUER`        | `https://login.microsoftonline.com/{tenant-id}/v2.0` |
+
+## Full Examples
+
+### Example 1: Basic Entra ID Federation
+
+**Step 1: Set environment variables**
+
+Add to your `.env` file:
+
+```
+# NOTE: these are made up example values
+ENTRA_CLIENT_ID=f62ee823-2811-8314-a040-62848442c0d5
+ENTRA_CLIENT_SECRET=~Gp7Q~97MAzTAUyeTLzTVzX31DRTY28chehU6c_a
+ENTRA_ISSUER=https://login.microsoftonline.com/1cd0d912-0ac4-48a0-91b6-cd849ce9498f/v2.0
+```
+
+**Step 2: Create the extension**
+
+Create `extensions/entraid/Extension.tsx`:
+
+```tsx
+import React from "react";
+import { Cognito } from "@webiny/cognito";
+
+export const CognitoFederation = () => {
+  return (
+    <Cognito
+      federation={{
+        domain: "my-app-entraid",
+        callbackUrls: ["http://localhost:3001"],
+        responseType: "code",
+        identityProviders: [
+          {
+            name: "EntraID",
+            type: "oidc",
+            label: "Sign in with Microsoft",
+            providerDetails: {
+              attributes_request_method: "POST",
+              authorize_scopes: "email profile openid",
+              client_id: String(process.env.ENTRA_CLIENT_ID),
+              client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+              oidc_issuer: String(process.env.ENTRA_ISSUER)
+            }
+          }
+        ]
+      }}
+    />
+  );
+};
+```
+
+**Step 3: Register in `webiny.config.tsx`**
+
+```tsx
+import { CognitoFederation } from "@/extensions/entraid/Extension.js";
+
+export const Extensions = () => {
+  return (
+    <>
+      {/* Replace <Cognito /> with the federation extension */}
+      <CognitoFederation />
+
+      {/* ... other extensions ... */}
+    </>
+  );
+};
+```
+
+**Step 4: Deploy**
+
+```bash
+# Deploy core first (creates Cognito IdP resources)
+yarn webiny deploy core --env=dev
+
+# Get the Cognito domain for Entra ID redirect URI config
+yarn webiny output core --env=dev
+# Look for cognitoUserPoolDomain — use it to update the redirect URI in Entra ID
+
+# Deploy API + Admin
+yarn webiny deploy api --env=dev
+yarn webiny deploy admin --env=dev
+```
+
+**Step 5: Update Entra ID redirect URI**
+
+After the first deploy, update the redirect URI in your Entra ID app registration to:
+`https://{cognitoUserPoolDomain}/oauth2/idpresponse`
+
+### Example 2: Entra ID Only (No Password Login)
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app-entraid",
+    callbackUrls: ["http://localhost:3001", "https://admin.example.com"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+This hides the email/password form and shows only the "Sign in with Microsoft" button with a description that the user will be redirected.
+
+### Example 3: Entra ID with Custom Role Mapping
+
+Map Entra ID groups (via Cognito groups or token claims) to Webiny roles:
+
+```tsx
+// webiny.config.tsx
+<CognitoFederation />
+// where CognitoFederation includes:
+// apiConfig={"@/extensions/entraid/api.ts"}
+```
+
+```ts
+// extensions/entraid/api.ts
+import { CognitoIdpConfig } from "@webiny/cognito";
+
+class EntraIdConfig implements CognitoIdpConfig.Interface {
+  getIdentity(token: CognitoIdpConfig.JwtPayload) {
+    const groups: string[] = (token["cognito:groups"] as string[]) || [];
+
+    return {
+      roles: groups.includes("WebinyAdmins") ? ["full-access"] : ["content-editor"],
+      teams: groups.filter(g => g.startsWith("team-"))
+    };
+  }
+}
+
+export default CognitoIdpConfig.createImplementation({
+  implementation: EntraIdConfig,
+  dependencies: []
+});
+```
+
+### Example 4: Production Setup with Multiple Callback URLs
+
+```tsx
+<Cognito
+    federation={{
+        domain: "mycompany-webiny",
+        callbackUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+        logoutUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+        responseType: "code",
+        allowCredentialsLogin: false,
+        identityProviders: [
+            {
+                name: "EntraID",
+                type: "oidc",
+                label: "Sign in with Microsoft",
+                providerDetails: {
+                    attributes_request_method: "POST",
+                    authorize_scopes: "email profile openid",
+                    client_id: String(process.env.ENTRA_CLIENT_ID),
+                    client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+                    oidc_issuer: String(process.env.ENTRA_ISSUER)
+                }
+            }
+        ]
+    }}
+/>
+```
+
+Remember to add **all** callback URLs to your Entra ID app registration's redirect URIs.
+
+## Quick Reference
+
+### Imports
+
+```typescript
+import { Cognito } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito"; // for API config
+import { CognitoSignInConfig } from "@webiny/cognito"; // for Admin config
+```
+
+### File Structure
+
+```
+extensions/entraid/
+├── Extension.tsx       # Extension component with <Cognito federation={...} />
+├── api.ts              # API config (role mapping) — optional
+└── admin.tsx           # Admin config (login customization) — optional
+```
+
+### Deploy Order
+
+1. `yarn webiny deploy core --env=dev` — creates Cognito IdP resources
+2. Update Entra ID redirect URI with the `cognitoUserPoolDomain` output
+3. `yarn webiny deploy api --env=dev` — deploys API with identity mapping
+4. `yarn webiny deploy admin --env=dev` — deploys admin with login screen
+
+## Related Skills
+
+- **webiny-cognito-federation** — Full reference for all Cognito Federation options
+- **webiny-configure-okta** — Alternative: Okta replaces Cognito entirely
+- **webiny-configure-auth0** — Alternative: Auth0 replaces Cognito entirely

--- a/skills/user-skills/configure-entraid/SKILL.md
+++ b/skills/user-skills/configure-entraid/SKILL.md
@@ -47,6 +47,44 @@ Before configuring Webiny, you need to register an application in the Microsoft 
 | `ENTRA_CLIENT_SECRET` | Entra ID client secret value                         |
 | `ENTRA_ISSUER`        | `https://login.microsoftonline.com/{tenant-id}/v2.0` |
 
+### Attribute Mapping
+
+When Cognito receives tokens from Entra ID, it maps the OIDC claims to Cognito user attributes. The default OIDC mapping is:
+
+| Cognito Attribute    | OIDC Claim    | Description                        |
+| -------------------- | ------------- | ---------------------------------- |
+| `username`           | `sub`         | Unique user identifier             |
+| `custom:id`          | `sub`         | Webiny internal user ID            |
+| `email`              | `email`       | User's email address               |
+| `given_name`         | `given_name`  | First name                         |
+| `family_name`        | `family_name` | Last name                          |
+| `preferred_username` | `email`       | Used as the Cognito username alias |
+
+You can override this mapping with the `attributeMapping` property on the identity provider config. This is useful when:
+
+- Your Entra ID uses non-standard claim names
+- You want to skip `custom:id` mapping (e.g., when the `sub` value exceeds the attribute's max length on existing pools)
+- You need to map additional custom attributes
+
+```tsx
+{
+    name: "EntraID",
+    type: "oidc",
+    label: "Sign in with Microsoft",
+    providerDetails: { /* ... */ },
+    attributeMapping: {
+        username: "sub",
+        email: "email",
+        given_name: "given_name",
+        family_name: "family_name",
+        preferred_username: "email"
+        // custom:id intentionally omitted
+    }
+}
+```
+
+When `attributeMapping` is provided, it **replaces** the defaults entirely — include all mappings you need.
+
 ## Full Examples
 
 ### Example 1: Basic Entra ID Federation
@@ -176,7 +214,7 @@ Map Entra ID groups (via Cognito groups or token claims) to Webiny roles:
 
 ```ts
 // extensions/entraid/api.ts
-import { CognitoIdpConfig } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito/api";
 
 class EntraIdConfig implements CognitoIdpConfig.Interface {
   getIdentity(token: CognitoIdpConfig.JwtPayload) {
@@ -225,7 +263,41 @@ export default CognitoIdpConfig.createImplementation({
 
 Remember to add **all** callback URLs to your Entra ID app registration's redirect URIs.
 
-### Example 5: Entra ID with MFA
+### Example 5: Custom Attribute Mapping
+
+Override the default claim mapping — useful for existing Cognito pools where `custom:id` has a max length of 36 characters (Entra ID `sub` values can be longer):
+
+```tsx
+<Cognito
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        },
+        attributeMapping: {
+          username: "sub",
+          email: "email",
+          given_name: "given_name",
+          family_name: "family_name",
+          preferred_username: "email"
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 6: Entra ID with MFA
 
 Add TOTP-based MFA on top of Entra ID federation:
 
@@ -247,6 +319,14 @@ Add TOTP-based MFA on top of Entra ID federation:
           client_id: String(process.env.ENTRA_CLIENT_ID),
           client_secret: String(process.env.ENTRA_CLIENT_SECRET),
           oidc_issuer: String(process.env.ENTRA_ISSUER)
+        },
+        attributeMapping: {
+          "custom:id": "sub",
+          username: "sub",
+          email: "email",
+          given_name: "given_name",
+          family_name: "family_name",
+          preferred_username: "email"
         }
       }
     ]
@@ -262,8 +342,8 @@ MFA applies to password-based logins. Federated sign-ins via Entra ID are handle
 
 ```typescript
 import { Cognito } from "@webiny/cognito";
-import { CognitoIdpConfig } from "@webiny/cognito"; // for API config
-import { CognitoSignInConfig } from "@webiny/cognito"; // for Admin config
+import { CognitoIdpConfig } from "@webiny/cognito/api"; // for API config
+import { CognitoSignInConfig } from "@webiny/cognito/admin"; // for Admin config
 ```
 
 ### File Structure

--- a/skills/user-skills/configure-entraid/SKILL.md
+++ b/skills/user-skills/configure-entraid/SKILL.md
@@ -199,27 +199,27 @@ export default CognitoIdpConfig.createImplementation({
 
 ```tsx
 <Cognito
-    federation={{
-        domain: "mycompany-webiny",
-        callbackUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
-        logoutUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
-        responseType: "code",
-        allowCredentialsLogin: false,
-        identityProviders: [
-            {
-                name: "EntraID",
-                type: "oidc",
-                label: "Sign in with Microsoft",
-                providerDetails: {
-                    attributes_request_method: "POST",
-                    authorize_scopes: "email profile openid",
-                    client_id: String(process.env.ENTRA_CLIENT_ID),
-                    client_secret: String(process.env.ENTRA_CLIENT_SECRET),
-                    oidc_issuer: String(process.env.ENTRA_ISSUER)
-                }
-            }
-        ]
-    }}
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+    logoutUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
 />
 ```
 

--- a/skills/user-skills/configure-entraid/SKILL.md
+++ b/skills/user-skills/configure-entraid/SKILL.md
@@ -225,6 +225,37 @@ export default CognitoIdpConfig.createImplementation({
 
 Remember to add **all** callback URLs to your Entra ID app registration's redirect URIs.
 
+### Example 5: Entra ID with MFA
+
+Add TOTP-based MFA on top of Entra ID federation:
+
+```tsx
+<Cognito
+  mfa={true}
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001"],
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+MFA applies to password-based logins. Federated sign-ins via Entra ID are handled by Microsoft's own authentication — configure MFA on the Entra ID side if needed for those users.
+
 ## Quick Reference
 
 ### Imports

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Admin, Api, Cli, Infra, Project } from "webiny/extensions";
-import { Cognito } from "@webiny/cognito";
 import { MyFeature } from "@/extensions/myFeature/Extension.js";
+import { CognitoFederation } from "@/extensions/idp/entraid/Extension.js";
 // import { MyIdpExtension } from "./extensions/idp/okta/MyIdpExtension.js";
 
 export const Extensions = () => {
@@ -118,7 +118,7 @@ export const Extensions = () => {
             )}
             {/* API */}
             {/*<MyIdpExtension />*/}
-            <Cognito />
+            <CognitoFederation />
             {/* Security 👇 */}
             <Api.Extension src={"/extensions/MyApiKey.ts"} />
             <Api.Extension src={"/extensions/MyApiKeyAfterUpdate.ts"} />


### PR DESCRIPTION
## Summary

- Add `federation` prop to `<Cognito />` extension for configuring federated sign-in (Google, Facebook, Apple, Amazon, OIDC)
- Auto-detect federated users via `identities` JWT claim, set `external: true` to trigger `ExternalIdpUserSyncHandler`
- Introduce `CognitoSignInConfig` abstraction for login screen customization (providers, credentials toggle, title/description)
- Wire existing `FederatedLogin` component into `SignIn` with `FederatedProvider` union type (`{ name, label }` or `{ name, component }`)
- Configure Amplify OAuth in `CognitoPresenter.init()` from federation config
- Add Pulumi hook to call `configureAdminCognitoFederation()` and fix IdP→client dependency ordering
- Increase `custom:id` max length to 256 for new deployments (federated OIDC `sub` values can exceed 36 chars)
- Add `apiConfig` and `adminConfig` extension points for custom identity mapping and login screen behavior
- Add skills: `cognito-federation`, `configure-entraid`

https://github.com/user-attachments/assets/44c18f7c-d1de-446e-819f-d8df2a9064cb

<img width="619" height="346" alt="image" src="https://github.com/user-attachments/assets/ac5a06e2-1fcf-4c85-a72d-33cd6c1bc73c" />

<img width="1026" height="799" alt="CleanShot 2026-07-08 at 10 04 05" src="https://github.com/user-attachments/assets/13f7d92e-3c4b-4623-add4-59bc26c4d727" />

<img width="1434" height="906" alt="CleanShot 2026-07-07 at 23 02 21@2x" src="https://github.com/user-attachments/assets/0c84c1c9-7482-49d3-95c2-b0257e5dbfb8" />

## Test plan

- [x] Existing Cognito tests pass (13/13)
- [x] Tested end-to-end with Microsoft Entra ID as OIDC provider
- [x] Verify `custom:id` max length is 256 on fresh deploy, 36 on existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)