### PR TITLE
fix(build): invalidate freshness marker when watch writes dist

### DIFF
--- a/packages/build-tools/packages/watchPackage.js
+++ b/packages/build-tools/packages/watchPackage.js
@@ -1,5 +1,15 @@
+import fs from "node:fs";
+import { join } from "node:path";
+
 export default async options => {
     const { cwd } = options;
+
+    // Invalidate the build-cache freshness marker (see scripts/buildPackages
+    // distBuildHash.ts, ".webiny-build-hash"). Watch writes into dist without
+    // updating that marker, so its contents no longer match the last full
+    // build — a later `yarn build` must restore/rebuild instead of trusting the
+    // marker and skipping the cache→dist copy.
+    fs.rmSync(join(cwd, "dist", ".webiny-build-hash"), { force: true });
 
     // Must be a dynamic import — see rslibCompile.js for the reason.
     const [{ createRslib }, { pluginSvgr }] = await Promise.all([


### PR DESCRIPTION
Follow-up bugfix for #5409 (skip redundant cache→dist copy when dist is fresh).

## Bug

#5409 stamps each package's `dist` with `.webiny-build-hash` and, on a cache hit, skips the cache→dist copy when the marker matches the current source hash. But `webiny watch` also writes into `dist` (rslib, `cleanDistPath: false`) **without touching the marker**.

So after a watch session, the marker still claims `dist` matches the last full build, while `dist` actually holds watch's output. A subsequent `yarn build` trusts the marker, skips the restore, and leaves the non-canonical dist in place — `yarn build` appears to "do nothing."

## Fix

Delete `dist/.webiny-build-hash` when `watch` starts. Once watch has written into dist, the marker is gone, so a later `yarn build` treats dist as dirty and restores from cache (or rebuilds) before rewriting the marker.

## Verified

Reproduced the stale-dist case (dirty dist + marker kept → `yarn build` skips → stale) and confirmed removing the marker (what watch now does) makes `yarn build` restore the canonical dist.

## Known limitation

Covers the common flow (watch, then build). Running a full `yarn build` *concurrently* with a live watch could re-establish the marker mid-session; that's a narrower race (an actual source edit makes the package a cache-miss and rebuild anyway). Can harden with a per-rebuild hook if it proves to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)