### PR TITLE
refactor: rename hosting "flavour" to "hostingType"

### DIFF
--- a/packages/api-event-handler-core/src/WcpLicenseInitializer.ts
+++ b/packages/api-event-handler-core/src/WcpLicenseInitializer.ts
@@ -8,7 +8,7 @@ import { WcpLicenseProvider } from "@webiny/api-core";
  *
  * Lives in api-event-handler-core (the shared API request stack) rather than api-core so the domain
  * layer stays free of the transport request-lifecycle contract, while the refresh still runs for
- * every flavour (aws + server) via registerApiRequestStack.
+ * every hosting type (aws + server) via registerApiRequestStack.
  */
 class WcpLicenseInitializerImpl implements RequestInitializer.Interface {
     constructor(private provider: WcpLicenseProvider.Interface) {}

--- a/packages/api-event-handler-core/src/registerApiRequestStack.ts
+++ b/packages/api-event-handler-core/src/registerApiRequestStack.ts
@@ -23,7 +23,7 @@ import { WebsocketsFeature } from "@webiny/api-websockets";
 import { WorkflowsFeature } from "@webiny/api-workflows";
 import { SchedulerFeature } from "@webiny/api-scheduler";
 
-/** Installs a flavour-specific transport adapter into the per-request container at its interleave point. */
+/** Installs a hosting-specific transport adapter into the per-request container at its interleave point. */
 export type TransportRegistrar = (container: Container) => void | Promise<void>;
 
 export interface RegisterApiRequestStackConfig {
@@ -38,7 +38,7 @@ export interface RegisterApiRequestStackConfig {
      */
     registerRequestStorage?: (container: Container) => void | Promise<void>;
     /**
-     * Flavour-specific transport adapters, each installed at its exact interleave point in the stack.
+     * Hosting-specific transport adapters, each installed at its exact interleave point in the stack.
      * Every entry follows the same shape: it runs immediately AFTER the transport-agnostic domain
      * Feature has registered its NULL default, and overrides that default (nearest-container-last-wins)
      * with the real adapter. Each is optional — omit one for a deployment/transport that lacks that
@@ -88,7 +88,7 @@ export async function registerApiRequestStack(
 
     // Refresh the WCP license once per request (RequestInitializer). Lives here (the shared request
     // stack) rather than api-core, so the domain layer has no transport dependency; runs for all
-    // flavours. Registered after ApiCoreFeature (which provides WcpLicenseProvider).
+    // hosting types. Registered after ApiCoreFeature (which provides WcpLicenseProvider).
     container.register(WcpLicenseInitializer);
 
     // ── Request-phase storage (variant-specific; must precede HeadlessCmsFeature) ──

--- a/packages/api-event-handler-server-sql/src/createSqliteConnection.ts
+++ b/packages/api-event-handler-server-sql/src/createSqliteConnection.ts
@@ -12,7 +12,7 @@ export interface CreateSqliteConnectionOptions {
 
 /**
  * Build a Knex client backed by a local SQLite file (better-sqlite3) for the self-hosted server
- * flavour. This is the default self-hosted storage connection; a real deployment can instead pass its
+ * hosting type. This is the default self-hosted storage connection; a real deployment can instead pass its
  * own Knex client (Postgres/MySQL) straight to `createSqlApiHandler`.
  *
  * The database file is mandatory: it comes from `WEBINY_SQL_FILENAME` (or an explicit `filename`),

--- a/packages/api-event-handler-server/src/scheduler/schedulerServer.ts
+++ b/packages/api-event-handler-server/src/scheduler/schedulerServer.ts
@@ -78,7 +78,7 @@ export function registerSchedulerServer(rootContainer: Container): void {
 
     // Register the ONE Bree instance under TWO tokens — two views of the same object:
     //
-    //   - SchedulerService: the flavour-agnostic contract (create/update/delete/exists) that AWS
+    //   - SchedulerService: the hosting-agnostic contract (create/update/delete/exists) that AWS
     //     implements too. This is what per-request GraphQL mutations resolve to schedule/reschedule.
     //   - SchedulerSingleton: typed as the CONCRETE BreeSchedulerService, so it also exposes the
     //     methods that aren't on that contract — start() and recover(). Those are Bree-only: AWS's

--- a/packages/api-file-manager-server/src/graphql/schema.ts
+++ b/packages/api-file-manager-server/src/graphql/schema.ts
@@ -20,7 +20,7 @@ import type { FileData } from "@webiny/api-file-manager/features/upload/types.js
 const createNormalizer = () => new FileNormalizer();
 
 /**
- * Upload GraphQL for the self-hosted (server) flavour. Mirrors the SDL that `api-file-manager-s3`'s
+ * Upload GraphQL for the self-hosted (server) hosting type. Mirrors the SDL that `api-file-manager-s3`'s
  * `createS3GraphQLSchema` contributes (same query/mutation names + `PreSignedPostPayloadInput`), so the
  * transport-agnostic SDK (`getPresignedPostPayload` + the generic multipart-form `uploadToS3`, and the
  * multipart methods) works unchanged. The payload shape (`{ url, fields }`) is generic; only the

--- a/packages/api-file-manager/src/features/settings/SettingsInstaller/SettingsInstaller.ts
+++ b/packages/api-file-manager/src/features/settings/SettingsInstaller/SettingsInstaller.ts
@@ -24,8 +24,8 @@ class SettingsInstallerImpl implements AppInstaller.Interface {
         // If no records in the database, `manifest` object is empty POJO.
         // That's why the heavy `?.` usage.
         //
-        // The AWS flavour serves files from a CloudFront domain (in the manifest). The self-hosted
-        // (server) flavour has no CloudFront — files are served by the api's own `/files/*` route — so
+        // The AWS hosting type serves files from a CloudFront domain (in the manifest). The self-hosted
+        // (server) hosting type has no CloudFront — files are served by the api's own `/files/*` route — so
         // fall back to the configured API origin, read from the WEBINY_API_URL build param (baked by
         // Infra.ApiUrl), not a process.env read.
         const domain =

--- a/packages/app-admin/src/presentation/installation/components/SystemInstaller/steps/AdminUserStep.tsx
+++ b/packages/app-admin/src/presentation/installation/components/SystemInstaller/steps/AdminUserStep.tsx
@@ -33,8 +33,8 @@ const AdminUserInputs = () => {
     // The install wizard renders BEFORE any auth-provider extension is mounted (it replaces the app
     // tree), so the installer's app name can't come from DI here — it must be a build-time value.
     // The submitted data is keyed under this name, becoming `installationInput: [{ app, data }]`, so
-    // it has to match the API-side AppInstaller's `appName`. Defaults to "Cognito" (AWS flavour);
-    // the self-hosted flavour sets REACT_APP_AUTH_INSTALLER_APP_NAME="SelfHostedAuth".
+    // it has to match the API-side AppInstaller's `appName`. Defaults to "Cognito" (AWS hosting type);
+    // the self-hosted hosting type sets REACT_APP_AUTH_INSTALLER_APP_NAME="SelfHostedAuth".
     const appName = process.env.REACT_APP_AUTH_INSTALLER_APP_NAME || "Cognito";
 
     return (

--- a/packages/app-websockets/src/WebsocketsContextProvider.tsx
+++ b/packages/app-websockets/src/WebsocketsContextProvider.tsx
@@ -139,7 +139,7 @@ export const WebsocketsContextProvider = (props: IWebsocketsContextProviderProps
             const url = wsUrl;
 
             if (!url) {
-                // No WS URL configured (e.g. self-hosted server flavour) — skip WS, run app anyway.
+                // No WS URL configured (e.g. self-hosted server hosting type) — skip WS, run app anyway.
                 console.warn("WebSocket URL not configured; real-time updates are disabled.");
                 return;
             }
@@ -248,7 +248,7 @@ export const WebsocketsContextProvider = (props: IWebsocketsContextProviderProps
     );
 
     // Only block the app on the WS connection when WS is actually configured. Without a URL
-    // (e.g. the self-hosted server flavour), skip WS and render the app anyway.
+    // (e.g. the self-hosted server hosting type), skip WS and render the app anyway.
     if (wsUrl && !socketsRef.current) {
         return props.loader || null;
     }

--- a/packages/background-tasks-server/src/service/WorkerTaskService.ts
+++ b/packages/background-tasks-server/src/service/WorkerTaskService.ts
@@ -7,7 +7,7 @@ import { TenantContext } from "@webiny/api-core/exports/api/tenancy.js";
 import { InternalToken } from "~/domain/InternalToken.js";
 
 // Matches findFreePort's search base in runApiServer (and the scheduler's self-callback default), so
-// every self-callback in the server flavour agrees on the same fallback. In practice never used:
+// every self-callback in the server hosting type agrees on the same fallback. In practice never used:
 // runApiServer always injects the resolved port as process.env.PORT.
 const DEFAULT_SERVER_PORT = 3002;
 const DEFAULT_MAX_DURATION_MS = 86_400_000;
@@ -28,7 +28,7 @@ class WorkerServiceImpl implements TaskService.Interface {
         private readonly tenantContext: TenantContext.Interface,
         private readonly internalToken: InternalToken.Interface
     ) {
-        // Single-process server flavour: the worker POSTs the task back to THIS server's
+        // Single-process server hosting type: the worker POSTs the task back to THIS server's
         // `/background-task` route. The port is the one the server actually listens on — injected at
         // runtime as `process.env.PORT` by `runApiServer` (dynamic, chosen via findFreePort), NOT a
         // build-time value. It cannot be a build param: the port isn't known until the process starts.

--- a/packages/build-tools/bundling/function/createRsbuildConfig.js
+++ b/packages/build-tools/bundling/function/createRsbuildConfig.js
@@ -56,7 +56,7 @@ export const createRsbuildConfig = async ({ cwd, enforceMaxBundleSize }) => {
                     // driver for EVERY SQL dialect (pg, mysql, mariadb, mssql, sqlite, ...) and
                     // picks one at runtime from the configured `client`. Bundling it forces the
                     // bundler to resolve drivers that aren't installed (the mariadb/tedious/pg
-                    // "Module not found" errors). The server flavour runs as a Node process with
+                    // "Module not found" errors). The server hosting type runs as a Node process with
                     // node_modules present, so we externalize knex and let Node load it — knex then
                     // lazily require()s ONLY the configured dialect's driver (e.g. better-sqlite3),
                     // never the others.

--- a/packages/cli-aws/src/bin.ts
+++ b/packages/cli-aws/src/bin.ts
@@ -9,9 +9,9 @@ import { ensureSameWebinyPackageVersions } from "@webiny/cli-core/utils/ensureSa
 import { registerAwsFeatures } from "./index.js";
 import { ensureSystemRequirements } from "@webiny/system-requirements";
 
-// Flavour marker — lets webiny.config.tsx branch on which CLI is running (e.g. Cognito for AWS,
+// Hosting-type marker — lets webiny.config.tsx branch on which CLI is running (e.g. Cognito for AWS,
 // SelfHostedAuth + Admin.ApiUrl for server). Read at build/watch time when the config is evaluated.
-process.env.WEBINY_FLAVOUR = "aws";
+process.env.WEBINY_HOSTING_TYPE = "aws";
 
 // Ensure system requirements are met.
 ensureSystemRequirements();

--- a/packages/cli-core/src/createCliContainer.ts
+++ b/packages/cli-core/src/createCliContainer.ts
@@ -100,7 +100,7 @@ export const createCliContainer = async (
     container.register(stdioService).inSingletonScope();
     container.register(uiService).inSingletonScope();
 
-    // Allow flavour-specific registrations (e.g. cli-aws, cli-server).
+    // Allow hosting-specific registrations (e.g. cli-aws, cli-server).
     register?.(container);
 
     // Extensions.

--- a/packages/cli-server/src/bin.ts
+++ b/packages/cli-server/src/bin.ts
@@ -8,9 +8,9 @@ import { Cli } from "@webiny/cli-core";
 import { ensureSameWebinyPackageVersions } from "@webiny/cli-core/utils/ensureSameWebinyPackageVersions.js";
 import { registerServerFeatures } from "./registerServerFeatures.js";
 
-// Flavour marker — lets webiny.config.tsx branch on which CLI is running (e.g. SelfHostedAuth +
+// Hosting-type marker — lets webiny.config.tsx branch on which CLI is running (e.g. SelfHostedAuth +
 // Admin.ApiUrl for server, Cognito for AWS). Read at build/watch time when the config is evaluated.
-process.env.WEBINY_FLAVOUR = "server";
+process.env.WEBINY_HOSTING_TYPE = "server";
 
 // Ensure all @webiny/* packages use the same version.
 ensureSameWebinyPackageVersions();

--- a/packages/cli-server/src/features/WatchCommand.ts
+++ b/packages/cli-server/src/features/WatchCommand.ts
@@ -64,7 +64,7 @@ export class ServerWatchCommand implements CliCommandFactory.Interface<IServerWa
                 const apps = params.app ? [params.app] : [];
 
                 // Collect PackagesWatcher instances (one per app or for package-only mode) plus any
-                // long-running server processes the flavour attaches (e.g. the api HTTP server).
+                // long-running server processes the hosting type attaches (e.g. the api HTTP server).
                 const watchers = [];
                 const serverProcesses: Watch.Process[] = [];
 
@@ -127,7 +127,7 @@ export class ServerWatchCommand implements CliCommandFactory.Interface<IServerWa
                     });
                 }
 
-                // Render the flavour's server processes (filtered/prefixed) then run them alongside
+                // Render the hosting type's server processes (filtered/prefixed) then run them alongside
                 // the build watchers.
                 for (const serverProcess of serverProcesses) {
                     const prefix = chalk.hex(colorForString(serverProcess.name))(

--- a/packages/create-webiny-project/_templates/server/sqlite/webiny.config.tsx
+++ b/packages/create-webiny-project/_templates/server/sqlite/webiny.config.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Admin } from "webiny/extensions";
-// Server-only namespaces come from the server flavour package. `webiny/extensions` exposes the AWS
-// namespaces, which don't include server-only extensions like `Infra.Sqlite`.
+// Server-only namespaces come from the server hosting-type package. `webiny/extensions` exposes the
+// AWS namespaces, which don't include server-only extensions like `Infra.Sqlite`.
 import { Infra } from "@webiny/project-server";
 import { SelfHostedAuth } from "@webiny/self-hosted-auth";
 
 /**
- * Self-hosted (server) flavour project extensions. No AWS, no Pulumi, no `deploy` — a single
+ * Self-hosted (server) hosting-type project extensions. No AWS, no Pulumi, no `deploy` — a single
  * long-running Node HTTP server backed by SQL storage. Run it with `yarn webiny watch`.
  */
 export const Extensions = () => {

--- a/packages/create-webiny-project/src/bin.ts
+++ b/packages/create-webiny-project/src/bin.ts
@@ -61,8 +61,8 @@ argv.command<CliParams>(
             default: "aws",
             demandOption: false
         });
-        yargs.option("flavour", {
-            describe: `Hosting flavour to use: "aws" (default) or "server" (self-hosted, ALPHA). Used in non-interactive mode`,
+        yargs.option("hosting-type", {
+            describe: `Hosting type to use: "aws" (default) or "server" (self-hosted, ALPHA). Used in non-interactive mode`,
             type: "string",
             default: "aws",
             demandOption: false

--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -11,7 +11,10 @@ import type { IUi } from "@webiny/mcp";
 import { SetupBaseWebinyProject } from "./CreateWebinyProject/projects/base/SetupBaseWebinyProject.js";
 import { SetupAwsWebinyProject } from "./CreateWebinyProject/projects/aws/SetupAwsWebinyProject.js";
 import { SetupServerWebinyProject } from "./CreateWebinyProject/projects/server/SetupServerWebinyProject.js";
-import { runFlavourPrompt, type Flavour } from "./CreateWebinyProject/projects/runFlavourPrompt.js";
+import {
+    runHostingTypePrompt,
+    type HostingType
+} from "./CreateWebinyProject/projects/runHostingTypePrompt.js";
 import {
     Analytics,
     EnsureNoGlobalWebinyCli,
@@ -89,12 +92,12 @@ export class CreateWebinyProject {
         const analytics = new Analytics();
         await analytics.track("start");
 
-        // AI agent selected during the flavour-specific prompt (used for MCP setup + final messages).
+        // AI agent selected during the hosting-type prompt (used for MCP setup + final messages).
         let aiAgent: string = "other";
 
-        // Hosting flavour. Resolved interactively below, or taken from `--flavour` in non-interactive
+        // Hosting type. Resolved interactively below, or taken from `--hosting-type` in non-interactive
         // mode (defaults to "aws").
-        let flavour: Flavour = cliArgs.flavour === "server" ? "server" : "aws";
+        let hostingType: HostingType = cliArgs.hostingType === "server" ? "server" : "aws";
 
         try {
             const taskItems: ListrTask[] = [
@@ -131,16 +134,16 @@ export class CreateWebinyProject {
 
             console.log();
 
-            // Ask which flavour to scaffold before anything flavour-specific is copied.
+            // Ask which hosting type to scaffold before anything hosting-specific is copied.
             if (cliArgs.interactive !== false) {
-                flavour = await runFlavourPrompt();
+                hostingType = await runHostingTypePrompt();
                 console.log();
             }
 
             const setupBaseWebinyProject = new SetupBaseWebinyProject();
             setupBaseWebinyProject.execute(cliArgs);
 
-            if (flavour === "server") {
+            if (hostingType === "server") {
                 const setupServerWebinyProject = new SetupServerWebinyProject();
                 const serverProjectParams = await setupServerWebinyProject.execute(cliArgs);
                 aiAgent = serverProjectParams.aiAgent;
@@ -221,15 +224,15 @@ export class CreateWebinyProject {
 
         console.log();
 
-        // Self-hosted (server) flavour: no deploy step (ALPHA — dev-first, run with `webiny watch`).
-        if (flavour === "server") {
+        // Self-hosted (server) hosting type: no deploy step (ALPHA — dev-first, run with `webiny watch`).
+        if (hostingType === "server") {
             console.log(
                 `🎉 Your new self-hosted Webiny project ${green(projectName)} has been created!`
             );
             console.log();
             console.log(
                 yellow(
-                    "⚠ The self-hosted (server) flavour is in ALPHA. It is designed for local\n" +
+                    "⚠ The self-hosted (server) hosting type is in ALPHA. It is designed for local\n" +
                         "  development via `webiny watch`. Standalone production packaging is still a\n" +
                         "  work in progress (tracked in webiny-js#5429)."
                 )

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/addProjectDependencies.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/addProjectDependencies.ts
@@ -2,10 +2,10 @@ import fs from "fs-extra";
 import path from "path";
 
 /**
- * Merges flavour-specific dependencies into the generated project's `package.json`.
+ * Merges hosting-specific dependencies into the generated project's `package.json`.
  *
- * The base template's `package.json` is flavour-neutral (only shared deps like `webiny`, `react` and
- * `@webiny/mcp`); each flavour setup injects its own packages here. Values can be `"latest"` — the
+ * The base template's `package.json` is hosting-neutral (only shared deps like `webiny`, `react` and
+ * `@webiny/mcp`); each hosting-type setup injects its own packages here. Values can be `"latest"` — the
  * later `SetWebinyPackageVersions` step rewrites every `@webiny/*` / `webiny` entry to the actual CWP
  * version, so only the presence of the dependency matters at this point.
  */

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/aws/SetupAwsWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/aws/SetupAwsWebinyProject.ts
@@ -21,7 +21,7 @@ export class SetupAwsWebinyProject {
 
         fs.copySync(storageTemplatePath, projectRootFolderPath);
 
-        // AWS flavour dependencies: the `webiny` CLI (AWS bin) + Cognito (AWS-managed IdP).
+        // AWS hosting-type dependencies: the `webiny` CLI (AWS bin) + Cognito (AWS-managed IdP).
         addProjectDependencies(projectRootFolderPath, {
             "@webiny/cli-aws": "latest",
             "@webiny/cognito": "latest"

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runHostingTypePrompt.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/runHostingTypePrompt.ts
@@ -1,8 +1,8 @@
 import inquirer from "inquirer";
 
-export type Flavour = "aws" | "server";
+export type HostingType = "aws" | "server";
 
-const FLAVOUR_OPTIONS: { value: Flavour; name: string }[] = [
+const HOSTING_TYPE_OPTIONS: { value: HostingType; name: string }[] = [
     {
         value: "aws",
         name: "AWS (Lambda, DynamoDB, API Gateway — deployed with Pulumi)"
@@ -13,19 +13,19 @@ const FLAVOUR_OPTIONS: { value: Flavour; name: string }[] = [
     }
 ];
 
-export const runFlavourPrompt = async (): Promise<Flavour> => {
+export const runHostingTypePrompt = async (): Promise<HostingType> => {
     console.log("How would you like to host your new Webiny project?");
     console.log();
 
-    const { flavour } = await inquirer.prompt<{ flavour: Flavour }>([
+    const { hostingType } = await inquirer.prompt<{ hostingType: HostingType }>([
         {
             type: "select",
-            name: "flavour",
+            name: "hostingType",
             default: "aws",
             message: "Please choose how you would like to host your project:",
-            choices: FLAVOUR_OPTIONS
+            choices: HOSTING_TYPE_OPTIONS
         }
     ]);
 
-    return flavour;
+    return hostingType;
 };

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
@@ -7,7 +7,7 @@ import { ServerProjectParams } from "./types.js";
 import { GetTemplatesFolderPath } from "../../../../services/GetTemplatesFolderPath.js";
 import { addProjectDependencies } from "../addProjectDependencies.js";
 
-const DOT_ENV = `# Self-hosted (server) flavour environment variables.
+const DOT_ENV = `# Self-hosted (server) hosting-type environment variables.
 # The values below are safe dev defaults. CHANGE the secrets before any real deployment.
 
 # Ports the API and Admin servers listen on during \`webiny watch\` / \`webiny serve\`.
@@ -42,9 +42,9 @@ export class SetupServerWebinyProject {
 
         fs.copySync(storageTemplatePath, projectRootFolderPath);
 
-        // Server (self-hosted) flavour dependencies. The `webiny` CLI (server bin) sets
-        // WEBINY_FLAVOUR=server; `@webiny/project-server` provides the server `Infra.*` extensions and
-        // resolves `@webiny/project-server-template` (the workspace base config) at build time;
+        // Server (self-hosted) hosting-type dependencies. The `webiny` CLI (server bin) sets
+        // WEBINY_HOSTING_TYPE=server; `@webiny/project-server` provides the server `Infra.*` extensions
+        // and resolves `@webiny/project-server-template` (the workspace base config) at build time;
         // `@webiny/self-hosted-auth` is the built-in JWT identity provider (replaces Cognito).
         addProjectDependencies(projectRootFolderPath, {
             "@webiny/cli-server": "latest",
@@ -53,7 +53,7 @@ export class SetupServerWebinyProject {
             "@webiny/self-hosted-auth": "latest"
         });
 
-        // Write the `.env` with the server-flavour dev defaults.
+        // Write the `.env` with the server hosting-type dev defaults.
         fs.writeFileSync(path.join(projectRootFolderPath, ".env"), DOT_ENV);
 
         return serverArgs;

--- a/packages/create-webiny-project/src/types.ts
+++ b/packages/create-webiny-project/src/types.ts
@@ -8,8 +8,8 @@ export interface CliParams {
     /** Name of template to use (defaults to "aws") */
     template: string;
 
-    /** Deployment flavour: "aws" or "server" (self-hosted). Used in non-interactive mode. */
-    flavour: "aws" | "server";
+    /** Hosting type: "aws" or "server" (self-hosted). Used in non-interactive mode. */
+    hostingType: "aws" | "server";
 
     /** JSON string with template-specific options */
     templateOptions: string | null;

--- a/packages/project-aws/src/extensions/ProjectAws.tsx
+++ b/packages/project-aws/src/extensions/ProjectAws.tsx
@@ -56,7 +56,7 @@ export const ProjectAws = () => {
             <ApiBeforeDeploy src={p("ProjectAws/EnsureCoreDeployedBeforeApiDeploy.js")} />
             <CoreBeforeDeploy src={p("ProjectAws/ValidateProductionPulumiState.js")} />
 
-            {/* Deploy-time hooks — server flavour has no deploy command, so these are AWS-only */}
+            {/* Deploy-time hooks — server hosting type has no deploy command, so these are AWS-only */}
             <BeforeDeploy src={p("ProjectAws/EnsureTelemetryEnabledForOss.js")} />
             <BeforeDeploy src={p("ProjectAws/ValidateEncryptionBeforeDeploy.js")} />
             <AdminAfterDeploy src={p("ProjectAws/TelemetryNoLongerNewUser.js")} />

--- a/packages/project-aws/src/pulumi/utils/lambdaEnvVariables.ts
+++ b/packages/project-aws/src/pulumi/utils/lambdaEnvVariables.ts
@@ -15,7 +15,7 @@ export let sealEnvVariables: () => void;
 const variablesPromise = new Promise<EnvVariables>(resolve => {
     sealEnvVariables = () => {
         // The api runtime allowlist (WEBINY_/WCP_PROJECT_ENVIRONMENT/OKTA_/AUTH0_ + DEBUG) is shared
-        // with the self-hosted server flavour — see @webiny/project's pickApiRuntimeEnvVariables.
+        // with the self-hosted server hosting type — see @webiny/project's pickApiRuntimeEnvVariables.
         const baseVariables: EnvVariables = {
             ...pickApiRuntimeEnvVariables(),
             // This flag means that Lambda was deployed using the new Pulumi Apps architecture.

--- a/packages/project-server-template/template/appTemplates/api/graphql/src/index.ts
+++ b/packages/project-server-template/template/appTemplates/api/graphql/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * DI-native API GraphQL handler — self-hosted Node server flavour (SQL storage).
+ * DI-native API GraphQL handler — self-hosted Node server hosting type (SQL storage).
  *
  * The composition root lives in @webiny/api-event-handler-server-sql (`createSqlApiHandler`) —
  * the same shared, transport-agnostic request stack the AWS handler uses, over the Node HTTP server

--- a/packages/project-server-template/template/webiny.config.base.tsx
+++ b/packages/project-server-template/template/webiny.config.base.tsx
@@ -4,9 +4,9 @@ import { DefaultExtensions } from "@webiny/project-template-base";
 import { Extensions as WebinyConfigTsx } from "../../webiny.config.js";
 
 /**
- * Server-flavour project composition. Mirrors the AWS flavour's base config, but renders the
- * flavour-agnostic `<ProjectServer />` (build/watch hooks only) instead of `<ProjectAws />` — there
- * is no Pulumi, no stack output, no `deploy`, and no deploy environments in the self-hosted flavour.
+ * Server hosting-type project composition. Mirrors the AWS hosting type's base config, but renders the
+ * hosting-agnostic `<ProjectServer />` (build/watch hooks only) instead of `<ProjectAws />` — there
+ * is no Pulumi, no stack output, no `deploy`, and no deploy environments in the self-hosted hosting type.
  * The self-hosted IdP and any other extensions come in via the user's `webiny.config.tsx`.
  */
 export const Extensions = () => {

--- a/packages/project-server/src/extensions/ApiUrl.tsx
+++ b/packages/project-server/src/extensions/ApiUrl.tsx
@@ -3,21 +3,21 @@ import { z } from "zod";
 import { defineExtension, BuildParam } from "@webiny/project/extensions/index.js";
 
 /**
- * Configure the self-hosted (server) flavour's own public API origin.
+ * Configure the self-hosted (server) hosting type's own public API origin.
  *
  * Emitted as the API build parameter `WEBINY_API_URL`, read via `BuildParams` by api code that must
  * hand the client an absolute, reachable URL back to this API — e.g. the file-manager upload endpoint
  * and the file `srcPrefix`. It is a BUILD PARAM (not a `process.env` read in api runtime code): the
  * value is resolved once here, at build time, from whatever env the config chooses.
  *
- * AWS derives this from stack output (CloudFront domain) at deploy time; the self-hosted flavour has
+ * AWS derives this from stack output (CloudFront domain) at deploy time; the self-hosted hosting type has
  * no deploy step, so the origin is configured explicitly. Counterpart to `Admin.ApiUrl` (which points
  * the admin bundle at the API); this one tells the API its own origin.
  */
 export const ApiUrl = defineExtension({
     type: "Infra/ApiUrl",
     tags: { runtimeContext: "project" },
-    description: "Configure the server flavour's own public API origin.",
+    description: "Configure the server hosting type's own public API origin.",
     paramsSchema: z.object({
         url: z
             .string()

--- a/packages/project-server/src/extensions/FileStorage.tsx
+++ b/packages/project-server/src/extensions/FileStorage.tsx
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { defineExtension, BuildParam } from "@webiny/project/extensions/index.js";
 
 /**
- * Configure the self-hosted (server) flavour's local file storage (uploaded files) + upload secret.
+ * Configure the self-hosted (server) hosting type's local file storage (uploaded files) + upload secret.
  *
  * Emitted as the API build parameters `WEBINY_LOCAL_STORAGE_PATH` (the on-disk directory uploaded
  * files are written to and served from) and `WEBINY_UPLOAD_SECRET` (used to sign upload tokens),
@@ -16,12 +16,13 @@ import { defineExtension, BuildParam } from "@webiny/project/extensions/index.js
  * A relative storage path is resolved against the project root (not the disposable app workspace), so
  * uploaded files survive rebuilds — same rule as `Infra.Sqlite`.
  *
- * AWS-flavour counterpart concept: the S3 bucket (`ApiFileManager`).
+ * AWS hosting-type counterpart concept: the S3 bucket (`ApiFileManager`).
  */
 export const FileStorage = defineExtension({
     type: "Infra/FileStorage",
     tags: { runtimeContext: "project" },
-    description: "Configure the server flavour's local file storage directory and upload secret.",
+    description:
+        "Configure the server hosting type's local file storage directory and upload secret.",
     paramsSchema: z.object({
         path: z
             .string()

--- a/packages/project-server/src/extensions/Postgres.tsx
+++ b/packages/project-server/src/extensions/Postgres.tsx
@@ -59,7 +59,7 @@ const SslEnvVars = ({ ssl }: SslEnvVarsProps) => {
 export const Postgres = defineExtension({
     type: "Infra/Postgres",
     tags: { runtimeContext: "project" },
-    description: "Configure the server flavour's Postgres database connection.",
+    description: "Configure the server hosting type's Postgres database connection.",
     paramsSchema: z.object({
         host: z.string().describe("Postgres server hostname."),
         port: z.number().describe("Postgres server port."),

--- a/packages/project-server/src/extensions/ProjectServer.tsx
+++ b/packages/project-server/src/extensions/ProjectServer.tsx
@@ -5,7 +5,7 @@ import { createPathResolver } from "@webiny/project";
 const p = createPathResolver(import.meta.dirname);
 
 /**
- * Server-flavour counterpart to project-aws's `<ProjectAws />`: renders the flavour-agnostic
+ * Server hosting-type counterpart to project-aws's `<ProjectAws />`: renders the hosting-agnostic
  * `<Project />` (build/watch hooks) and registers the built-in extension definitions so the config
  * hydrator can resolve built-in extension types (Project/EnvVar, Admin/ApiUrl, hooks, ...). There is
  * no Pulumi, stack output, or deploy command here, so none of the AWS-only pieces apply.

--- a/packages/project-server/src/extensions/Sqlite.tsx
+++ b/packages/project-server/src/extensions/Sqlite.tsx
@@ -4,20 +4,20 @@ import { z } from "zod";
 import { defineExtension, EnvVar } from "@webiny/project/extensions/index.js";
 
 /**
- * Configure the self-hosted (server) flavour's SQLite database file.
+ * Configure the self-hosted (server) hosting type's SQLite database file.
  *
  * Baked into the api runtime as `WEBINY_SQL_FILENAME`, which the api handler reads for its Knex
  * connection. A relative path is resolved against the project root (not the disposable app
  * workspace), so the DB survives rebuilds. When omitted, the api server defaults to
  * `<projectRoot>/.webiny/server.sqlite`.
  *
- * AWS-flavour counterpart concept: `Infra.OpenSearch` / `DatabaseSetup`. Future SQL engines
+ * AWS hosting-type counterpart concept: `Infra.OpenSearch` / `DatabaseSetup`. Future SQL engines
  * (Postgres, MySQL) would be sibling `Infra.*` extensions.
  */
 export const Sqlite = defineExtension({
     type: "Infra/Sqlite",
     tags: { runtimeContext: "project" },
-    description: "Configure the server flavour's SQLite database file.",
+    description: "Configure the server hosting type's SQLite database file.",
     paramsSchema: z.object({
         filename: z
             .string()

--- a/packages/project-server/src/extensions/definitions.ts
+++ b/packages/project-server/src/extensions/definitions.ts
@@ -7,13 +7,13 @@ import { Sqlite } from "./Sqlite.js";
 import { Postgres } from "./Postgres.js";
 
 /**
- * Built-in extension definitions the server flavour registers with the SDK (via
+ * Built-in extension definitions the server hosting type registers with the SDK (via
  * `<ExtensionDefinitions>` in the server `webiny.config.base.tsx`). Without this, `hydrateConfig`
  * can't resolve built-in extension types (e.g. `Project/EnvVar`, `Admin/ApiUrl`) and silently drops
  * them — which is how the admin API URL (baked as `WEBINY_ADMIN_API_URL`) went missing.
  *
  * Mirrors project-aws's `ProjectAws/definitions.ts`, minus the AWS/Pulumi-only definitions (there is
- * no Pulumi or deploy in the self-hosted flavour).
+ * no Pulumi or deploy in the self-hosted hosting type).
  */
 const definitions = [
     ...cliDefinitions,

--- a/packages/project-server/src/features/BuildServerProjectWorkspace.ts
+++ b/packages/project-server/src/features/BuildServerProjectWorkspace.ts
@@ -8,9 +8,9 @@ import {
 import { getServerTemplatesFolderPath } from "../utils/getServerTemplatesFolderPath.js";
 
 /**
- * Server-flavour counterpart to project-aws's BuildProjectWorkspace: after the base workspace is
+ * Server hosting-type counterpart to project-aws's BuildProjectWorkspace: after the base workspace is
  * built, copy the server `webiny.config.base.tsx` (which renders `<Project />`, not `<ProjectAws />`)
- * into the workspace, overwriting whatever a previous flavour may have left behind.
+ * into the workspace, overwriting whatever a previous hosting type may have left behind.
  */
 class BuildServerProjectWorkspaceImpl implements BuildProjectWorkspaceService.Interface {
     constructor(

--- a/packages/project-server/src/features/Watch/ServerWatch.ts
+++ b/packages/project-server/src/features/Watch/ServerWatch.ts
@@ -3,10 +3,10 @@ import { ServersWatcher } from "@webiny/project/features/Watch/watchers/ServersW
 import { runApiServer } from "../../serve/runApiServer.js";
 
 /**
- * Server-flavour counterpart to project-aws's `AwsWatch`: where AWS forwards Lambda invocations to
- * local code, the self-hosted flavour boots the built api handler as a live HTTP server that reloads
+ * Server hosting-type counterpart to project-aws's `AwsWatch`: where AWS forwards Lambda invocations to
+ * local code, the self-hosted hosting type boots the built api handler as a live HTTP server that reloads
  * on rebuild — so `webiny watch api` both compiles AND serves. Kept out of the CLI command (which
- * stays flavour-agnostic, like cli-aws) and composed only when the server flavour is registered.
+ * stays hosting-agnostic, like cli-aws) and composed only when the server hosting type is registered.
  */
 export class ServerWatch implements Watch.Interface {
     constructor(
@@ -23,7 +23,7 @@ export class ServerWatch implements Watch.Interface {
         }
 
         // Only the api app builds an HTTP server handler. Name-matched here, but isolated in this
-        // one flavour-owned place — swap for a capability check on the app model when available.
+        // one hosting-owned place — swap for a capability check on the app model when available.
         if (params.app !== "api") {
             return result;
         }

--- a/packages/project-server/src/infra.ts
+++ b/packages/project-server/src/infra.ts
@@ -16,10 +16,10 @@ import { FileStorage } from "./extensions/FileStorage.js";
 import { ApiUrl } from "./extensions/ApiUrl.js";
 
 /**
- * Server-flavour counterpart to project-aws's `Infra`, limited to what applies off-AWS. Omits the
+ * Server hosting-type counterpart to project-aws's `Infra`, limited to what applies off-AWS. Omits the
  * AWS-only surface (Pulumi, deploy, Lambda, stack outputs, custom domains, Vpc, OpenSearch,
  * blue/green) and the environments surface (`Env.*`, `ProductionEnvironments`) — the self-hosted
- * flavour has no notion of deploy environments. Only build/watch hooks for the api + admin apps,
+ * hosting type has no notion of deploy environments. Only build/watch hooks for the api + admin apps,
  * crypto config, env vars, and CI detection remain.
  */
 export const Infra = {
@@ -31,12 +31,12 @@ export const Infra = {
     // Kept top-level for backward compatibility (prefer Infra.Crypto.Encryption going forward).
     Encryption,
     EnvVar,
-    // Server-flavour SQL storage (engine-named, like Infra.OpenSearch on AWS).
+    // Server hosting-type SQL storage (engine-named, like Infra.OpenSearch on AWS).
     Sqlite,
     Postgres,
-    // Server-flavour local file storage (counterpart to the AWS S3 bucket).
+    // Server hosting-type local file storage (counterpart to the AWS S3 bucket).
     FileStorage,
-    // Server-flavour public API origin (baked as the WEBINY_API_URL build param).
+    // Server hosting-type public API origin (baked as the WEBINY_API_URL build param).
     ApiUrl,
     Ci: {
         Is: CiIs,

--- a/packages/project-server/src/registerServerProjectFeatures.ts
+++ b/packages/project-server/src/registerServerProjectFeatures.ts
@@ -6,20 +6,20 @@ import { serverServe } from "./serve/ServerServe.js";
 import { serveWithBuildChecks } from "./serve/ServeWithBuildChecks.js";
 
 export const registerServerProjectFeatures = (container: Container): void => {
-    // Replace the default (AWS) workspace builder with the server-flavour one.
+    // Replace the default (AWS) workspace builder with the server hosting-type one.
     // The server workspace has no Pulumi scaffolding — only app source templates.
     container.register(serverBuildAppWorkspaceService).inSingletonScope();
     // Copy the server `webiny.config.base.tsx` (renders <Project />, not <ProjectAws />) into the
-    // workspace, so none of the AWS deploy/Pulumi hooks are composed in the self-hosted flavour.
+    // workspace, so none of the AWS deploy/Pulumi hooks are composed in the self-hosted hosting type.
     container.registerDecorator(BuildServerProjectWorkspace);
     // The admin API URL is configured via `<Admin.ApiUrl>` in webiny.config.tsx (baked into the
     // bundle as WEBINY_ADMIN_API_URL), so no env-mutating watch hook is needed here.
     // Boot the built api handler as a live, reload-on-rebuild HTTP server during `watch api`
-    // (server-flavour counterpart to project-aws's Lambda invocation forwarding).
+    // (server hosting-type counterpart to project-aws's Lambda invocation forwarding).
     container.registerDecorator(serverWatch);
 
     // Serve built apps as long-running servers (`webiny-server serve`). Replace the base
-    // DefaultServe (which refuses) with the real server-flavour implementation, then decorate it so
+    // DefaultServe (which refuses) with the real server hosting-type implementation, then decorate it so
     // the required app builds are asserted before anything is served.
     container.register(serverServe).inSingletonScope();
     container.registerDecorator(serveWithBuildChecks);

--- a/packages/project-server/src/serve/ServerServe.ts
+++ b/packages/project-server/src/serve/ServerServe.ts
@@ -8,7 +8,7 @@ import { runApiServer } from "./runApiServer.js";
 import { runAdminServer } from "./runAdminServer.js";
 
 /**
- * Server-flavour Serve implementation: describes the server process(es) for the requested app(s) as
+ * Server hosting-type Serve implementation: describes the server process(es) for the requested app(s) as
  * a `ServersWatcher` (lazy — nothing spawns until the caller runs them) and returns it. Replaces the
  * base DefaultServe (which refuses). api = HTTP handler; admin = static SPA; no app = both. Build
  * checks run via a decorator (serveWithBuildChecks); terminal rendering + lifecycle are the caller's

--- a/packages/project-server/src/serve/runApiServer.ts
+++ b/packages/project-server/src/serve/runApiServer.ts
@@ -24,7 +24,7 @@ interface IRunApiServerOptions {
  * Run the built api handler as a live HTTP server.
  *
  * The api workspace compiles to `<workspace>/apps/api/graphql/build/handler.mjs`, which (for the
- * server flavour) exports the Node `http.Server` from `createServerHandler`. We copy a tiny runner
+ * server hosting type) exports the Node `http.Server` from `createServerHandler`. We copy a tiny runner
  * (`apiServerRunner.mjs`) next to it that imports the handler and calls `.listen(PORT)`, then spawn
  * it in an isolated child process. In watch mode we add `--watch-path <buildDir>` so every rebuild
  * restarts that child (a server crash never kills the watcher).
@@ -74,7 +74,7 @@ export async function runApiServer(
     const sqlFilename = process.env.WEBINY_SQL_FILENAME;
     if (!sqlFilename) {
         throw new Error(
-            `No database configured for the server flavour. Add ${'`<Infra.Sqlite filename="./.webiny/server.sqlite" />`'} ` +
+            `No database configured for the server hosting type. Add ${'`<Infra.Sqlite filename="./.webiny/server.sqlite" />`'} ` +
                 `to your webiny.config (or set WEBINY_SQL_FILENAME).`
         );
     }

--- a/packages/project-server/src/services/ServerBuildAppWorkspaceService.ts
+++ b/packages/project-server/src/services/ServerBuildAppWorkspaceService.ts
@@ -20,7 +20,7 @@ export class ServerBuildAppWorkspaceService implements BuildAppWorkspaceService.
     async execute(appName: GetApp.AppName, options: BuildAppWorkspaceService.Options = {}) {
         if (appName === "core") {
             throw new Error(
-                `The "core" app does not exist in server-flavour Webiny projects. Only "api" and "admin" are available.`
+                `The "core" app does not exist in server hosting-type Webiny projects. Only "api" and "admin" are available.`
             );
         }
 

--- a/packages/project-template-base/src/DefaultExtensions.tsx
+++ b/packages/project-template-base/src/DefaultExtensions.tsx
@@ -4,10 +4,10 @@ import { TenantManager } from "@webiny/tenant-manager";
 import { AiPowerups } from "@webiny/ai-powerups";
 
 /**
- * Default feature extensions every Webiny project gets, shared across flavours (aws + server). The
- * flavour-specific composition (`<ProjectAws />` / `<ProjectServer />`), any flavour-only extensions
+ * Default feature extensions every Webiny project gets, shared across hosting types (aws + server). The
+ * hosting-specific composition (`<ProjectAws />` / `<ProjectServer />`), any hosting-specific extensions
  * (e.g. `<Infra.ProductionEnvironments />`), and the user's `webiny.config.tsx` are added by each
- * flavour's `webiny.config.base.tsx`.
+ * hosting type's `webiny.config.base.tsx`.
  */
 export const DefaultExtensions = () => {
     return (

--- a/packages/project/src/ProjectSdk.ts
+++ b/packages/project/src/ProjectSdk.ts
@@ -78,8 +78,8 @@ export class ProjectSdk {
         const env = params.env || "";
         const variant = params.variant || "";
         const region = params.region || "";
-        const flavour = register?.name || "";
-        return `${env}:${variant}:${region}:${flavour}`;
+        const hostingType = register?.name || "";
+        return `${env}:${variant}:${region}:${hostingType}`;
     }
 
     // Project-related methods.

--- a/packages/project/src/abstractions/features/Serve.ts
+++ b/packages/project/src/abstractions/features/Serve.ts
@@ -8,7 +8,7 @@ import {
 export interface IServeParams {
     /**
      * App to serve. Omit to serve all servable apps at once. Which apps are servable (and how) is
-     * flavour-specific — the base flavour supports none.
+     * hosting-specific — the base hosting type supports none.
      */
     app?: GetApp.AppName;
 }

--- a/packages/project/src/abstractions/features/Watch.ts
+++ b/packages/project/src/abstractions/features/Watch.ts
@@ -29,7 +29,7 @@ export type IWatchResult = {
     packagesWatcher: PackagesWatcher;
     webinyConfigWatcher?: WebinyConfigWatcher;
     /**
-     * Long-running server process(es) the flavour attached to this watch session (e.g. the api HTTP
+     * Long-running server process(es) the hosting type attached to this watch session (e.g. the api HTTP
      * server). The serve-side counterpart to `packagesWatcher`; the caller (e.g. the CLI) renders +
      * awaits them alongside the build watchers.
      */

--- a/packages/project/src/createProjectSdkContainer.ts
+++ b/packages/project/src/createProjectSdkContainer.ts
@@ -146,7 +146,7 @@ export const createProjectSdkContainer = async (
     // Initialize project SDK.
     container.resolve(ProjectSdkParamsService).set(params);
 
-    // Allow flavour-specific registrations (e.g. project-aws, project-server).
+    // Allow hosting-specific registrations (e.g. project-aws, project-server).
     // Must run before workspace services execute so decorators are in place.
     register?.(container);
 

--- a/packages/project/src/extensions/AdminWebsocketsUrl.tsx
+++ b/packages/project/src/extensions/AdminWebsocketsUrl.tsx
@@ -6,7 +6,7 @@ import { EnvVar } from "./EnvVar.js";
 /**
  * Sets a dedicated WebSocket URL for the Admin app, baked into the admin bundle as
  * `WEBINY_ADMIN_WS_API_URL`. This is optional: when omitted, the admin derives the WebSocket URL
- * from the API URL (same origin, http -> ws), which is what the self-hosted server flavour needs by
+ * from the API URL (same origin, http -> ws), which is what the self-hosted server hosting type needs by
  * default. Set it only when WebSockets are served from a different origin than the API. Because the
  * config is evaluated at build time, the value can come from any env var the user chooses, e.g.
  * `<Admin.WebsocketsUrl url={process.env.MY_WS_URL} />`.

--- a/packages/project/src/features/Serve/Serve.ts
+++ b/packages/project/src/features/Serve/Serve.ts
@@ -2,13 +2,13 @@ import { createImplementation } from "@webiny/di";
 import { Serve } from "~/abstractions/index.js";
 
 /**
- * Base (flavour-agnostic) Serve implementation. There is no cloud-agnostic notion of "serving" a
- * built app — the AWS flavour deploys, it doesn't serve locally — so this default refuses. Flavours
- * that DO support serving (e.g. the self-hosted server flavour) replace this implementation.
+ * Base (hosting-agnostic) Serve implementation. There is no cloud-agnostic notion of "serving" a
+ * built app — the AWS hosting type deploys, it doesn't serve locally — so this default refuses. Hosting types
+ * that DO support serving (e.g. the self-hosted server hosting type) replace this implementation.
  */
 export class DefaultServe implements Serve.Interface {
     async execute(): Promise<Serve.Result> {
-        throw new Error(`The "serve" command is not supported in this project flavour.`);
+        throw new Error(`The "serve" command is not supported in this project hosting type.`);
     }
 }
 

--- a/packages/project/src/features/Watch/watchers/ServersWatcher.ts
+++ b/packages/project/src/features/Watch/watchers/ServersWatcher.ts
@@ -3,7 +3,7 @@ import { type ChildProcess } from "node:child_process";
 /**
  * A server process the project layer knows how to spawn (port resolution, runner, env), but does NOT
  * spawn until the caller runs it — the serve-side counterpart to a build watcher process. `spawn` is
- * flavour-provided and lazy so nothing binds a port until `run()` is called.
+ * hosting-provided and lazy so nothing binds a port until `run()` is called.
  */
 export interface IServerProcessSpec {
     name: string;

--- a/packages/project/src/utils/apiRuntimeEnv.ts
+++ b/packages/project/src/utils/apiRuntimeEnv.ts
@@ -1,7 +1,7 @@
 /**
  * Environment variable name prefixes that are safe to expose to the api RUNTIME — as opposed to
  * build-time-only vars (notably `WCP_PROJECT_LICENSE`, which the runtime deliberately re-fetches a
- * fresh copy of). This is the single source of truth shared by both flavours: the AWS Lambda sets
+ * fresh copy of). This is the single source of truth shared by both hosting types: the AWS Lambda sets
  * exactly these on the function, and the self-hosted server spawns its api process with exactly
  * these. `WCP_PROJECT_LICENSE` is excluded simply by not being listed.
  */

--- a/packages/self-hosted-auth/src/SelfHostedAuth.tsx
+++ b/packages/self-hosted-auth/src/SelfHostedAuth.tsx
@@ -6,7 +6,7 @@ import { AdminExtension, EnvVar, BuildParam } from "@webiny/project/extensions/i
 /**
  * Config-time extension rendered in `webiny.config.tsx` (like `Cognito`). It only wires things by
  * path/env/build-param — it does NOT import the admin app code, so `webiny.config.tsx` stays
- * lightweight. The API side (SelfHostedAuthApiFeature) is registered by the server flavour's
+ * lightweight. The API side (SelfHostedAuthApiFeature) is registered by the server hosting type's
  * request handler; it reads the signing secret from the `SelfHostedAuthSigningSecret` build param.
  */
 export const SelfHostedAuth = defineExtension({

--- a/webiny.config.aws.tsx
+++ b/webiny.config.aws.tsx
@@ -3,7 +3,7 @@ import { Infra } from "webiny/extensions";
 import { Cognito } from "@webiny/cognito";
 
 /**
- * AWS-only extensions, rendered by webiny.config.tsx when WEBINY_FLAVOUR !== "server".
+ * AWS-only extensions, rendered by webiny.config.tsx when WEBINY_HOSTING_TYPE !== "server".
  * Everything AWS/Pulumi-specific lives here so it never leaks into the server flavour.
  */
 export const AwsExtensions = () => {

--- a/webiny.config.server.tsx
+++ b/webiny.config.server.tsx
@@ -6,7 +6,7 @@ import { Infra } from "@webiny/project-server";
 import { SelfHostedAuth } from "@webiny/self-hosted-auth";
 
 /**
- * Server-only (self-hosted) extensions, rendered by webiny.config.tsx when WEBINY_FLAVOUR === "server".
+ * Server-only (self-hosted) extensions, rendered by webiny.config.tsx when WEBINY_HOSTING_TYPE === "server".
  * No Pulumi / no AWS infra here.
  */
 export const ServerExtensions = () => {

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -5,12 +5,12 @@ import { AwsExtensions } from "./webiny.config.aws.js";
 import { ServerExtensions } from "./webiny.config.server.js";
 
 /**
- * In this monorepo we develop both flavours. The CLI bin sets WEBINY_FLAVOUR ("aws" via `webiny`,
- * "server" via `webiny-server`). Shared extensions live here; the flavour-specific block below pulls
- * in AWS-only (webiny.config.aws.tsx) or server-only (webiny.config.server.tsx) extensions so neither
- * leaks into the other flavour.
+ * In this monorepo we develop both hosting types. The CLI bin sets WEBINY_HOSTING_TYPE ("aws" via
+ * `webiny`, "server" via `webiny-server`). Shared extensions live here; the hosting-specific block
+ * below pulls in AWS-only (webiny.config.aws.tsx) or server-only (webiny.config.server.tsx)
+ * extensions so neither leaks into the other hosting type.
  */
-const isServer = process.env.WEBINY_FLAVOUR === "server";
+const isServer = process.env.WEBINY_HOSTING_TYPE === "server";
 
 export const Extensions = () => {
     return (
@@ -81,7 +81,7 @@ export const Extensions = () => {
                 replyTo={"No-reply <no-reply@webiny.com>"}
             />
 
-            {/* Flavour-specific 👇 (AWS: Pulumi + Cognito; Server: Admin.ApiUrl + SelfHostedAuth) */}
+            {/* Hosting-specific 👇 (AWS: Pulumi + Cognito; Server: Admin.ApiUrl + SelfHostedAuth) */}
             {isServer ? <ServerExtensions /> : <AwsExtensions />}
         </>
     );


### PR DESCRIPTION
## Summary

Renames the AWS-vs-self-hosted **"flavour"** concept to **"hostingType"** — the term "flavour" wasn't well understood by the team, and user-facing copy already says "hosting".

Follow-up to #5454 (which introduced the hosting-type prompt in `create-webiny-project` and flagged this rename in its Terminology note).

## Naming decisions

- **Code identifier**: `flavour` / `Flavour` → `hostingType` / `HostingType`
- **Env var**: `WEBINY_FLAVOUR` → `WEBINY_HOSTING_TYPE`
- **Values unchanged**: `"aws"` / `"server"`

## Changes

- **Env var** — writers `cli-aws` / `cli-server` bins; reader monorepo root `webiny.config.tsx`. No *shipped* project template reads the env var (the server template is single-hosting-type), so **generated projects are unaffected**.
- **`create-webiny-project`** — `--flavour` → `--hosting-type`; `CliParams.flavour` → `hostingType`; `Flavour` type → `HostingType`; `runFlavourPrompt` → `runHostingTypePrompt` (file renamed); prompt field `flavour` → `hostingType`.
- **Comments/strings** — reworded "flavour" out of ~35 files across the server + shared packages (`hosting-agnostic`, `hosting-specific`, "server hosting type", etc.).

## Intentionally left as-is

The unrelated **storage** "flavour" (ddb / opensearch / sql) in `api-headless-cms-tasks*` and `api-background-tasks-os` is a separate concept from hosting type and was **not** touched.

## Testing

- `tsc -b` clean on `@webiny/create-webiny-project` and `@webiny/project` (the packages with identifier changes; the rest are comment-only).
- Dry-ran both hosting types (non-interactive) after the rename — `server` and `aws` scaffold the correct deps + `.env` as before.
- `adio` ✅, `lint` ✅, `format` ✅. Repo-wide sweep confirms no `WEBINY_FLAVOUR` or old CWP identifiers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)