### PR TITLE
refactor(api-mailer): remove ContextPlugin from tests

### DIFF
--- a/packages/api-mailer/__tests__/contextHandler.ts
+++ b/packages/api-mailer/__tests__/contextHandler.ts
@@ -62,10 +62,13 @@ export const createContextHandler = (params?: CreateHandlerParams) => {
 
             const ctx: Record<string, any> = { container: child };
 
-            // Apply additional plugins (e.g. registerCodeSmtpSettings)
+            // Apply additional plugins (e.g. registerCodeSmtpSettings). DI-native plugins are plain
+            // `container => {}` functions; legacy ContextPlugins expose `apply(ctx)`.
             const additionalPlugins = [params?.plugins ?? []].flat(Infinity as 1).filter(Boolean);
             for (const plugin of additionalPlugins as any[]) {
-                if (typeof plugin.apply === "function") {
+                if (typeof plugin === "function" && !plugin.prototype) {
+                    plugin(child);
+                } else if (typeof plugin.apply === "function") {
                     await plugin.apply(ctx);
                 }
             }

--- a/packages/api-mailer/__tests__/graphQLHandler.ts
+++ b/packages/api-mailer/__tests__/graphQLHandler.ts
@@ -62,11 +62,16 @@ export const createGraphQLHandler = (params?: CreateHandlerParams) => {
             GraphQLEngineFeature.register(container);
             MailerFeature.register(container);
 
-            // Apply additional plugins (e.g. registerCodeSmtpSettings)
+            // Apply additional plugins (e.g. registerCodeSmtpSettings). DI-native plugins are plain
+            // `container => {}` functions; legacy ContextPlugins expose a custom `apply(ctx)`. Check
+            // for a function FIRST — a plain function also has `Function.prototype.apply`, which would
+            // otherwise be invoked with no args (container undefined).
             const additionalPlugins = [params?.plugins ?? []].flat(Infinity as 1).filter(Boolean);
             const ctx: Record<string, any> = { container };
             for (const plugin of additionalPlugins as any[]) {
-                if (typeof plugin.apply === "function") {
+                if (typeof plugin === "function" && !plugin.prototype) {
+                    plugin(container);
+                } else if (typeof plugin.apply === "function") {
                     await plugin.apply(ctx);
                 }
             }

--- a/packages/api-mailer/__tests__/helpers/registerCodeSmtpSettings.ts
+++ b/packages/api-mailer/__tests__/helpers/registerCodeSmtpSettings.ts
@@ -1,4 +1,4 @@
-import { createContextPlugin } from "@webiny/api";
+import type { Container } from "@webiny/di";
 import { BuildParam } from "@webiny/api-core/features/buildParams/index.js";
 import type { TransportSettings } from "~/types.js";
 
@@ -13,7 +13,7 @@ export const registerCodeSmtpSettings = (settings: TransportSettings) => {
         dependencies: []
     });
 
-    return createContextPlugin(context => {
-        context.container.register(implementation);
-    });
+    return (container: Container) => {
+        container.register(implementation);
+    };
 };

--- a/packages/api-mailer/__tests__/saveSettingsEvents.test.ts
+++ b/packages/api-mailer/__tests__/saveSettingsEvents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createContextPlugin } from "@webiny/api";
+import type { Container } from "@webiny/di";
 import { createContextHandler } from "./contextHandler";
 import {
     SaveSettingsUseCase,
@@ -41,10 +41,10 @@ const AfterCaptureImpl = MailerSettingsAfterSaveEventHandler.createImplementatio
     dependencies: []
 });
 
-const registerCapturePlugin = createContextPlugin(ctx => {
-    ctx.container.register(BeforeCaptureImpl);
-    ctx.container.register(AfterCaptureImpl);
-});
+const registerCapturePlugin = (container: Container) => {
+    container.register(BeforeCaptureImpl);
+    container.register(AfterCaptureImpl);
+};
 
 const input = {
     host: "dummy.webiny",

--- a/packages/api-mailer/package.json
+++ b/packages/api-mailer/package.json
@@ -18,7 +18,6 @@
   "description": "The API to send e-mails.",
   "license": "MIT",
   "dependencies": {
-    "@webiny/api": "0.0.0",
     "@webiny/feature": "0.0.0",
     "@webiny/handler-graphql": "0.0.0",
     "@webiny/plugins": "0.0.0",

--- a/packages/api-mailer/tsconfig.build.json
+++ b/packages/api-mailer/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
   "references": [
-    { "path": "../api/tsconfig.build.json" },
     { "path": "../feature/tsconfig.build.json" },
     { "path": "../handler-graphql/tsconfig.build.json" },
     { "path": "../plugins/tsconfig.build.json" },
@@ -18,8 +17,6 @@
     "paths": {
       "~/*": ["./src/*"],
       "~tests/*": ["./__tests__/*"],
-      "@webiny/api/*": ["../api/src/*"],
-      "@webiny/api": ["../api/src"],
       "@webiny/feature/*": ["../feature/src/*"],
       "@webiny/feature": ["../feature/src"],
       "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],

--- a/packages/api-mailer/tsconfig.json
+++ b/packages/api-mailer/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src", "__tests__"],
   "references": [
-    { "path": "../api" },
     { "path": "../feature" },
     { "path": "../handler-graphql" },
     { "path": "../plugins" },
@@ -18,8 +17,6 @@
     "paths": {
       "~/*": ["./src/*"],
       "~tests/*": ["./__tests__/*"],
-      "@webiny/api/*": ["../api/src/*"],
-      "@webiny/api": ["../api/src"],
       "@webiny/feature/*": ["../feature/src/*"],
       "@webiny/feature": ["../feature/src"],
       "@webiny/handler-graphql/*": ["../handler-graphql/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11309,7 +11309,6 @@ __metadata:
   resolution: "@webiny/api-mailer@workspace:packages/api-mailer"
   dependencies:
     "@types/nodemailer": "npm:^8.0.1"
-    "@webiny/api": "npm:0.0.0"
     "@webiny/api-core": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
     "@webiny/di": "npm:^1.0.2"


### PR DESCRIPTION
### What changed

**#40** (grep `ContextPlugin` → zero): **api-mailer tests are now ContextPlugin-free.**

Re-targeted to `next` (the original #5417 was accidentally merged into a stacked branch). Self-contained — api-mailer already uses `@webiny/api-core-testing` (in `next` via #5400), so this cherry-picks cleanly onto `next`.

- Both ContextPlugins were pure `context.container.register(...)` → plain `container => {}` function plugins (`registerCodeSmtpSettings` + the capture plugin in `saveSettingsEvents`).
- Both test handlers (`contextHandler` + `graphQLHandler`) now dispatch function plugins directly.
- Dropped the now-unused `@webiny/api` dependency.

Fixes a latent trap: the old dispatch matched `typeof plugin.apply === "function"`, which is **also true for a plain function** (`Function.prototype.apply`) → it would call `fn.apply(ctx)` with no args (container undefined). Now checks for a function first.

### Verification

`yarn test packages/api-mailer` → **41 passed** (ddb + sql). adio clean, references.json in sync.

### Squash Merge Commit

```
refactor(api-mailer): remove ContextPlugin from tests (#5423)
```
