### PR TITLE
fix(project-aws): generate DI HttpRoute registration for Api/Route scaffolding

### DIFF
--- a/packages/project-aws/src/extensions/ApiRoute.tsx
+++ b/packages/project-aws/src/extensions/ApiRoute.tsx
@@ -13,17 +13,6 @@ const p = createPathResolver(import.meta.dirname);
 
 const HTTP_METHODS = ["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT", "OPTIONS", "ANY"] as const;
 
-const METHOD_HANDLER: Record<string, string> = {
-    DELETE: "onDelete",
-    GET: "onGet",
-    HEAD: "onHead",
-    PATCH: "onPatch",
-    POST: "onPost",
-    PUT: "onPut",
-    OPTIONS: "onOptions",
-    ANY: "onAll"
-};
-
 export const ApiRoute = defineExtension({
     type: "Api/Route",
     tags: { runtimeContext: "app-build", appName: "api" },
@@ -33,7 +22,10 @@ export const ApiRoute = defineExtension({
         return z.object({
             path: z.string().startsWith("/"),
             method: z.enum(HTTP_METHODS),
-            // TODO: add zodSrcPath abstraction validation once Route abstraction is wired to zodSrcPath.
+            // The `src` file must default-export an HttpRoute implementation
+            // (HttpRoute.createImplementation from @webiny/event-handler-core), the same shape as
+            // the framework's own routes (e.g. createCmsRoute). Its `method`/`path` must match the
+            // `method`/`path` params here (used to configure the API Gateway route).
             src: zodSrcPath({ project }),
             routeName: z.string().optional()
         });
@@ -87,50 +79,15 @@ export const ApiRoute = defineExtension({
             });
         }
 
-        // Ensure createRoute and Route are imported from @webiny/handler.
-        const handlerImportPath = "@webiny/handler";
-        const existingHandlerImport = source.getImportDeclaration(handlerImportPath);
-        const requiredHandlerImports = ["createRoute", "Route"];
-        if (!existingHandlerImport) {
-            const lastIdx =
-                source
-                    .getImportDeclarations()
-                    [source.getImportDeclarations().length - 1].getChildIndex() + 1;
-            source.insertImportDeclaration(lastIdx, {
-                namedImports: requiredHandlerImports,
-                moduleSpecifier: handlerImportPath
-            });
-        } else {
-            const present = existingHandlerImport.getNamedImports().map(i => i.getName());
-            for (const name of requiredHandlerImports) {
-                if (!present.includes(name)) {
-                    existingHandlerImport.addNamedImport(name);
-                }
-            }
-        }
-
-        const onMethod = METHOD_HANDLER[params.method];
-        const routePath = params.path as `/${string}`;
-
         const pluginsArray = source.getFirstDescendant(node =>
             Node.isArrayLiteralExpression(node)
         ) as ArrayLiteralExpression;
 
-        // Register factory in DI container.
+        // Register the route's HttpRoute implementation in the DI container. The DI HttpRouter
+        // resolves every registered HttpRoute and dispatches by matching the request method/path
+        // against each route's own `method`/`path` — no explicit route wiring needed.
         pluginsArray.addElement(
             `\ncreateRegisterExtensionPlugin(ctx => {\n\tregisterExtension(ctx.container, ${alias});\n})`
-        );
-
-        // Register Fastify route with hardcoded path/method.
-        // We use resolveAll(Route) + instanceof to find the correct handler when multiple
-        // Api.Route extensions are registered.
-        pluginsArray.addElement(
-            `\ncreateRoute(({ ${onMethod}, context }) => {\n` +
-                `\t${onMethod}("${routePath}", async (request, reply) => {\n` +
-                `\t\tconst instance = context.container.resolveAll(Route).find(i => i instanceof ${alias})!;\n` +
-                `\t\treturn instance.execute(request, reply);\n` +
-                `\t});\n` +
-                `})`
         );
 
         await source.save();


### PR DESCRIPTION
## Bug

The `Api/Route` extension scaffold (`ApiRoute.tsx`) generated:
```ts
import { createRoute, Route } from "@webiny/handler";
...
createRoute(({ onGet, context }) => {
  onGet("/path", async (request, reply) => {
    const instance = context.container.resolveAll(Route).find(i => i instanceof ApiRoute_x)!;
    return instance.execute(request, reply);
  });
});
```
But `createRoute` and `Route` were **removed** in the Fastify→DI migration (`packages/handler/src/exports/api.ts`: *"Route abstraction was removed… use IHttpRoute from @webiny/event-handler-core"*). So any custom `Api/Route` extension emitted app code that doesn't compile.

## Fix

Emit the current DI route idiom — the same one the framework's own routes use (`createCmsRoute`, `WebsiteBuilderRedirectsRoute`):

- The route `src` default-exports an `HttpRoute` implementation (`HttpRoute.createImplementation` from `@webiny/event-handler-core`).
- The scaffold registers it: `createRegisterExtensionPlugin(ctx => registerExtension(ctx.container, ApiRoute_x))`.
- The DI `HttpRouter` resolves every registered `HttpRoute` and dispatches by matching `method`/`path`, so the old `createRoute`/Fastify-`onGet`/`resolveAll(Route)+instanceof` wiring is obsolete and removed (along with the `METHOD_HANDLER` map).

`method`/`path` params stay — `RegisterRoutesPulumi` reads them to configure the API Gateway route. Documented in the params schema that the route's own `method`/`path` must match.

## Notes

- project-aws has no extension-scaffold test harness; verified by build + parity with the working route idiom.
- No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)