### PR TITLE
chore: merge release/6.4.4 into release/6.5.0

### DIFF
--- a/extensions/idp/entraid/EntraIdApiConfig.ts
+++ b/extensions/idp/entraid/EntraIdApiConfig.ts
@@ -1,0 +1,15 @@
+import { CognitoIdpConfig } from "@webiny/cognito/api";
+
+class EntraIdConfig implements CognitoIdpConfig.Interface {
+    getIdentity(_token: CognitoIdpConfig.JwtPayload) {
+        return {
+            roles: ["full-access"],
+            teams: []
+        };
+    }
+}
+
+export default CognitoIdpConfig.createImplementation({
+    implementation: EntraIdConfig,
+    dependencies: []
+});

--- a/extensions/idp/entraid/Extension.tsx
+++ b/extensions/idp/entraid/Extension.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Cognito } from "@webiny/cognito";
+
+async function getCredentials() {
+    return {
+        client_id: process.env.ENTRA_CLIENT_ID,
+        client_secret: process.env.ENTRA_CLIENT_SECRET,
+        oidc_issuer: process.env.ENTRA_OIDC_ISSUER
+    };
+}
+
+export const CognitoFederation = () => {
+    return (
+        <Cognito
+            mfa={true}
+            apiConfig={"@/extensions/idp/entraid/EntraIdApiConfig.ts"}
+            federation={async () => {
+                const credentials = await getCredentials();
+
+                return {
+                    domain: "myproj-webiny-with-entraid",
+                    callbackUrls: ["https://webiny-6.4.x.localhost"],
+                    responseType: "code",
+                    allowCredentialsLogin: true,
+                    identityProviders: [
+                        {
+                            name: "EntraID",
+                            type: "oidc",
+                            label: "Sign in with Microsoft",
+                            providerDetails: {
+                                attributes_request_method: "POST",
+                                authorize_scopes: "email profile openid",
+                                ...credentials
+                            },
+                            attributeMapping: {
+                                "custom:id": "sub",
+                                username: "sub",
+                                email: "email",
+                                given_name: "given_name",
+                                family_name: "family_name",
+                                preferred_username: "email"
+                            }
+                        }
+                    ]
+                };
+            }}
+        />
+    );
+};

--- a/extensions/models/BannerModel.ts
+++ b/extensions/models/BannerModel.ts
@@ -1,0 +1,150 @@
+import { ModelFactory } from "webiny/api/cms/model";
+
+class BannerModelImpl implements ModelFactory.Interface {
+    async execute(builder: ModelFactory.Builder) {
+        return [
+            builder
+                .public({
+                    modelId: "siteBanner",
+                    name: "Banner",
+                    group: "ungrouped"
+                })
+                .description("Site and special offer banners.")
+                .fields(fields => ({
+                    name: fields
+                        .text()
+                        .renderer("textInput")
+                        .label("Name")
+                        .required("Name is required.")
+                        .minLength(2)
+                        .maxLength(100),
+                    bannerTypes: fields
+                        .dynamicZone()
+                        .renderer("dynamicZone")
+                        .label("Banner Type")
+                        .template("siteBanner", {
+                            name: "Site Banner",
+                            gqlTypeName: "SiteBannerBlock",
+                            fields: templateFields => ({
+                                enabled: templateFields
+                                    .boolean()
+                                    .renderer("switch")
+                                    .label("Enabled"),
+                                text: templateFields
+                                    .richText()
+                                    .renderer("lexicalEditor")
+                                    .label("Text"),
+                                backgroundColor: templateFields
+                                    .text()
+                                    .renderer("dropdown")
+                                    .label("Background Color")
+                                    .predefinedValues([
+                                        { label: "Teal: #009CA6", value: "#009CA6" },
+                                        { label: "Navy: #00205B", value: "#00205B" },
+                                        { label: "Yellow: #EDE04B", value: "#EDE04B" }
+                                    ]),
+                                additionalInformation: templateFields
+                                    .boolean()
+                                    .renderer("switch")
+                                    .label("Additional Information")
+                                    .description(
+                                        "Enable this option to add additional information for the banner."
+                                    ),
+                                additionalInfoTab: templateFields
+                                    .uiTabs()
+                                    .label("Tab")
+                                    .tab("Additional Information", {
+                                        label: "Additional Information",
+                                        description: "Additional information for the banner.",
+                                        fields: tabFields => ({
+                                            additionalInformationText: tabFields
+                                                .richText()
+                                                .renderer("lexicalEditor")
+                                                .label("Additional Information Text")
+                                        }),
+                                        layout: [["additionalInformationText"]]
+                                    })
+                                    .rules([
+                                        {
+                                            type: "condition",
+                                            target: "$.additionalInformation",
+                                            operator: "!=",
+                                            value: true,
+                                            action: "hide"
+                                        }
+                                    ]),
+                                global: templateFields
+                                    .boolean()
+                                    .renderer("switch")
+                                    .label("Global")
+                                    .description(
+                                        "Global banners will be displayed on all pages of the website."
+                                    ),
+                                locationTab: templateFields
+                                    .uiTabs()
+                                    .label("Location")
+                                    .tab("Location", {
+                                        label: "Location",
+                                        description: "Location for the banner.",
+                                        fields: tabFields => ({
+                                            location: tabFields
+                                                .text()
+                                                .label("Location")
+                                                .renderer("textInput")
+                                                .required("Location is required.")
+                                        }),
+                                        layout: [["location"]]
+                                    })
+                                    .rules([
+                                        {
+                                            type: "condition",
+                                            target: "$.global",
+                                            operator: "==",
+                                            value: true,
+                                            action: "hide"
+                                        }
+                                    ])
+                            }),
+                            layout: [
+                                ["enabled"],
+                                ["text"],
+                                ["backgroundColor"],
+                                ["additionalInformation"],
+                                ["additionalInfoTab"],
+                                ["global"],
+                                ["locationTab"]
+                            ]
+                        })
+                        .template("specialOfferBanner", {
+                            name: "Special Offer Banner",
+                            gqlTypeName: "SpecialOfferBannerBlock",
+                            fields: templateFields => ({
+                                enabled: templateFields
+                                    .boolean()
+                                    .renderer("switch")
+                                    .label("Enabled"),
+                                text: templateFields
+                                    .richText()
+                                    .renderer("lexicalEditor")
+                                    .label("Text"),
+                                ctaLabel: templateFields
+                                    .text()
+                                    .renderer("textInput")
+                                    .label("CTA Label"),
+                                ctaUrl: templateFields.text().renderer("textInput").label("CTA URL")
+                            }),
+                            layout: [["enabled"], ["text"], ["ctaLabel", "ctaUrl"]]
+                        })
+                }))
+                .layout([["name"], ["bannerTypes"]])
+                .titleFieldId("name")
+                .singularApiName("Banner")
+                .pluralApiName("Banners")
+        ];
+    }
+}
+
+export default ModelFactory.createImplementation({
+    implementation: BannerModelImpl,
+    dependencies: []
+});

--- a/extensions/models/FieldRulesModel.ts
+++ b/extensions/models/FieldRulesModel.ts
@@ -1,0 +1,140 @@
+import { ModelFactory } from "webiny/api/cms/model";
+
+export const FIELD_RULES_MODEL_ID = "fieldRulesTest";
+
+class FieldRulesModelImpl implements ModelFactory.Interface {
+    async execute(builder: ModelFactory.Builder) {
+        return [
+            builder
+                .public({
+                    modelId: FIELD_RULES_MODEL_ID,
+                    name: "Field Rules Test",
+                    group: "ungrouped"
+                })
+                .description("Test model for field rules defined via code")
+                .fields(fields => ({
+                    status: fields
+                        .text()
+                        .renderer("radioButtons")
+                        .label("Status")
+                        .required()
+                        .predefinedValues([
+                            { label: "Draft", value: "draft" },
+                            { label: "Published", value: "published" }
+                        ]),
+                    title: fields
+                        .text()
+                        .renderer("textInput")
+                        .label("Title")
+                        .required()
+                        .rules([
+                            {
+                                type: "accessControl",
+                                target: "identity",
+                                operator: "matches",
+                                value: "team:marketing",
+                                action: "disable"
+                            }
+                        ]),
+                    seo: fields
+                        .object()
+                        .renderer("objectAccordionSingle")
+                        .label("SEO")
+                        .rules([
+                            {
+                                type: "condition",
+                                target: "status",
+                                operator: "!=",
+                                value: "published",
+                                action: "hide"
+                            }
+                        ])
+                        .fields(sub => ({
+                            seoTitle: sub.text().renderer("textInput").label("SEO Title"),
+                            seoDescription: sub
+                                .longText()
+                                .renderer("textarea")
+                                .label("SEO Description")
+                                .rules([
+                                    {
+                                        type: "condition",
+                                        target: "seo.seoTitle",
+                                        operator: "isEmpty",
+                                        value: null,
+                                        action: "disable"
+                                    }
+                                ])
+                        }))
+                        .layout([["seoTitle"], ["seoDescription"]]),
+                    separator: fields
+                        .uiSeparator()
+                        .label("Admin Section")
+                        .rules([
+                            {
+                                type: "accessControl",
+                                target: "identity",
+                                operator: "matches",
+                                value: "team:admins",
+                                action: "hide"
+                            }
+                        ]),
+                    alert: fields
+                        .uiAlert()
+                        .label("This content is in draft mode.")
+                        .alertType("warning")
+                        .rules([
+                            {
+                                type: "condition",
+                                target: "status",
+                                operator: "==",
+                                value: "published",
+                                action: "hide"
+                            }
+                        ]),
+                    tabs: fields
+                        .uiTabs()
+                        .tab("content", {
+                            label: "Content",
+                            fields: sub => ({
+                                body: sub.richText().renderer("lexicalEditor").label("Body")
+                            }),
+                            layout: [["body"]]
+                        })
+                        .tab("advanced", {
+                            label: "Advanced",
+                            fields: sub => ({
+                                slug: sub.text().renderer("textInput").label("Slug").unique()
+                            }),
+                            layout: [["slug"]],
+                            rules: [
+                                {
+                                    type: "accessControl",
+                                    target: "identity",
+                                    operator: "matches",
+                                    value: "team:developers",
+                                    action: "hide"
+                                }
+                            ]
+                        })
+                        .rules([
+                            {
+                                type: "condition",
+                                target: "title",
+                                operator: "isEmpty",
+                                value: null,
+                                action: "hide"
+                            }
+                        ])
+                }))
+                .layout([["status"], ["title"], ["alert"], ["seo"], ["separator"], ["tabs"]])
+                .titleFieldId("title")
+                .singularApiName("FieldRulesTest")
+                .pluralApiName("FieldRulesTests")
+        ];
+    }
+}
+
+export const FieldRulesModel = ModelFactory.createImplementation({
+    implementation: FieldRulesModelImpl,
+    dependencies: []
+});

--- a/packages/api-headless-cms/__tests__/graphql/schema/cms/helpers.test.ts
+++ b/packages/api-headless-cms/__tests__/graphql/schema/cms/helpers.test.ts
@@ -116,5 +116,130 @@ describe("CMS Schema Helpers", () => {
                 AND: [{ values: { name: "Keyboard" } }, { values: { price: 150 } }]
             });
         });
+
+        /**
+         * CVE proof: second-order prototype pollution via inherited builtins.
+         *
+         * A fresh `{}` inherits Object.prototype methods (toString, hasOwnProperty, valueOf).
+         * When the dot-notation key head matches one of these inherited names, the
+         * `result[head] === undefined` guard sees a function (not undefined) and skips
+         * creating a fresh own object. `nested` then becomes the real shared builtin,
+         * and `Object.assign(nested, ...)` overwrites its properties process-wide.
+         *
+         * This is a second-order prototype pollution: no `__proto__`, `constructor`, or
+         * `prototype` key is used, so classic 3-key blocklists do not catch it.
+         *
+         * IMPORTANT: each test must restore the corrupted builtin BEFORE calling expect(),
+         * because vitest internals use Object.prototype.toString.call() and will hang/crash
+         * if it's corrupted when expect() runs.
+         */
+        describe("second-order prototype pollution via inherited builtins", () => {
+            it("should not corrupt Object.prototype.toString via 'toString.call' key", () => {
+                const originalCall = Object.prototype.toString.call;
+
+                transformWhereToNested({ "toString.call": "pwned" });
+
+                // Capture corruption state BEFORE restoring.
+                const callType = typeof Object.prototype.toString.call;
+
+                // Restore IMMEDIATELY — before expect() triggers vitest internals.
+                Object.prototype.toString.call = originalCall;
+
+                // Now safe to assert.
+                expect(callType).toBe("function");
+            });
+
+            it("should not corrupt Object.prototype.hasOwnProperty via 'hasOwnProperty.call' key", () => {
+                const originalCall = Object.prototype.hasOwnProperty.call;
+
+                transformWhereToNested({ "hasOwnProperty.call": "pwned" });
+
+                const callType = typeof Object.prototype.hasOwnProperty.call;
+                Object.prototype.hasOwnProperty.call = originalCall;
+
+                expect(callType).toBe("function");
+            });
+
+            it("should not corrupt Object.prototype.valueOf via 'valueOf.bind' key", () => {
+                const originalBind = Object.prototype.valueOf.bind;
+
+                transformWhereToNested({ "valueOf.bind": "pwned" });
+
+                const bindType = typeof Object.prototype.valueOf.bind;
+                Object.prototype.valueOf.bind = originalBind;
+
+                expect(bindType).toBe("function");
+            });
+
+            it("should produce correct nested output for builtin-named head keys", () => {
+                const originalCall = Object.prototype.toString.call;
+
+                const result = transformWhereToNested({ "toString.call": "x" });
+
+                // Capture what we need before restoring.
+                const hasOwnToString = Object.prototype.hasOwnProperty.call(result, "toString");
+                const toStringType = typeof result!.toString;
+
+                Object.prototype.toString.call = originalCall;
+
+                // Result must have its own 'toString' property (a plain object, not inherited fn).
+                expect(hasOwnToString).toBe(true);
+                expect(toStringType).toBe("object");
+            });
+
+            it("should merge multiple dotted keys under a builtin-named head", () => {
+                const result = transformWhereToNested({
+                    "toString.a": 1,
+                    "toString.b": 2
+                });
+
+                expect(result).toEqual({ toString: { a: 1, b: 2 } });
+            });
+        });
+
+        describe("forbidden keys", () => {
+            it("should throw on __proto__ as top-level key", () => {
+                const input = Object.fromEntries([["__proto__", "x"]]);
+                expect(() => transformWhereToNested(input)).toThrow(
+                    'Invalid where key: "__proto__".'
+                );
+            });
+
+            it("should throw on constructor as top-level key", () => {
+                expect(() => transformWhereToNested({ constructor: "x" })).toThrow(
+                    'Invalid where key: "constructor".'
+                );
+            });
+
+            it("should throw on prototype as top-level key", () => {
+                expect(() => transformWhereToNested({ prototype: "x" })).toThrow(
+                    'Invalid where key: "prototype".'
+                );
+            });
+
+            it("should throw on __proto__ as dotted head segment", () => {
+                expect(() => transformWhereToNested({ "__proto__.polluted": "x" })).toThrow(
+                    'Invalid where key: "__proto__".'
+                );
+            });
+
+            it("should throw on constructor as dotted head segment", () => {
+                expect(() => transformWhereToNested({ "constructor.polluted": "x" })).toThrow(
+                    'Invalid where key: "constructor".'
+                );
+            });
+
+            it("should throw on __proto__ in nested tail segment", () => {
+                expect(() => transformWhereToNested({ "a.__proto__": "x" })).toThrow(
+                    'Invalid where key: "__proto__".'
+                );
+            });
+
+            it("should throw on constructor in deep tail segment", () => {
+                expect(() => transformWhereToNested({ "a.constructor.b": "x" })).toThrow(
+                    'Invalid where key: "constructor".'
+                );
+            });
+        });
     });
 });

