### PR TITLE
fix(api-scheduler): use a valid EventBridge name for scheduled actions

### DIFF
--- a/packages/api-scheduler/src/features/SchedulerService/EventBridgeSchedulerService.ts
+++ b/packages/api-scheduler/src/features/SchedulerService/EventBridgeSchedulerService.ts
@@ -59,7 +59,7 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
 
         await client.send(
             new CreateScheduleCommand({
-                Name: id,
+                Name: this.createScheduleName(params),
                 ScheduleExpression: this.createScheduleExpression(scheduleFor),
                 FlexibleTimeWindow: {
                     Mode: "OFF"
@@ -93,7 +93,7 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
 
         await client.send(
             new UpdateScheduleCommand({
-                Name: id,
+                Name: this.createScheduleName(params),
                 ScheduleExpression: this.createScheduleExpression(scheduleFor),
                 FlexibleTimeWindow: {
                     Mode: "OFF"
@@ -173,6 +173,11 @@ export class EventBridgeSchedulerService implements SchedulerService.Interface {
     }
 
     private createScheduleName(params: SchedulerService.ExistsParams): string {
-        return `schedule_${params.tenant}-${params.namespace}-${params.id}`;
+        // AWS EventBridge Scheduler names must match [0-9a-zA-Z-_.]+ and be <= 64 chars. `id`
+        // (ScheduledActionId: "wby-schedule-<hash>") already satisfies both and is unique per
+        // namespace + action type + target, so use it verbatim. Do NOT interpolate `namespace`
+        // (contains "/", e.g. "Cms/Entry/<modelId>") or `tenant` — that produced names with illegal
+        // characters that exceeded the length limit (ValidationException).
+        return params.id;
     }
 }


### PR DESCRIPTION
Backport of #5445 to `release/6.4.4`.

## Problem

Scheduling any CMS entry publish/unpublish fails with:

> ValidationException: Value 'schedule_root-Cms/Entry/xyz-wby-schedule-…' at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: [0-9a-zA-Z-_.]+; … Member must have length less than or equal to 64

## Root cause

`EventBridgeSchedulerService.createScheduleName()` built the AWS EventBridge Scheduler name as `schedule_${tenant}-${namespace}-${id}`. CMS namespaces are `Cms/Entry/<modelId>`, so the name contains `/` (illegal — names must match `[0-9a-zA-Z-_.]+`) and exceeds 64 chars. The error surfaces from the `exists()` pre-check inside `create()`. It was also inconsistent: `create`/`update` wrote with `Name: id` while `delete`/`exists` looked up by the composite name.

## Fix

Use the schedule `id` (`wby-schedule-<hash>`) as the EventBridge name in all four operations — already unique and AWS-valid (`[a-z0-9-]`, 37 chars).

## Notes

- On 6.4.4 the code is pre scheduler-split (#5291), so the service lives in `packages/api-scheduler` (not `api-scheduler-aws`).
- **Src-only backport** — the regression test + `vitest.config` from #5445 are already covered by that merged PR; this keeps the 6.4.4 change minimal.
- Pre-existing unrelated type errors in `createEventHandler.ts`/`manifest.ts` on this branch are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)