### PR TITLE
fix(background-tasks-server): make background tasks run on the server flavour

### DIFF
--- a/packages/background-tasks-server/src/service/WorkerTaskService.ts
+++ b/packages/background-tasks-server/src/service/WorkerTaskService.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import type { WorkerToParentMessage } from "~/worker/TaskOrchestratorMessage.js";
 import { TaskService } from "@webiny/background-tasks/api/domain/TaskService.js";
@@ -38,7 +40,18 @@ class WorkerServiceImpl implements TaskService.Interface {
             return null;
         }
 
-        const workerPath = new URL("../worker/workerEntry.js", import.meta.url);
+        // Resolve the worker entry from this module's own dist directory via `path.join`.
+        // We deliberately AVOID `new URL("../worker/workerEntry.js", import.meta.url)`: the app
+        // bundler rewrites that expression to a publicPath-based asset URL
+        // ("/static/assets/workerEntry.<hash>.js") that `new Worker()` can't load as a filesystem
+        // path. `path.join` off `import.meta.url` (which resolves to this file inside dist) is left
+        // untouched by the bundler and points at the real, node-resolvable dist worker.
+        const workerPath = path.join(
+            path.dirname(fileURLToPath(import.meta.url)),
+            "..",
+            "worker",
+            "workerEntry.js"
+        );
         const worker = new Worker(workerPath);
 
         const handle: WorkerHandle = {
@@ -56,6 +69,8 @@ class WorkerServiceImpl implements TaskService.Interface {
                 handle.status = "done";
             } else if (msg.type === "error") {
                 handle.status = "error";
+                // Surface the worker's error — otherwise a failed task shows only as a stuck record.
+                console.error(`Background task "${task.id}" (${task.definitionId}) failed:`, msg.error);
             }
         });
 
@@ -81,7 +96,13 @@ class WorkerServiceImpl implements TaskService.Interface {
                 webinyTaskId: task.id,
                 webinyTaskDefinitionId: task.definitionId,
                 tenant: tenant.id,
-                delay
+                delay,
+                // Satisfy the shared runner's AWS-Step-Functions-shaped validation. No SFN in a single
+                // process: executionName is a stable run id (the task id); endpoint/stateMachineId are
+                // validate-only off-AWS.
+                endpoint: this.serverUrl,
+                executionName: task.id,
+                stateMachineId: ""
             },
             serverUrl: this.serverUrl,
             maxDurationMs: DEFAULT_MAX_DURATION_MS,

--- a/packages/background-tasks-server/src/worker/TaskOrchestratorMessage.ts
+++ b/packages/background-tasks-server/src/worker/TaskOrchestratorMessage.ts
@@ -3,6 +3,13 @@ export interface TaskEventPayload {
     readonly webinyTaskDefinitionId: string;
     readonly tenant: string;
     readonly delay: number;
+    // Fields the shared TaskRunner/TaskEventValidation expects (AWS Step Functions execution context).
+    // The single-process server has no Step Functions, so: `executionName` is a stable run identifier
+    // (the task id, used by the runner for log entries), while `endpoint`/`stateMachineId` are
+    // validate-only (unused by the runner off-AWS) and carry the callback URL / an empty marker.
+    readonly endpoint: string;
+    readonly executionName: string;
+    readonly stateMachineId: string;
 }
 
 export interface StartMessage {


### PR DESCRIPTION
Every background task on the self-hosted (server) flavour stayed stuck `pending` — the worker never completed. Two root causes, both confirmed via runtime logging:

## 1. Worker asset path
`WorkerService` spawned the worker via `new Worker(new URL("../worker/workerEntry.js", import.meta.url))`. The app bundler rewrites that `new URL(...)` to a publicPath asset (`/static/assets/workerEntry.<hash>.js`), which `new Worker()` then can't load as a filesystem path → `Cannot find module '/static/assets/...'`.

`import.meta.url` resolves to this module inside its own **dist** (the bundler preserves it and doesn't inline the package), and the compiled worker + deps live beside it under `dist/worker/` (relative + node-builtin imports only). So resolve it with `path.join` off `import.meta.url` — an expression the bundler leaves untouched — pointing at the real dist worker.

## 2. Task-event validation (AWS leak in the shared runner)
Past the worker, the shared `TaskRunner`'s `TaskEventValidation` **requires AWS Step Functions fields** — `endpoint`, `executionName`, `stateMachineId`:
```
VALIDATION_FAILED_INVALID_FIELDS — endpoint/executionName/stateMachineId: expected string, received undefined
```
AWS's Lambda passes them from the SFN execution context; the server worker's event didn't. Supply them from the server transport: `executionName` = the task id (a stable run id the runner uses for log entries); `endpoint`/`stateMachineId` are validate-only off-AWS.

Also surfaces the worker's error (previously discarded) so a failed task logs instead of silently staying `pending`.

## Verified
End-to-end on the server flavour: image upload → worker spawns → POSTs `/background-task` → validation passes → task runs to completion, AI SDK invoked. AWS flavour unaffected (uses `StepFunctionService`, not this worker).

> Note: AI *image enrichment* separately fails in local dev because it sends the external AI a localhost image URL (`https://api2.localhost/...`) it can't fetch — a deployment/ai-powerups concern, not a bg-tasks issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)