### PR TITLE
feat: edit referenced CMS entry in a drawer

### DIFF
--- a/packages/app-headless-cms/src/features/contentEntry/refTypes.ts
+++ b/packages/app-headless-cms/src/features/contentEntry/refTypes.ts
@@ -19,6 +19,12 @@ export interface CmsReferenceValue {
     modelId: string;
 }
 
+/**
+ * A partial update to an already-resolved reference entry, keyed by `entryId`.
+ * Used to patch the in-memory card after editing a referenced entry, avoiding a refetch.
+ */
+export type CmsReferenceEntryPatch = Partial<CmsReferenceEntry> & { entryId: string };
+
 export const REFERENCE_ENTRY_FIELDS = /* GraphQL */ `
     data {
         id

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/CmsRefDetailedMultipleRenderer.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/CmsRefDetailedMultipleRenderer.tsx
@@ -13,6 +13,7 @@ import { EntryList } from "./components/EntryList.js";
 import { RefFieldOptions } from "./components/RefFieldOptions.js";
 import { ReferencesDialog } from "./components/ReferencesDialog.js";
 import { NewEntryDrawer } from "./components/NewEntryDrawer.js";
+import { EditEntryDrawer } from "./components/EditEntryDrawer.js";
 import { parseIdentifier } from "@webiny/utils";
 
 declare module "@webiny/app-admin/features/formModel/abstractions.js" {
@@ -48,6 +49,7 @@ const RefDetailedMultipleInner = observer(({ field }: InnerFieldProps) => {
 
     const [selectDialogModel, setSelectDialogModel] = useState<CmsModel | null>(null);
     const [newEntryModelId, setNewEntryModelId] = useState<string | null>(null);
+    const [editEntry, setEditEntry] = useState<CmsReferenceEntry | null>(null);
 
     const settings = field.rendererSettings;
     const modelIds = (settings.models || []).map(m => m.modelId);
@@ -174,6 +176,7 @@ const RefDetailedMultipleInner = observer(({ field }: InnerFieldProps) => {
                                 index={index}
                                 entry={entry}
                                 onRemove={onRemove}
+                                onEdit={setEditEntry}
                                 onMoveUp={!isFirst ? onMoveUp : undefined}
                                 onMoveDown={!isLast ? onMoveDown : undefined}
                             />
@@ -213,6 +216,14 @@ const RefDetailedMultipleInner = observer(({ field }: InnerFieldProps) => {
                         );
                         setNewEntryModelId(null);
                     }}
+                />
+            )}
+            {editEntry && (
+                <EditEntryDrawer
+                    modelId={editEntry.model.modelId}
+                    entryId={editEntry.id}
+                    onClose={() => setEditEntry(null)}
+                    onSaved={patch => presenter.patchEntry(patch)}
                 />
             )}
         </div>

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/CmsRefDetailedSingleRenderer.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/CmsRefDetailedSingleRenderer.tsx
@@ -12,6 +12,7 @@ import { EntryCard } from "./components/EntryCard.js";
 import { RefFieldOptions } from "./components/RefFieldOptions.js";
 import { ReferencesDialog } from "./components/ReferencesDialog.js";
 import { NewEntryDrawer } from "./components/NewEntryDrawer.js";
+import { EditEntryDrawer } from "./components/EditEntryDrawer.js";
 
 declare module "@webiny/app-admin/features/formModel/abstractions.js" {
     interface IFieldRendererRegistry {
@@ -46,6 +47,7 @@ const RefDetailedSingleInner = observer(({ field }: InnerFieldProps) => {
 
     const [selectDialogModel, setSelectDialogModel] = useState<CmsModel | null>(null);
     const [newEntryModelId, setNewEntryModelId] = useState<string | null>(null);
+    const [editEntry, setEditEntry] = useState<CmsReferenceEntry | null>(null);
 
     const settings = field.rendererSettings;
     const modelIds = (settings.models || []).map(m => m.modelId);
@@ -123,6 +125,7 @@ const RefDetailedSingleInner = observer(({ field }: InnerFieldProps) => {
                         index={0}
                         entry={entry}
                         onRemove={onRemove}
+                        onEdit={setEditEntry}
                         disabled={disabled}
                     />
                 )}
@@ -157,6 +160,14 @@ const RefDetailedSingleInner = observer(({ field }: InnerFieldProps) => {
                         field.onChange(ref);
                         setNewEntryModelId(null);
                     }}
+                />
+            )}
+            {editEntry && (
+                <EditEntryDrawer
+                    modelId={editEntry.model.modelId}
+                    entryId={editEntry.id}
+                    onClose={() => setEditEntry(null)}
+                    onSaved={patch => presenter.patchEntry(patch)}
                 />
             )}
         </div>

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { DiContainerProvider, useContainer, useFeature } from "@webiny/app";
-import { Drawer, OverlayLoader } from "@webiny/admin-ui";
+import { Drawer, OverlayLoader, useToast } from "@webiny/admin-ui";
 import { DialogsProvider } from "@webiny/app-admin";
 import { FormView } from "@webiny/app-admin/features/formModel/FormView.js";
 import { ContentEntryFeature } from "~/features/contentEntry/feature.js";
@@ -74,6 +74,7 @@ interface EditEntryDrawerContentProps {
 const EditEntryDrawerContent = observer(
     ({ model, entryId, onClose, onSaved }: EditEntryDrawerContentProps) => {
         const { presenter } = useFeature(EditEntryPresenterFeature);
+        const { showSuccessToast } = useToast();
 
         useEffect(() => {
             presenter.init(entryId);
@@ -89,8 +90,9 @@ const EditEntryDrawerContent = observer(
                 // overlay flash behind the still-open drawer. The drawer stays open so the
                 // editor can keep editing.
                 onSaved(toReferenceEntryPatch(savedEntry));
+                showSuccessToast({ title: `"${savedEntry.meta.title}" saved successfully.` });
             }
-        }, [onSaved]);
+        }, [onSaved, showSuccessToast]);
 
         const vm = presenter.form.vm;
 
@@ -103,7 +105,7 @@ const EditEntryDrawerContent = observer(
                 headerSeparator={true}
                 footerSeparator={true}
                 bodyPadding={false}
-                title={`Edit ${model.name} Entry`}
+                title={vm.entry?.meta?.title || `Edit ${model.name} Entry`}
                 actions={
                     <>
                         <Drawer.CancelButton />

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { DiContainerProvider, useContainer, useFeature } from "@webiny/app";
 import { Drawer, OverlayLoader } from "@webiny/admin-ui";
@@ -75,11 +75,6 @@ const EditEntryDrawerContent = observer(
     ({ model, entryId, onClose, onSaved }: EditEntryDrawerContentProps) => {
         const { presenter } = useFeature(EditEntryPresenterFeature);
 
-        // Tracks whether at least one save happened, so we can refresh the parent card
-        // once, on close. Refreshing while the drawer is open would flip the parent
-        // renderer's loading state and flash its overlay *behind* the drawer.
-        const savedRef = useRef(false);
-
         useEffect(() => {
             presenter.init(entryId);
             return () => presenter.dispose();
@@ -87,29 +82,22 @@ const EditEntryDrawerContent = observer(
 
         const onSave = useCallback(async () => {
             const saved = await presenter.form.saveRevision({ skipValidation: false });
-            if (saved) {
-                // Keep the drawer open after saving so the editor can continue editing.
-                savedRef.current = true;
-            }
-        }, []);
-
-        const handleClose = useCallback(() => {
-            // If anything was saved, patch the parent card in memory from the saved entry
-            // (no refetch, no loading overlay). Runs on close since the card is hidden
-            // behind the drawer while it's open.
             const savedEntry = presenter.form.vm.entry;
-            if (savedRef.current && savedEntry) {
+            if (saved && savedEntry) {
+                // Patch the parent card in memory from the saved entry (no refetch). This is a
+                // pure MobX state update — it does not flip any loading flag, so there is no
+                // overlay flash behind the still-open drawer. The drawer stays open so the
+                // editor can keep editing.
                 onSaved(toReferenceEntryPatch(savedEntry));
             }
-            onClose();
-        }, [onSaved, onClose]);
+        }, [onSaved]);
 
         const vm = presenter.form.vm;
 
         return (
             <Drawer
                 open={true}
-                onClose={handleClose}
+                onClose={onClose}
                 width={1000}
                 modal={true}
                 headerSeparator={true}

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EditEntryDrawer.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { observer } from "mobx-react-lite";
+import { DiContainerProvider, useContainer, useFeature } from "@webiny/app";
+import { Drawer, OverlayLoader } from "@webiny/admin-ui";
+import { DialogsProvider } from "@webiny/app-admin";
+import { FormView } from "@webiny/app-admin/features/formModel/FormView.js";
+import { ContentEntryFeature } from "~/features/contentEntry/feature.js";
+import { CmsModelContext } from "~/features/contentEntry/CmsModelContext.js";
+import { ContentEntryFormPresenterFeature } from "~/presentation/contentEntries/form/feature.js";
+import { EditEntryPresenterFeature } from "../editEntry/feature.js";
+import { GenericModelLoader } from "~/presentation/contentEntries/views/GenericModelLoader.js";
+import type { CmsContentEntry, CmsModel } from "~/types.js";
+import type { CmsReferenceEntryPatch } from "~/features/contentEntry/refTypes.js";
+
+interface EditEntryDrawerProps {
+    modelId: string;
+    entryId: string;
+    onClose: () => void;
+    onSaved: (patch: CmsReferenceEntryPatch) => void;
+}
+
+/**
+ * Maps a saved content entry to a partial reference-entry patch, so the parent card can be
+ * updated in memory (title, status, revision, ...) without refetching from the API.
+ */
+const toReferenceEntryPatch = (entry: CmsContentEntry): CmsReferenceEntryPatch => ({
+    entryId: entry.entryId,
+    id: entry.id,
+    status: entry.meta.status,
+    title: entry.meta.title,
+    description: entry.meta.description ?? null,
+    image: entry.meta.image ?? null,
+    savedOn: entry.savedOn,
+    modifiedBy: entry.modifiedBy
+});
+
+export const EditEntryDrawer = ({ modelId, entryId, onClose, onSaved }: EditEntryDrawerProps) => {
+    const parentContainer = useContainer();
+
+    const dialogContainer = useMemo(() => {
+        const child = parentContainer.createChildContainer();
+        ContentEntryFeature.register(child);
+        child.register(CmsModelContext).inSingletonScope();
+        ContentEntryFormPresenterFeature.register(child);
+        EditEntryPresenterFeature.register(child);
+        return child;
+    }, [modelId]);
+
+    return (
+        <DiContainerProvider container={dialogContainer}>
+            <DialogsProvider>
+                <GenericModelLoader modelId={modelId}>
+                    {model => (
+                        <EditEntryDrawerContent
+                            model={model}
+                            entryId={entryId}
+                            onClose={onClose}
+                            onSaved={onSaved}
+                        />
+                    )}
+                </GenericModelLoader>
+            </DialogsProvider>
+        </DiContainerProvider>
+    );
+};
+
+interface EditEntryDrawerContentProps {
+    model: CmsModel;
+    entryId: string;
+    onClose: () => void;
+    onSaved: (patch: CmsReferenceEntryPatch) => void;
+}
+
+const EditEntryDrawerContent = observer(
+    ({ model, entryId, onClose, onSaved }: EditEntryDrawerContentProps) => {
+        const { presenter } = useFeature(EditEntryPresenterFeature);
+
+        // Tracks whether at least one save happened, so we can refresh the parent card
+        // once, on close. Refreshing while the drawer is open would flip the parent
+        // renderer's loading state and flash its overlay *behind* the drawer.
+        const savedRef = useRef(false);
+
+        useEffect(() => {
+            presenter.init(entryId);
+            return () => presenter.dispose();
+        }, [entryId]);
+
+        const onSave = useCallback(async () => {
+            const saved = await presenter.form.saveRevision({ skipValidation: false });
+            if (saved) {
+                // Keep the drawer open after saving so the editor can continue editing.
+                savedRef.current = true;
+            }
+        }, []);
+
+        const handleClose = useCallback(() => {
+            // If anything was saved, patch the parent card in memory from the saved entry
+            // (no refetch, no loading overlay). Runs on close since the card is hidden
+            // behind the drawer while it's open.
+            const savedEntry = presenter.form.vm.entry;
+            if (savedRef.current && savedEntry) {
+                onSaved(toReferenceEntryPatch(savedEntry));
+            }
+            onClose();
+        }, [onSaved, onClose]);
+
+        const vm = presenter.form.vm;
+
+        return (
+            <Drawer
+                open={true}
+                onClose={handleClose}
+                width={1000}
+                modal={true}
+                headerSeparator={true}
+                footerSeparator={true}
+                bodyPadding={false}
+                title={`Edit ${model.name} Entry`}
+                actions={
+                    <>
+                        <Drawer.CancelButton />
+                        <Drawer.ConfirmButton onClick={onSave} text="Save" />
+                    </>
+                }
+            >
+                <div className={"p-md relative h-full min-h-[60vh]"}>
+                    {vm.loading ? <OverlayLoader text={"Loading entry..."} /> : null}
+                    {vm.form ? <FormView name="EditRefEntryForm" form={vm.form} /> : null}
+                </div>
+            </Drawer>
+        );
+    }
+);

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EntryCard.tsx
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/components/EntryCard.tsx
@@ -5,6 +5,7 @@ import { EntryImage } from "./EntryImage.js";
 import { Tag, TimeAgo, Text, DropdownMenu, IconButton, Checkbox, cn } from "@webiny/admin-ui";
 import { ReactComponent as MoreVertIcon } from "@webiny/icons/more_vert.svg";
 import { ReactComponent as OpenInNewIcon } from "@webiny/icons/open_in_new.svg";
+import { ReactComponent as EditIcon } from "@webiny/icons/edit.svg";
 import { ReactComponent as RemoveIcon } from "@webiny/icons/close.svg";
 import { ReactComponent as ArrowUp } from "@webiny/icons/arrow_upward.svg";
 import { ReactComponent as ArrowDown } from "@webiny/icons/arrow_downward.svg";
@@ -22,6 +23,7 @@ interface DialogEntryCardProps {
     onMoveDown?: never;
     index?: never;
     placement?: string;
+    onEdit?: (entry: CmsReferenceEntry) => void;
 }
 
 interface FieldEntryCardProps {
@@ -35,12 +37,22 @@ interface FieldEntryCardProps {
     onChange?: never;
     selected?: never;
     placement?: string;
+    onEdit?: (entry: CmsReferenceEntry) => void;
 }
 
 type EntryCardProps = DialogEntryCardProps | FieldEntryCardProps;
 
 export const EntryCard = (props: EntryCardProps) => {
-    const { entry, onChange, onRemove, selected, index, placement, disabled = false } = props;
+    const {
+        entry,
+        onChange,
+        onRemove,
+        onEdit,
+        selected,
+        index,
+        placement,
+        disabled = false
+    } = props;
     const onMoveUpClick = props.onMoveUp;
     const onMoveDownClick = props.onMoveDown;
     const { getLink } = useRouter();
@@ -157,6 +169,16 @@ export const EntryCard = (props: EntryCardProps) => {
                                     onClick={onMoveDown}
                                 />
                             </div>
+                        ) : null}
+                        {!disabled && onEdit ? (
+                            <IconButton
+                                variant={"ghost"}
+                                size={"sm"}
+                                title={"Edit"}
+                                aria-label={"Edit"}
+                                icon={<EditIcon />}
+                                onClick={() => onEdit(entry)}
+                            />
                         ) : null}
                         {!disabled ? (
                             <DropdownMenu

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/detailed/RefDetailedPresenter.ts
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/detailed/RefDetailedPresenter.ts
@@ -2,7 +2,11 @@ import { computed, makeAutoObservable, runInAction } from "mobx";
 import { GetContentEntriesUseCase } from "~/features/contentEntry/getContentEntries/abstractions.js";
 import { ListModelsUseCase } from "~/features/model/listModels/abstractions.js";
 import type { CmsModel } from "~/types.js";
-import type { CmsReferenceEntry, CmsReferenceValue } from "~/features/contentEntry/refTypes.js";
+import type {
+    CmsReferenceEntry,
+    CmsReferenceEntryPatch,
+    CmsReferenceValue
+} from "~/features/contentEntry/refTypes.js";
 import {
     RefDetailedPresenter as Abstraction,
     type IRefDetailedPresenterInitConfig,
@@ -67,6 +71,12 @@ class RefDetailedPresenterImpl implements Abstraction.Interface {
         const existingIds = new Set(this.entries.map(e => e.entryId));
         const newEntries = entries.filter(e => !existingIds.has(e.entryId));
         this.entries = [...this.entries, ...newEntries];
+    }
+
+    patchEntry(patch: CmsReferenceEntryPatch): void {
+        this.entries = this.entries.map(e =>
+            e.entryId === patch.entryId ? { ...e, ...patch } : e
+        );
     }
 
     removeEntry(entryId: string): void {

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/detailed/abstractions.ts
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/detailed/abstractions.ts
@@ -1,6 +1,10 @@
 import { createAbstraction } from "@webiny/feature/admin";
 import type { CmsModel } from "~/types.js";
-import type { CmsReferenceEntry, CmsReferenceValue } from "~/features/contentEntry/refTypes.js";
+import type {
+    CmsReferenceEntry,
+    CmsReferenceEntryPatch,
+    CmsReferenceValue
+} from "~/features/contentEntry/refTypes.js";
 
 export interface IRefDetailedPresenterInitConfig {
     modelIds: string[];
@@ -19,6 +23,7 @@ export interface IRefDetailedPresenter {
     init(config: IRefDetailedPresenterInitConfig): Promise<void>;
     resolveValues(values: CmsReferenceValue[]): Promise<void>;
     addEntries(entries: CmsReferenceEntry[]): void;
+    patchEntry(patch: CmsReferenceEntryPatch): void;
     removeEntry(entryId: string): void;
     loadMore(): void;
     dispose(): void;

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/EditEntryPresenter.ts
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/EditEntryPresenter.ts
@@ -1,0 +1,23 @@
+import { ContentEntryFormPresenter } from "~/presentation/contentEntries/form/abstractions.js";
+import { EditEntryPresenter as Abstraction } from "./abstractions.js";
+
+class EditEntryPresenterImpl implements Abstraction.Interface {
+    constructor(private formPresenter: ContentEntryFormPresenter.Interface) {}
+
+    get form(): ContentEntryFormPresenter.Interface {
+        return this.formPresenter;
+    }
+
+    init(entryId: string): void {
+        this.formPresenter.loadRevision(entryId);
+    }
+
+    dispose(): void {
+        this.formPresenter.reset();
+    }
+}
+
+export const EditEntryPresenter = Abstraction.createImplementation({
+    implementation: EditEntryPresenterImpl,
+    dependencies: [ContentEntryFormPresenter]
+});

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/abstractions.ts
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/abstractions.ts
@@ -1,0 +1,14 @@
+import { createAbstraction } from "@webiny/feature/admin";
+import type { ContentEntryFormPresenter } from "~/presentation/contentEntries/form/abstractions.js";
+
+export interface IEditEntryPresenter {
+    readonly form: ContentEntryFormPresenter.Interface;
+    init(entryId: string): void;
+    dispose(): void;
+}
+
+export const EditEntryPresenter = createAbstraction<IEditEntryPresenter>("EditEntryPresenter");
+
+export namespace EditEntryPresenter {
+    export type Interface = IEditEntryPresenter;
+}

--- a/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/feature.ts
+++ b/packages/app-headless-cms/src/presentation/fieldRenderers/ref/editEntry/feature.ts
@@ -1,0 +1,15 @@
+import { createFeature } from "@webiny/feature/admin";
+import { EditEntryPresenter as Abstraction } from "./abstractions.js";
+import { EditEntryPresenter } from "./EditEntryPresenter.js";
+
+export const EditEntryPresenterFeature = createFeature({
+    name: "CmsRefField/EditEntryPresenter",
+    register(container) {
+        container.register(EditEntryPresenter).inSingletonScope();
+    },
+    resolve(container) {
+        return {
+            presenter: container.resolve(Abstraction)
+        };
+    }
+});


### PR DESCRIPTION
## Summary

Adds an **"edit in drawer"** action to the detailed `ref` field renderers, so editors can edit a referenced entry inline — without leaving the entry they're on. From [Slack thread](https://webiny.slack.com/archives/C0100FKHX6J/p1784211867055489) (Adrian + Sven).

Today the only action on a referenced entry card is "Open in new tab", which pulls the editor out to a separate tab. This adds a lightweight in-place editing flow.

## Changes

- **New `editEntry/` presenter + feature** — mirrors the sibling `newEntry/` trio; wraps `ContentEntryFormPresenter`, `init(entryId)` calls `loadRevision`.
- **New `EditEntryDrawer`** — adapted from `NewEntryDrawer` (no folder-tree panel, since folder move isn't part of quick-edit). Loads the referenced entry, save-only, **stays open on save** so the editor can keep editing.
  - Header shows the **saved entry title** (updates on save), mirroring the main content-entry form header.
  - **Success toast** on save via `useToast().showSuccessToast`.
- **`EntryCard`** — dedicated pencil **edit icon directly on the card** (single + multi); keeps "Open in new tab" in the `⋮` menu.
- **In-memory card refresh, no refetch** — on save, the saved `CmsContentEntry` is mapped to a patch and merged into the parent `RefDetailedPresenter.entries` via new `patchEntry`. Everything the card shows (title/status/revision) lives in the saved entry's `meta`, so no query re-run and no loading overlay behind the drawer. `patchEntry` is a pure MobX update (no loading flag), so the card updates immediately on save. Aligns with the ongoing Apollo removal — no shared cache to lean on, so presenter state is patched directly.

## Scope

- Detailed renderers only (single + multiple). Simple renderers don't render `EntryCard`.
- Dialog variant (`ReferencesDialog`) leaves `onEdit` unset → no edit action there.
- Save-only; publish/unpublish/delete/revisions and folder move stay in the full editor (via "Open in new tab").

## Test plan

- [ ] Open an entry with single + multiple detailed `ref` fields referencing other entries
- [ ] Pencil icon on card opens the drawer with the referenced entry populated
- [ ] Edit a field, Save: drawer stays open, success toast shows, header title reflects the new title, card reflects new title/status with no overlay flash behind the drawer
- [ ] Close the drawer: no extra reload
- [ ] "Open in new tab" still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)