### PR TITLE
refactor(build): remove --rebuild-dependents (redundant after dep-aware key)

### DIFF
--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -112,7 +112,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - uses: actions/cache@v5
         with:
@@ -149,7 +149,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Build core
         run: yarn webiny build core
@@ -233,7 +233,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Sync Dependencies Verification
         run: yarn verify-dependencies
@@ -335,7 +335,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -418,7 +418,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -511,7 +511,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -596,7 +596,7 @@ jobs:
         run: yarn --immutable
         working-directory: ${{ github.base_ref }}
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: ${{ github.base_ref }}
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - uses: actions/cache@v5
         with:
@@ -133,7 +133,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Sync Dependencies Verification
         run: yarn verify-dependencies
@@ -226,7 +226,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -300,7 +300,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -382,7 +382,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -458,7 +458,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Run tests
         run: ${{ matrix.testCommand.cmd }}
@@ -534,7 +534,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Start Verdaccio local server
         working-directory: v6
@@ -695,7 +695,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Start Verdaccio local server
         working-directory: v6

--- a/.github/workflows/wac/pullRequests.wac.ts
+++ b/.github/workflows/wac/pullRequests.wac.ts
@@ -25,8 +25,7 @@ import {
 const DIR_WEBINY_JS = "${{ github.base_ref }}";
 
 const installBuildSteps = createInstallBuildSteps({
-    workingDirectory: DIR_WEBINY_JS,
-    rebuildDependents: true
+    workingDirectory: DIR_WEBINY_JS
 });
 const yarnCacheSteps = createYarnCacheSteps({ workingDirectory: DIR_WEBINY_JS });
 const globalBuildCacheSteps = createGlobalBuildCacheSteps({ workingDirectory: DIR_WEBINY_JS });

--- a/.github/workflows/wac/push.wac.ts
+++ b/.github/workflows/wac/push.wac.ts
@@ -21,8 +21,7 @@ const DIR_WEBINY_JS = "v6";
 const DIR_TEST_PROJECT = "new-webiny-project";
 
 const installBuildSteps = createInstallBuildSteps({
-    workingDirectory: DIR_WEBINY_JS,
-    rebuildDependents: true
+    workingDirectory: DIR_WEBINY_JS
 });
 const yarnCacheSteps = createYarnCacheSteps({
     workingDirectory: DIR_WEBINY_JS

--- a/.github/workflows/wac/steps/createInstallBuildSteps.ts
+++ b/.github/workflows/wac/steps/createInstallBuildSteps.ts
@@ -2,17 +2,15 @@ import { withCommonParams } from "./withCommonParams.js";
 
 interface CreateInstallBuildStepsParams {
     workingDirectory: string;
-    rebuildDependents?: boolean;
 }
 
 export const createInstallBuildSteps = (params: CreateInstallBuildStepsParams) => {
-    const rebuildDependents = params.rebuildDependents ?? false;
-    const buildCommand = rebuildDependents ? "yarn build --rebuild-dependents" : "yarn build";
-
     return withCommonParams(
         [
             { name: "Install dependencies", run: "yarn --immutable" },
-            { name: "Build packages", run: buildCommand }
+            // The build's dependency-aware cache key rebuilds dependents of any
+            // changed package on its own — no `--rebuild-dependents` needed.
+            { name: "Build packages", run: "yarn build" }
         ],
         { "working-directory": params.workingDirectory }
     );

--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -33,7 +33,6 @@ interface BuildOptions {
     p?: string | string[];
     debug?: boolean;
     cache?: boolean;
-    rebuildDependents?: boolean;
     buildOverrides?: string;
     safeReplace?: boolean;
 }
@@ -64,8 +63,7 @@ export const buildPackages = async () => {
 
     const { batches, packagesNoCache, allPackages, effectiveKeys } = await getBatches({
         cache: options.cache ?? true,
-        packagesWhitelist,
-        rebuildDependents: options.rebuildDependents
+        packagesWhitelist
     });
 
     if (!packagesNoCache.length) {

--- a/scripts/buildPackages/src/getBatches.ts
+++ b/scripts/buildPackages/src/getBatches.ts
@@ -16,7 +16,6 @@ const { green } = chalk;
 interface GetBatchesOptions {
     cache?: boolean;
     packagesWhitelist?: string[];
-    rebuildDependents?: boolean;
 }
 
 export async function getBatches(options: GetBatchesOptions = {}) {
@@ -74,36 +73,9 @@ export async function getBatches(options: GetBatchesOptions = {}) {
         }
     }
 
-    // 1.5 When using cache and --rebuild-dependents, also rebuild any package that depends on a changed package.
-    if (options.rebuildDependents && packagesNoCache.length > 0 && useCache) {
-        const dependents = workspaceGraph.getDependents();
-
-        const tainted = new Set(packagesNoCache.map(p => p.packageJson.name));
-        const queue = [...tainted];
-        while (queue.length > 0) {
-            const name = queue.pop()!;
-            for (const dependent of dependents.get(name) || []) {
-                if (!tainted.has(dependent)) {
-                    tainted.add(dependent);
-                    queue.push(dependent);
-                }
-            }
-        }
-
-        for (const name of tainted) {
-            if (packagesNoCache.some(p => p.packageJson.name === name)) continue;
-            const pkg = workspacesPackages.find(p => p.packageJson.name === name);
-            if (pkg) {
-                packagesNoCache.push(pkg);
-            }
-        }
-
-        for (let i = packagesUseCache.length - 1; i >= 0; i--) {
-            if (tainted.has(packagesUseCache[i].packageJson.name)) {
-                packagesUseCache.splice(i, 1);
-            }
-        }
-    }
+    // Dependents of a changed package no longer need explicit tainting: the
+    // effective key folds in dependency keys, so any dependent of a changed
+    // package is already a cache miss above.
 
     // 2. Let's use cached built code where possible.
     if (packagesUseCache.length) {


### PR DESCRIPTION
**Stacked on #5425 — merge that first.** Base is the dep-aware-key branch so this diff shows only the removal; retarget to `next` once #5425 lands.

## Why

The dependency-aware effective key (#5425) marks every dependent of a changed package as a cache miss, so dependents rebuild on a plain `yarn build`. `--rebuild-dependents` was a manual, order-dependent approximation of the same propagation — it anchored off *transient* cache misses and silently did nothing if not run on the first build after a change. Now redundant.

## Changes

- `getBatches.ts`: delete step 1.5 (the dependents taint loop) + the `rebuildDependents` option
- `buildPackages.ts`: drop the `rebuildDependents` option + pass-through
- CI: remove `--rebuild-dependents` → plain `yarn build`, edited the **WAC sources** (`createInstallBuildSteps.ts`, `push.wac.ts`, `pullRequests.wac.ts`) and regenerated `push.yml` / `pullRequests.yml`

## Verified

- `yarn build` runs unchanged (flag no longer referenced)
- generated yml contains no `--rebuild-dependents`; diffs are purely the flag removal
- format + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)