### PR TITLE
chore(testing): drop dead context.db bag from dbPlugins

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
+++ b/packages/api-headless-cms-ddb-es/__tests__/__api__/setupFile.js
@@ -1,6 +1,6 @@
 import { EntryBeforeCreateEventHandler } from "@webiny/api-headless-cms/features/contentEntry/CreateEntry/index.js";
 import { dbPlugins } from "@webiny/db-dynamodb/testing.js";
-import { DynamoDbDriver, registerDynamoDBCore } from "@webiny/db-dynamodb";
+import { registerDynamoDBCore } from "@webiny/db-dynamodb";
 import { getDocumentClient, simulateStream } from "@webiny/project-utils/testing/dynamodb/index.js";
 import { registerCmsOpenSearchStorageOperations } from "../../src/index";
 import { CmsEntryOpenSearchBodyModifier } from "../../src/features/CmsEntryOpenSearchBodyModifier/index.js";
@@ -70,12 +70,7 @@ setStorageOps("cms", () => {
     createOrRefreshIndexSubscription.name =
         "headlessCmsDdbEs.context.createOrRefreshIndexSubscription";
 
-    const initializedDbPlugins = dbPlugins({
-        table: process.env.DB_TABLE,
-        driver: new DynamoDbDriver({
-            documentClient
-        })
-    });
+    const initializedDbPlugins = dbPlugins();
 
     createOrRefreshIndexSubscription.name =
         "headlessCmsDdbEs.context.createOrRefreshIndexSubscription";

--- a/packages/api-headless-cms-ddb/__tests__/__api__/setupFile.js
+++ b/packages/api-headless-cms-ddb/__tests__/__api__/setupFile.js
@@ -1,5 +1,5 @@
 import { dbPlugins } from "@webiny/db-dynamodb/testing.js";
-import { DynamoDbDriver, registerDynamoDBCore } from "@webiny/db-dynamodb";
+import { registerDynamoDBCore } from "@webiny/db-dynamodb";
 import { createCmsEntryFieldSortingPlugin, registerDynamoDbStorageOperations } from "../../src";
 import { setStorageOps } from "@webiny/project-utils/testing/environment/index.js";
 import { getDocumentClient } from "@webiny/project-utils/testing/dynamodb/index.js";
@@ -15,12 +15,7 @@ setStorageOps("cms", () => {
         /**
          * TODO remove when all apps are created with their own storage operations factory and drivers.
          */
-        dbPlugins({
-            table: process.env.DB_TABLE,
-            driver: new DynamoDbDriver({
-                documentClient
-            })
-        }),
+        dbPlugins(),
         createCmsEntryFieldSortingPlugin({
             canUse: params => {
                 const { fieldId } = params;

--- a/packages/db-dynamodb/src/testing.ts
+++ b/packages/db-dynamodb/src/testing.ts
@@ -1,29 +1,16 @@
-import type { ConstructorArgs } from "@webiny/db";
-import { Db } from "@webiny/db";
 import { createRegisterExtensionPlugin } from "@webiny/handler";
 import { DbRegistryFeature } from "@webiny/db/exports/api/db.js";
-import type { Context } from "@webiny/api/types.js";
-
-interface DbContext extends Context {
-    db: Db<unknown>;
-}
 
 /**
- * @deprecated Test-only storage-preset glue: registers `DbRegistry` and sets the legacy `context.db`
- * bag. Production wires the DB via storage-operations factories/drivers and never reads `context.db`.
- * Used only by the DDB/DDB-ES `setupFile.js` test presets — remove once those move to their own
- * storage-operations factories/drivers. The `DbRegistry` registration must be preserved (the DDB-ES
- * CMS storage resolves it in `beforeInit`).
+ * @deprecated Test-only storage-preset glue: registers `DbRegistry`, which the DDB-ES CMS storage
+ * resolves in `beforeInit` to stage the entities it syncs to OpenSearch. (It used to also set a
+ * legacy `context.db` bag, but nothing reads `context.db` anymore, so that's gone.) Used only by the
+ * DDB / DDB-ES `setupFile.js` test presets — remove once those register `DbRegistryFeature`
+ * themselves, the way production does via `registerRequestStorage`.
  */
-export const dbPlugins = <T = unknown>(args: ConstructorArgs<T>) => {
-    const plugin = createRegisterExtensionPlugin<DbContext>(async context => {
-        if (context.db) {
-            return;
-        }
-
+export const dbPlugins = () => {
+    const plugin = createRegisterExtensionPlugin(async context => {
         DbRegistryFeature.register(context.container);
-
-        context.db = new Db<T>(args);
     });
     plugin.name = "db-dynamodb/extension/db";
     return [plugin];


### PR DESCRIPTION
### What changed

Test-only cleanup. The `dbPlugins` test helper used to set a legacy `context.db` bag, but nothing in the codebase reads `context.db` anymore — the DI migration moved every reader onto storage-operations and DI abstractions. So that bag (and the throwaway DynamoDB driver constructed to fill it) was pure dead weight.

`dbPlugins` is slimmed down to the one thing still live: registering `DbRegistryFeature` (the DDB+OpenSearch CMS storage resolves it in `beforeInit` to stage the entities it syncs). It now takes no arguments, and the DDB / DDB-ES test setups call `dbPlugins()` without building a driver.

This removes the last `Db` instantiation in the repo. No production code changes.

> Scope note: this is the safe half of retiring the legacy DB glue. Fully removing `DbRegistryFeature` (the deeper TODO) is a separate storage-ops refactor — it's still real production wiring for the DDB+ES flavour — and is intentionally left out.

### Changelog

**Internal test cleanup**

Removed an unused legacy database context object from the test harness. No functional change.

### Squash Merge Commit

```
chore(testing): drop dead context.db bag from dbPlugins (#5405)
```
