### PR TITLE
feat(create-webiny-project): add self-hosted (server) flavour prompt

### DIFF
--- a/packages/create-webiny-project/_templates/base/template.package.json
+++ b/packages/create-webiny-project/_templates/base/template.package.json
@@ -1,8 +1,6 @@
 {
   "type": "module",
   "dependencies": {
-    "@webiny/cli-aws": "latest",
-    "@webiny/cognito": "latest",
     "@webiny/mcp": "latest",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/create-webiny-project/_templates/server/sqlite/webiny.config.tsx
+++ b/packages/create-webiny-project/_templates/server/sqlite/webiny.config.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Admin } from "webiny/extensions";
+// Server-only namespaces come from the server flavour package. `webiny/extensions` exposes the AWS
+// namespaces, which don't include server-only extensions like `Infra.Sqlite`.
+import { Infra } from "@webiny/project-server";
+import { SelfHostedAuth } from "@webiny/self-hosted-auth";
+
+/**
+ * Self-hosted (server) flavour project extensions. No AWS, no Pulumi, no `deploy` — a single
+ * long-running Node HTTP server backed by SQL storage. Run it with `yarn webiny watch`.
+ */
+export const Extensions = () => {
+    return (
+        <>
+            {/* SQL database. Relative paths resolve against the project root (not the disposable app
+                workspace), so data persists across builds / watch restarts. */}
+            <Infra.Sqlite filename={process.env.WEBINY_SQL_FILENAME || "./.webiny/server.sqlite"} />
+
+            {/* Local file storage (uploaded files) + upload signing secret. Storage path resolves like
+                the SQLite file — against the project root — so uploads persist across rebuilds. */}
+            <Infra.FileStorage
+                path={process.env.WEBINY_LOCAL_STORAGE_PATH || "./.webiny/storage"}
+                uploadSecret={process.env.WEBINY_UPLOAD_SECRET || "dev-only-insecure-upload-secret"}
+            />
+
+            {/* The API's public origin. AWS derives this from stack output; the server has none, so it
+                is configured here. `Admin.ApiUrl` points the admin bundle at it; `Infra.ApiUrl` tells
+                the API its own origin (used for the file-upload URL + file srcPrefix). */}
+            <Admin.ApiUrl url={process.env.WEBINY_API_URL || "http://localhost:3002"} />
+            <Infra.ApiUrl url={process.env.WEBINY_API_URL || "http://localhost:3002"} />
+
+            {/* Auth: built-in self-hosted IdP (login screen + JWT). Back the secret with any env var. */}
+            <SelfHostedAuth
+                signingSecret={
+                    process.env.WEBINY_SELF_HOSTED_AUTH_SECRET || "dev-only-insecure-secret"
+                }
+            />
+        </>
+    );
+};

--- a/packages/create-webiny-project/src/bin.ts
+++ b/packages/create-webiny-project/src/bin.ts
@@ -61,6 +61,12 @@ argv.command<CliParams>(
             default: "aws",
             demandOption: false
         });
