### PR TITLE
fix(handler): fastify deprecation

### DIFF
--- a/packages/handler/src/fastify.ts
+++ b/packages/handler/src/fastify.ts
@@ -1,6 +1,10 @@
 import type { PluginCollection } from "@webiny/plugins/types.js";
 import { PluginsContainer } from "@webiny/plugins/types.js";
-import type { FastifyInstance, FastifyServerOptions as ServerOptions } from "fastify";
+import {
+    type FastifyInstance,
+    type FastifyServerOptions as ServerOptions,
+    LogController
+} from "fastify";
 import fastify from "fastify";
 import type { MiddlewareCallable } from "@webiny/utils";
 import { middleware } from "@webiny/utils";
@@ -149,7 +153,9 @@ export const createHandler = (params: CreateHandlerParams) => {
      */
     const app = fastify({
         bodyLimit: 536870912, // 512MB
-        disableRequestLogging: true,
+        logController: new LogController({
+            disableRequestLogging: true
+        }),
         allowErrorHandlerOverride: true,
         ...(params.options || {})
     });

--- a/packages/webhooks/ci.config.json
+++ b/packages/webhooks/ci.config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../.github/workflows/ci.config.schema.json",
+  "vitest": {
+    "storageOps": ["ddb", "ddb-os,ddb"]
+  }
+}

--- a/packages/webhooks/jest-dynalite-config.cjs
+++ b/packages/webhooks/jest-dynalite-config.cjs
@@ -1,0 +1,3 @@
+const { createDynaliteTables } = require("../../dynalite.cjs");
+
+module.exports = createDynaliteTables();


### PR DESCRIPTION
## Changes
Fix for Fastify log deprecation - use LogController.

OpenSearch tests will now be running on Webhooks.