--- a/packages/api-headless-cms/src/domain/contentModel/schemas.ts
+++ b/packages/api-headless-cms/src/domain/contentModel/schemas.ts
@@ -139,7 +139,7 @@ const fieldSchema = zod.object({
     rules: zod
         .array(
             zod.object({
-                type: zod.enum(["accessControl", "entryValue"]),
+                type: zod.enum(["accessControl", "condition"]),
                 target: shortString,
                 operator: shortString,
                 value: zod.union([zod.string(), zod.number(), zod.boolean(), zod.null()]),

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/BaseFieldBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/BaseFieldBuilder.ts
@@ -1,4 +1,4 @@
-import type { CmsModelField, CmsModelLayoutCell } from "~/types/index.js";
+import type { CmsModelField, CmsModelLayoutCell, FieldRule } from "~/types/index.js";
 
 export interface DataFieldBuildResult {
     type: "data";
@@ -19,6 +19,7 @@ export interface BaseFieldBuilderConfig {
     description?: string | null;
     note?: string | null;
     _fieldId?: string;
+    rules?: FieldRule[];
 }
 
 /**
@@ -65,6 +66,11 @@ export abstract class BaseFieldBuilder<TType extends string = string> {
 
     public fieldId(id: string): this {
         this.config._fieldId = id;
+        return this;
+    }
+
+    public rules(rules: FieldRule[]): this {
+        this.config.rules = rules;
         return this;
     }
 

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/DataFieldBuilder.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/DataFieldBuilder.ts
@@ -401,7 +401,8 @@ export class DataFieldBuilder<TType extends string = string> extends BaseFieldBu
                 note: this.config.note || null,
                 renderer: this.config.renderer || null,
                 settings: this.config.settings || {},
-                tags: this.config.tags || []
+                tags: this.config.tags || [],
+                rules: this.config.rules
             }
         };
     }

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/DynamicZoneFieldType.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/DynamicZoneFieldType.ts
@@ -2,7 +2,12 @@ import { FieldType, type IFieldTypeFactory } from "./abstractions.js";
 import { type FieldBuildResult } from "./BaseFieldBuilder.js";
 import { DataFieldBuilder, type BaseFieldBuilder } from "./FieldBuilder.js";
 import { type IFieldBuilderRegistry } from "../abstractions.js";
-import type { CmsIcon, CmsModelField, CmsModelFieldValidation } from "~/types/index.js";
+import type {
+    CmsIcon,
+    CmsModelField,
+    CmsModelFieldValidation,
+    CmsModelLayoutCell
+} from "~/types/index.js";
 
 interface IDynamicZoneTemplate {
     id: string;
@@ -11,7 +16,7 @@ interface IDynamicZoneTemplate {
     icon: CmsIcon | undefined;
     description: string;
     fields: any[];
-    layout: string[][];
+    layout: CmsModelLayoutCell[][];
     validation: CmsModelFieldValidation[];
 }
 
@@ -60,16 +65,23 @@ class DynamicZoneFieldBuilder
     public template(id: string, config: IDynamicZoneFieldBuilderTemplateConfig): this {
         const fieldBuilders = config.fields(this.registry);
         const fields: CmsModelField[] = [];
+        const layoutReplacements = new Map<string, CmsModelLayoutCell>();
 
         for (const [key, fieldBuilder] of Object.entries(fieldBuilders)) {
             fieldBuilder.fieldId(key);
             const result: FieldBuildResult = (fieldBuilder as any).build();
-            if (result.type === "data") {
+            if (result.type === "layout") {
+                layoutReplacements.set(key, result.layoutCell);
+                if (result.fields) {
+                    fields.push(...result.fields);
+                }
+            } else {
                 fields.push(result.field);
-            } else if (result.fields) {
-                fields.push(...result.fields);
             }
         }
+
+        const rawLayout: string[][] = config.layout || [];
+        const layout = rawLayout.map(row => row.map(cell => layoutReplacements.get(cell) ?? cell));
 
         this.templates.push({
             id,
@@ -78,7 +90,7 @@ class DynamicZoneFieldBuilder
             icon: config.icon,
             description: config.description || "",
             fields,
-            layout: config.layout || [],
+            layout,
             validation: []
         });
 

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/UiAlertFieldType.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/UiAlertFieldType.ts
@@ -26,7 +26,8 @@ class AlertFieldBuilder extends LayoutFieldBuilder<"uiAlert"> implements IUiAler
             layoutCell: {
                 type: "alert",
                 label: this.config.label,
-                alertType: this._alertType
+                alertType: this._alertType,
+                rules: this.config.rules
             }
         };
     }

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/UiSeparatorFieldType.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/UiSeparatorFieldType.ts
@@ -18,7 +18,8 @@ class SeparatorFieldBuilder
             layoutCell: {
                 type: "separator",
                 label: this.config.label,
-                description: this.config.description
+                description: this.config.description,
+                rules: this.config.rules
             }
         };
     }

--- a/packages/api-headless-cms/src/features/modelBuilder/fields/UiTabsFieldType.ts
+++ b/packages/api-headless-cms/src/features/modelBuilder/fields/UiTabsFieldType.ts
@@ -6,7 +6,13 @@ import {
 } from "./BaseFieldBuilder.js";
 import { LayoutFieldBuilder } from "./LayoutFieldBuilder.js";
 import { type IFieldBuilderRegistry } from "../abstractions.js";
-import type { CmsIcon, CmsModelField, CmsModelLayout, CmsModelLayoutCell } from "~/types/index.js";
+import type {
+    CmsIcon,
+    CmsModelField,
+    CmsModelLayout,
+    CmsModelLayoutCell,
+    FieldRule
+} from "~/types/index.js";
 
 interface ITab {
     id: string;
@@ -15,6 +21,7 @@ interface ITab {
     description: string;
     fields: CmsModelField[];
     layout: CmsModelLayout;
+    rules?: FieldRule[];
 }
 
 interface ITabConfig {
@@ -23,6 +30,7 @@ interface ITabConfig {
     description?: string;
     fields: (registry: IFieldBuilderRegistry) => Record<string, BaseFieldBuilder<any>>;
     layout?: string[][];
+    rules?: FieldRule[];
 }
 
 export interface IUiTabsFieldBuilder extends LayoutFieldBuilder<"uiTabs"> {
@@ -65,7 +73,8 @@ class TabsFieldBuilder extends LayoutFieldBuilder<"uiTabs"> implements IUiTabsFi
             icon: config.icon,
             description: config.description || "",
             fields,
-            layout
+            layout,
+            rules: config.rules
         });
 
         return this;
@@ -81,7 +90,8 @@ class TabsFieldBuilder extends LayoutFieldBuilder<"uiTabs"> implements IUiTabsFi
                 id: tab.id,
                 label: tab.label,
                 icon: tab.icon || null,
-                layout: tab.layout
+                layout: tab.layout,
+                rules: tab.rules
             });
         }
 
@@ -92,7 +102,8 @@ class TabsFieldBuilder extends LayoutFieldBuilder<"uiTabs"> implements IUiTabsFi
                 label: this.config.label,
                 description: this.config.description || null,
                 help: this.config.help || null,
-                tabs: layoutTabs
+                tabs: layoutTabs,
+                rules: this.config.rules
             },
             fields: hoistedFields
         };

--- a/packages/api-headless-cms/src/graphql/schema/cms/helpers/transformWhereToNested.ts
+++ b/packages/api-headless-cms/src/graphql/schema/cms/helpers/transformWhereToNested.ts
@@ -1,3 +1,5 @@
+const FORBIDDEN_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 /**
  * Transforms a flat where object with dot-notation keys into a nested object.
  * Keys without dots are passed through unchanged.
@@ -21,40 +23,52 @@ export const transformWhereToNested = (
         return undefined;
     }
 
-    const result: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(where)) {
-        // Handle logical operators recursively.
+    return Object.entries(where).reduce<Record<string, unknown>>((result, [key, value]) => {
         if (key === "AND" || key === "OR") {
-            if (Array.isArray(value)) {
-                result[key] = value.map(item =>
-                    transformWhereToNested(item as Record<string, unknown>)
-                );
-            } else {
-                result[key] = value;
+            if (!Array.isArray(value)) {
+                return {
+                    ...result,
+                    [key]: value
+                };
             }
-            continue;
+            return {
+                ...result,
+                [key]: value.map(item => transformWhereToNested(item))
+            };
         }
 
         const dotIndex = key.indexOf(".");
+
         if (dotIndex === -1) {
-            // No dot — pass through unchanged.
-            result[key] = value;
-        } else {
-            // Dot-notation key — expand into nested object.
-            const head = key.slice(0, dotIndex);
-            const tail = key.slice(dotIndex + 1);
-
-            if (result[head] === undefined) {
-                result[head] = {};
+            if (FORBIDDEN_KEYS.has(key)) {
+                throw new Error(`Invalid where key: "${key}".`);
             }
-
-            const nested = result[head] as Record<string, unknown>;
-            // Recursively expand in case of multiple levels of nesting.
-            const expanded = transformWhereToNested({ [tail]: value }) as Record<string, unknown>;
-            Object.assign(nested, expanded);
+            return {
+                ...result,
+                [key]: value
+            };
         }
-    }
 
-    return result;
+        const head = key.slice(0, dotIndex);
+        const tail = key.slice(dotIndex + 1);
+
+        if (FORBIDDEN_KEYS.has(head)) {
+            throw new Error(`Invalid where key: "${head}".`);
+        }
+
+        if (Object.hasOwn(result, head)) {
+            return {
+                ...result,
+                [head]: {
+                    ...(result[head] as Record<string, unknown>),
+                    ...transformWhereToNested({ [tail]: value })
+                }
+            };
+        }
+
+        return {
+            ...result,
+            [head]: transformWhereToNested({ [tail]: value })
+        };
+    }, {});
 };

--- a/packages/api-headless-cms/src/types/fields/dynamicZoneField.ts
+++ b/packages/api-headless-cms/src/types/fields/dynamicZoneField.ts
@@ -1,5 +1,5 @@
 import type { CmsModelField, CmsModelFieldValidation } from "../modelField.js";
-import type { CmsIcon } from "~/types/index.js";
+import type { CmsIcon, CmsModelLayoutCell } from "~/types/index.js";
 
 export interface CmsDynamicZoneTemplate {
     id: string;
@@ -8,7 +8,7 @@ export interface CmsDynamicZoneTemplate {
     description: string;
     icon?: CmsIcon;
     fields: CmsModelField[];
-    layout: string[][];
+    layout: CmsModelLayoutCell[][];
     validation: CmsModelFieldValidation[];
     tags?: string[];
 }

--- a/packages/api-headless-cms/src/types/modelField.ts
+++ b/packages/api-headless-cms/src/types/modelField.ts
@@ -6,7 +6,7 @@ import type { IModelSettings } from "~/features/modelBuilder/abstractions.js";
 export type FieldRuleAction = "hide" | "disable" | string;
 
 export interface FieldRule {
-    type: "accessControl" | "entryValue";
+    type: "accessControl" | "condition";
     target: string;
     operator: string;
     value: string | number | boolean | null;

--- a/packages/app-admin/src/components/OverlayLayout/OverlayLayout.tsx
+++ b/packages/app-admin/src/components/OverlayLayout/OverlayLayout.tsx
@@ -42,17 +42,14 @@ export const OverlayLayout: React.FC<OverlayLayoutProps> = ({
             <OverlayRoot visible={visible} onExited={onExited}>
                 <OverlayBackdrop visible={visible} hideOverlay={hideOverlay} />
                 <OverlayContent visible={visible}>
-                    <>
-                        <OverlayHeader
-                            start={barLeft}
-                            middle={barMiddle}
-                            end={barRight}
-                            variant={variant}
-                            hideOverlay={hideOverlay}
-                        />
-
-                        {children}
-                    </>
+                    <OverlayHeader
+                        start={barLeft}
+                        middle={barMiddle}
+                        end={barRight}
+                        variant={variant}
+                        hideOverlay={hideOverlay}
+                    />
+                    <div className={"flex-1 min-h-0 overflow-hidden"}>{children}</div>
                 </OverlayContent>
             </OverlayRoot>
         </Portal>

--- a/packages/app-admin/src/components/OverlayLayout/components/OverlayContent.tsx
+++ b/packages/app-admin/src/components/OverlayLayout/components/OverlayContent.tsx
@@ -13,6 +13,7 @@ const OverlayContent = ({ visible, className, style, children, ...props }: Overl
                 [
                     "fixed inset-x-0 top-lg z-overlay",
                     "w-screen",
+                    "flex flex-col",
                     "rounded-t-lg overflow-hidden",
                     "bg-neutral-base",
                     "transition ease-in-out",

--- a/packages/app-admin/src/features/formModel/Field.ts
+++ b/packages/app-admin/src/features/formModel/Field.ts
@@ -221,6 +221,15 @@ export class Field implements IField {
         if (all.length === 0) {
             return { visible: true, disabled: false };
         }
+        if (this._parentPath) {
+            const resolved = all.map(rule => {
+                if (rule.target.startsWith("$.")) {
+                    return { ...rule, target: `${this._parentPath}.${rule.target.slice(2)}` };
+                }
+                return rule;
+            });
+            return this._form.evaluateRules(resolved);
+        }
         return this._form.evaluateRules(all);
     }
 

--- a/packages/app-admin/src/features/formModel/FormModel.test.ts
+++ b/packages/app-admin/src/features/formModel/FormModel.test.ts
@@ -4369,4 +4369,62 @@ describe("FormModel", () => {
             });
         });
     });
+
+    describe("$. static references in rules", () => {
+        it("$. resolves rule targets relative to the parent object", () => {
+            const form = createForm({
+                fields: fields => ({
+                    wrapper: fields
+                        .object()
+                        .renderer("passthrough")
+                        .fields(f => ({
+                            status: f.text().defaultValue("draft"),
+                            details: f.text().rules([
+                                {
+                                    type: "condition",
+                                    target: "$.status",
+                                    operator: "eq",
+                                    value: "draft",
+                                    action: "hide"
+                                }
+                            ])
+                        }))
+                }),
+                layout: l => [l.row("wrapper")]
+            });
+
+            expect(form.field("wrapper.details").visible).toBe(false);
+
+            form.field("wrapper.status").setValue("published");
+            expect(form.field("wrapper.details").visible).toBe(true);
+        });
+
+        it("$. in rules with disable action", () => {
+            const form = createForm({
+                fields: fields => ({
+                    wrapper: fields
+                        .object()
+                        .renderer("passthrough")
+                        .fields(f => ({
+                            locked: f.text().defaultValue("yes"),
+                            editable: f.text().rules([
+                                {
+                                    type: "condition",
+                                    target: "$.locked",
+                                    operator: "eq",
+                                    value: "yes",
+                                    action: "disable"
+                                }
+                            ])
+                        }))
+                }),
+                layout: l => [l.row("wrapper")]
+            });
+
+            expect(form.field("wrapper.editable").disabled).toBe(true);
+
+            form.field("wrapper.locked").setValue("no");
+            expect(form.field("wrapper.editable").disabled).toBe(false);
+        });
+    });
 });

--- a/packages/app-file-manager/src/presentation/FileManager/FileManagerView.tsx
+++ b/packages/app-file-manager/src/presentation/FileManager/FileManagerView.tsx
@@ -131,14 +131,14 @@ const FileManagerViewLayout = observer(function FileManagerViewLayout() {
 
         if (vm.viewMode === "table") {
             return (
-                <ScrollArea onScroll={loadMoreOnScroll}>
+                <ScrollArea className={"h-full"} onScroll={loadMoreOnScroll}>
                     <FileTable />
                 </ScrollArea>
             );
         }
 
         return (
-            <ScrollArea onScroll={loadMoreOnScroll}>
+            <ScrollArea className={"h-full"} onScroll={loadMoreOnScroll}>
                 <FileGrid />
             </ScrollArea>
         );
@@ -158,7 +158,7 @@ const FileManagerViewLayout = observer(function FileManagerViewLayout() {
                     <FileDetailsDrawer />
                     <SplitView namespace={"fm/file/list"}>
                         <LeftPanel span={2}>
-                            <div className={"flex flex-col h-main-content"}>
+                            <div className={"flex flex-col h-full"}>
                                 <div className={"py-sm px-md"}>
                                     <Heading level={5}>{t`File Manager`}</Heading>
                                 </div>
@@ -201,13 +201,10 @@ const FileManagerViewLayout = observer(function FileManagerViewLayout() {
                             </div>
                         </LeftPanel>
                         <RightPanel span={10}>
-                            <div
-                                className={"flex flex-col relative"}
-                                style={{ height: "calc(100vh - 45px" }}
-                            >
+                            <div className={"flex flex-col relative h-full overflow-hidden"}>
                                 <FileManagerHeader browseFiles={browseFiles} />
                                 <div
-                                    className={"flex-1"}
+                                    className={"flex-1 min-h-0 overflow-hidden"}
                                     {...getDropZoneProps({
                                         onDragEnter: () => actions.setDragging(true),
                                         onDrop: () => actions.setDragging(false),

--- a/packages/app-headless-cms/src/admin/components/ContentModelEditor/evaluateExpression.ts
+++ b/packages/app-headless-cms/src/admin/components/ContentModelEditor/evaluateExpression.ts
@@ -31,6 +31,11 @@ export function resolveFieldPath(fieldPath: string, bindParentName?: string): st
         return fieldPath;
     }
 
+    if (fieldPath.startsWith("$.")) {
+        const relative = fieldPath.slice(2);
+        return bindParentName ? `${bindParentName}.${relative}` : relative;
+    }
+
     if (!bindParentName) {
         // No parent context, replace $ with 0 as fallback
         return fieldPath.replace(/\$/g, "0");

--- a/packages/cognito/package.json
+++ b/packages/cognito/package.json
@@ -6,7 +6,9 @@
   "sideEffects": false,
   "exports": {
     ".": "./index.js",
-    "./*": "./*"
+    "./*": "./*",
+    "./api": "./api/index.js",
+    "./admin": "./admin/index.js"
   },
   "description": "Security plugins for Cognito",
   "author": "Webiny Ltd.",
@@ -23,6 +25,7 @@
     "@webiny/icons": "0.0.0",
     "@webiny/project": "0.0.0",
     "@webiny/project-aws": "0.0.0",
+    "@webiny/react-properties": "0.0.0",
     "@webiny/validation": "0.0.0",
     "aws-amplify": "^6.18.0",
     "graphql": "^16.14.2",

--- a/packages/cognito/src/Cognito.tsx
+++ b/packages/cognito/src/Cognito.tsx
@@ -1,27 +1,115 @@
 import React from "react";
 import { defineExtension } from "@webiny/project/defineExtension/index.js";
 import { Api, Admin, Infra } from "@webiny/project-aws";
+import { Await } from "@webiny/react-properties";
 import { z } from "zod";
+
+const identityProviderSchema = z.object({
+    type: z.enum(["google", "facebook", "amazon", "apple", "oidc"]),
+    name: z.string().optional(),
+    label: z.string(),
+    providerDetails: z.record(z.string(), z.any()),
+    idpIdentifiers: z.array(z.string()).optional(),
+    attributeMapping: z.record(z.string(), z.string()).optional()
+});
+
+const federationSchema = z.object({
+    domain: z.string().describe("Cognito User Pool domain prefix."),
+    callbackUrls: z.array(z.string()).describe("OAuth callback URLs."),
+    logoutUrls: z.array(z.string()).optional(),
+    responseType: z.enum(["code", "token"]).default("code"),
+    allowCredentialsLogin: z.boolean().default(true),
+    identityProviders: z.array(identityProviderSchema)
+});
 
 export const Cognito = defineExtension({
     type: "Project/Cognito",
     tags: { runtimeContext: "project" },
     description: "Enable and configure Cognito authentication.",
     paramsSchema: z.object({
-        apiConfig: z.string().describe("Path to API configuration.").optional()
+        apiConfig: z.string().describe("Path to API configuration.").optional(),
+        adminConfig: z.string().describe("Path to Admin configuration.").optional(),
+        federation: z
+            .union([
+                federationSchema,
+                z.custom<() => Promise<z.infer<typeof federationSchema>>>(
+                    val => typeof val === "function"
+                )
+            ])
+            .optional(),
+        mfa: z.boolean().describe("Enable TOTP MFA for all users.").default(false)
     }),
     render: props => {
+        const federationProp = props.federation;
+        const federationFn = federationProp
+            ? typeof federationProp === "function"
+                ? federationProp
+                : () => Promise.resolve(federationProp)
+            : null;
+
         return (
             <>
                 <Infra.EnvVar varName={"REACT_APP_IDP_TYPE"} value={"cognito"} />
+                {props.mfa ? <Infra.EnvVar varName={"COGNITO_MFA"} value={"true"} /> : null}
+
                 {/* Api extensions */}
                 <Api.Extension
                     src={import.meta.dirname + "/api/CognitoApiFeature.js"}
                     exportName={"CognitoApiFeature"}
                 />
                 {props.apiConfig ? <Api.Extension src={props.apiConfig} /> : null}
+
                 {/* Admin extensions */}
                 <Admin.Extension src={import.meta.dirname + "/admin/Extension.js"} />
+                {props.adminConfig ? <Admin.Extension src={props.adminConfig} /> : null}
+
+                {/* Federation infra + admin config */}
+                {federationFn ? (
+                    <Await fn={federationFn}>
+                        {federation => (
+                            <>
+                                <Admin.Extension
+                                    src={import.meta.dirname + "/admin/SignInExtension.js"}
+                                    exportName={"SignInExtension"}
+                                />
+                                <Infra.EnvVar
+                                    varName={"COGNITO_FEDERATION_INFRA_CONFIG"}
+                                    value={JSON.stringify({
+                                        domain: federation.domain,
+                                        callbackUrls: federation.callbackUrls,
+                                        logoutUrls: federation.logoutUrls,
+                                        identityProviders: federation.identityProviders.map(
+                                            idp => ({
+                                                type: idp.type,
+                                                name: idp.name,
+                                                providerDetails: idp.providerDetails,
+                                                idpIdentifiers: idp.idpIdentifiers,
+                                                attributeMapping: idp.attributeMapping
+                                            })
+                                        )
+                                    })}
+                                />
+                                <Infra.Core.Pulumi
+                                    src={import.meta.dirname + "/infra/CognitoFederationPulumi.js"}
+                                />
+                                <Admin.BuildParam
+                                    paramName={"cognitoFederation"}
+                                    value={{
+                                        callbackUrls: federation.callbackUrls,
+                                        logoutUrls:
+                                            federation.logoutUrls || federation.callbackUrls,
+                                        responseType: federation.responseType,
+                                        allowCredentialsLogin: federation.allowCredentialsLogin,
+                                        providers: federation.identityProviders.map(idp => ({
+                                            name: idp.name || idp.type,
+                                            label: idp.label
+                                        }))
+                                    }}
+                                />
+                            </>
+                        )}
+                    </Await>
+                ) : null}
             </>
         );
     }

--- a/packages/cognito/src/admin/DefaultCognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/DefaultCognitoSignInConfig.ts
@@ -1,0 +1,50 @@
+import { BuildParams } from "@webiny/app-admin/features/buildParams/index.js";
+import {
+    CognitoSignInConfig,
+    type ICognitoSignInConfig
+} from "./presentation/Cognito/CognitoSignInConfig.js";
+
+interface FederationBuildParam {
+    callbackUrls: string[];
+    logoutUrls: string[];
+    responseType: "code" | "token";
+    allowCredentialsLogin: boolean;
+    providers: { name: string; label: string }[];
+}
+
+class DefaultCognitoSignInConfigImpl implements ICognitoSignInConfig {
+    constructor(private buildParams: BuildParams.Interface) {}
+
+    async getConfig() {
+        const config = this.buildParams.get<FederationBuildParam>("cognitoFederation");
+
+        if (!config) {
+            return {
+                oauth: {
+                    scopes: ["profile", "email", "openid"],
+                    redirectSignIn: [window.location.origin],
+                    redirectSignOut: [window.location.origin],
+                    responseType: "code" as const
+                },
+                allowCredentialsLogin: true,
+                providers: []
+            };
+        }
+
+        return {
+            oauth: {
+                scopes: ["profile", "email", "openid"],
+                redirectSignIn: config.callbackUrls,
+                redirectSignOut: config.logoutUrls,
+                responseType: config.responseType
+            },
+            allowCredentialsLogin: config.allowCredentialsLogin,
+            providers: config.providers
+        };
+    }
+}
+
+export const DefaultCognitoSignInConfig = CognitoSignInConfig.createImplementation({
+    implementation: DefaultCognitoSignInConfigImpl,
+    dependencies: [BuildParams]
+});

--- a/packages/cognito/src/admin/SignInExtension.tsx
+++ b/packages/cognito/src/admin/SignInExtension.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { RegisterFeature } from "@webiny/app-admin";
+import { CognitoSignInFeature } from "./presentation/Cognito/signInFeature.js";
+
+export const SignInExtension = () => {
+    return <RegisterFeature feature={CognitoSignInFeature} />;
+};

--- a/packages/cognito/src/admin/index.ts
+++ b/packages/cognito/src/admin/index.ts
@@ -1,0 +1,2 @@
+export { CognitoSignInConfig } from "./presentation/Cognito/CognitoSignInConfig.js";
+export { Components as CognitoComponents } from "./presentation/Cognito/components/index.js";

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoLoginScreen.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoLoginScreen.tsx
@@ -8,6 +8,8 @@ import { RequireNewPassword } from "./components/RequireNewPassword.js";
 import { RequestPasswordResetCode } from "./components/RequestPasswordResetCode.js";
 import { SetNewPassword } from "./components/SetNewPassword.js";
 import { PasswordResetCodeSent } from "~/admin/presentation/Cognito/components/PasswordResetCodeSent.js";
+import { ConfirmTotpCode } from "./components/ConfirmTotpCode.js";
+import { SetupTotp } from "./components/SetupTotp.js";
 
 export interface CognitoLoginScreenProps {
     region: string;
@@ -74,6 +76,21 @@ export const CognitoLoginScreen = observer((props: CognitoLoginScreenProps) => {
                                 presenter.confirmPasswordReset(code, password)
                             }
                             onCancel={() => presenter.showSignIn()}
+                        />
+                    )}
+
+                    {vm.authState === "confirmTotpCode" && (
+                        <ConfirmTotpCode
+                            vm={vm.confirmTotpCode}
+                            onSubmit={code => presenter.confirmTotpCode(code)}
+                            onCancel={() => presenter.showSignIn()}
+                        />
+                    )}
+
+                    {vm.authState === "setupTotp" && (
+                        <SetupTotp
+                            vm={vm.setupTotp}
+                            onSubmit={code => presenter.verifyTotpSetup(code)}
                         />
                     )}
 

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoPresenter.ts
@@ -17,6 +17,10 @@ import {
 } from "./abstractions.js";
 import { LogInUseCase } from "@webiny/app-admin/features/security/LogIn/index.js";
 import { IdentityContext } from "@webiny/app-admin/features/security/IdentityContext/index.js";
+import { CognitoSignInConfig } from "./CognitoSignInConfig.js";
+
+const federatedDescription =
+    "You will be taken to an external service to complete the sign-in process.";
 
 class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private authState: AuthState = "signIn";
@@ -27,9 +31,18 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     private formLoading = false;
     private initialized = false;
 
+    private signInTitle = "Sign in";
+    private signInDescription: string | undefined = undefined;
+    private allowCredentialsLogin = true;
+    private federatedProviders: CognitoSignInConfig.FederatedProvider[] = [];
+
+    private totpSharedSecret = "";
+    private totpQrCodeUri = "";
+
     constructor(
         private identity: IdentityContext.Interface,
-        private logInUseCase: LogInUseCase.Interface
+        private logInUseCase: LogInUseCase.Interface,
+        private signInConfig: CognitoSignInConfig.Interface | undefined
     ) {
         makeAutoObservable(this);
     }
@@ -46,7 +59,11 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             // View-specific VMs
             signIn: {
                 isLoading: this.formLoading,
-                message: this.message
+                message: this.message,
+                title: this.signInTitle,
+                description: this.signInDescription,
+                allowCredentialsLogin: this.allowCredentialsLogin,
+                federatedProviders: this.federatedProviders
             },
             requestPasswordResetCode: {
                 isLoading: this.formLoading,
@@ -63,6 +80,16 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             requireNewPassword: {
                 isLoading: this.formLoading,
                 requiredAttributes: (this.authData && this.authData.requiredAttributes) || []
+            },
+            confirmTotpCode: {
+                isLoading: this.formLoading,
+                message: this.message
+            },
+            setupTotp: {
+                isLoading: this.formLoading,
+                sharedSecret: this.totpSharedSecret,
+                qrCodeUri: this.totpQrCodeUri,
+                message: this.message
             }
         };
     }
@@ -72,8 +99,47 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
             return;
         }
 
+        let oauthConfig:
+            | { Cognito: { userPoolId: string; userPoolClientId: string; loginWith: any } }
+            | undefined;
+
+        if (this.signInConfig) {
+            const config = await this.signInConfig.getConfig();
+
+            runInAction(() => {
+                this.signInTitle = config.title ?? "Sign in";
+                this.signInDescription = config.description;
+
+                if (!config.description && !config.allowCredentialsLogin) {
+                    this.signInDescription = federatedDescription;
+                }
+
+                this.allowCredentialsLogin = config.allowCredentialsLogin;
+                this.federatedProviders = config.providers;
+            });
+
+            const domain = process.env.REACT_APP_USER_POOL_DOMAIN;
+            if (domain) {
+                oauthConfig = {
+                    Cognito: {
+                        userPoolId: params.userPoolId,
+                        userPoolClientId: params.clientId,
+                        loginWith: {
+                            oauth: {
+                                domain,
+                                redirectSignIn: config.oauth.redirectSignIn,
+                                redirectSignOut: config.oauth.redirectSignOut,
+                                scopes: config.oauth.scopes,
+                                responseType: config.oauth.responseType
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
         Amplify.configure({
-            Auth: {
+            Auth: oauthConfig ?? {
                 Cognito: {
                     userPoolId: params.userPoolId,
                     userPoolClientId: params.clientId
@@ -104,6 +170,20 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
                     this.authData = {
                         requiredAttributes: nextStep.missingAttributes || []
                     };
+                    this.formLoading = false;
+                });
+            } else if (nextStep.signInStep === "CONFIRM_SIGN_IN_WITH_TOTP_CODE") {
+                runInAction(() => {
+                    this.authState = "confirmTotpCode";
+                    this.formLoading = false;
+                });
+            } else if (nextStep.signInStep === "CONTINUE_SIGN_IN_WITH_TOTP_SETUP") {
+                const totpSetup = nextStep.totpSetupDetails;
+                const uri = totpSetup.getSetupUri("Webiny").toString();
+                runInAction(() => {
+                    this.totpSharedSecret = totpSetup.sharedSecret;
+                    this.totpQrCodeUri = uri;
+                    this.authState = "setupTotp";
                     this.formLoading = false;
                 });
             } else {
@@ -233,6 +313,54 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
         }
     }
 
+    async confirmTotpCode(code: string): Promise<void> {
+        runInAction(() => {
+            this.formLoading = true;
+            this.message = null;
+        });
+
+        try {
+            await confirmSignIn({ challengeResponse: code });
+            await this.handleSignedIn();
+        } catch (error) {
+            runInAction(() => {
+                this.message = {
+                    title: "Verification Failed",
+                    text: error.message,
+                    type: "danger"
+                };
+            });
+        } finally {
+            runInAction(() => {
+                this.formLoading = false;
+            });
+        }
+    }
+
+    async verifyTotpSetup(code: string): Promise<void> {
+        runInAction(() => {
+            this.formLoading = true;
+            this.message = null;
+        });
+
+        try {
+            await confirmSignIn({ challengeResponse: code });
+            await this.handleSignedIn();
+        } catch (error) {
+            runInAction(() => {
+                this.message = {
+                    title: "Setup Failed",
+                    text: error.message,
+                    type: "danger"
+                };
+            });
+        } finally {
+            runInAction(() => {
+                this.formLoading = false;
+            });
+        }
+    }
+
     showSignIn(): void {
         this.authState = "signIn";
         this.authData = null;
@@ -290,16 +418,6 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
     }
 
     private async checkUrl(): Promise<void> {
-        const query = new URLSearchParams(window.location.search);
-        const queryData: Record<string, string> = {};
-        query.forEach((value, key) => (queryData[key] = value));
-        const { state } = queryData;
-
-        if (state) {
-            // Handle state from URL if needed
-            return;
-        }
-
         return this.checkSession();
     }
 
@@ -326,5 +444,5 @@ class CognitoPresenterImpl implements CognitoPresenterAbstraction.Interface {
 
 export const CognitoPresenter = CognitoPresenterAbstraction.createImplementation({
     implementation: CognitoPresenterImpl,
-    dependencies: [IdentityContext, LogInUseCase]
+    dependencies: [IdentityContext, LogInUseCase, [CognitoSignInConfig, { optional: true }]]
 });

--- a/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/CognitoSignInConfig.ts
@@ -1,0 +1,33 @@
+import type React from "react";
+import { createAbstraction } from "@webiny/feature/admin";
+
+export interface SignInProps {
+    signIn: () => void;
+}
+
+export type IFederatedProvider =
+    | { name: string; label: string }
+    | { name: string; component: React.FC<SignInProps> };
+
+export interface ICognitoSignInConfig {
+    getConfig(): Promise<{
+        oauth: {
+            scopes: string[];
+            redirectSignIn: string[];
+            redirectSignOut: string[];
+            responseType: "code" | "token";
+        };
+        allowCredentialsLogin: boolean;
+        providers: IFederatedProvider[];
+        title?: string;
+        description?: string;
+    }>;
+}
+
+export const CognitoSignInConfig = createAbstraction<ICognitoSignInConfig>("CognitoSignInConfig");
+
+export namespace CognitoSignInConfig {
+    export type Interface = ICognitoSignInConfig;
+    export type Config = Awaited<ReturnType<ICognitoSignInConfig["getConfig"]>>;
+    export type FederatedProvider = IFederatedProvider;
+}

--- a/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/abstractions.ts
@@ -1,4 +1,5 @@
 import { createAbstraction } from "@webiny/feature/admin";
+import type { IFederatedProvider } from "./CognitoSignInConfig.js";
 
 export type AuthState =
     | "signIn"
@@ -7,7 +8,9 @@ export type AuthState =
     | "requestPasswordResetCode"
     | "passwordResetCodeSent"
     | "setNewPassword"
-    | "requireNewPassword";
+    | "requireNewPassword"
+    | "confirmTotpCode"
+    | "setupTotp";
 
 export interface AuthDataVerified {
     email?: string;
@@ -49,6 +52,10 @@ export interface ICognitoInitParams {
 export interface SignInVM {
     isLoading: boolean;
     message: AuthMessage | null;
+    title: string;
+    description: string | undefined;
+    allowCredentialsLogin: boolean;
+    federatedProviders: IFederatedProvider[];
 }
 
 export interface RequireNewPasswordVM {
@@ -71,6 +78,18 @@ export interface SetNewPasswordVM {
     message: AuthMessage | null;
 }
 
+export interface ConfirmTotpCodeVM {
+    isLoading: boolean;
+    message: AuthMessage | null;
+}
+
+export interface SetupTotpVM {
+    isLoading: boolean;
+    sharedSecret: string;
+    qrCodeUri: string;
+    message: AuthMessage | null;
+}
+
 export interface ICognitoPresenter {
     vm: {
         authState: AuthState;
@@ -82,6 +101,8 @@ export interface ICognitoPresenter {
         requestPasswordResetCode: RequestPasswordResetCodeVM;
         passwordResetCodeSent: PasswordResetCodeSentVM;
         setNewPassword: SetNewPasswordVM;
+        confirmTotpCode: ConfirmTotpCodeVM;
+        setupTotp: SetupTotpVM;
     };
 
     // Lifecycle
@@ -93,6 +114,8 @@ export interface ICognitoPresenter {
     requestPasswordReset(username: string): Promise<void>;
     resendPasswordResetCode(): Promise<void>;
     confirmPasswordReset(code: string, password: string): Promise<void>;
+    confirmTotpCode(code: string): Promise<void>;
+    verifyTotpSetup(code: string): Promise<void>;
 
     // Navigation actions
     showSignIn(): void;

--- a/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/ConfirmTotpCode.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
+import { Form, Bind } from "@webiny/form";
+import { validation } from "@webiny/validation";
+import { View } from "./View.js";
+import type { ConfirmTotpCodeVM } from "~/admin/presentation/Cognito/abstractions.js";
+import { FooterSignIn } from "~/admin/presentation/Cognito/components/FooterSignIn.js";
+
+export interface ConfirmTotpCodeProps {
+    vm: ConfirmTotpCodeVM;
+    onSubmit: (code: string) => void;
+    onCancel: () => void;
+}
+
+export const ConfirmTotpCode = makeDecoratable(
+    "CognitoConfirmTotpCode",
+    (props: ConfirmTotpCodeProps) => {
+        const { vm, onSubmit, onCancel } = props;
+
+        return (
+            <View.Container>
+                <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title
+                                title={"Two-factor authentication"}
+                                description={"Enter the 6-digit code from your authenticator app."}
+                            />
+
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
+                                </div>
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind name="code" validators={validation.create("required")}>
+                                        <Input
+                                            label={"Verification Code"}
+                                            autoComplete={"one-time-code"}
+                                            inputMode={"numeric"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div className={"flex items-center justify-between"}>
+                                        <FooterSignIn onSignIn={onCancel} />
+                                        <Button
+                                            text={"Verify"}
+                                            onClick={submit}
+                                            containerClassName={"ml-auto"}
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/Divider.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/Divider.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Separator, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 
-export const Divider = () => {
+export const Divider = makeDecoratable("CognitoDivider", () => {
     return (
         <div className={"relative my-lg"}>
             <div className={"absolute inset-0 flex items-center"}>
@@ -14,4 +15,4 @@ export const Divider = () => {
             </div>
         </div>
     );
-};
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FederatedLogin.tsx
@@ -1,38 +1,56 @@
 import React from "react";
 import { signInWithRedirect } from "aws-amplify/auth";
-import type { FederatedIdentityProvider } from "~/admin/federatedIdentityProviders.js";
+import { Button } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { federatedIdentityProviders } from "~/admin/federatedIdentityProviders.js";
 import { FederatedProviders } from "./FederatedProviders.js";
+import { CognitoSignInConfig } from "~/admin/index.js";
 
 type AuthProvider = "Amazon" | "Apple" | "Facebook" | "Google";
 
 const builtInProviders = new Set<string>(["Amazon", "Apple", "Facebook", "Google"]);
 
-interface FederatedLoginProps {
-    providers: FederatedIdentityProvider[];
+export interface FederatedLoginProps {
+    providers: CognitoSignInConfig.FederatedProvider[];
 }
 
-export const FederatedLogin = ({ providers }: FederatedLoginProps) => {
-    return (
-        <FederatedProviders.Container>
-            {providers.map(({ name, component: Component }) => {
-                const cognitoProviderName = federatedIdentityProviders[name] ?? name;
-                const isBuiltIn = builtInProviders.has(cognitoProviderName);
+export const FederatedLogin = makeDecoratable(
+    "CognitoFederatedLogin",
+    ({ providers }: FederatedLoginProps) => {
+        return (
+            <FederatedProviders.Container>
+                {providers.map(provider => {
+                    const cognitoProviderName =
+                        federatedIdentityProviders[provider.name] ?? provider.name;
+                    const isBuiltIn = builtInProviders.has(cognitoProviderName);
 
-                const signIn = () => {
-                    if (isBuiltIn) {
-                        signInWithRedirect({
-                            provider: cognitoProviderName as AuthProvider
-                        });
-                    } else {
-                        signInWithRedirect({
-                            provider: { custom: cognitoProviderName }
-                        });
+                    const signIn = () => {
+                        if (isBuiltIn) {
+                            signInWithRedirect({
+                                provider: cognitoProviderName as AuthProvider
+                            });
+                        } else {
+                            signInWithRedirect({
+                                provider: { custom: cognitoProviderName }
+                            });
+                        }
+                    };
+
+                    if ("component" in provider) {
+                        const Component = provider.component;
+                        return <Component key={provider.name} signIn={signIn} />;
                     }
-                };
 
-                return <Component key={name} signIn={signIn} />;
-            })}
-        </FederatedProviders.Container>
-    );
-};
+                    return (
+                        <Button
+                            key={provider.name}
+                            text={provider.label}
+                            onClick={signIn}
+                            style={{ width: "100%" }}
+                        />
+                    );
+                })}
+            </FederatedProviders.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/FooterSignIn.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/FooterSignIn.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { Link, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 
-interface FooterSignInProps {
+export interface FooterSignInProps {
     onSignIn: () => void;
 }
 
-export const FooterSignIn = ({ onSignIn }: FooterSignInProps) => {
-    return (
-        <Text as={"div"} size={"sm"}>
-            Want to sign in?&nbsp;
-            <Link to="#" onClick={onSignIn}>
-                Sign in
-            </Link>
-            .
-        </Text>
-    );
-};
+export const FooterSignIn = makeDecoratable(
+    "CognitoFooterSignIn",
+    ({ onSignIn }: FooterSignInProps) => {
+        return (
+            <Text as={"div"} size={"sm"}>
+                Want to sign in?&nbsp;
+                <Link to="#" onClick={onSignIn}>
+                    Sign in
+                </Link>
+                .
+            </Text>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/PasswordResetCodeSent.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/PasswordResetCodeSent.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert, Button, Grid, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { View } from "./View.js";
 import type { PasswordResetCodeSentVM } from "~/admin/presentation/Cognito/abstractions.js";
 import { FooterSignIn } from "~/admin/presentation/Cognito/components/FooterSignIn.js";
@@ -11,55 +12,58 @@ export interface PasswordResetCodeSentProps {
     onCancel: () => void;
 }
 
-export const PasswordResetCodeSent = (props: PasswordResetCodeSentProps) => {
-    const { vm, onResendCode, onCodeAcquired, onCancel } = props;
+export const PasswordResetCodeSent = makeDecoratable(
+    "CognitoPasswordResetCodeSent",
+    (props: PasswordResetCodeSentProps) => {
+        const { vm, onResendCode, onCodeAcquired, onCancel } = props;
 
-    return (
-        <View.Container>
-            <View.Content>
-                <View.Title
-                    title={"Password recovery"}
-                    description={"Request a password reset code."}
-                />
+        return (
+            <View.Container>
+                <View.Content>
+                    <View.Title
+                        title={"Password recovery"}
+                        description={"Request a password reset code."}
+                    />
 
-                {vm.message && (
-                    <div className={"mb-lg"}>
-                        <Alert title={vm.message.title} type={vm.message.type}>
-                            {vm.message.text}
-                        </Alert>
-                    </div>
-                )}
-
-                <Grid>
-                    <Grid.Column span={12}>
-                        <Text>We have sent you a code to reset your password.</Text>
-                    </Grid.Column>
-                    <Grid.Column span={12}>
-                        <Text>
-                            Click the &quot;Resend code&quot; button below to resend the code in
-                            case you haven&apos;t received it the first time.
-                        </Text>
-                    </Grid.Column>
-
-                    <Grid.Column span={12}>
-                        <div className={"flex items-center justify-between"}>
-                            <FooterSignIn onSignIn={onCancel} />
-                            <div className={"flex gap-x-sm"}>
-                                <Button
-                                    variant={"secondary"}
-                                    text={"Resend code"}
-                                    onClick={onResendCode}
-                                />
-                                <Button
-                                    variant={"primary"}
-                                    text={"I got the code!"}
-                                    onClick={onCodeAcquired}
-                                />
-                            </div>
+                    {vm.message && (
+                        <div className={"mb-lg"}>
+                            <Alert title={vm.message.title} type={vm.message.type}>
+                                {vm.message.text}
+                            </Alert>
                         </div>
-                    </Grid.Column>
-                </Grid>
-            </View.Content>
-        </View.Container>
-    );
-};
+                    )}
+
+                    <Grid>
+                        <Grid.Column span={12}>
+                            <Text>We have sent you a code to reset your password.</Text>
+                        </Grid.Column>
+                        <Grid.Column span={12}>
+                            <Text>
+                                Click the &quot;Resend code&quot; button below to resend the code in
+                                case you haven&apos;t received it the first time.
+                            </Text>
+                        </Grid.Column>
+
+                        <Grid.Column span={12}>
+                            <div className={"flex items-center justify-between"}>
+                                <FooterSignIn onSignIn={onCancel} />
+                                <div className={"flex gap-x-sm"}>
+                                    <Button
+                                        variant={"secondary"}
+                                        text={"Resend code"}
+                                        onClick={onResendCode}
+                                    />
+                                    <Button
+                                        variant={"primary"}
+                                        text={"I got the code!"}
+                                        onClick={onCodeAcquired}
+                                    />
+                                </div>
+                            </div>
+                        </Grid.Column>
+                    </Grid>
+                </View.Content>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/RequestPasswordResetCode.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/RequestPasswordResetCode.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -12,52 +13,57 @@ export interface ForgotPasswordProps {
     onCancel: () => void;
 }
 
-export const RequestPasswordResetCode = (props: ForgotPasswordProps) => {
-    const { vm, ...actions } = props;
+export const RequestPasswordResetCode = makeDecoratable(
+    "CognitoRequestPasswordResetCode",
+    (props: ForgotPasswordProps) => {
+        const { vm, ...actions } = props;
 
-    return (
-        <View.Container>
-            <Form onSubmit={(data: any) => actions.onRequestCode(data.username)} submitOnEnter>
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title
-                            title={"Password recovery"}
-                            description={"Request a password reset code."}
-                        />
+        return (
+            <View.Container>
+                <Form onSubmit={(data: any) => actions.onRequestCode(data.username)} submitOnEnter>
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title
+                                title={"Password recovery"}
+                                description={"Request a password reset code."}
+                            />
 
-                        {vm.message && (
-                            <div className={"mb-lg"}>
-                                <Alert title={vm.message.title} type={vm.message.type}>
-                                    {vm.message.text}
-                                </Alert>
-                            </div>
-                        )}
-
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="username"
-                                    validators={validation.create("required,email")}
-                                >
-                                    <Input label={"Email"} />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Send me the code"}
-                                        onClick={submit}
-                                        disabled={vm.isLoading}
-                                    />
-                                    <FooterSignIn onSignIn={actions.onCancel} />
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
                                 </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="username"
+                                        validators={validation.create("required,email")}
+                                    >
+                                        <Input label={"Email"} />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Send me the code"}
+                                            onClick={submit}
+                                            disabled={vm.isLoading}
+                                        />
+                                        <FooterSignIn onSignIn={actions.onCancel} />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/RequireNewPassword.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/RequireNewPassword.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Heading, Input } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -21,64 +22,72 @@ type FormData = {
     requiredAttributes: Record<string, string>;
 };
 
-export const RequireNewPassword = (props: RequireNewPasswordProps) => {
-    const { vm, onSubmit } = props;
+export const RequireNewPassword = makeDecoratable(
+    "CognitoRequireNewPassword",
+    (props: RequireNewPasswordProps) => {
+        const { vm, onSubmit } = props;
 
-    return (
-        <View.Container>
-            <Form<FormData>
-                onSubmit={data => onSubmit(data.password, data.requiredAttributes)}
-                submitOnEnter
-            >
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title title={"Set new password"} />
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind name="password" validators={validation.create("required")}>
-                                    <Input
-                                        type={"password"}
-                                        label={"New password"}
-                                        autoComplete={"off"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
+        return (
+            <View.Container>
+                <Form<FormData>
+                    onSubmit={data => onSubmit(data.password, data.requiredAttributes)}
+                    submitOnEnter
+                >
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title title={"Set new password"} />
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={validation.create("required")}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"New password"}
+                                            autoComplete={"off"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
 
-                            {vm.requiredAttributes.length > 0 ? (
-                                <>
-                                    <Grid.Column span={12}>
-                                        <Heading level={6} className={"text-center"}>
-                                            Please enter additional information
-                                        </Heading>
-                                    </Grid.Column>
-                                    {vm.requiredAttributes.map(attr => (
-                                        <Grid.Column key={attr} span={12}>
-                                            <Bind name={`requiredAttributes.${attr}`}>
-                                                <Input label={sentenceCase(attr)} />
-                                            </Bind>
+                                {vm.requiredAttributes.length > 0 ? (
+                                    <>
+                                        <Grid.Column span={12}>
+                                            <Heading level={6} className={"text-center"}>
+                                                Please enter additional information
+                                            </Heading>
                                         </Grid.Column>
-                                    ))}
-                                </>
-                            ) : (
-                                <></>
-                            )}
+                                        {vm.requiredAttributes.map(attr => (
+                                            <Grid.Column key={attr} span={12}>
+                                                <Bind name={`requiredAttributes.${attr}`}>
+                                                    <Input label={sentenceCase(attr)} />
+                                                </Bind>
+                                            </Grid.Column>
+                                        ))}
+                                    </>
+                                ) : (
+                                    <></>
+                                )}
 
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Confirm"}
-                                        onClick={submit}
-                                        size="lg"
-                                        disabled={vm.isLoading}
-                                    />
-                                </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Confirm"}
+                                            onClick={submit}
+                                            size="lg"
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);

--- a/packages/cognito/src/admin/presentation/Cognito/components/SetNewPassword.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SetNewPassword.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button, Grid, Input, Alert } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
 import { Form, Bind, useForm } from "@webiny/form";
 import { validation } from "@webiny/validation";
 import { View } from "./View.js";
@@ -13,72 +14,78 @@ export interface SetNewPasswordProps {
     onCancel: () => void;
 }
 
-export const SetNewPassword = (props: SetNewPasswordProps) => {
-    const { vm, onSetNewPassword, onCancel } = props;
-    const passwordValidator = usePasswordValidator();
+export const SetNewPassword = makeDecoratable(
+    "CognitoSetNewPassword",
+    (props: SetNewPasswordProps) => {
+        const { vm, onSetNewPassword, onCancel } = props;
+        const passwordValidator = usePasswordValidator();
 
-    return (
-        <View.Container>
-            <Form
-                onSubmit={(data: any) => onSetNewPassword(data.code, data.password)}
-                submitOnEnter
-            >
-                {({ submit }) => (
-                    <View.Content>
-                        <View.Title title={"Set new password"} />
+        return (
+            <View.Container>
+                <Form
+                    onSubmit={(data: any) => onSetNewPassword(data.code, data.password)}
+                    submitOnEnter
+                >
+                    {({ submit }) => (
+                        <View.Content>
+                            <View.Title title={"Set new password"} />
 
-                        {vm.message && (
-                            <div className={"mb-lg"}>
-                                <Alert title={vm.message.title} type={vm.message.type}>
-                                    {vm.message.text}
-                                </Alert>
-                            </div>
-                        )}
-
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind name="code" validators={validation.create("required")}>
-                                    <Input
-                                        label={"Verification Code"}
-                                        description={"Enter the code we sent to your email."}
-                                        autoComplete={"new-password"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="password"
-                                    validators={[validation.create("required"), passwordValidator]}
-                                >
-                                    <Input
-                                        type={"password"}
-                                        label={"New Password"}
-                                        description={"Enter your new password."}
-                                        autoComplete={"new-password"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <RetypePassword />
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div className={"flex items-center justify-between"}>
-                                    <FooterSignIn onSignIn={onCancel} />
-                                    <Button
-                                        text={"Reset Password"}
-                                        onClick={submit}
-                                        containerClassName={"ml-auto"}
-                                        disabled={vm.isLoading}
-                                    />
+                            {vm.message && (
+                                <div className={"mb-lg"}>
+                                    <Alert title={vm.message.title} type={vm.message.type}>
+                                        {vm.message.text}
+                                    </Alert>
                                 </div>
-                            </Grid.Column>
-                        </Grid>
-                    </View.Content>
-                )}
-            </Form>
-        </View.Container>
-    );
-};
+                            )}
+
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind name="code" validators={validation.create("required")}>
+                                        <Input
+                                            label={"Verification Code"}
+                                            description={"Enter the code we sent to your email."}
+                                            autoComplete={"new-password"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={[
+                                            validation.create("required"),
+                                            passwordValidator
+                                        ]}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"New Password"}
+                                            description={"Enter your new password."}
+                                            autoComplete={"new-password"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <RetypePassword />
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div className={"flex items-center justify-between"}>
+                                        <FooterSignIn onSignIn={onCancel} />
+                                        <Button
+                                            text={"Reset Password"}
+                                            onClick={submit}
+                                            containerClassName={"ml-auto"}
+                                            disabled={vm.isLoading}
+                                        />
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        </View.Content>
+                    )}
+                </Form>
+            </View.Container>
+        );
+    }
+);
 
 const RetypePassword = () => {
     const form = useForm();

--- a/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SetupTotp.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Button, Grid, Input, Alert, Text } from "@webiny/admin-ui";
+import { makeDecoratable } from "@webiny/app-admin";
+import { Form, Bind } from "@webiny/form";
+import { validation } from "@webiny/validation";
+import { View } from "./View.js";
+import type { SetupTotpVM } from "~/admin/presentation/Cognito/abstractions.js";
+
+export interface SetupTotpProps {
+    vm: SetupTotpVM;
+    onSubmit: (code: string) => void;
+}
+
+export const SetupTotp = makeDecoratable("CognitoSetupTotp", (props: SetupTotpProps) => {
+    const { vm, onSubmit } = props;
+
+    return (
+        <View.Container>
+            <Form<{ code: string }> onSubmit={data => onSubmit(data.code)} submitOnEnter>
+                {({ submit }) => (
+                    <View.Content>
+                        <View.Title
+                            title={"Set up two-factor authentication"}
+                            description={
+                                "Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.), then enter the 6-digit code to verify."
+                            }
+                        />
+
+                        {vm.message && (
+                            <div className={"mb-lg"}>
+                                <Alert title={vm.message.title} type={vm.message.type}>
+                                    {vm.message.text}
+                                </Alert>
+                            </div>
+                        )}
+
+                        <Grid>
+                            <Grid.Column span={12}>
+                                <div className={"flex justify-center my-md"}>
+                                    <img
+                                        src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(vm.qrCodeUri)}`}
+                                        alt={"TOTP QR Code"}
+                                        width={200}
+                                        height={200}
+                                    />
+                                </div>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <Text size={"sm"} className={"text-neutral-strong"}>
+                                    {"Can't scan the code? Enter this key manually:"}
+                                </Text>
+                                <Text
+                                    as={"div"}
+                                    size={"sm"}
+                                    className={"font-mono mt-xs select-all break-all"}
+                                >
+                                    {vm.sharedSecret}
+                                </Text>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <Bind name="code" validators={validation.create("required")}>
+                                    <Input
+                                        label={"Verification Code"}
+                                        description={
+                                            "Enter the 6-digit code from your authenticator app."
+                                        }
+                                        autoComplete={"one-time-code"}
+                                        inputMode={"numeric"}
+                                    />
+                                </Bind>
+                            </Grid.Column>
+                            <Grid.Column span={12}>
+                                <div className={"flex justify-end"}>
+                                    <Button
+                                        text={"Verify & Enable"}
+                                        onClick={submit}
+                                        disabled={vm.isLoading}
+                                    />
+                                </div>
+                            </Grid.Column>
+                        </Grid>
+                    </View.Content>
+                )}
+            </Form>
+        </View.Container>
+    );
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/SignIn.tsx
+++ b/packages/cognito/src/admin/presentation/Cognito/components/SignIn.tsx
@@ -2,19 +2,22 @@ import React from "react";
 import { Grid, Input, Alert, Link, Button, Text, OverlayLoader } from "@webiny/admin-ui";
 import { Form, Bind } from "@webiny/form";
 import { validation } from "@webiny/validation";
+import { makeDecoratable } from "@webiny/app-admin";
 import { View } from "./View.js";
+import { FederatedLogin } from "./FederatedLogin.js";
+import { Divider } from "./Divider.js";
 import type { SignInVM } from "~/admin/presentation/Cognito/abstractions.js";
 
 export interface SignInProps {
     vm: SignInVM;
     onSubmit: (username: string, password: string) => void;
     onForgotPassword: () => void;
-    title?: string;
-    description?: React.ReactNode;
 }
 
-export const SignIn = (props: SignInProps) => {
-    const { vm, onSubmit, onForgotPassword, title = "Sign in", description } = props;
+export const SignIn = makeDecoratable("CognitoSignIn", (props: SignInProps) => {
+    const { vm, onSubmit, onForgotPassword } = props;
+    const showCredentials = vm.allowCredentialsLogin;
+    const showFederated = vm.federatedProviders.length > 0;
 
     return (
         <View.Container>
@@ -22,7 +25,7 @@ export const SignIn = (props: SignInProps) => {
                 {({ submit }) => (
                     <View.Content>
                         {vm.isLoading ? <OverlayLoader text={"Authenticating..."} /> : null}
-                        <View.Title title={title} description={description} />
+                        <View.Title title={vm.title} description={vm.description} />
 
                         {vm.message && (
                             <div className={"mb-lg"}>
@@ -32,48 +35,59 @@ export const SignIn = (props: SignInProps) => {
                             </div>
                         )}
 
-                        <Grid>
-                            <Grid.Column span={12}>
-                                <Bind
-                                    name="username"
-                                    validators={validation.create("required,email")}
-                                    beforeChange={(val: string, cb: (value: string) => void) =>
-                                        cb(val.toLowerCase())
-                                    }
-                                >
-                                    <Input label={"Email"} />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <Bind name="password" validators={validation.create("required")}>
-                                    <Input
-                                        type={"password"}
-                                        label={"Password"}
-                                        autoComplete={"off"}
-                                    />
-                                </Bind>
-                            </Grid.Column>
-                            <Grid.Column span={12}>
-                                <div
-                                    className={"flex flex-row-reverse items-center justify-between"}
-                                >
-                                    <Button
-                                        text={"Submit"}
-                                        data-testid="submit-sign-in-form-button"
-                                        onClick={submit}
-                                        disabled={vm.isLoading}
-                                    />
-                                    <Text as={"div"} size={"sm"}>
-                                        <Link to="#" onClick={onForgotPassword}>
-                                            Forgot password?
-                                        </Link>
-                                    </Text>
-                                </div>
-                            </Grid.Column>
-                        </Grid>
+                        {showCredentials && (
+                            <Grid>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="username"
+                                        validators={validation.create("required,email")}
+                                        beforeChange={(val: string, cb: (value: string) => void) =>
+                                            cb(val.toLowerCase())
+                                        }
+                                    >
+                                        <Input label={"Email"} />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <Bind
+                                        name="password"
+                                        validators={validation.create("required")}
+                                    >
+                                        <Input
+                                            type={"password"}
+                                            label={"Password"}
+                                            autoComplete={"off"}
+                                        />
+                                    </Bind>
+                                </Grid.Column>
+                                <Grid.Column span={12}>
+                                    <div
+                                        className={
+                                            "flex flex-row-reverse items-center justify-between"
+                                        }
+                                    >
+                                        <Button
+                                            text={"Submit"}
+                                            data-testid="submit-sign-in-form-button"
+                                            onClick={submit}
+                                            disabled={vm.isLoading}
+                                        />
+                                        <Text as={"div"} size={"sm"}>
+                                            <Link to="#" onClick={onForgotPassword}>
+                                                Forgot password?
+                                            </Link>
+                                        </Text>
+                                    </div>
+                                </Grid.Column>
+                            </Grid>
+                        )}
+
+                        {showCredentials && showFederated && <Divider />}
+
+                        {showFederated && <FederatedLogin providers={vm.federatedProviders} />}
                     </View.Content>
                 )}
             </Form>
         </View.Container>
     );
-};
+});

--- a/packages/cognito/src/admin/presentation/Cognito/components/index.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/components/index.ts
@@ -1,0 +1,27 @@
+import { SignIn } from "./SignIn.js";
+import { ConfirmTotpCode } from "./ConfirmTotpCode.js";
+import { SetupTotp } from "./SetupTotp.js";
+import { RequireNewPassword } from "./RequireNewPassword.js";
+import { RequestPasswordResetCode } from "./RequestPasswordResetCode.js";
+import { PasswordResetCodeSent } from "./PasswordResetCodeSent.js";
+import { SetNewPassword } from "./SetNewPassword.js";
+import { FederatedLogin } from "./FederatedLogin.js";
+import { FederatedProviders } from "./FederatedProviders.js";
+import { Divider } from "./Divider.js";
+import { FooterSignIn } from "./FooterSignIn.js";
+import { View } from "./View.js";
+
+export const Components = {
+    SignIn,
+    ConfirmTotpCode,
+    SetupTotp,
+    RequireNewPassword,
+    RequestPasswordResetCode,
+    PasswordResetCodeSent,
+    SetNewPassword,
+    FederatedLogin,
+    FederatedProviders,
+    Divider,
+    FooterSignIn,
+    View
+};

--- a/packages/cognito/src/admin/presentation/Cognito/signInFeature.ts
+++ b/packages/cognito/src/admin/presentation/Cognito/signInFeature.ts
@@ -1,0 +1,9 @@
+import { createFeature } from "@webiny/feature/admin";
+import { DefaultCognitoSignInConfig } from "~/admin/DefaultCognitoSignInConfig.js";
+
+export const CognitoSignInFeature = createFeature({
+    name: "CognitoSignIn",
+    register(container) {
+        container.register(DefaultCognitoSignInConfig).inSingletonScope();
+    }
+});

--- a/packages/cognito/src/admin/ui/views/Users/UsersForm.tsx
+++ b/packages/cognito/src/admin/ui/views/Users/UsersForm.tsx
@@ -176,11 +176,16 @@ export const UserForm = ({ teams }: UserFormProps) => {
                                 <Grid>
                                     <Grid.Column span={12}>
                                         <Bind name={"roles"} validators={groupValidators}>
-                                            <RolesMultiAutocomplete
-                                                label={"Roles"}
-                                                data-testid="roles-autocomplete"
-                                                disabled={isDisabled}
-                                            />
+                                            {({ value, onChange, validation }) => (
+                                                <RolesMultiAutocomplete
+                                                    values={value}
+                                                    onChange={onChange}
+                                                    validation={validation}
+                                                    label={"Roles"}
+                                                    data-testid="roles-autocomplete"
+                                                    disabled={isDisabled}
+                                                />
+                                            )}
                                         </Bind>
                                     </Grid.Column>
                                 </Grid>
@@ -194,11 +199,16 @@ export const UserForm = ({ teams }: UserFormProps) => {
                                     <Grid>
                                         <Grid.Column span={12}>
                                             <Bind name={"teams"}>
-                                                <TeamsMultiAutocomplete
-                                                    label={"Teams"}
-                                                    data-testid="teams-autocomplete"
-                                                    disabled={isDisabled}
-                                                />
+                                                {({ value, onChange, validation }) => (
+                                                    <TeamsMultiAutocomplete
+                                                        values={value}
+                                                        onChange={onChange}
+                                                        validation={validation}
+                                                        label={"Teams"}
+                                                        data-testid="teams-autocomplete"
+                                                        disabled={isDisabled}
+                                                    />
+                                                )}
                                             </Bind>
                                         </Grid.Column>
                                     </Grid>

--- a/packages/cognito/src/api/features/CognitoIdp/CognitoIdentityProvider.ts
+++ b/packages/cognito/src/api/features/CognitoIdp/CognitoIdentityProvider.ts
@@ -24,26 +24,14 @@ class CognitoIdentityProviderImpl implements OidcIdentityProvider.Interface {
     async getIdentity(
         token: OidcIdentityProvider.JwtPayload
     ): Promise<OidcIdentityProvider.IdentityData> {
-        const customIdentity = this.config ? await this.config.getIdentity(token) : null;
+        const isFederated = Array.isArray(token.identities) && token.identities.length > 0;
 
-        if (customIdentity) {
-            return {
-                ...customIdentity,
-                type: "admin",
-                profile: {
-                    ...customIdentity,
-                    external: false
-                }
-            };
-        }
-
-        // Default identity
         const customId = token["custom:id"] as string | undefined;
         const givenName = token["given_name"] as string | undefined;
         const familyName = token["family_name"] as string | undefined;
         const email = token["email"] as string | undefined;
 
-        return {
+        const defaultIdentity: OidcIdentityProvider.IdentityData = {
             id: customId || token.sub || "",
             displayName: `${givenName || ""} ${familyName || ""}`.trim() || email || "Unknown User",
             type: "admin",
@@ -51,7 +39,24 @@ class CognitoIdentityProviderImpl implements OidcIdentityProvider.Interface {
                 email: email || "",
                 firstName: givenName || "",
                 lastName: familyName || "",
-                external: false
+                external: isFederated
+            }
+        };
+
+        const customIdentity = this.config ? await this.config.getIdentity(token) : null;
+
+        if (!customIdentity) {
+            return defaultIdentity;
+        }
+
+        return {
+            ...defaultIdentity,
+            ...customIdentity,
+            type: "admin",
+            profile: {
+                ...defaultIdentity.profile,
+                ...customIdentity.profile,
+                external: isFederated
             }
         };
     }

--- a/packages/cognito/src/api/features/CognitoIdp/abstractions.ts
+++ b/packages/cognito/src/api/features/CognitoIdp/abstractions.ts
@@ -3,7 +3,7 @@ import type jwt from "jsonwebtoken";
 import type { IdentityData } from "@webiny/api-core/idp";
 
 export type CognitoIdentity = Omit<IdentityData, "type"> & {
-    profile: Omit<IdentityData["profile"], "external">;
+    profile?: Omit<IdentityData["profile"], "external">;
 };
 
 export interface ICognitoIdpConfig {

--- a/packages/cognito/src/api/index.ts
+++ b/packages/cognito/src/api/index.ts
@@ -1,0 +1,1 @@
+export { CognitoIdpConfig } from "./features/CognitoIdp/index.js";

--- a/packages/cognito/src/index.ts
+++ b/packages/cognito/src/index.ts
@@ -1,2 +1,1 @@
 export { Cognito } from "./Cognito.js";
-export { CognitoIdpConfig } from "./api/features/CognitoIdp/index.js";

--- a/packages/cognito/src/infra/CognitoFederationPulumi.ts
+++ b/packages/cognito/src/infra/CognitoFederationPulumi.ts
@@ -1,0 +1,22 @@
+import { CorePulumi } from "@webiny/project-aws/exports/infra/core.js";
+import {
+    configureAdminCognitoFederation,
+    type CognitoIdentityProvidersConfig
+} from "@webiny/project-aws/pulumi/apps/core/cognitoIdentityProviders/configure.js";
+
+class CognitoFederationPulumiImpl implements CorePulumi.Interface {
+    execute(app: CorePulumi.Params): void {
+        const raw = process.env.COGNITO_FEDERATION_INFRA_CONFIG;
+        if (!raw) {
+            return;
+        }
+
+        const config: CognitoIdentityProvidersConfig = JSON.parse(raw);
+        configureAdminCognitoFederation(app, config);
+    }
+}
+
+export default CorePulumi.createImplementation({
+    implementation: CognitoFederationPulumiImpl,
+    dependencies: []
+});

--- a/packages/cognito/tsconfig.build.json
+++ b/packages/cognito/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "../handler-graphql/tsconfig.build.json" },
     { "path": "../project/tsconfig.build.json" },
     { "path": "../project-aws/tsconfig.build.json" },
+    { "path": "../react-properties/tsconfig.build.json" },
     { "path": "../validation/tsconfig.build.json" },
     { "path": "../wcp/tsconfig.build.json" }
   ],
@@ -44,6 +45,8 @@
       "@webiny/project": ["../project/src"],
       "@webiny/project-aws/*": ["../project-aws/src/*"],
       "@webiny/project-aws": ["../project-aws/src"],
+      "@webiny/react-properties/*": ["../react-properties/src/*"],
+      "@webiny/react-properties": ["../react-properties/src"],
       "@webiny/validation/*": ["../validation/src/*"],
       "@webiny/validation": ["../validation/src"],
       "@webiny/wcp/*": ["../wcp/src/*"],

--- a/packages/cognito/tsconfig.json
+++ b/packages/cognito/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../handler-graphql" },
     { "path": "../project" },
     { "path": "../project-aws" },
+    { "path": "../react-properties" },
     { "path": "../validation" },
     { "path": "../wcp" }
   ],
@@ -44,6 +45,8 @@
       "@webiny/project": ["../project/src"],
       "@webiny/project-aws/*": ["../project-aws/src/*"],
       "@webiny/project-aws": ["../project-aws/src"],
+      "@webiny/react-properties/*": ["../react-properties/src/*"],
+      "@webiny/react-properties": ["../react-properties/src"],
       "@webiny/validation/*": ["../validation/src/*"],
       "@webiny/validation": ["../validation/src"],
       "@webiny/wcp/*": ["../wcp/src/*"],

--- a/packages/project-aws/src/pulumi/apps/core/CoreCognito.ts
+++ b/packages/project-aws/src/pulumi/apps/core/CoreCognito.ts
@@ -4,6 +4,7 @@ import { createAppModule, type PulumiApp, type PulumiAppModule } from "@webiny/p
 export interface CoreCognitoParams {
     protect: boolean;
     useEmailAsUsername: boolean;
+    mfa?: boolean;
 }
 
 export type CoreCognito = PulumiAppModule<typeof CoreCognito>;
@@ -35,7 +36,8 @@ export const CoreCognito = createAppModule({
                 usernameAttributes: params.useEmailAsUsername ? ["email"] : undefined,
                 aliasAttributes: params.useEmailAsUsername ? undefined : ["preferred_username"],
                 lambdaConfig: {},
-                mfaConfiguration: "OFF",
+                mfaConfiguration: params.mfa ? "ON" : "OFF",
+                softwareTokenMfaConfiguration: params.mfa ? { enabled: true } : undefined,
                 userPoolAddOns: {
                     advancedSecurityMode: "OFF" /* required */
                 },

--- a/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
+++ b/packages/project-aws/src/pulumi/apps/core/cognitoIdentityProviders/configure.ts
@@ -75,6 +75,7 @@ export const configureAdminCognitoFederation = (
     );
 
     const idpConfigs: aws.cognito.IdentityProviderArgs[] = [];
+    const idpOutputs: pulumi.Output<aws.cognito.IdentityProvider>[] = [];
 
     for (const idp of config.identityProviders) {
         const config = getIdpConfig(idp.type, userPool.output.id, idp);
@@ -87,10 +88,20 @@ export const configureAdminCognitoFederation = (
         // names to be all lowercase anyway.
         const name = config.providerName.toString().toLowerCase();
 
-        app.addResource(aws.cognito.IdentityProvider, { name, config });
+        const idpResource = app.addResource(aws.cognito.IdentityProvider, { name, config });
+        idpOutputs.push(idpResource.output);
 
         idpConfigs.push(config);
     }
+
+    appClient.opts.dependsOn = [
+        ...(appClient.opts.dependsOn
+            ? Array.isArray(appClient.opts.dependsOn)
+                ? appClient.opts.dependsOn
+                : [appClient.opts.dependsOn]
+            : []),
+        ...idpOutputs
+    ] as pulumi.Input<pulumi.Resource>[];
 
     appClient.config.supportedIdentityProviders([
         "COGNITO",

--- a/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
@@ -246,8 +246,36 @@ export function createCorePulumiApp() {
             // Setup Cognito
             const cognito = app.addModule(CoreCognito, {
                 protect,
-                useEmailAsUsername: false
+                useEmailAsUsername: false,
+                mfa: process.env.COGNITO_MFA === "true"
             });
+
+            // Cognito custom:id was originally set to maxLength 36 (UUID). Federated OIDC
+            // providers (e.g., Entra ID) can produce sub values longer than 36 chars. Since
+            // Cognito doesn't allow changing custom attribute constraints after pool creation,
+            // we only increase it for new deployments. Existing pools keep their original limit.
+            const isNewDeployment = !coreStackOutput || Object.keys(coreStackOutput).length === 0;
+            if (isNewDeployment) {
+                cognito.userPool.config.schemas(schemas => {
+                    return schemas?.map(schema => {
+                        if (schema.name === "id") {
+                            return {
+                                ...schema,
+                                stringAttributeConstraints: {
+                                    ...schema.stringAttributeConstraints,
+                                    maxLength: "256"
+                                }
+                            };
+                        }
+                        return schema;
+                    });
+                });
+            } else {
+                cognito.userPool.opts.ignoreChanges = [
+                    ...(cognito.userPool.opts.ignoreChanges || []),
+                    "schemas"
+                ];
+            }
 
             // Setup event bus
             const eventBus = app.addModule(CoreEventBus);

--- a/packages/project/src/abstractions/features/DestroyApp.ts
+++ b/packages/project/src/abstractions/features/DestroyApp.ts
@@ -4,11 +4,11 @@ import { type ExecaChildProcess } from "execa";
 
 type IPulumiProcess = ExecaChildProcess<string>;
 
-interface IDestroyAppParams {
+export interface IDestroyAppParams {
     app: AppName;
 }
 
-interface IDestroyApp {
+export interface IDestroyApp {
     execute(params: IDestroyAppParams): Promise<{ pulumiProcess: IPulumiProcess }>;
 }
 

--- a/packages/project/src/abstractions/services/StackOutputCacheService.ts
+++ b/packages/project/src/abstractions/services/StackOutputCacheService.ts
@@ -1,0 +1,15 @@
+import { createAbstraction } from "~/abstractions/createAbstraction.js";
+import { type IAppModel } from "~/abstractions/models/IAppModel.js";
+
+export interface IStackOutputCacheService {
+    read(app: IAppModel): Promise<Record<string, any> | null>;
+    write(app: IAppModel, data: Record<string, any>): Promise<void>;
+    delete(app: IAppModel): Promise<void>;
+}
+
+export const StackOutputCacheService =
+    createAbstraction<IStackOutputCacheService>("StackOutputCacheService");
+
+export namespace StackOutputCacheService {
+    export type Interface = IStackOutputCacheService;
+}

--- a/packages/project/src/abstractions/services/index.ts
+++ b/packages/project/src/abstractions/services/index.ts
@@ -29,6 +29,7 @@ export { PulumiGetStackOutputService } from "./PulumiGetStackOutputService.js";
 export { PulumiLoginService } from "./PulumiLoginService.js";
 export { PulumiSelectStackService } from "./PulumiSelectStackService.js";
 export { SetProjectIdService } from "./SetProjectIdService.js";
+export { StackOutputCacheService } from "./StackOutputCacheService.js";
 export { StdioService } from "./StdioService.js";
 export { UiService } from "./UiService.js";
 export { ValidateProjectConfigService } from "./ValidateProjectConfigService.js";

--- a/packages/project/src/createProjectSdkContainer.ts
+++ b/packages/project/src/createProjectSdkContainer.ts
@@ -83,6 +83,7 @@ import {
     pulumiLoginService,
     pulumiSelectStackService,
     setProjectIdService,
+    stackOutputCacheService,
     stdioService,
     uiService,
     validateProjectConfigService,
@@ -143,6 +144,7 @@ export const createProjectSdkContainer = async (
     container.register(pulumiLoginService).inSingletonScope();
     container.register(pulumiSelectStackService).inSingletonScope();
     container.register(setProjectIdService).inSingletonScope();
+    container.register(stackOutputCacheService).inSingletonScope();
     container.register(stdioService).inSingletonScope();
     container.register(uiService).inSingletonScope();
     container.register(validateProjectConfigService).inSingletonScope();

--- a/packages/project/src/decorators/DestroyAppClearStackOutputCache.ts
+++ b/packages/project/src/decorators/DestroyAppClearStackOutputCache.ts
@@ -1,0 +1,43 @@
+import {
+    DestroyApp,
+    GetApp,
+    LoggerService,
+    StackOutputCacheService
+} from "~/abstractions/index.js";
+
+/**
+ * Decorator that clears the stack output cache when an app is destroyed.
+ *
+ * Without this, the cache file written during deploy would remain on disk after a
+ * destroy, and a subsequent deploy (or any stack output read) would use it and behave
+ * as if the stack were still deployed.
+ *
+ * The cache is cleared before the destroy runs. Since the cache is only a performance
+ * optimization, this is safe even if the destroy fails and the stack remains: the next
+ * read simply fetches fresh output from Pulumi again.
+ */
+export class DestroyAppClearStackOutputCache implements DestroyApp.Interface {
+    constructor(
+        private getApp: GetApp.Interface,
+        private logger: LoggerService.Interface,
+        private stackOutputCacheService: StackOutputCacheService.Interface,
+        private decoratee: DestroyApp.Interface
+    ) {}
+
+    async execute(params: DestroyApp.Params) {
+        try {
+            const app = this.getApp.execute(params.app);
+            await this.stackOutputCacheService.delete(app);
+        } catch (error) {
+            // Cache clearing failure shouldn't prevent the destroy from running.
+            this.logger.error("Failed to clear stack output cache before destroy.", error);
+        }
+
+        return this.decoratee.execute(params);
+    }
+}
+
+export const destroyAppClearStackOutputCache = DestroyApp.createDecorator({
+    decorator: DestroyAppClearStackOutputCache,
+    dependencies: [GetApp, LoggerService, StackOutputCacheService]
+});

--- a/packages/project/src/decorators/index.ts
+++ b/packages/project/src/decorators/index.ts
@@ -3,6 +3,7 @@ export * from "./DeployAppClearWatchedLambdaFunctions.js";
 export * from "./DeployAppRefreshStackOutputCache.js";
 export * from "./DeployAppWithHooks.js";
 export * from "./DeployAppWithWatchedLambdaReplacement.js";
+export * from "./DestroyAppClearStackOutputCache.js";
 export * from "./WatchWithHooks.js";
 export * from "./GetPulumiServiceWithDownloadInfo.js";
 export * from "./GetFeatureFlagsWithLicense.js";

--- a/packages/project/src/services/GetProjectConfigService/renderConfigWorker.tsx
+++ b/packages/project/src/services/GetProjectConfigService/renderConfigWorker.tsx
@@ -1,5 +1,5 @@
 import "tsx/esm";
-import { Properties, toObject } from "@webiny/react-properties";
+import { AsyncProperties, toObject } from "@webiny/react-properties";
 import debounce from "debounce";
 import React from "react";
 import { createRoot } from "react-dom/client";
@@ -58,7 +58,20 @@ const { Extensions } = await import(
     toImportSpecifier(project.paths.webinyConfigBaseFile.toString())
 );
 
+const RENDER_TIMEOUT_MS = 30_000;
+
+const timeout = setTimeout(() => {
+    sendError(
+        new Error(
+            `Config rendering timed out after ${RENDER_TIMEOUT_MS}ms. ` +
+                `This usually means an <Await> promise never settled.`
+        )
+    );
+    process.exit(1);
+}, RENDER_TIMEOUT_MS);
+
 const onChange = debounce((value: any) => {
+    clearTimeout(timeout);
     sendSuccess(toObject(value));
     process.exit(0);
 });
@@ -77,9 +90,9 @@ reactRoot.render(
     <WcpProjectLicenseProvider>
         <EnvProvider>
             <ProductionEnvironmentsCollector>
-                <Properties onChange={onChange}>
+                <AsyncProperties onChange={onChange}>
                     <Extensions />
-                </Properties>
+                </AsyncProperties>
             </ProductionEnvironmentsCollector>
         </EnvProvider>
     </WcpProjectLicenseProvider>

--- a/packages/project/src/services/InitProjectSdkService/InitProjectSdkService.ts
+++ b/packages/project/src/services/InitProjectSdkService/InitProjectSdkService.ts
@@ -10,6 +10,7 @@ import {
     deployAppRefreshStackOutputCache,
     deployAppWithHooks,
     deployAppWithWatchedLambdaReplacement,
+    destroyAppClearStackOutputCache,
     watchWithHooks,
     getPulumiServiceWithDownloadInfo
 } from "~/decorators/index.js";
@@ -49,6 +50,7 @@ export class DefaultInitProjectSdkService implements InitProjectSdkService.Inter
         container.registerDecorator(deployAppWithWatchedLambdaReplacement);
         container.registerDecorator(deployAppClearWatchedLambdaFunctions);
         container.registerDecorator(deployAppRefreshStackOutputCache);
+        container.registerDecorator(destroyAppClearStackOutputCache);
         container.registerDecorator(deployAppWithHooks);
         container.registerDecorator(watchWithHooks);
         container.registerDecorator(getPulumiServiceWithDownloadInfo);

--- a/packages/project/src/services/PulumiGetStackOutputService/PulumiGetStackOutputService.ts
+++ b/packages/project/src/services/PulumiGetStackOutputService/PulumiGetStackOutputService.ts
@@ -1,29 +1,21 @@
 import { createImplementation } from "@webiny/di";
 import {
     GetPulumiService,
-    GetProjectService,
     LoggerService,
     PulumiGetStackOutputService,
     PulumiSelectStackService,
-    ProjectSdkParamsService
+    StackOutputCacheService
 } from "~/abstractions/index.js";
 import { type AppModel } from "~/models/index.js";
 import { createEnvConfiguration, withPulumiConfigPassphrase } from "~/utils/env/index.js";
 import { mapStackOutput } from "./mapStackOutput.js";
-import fs from "fs/promises";
-import path from "path";
 
 export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputService.Interface {
-    private static readonly DEFAULT_ENV = "dev";
-    private static readonly DEFAULT_REGION = "default";
-    private static readonly DEFAULT_VARIANT = "default";
-
     constructor(
         private getPulumiService: GetPulumiService.Interface,
         private pulumiSelectStackService: PulumiSelectStackService.Interface,
         private loggerService: LoggerService.Interface,
-        private getProjectService: GetProjectService.Interface,
-        private projectSdkParamsService: ProjectSdkParamsService.Interface
+        private stackOutputCacheService: StackOutputCacheService.Interface
     ) {}
 
     async execute<TOutput extends Record<string, any> = Record<string, any>>(
@@ -32,12 +24,8 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
     ): Promise<TOutput | null> {
         // Try to read from cache if skipCache is not true
         if (!params?.skipCache) {
-            const cachedOutput = await this.readFromCache(app);
+            const cachedOutput = await this.stackOutputCacheService.read(app);
             if (cachedOutput !== null) {
-                this.loggerService.debug(
-                    { app: app.name, cacheKey: this.getCacheKey(app) },
-                    "Stack output read from cache"
-                );
                 return this.applyMapping(cachedOutput, params?.map) as TOutput;
             }
         }
@@ -64,12 +52,7 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
                 return null;
             }
 
-            // Write to cache
-            await this.writeToCache(app, stackOutputJson);
-            this.loggerService.debug("Stack output stored to cache", {
-                app: app.name,
-                cacheKey: this.getCacheKey(app)
-            });
+            await this.stackOutputCacheService.write(app, stackOutputJson);
 
             return this.applyMapping(stackOutputJson, params?.map) as TOutput;
         } catch {
@@ -93,46 +76,6 @@ export class DefaultPulumiGetStackOutputService implements PulumiGetStackOutputS
         // If a mapping is provided, we map the output to the specified structure.
         return mapStackOutput(data, map);
     }
-
-    private getCacheKey(app: AppModel): string {
-        const sdkParams = this.projectSdkParamsService.get();
-        const env = sdkParams.env || DefaultPulumiGetStackOutputService.DEFAULT_ENV;
-        const region = sdkParams.region || DefaultPulumiGetStackOutputService.DEFAULT_REGION;
-        const variant = sdkParams.variant || DefaultPulumiGetStackOutputService.DEFAULT_VARIANT;
-        return `${app.name}-${env}-${region}-${variant}.json`;
-    }
-
-    private getCachePath(app: AppModel): string {
-        const project = this.getProjectService.execute();
-        const cacheDir = project.paths.dotWebinyFolder.join("caches", "stack-output").toString();
-        const cacheKey = this.getCacheKey(app);
-        return path.join(cacheDir, cacheKey);
-    }
-
-    private async readFromCache(app: AppModel): Promise<Record<string, any> | null> {
-        const cachePath = this.getCachePath(app);
-
-        try {
-            const content = await fs.readFile(cachePath, "utf-8");
-            return JSON.parse(content);
-        } catch {
-            // File doesn't exist or couldn't be read/parsed - this is expected on first run
-            return null;
-        }
-    }
-
-    private async writeToCache(app: AppModel, data: Record<string, any>): Promise<void> {
-        const cachePath = this.getCachePath(app);
-        const cacheDir = path.dirname(cachePath);
-
-        try {
-            // Create cache directory if it doesn't exist
-            await fs.mkdir(cacheDir, { recursive: true });
-            await fs.writeFile(cachePath, JSON.stringify(data, null, 2), "utf-8");
-        } catch (error) {
-            this.loggerService.error("Could not write to cache file.", cachePath, error);
-        }
-    }
 }
 
 export const pulumiGetStackOutputService = createImplementation({
@@ -142,7 +85,6 @@ export const pulumiGetStackOutputService = createImplementation({
         GetPulumiService,
         PulumiSelectStackService,
         LoggerService,
-        GetProjectService,
-        ProjectSdkParamsService
+        StackOutputCacheService
     ]
 });

--- a/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
+++ b/packages/project/src/services/StackOutputCacheService/StackOutputCacheService.ts
@@ -1,0 +1,93 @@
+import { createImplementation } from "@webiny/di";
+import {
+    GetProjectService,
+    LoggerService,
+    ProjectSdkParamsService,
+    StackOutputCacheService
+} from "~/abstractions/index.js";
+import { type AppModel } from "~/models/index.js";
+import fs from "fs/promises";
+
+export class DefaultStackOutputCacheService implements StackOutputCacheService.Interface {
+    private static readonly DEFAULT_ENV = "dev";
+    private static readonly DEFAULT_REGION = "default";
+    private static readonly DEFAULT_VARIANT = "default";
+
+    constructor(
+        private getProjectService: GetProjectService.Interface,
+        private projectSdkParamsService: ProjectSdkParamsService.Interface,
+        private loggerService: LoggerService.Interface
+    ) {}
+
+    async read(app: AppModel): Promise<Record<string, any> | null> {
+        const cachePath = this.getCachePath(app);
+
+        try {
+            const content = await fs.readFile(cachePath, "utf-8");
+            const data = JSON.parse(content);
+            this.loggerService.debug(
+                { app: app.name, cacheKey: this.getCacheKey(app) },
+                "Stack output read from cache"
+            );
+            return data;
+        } catch {
+            // File doesn't exist or couldn't be read/parsed - this is expected on first run.
+            return null;
+        }
+    }
+
+    async write(app: AppModel, data: Record<string, any>): Promise<void> {
+        const cachePath = this.getCachePath(app);
+        const cacheDir = this.getCacheDir().toString();
+
+        try {
+            // Create cache directory if it doesn't exist.
+            await fs.mkdir(cacheDir, { recursive: true });
+            await fs.writeFile(cachePath, JSON.stringify(data, null, 2), "utf-8");
+            this.loggerService.debug("Stack output stored to cache", {
+                app: app.name,
+                cacheKey: this.getCacheKey(app)
+            });
+        } catch (error) {
+            this.loggerService.error("Could not write to cache file.", cachePath, error);
+        }
+    }
+
+    async delete(app: AppModel): Promise<void> {
+        const cachePath = this.getCachePath(app);
+
+        try {
+            // `force: true` makes this a no-op if the cache file doesn't exist.
+            await fs.rm(cachePath, { force: true });
+            this.loggerService.debug("Stack output cache deleted.", {
+                app: app.name,
+                cacheKey: this.getCacheKey(app)
+            });
+        } catch (error) {
+            this.loggerService.error("Could not delete stack output cache file.", cachePath, error);
+        }
+    }
+
+    private getCacheKey(app: AppModel): string {
+        const sdkParams = this.projectSdkParamsService.get();
+        const env = sdkParams.env || DefaultStackOutputCacheService.DEFAULT_ENV;
+        const region = sdkParams.region || DefaultStackOutputCacheService.DEFAULT_REGION;
+        const variant = sdkParams.variant || DefaultStackOutputCacheService.DEFAULT_VARIANT;
+        return `${app.name}-${env}-${region}-${variant}.json`;
+    }
+
+    private getCacheDir() {
+        const project = this.getProjectService.execute();
+        return project.paths.dotWebinyFolder.join("caches", "stack-output");
+    }
+
+    private getCachePath(app: AppModel): string {
+        return this.getCacheDir().join(this.getCacheKey(app)).toString();
+    }
+}
+
+export const stackOutputCacheService = createImplementation({
+    abstraction: StackOutputCacheService,
+    implementation: DefaultStackOutputCacheService,
+    dependencies: [GetProjectService, ProjectSdkParamsService, LoggerService]
+});

--- a/packages/project/src/services/StackOutputCacheService/index.ts
+++ b/packages/project/src/services/StackOutputCacheService/index.ts
@@ -1,0 +1,1 @@
+export * from "./StackOutputCacheService.js";

--- a/packages/project/src/services/index.ts
+++ b/packages/project/src/services/index.ts
@@ -29,6 +29,7 @@ export * from "./PulumiGetStackOutputService/index.js";
 export * from "./PulumiLoginService/index.js";
 export * from "./PulumiSelectStackService/index.js";
 export * from "./SetProjectIdService/index.js";
+export * from "./StackOutputCacheService/index.js";
 export * from "./StdioService/index.js";
 export * from "./UiService/index.js";
 export * from "./ValidateProjectConfigService/index.js";

--- a/packages/pulumi/src/constants.ts
+++ b/packages/pulumi/src/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_PROD_ENV_NAMES = ["prod", "production"];

--- a/packages/pulumi/src/createPulumiApp.ts
+++ b/packages/pulumi/src/createPulumiApp.ts
@@ -23,7 +23,7 @@ import type {
 } from "~/types.js";
 import type { PulumiAppRemoteResource } from "~/PulumiAppRemoteResource.js";
 import cloneDeep from "lodash/cloneDeep.js";
-import { DEFAULT_PROD_ENV_NAMES } from "./constants.js";
+import { getProjectSdk } from "@webiny/project";
 
 export function createPulumiApp<TResources extends Record<string, unknown>>(
     params: CreatePulumiAppParams<TResources>
@@ -79,9 +79,11 @@ export function createPulumiApp<TResources extends Record<string, unknown>>(
         async run(config) {
             app.params.run = config;
 
-            // Add environment-related variables.
-            const productionEnvironments =
-                app.params.create.productionEnvironments || DEFAULT_PROD_ENV_NAMES;
+            // Add environment-related variables. The list of production environments is
+            // resolved from the project SDK, which merges the built-in defaults with any
+            // environments registered via the `Infra.ProductionEnvironments` extension.
+            const sdk = await getProjectSdk();
+            const productionEnvironments = await sdk.getProductionEnvironments();
             const isProduction = productionEnvironments.includes(app.params.run.env);
 
             app.env = {

--- a/packages/pulumi/src/types.ts
+++ b/packages/pulumi/src/types.ts
@@ -64,9 +64,9 @@ export interface PulumiApp<TResources = Record<string, unknown>> {
         name: string;
 
         // Set to `true` if the environment into which the application is being deployed
-        // is considered a production environment. The list of environment names
-        // that are considered production environments is defined via the
-        // `productionEnvironments` parameter. Learn more:
+        // is considered a production environment. The list of environment names that are
+        // considered production environments consists of the built-in defaults merged with
+        // any registered via the `Infra.ProductionEnvironments` extension. Learn more:
         // https://www.webiny.com/docs/infrastructure/basics/modify-cloud-infrastructure#defining-multiple-production-environments
         isProduction: boolean;
     };

--- a/packages/react-properties/__tests__/await.test.tsx
+++ b/packages/react-properties/__tests__/await.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import { AsyncProperties, Await, Property, toObject } from "~/index";
+import { getLastCall, flush } from "./utils";
+
+async function flushAsync() {
+    await flush();
+    await flush();
+}
+
+function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe("Await", () => {
+    it("should wait for async properties before calling onChange", async () => {
+        const onChange = vi.fn();
+        const deferred = createDeferred<string>();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Property name="sync" value="yes" root />
+                <Await fn={() => deferred.promise}>
+                    {val => <Property name="async" value={val} root />}
+                </Await>
+            </AsyncProperties>
+        );
+
+        await flush();
+        expect(onChange).not.toHaveBeenCalled();
+
+        deferred.resolve("resolved");
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ sync: "yes", async: "resolved" });
+    });
+
+    it("should handle multiple Await components", async () => {
+        const onChange = vi.fn();
+        const d1 = createDeferred<string>();
+        const d2 = createDeferred<string>();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Await fn={() => d1.promise}>
+                    {val => <Property name="first" value={val} root />}
+                </Await>
+                <Await fn={() => d2.promise}>
+                    {val => <Property name="second" value={val} root />}
+                </Await>
+            </AsyncProperties>
+        );
+
+        await flush();
+        expect(onChange).not.toHaveBeenCalled();
+
+        d1.resolve("one");
+        await flushAsync();
+        expect(onChange).not.toHaveBeenCalled();
+
+        d2.resolve("two");
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ first: "one", second: "two" });
+    });
+
+    it("should handle nested Await components", async () => {
+        const onChange = vi.fn();
+        const outer = createDeferred<string>();
+        const inner = createDeferred<string>();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Await fn={() => outer.promise}>
+                    {outerVal => (
+                        <>
+                            <Property name="outer" value={outerVal} root />
+                            <Await fn={() => inner.promise}>
+                                {innerVal => <Property name="inner" value={innerVal} root />}
+                            </Await>
+                        </>
+                    )}
+                </Await>
+            </AsyncProperties>
+        );
+
+        await flush();
+        expect(onChange).not.toHaveBeenCalled();
+
+        outer.resolve("outerValue");
+        await flushAsync();
+        expect(onChange).not.toHaveBeenCalled();
+
+        inner.resolve("innerValue");
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ outer: "outerValue", inner: "innerValue" });
+    });
+
+    it("should work without async properties (backward compat)", async () => {
+        const onChange = vi.fn();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Property name="a" value="1" root />
+                <Property name="b" value="2" root />
+            </AsyncProperties>
+        );
+
+        await flush();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ a: "1", b: "2" });
+    });
+
+    it("should fire onChange even when Await children render no properties", async () => {
+        const onChange = vi.fn();
+        const deferred = createDeferred<string>();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Property name="sync" value="yes" root />
+                <Await fn={() => deferred.promise}>{() => null}</Await>
+            </AsyncProperties>
+        );
+
+        await flush();
+        expect(onChange).not.toHaveBeenCalled();
+
+        deferred.resolve("done");
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ sync: "yes" });
+    });
+
+    it("should handle promise rejection", async () => {
+        const onChange = vi.fn();
+        const deferred = createDeferred<string>();
+
+        render(
+            <AsyncProperties onChange={onChange}>
+                <Property name="sync" value="yes" root />
+                <Await fn={() => deferred.promise}>
+                    {val => <Property name="async" value={val} root />}
+                </Await>
+            </AsyncProperties>
+        );
+
+        await flush();
+        expect(onChange).not.toHaveBeenCalled();
+
+        deferred.reject(new Error("test error"));
+        await flushAsync();
+
+        expect(onChange).toHaveBeenCalled();
+        const obj = toObject(getLastCall(onChange));
+        expect(obj).toEqual({ sync: "yes" });
+    });
+});

--- a/packages/react-properties/src/AsyncProperties.tsx
+++ b/packages/react-properties/src/AsyncProperties.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useCallback, useContext, useRef } from "react";
+import { Properties, useProperties } from "./Properties.js";
+import type { Property } from "./Properties.js";
+import type { PropertyStore } from "./domain/index.js";
+
+interface AsyncPropertiesContextValue {
+    incrementPending(): void;
+    decrementPending(): void;
+}
+
+const AsyncPropertiesContext = createContext<AsyncPropertiesContextValue | undefined>(undefined);
+
+export function useAsyncProperties() {
+    return useContext(AsyncPropertiesContext);
+}
+
+interface AsyncPropertiesProps {
+    name?: string;
+    onChange?(properties: Property[]): void;
+    children: React.ReactNode;
+}
+
+const StoreCapture = ({
+    storeRef,
+    children
+}: {
+    storeRef: React.MutableRefObject<PropertyStore | null>;
+    children: React.ReactNode;
+}) => {
+    const { store } = useProperties();
+    storeRef.current = store;
+    return <>{children}</>;
+};
+
+export const AsyncProperties = ({ name, onChange, children }: AsyncPropertiesProps) => {
+    const pendingRef = useRef(0);
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const storeRef = useRef<PropertyStore | null>(null);
+
+    const interceptedOnChange = useCallback((properties: Property[]) => {
+        if (pendingRef.current > 0) {
+            return;
+        }
+        onChangeRef.current?.(properties);
+    }, []);
+
+    const contextValue = useRef<AsyncPropertiesContextValue>({
+        incrementPending() {
+            pendingRef.current++;
+        },
+        decrementPending() {
+            pendingRef.current = Math.max(0, pendingRef.current - 1);
+            if (pendingRef.current === 0) {
+                setTimeout(() => {
+                    if (pendingRef.current === 0 && storeRef.current) {
+                        storeRef.current.notify();
+                    }
+                }, 0);
+            }
+        }
+    }).current;
+
+    return (
+        <AsyncPropertiesContext.Provider value={contextValue}>
+            <Properties name={name} onChange={interceptedOnChange}>
+                <StoreCapture storeRef={storeRef}>{children}</StoreCapture>
+            </Properties>
+        </AsyncPropertiesContext.Provider>
+    );
+};

--- a/packages/react-properties/src/Await.tsx
+++ b/packages/react-properties/src/Await.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useAsyncProperties } from "./AsyncProperties.js";
+
+interface AwaitProps<T> {
+    fn: () => Promise<T>;
+    children: (value: T) => React.ReactNode;
+}
+
+export function Await<T>({ fn, children }: AwaitProps<T>) {
+    const async = useAsyncProperties();
+    const [result, setResult] = useState<{ data: T } | { error: unknown } | null>(null);
+    const registeredRef = useRef(false);
+    const settledRef = useRef(false);
+
+    if (!registeredRef.current && async) {
+        registeredRef.current = true;
+        async.incrementPending();
+    }
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fn().then(
+            data => {
+                if (!cancelled) {
+                    settledRef.current = true;
+                    setResult({ data });
+                }
+            },
+            error => {
+                if (!cancelled) {
+                    settledRef.current = true;
+                    setResult({ error });
+                }
+            }
+        );
+
+        return () => {
+            cancelled = true;
+            if (!settledRef.current && async) {
+                async.decrementPending();
+            }
+        };
+    }, []);
+
+    useEffect(() => {
+        if (result !== null && async) {
+            async.decrementPending();
+        }
+    }, [result]);
+
+    if (result && "data" in result) {
+        return <>{children(result.data)}</>;
+    }
+
+    return null;
+}

--- a/packages/react-properties/src/domain/PropertyStore.ts
+++ b/packages/react-properties/src/domain/PropertyStore.ts
@@ -33,6 +33,18 @@ export class PropertyStore {
         this.processQueue();
     }, 0);
 
+    notify(): void {
+        this.scheduleFlush.cancel();
+        if (this.queue.length > 0) {
+            this.processQueue();
+        } else {
+            const properties = this.allProperties;
+            for (const listener of this.listeners) {
+                listener(properties);
+            }
+        }
+    }
+
     get allProperties(): Property[] {
         return this.order.filter(id => this.map.has(id)).map(id => this.map.get(id)!);
     }

--- a/packages/react-properties/src/index.ts
+++ b/packages/react-properties/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./utils.js";
 export * from "./Properties.js";
+export * from "./AsyncProperties.js";
+export * from "./Await.js";
 export * from "./useDebugConfig.js";
 export * from "./useIdGenerator.js";
 export * from "./createConfigurableComponent.js";

--- a/skills/user-skills/cognito-federation/SKILL.md
+++ b/skills/user-skills/cognito-federation/SKILL.md
@@ -1,0 +1,527 @@
+---
+name: webiny-cognito-federation
+description: >
+  Configuring Cognito Federation for Webiny projects — federated sign-in via
+  external identity providers (Google, Facebook, Apple, Amazon, OIDC/Entra ID)
+  while keeping Cognito as the user pool. Use this skill when the developer asks
+  about Cognito federation, SSO with Cognito, adding Google/Microsoft/OIDC login
+  to Cognito, federated identity providers, CognitoSignInConfig, CognitoIdpConfig, external
+  users, signInWithRedirect, OAuth redirect URLs, hiding the password form,
+  allowCredentialsLogin, or customizing the federated login screen.
+---
+
+# Cognito Federation
+
+## TL;DR
+
+Webiny supports federated sign-in through Cognito — users authenticate via external identity providers (Google, Entra ID, etc.) while Cognito remains the user pool. Configure it by adding a `federation` prop to `<Cognito />` in `webiny.config.tsx`. This handles both infrastructure (Cognito User Pool Domain, IdP resources, OAuth client) and the admin login screen (provider buttons, OAuth for Amplify). Federated users are auto-detected and synced into Webiny. For advanced use cases, provide `apiConfig` (custom identity mapping) and/or `adminConfig` (custom login screen behavior).
+
+## Pattern / Core Concept
+
+Cognito Federation has three layers:
+
+1. **Infrastructure** — The `federation` prop on `<Cognito />`, under the hood, creates the Cognito User Pool Domain, Identity Provider resources, and configures OAuth on the User Pool Client.
+
+2. **Admin Login Screen** — The federation config is passed as an `Admin.BuildParam` to the admin app. A `CognitoSignInConfig` abstraction provides the login screen with provider buttons, OAuth settings for Amplify, and credentials visibility. By default, this is auto-generated from the `federation` prop. For advanced customization (IP whitelists, async logic), provide an `adminConfig` extension.
+
+3. **API Identity** — Federated tokens are auto-detected via the `identities` JWT claim and marked `external: true`. The `ExternalIdpUserSyncHandler` auto-creates/updates users on login. For custom role/team mapping, provide an `apiConfig` extension implementing `CognitoIdpConfig`.
+
+### How Federated Login Works
+
+1. User clicks a provider button on the login screen
+2. `signInWithRedirect()` redirects to Cognito Hosted UI
+3. Cognito redirects to the external IdP (Google, Entra ID, etc.)
+4. After authentication, Cognito creates an `idToken` with an `identities` claim
+5. The admin app picks up the session via `fetchAuthSession()`
+6. The API detects `identities` in the token, sets `external: true`
+7. `ExternalIdpUserSyncHandler` creates/updates the Webiny user with roles/teams
+
+## Reference Tables
+
+### `<Cognito />` Props
+
+| Prop          | Type                              | Description                                      |
+| ------------- | --------------------------------- | ------------------------------------------------ |
+| `federation`  | `object \| () => Promise<object>` | Federation config (see below) — sync or async    |
+| `mfa`         | `boolean`                         | Enable TOTP MFA for all users (default: `false`) |
+| `apiConfig`   | `string`                          | Path to API identity mapping extension           |
+| `adminConfig` | `string`                          | Path to Admin login customization extension      |
+
+### `federation` Object
+
+| Field                   | Type                | Required | Default        | Description                     |
+| ----------------------- | ------------------- | -------- | -------------- | ------------------------------- |
+| `domain`                | `string`            | Yes      | —              | Cognito User Pool domain prefix |
+| `callbackUrls`          | `string[]`          | Yes      | —              | OAuth callback/redirect URLs    |
+| `logoutUrls`            | `string[]`          | No       | `callbackUrls` | OAuth logout redirect URLs      |
+| `responseType`          | `"code" \| "token"` | No       | `"code"`       | OAuth response type             |
+| `allowCredentialsLogin` | `boolean`           | No       | `true`         | Show email/password form        |
+| `identityProviders`     | `array`             | Yes      | —              | List of federated IdPs          |
+
+### `identityProviders[]` Items
+
+| Field              | Type                                                      | Required | Description                                                   |
+| ------------------ | --------------------------------------------------------- | -------- | ------------------------------------------------------------- |
+| `type`             | `"google" \| "facebook" \| "amazon" \| "apple" \| "oidc"` | Yes      | Provider type                                                 |
+| `name`             | `string`                                                  | No       | Custom provider name (required for OIDC)                      |
+| `label`            | `string`                                                  | Yes      | Button text on the login screen                               |
+| `providerDetails`  | `object`                                                  | Yes      | AWS Cognito provider details (client_id, client_secret, etc.) |
+| `attributeMapping` | `object`                                                  | No       | Custom attribute mapping (overrides defaults)                 |
+
+### `CognitoSignInConfig.Interface` (Admin Customization)
+
+| Method        | Signature               | Description                                    |
+| ------------- | ----------------------- | ---------------------------------------------- |
+| `getConfig()` | `() => Promise<Config>` | Returns federation config for the login screen |
+
+### `CognitoSignInConfig.Config` (Return Type)
+
+| Field                   | Type                                                        | Required | Description                             |
+| ----------------------- | ----------------------------------------------------------- | -------- | --------------------------------------- |
+| `oauth`                 | `{ scopes, redirectSignIn, redirectSignOut, responseType }` | Yes      | Amplify OAuth config                    |
+| `allowCredentialsLogin` | `boolean`                                                   | Yes      | Show email/password form                |
+| `providers`             | `FederatedProvider[]`                                       | Yes      | Provider buttons                        |
+| `title`                 | `string`                                                    | No       | Login screen title (default: "Sign in") |
+| `description`           | `string`                                                    | No       | Login screen description                |
+
+### `FederatedProvider` (Union Type)
+
+```ts
+type FederatedProvider =
+  | { name: string; label: string } // Auto-rendered button
+  | { name: string; component: React.FC<{ signIn: () => void }> }; // Custom button
+```
+
+### `CognitoIdpConfig.Interface` (API Identity Mapping)
+
+| Method              | Signature                                                            | Required | Description                        |
+| ------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------- |
+| `getIdentity`       | `(token: JwtPayload) => CognitoIdentity \| Promise<CognitoIdentity>` | Yes      | Maps JWT claims to Webiny identity |
+| `verifyTokenClaims` | `(token: JwtPayload) => void \| Promise<void>`                       | No       | Custom claim verification          |
+
+### Identity Return Type
+
+Default identity fields (`id`, `displayName`, `profile`) are auto-populated from standard Cognito claims (`custom:id`, `given_name`, `family_name`, `email`). The custom `getIdentity` only needs to return fields it wants to **override** — typically `roles` and `teams`.
+
+| Field         | Type                             | Description                              |
+| ------------- | -------------------------------- | ---------------------------------------- |
+| `id`          | `string`                         | User ID (default: `custom:id` or `sub`)  |
+| `displayName` | `string`                         | Display name (default: from name claims) |
+| `roles`       | `string[]`                       | Webiny roles by slug                     |
+| `teams`       | `string[]`                       | Webiny teams by slug                     |
+| `profile`     | `{ email, firstName, lastName }` | User profile (defaults from claims)      |
+
+## Full Examples
+
+### Example 1: Simple Federation (No Extension Files)
+
+```tsx
+// webiny.config.tsx
+import { Cognito } from "@webiny/cognito";
+
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001", "https://admin.example.com"],
+    responseType: "code",
+    identityProviders: [
+      {
+        type: "google",
+        label: "Sign in with Google",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.GOOGLE_CLIENT_ID),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET)
+        }
+      }
+    ]
+  }}
+/>;
+```
+
+This alone creates the Cognito IdP, configures OAuth, shows a "Sign in with Google" button, and auto-syncs federated users.
+
+### Example 2: OIDC Provider (Entra ID / Custom)
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 3: Async Federation Config
+
+When provider credentials need to be fetched asynchronously (e.g., from a secrets manager, vault, or remote API), pass `federation` as an async function instead of a plain object. The config rendering pipeline will wait for the promise to resolve before continuing.
+
+```tsx
+// extensions/idp/entraid/Extension.tsx
+import React from "react";
+import { Cognito } from "@webiny/cognito";
+
+async function getCredentials() {
+  return {
+    client_id: process.env.ENTRA_CLIENT_ID,
+    client_secret: process.env.ENTRA_CLIENT_SECRET,
+    oidc_issuer: process.env.ENTRA_OIDC_ISSUER
+  };
+}
+
+export const CognitoFederation = () => {
+  return (
+    <Cognito
+      mfa={true}
+      apiConfig={"@/extensions/idp/entraid/EntraIdApiConfig.ts"}
+      federation={async () => {
+        const credentials = await getCredentials();
+
+        return {
+          domain: "myproj-webiny-with-entraid",
+          callbackUrls: ["https://webiny-6.4.x.localhost"],
+          responseType: "code",
+          allowCredentialsLogin: true,
+          identityProviders: [
+            {
+              name: "EntraID",
+              type: "oidc",
+              label: "Sign in with Microsoft",
+              providerDetails: {
+                attributes_request_method: "POST",
+                authorize_scopes: "email profile openid",
+                ...credentials
+              },
+              attributeMapping: {
+                "custom:id": "sub",
+                username: "sub",
+                email: "email",
+                given_name: "given_name",
+                family_name: "family_name",
+                preferred_username: "email"
+              }
+            }
+          ]
+        };
+      }}
+    />
+  );
+};
+```
+
+Under the hood, the `<Cognito>` component uses `<Await fn={...}>` from `@webiny/react-properties` to resolve the async function. The `AsyncProperties` wrapper in the config rendering worker gates `onChange` until all `<Await>` promises settle, so the CLI won't exit prematurely.
+
+### Example 4: Multiple Providers
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    responseType: "code",
+    identityProviders: [
+      {
+        type: "google",
+        label: "Sign in with Google",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.GOOGLE_CLIENT_ID),
+          client_secret: String(process.env.GOOGLE_CLIENT_SECRET)
+        }
+      },
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 5: Custom Identity Mapping (apiConfig)
+
+Map Cognito groups to Webiny roles/teams:
+
+```tsx
+// webiny.config.tsx
+<Cognito
+  federation={
+    {
+      /* ... */
+    }
+  }
+  apiConfig={"/extensions/cognito/api.ts"}
+/>
+```
+
+```ts
+// extensions/cognito/api.ts
+import { CognitoIdpConfig } from "@webiny/cognito/api";
+
+class MyConfig implements CognitoIdpConfig.Interface {
+  getIdentity(token: CognitoIdpConfig.JwtPayload) {
+    const cognitoGroups: string[] = (token["cognito:groups"] as string[]) || [];
+
+    return {
+      roles: cognitoGroups.includes("admins") ? ["full-access"] : ["content-editor"],
+      teams: cognitoGroups.filter(g => g.startsWith("team-"))
+    };
+  }
+}
+
+export default CognitoIdpConfig.createImplementation({
+  implementation: MyConfig,
+  dependencies: []
+});
+```
+
+### Example 6: Custom Admin Login Screen (adminConfig)
+
+#### IP-based credentials whitelist
+
+```tsx
+// webiny.config.tsx
+<Cognito
+  federation={
+    {
+      /* ... */
+    }
+  }
+  adminConfig={"/extensions/cognito/admin.tsx"}
+/>
+```
+
+```tsx
+// extensions/cognito/admin.tsx
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
+
+const ALLOWED_IPS = ["1.2.3.4", "5.6.7.8"];
+
+async function fetchUserIP(): Promise<string> {
+  const response = await fetch("https://api64.ipify.org?format=json");
+  const data = await response.json();
+  return data.ip;
+}
+
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+  async getConfig() {
+    let allowCredentials = false;
+
+    if (process.env.REACT_APP_STAGE !== "prod") {
+      const ip = await fetchUserIP();
+      allowCredentials = ALLOWED_IPS.includes(ip);
+    }
+
+    return {
+      oauth: {
+        scopes: ["profile", "email", "openid"],
+        redirectSignIn: [window.location.origin],
+        redirectSignOut: [window.location.origin],
+        responseType: "code" as const
+      },
+      allowCredentialsLogin: allowCredentials,
+      providers: [{ name: "EntraID", label: "Sign in with Microsoft" }],
+      title: "Welcome"
+    };
+  }
+}
+
+export default CognitoSignInConfig.createImplementation({
+  implementation: MyFederationConfig,
+  dependencies: []
+});
+```
+
+#### Custom button component
+
+```tsx
+// extensions/cognito/admin.tsx
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
+import { GoogleLoginButton } from "react-social-login-buttons";
+
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+  async getConfig() {
+    return {
+      oauth: {
+        scopes: ["profile", "email", "openid"],
+        redirectSignIn: [window.location.origin],
+        redirectSignOut: [window.location.origin],
+        responseType: "code" as const
+      },
+      allowCredentialsLogin: true,
+      providers: [
+        {
+          name: "google",
+          component: ({ signIn }) => <GoogleLoginButton onClick={signIn} />
+        }
+      ]
+    };
+  }
+}
+
+export default CognitoSignInConfig.createImplementation({
+  implementation: MyFederationConfig,
+  dependencies: []
+});
+```
+
+#### Custom title and description
+
+```tsx
+class MyFederationConfig implements CognitoSignInConfig.Interface {
+  async getConfig() {
+    return {
+      oauth: {
+        /* ... */
+      },
+      allowCredentialsLogin: false,
+      providers: [{ name: "EntraID", label: "Sign In" }],
+      title: "Company Portal",
+      description: "Use your corporate credentials to sign in."
+    };
+  }
+}
+```
+
+### Example 7: Custom Attribute Mapping
+
+Override the default OIDC attribute mapping when your IdP uses non-standard claim names.
+
+The `custom:id` mapping is important — Webiny uses it as the primary user identifier. It's mapped to the IdP's `sub` claim by default. Always include it in custom mappings unless the IdP's `sub` value exceeds 36 characters on an existing Cognito pool (deployed prior to Webiny 6.4.4). New pools support up to 256 characters.
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "MyIDP",
+        type: "oidc",
+        label: "Sign in with MyIDP",
+        providerDetails: {
+          authorize_scopes: "email profile openid",
+          client_id: "...",
+          client_secret: "...",
+          oidc_issuer: "..."
+        },
+        attributeMapping: {
+          "custom:id": "sub",
+          username: "sub",
+          email: "email",
+          given_name: "first_name",
+          family_name: "last_name"
+        }
+      }
+    ]
+  }}
+/>
+```
+
+## MFA (Multi-Factor Authentication)
+
+Enable TOTP-based MFA for all admin users with `mfa={true}`:
+
+```tsx
+<Cognito mfa={true} />
+```
+
+Or combine with federation:
+
+```tsx
+<Cognito
+  mfa={true}
+  federation={{
+    domain: "my-app",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          /* ... */
+        }
+      }
+    ]
+  }}
+/>
+```
+
+When MFA is enabled:
+
+- The Cognito User Pool requires TOTP for all users (`mfaConfiguration: "ON"`)
+- On first login, users see a TOTP setup screen with a QR code to scan with their authenticator app (Google Authenticator, Authy, etc.)
+- On subsequent logins, users enter a 6-digit code from their authenticator app
+- MFA applies to password-based logins only — federated IdP logins are handled by the external provider
+
+## Quick Reference
+
+### Imports
+
+```typescript
+// Extension component
+import { Cognito } from "@webiny/cognito";
+
+// API identity mapping
+import { CognitoIdpConfig } from "@webiny/cognito/api";
+
+// Admin login customization
+import { CognitoSignInConfig } from "@webiny/cognito/admin";
+```
+
+### Key Interfaces
+
+| Interface                               | Package                 | Purpose                                   |
+| --------------------------------------- | ----------------------- | ----------------------------------------- |
+| `CognitoIdpConfig.Interface`            | `@webiny/cognito/api`   | API-side JWT-to-identity mapping          |
+| `CognitoIdpConfig.JwtPayload`           | `@webiny/cognito/api`   | JWT token payload type                    |
+| `CognitoSignInConfig.Interface`         | `@webiny/cognito/admin` | Admin login screen customization          |
+| `CognitoSignInConfig.FederatedProvider` | `@webiny/cognito/admin` | Provider button type (label or component) |
+
+### File Structure (Advanced)
+
+```
+extensions/cognito/
+├── api.ts       # API config (identity mapping) — optional
+└── admin.tsx    # Admin config (login customization) — optional
+```
+
+### Deploy
+
+```bash
+yarn webiny deploy        # Deploy all (Core + API + Admin)
+```
+
+Core must be deployed first (creates IdP resources), then API + Admin.
+
+## Related Skills
+
+- **webiny-configure-entraid** — Specific guide for Microsoft Entra ID federation
+- **webiny-configure-okta** — Alternative: Okta replaces Cognito entirely
+- **webiny-configure-auth0** — Alternative: Auth0 replaces Cognito entirely
+- **webiny-dependency-injection** — The DI pattern used by `createImplementation()`

--- a/skills/user-skills/configure-entraid/SKILL.md
+++ b/skills/user-skills/configure-entraid/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: webiny-configure-entraid
+description: >
+  Configuring Microsoft Entra ID (formerly Azure AD) as a federated identity
+  provider for Webiny projects using Cognito Federation. Use this skill when the
+  developer asks about Entra ID, Azure AD, Microsoft SSO, OIDC with Microsoft,
+  Microsoft login for Webiny, or configuring login.microsoftonline.com as an
+  identity provider. Also relevant for tenant IDs, Entra application registration,
+  or connecting Microsoft 365 accounts to Webiny.
+---
+
+# Configure Microsoft Entra ID Authentication
+
+## TL;DR
+
+Webiny supports Microsoft Entra ID (formerly Azure AD) as a federated identity provider through Cognito Federation. Unlike Okta or Auth0 which replace Cognito entirely, Entra ID works **alongside** Cognito — users authenticate via Microsoft, but Cognito remains the user pool. Configure it by adding `federation` to the `<Cognito />` extension in `webiny.config.tsx` with your Entra ID application's client ID, client secret, and issuer URL.
+
+## Prerequisites
+
+Before configuring Webiny, you need to register an application in the Microsoft Entra ID portal:
+
+1. Go to [Microsoft Entra admin center](https://entra.microsoft.com) > **App registrations** > **New registration**
+2. Set a name (e.g., "Webiny Admin")
+3. Set **Supported account types** (typically "Accounts in this organizational directory only")
+4. Set **Redirect URI**: Web — use your Cognito domain callback URL (you'll get this after the first deploy: `https://{domain}.auth.{region}.amazoncognito.com/oauth2/idpresponse`)
+5. After registration, note:
+   - **Application (client) ID** — this is your `client_id`
+   - **Directory (tenant) ID** — part of your issuer URL
+6. Go to **Certificates & secrets** > **New client secret** — note the **Value** (this is your `client_secret`)
+7. The **Issuer URL** is: `https://login.microsoftonline.com/{tenant-id}/v2.0`
+
+## Reference Tables
+
+### Required Entra ID Values
+
+| Value                   | Where to find it                          | Used as                              |
+| ----------------------- | ----------------------------------------- | ------------------------------------ |
+| Application (client) ID | App registration > Overview               | `client_id` in `providerDetails`     |
+| Client secret value     | App registration > Certificates & secrets | `client_secret` in `providerDetails` |
+| Directory (tenant) ID   | App registration > Overview               | Part of `oidc_issuer` URL            |
+
+### Environment Variables
+
+| Variable              | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `ENTRA_CLIENT_ID`     | Entra ID Application (client) ID                     |
+| `ENTRA_CLIENT_SECRET` | Entra ID client secret value                         |
+| `ENTRA_ISSUER`        | `https://login.microsoftonline.com/{tenant-id}/v2.0` |
+
+### Attribute Mapping
+
+When Cognito receives tokens from Entra ID, it maps the OIDC claims to Cognito user attributes. The default OIDC mapping is:
+
+| Cognito Attribute    | OIDC Claim    | Description                        |
+| -------------------- | ------------- | ---------------------------------- |
+| `username`           | `sub`         | Unique user identifier             |
+| `custom:id`          | `sub`         | Webiny internal user ID            |
+| `email`              | `email`       | User's email address               |
+| `given_name`         | `given_name`  | First name                         |
+| `family_name`        | `family_name` | Last name                          |
+| `preferred_username` | `email`       | Used as the Cognito username alias |
+
+You can override this mapping with the `attributeMapping` property on the identity provider config. This is useful when:
+
+- Your Entra ID uses non-standard claim names
+- You want to skip `custom:id` mapping (e.g., when the `sub` value exceeds the attribute's max length on existing pools)
+- You need to map additional custom attributes
+
+```tsx
+{
+    name: "EntraID",
+    type: "oidc",
+    label: "Sign in with Microsoft",
+    providerDetails: { /* ... */ },
+    attributeMapping: {
+        username: "sub",
+        email: "email",
+        given_name: "given_name",
+        family_name: "family_name",
+        preferred_username: "email"
+        // custom:id intentionally omitted
+    }
+}
+```
+
+When `attributeMapping` is provided, it **replaces** the defaults entirely — include all mappings you need.
+
+## Full Examples
+
+### Example 1: Basic Entra ID Federation
+
+**Step 1: Set environment variables**
+
+Add to your `.env` file:
+
+```
+# NOTE: these are made up example values
+ENTRA_CLIENT_ID=f62ee823-2811-8314-a040-62848442c0d5
+ENTRA_CLIENT_SECRET=~Gp7Q~97MAzTAUyeTLzTVzX31DRTY28chehU6c_a
+ENTRA_ISSUER=https://login.microsoftonline.com/1cd0d912-0ac4-48a0-91b6-cd849ce9498f/v2.0
+```
+
+**Step 2: Create the extension**
+
+Create `extensions/entraid/Extension.tsx`:
+
+```tsx
+import React from "react";
+import { Cognito } from "@webiny/cognito";
+
+export const CognitoFederation = () => {
+  return (
+    <Cognito
+      federation={{
+        domain: "my-app-entraid",
+        callbackUrls: ["http://localhost:3001"],
+        responseType: "code",
+        identityProviders: [
+          {
+            name: "EntraID",
+            type: "oidc",
+            label: "Sign in with Microsoft",
+            providerDetails: {
+              attributes_request_method: "POST",
+              authorize_scopes: "email profile openid",
+              client_id: String(process.env.ENTRA_CLIENT_ID),
+              client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+              oidc_issuer: String(process.env.ENTRA_ISSUER)
+            }
+          }
+        ]
+      }}
+    />
+  );
+};
+```
+
+**Step 3: Register in `webiny.config.tsx`**
+
+```tsx
+import { CognitoFederation } from "@/extensions/entraid/Extension.js";
+
+export const Extensions = () => {
+  return (
+    <>
+      {/* Replace <Cognito /> with the federation extension */}
+      <CognitoFederation />
+
+      {/* ... other extensions ... */}
+    </>
+  );
+};
+```
+
+**Step 4: Deploy**
+
+```bash
+# Deploy core first (creates Cognito IdP resources)
+yarn webiny deploy core --env=dev
+
+# Get the Cognito domain for Entra ID redirect URI config
+yarn webiny output core --env=dev
+# Look for cognitoUserPoolDomain — use it to update the redirect URI in Entra ID
+
+# Deploy API + Admin
+yarn webiny deploy api --env=dev
+yarn webiny deploy admin --env=dev
+```
+
+**Step 5: Update Entra ID redirect URI**
+
+After the first deploy, update the redirect URI in your Entra ID app registration to:
+`https://{cognitoUserPoolDomain}/oauth2/idpresponse`
+
+### Example 2: Entra ID Only (No Password Login)
+
+```tsx
+<Cognito
+  federation={{
+    domain: "my-app-entraid",
+    callbackUrls: ["http://localhost:3001", "https://admin.example.com"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+This hides the email/password form and shows only the "Sign in with Microsoft" button with a description that the user will be redirected.
+
+### Example 3: Entra ID with Custom Role Mapping
+
+Map Entra ID groups (via Cognito groups or token claims) to Webiny roles:
+
+```tsx
+// webiny.config.tsx
+<CognitoFederation />
+// where CognitoFederation includes:
+// apiConfig={"@/extensions/entraid/api.ts"}
+```
+
+```ts
+// extensions/entraid/api.ts
+import { CognitoIdpConfig } from "@webiny/cognito/api";
+
+class EntraIdConfig implements CognitoIdpConfig.Interface {
+  getIdentity(token: CognitoIdpConfig.JwtPayload) {
+    const groups: string[] = (token["cognito:groups"] as string[]) || [];
+
+    return {
+      roles: groups.includes("WebinyAdmins") ? ["full-access"] : ["content-editor"],
+      teams: groups.filter(g => g.startsWith("team-"))
+    };
+  }
+}
+
+export default CognitoIdpConfig.createImplementation({
+  implementation: EntraIdConfig,
+  dependencies: []
+});
+```
+
+### Example 4: Production Setup with Multiple Callback URLs
+
+```tsx
+<Cognito
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+    logoutUrls: ["http://localhost:3001", "https://admin.mycompany.com"],
+    responseType: "code",
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        }
+      }
+    ]
+  }}
+/>
+```
+
+Remember to add **all** callback URLs to your Entra ID app registration's redirect URIs.
+
+### Example 5: Custom Attribute Mapping
+
+Override the default claim mapping — useful for existing Cognito pools where `custom:id` has a max length of 36 characters (Entra ID `sub` values can be longer):
+
+```tsx
+<Cognito
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001"],
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        },
+        attributeMapping: {
+          username: "sub",
+          email: "email",
+          given_name: "given_name",
+          family_name: "family_name",
+          preferred_username: "email"
+        }
+      }
+    ]
+  }}
+/>
+```
+
+### Example 6: Entra ID with MFA
+
+Add TOTP-based MFA on top of Entra ID federation:
+
+```tsx
+<Cognito
+  mfa={true}
+  federation={{
+    domain: "mycompany-webiny",
+    callbackUrls: ["http://localhost:3001"],
+    allowCredentialsLogin: false,
+    identityProviders: [
+      {
+        name: "EntraID",
+        type: "oidc",
+        label: "Sign in with Microsoft",
+        providerDetails: {
+          attributes_request_method: "POST",
+          authorize_scopes: "email profile openid",
+          client_id: String(process.env.ENTRA_CLIENT_ID),
+          client_secret: String(process.env.ENTRA_CLIENT_SECRET),
+          oidc_issuer: String(process.env.ENTRA_ISSUER)
+        },
+        attributeMapping: {
+          "custom:id": "sub",
+          username: "sub",
+          email: "email",
+          given_name: "given_name",
+          family_name: "family_name",
+          preferred_username: "email"
+        }
+      }
+    ]
+  }}
+/>
+```
+
+MFA applies to password-based logins. Federated sign-ins via Entra ID are handled by Microsoft's own authentication — configure MFA on the Entra ID side if needed for those users.
+
+## Quick Reference
+
+### Imports
+
+```typescript
+import { Cognito } from "@webiny/cognito";
+import { CognitoIdpConfig } from "@webiny/cognito/api"; // for API config
+import { CognitoSignInConfig } from "@webiny/cognito/admin"; // for Admin config
+```
+
+### File Structure
+
+```
+extensions/entraid/
+├── Extension.tsx       # Extension component with <Cognito federation={...} />
+├── api.ts              # API config (role mapping) — optional
+└── admin.tsx           # Admin config (login customization) — optional
+```
+
+### Deploy Order
+
+1. `yarn webiny deploy core --env=dev` — creates Cognito IdP resources
+2. Update Entra ID redirect URI with the `cognitoUserPoolDomain` output
+3. `yarn webiny deploy api --env=dev` — deploys API with identity mapping
+4. `yarn webiny deploy admin --env=dev` — deploys admin with login screen
+
+## Related Skills
+
+- **webiny-cognito-federation** — Full reference for all Cognito Federation options
+- **webiny-configure-okta** — Alternative: Okta replaces Cognito entirely
+- **webiny-configure-auth0** — Alternative: Auth0 replaces Cognito entirely

--- a/skills/user-skills/content-models/SKILL.md
+++ b/skills/user-skills/content-models/SKILL.md
@@ -12,7 +12,8 @@ description: >
   (text, longText, number, boolean, datetime, file, ref, object, richText, dynamicZone),
   list (array) fields via .list() and the singular-vs-plural renderer rule,
   validation (required, unique, email, pattern, minLength, maxLength, gte, predefinedValues),
-  single-entry (singleton) models via .singleEntry(), and model/field tags via .tags().
+  single-entry (singleton) models via .singleEntry(), model/field tags via .tags(),
+  and field rules via .rules() for access-control and conditional visibility/editability.
   Includes the correct `fields` projection syntax when querying entries via the SDK:
   `ref` fields use double-`values.` nesting (e.g. `values.author.values.name`) because
   they resolve to another entry, while `object` and `dynamicZone` sub-fields are inline
@@ -262,6 +263,95 @@ The same rule applies to every field type that has both variants:
 For `ref()` fields the pluralization rule is the same but the singular/multiple renderers
 have distinct names (e.g. `refDialogSingle` → `refDialogMultiple`) — see the table.
 
+## Layout Fields
+
+Layout fields are UI-only elements that do not store data. They decorate the editor
+form with visual structure. Place them in `.fields()` like data fields, and reference
+them by key in `.layout()`.
+
+All layout fields inherit the base methods: `.label()`, `.help()`, `.description()`,
+`.note()`, `.fieldId()`, `.rules()`.
+
+| Builder Method         | Description                                     | Extra Methods                                              |
+| ---------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `fields.uiSeparator()` | Horizontal divider with an optional label       | —                                                          |
+| `fields.uiAlert()`     | Colored banner (info, success, warning, danger) | `.alertType("info" \| "success" \| "warning" \| "danger")` |
+| `fields.uiTabs()`      | Tabbed container that groups fields into tabs   | `.tab(id, config)` — see below                             |
+
+### uiSeparator
+
+A horizontal line to visually separate field groups. The label appears as section text.
+
+```typescript
+.fields(fields => ({
+  name: fields.text().renderer("textInput").label("Name"),
+  divider: fields.uiSeparator().label("Additional Info"),
+  bio: fields.longText().renderer("textarea").label("Bio")
+}))
+.layout([["name"], ["divider"], ["bio"]])
+```
+
+### uiAlert
+
+A colored callout banner. Use `.alertType()` to set the severity.
+
+```typescript
+.fields(fields => ({
+  warning: fields
+    .uiAlert()
+    .label("Changes to this section require approval.")
+    .alertType("warning"),
+  title: fields.text().renderer("textInput").label("Title")
+}))
+.layout([["warning"], ["title"]])
+```
+
+### uiTabs
+
+Groups fields into tabs. Each tab has its own fields and layout. Fields inside tabs
+are hoisted to the model level (flat field list), but visually grouped under their tab.
+
+`.tab(id, config)` accepts:
+
+| Config Property | Type                                             | Required | Description                   |
+| --------------- | ------------------------------------------------ | -------- | ----------------------------- |
+| `label`         | `string`                                         | yes      | Tab label                     |
+| `icon`          | `CmsIcon`                                        | no       | Tab icon                      |
+| `description`   | `string`                                         | no       | Tab description               |
+| `fields`        | `(registry) => Record<string, BaseFieldBuilder>` | yes      | Fields inside this tab        |
+| `layout`        | `string[][]`                                     | no       | Layout for fields in this tab |
+| `rules`         | `FieldRule[]`                                    | no       | Rules for this individual tab |
+
+```typescript
+.fields(fields => ({
+  tabs: fields
+    .uiTabs()
+    .tab("general", {
+      label: "General",
+      fields: sub => ({
+        title: sub.text().renderer("textInput").label("Title").required(),
+        slug: sub.text().renderer("textInput").label("Slug").required()
+      }),
+      layout: [["title", "slug"]]
+    })
+    .tab("seo", {
+      label: "SEO",
+      fields: sub => ({
+        seoTitle: sub.text().renderer("textInput").label("SEO Title"),
+        seoDescription: sub.longText().renderer("textarea").label("SEO Description")
+      }),
+      layout: [["seoTitle"], ["seoDescription"]],
+      rules: [
+        { type: "accessControl", target: "identity", operator: "matches", value: "team:marketing", action: "hide" }
+      ]
+    })
+}))
+.layout([["tabs"]])
+```
+
+The outer `.layout()` references `"tabs"` as a single cell. Tab-internal layouts only
+reference their own field keys (same scoping rule as object/dynamicZone layouts).
+
 ## Field Validators (Chainable)
 
 | Validator                  | Description                         | Example                                                  |
@@ -285,6 +375,231 @@ have distinct names (e.g. `refDialogSingle` → `refDialogMultiple`) — see the
 | `.list()`                       | Make the field accept multiple values (arrays). Requires a multi-value renderer variant — see Field Types table. |
 | `.models([{ modelId: "..." }])` | For `ref()` fields: which models can be referenced                                                               |
 | `.tags(["tag1"])`               | Assign tags to a field (e.g., `"$bulk-edit"`)                                                                    |
+| `.rules([...])`                 | Conditional visibility/editability rules — see [Field Rules](#field-rules) section                               |
+
+## Field Rules
+
+`.rules()` accepts an array of `FieldRule` objects that control field visibility and
+editability in the Admin UI. Rules are evaluated client-side. Available on **all** field
+types (data fields and layout fields — separators, alerts, tabs).
+
+Each rule has the shape:
+
+```typescript
+interface FieldRule {
+  type: "accessControl" | "condition";
+  target: string;
+  operator: string;
+  value: string | number | boolean | null;
+  action: "hide" | "disable";
+}
+```
+
+### Rule types
+
+| `type`            | Purpose                                                                                                | `target`                                     | `value`                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------------- |
+| `"accessControl"` | Show/hide or enable/disable a field based on the current user's identity or team membership            | `"identity"`                                 | `"admin:<userId>"` or `"team:<teamSlug>"`               |
+| `"condition"`     | Show/hide or enable/disable a field based on the current entry's field values (reactive, updates live) | Field path, e.g. `"status"` or `"seo.title"` | The value to compare against (type depends on operator) |
+
+### Actions
+
+| `action`    | Effect                                                            |
+| ----------- | ----------------------------------------------------------------- |
+| `"hide"`    | Hides the field entirely from the editor                          |
+| `"disable"` | Shows the field but makes it read-only (greyed out, not editable) |
+
+### Condition operators
+
+Operators available for `type: "condition"` rules, grouped by target field type:
+
+| Operator       | Label            | Applicable to                   | `value`                   |
+| -------------- | ---------------- | ------------------------------- | ------------------------- |
+| `"=="`         | Equals           | text, number, boolean, datetime | The value to match        |
+| `"!="`         | Not equals       | text, number, boolean, datetime | The value to not match    |
+| `">"`          | Greater than     | number, datetime                | Numeric/date threshold    |
+| `"<"`          | Less than        | number, datetime                | Numeric/date threshold    |
+| `">="`         | Greater or equal | number, datetime                | Numeric/date threshold    |
+| `"<="`         | Less or equal    | number, datetime                | Numeric/date threshold    |
+| `"contains"`   | Contains         | text, long-text                 | Substring to search for   |
+| `"startsWith"` | Starts with      | text, long-text                 | Prefix to match           |
+| `"endsWith"`   | Ends with        | text, long-text                 | Suffix to match           |
+| `"isEmpty"`    | Is empty         | all field types                 | `null` (value is ignored) |
+| `"isNotEmpty"` | Is not empty     | all field types                 | `null` (value is ignored) |
+
+### Access control operators
+
+| Operator    | Description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| `"matches"` | Checks if the current user's identity or team matches `value` |
+
+### Target field paths (condition rules)
+
+The `target` for condition rules is a **dot-separated field path** relative to the form
+root. Use the field's `fieldId` (the key in the `.fields()` callback).
+
+- Simple field: `"status"`
+- Nested inside object: `"seo.title"`, `"address.city"`
+- Inside a list item (current index): `"items.$.name"` — the `$` resolves to the
+  current list index at evaluation time
+- Array length: `"items.length"` — evaluates to the number of items in the array
+- **Static relative path**: `"$.fieldId"` — resolves relative to the **parent object or
+  template** that contains the field. Use this inside `object`, `dynamicZone` template,
+  or `uiTabs` scopes to reference a sibling field without hard-coding the full path.
+  For example, inside a dynamicZone template, `"$.enabled"` resolves to the sibling
+  `enabled` field within the same template instance. This is the recommended approach
+  for rules inside nested scopes — it keeps the rule portable and avoids coupling to
+  the parent field's name.
+
+### Examples
+
+**Access control — hide field from non-marketing team:**
+
+```typescript
+title: fields
+  .text()
+  .renderer("textInput")
+  .label("Marketing Title")
+  .rules([
+    {
+      type: "accessControl",
+      target: "identity",
+      operator: "matches",
+      value: "team:marketing",
+      action: "hide"
+    }
+  ]);
+```
+
+**Condition — disable field when another field is empty:**
+
+```typescript
+seoDescription: fields
+  .longText()
+  .renderer("textarea")
+  .label("SEO Description")
+  .rules([
+    { type: "condition", target: "seoTitle", operator: "isEmpty", value: null, action: "disable" }
+  ]);
+```
+
+**Condition — show field only when status equals "published":**
+
+```typescript
+publishDate: fields
+  .datetime()
+  .renderer("dateTimeInput")
+  .label("Publish Date")
+  .rules([
+    { type: "condition", target: "status", operator: "!=", value: "published", action: "hide" }
+  ]);
+```
+
+**Multiple rules on a single field:**
+
+```typescript
+internalNotes: fields
+  .longText()
+  .renderer("textarea")
+  .label("Internal Notes")
+  .rules([
+    {
+      type: "accessControl",
+      target: "identity",
+      operator: "matches",
+      value: "team:editors",
+      action: "hide"
+    },
+    { type: "condition", target: "status", operator: "==", value: "draft", action: "disable" }
+  ]);
+```
+
+**Rules on layout fields (separator, alert, tabs):**
+
+```typescript
+.fields(fields => ({
+  adminAlert: fields
+    .uiAlert()
+    .label("Admin only")
+    .alertType("warning")
+    .rules([
+      { type: "accessControl", target: "identity", operator: "matches", value: "team:admins", action: "hide" }
+    ]),
+}))
+```
+
+**Rules on individual tabs:**
+
+```typescript
+.fields(fields => ({
+  tabs: fields
+    .uiTabs()
+    .tab("general", {
+      label: "General",
+      fields: sub => ({ /* ... */ }),
+      layout: [/* ... */]
+    })
+    .tab("advanced", {
+      label: "Advanced",
+      fields: sub => ({ /* ... */ }),
+      layout: [/* ... */],
+      rules: [
+        { type: "accessControl", target: "identity", operator: "matches", value: "team:developers", action: "hide" }
+      ]
+    })
+    .rules([/* rules on the entire tabs container */])
+}))
+```
+
+**Static `$.` paths — referencing siblings inside a nested scope:**
+
+Use `$.` to target a sibling field within the same parent object or dynamicZone
+template. The `$` resolves to the parent path at runtime, so the rule stays portable
+regardless of the outer structure.
+
+```typescript
+.fields(fields => ({
+  bannerTypes: fields
+    .dynamicZone()
+    .label("Banner Type")
+    .template("siteBanner", {
+      name: "Site Banner",
+      gqlTypeName: "SiteBannerBlock",
+      fields: t => ({
+        enabled: t.boolean().renderer("switch").label("Enabled"),
+        text: t.richText().renderer("lexicalEditor").label("Text"),
+        global: t
+          .boolean()
+          .renderer("switch")
+          .label("Global"),
+        locationTab: t
+          .uiTabs()
+          .tab("Location", {
+            label: "Location",
+            fields: tabFields => ({
+              location: tabFields.text().label("Location")
+            }),
+            layout: [["location"]]
+          })
+          .rules([
+            {
+              type: "condition",
+              target: "$.global",      // resolves to sibling "global" in this template
+              operator: "==",
+              value: true,
+              action: "hide"
+            }
+          ])
+      }),
+      layout: [["enabled"], ["text"], ["global"], ["locationTab"]]
+    })
+}))
+```
+
+In this example, `"$.global"` resolves to the `global` field within the same
+dynamicZone template instance. Without the `$.` prefix, you would need to hard-code the
+full path (e.g. `"bannerTypes.0.global"`), which breaks across list indices. The same
+pattern works inside `object` fields and `uiTabs` scopes.
 
 ## Querying `ref`, `object`, and `dynamicZone` fields
 

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Admin, Api, Cli, Infra, Project } from "webiny/extensions";
 import { Cognito } from "@webiny/cognito";
 import { MyFeature } from "@/extensions/myFeature/Extension.js";
+// import { CognitoFederation } from "@/extensions/idp/entraid/Extension.js";
 // import { MyIdpExtension } from "./extensions/idp/okta/MyIdpExtension.js";
 
 export const Extensions = () => {
@@ -121,6 +122,7 @@ export const Extensions = () => {
             )}
             {/* API */}
             {/*<MyIdpExtension />*/}
+            {/*<CognitoFederation />*/}
             <Cognito />
             {/* Security 👇 */}
             <Api.Extension src={"/extensions/MyApiKey.ts"} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -12446,6 +12446,7 @@ __metadata:
     "@webiny/project": "npm:0.0.0"
     "@webiny/project-aws": "npm:0.0.0"
     "@webiny/project-utils": "npm:0.0.0"
+    "@webiny/react-properties": "npm:0.0.0"
     "@webiny/validation": "npm:0.0.0"
     "@webiny/wcp": "npm:0.0.0"
     aws-amplify: "npm:^6.18.0"


### PR DESCRIPTION
## Summary

- Merges 26 commits from `release/6.4.4` into `release/6.5.0`
- Key features: Cognito Federation & MFA (#5376), stack output cache (#5375), custom domains (#5298), AsyncProperties
- Key fixes: non-root tenant scheduling (#5287), prototype pollution (#5373), production environment detection (#5371)

## Conflict Resolutions

- **7 modify/delete files**: deleted (fixes already exist in 6.5.0 replacement files)
- **Content conflicts**: took 6.5.0 side (superset of 6.4.4 changes in all cases)
- **FormModel.test.ts**: took 6.5.0 + appended `$. static references in rules` test cases from 6.4.4
- **cognito/package.json**: kept both `./*` wildcard and explicit `./api`, `./admin` sub-path exports
- **File manager tests**: removed duplicate `loading`/`empty` properties added independently by both branches

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `packages/app-admin` tests pass (434 tests, including new `$.` rule target tests)
- [x] `packages/react-properties` tests pass (44 tests, including new `Await` tests)
- [x] `packages/app-file-manager` tests pass (118 tests)
- [x] `packages/api-headless-cms` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)