### PR TITLE
chore: preserve manual tsconfig `exclude` when regenerating tsconfigs

### DIFF
--- a/scripts/generateTsConfigsInPackages.js
+++ b/scripts/generateTsConfigsInPackages.js
@@ -23,6 +23,19 @@ async function output(target, content) {
 }
 
 /**
+ * Preserve a manually-added `exclude` from an existing generated tsconfig. The generator rewrites
+ * these files from a fixed template, so without this any hand-added `exclude` (e.g. non-TS binaries
+ * under `src`) would be clobbered on every run.
+ */
+function readExistingExclude(target) {
+    try {
+        return JSON.parse(fs.readFileSync(target, "utf8")).exclude;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * The key point: both tsconfig.json and tsconfig.build.json should reference source files during
  * development and build. TypeScript's project references handle building dependencies in the correct
  * order, so each package always compiles against the source of its dependencies, not their built
@@ -85,6 +98,9 @@ async function output(target, content) {
         const tsconfigJson = {
             extends: "../../tsconfig.json",
             include: ["src", "__tests__"],
+            ...(readExistingExclude(wpObject.tsConfigJsonPath) && {
+                exclude: readExistingExclude(wpObject.tsConfigJsonPath)
+            }),
             references: dependencies.map(dep => ({
                 path: `${getRelativePath(wpObject.packageFolder, dep.packageFolder)}`
             })),
@@ -114,6 +130,9 @@ async function output(target, content) {
         const tsconfigBuildJson = {
             extends: "../../tsconfig.build.json",
             include: ["src"],
+            ...(readExistingExclude(wpObject.tsConfigBuildJsonPath) && {
+                exclude: readExistingExclude(wpObject.tsConfigBuildJsonPath)
+            }),
             references: dependencies.map(dep => ({
                 path: `${getRelativePath(
                     wpObject.packageFolder,


### PR DESCRIPTION
## Problem

`scripts/generateTsConfigsInPackages.js` rewrites each package's `tsconfig.json` / `tsconfig.build.json` from a fixed template. It **clobbered** any hand-added `exclude`, so on regeneration the vendored Yarn binary in `create-webiny-project` was no longer excluded and declaration emit failed the build with:

> error TS6424: Multiple 'module.exports' assignments cannot be serialized for declaration emit.

This blocks building `release/6.5.0`.

## Fix

Preserve an existing `exclude` from the current generated tsconfig across regeneration (`readExistingExclude`). `create-webiny-project/tsconfig.build.json` already carries `"exclude": ["src/services/SetupYarn/binaries"]`; the generator now keeps it instead of stripping it.

## Verification

- Ran `node scripts/generateTsConfigsInPackages.js @webiny/create-webiny-project` — the `exclude` survives regeneration (no diff), where before it was removed.

Cherry-picked from the scheduled-indicator branch so it can land independently and unblock the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)