+        yargs.option("flavour", {
+            describe: `Deployment flavour to use: "aws" (default) or "server" (self-hosted, ALPHA). Used in non-interactive mode`,
+            type: "string",
+            default: "aws",
+            demandOption: false
+        });
         yargs.option("template-options", {
             describe: `A JSON containing template-specific options (usually used in non-interactive environments)`,
             default: null,

--- a/packages/create-webiny-project/src/bin.ts
+++ b/packages/create-webiny-project/src/bin.ts
@@ -62,7 +62,7 @@ argv.command<CliParams>(
             demandOption: false
         });
         yargs.option("flavour", {
-            describe: `Deployment flavour to use: "aws" (default) or "server" (self-hosted, ALPHA). Used in non-interactive mode`,
+            describe: `Hosting flavour to use: "aws" (default) or "server" (self-hosted, ALPHA). Used in non-interactive mode`,
             type: "string",
             default: "aws",
             demandOption: false

--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -10,6 +10,8 @@ import { configureMcp } from "@webiny/mcp";
 import type { IUi } from "@webiny/mcp";
 import { SetupBaseWebinyProject } from "./CreateWebinyProject/projects/base/SetupBaseWebinyProject.js";
 import { SetupAwsWebinyProject } from "./CreateWebinyProject/projects/aws/SetupAwsWebinyProject.js";
+import { SetupServerWebinyProject } from "./CreateWebinyProject/projects/server/SetupServerWebinyProject.js";
+import { runFlavourPrompt, type Flavour } from "./CreateWebinyProject/projects/runFlavourPrompt.js";
 import {
     Analytics,
     EnsureNoGlobalWebinyCli,
@@ -25,7 +27,6 @@ import {
     SetWebinyPackageVersions
 } from "../services/index.js";
 import { CliParams } from "../types.js";
-import { AwsProjectParams } from "./CreateWebinyProject/projects/aws/types.js";
 import ora from "ora";
 
 const { green, bold, cyan, gray, yellow } = chalk;
@@ -88,11 +89,12 @@ export class CreateWebinyProject {
         const analytics = new Analytics();
         await analytics.track("start");
 
-        let awsProjectParams: AwsProjectParams = {
-            region: "us-east-1",
-            storageOps: "ddb",
-            aiAgent: "other"
-        };
+        // AI agent selected during the flavour-specific prompt (used for MCP setup + final messages).
+        let aiAgent: string = "other";
+
+        // Deployment flavour. Resolved interactively below, or taken from `--flavour` in non-interactive
+        // mode (defaults to "aws").
+        let flavour: Flavour = cliArgs.flavour === "server" ? "server" : "aws";
 
         try {
             const taskItems: ListrTask[] = [
@@ -129,11 +131,24 @@ export class CreateWebinyProject {
 
             console.log();
 
+            // Ask which flavour to scaffold before anything flavour-specific is copied.
+            if (cliArgs.interactive !== false) {
+                flavour = await runFlavourPrompt();
+                console.log();
+            }
+
             const setupBaseWebinyProject = new SetupBaseWebinyProject();
             setupBaseWebinyProject.execute(cliArgs);
 
-            const setupAwsWebinyProject = new SetupAwsWebinyProject();
-            awsProjectParams = await setupAwsWebinyProject.execute(cliArgs);
+            if (flavour === "server") {
+                const setupServerWebinyProject = new SetupServerWebinyProject();
+                const serverProjectParams = await setupServerWebinyProject.execute(cliArgs);
+                aiAgent = serverProjectParams.aiAgent;
+            } else {
+                const setupAwsWebinyProject = new SetupAwsWebinyProject();
+                const awsProjectParams = await setupAwsWebinyProject.execute(cliArgs);
+                aiAgent = awsProjectParams.aiAgent;
+            }
 
             const setWebinyPackageVersions = new SetWebinyPackageVersions();
             await setWebinyPackageVersions.execute(cliArgs);
@@ -160,14 +175,12 @@ export class CreateWebinyProject {
             }
 
             // Configure MCP server for the selected AI agent.
-            if (awsProjectParams.aiAgent !== "other") {
+            if (aiAgent !== "other") {
                 console.log();
-                console.log(
-                    bold(`Configuring MCP server for ${cyan(awsProjectParams.aiAgent)}...`)
-                );
+                console.log(bold(`Configuring MCP server for ${cyan(aiAgent)}...`));
                 console.log();
                 await configureMcp({
-                    agent: awsProjectParams.aiAgent,
+                    agent: aiAgent,
                     ui: new CwpUi(),
                     cwd: projectRootPath
                 });
@@ -207,6 +220,49 @@ export class CreateWebinyProject {
         }
 
         console.log();
+
+        // Self-hosted (server) flavour: no deploy step (ALPHA — dev-first, run with `webiny watch`).
+        if (flavour === "server") {
+            console.log(
+                `🎉 Your new self-hosted Webiny project ${green(projectName)} has been created!`
+            );
+            console.log();
+            console.log(
+                yellow(
+                    "⚠ The self-hosted (server) flavour is in ALPHA. It is designed for local\n" +
+                        "  development via `webiny watch`. Standalone production packaging is still a\n" +
+                        "  work in progress (tracked in webiny-js#5429)."
+                )
+            );
+            console.log();
+
+            // For "other" agents, show manual MCP setup instructions.
+            if (aiAgent === "other") {
+                await configureMcp({ instructions: true });
+            }
+
+            console.log(
+                [
+                    `Start your project in development mode by running: ${green(
+                        `cd ${projectName} && yarn webiny watch`
+                    )}`,
+                    "",
+                    `To see all of the available CLI commands, run ${green(
+                        "yarn webiny --help"
+                    )} in your ${green(projectName)} directory.`,
+                    "",
+                    "Want to dive deeper into Webiny? Check out https://webiny.com/docs/!",
+                    "Like the project? Star us on https://github.com/webiny/webiny-js!",
+                    "",
+                    "Need help? Join our Slack community! https://www.webiny.com/slack",
+                    "",
+                    "🚀 Happy coding!"
+                ].join("\n")
+            );
+
+            return;
+        }
+
         console.log(
             `🎉 Your new Webiny project ${green(
                 projectName
@@ -242,7 +298,7 @@ export class CreateWebinyProject {
             }
 
             // For "other" agents, show manual MCP setup instructions after deploy has finished.
-            if (awsProjectParams.aiAgent === "other") {
+            if (aiAgent === "other") {
                 await configureMcp({ instructions: true });
             }
 
@@ -250,7 +306,7 @@ export class CreateWebinyProject {
         }
 
         // For "other" agents, show manual MCP setup instructions instead of blocking the deploy step.
-        if (awsProjectParams.aiAgent === "other") {
+        if (aiAgent === "other") {
             await configureMcp({ instructions: true });
         }
 

--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -92,7 +92,7 @@ export class CreateWebinyProject {
         // AI agent selected during the flavour-specific prompt (used for MCP setup + final messages).
         let aiAgent: string = "other";
 
-        // Deployment flavour. Resolved interactively below, or taken from `--flavour` in non-interactive
+        // Hosting flavour. Resolved interactively below, or taken from `--flavour` in non-interactive
         // mode (defaults to "aws").
         let flavour: Flavour = cliArgs.flavour === "server" ? "server" : "aws";
 

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/addProjectDependencies.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/addProjectDependencies.ts
@@ -1,0 +1,30 @@
+import fs from "fs-extra";
+import path from "path";
+
+/**
+ * Merges flavour-specific dependencies into the generated project's `package.json`.
+ *
+ * The base template's `package.json` is flavour-neutral (only shared deps like `webiny`, `react` and
+ * `@webiny/mcp`); each flavour setup injects its own packages here. Values can be `"latest"` — the
+ * later `SetWebinyPackageVersions` step rewrites every `@webiny/*` / `webiny` entry to the actual CWP
+ * version, so only the presence of the dependency matters at this point.
+ */
+export const addProjectDependencies = (
+    projectRootFolderPath: string,
+    dependencies: Record<string, string>
+) => {
+    const pkgPath = path.join(projectRootFolderPath, "package.json");
+    const pkg = fs.readJsonSync(pkgPath);
+
+    pkg.dependencies = {
+        ...pkg.dependencies,
+        ...dependencies
+    };
+
+    // Keep dependencies sorted, matching the base template's alphabetical ordering.
+    pkg.dependencies = Object.fromEntries(
+        Object.entries(pkg.dependencies).sort(([a], [b]) => a.localeCompare(b))
+    );
+
+    fs.writeJsonSync(pkgPath, pkg, { spaces: 2 });
+};

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/aws/SetupAwsWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/aws/SetupAwsWebinyProject.ts
@@ -5,6 +5,7 @@ import { CliParams } from "../../../../types.js";
 import { GetProjectRootPath } from "../../../../services/index.js";
 import { AwsProjectParams } from "./types.js";
 import { GetTemplatesFolderPath } from "../../../../services/GetTemplatesFolderPath.js";
+import { addProjectDependencies } from "../addProjectDependencies.js";
 
 export class SetupAwsWebinyProject {
     async execute(cliArgs: CliParams): Promise<AwsProjectParams> {
@@ -19,6 +20,12 @@ export class SetupAwsWebinyProject {
         const projectRootFolderPath = getProjectRoot.execute(cliArgs);
 
         fs.copySync(storageTemplatePath, projectRootFolderPath);
+
+        // AWS flavour dependencies: the `webiny` CLI (AWS bin) + Cognito (AWS-managed IdP).
+        addProjectDependencies(projectRootFolderPath, {
+            "@webiny/cli-aws": "latest",
+            "@webiny/cognito": "latest"
+        });
 
         // Update .env file.
         const webinyConfigTsxEnvFilePath = path.join(projectRootFolderPath, "webiny.config.tsx");

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runFlavourPrompt.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runFlavourPrompt.ts
@@ -14,7 +14,7 @@ const FLAVOUR_OPTIONS: { value: Flavour; name: string }[] = [
 ];
 
 export const runFlavourPrompt = async (): Promise<Flavour> => {
-    console.log("Which deployment flavour would you like to use for your new Webiny project?");
+    console.log("How would you like to host your new Webiny project?");
     console.log();
 
     const { flavour } = await inquirer.prompt<{ flavour: Flavour }>([
@@ -22,7 +22,7 @@ export const runFlavourPrompt = async (): Promise<Flavour> => {
             type: "select",
             name: "flavour",
             default: "aws",
-            message: "Please choose the deployment flavour:",
+            message: "Please choose how you would like to host your project:",
             choices: FLAVOUR_OPTIONS
         }
     ]);

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runFlavourPrompt.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runFlavourPrompt.ts
@@ -1,0 +1,31 @@
+import inquirer from "inquirer";
+
+export type Flavour = "aws" | "server";
+
+const FLAVOUR_OPTIONS: { value: Flavour; name: string }[] = [
+    {
+        value: "aws",
+        name: "AWS (Lambda, DynamoDB, API Gateway — deployed with Pulumi)"
+    },
+    {
+        value: "server",
+        name: "Self-hosted / server (Node HTTP server + SQL storage) — ALPHA"
+    }
+];
+
+export const runFlavourPrompt = async (): Promise<Flavour> => {
+    console.log("Which deployment flavour would you like to use for your new Webiny project?");
+    console.log();
+
+    const { flavour } = await inquirer.prompt<{ flavour: Flavour }>([
+        {
+            type: "select",
+            name: "flavour",
+            default: "aws",
+            message: "Please choose the deployment flavour:",
+            choices: FLAVOUR_OPTIONS
+        }
+    ]);
+
+    return flavour;
+};

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
@@ -1,0 +1,83 @@
+import fs from "fs-extra";
+import path from "path";
+import { runInteractivePrompt } from "./runInteractivePrompt.js";
+import { CliParams } from "../../../../types.js";
+import { GetProjectRootPath } from "../../../../services/index.js";
+import { ServerProjectParams } from "./types.js";
+import { GetTemplatesFolderPath } from "../../../../services/GetTemplatesFolderPath.js";
+import { addProjectDependencies } from "../addProjectDependencies.js";
+
+const DOT_ENV = `# Self-hosted (server) flavour environment variables.
+# The values below are safe dev defaults. CHANGE the secrets before any real deployment.
+
+# Ports the API and Admin servers listen on during \`webiny watch\` / \`webiny serve\`.
+WEBINY_API_PORT=3002
+WEBINY_ADMIN_PORT=3001
+
+# Public origin of the API (used by the Admin app + for file-upload URLs).
+WEBINY_API_URL=http://localhost:3002
+
+# SQLite database file (relative paths resolve against the project root).
+WEBINY_SQL_FILENAME=./.webiny/server.sqlite
+
+# Local file storage for uploaded files + upload signing secret.
+WEBINY_LOCAL_STORAGE_PATH=./.webiny/storage
+WEBINY_UPLOAD_SECRET=dev-only-insecure-upload-secret
+
+# JWT signing secret for the built-in self-hosted identity provider.
+WEBINY_SELF_HOSTED_AUTH_SECRET=dev-only-insecure-secret
+`;
+
+export class SetupServerWebinyProject {
+    async execute(cliArgs: CliParams): Promise<ServerProjectParams> {
+        const serverArgs = await this.getServerArgs(cliArgs);
+
+        const getTemplatesFolderPath = new GetTemplatesFolderPath();
+        const templatesFolderPath = getTemplatesFolderPath.execute();
+
+        const storageTemplatePath = path.join(templatesFolderPath, "server", serverArgs.storageOps);
+
+        const getProjectRoot = new GetProjectRootPath();
+        const projectRootFolderPath = getProjectRoot.execute(cliArgs);
+
+        fs.copySync(storageTemplatePath, projectRootFolderPath);
+
+        // Server (self-hosted) flavour dependencies. The `webiny` CLI (server bin) sets
+        // WEBINY_FLAVOUR=server; `@webiny/project-server` provides the server `Infra.*` extensions and
+        // resolves `@webiny/project-server-template` (the workspace base config) at build time;
+        // `@webiny/self-hosted-auth` is the built-in JWT identity provider (replaces Cognito).
+        addProjectDependencies(projectRootFolderPath, {
+            "@webiny/cli-server": "latest",
+            "@webiny/project-server": "latest",
+            "@webiny/project-server-template": "latest",
+            "@webiny/self-hosted-auth": "latest"
+        });
+
+        // Write the `.env` with the server-flavour dev defaults.
+        fs.writeFileSync(path.join(projectRootFolderPath, ".env"), DOT_ENV);
+
+        return serverArgs;
+    }
+
+    private async getServerArgs(cliArgs: CliParams) {
+        const serverArgs: ServerProjectParams = {
+            storageOps: "sqlite",
+            aiAgent: "other"
+        };
+
+        const { templateOptions: templateOptionsString } = cliArgs;
+        if (templateOptionsString) {
+            try {
+                Object.assign(serverArgs, JSON.parse(templateOptionsString));
+            } catch {
+                // Do nothing.
+            }
+        }
+
+        if (cliArgs.interactive !== false) {
+            Object.assign(serverArgs, await runInteractivePrompt());
+        }
+
+        return serverArgs;
+    }
+}

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/runInteractivePrompt.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/runInteractivePrompt.ts
@@ -1,0 +1,43 @@
+import inquirer from "inquirer";
+import { discoverAgents } from "@webiny/mcp";
+import { StorageOps } from "./types.js";
+
+const STORAGE_OPTIONS: Record<StorageOps, { value: StorageOps; name: string }> = {
+    sqlite: {
+        value: "sqlite",
+        name: "SQLite (single-file local database)"
+    }
+};
+
+export const runInteractivePrompt = async () => {
+    console.log(
+        "In order to create your new self-hosted Webiny project, please answer the following questions."
+    );
+    console.log();
+
+    const agents = await discoverAgents();
+    const agentChoices = [
+        ...Array.from(agents.values()).map(a => ({
+            value: a.preset.slug,
+            name: a.preset.displayName
+        })),
+        { value: "other", name: "Other / not listed" }
+    ];
+
+    return inquirer.prompt([
+        {
+            type: "select",
+            name: "storageOps",
+            default: "sqlite",
+            message: `Please choose the database setup you wish to use with your project:`,
+            choices: Object.values(STORAGE_OPTIONS)
+        },
+        {
+            type: "select",
+            name: "aiAgent",
+            default: "claude",
+            message: "Please choose the AI agent you will use with your project:",
+            choices: agentChoices
+        }
+    ]);
+};

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/types.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/types.ts
@@ -1,0 +1,7 @@
+export type StorageOps = "sqlite";
+export type AiAgent = string | "other";
+
+export interface ServerProjectParams {
+    storageOps: StorageOps;
+    aiAgent: AiAgent;
+}

--- a/packages/create-webiny-project/src/types.ts
+++ b/packages/create-webiny-project/src/types.ts
@@ -8,6 +8,9 @@ export interface CliParams {
     /** Name of template to use (defaults to "aws") */
     template: string;
 
+    /** Deployment flavour: "aws" or "server" (self-hosted). Used in non-interactive mode. */
+    flavour: "aws" | "server";
+
     /** JSON string with template-specific options */
     templateOptions: string | null;
 


### PR DESCRIPTION
## Summary

Adds an interactive **hosting-flavour** prompt to `create-webiny-project` (CWP) — "How would you like to host your new Webiny project?" — letting users pick between:

- **AWS** — Lambda + API Gateway + DynamoDB, deployed with Pulumi (existing, default)
- **Self-hosted / server (ALPHA)** — a single long-running Node HTTP server + SQL (SQLite) storage, no AWS/Pulumi/deploy

Selecting the server flavour scaffolds a self-hosted project instead of an AWS one.

## How it works

Flavour is determined by which packages the generated project installs (the CLI bin sets `WEBINY_FLAVOUR`; the runtime copies that flavour's `webiny.config.base.tsx` into the workspace):

- **AWS** → `@webiny/cli-aws` + `@webiny/cognito`
- **Server** → `@webiny/cli-server` + `@webiny/project-server` + `@webiny/project-server-template` + `@webiny/self-hosted-auth`

## Changes

- **Neutral base template** — `_templates/base/template.package.json` no longer hardcodes AWS deps. Each flavour setup injects its own via a shared `addProjectDependencies` helper. (`SetWebinyPackageVersions` still rewrites `@webiny/*` versions afterward.)
- **New `projects/server/`** setup + `_templates/server/sqlite/webiny.config.tsx` — renders server extensions (`Infra.Sqlite`, `Infra.FileStorage`, `Admin.ApiUrl`, `Infra.ApiUrl`, `SelfHostedAuth`) and writes a `.env` with dev defaults (ports 3002/3001, SQLite path, upload + auth secrets).
- **Flavour-aware end flow** — server flavour skips the deploy prompt (dev-first: `yarn webiny watch`) and surfaces the ALPHA / standalone-packaging caveat (webiny-js#5429).
- **Non-interactive** support via a new `--flavour aws|server` CLI option.

App-level runtime deps (`@webiny/api-event-handler-server-sql`, `better-sqlite3`, `knex`, …) come from `project-server-template/appTemplates` at build time — not the root `package.json` (existing mechanism, unchanged).

## Terminology

User-facing copy says **"hosting"** (prompts, `--flavour` help), while the code keeps **`flavour`** / `Flavour` to stay consistent with the existing framework vocabulary (the `WEBINY_FLAVOUR` env var, the aws/server flavour split in `webiny.config.base.tsx`, etc.). A follow-up will reconcile the two — likely renaming the code identifiers to `hosting` once the framework-wide term is settled.

## Testing

- `tsc -b` clean on `@webiny/create-webiny-project`.
- Dry-ran both setups into a temp dir (non-interactive):
  - **server** → correct file set + deps (no AWS packages), server config, `.env` present.
  - **AWS** → deps + `{REGION}` substitution intact, no `.env` (unchanged behaviour).
- Pre-commit checklist: `adio` ✅, `lint` ✅, `format` ✅. `sync-dependencies` not run (requires built CLI in this fresh checkout); no-op here since no new cross-package imports were added.

> [!NOTE]
> The self-hosted (server) flavour is **ALPHA** — designed for local development via `webiny watch`. Standalone production packaging is still a work in progress (webiny-js#5429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)