### PR TITLE
chore(api-scheduler): genericize EventBridge references to scheduler-neutral wording

### DIFF
--- a/packages/api-scheduler/src/domain/errors.ts
+++ b/packages/api-scheduler/src/domain/errors.ts
@@ -58,7 +58,7 @@ export class InvalidScheduleDateError extends BaseError<{ scheduleFor: string }>
 }
 
 /**
- * Scheduler service error (EventBridge/cloud provider errors)
+ * Scheduler service error (scheduler backend / provider errors)
  */
 export class SchedulerServiceError extends BaseError<{ originalError: Error }> {
     override readonly code = "Scheduler/Service/Error" as const;

--- a/packages/api-scheduler/src/features/CancelScheduledAction/CancelScheduledActionUseCase.ts
+++ b/packages/api-scheduler/src/features/CancelScheduledAction/CancelScheduledActionUseCase.ts
@@ -17,9 +17,9 @@ import { SchedulerPermissions } from "~/features/permissions/abstractions.js";
  *
  * Flow:
  * 1. Check if schedule exists
- * 2. Delete EventBridge schedule
+ * 2. Delete scheduler timer
  * 3. Delete CMS entry
- * 4. If EventBridge delete fails, continue anyway (schedule might already be executed/deleted)
+ * 4. If the scheduler delete fails, continue anyway (schedule might already be executed/deleted)
  */
 class CancelScheduledActionUseCaseImpl implements UseCaseAbstraction.Interface {
     constructor(
@@ -53,19 +53,19 @@ class CancelScheduledActionUseCaseImpl implements UseCaseAbstraction.Interface {
 
         const scheduleId = ScheduledActionIdWithVersion.from(id);
 
-        // Delete EventBridge schedule
+        // Delete the scheduler timer
         // Note: We continue even if this fails, as the schedule might already be executed/deleted
         try {
-            const eventBridgeSchedule = await this.schedulerService.exists(params);
+            const scheduleExists = await this.schedulerService.exists(params);
             /**
              * No point to even try deleting if it doesn't exist.
              */
-            if (eventBridgeSchedule) {
+            if (scheduleExists) {
                 await this.schedulerService.delete(params);
             }
         } catch (error) {
             console.warn(
-                `Failed to delete EventBridge schedule: ${scheduleId}, tenant "${params.tenant}". Continuing with CMS entry deletion.`,
+                `Failed to delete the schedule: ${scheduleId}, tenant "${params.tenant}". Continuing with CMS entry deletion.`,
                 error
             );
         }

--- a/packages/api-scheduler/src/features/CancelScheduledAction/abstractions.ts
+++ b/packages/api-scheduler/src/features/CancelScheduledAction/abstractions.ts
@@ -9,7 +9,7 @@ import {
 /**
  * CancelScheduledActionUseCase - Cancel a scheduled action
  *
- * Cancels both the CMS entry and the EventBridge schedule.
+ * Cancels both the CMS entry and the scheduler timer.
  * Used when a user manually cancels a scheduled action or when business logic
  * determines the action should no longer execute.
  */

--- a/packages/api-scheduler/src/features/CancelScheduledAction/feature.ts
+++ b/packages/api-scheduler/src/features/CancelScheduledAction/feature.ts
@@ -5,7 +5,7 @@ import { CancelScheduledActionUseCase } from "./CancelScheduledActionUseCase.js"
  * CancelScheduledAction Feature
  *
  * Provides the ability to cancel a scheduled action.
- * Removes both the EventBridge schedule and the CMS entry.
+ * Removes both the scheduler timer and the CMS entry.
  */
 export const CancelScheduledActionFeature = createFeature({
     name: "CancelScheduledAction",

--- a/packages/api-scheduler/src/features/ExecuteScheduledAction/abstractions.ts
+++ b/packages/api-scheduler/src/features/ExecuteScheduledAction/abstractions.ts
@@ -9,7 +9,7 @@ import {
 /**
  * ExecuteScheduledActionUseCase - Execute a scheduled action
  *
- * This is triggered by EventBridge when a schedule fires.
+ * This is triggered by the scheduler when a schedule fires.
  * Finds the appropriate handler based on namespace + actionType and executes it.
  *
  * Flow:

--- a/packages/api-scheduler/src/features/ExecuteScheduledAction/feature.ts
+++ b/packages/api-scheduler/src/features/ExecuteScheduledAction/feature.ts
@@ -5,7 +5,7 @@ import { ScheduledActionHandlerComposite } from "~/features/ExecuteScheduledActi
 /**
  * ExecuteScheduledAction Feature
  *
- * Provides the ability to execute a scheduled action when triggered by EventBridge.
+ * Provides the ability to execute a scheduled action when the scheduler fires.
  * Finds the appropriate handler and executes it, then cleans up the schedule entry.
  */
 export const ExecuteScheduledActionFeature = createFeature({

--- a/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
+++ b/packages/api-scheduler/src/features/ScheduleAction/ScheduleActionUseCase.ts
@@ -40,9 +40,9 @@ interface ICreateScheduleParams<T extends GenericRecord> {
  * Flow:
  * 1. Generate unique schedule ID from namespace+actionType+targetId
  * 2. Check if schedule already exists (for rescheduling logic)
- * 3. If exists: UPDATE schedule entry + EventBridge schedule
- * 4. If new: CREATE schedule entry + EventBridge schedule
- * 5. Rollback schedule entry if EventBridge fails
+ * 3. If exists: UPDATE schedule entry + scheduler timer
+ * 4. If new: CREATE schedule entry + scheduler timer
+ * 5. Rollback schedule entry if the scheduler fails
  */
 class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
     constructor(
@@ -70,7 +70,8 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
         } else if (params.immediately) {
             // If the action should be executed immediately, we set the scheduleFor to the current date.
             // Calculate the soonest possible execution time.
-            // Add at least 90 seconds of buffer to ensure EventBridge can process the schedule.
+            // Add at least 90 seconds of buffer to give the scheduler backend time to process the
+            // schedule (e.g. AWS EventBridge has a minimum lead time).
             scheduleFor = new Date(Date.now() + 90000);
         }
 
@@ -190,7 +191,7 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
             error: undefined
         };
 
-        // Create EventBridge schedule
+        // Create the scheduler timer
         try {
             await this.schedulerService.create({
                 id: scheduleId,
@@ -199,8 +200,8 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
                 scheduleFor: new Date(scheduleFor)
             });
         } catch (error) {
-            // Rollback - delete CMS entry if EventBridge fails
-            console.error(`Failed to create EventBridge schedule: ${scheduleId}. Rolling back...`);
+            // Rollback - delete CMS entry if the scheduler fails
+            console.error(`Failed to create the schedule: ${scheduleId}. Rolling back...`);
 
             await this.deleteEntryUseCase.execute(this.model, scheduleId, {
                 force: true,
@@ -251,7 +252,7 @@ class ScheduleActionUseCaseImpl implements UseCaseAbstraction.Interface {
             );
         }
 
-        // Update EventBridge schedule
+        // Update the scheduler timer
         try {
             await this.schedulerService.update({
                 id: existing.id,


### PR DESCRIPTION
### What changed

`api-scheduler` is flavour-agnostic — the `SchedulerService` abstraction backs AWS EventBridge, the self-hosted Bree scheduler, and any other backend. But its comments, one log string, and a local variable still referred to "EventBridge" specifically. This reworks them to neutral wording ("scheduler timer" / "the scheduler") so the base package reads correctly no matter which backend is wired in.

No behaviour change — comments, one `console` message, and one local variable rename (`eventBridgeSchedule` → `scheduleExists`).

AWS EventBridge is kept where it's a genuine illustrative example: the backend list in `shared/abstractions.ts` and the 90-second minimum-lead-time note in `ScheduleActionUseCase.ts`.

### Changelog

**Clearer scheduler code comments**

Internal cleanup — no functional change.

### Squash Merge Commit

```
chore(api-scheduler): genericize EventBridge references (#5426)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
