### PR TITLE
feat: image crop/hotspot editor UI + File Manager integration

### DIFF
--- a/packages/admin-ui/src/ImageEditor/AspectRatioPreview.tsx
+++ b/packages/admin-ui/src/ImageEditor/AspectRatioPreview.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { getPreviewStyles } from "./geometry.js";
+import type { ImageEditorAspectRatio, ImageEditorCrop, ImageEditorHotspot } from "./types.js";
+
+interface AspectRatioPreviewProps {
+    src: string;
+    imageWidth: number;
+    imageHeight: number;
+    crop: ImageEditorCrop | undefined;
+    hotspot: ImageEditorHotspot | undefined;
+    aspectRatio: ImageEditorAspectRatio;
+}
+
+// Fixed preview height (px). Each thumbnail keeps this height regardless of how
+// many are shown; the width is derived from the aspect ratio.
+const PREVIEW_HEIGHT = 120;
+
+/**
+ * A single live preview showing how the current crop + hotspot renders at one
+ * target aspect ratio. Uses the shared preview geometry so it matches the site.
+ */
+export const AspectRatioPreview = ({
+    src,
+    imageWidth,
+    imageHeight,
+    crop,
+    hotspot,
+    aspectRatio
+}: AspectRatioPreviewProps) => {
+    const styles = getPreviewStyles(imageWidth, imageHeight, crop, hotspot, aspectRatio.ratio);
+    const width = Math.round(PREVIEW_HEIGHT * aspectRatio.ratio);
+
+    return (
+        <div className={"flex flex-col items-center gap-xs"}>
+            <div
+                className={
+                    "relative overflow-hidden rounded-sm border border-neutral-dimmed bg-neutral-light"
+                }
+                style={{ width: `${width}px`, height: `${PREVIEW_HEIGHT}px` }}
+            >
+                <img src={src} alt={""} style={styles.image} draggable={false} />
+            </div>
+            <span className={"text-sm text-neutral-strong"}>{aspectRatio.label}</span>
+        </div>
+    );
+};

--- a/packages/admin-ui/src/ImageEditor/CropHotspotEditor.tsx
+++ b/packages/admin-ui/src/ImageEditor/CropHotspotEditor.tsx
@@ -1,0 +1,466 @@
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Select } from "~/Select/index.js";
+import { Text } from "~/Text/index.js";
+import { SectionLabel } from "./SectionLabel.js";
+import { DEFAULT_ASPECT_RATIOS } from "./types.js";
+import type { ImageEditorCrop, ImageEditorHotspot, ImageEditorImage } from "./types.js";
+
+interface CropHotspotEditorProps {
+    image: ImageEditorImage;
+    crop: ImageEditorCrop | undefined;
+    hotspot: ImageEditorHotspot | undefined;
+    onChangeCrop: (crop: ImageEditorCrop) => void;
+    onChangeHotspot: (hotspot: ImageEditorHotspot) => void;
+}
+
+/** Crop rectangle in edge positions (0..1): left/top/right/bottom, left<right, top<bottom. */
+interface Edges {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+type Handle = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+
+const MIN = 0.05;
+const FREE = "free";
+
+// Canvas fits within this box (px), preserving the image aspect ratio, so tall
+// images don't take up the full screen height.
+const MAX_CANVAS_WIDTH = 640;
+const MAX_CANVAS_HEIGHT = 460;
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+const cropToEdges = (crop: ImageEditorCrop | undefined): Edges => ({
+    left: clamp01(crop?.left ?? 0),
+    top: clamp01(crop?.top ?? 0),
+    right: 1 - clamp01(crop?.right ?? 0),
+    bottom: 1 - clamp01(crop?.bottom ?? 0)
+});
+
+const edgesToCrop = (e: Edges): ImageEditorCrop => ({
+    top: e.top,
+    left: e.left,
+    bottom: 1 - e.bottom,
+    right: 1 - e.right
+});
+
+// Which edges each handle moves.
+const HANDLE_EDGES: Record<Handle, Array<keyof Edges>> = {
+    nw: ["top", "left"],
+    n: ["top"],
+    ne: ["top", "right"],
+    e: ["right"],
+    se: ["bottom", "right"],
+    s: ["bottom"],
+    sw: ["bottom", "left"],
+    w: ["left"]
+};
+
+const CORNER_HANDLES: Handle[] = ["nw", "ne", "se", "sw"];
+const EDGE_HANDLES: Handle[] = ["n", "e", "s", "w"];
+
+const clampHotspot = (h: ImageEditorHotspot | undefined, e: Edges): ImageEditorHotspot => ({
+    x: Math.min(e.right, Math.max(e.left, h?.x ?? (e.left + e.right) / 2)),
+    y: Math.min(e.bottom, Math.max(e.top, h?.y ?? (e.top + e.bottom) / 2)),
+    width: h?.width ?? 1,
+    height: h?.height ?? 1
+});
+
+export const CropHotspotEditor = ({
+    image,
+    crop,
+    hotspot,
+    onChangeCrop,
+    onChangeHotspot
+}: CropHotspotEditorProps) => {
+    const surfaceRef = useRef<HTMLDivElement>(null);
+    const dragRef = useRef<
+        | { mode: "focal" }
+        | { mode: `resize:${Handle}` }
+        | { mode: "move"; startPointer: { x: number; y: number }; startEdges: Edges }
+        | null
+    >(null);
+    const [aspectId, setAspectId] = React.useState<string>(FREE);
+
+    // Measure the available width so we can fit the canvas into a max box while
+    // preserving the image aspect ratio (keeps the box == image aspect, which the
+    // pointer coordinate mapping relies on).
+    const wrapperRef = useRef<HTMLDivElement>(null);
+    const [availWidth, setAvailWidth] = useState(0);
+
+    useLayoutEffect(() => {
+        const el = wrapperRef.current;
+        if (!el) {
+            return;
+        }
+        const measure = () => setAvailWidth(el.getBoundingClientRect().width);
+        measure();
+        if (typeof ResizeObserver === "undefined") {
+            return;
+        }
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    const imageRatio = (image.width || 1) / (image.height || 1);
+    const surfaceStyle = useMemo<React.CSSProperties>(() => {
+        if (availWidth <= 0) {
+            return {
+                width: "100%",
+                aspectRatio: `${image.width || 1} / ${image.height || 1}`,
+                maxHeight: `${MAX_CANVAS_HEIGHT}px`
+            };
+        }
+        let width = Math.min(availWidth, MAX_CANVAS_WIDTH);
+        let height = width / imageRatio;
+        if (height > MAX_CANVAS_HEIGHT) {
+            height = MAX_CANVAS_HEIGHT;
+            width = height * imageRatio;
+        }
+        return { width: `${width}px`, height: `${height}px` };
+    }, [availWidth, imageRatio, image.width, image.height]);
+
+    const edges = useMemo(() => cropToEdges(crop), [crop]);
+    const ratio = DEFAULT_ASPECT_RATIOS.find(ar => ar.id === aspectId)?.ratio ?? null;
+
+    const aspectOptions = useMemo(
+        () => [
+            { label: "Free", value: FREE },
+            ...DEFAULT_ASPECT_RATIOS.map(ar => ({ label: ar.label, value: ar.id }))
+        ],
+        []
+    );
+
+    const toNorm = useCallback((clientX: number, clientY: number) => {
+        const rect = surfaceRef.current!.getBoundingClientRect();
+        return {
+            x: clamp01((clientX - rect.left) / rect.width),
+            y: clamp01((clientY - rect.top) / rect.height)
+        };
+    }, []);
+
+    const commitEdges = useCallback(
+        (next: Edges) => {
+            onChangeCrop(edgesToCrop(next));
+            // Keep the focal point inside the (new) crop.
+            onChangeHotspot(clampHotspot(hotspot, next));
+        },
+        [onChangeCrop, onChangeHotspot, hotspot]
+    );
+
+    const resizeFree = (handle: Handle, p: { x: number; y: number }): Edges => {
+        const moves = HANDLE_EDGES[handle];
+        const next = { ...edges };
+        if (moves.includes("left")) {
+            next.left = Math.min(p.x, next.right - MIN);
+        }
+        if (moves.includes("right")) {
+            next.right = Math.max(p.x, next.left + MIN);
+        }
+        if (moves.includes("top")) {
+            next.top = Math.min(p.y, next.bottom - MIN);
+        }
+        if (moves.includes("bottom")) {
+            next.bottom = Math.max(p.y, next.top + MIN);
+        }
+        return next;
+    };
+
+    const resizeLocked = (handle: Handle, p: { x: number; y: number }, r: number): Edges => {
+        const moves = HANDLE_EDGES[handle];
+        // `r` is a display (pixel) aspect ratio, but the crop is stored in normalized
+        // image coordinates. Convert so the on-screen crop actually has ratio `r`.
+        const rNorm = r / imageRatio;
+        // Anchor is the opposite corner (fixed).
+        const anchorX = moves.includes("left") ? edges.right : edges.left;
+        const anchorY = moves.includes("top") ? edges.bottom : edges.top;
+        const dirX = moves.includes("left") ? -1 : 1;
+        const dirY = moves.includes("top") ? -1 : 1;
+
+        const maxW = dirX > 0 ? 1 - anchorX : anchorX;
+        const maxH = dirY > 0 ? 1 - anchorY : anchorY;
+
+        let w = Math.abs(p.x - anchorX);
+        let h = w / rNorm;
+        if (h > Math.abs(p.y - anchorY)) {
+            // The vertical drag is the limiting axis.
+            h = Math.abs(p.y - anchorY);
+            w = h * rNorm;
+        }
+        // Fit inside the image while keeping the ratio.
+        w = Math.min(w, maxW);
+        h = w / rNorm;
+        if (h > maxH) {
+            h = maxH;
+            w = h * rNorm;
+        }
+        w = Math.max(w, MIN);
+        h = Math.max(h, MIN);
+
+        const next = { ...edges };
+        if (dirX > 0) {
+            next.left = anchorX;
+            next.right = anchorX + w;
+        } else {
+            next.right = anchorX;
+            next.left = anchorX - w;
+        }
+        if (dirY > 0) {
+            next.top = anchorY;
+            next.bottom = anchorY + h;
+        } else {
+            next.bottom = anchorY;
+            next.top = anchorY - h;
+        }
+        return next;
+    };
+
+    const moveCrop = (startEdges: Edges, dx: number, dy: number): Edges => {
+        const w = startEdges.right - startEdges.left;
+        const h = startEdges.bottom - startEdges.top;
+        const left = Math.min(Math.max(startEdges.left + dx, 0), 1 - w);
+        const top = Math.min(Math.max(startEdges.top + dy, 0), 1 - h);
+        return { left, top, right: left + w, bottom: top + h };
+    };
+
+    const onPointerMove = useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            const drag = dragRef.current;
+            if (!drag) {
+                return;
+            }
+            const p = toNorm(e.clientX, e.clientY);
+            if (drag.mode === "focal") {
+                onChangeHotspot(clampHotspot({ x: p.x, y: p.y, width: 1, height: 1 }, edges));
+                return;
+            }
+            if (drag.mode === "move") {
+                const dx = p.x - drag.startPointer.x;
+                const dy = p.y - drag.startPointer.y;
+                commitEdges(moveCrop(drag.startEdges, dx, dy));
+                return;
+            }
+            const handle = drag.mode.slice("resize:".length) as Handle;
+            commitEdges(ratio === null ? resizeFree(handle, p) : resizeLocked(handle, p, ratio));
+        },
+        [toNorm, onChangeHotspot, edges, commitEdges, ratio]
+    );
+
+    // Drag inside the crop rectangle repositions the whole crop window.
+    const startMoveCrop = useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            dragRef.current = {
+                mode: "move",
+                startPointer: toNorm(e.clientX, e.clientY),
+                startEdges: edges
+            };
+            surfaceRef.current?.setPointerCapture(e.pointerId);
+        },
+        [toNorm, edges]
+    );
+
+    // Dragging the marker itself moves the focal point (and only that).
+    const startFocal = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        dragRef.current = { mode: "focal" };
+        surfaceRef.current?.setPointerCapture(e.pointerId);
+    }, []);
+
+    const startResize = useCallback(
+        (handle: Handle) => (e: React.PointerEvent<HTMLDivElement>) => {
+            e.stopPropagation();
+            dragRef.current = { mode: `resize:${handle}` };
+            surfaceRef.current?.setPointerCapture(e.pointerId);
+        },
+        []
+    );
+
+    const endDrag = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+        dragRef.current = null;
+        surfaceRef.current?.releasePointerCapture(e.pointerId);
+    }, []);
+
+    const onSelectAspect = useCallback(
+        (value: string) => {
+            setAspectId(value);
+            const r = DEFAULT_ASPECT_RATIOS.find(ar => ar.id === value)?.ratio;
+            if (value === FREE || !r) {
+                return;
+            }
+            // `r` is a display (pixel) aspect ratio; convert to a normalized ratio
+            // so the crop, stored in normalized image coordinates, renders as `r`.
+            const rNorm = r / imageRatio;
+            // Re-fit the current crop to the chosen ratio, centered within it.
+            const cw = edges.right - edges.left;
+            const ch = edges.bottom - edges.top;
+            let w = cw;
+            let h = w / rNorm;
+            if (h > ch) {
+                h = ch;
+                w = h * rNorm;
+            }
+            const cx = (edges.left + edges.right) / 2;
+            const cy = (edges.top + edges.bottom) / 2;
+            commitEdges({
+                left: clamp01(cx - w / 2),
+                right: clamp01(cx + w / 2),
+                top: clamp01(cy - h / 2),
+                bottom: clamp01(cy + h / 2)
+            });
+        },
+        [edges, commitEdges, imageRatio]
+    );
+
+    const activeHotspot = clampHotspot(hotspot, edges);
+    const handles = ratio === null ? [...CORNER_HANDLES, ...EDGE_HANDLES] : CORNER_HANDLES;
+
+    const handlePosition = (handle: Handle): { left: string; top: string } => {
+        const cx = (edges.left + edges.right) / 2;
+        const cy = (edges.top + edges.bottom) / 2;
+        const x = handle.includes("w") ? edges.left : handle.includes("e") ? edges.right : cx;
+        const y = handle.includes("n") ? edges.top : handle.includes("s") ? edges.bottom : cy;
+        return { left: `${x * 100}%`, top: `${y * 100}%` };
+    };
+
+    const cursorFor = (handle: Handle): string => {
+        const map: Record<Handle, string> = {
+            nw: "nwse-resize",
+            se: "nwse-resize",
+            ne: "nesw-resize",
+            sw: "nesw-resize",
+            n: "ns-resize",
+            s: "ns-resize",
+            e: "ew-resize",
+            w: "ew-resize"
+        };
+        return map[handle];
+    };
+
+    return (
+        <div className={"flex flex-col gap-sm"}>
+            <div className={"flex items-end justify-between gap-md"}>
+                <SectionLabel>Crop &amp; focal point</SectionLabel>
+                <div className={"w-[200px] shrink-0"}>
+                    <Select
+                        label={"Crop shape"}
+                        value={aspectId}
+                        options={aspectOptions}
+                        onChange={onSelectAspect}
+                        displayResetAction={false}
+                    />
+                </div>
+            </div>
+
+            {/* Dark editing stage: the image sits centered on a near-black backdrop
+                (like a pro image editor), so letterboxing around portrait images
+                reads as intentional and the image stays the focal element. */}
+            <div className={"flex justify-center rounded-md bg-neutral-dark p-lg"}>
+                <div ref={wrapperRef} className={"w-full"}>
+                    <div
+                        ref={surfaceRef}
+                        onPointerMove={onPointerMove}
+                        onPointerUp={endDrag}
+                        className={
+                            "relative mx-auto touch-none select-none overflow-hidden rounded-sm"
+                        }
+                        style={surfaceStyle}
+                    >
+                        <img
+                            src={image.src}
+                            alt={""}
+                            draggable={false}
+                            className={
+                                "pointer-events-none absolute inset-0 h-full w-full object-cover"
+                            }
+                        />
+
+                        {/* Crop rectangle: dims outside via box-shadow; interior drag moves the
+                            crop. The border is two-tone (white edge + a 1px dark ring) so it stays
+                            visible over both light and dark image areas. */}
+                        <div
+                            onPointerDown={startMoveCrop}
+                            className={"absolute cursor-move border border-white/90"}
+                            style={{
+                                left: `${edges.left * 100}%`,
+                                top: `${edges.top * 100}%`,
+                                width: `${(edges.right - edges.left) * 100}%`,
+                                height: `${(edges.bottom - edges.top) * 100}%`,
+                                boxShadow:
+                                    "0 0 0 1px rgba(0, 0, 0, 0.55), 0 0 0 9999px rgba(0, 0, 0, 0.45)"
+                            }}
+                        >
+                            {/* Rule-of-thirds guides — a compositional aid and a cue for placing
+                                the focal point. */}
+                            <div className={"pointer-events-none absolute inset-0"}>
+                                <div className={"absolute inset-y-0 left-1/3 w-px bg-white/30"} />
+                                <div className={"absolute inset-y-0 left-2/3 w-px bg-white/30"} />
+                                <div className={"absolute inset-x-0 top-1/3 h-px bg-white/30"} />
+                                <div className={"absolute inset-x-0 top-2/3 h-px bg-white/30"} />
+                            </div>
+
+                            {/* Focal marker — the visible ring is small, but the draggable hit
+                                area around it is larger for easier grabbing. */}
+                            <div
+                                onPointerDown={startFocal}
+                                className={
+                                    "absolute flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab touch-none items-center justify-center active:cursor-grabbing"
+                                }
+                                style={{
+                                    left: `${((activeHotspot.x - edges.left) / Math.max(MIN, edges.right - edges.left)) * 100}%`,
+                                    top: `${((activeHotspot.y - edges.top) / Math.max(MIN, edges.bottom - edges.top)) * 100}%`
+                                }}
+                            >
+                                <div
+                                    className={
+                                        "pointer-events-none relative h-6 w-6 rounded-full border-2 border-white bg-white/25 shadow-lg"
+                                    }
+                                >
+                                    <div
+                                        className={
+                                            "absolute left-1/2 top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+                                        }
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Resize handles — small visible dot inside a larger transparent hit
+                            area so the corners/edges are easy to grab. */}
+                        {handles.map(handle => {
+                            const pos = handlePosition(handle);
+                            return (
+                                <div
+                                    key={handle}
+                                    onPointerDown={startResize(handle)}
+                                    className={
+                                        "absolute flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 touch-none items-center justify-center"
+                                    }
+                                    style={{
+                                        left: pos.left,
+                                        top: pos.top,
+                                        cursor: cursorFor(handle)
+                                    }}
+                                >
+                                    <div
+                                        className={
+                                            "pointer-events-none h-3 w-3 rounded-sm border border-neutral-dark bg-white shadow"
+                                        }
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+
+            <Text as={"div"} size={"sm"} className={"text-neutral-strong"}>
+                Drag the handles to crop, drag inside to reposition, and drag the circle to set the
+                focal point.
+            </Text>
+        </div>
+    );
+};

--- a/packages/admin-ui/src/ImageEditor/ImageEditor.stories.tsx
+++ b/packages/admin-ui/src/ImageEditor/ImageEditor.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "~/Button/index.js";
+import { ImageEditor, type ImageEditorValue } from "./index.js";
+
+const meta: Meta<typeof ImageEditor> = {
+    title: "Components/ImageEditor",
+    component: ImageEditor,
+    parameters: {
+        layout: "fullscreen"
+    }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ImageEditor>;
+
+const DemoImage = {
+    src: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1600",
+    width: 1600,
+    height: 1067
+};
+
+const Demo = () => {
+    const [open, setOpen] = useState(false);
+    const [value, setValue] = useState<ImageEditorValue | undefined>(undefined);
+
+    return (
+        <div className={"p-lg"}>
+            <Button variant={"primary"} text={"Edit image"} onClick={() => setOpen(true)} />
+            <pre className={"mt-md text-sm"}>{JSON.stringify(value, null, 2)}</pre>
+            <ImageEditor
+                open={open}
+                onClose={() => setOpen(false)}
+                image={DemoImage}
+                value={value}
+                onSave={setValue}
+            />
+        </div>
+    );
+};
+
+export const Default: Story = {
+    render: () => <Demo />
+};

--- a/packages/admin-ui/src/ImageEditor/ImageEditor.tsx
+++ b/packages/admin-ui/src/ImageEditor/ImageEditor.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useState } from "react";
+import { ReactComponent as ArrowDropDownIcon } from "@webiny/icons/arrow_drop_down.svg";
+import { Dialog } from "~/Dialog/index.js";
+import { Button } from "~/Button/index.js";
+import { DropdownMenu } from "~/DropdownMenu/index.js";
+import { CropHotspotEditor } from "./CropHotspotEditor.js";
+import { AspectRatioPreview } from "./AspectRatioPreview.js";
+import { MetaFields } from "./MetaFields.js";
+import { SectionLabel } from "./SectionLabel.js";
+import {
+    DEFAULT_ASPECT_RATIOS,
+    DEFAULT_PREVIEW_RATIO_IDS,
+    type ImageEditorAspectRatio,
+    type ImageEditorCrop,
+    type ImageEditorHotspot,
+    type ImageEditorImage,
+    type ImageEditorValue
+} from "./types.js";
+
+export interface ImageEditorProps {
+    open: boolean;
+    onClose: () => void;
+    /** The source image to edit. */
+    image: ImageEditorImage;
+    /** The current edit (crop/hotspot/alt/caption), if any. */
+    value?: ImageEditorValue;
+    /** Called with the new edit when the user saves. */
+    onSave: (value: ImageEditorValue) => void;
+    /** Preview ratios shown in the strip. Defaults to square / 4:3 / 16:9. */
+    aspectRatios?: ImageEditorAspectRatio[];
+    showAlt?: boolean;
+    showCaption?: boolean;
+    title?: React.ReactNode;
+}
+
+const isFullCrop = (crop: ImageEditorCrop | undefined): boolean => {
+    if (!crop) {
+        return true;
+    }
+    return crop.top === 0 && crop.left === 0 && crop.bottom === 0 && crop.right === 0;
+};
+
+const isCenteredHotspot = (hotspot: ImageEditorHotspot | undefined): boolean => {
+    return !hotspot || (hotspot.x === 0.5 && hotspot.y === 0.5);
+};
+
+export const ImageEditor = ({
+    open,
+    onClose,
+    image,
+    value,
+    onSave,
+    aspectRatios = DEFAULT_ASPECT_RATIOS,
+    showAlt = true,
+    showCaption = true,
+    title = "Edit image"
+}: ImageEditorProps) => {
+    const [crop, setCrop] = useState<ImageEditorCrop | undefined>(value?.crop);
+    const [hotspot, setHotspot] = useState<ImageEditorHotspot | undefined>(value?.hotspot);
+    const [alt, setAlt] = useState(value?.alt ?? "");
+    const [caption, setCaption] = useState(value?.caption ?? "");
+    const [selectedRatioIds, setSelectedRatioIds] = useState<string[]>(() => {
+        const defaults = aspectRatios
+            .filter(ar => DEFAULT_PREVIEW_RATIO_IDS.includes(ar.id))
+            .map(ar => ar.id);
+        return defaults.length > 0 ? defaults : aspectRatios.map(ar => ar.id);
+    });
+
+    const toggleRatio = (id: string) =>
+        setSelectedRatioIds(prev =>
+            prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+        );
+
+    const visibleRatios = aspectRatios.filter(ar => selectedRatioIds.includes(ar.id));
+
+    // Fall back to the image's natural dimensions when the caller didn't provide
+    // them (e.g. missing metadata). Without real dimensions the canvas and previews
+    // would assume a square and distort the image / mis-map the crop coordinates.
+    const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
+
+    useEffect(() => {
+        if (!open || !image.src || (image.width > 0 && image.height > 0)) {
+            return;
+        }
+        if (typeof document === "undefined") {
+            return;
+        }
+        const probe = document.createElement("img");
+        probe.onload = () =>
+            setNaturalSize({ width: probe.naturalWidth, height: probe.naturalHeight });
+        probe.src = image.src;
+        return () => {
+            probe.onload = null;
+        };
+    }, [open, image.src, image.width, image.height]);
+
+    const effectiveImage: ImageEditorImage = {
+        src: image.src,
+        width: image.width > 0 ? image.width : (naturalSize?.width ?? 0),
+        height: image.height > 0 ? image.height : (naturalSize?.height ?? 0)
+    };
+
+    // Re-seed local state whenever the dialog is (re)opened for a given value.
+    useEffect(() => {
+        if (open) {
+            setCrop(value?.crop);
+            setHotspot(value?.hotspot);
+            setAlt(value?.alt ?? "");
+            setCaption(value?.caption ?? "");
+        }
+    }, [open, value]);
+
+    const handleSave = () => {
+        const next: ImageEditorValue = {};
+        if (!isFullCrop(crop)) {
+            next.crop = crop;
+        }
+        if (!isCenteredHotspot(hotspot)) {
+            next.hotspot = hotspot;
+        }
+        if (showAlt && alt.trim()) {
+            next.alt = alt.trim();
+        }
+        if (showCaption && caption.trim()) {
+            next.caption = caption.trim();
+        }
+        onSave(next);
+        onClose();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            title={title}
+            size={"lg"}
+            actions={
+                <div className={"flex w-full items-center justify-end gap-sm"}>
+                    <Button variant={"secondary"} text={"Cancel"} onClick={onClose} />
+                    <Button variant={"primary"} text={"Save"} onClick={handleSave} />
+                </div>
+            }
+        >
+            <div className={"flex flex-col gap-lg"}>
+                <CropHotspotEditor
+                    image={effectiveImage}
+                    crop={crop}
+                    hotspot={hotspot}
+                    onChangeCrop={setCrop}
+                    onChangeHotspot={setHotspot}
+                />
+
+                <div className={"flex flex-col gap-sm"}>
+                    <div className={"flex items-center justify-between"}>
+                        <SectionLabel>Preview</SectionLabel>
+                        <DropdownMenu
+                            trigger={
+                                <Button
+                                    variant={"secondary"}
+                                    text={`Preview at (${visibleRatios.length})`}
+                                    icon={<ArrowDropDownIcon />}
+                                    iconPosition={"end"}
+                                />
+                            }
+                        >
+                            {aspectRatios.map(ar => (
+                                <DropdownMenu.CheckboxItem
+                                    key={ar.id}
+                                    text={ar.label}
+                                    checked={selectedRatioIds.includes(ar.id)}
+                                    onCheckedChange={() => toggleRatio(ar.id)}
+                                    onSelect={e => e.preventDefault()}
+                                />
+                            ))}
+                        </DropdownMenu>
+                    </div>
+                    {visibleRatios.length > 0 ? (
+                        <div className={"flex flex-wrap items-start gap-md"}>
+                            {visibleRatios.map(ar => (
+                                <AspectRatioPreview
+                                    key={ar.id}
+                                    src={effectiveImage.src}
+                                    imageWidth={effectiveImage.width}
+                                    imageHeight={effectiveImage.height}
+                                    crop={crop}
+                                    hotspot={hotspot}
+                                    aspectRatio={ar}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <div className={"text-sm text-neutral-strong"}>
+                            Select at least one shape to preview.
+                        </div>
+                    )}
+                </div>
+
+                {showAlt || showCaption ? (
+                    <div className={"flex flex-col gap-sm"}>
+                        <SectionLabel>Details</SectionLabel>
+                        <MetaFields
+                            alt={alt}
+                            caption={caption}
+                            showAlt={showAlt}
+                            showCaption={showCaption}
+                            onChangeAlt={setAlt}
+                            onChangeCaption={setCaption}
+                        />
+                    </div>
+                ) : null}
+            </div>
+        </Dialog>
+    );
+};

--- a/packages/admin-ui/src/ImageEditor/MetaFields.tsx
+++ b/packages/admin-ui/src/ImageEditor/MetaFields.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Input } from "~/Input/index.js";
+
+interface MetaFieldsProps {
+    alt: string;
+    caption: string;
+    showAlt: boolean;
+    showCaption: boolean;
+    onChangeAlt: (value: string) => void;
+    onChangeCaption: (value: string) => void;
+}
+
+/** Alt text + optional caption, captured alongside the crop/hotspot. */
+export const MetaFields = ({
+    alt,
+    caption,
+    showAlt,
+    showCaption,
+    onChangeAlt,
+    onChangeCaption
+}: MetaFieldsProps) => {
+    if (!showAlt && !showCaption) {
+        return null;
+    }
+
+    return (
+        <div className={"flex flex-col gap-md"}>
+            {showAlt ? (
+                <Input
+                    label={"Alternative text"}
+                    description={"Describe the image for screen readers and search engines."}
+                    value={alt}
+                    onChange={onChangeAlt}
+                />
+            ) : null}
+            {showCaption ? (
+                <Input label={"Caption"} value={caption} onChange={onChangeCaption} />
+            ) : null}
+        </div>
+    );
+};

--- a/packages/admin-ui/src/ImageEditor/SectionLabel.tsx
+++ b/packages/admin-ui/src/ImageEditor/SectionLabel.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+/**
+ * Consistent section heading for the image editor. Uses the primary (darkest)
+ * text token so it reads as a heading, distinct from the muted body/caption text.
+ */
+export const SectionLabel = ({ children }: { children: React.ReactNode }) => {
+    return <div className={"text-sm font-semibold text-neutral-primary"}>{children}</div>;
+};

--- a/packages/admin-ui/src/ImageEditor/geometry.ts
+++ b/packages/admin-ui/src/ImageEditor/geometry.ts
@@ -1,0 +1,124 @@
+/**
+ * Preview geometry for the image editor.
+ *
+ * IMPORTANT: this is a deliberate, minimal mirror of the canonical geometry core
+ * in `@webiny/website-builder-sdk` (`src/image/geometry.ts`). The SDK copy is the
+ * source of truth used for live frontend rendering; this copy exists only so the
+ * design-system layer stays free of an SDK dependency. Keep the two in sync — the
+ * whole point is that the editor preview matches what the site renders.
+ */
+import type { ImageEditorCrop, ImageEditorHotspot } from "./types.js";
+
+export interface PreviewStyles {
+    container: React.CSSProperties;
+    image: React.CSSProperties;
+}
+
+const clamp = (value: number, min = 0, max = 1): number => {
+    if (Number.isNaN(value)) {
+        return min;
+    }
+    return Math.min(max, Math.max(min, value));
+};
+
+const round = (n: number): number => Math.round(n * 1000) / 1000;
+
+interface Rect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+const getCropRect = (crop?: ImageEditorCrop | null): Rect => {
+    const top = clamp(crop?.top ?? 0);
+    const left = clamp(crop?.left ?? 0);
+    const bottom = clamp(crop?.bottom ?? 0);
+    const right = clamp(crop?.right ?? 0);
+    return {
+        x: left,
+        y: top,
+        width: Math.max(0, 1 - left - right),
+        height: Math.max(0, 1 - top - bottom)
+    };
+};
+
+/**
+ * The largest rectangle of `ratio` (w/h) that fits inside the crop, centered on
+ * the hotspot and clamped to the crop bounds.
+ */
+export const getVisibleRect = (
+    imageWidth: number,
+    imageHeight: number,
+    crop: ImageEditorCrop | undefined,
+    hotspot: ImageEditorHotspot | undefined,
+    ratio: number
+): Rect => {
+    const cropRect = getCropRect(crop);
+    if (cropRect.width <= 0 || cropRect.height <= 0) {
+        return cropRect;
+    }
+
+    const iw = imageWidth > 0 ? imageWidth : 1;
+    const ih = imageHeight > 0 ? imageHeight : 1;
+    const targetAR = ratio > 0 ? ratio : 1;
+
+    const cropWpx = cropRect.width * iw;
+    const cropHpx = cropRect.height * ih;
+    const cropAR = cropWpx / cropHpx;
+
+    let finalWpx: number;
+    let finalHpx: number;
+    if (targetAR > cropAR) {
+        finalWpx = cropWpx;
+        finalHpx = cropWpx / targetAR;
+    } else {
+        finalHpx = cropHpx;
+        finalWpx = cropHpx * targetAR;
+    }
+
+    const finalW = finalWpx / iw;
+    const finalH = finalHpx / ih;
+
+    const hx = clamp(hotspot?.x ?? 0.5);
+    const hy = clamp(hotspot?.y ?? 0.5);
+    const maxX = cropRect.x + cropRect.width - finalW;
+    const maxY = cropRect.y + cropRect.height - finalH;
+    const x = clamp(hx - finalW / 2, cropRect.x, Math.max(cropRect.x, maxX));
+    const y = clamp(hy - finalH / 2, cropRect.y, Math.max(cropRect.y, maxY));
+
+    return { x, y, width: finalW, height: finalH };
+};
+
+/**
+ * CSS for an overflow-clipped container + absolutely positioned image that shows
+ * exactly the visible rect for a given aspect ratio.
+ */
+export const getPreviewStyles = (
+    imageWidth: number,
+    imageHeight: number,
+    crop: ImageEditorCrop | undefined,
+    hotspot: ImageEditorHotspot | undefined,
+    ratio: number
+): PreviewStyles => {
+    const rect = getVisibleRect(imageWidth, imageHeight, crop, hotspot, ratio);
+    const safeW = rect.width > 0 ? rect.width : 1;
+    const safeH = rect.height > 0 ? rect.height : 1;
+
+    return {
+        container: {
+            position: "relative",
+            width: "100%",
+            aspectRatio: `${round(ratio > 0 ? ratio : 1)}`,
+            overflow: "hidden"
+        },
+        image: {
+            position: "absolute",
+            width: `${round(100 / safeW)}%`,
+            height: `${round(100 / safeH)}%`,
+            left: `${round(-(rect.x / safeW) * 100)}%`,
+            top: `${round(-(rect.y / safeH) * 100)}%`,
+            maxWidth: "none"
+        }
+    };
+};

--- a/packages/admin-ui/src/ImageEditor/geometry.ts
+++ b/packages/admin-ui/src/ImageEditor/geometry.ts
@@ -122,3 +122,74 @@ export const getPreviewStyles = (
         }
     };
 };
+
+export interface CroppedImageRenderStyles {
+    wrapper: React.CSSProperties;
+    image: React.CSSProperties;
+}
+
+/**
+ * Styles to render an already-cropped image inside a measured box, honoring the
+ * crop (and, for `cover`, the hotspot). Use when you know the box's pixel size:
+ *  - `cover`: fills the box, cover-cropping the crop region toward the hotspot;
+ *  - `contain`: fits the whole crop region inside the box (centered by the parent).
+ */
+export const getCroppedImageRenderStyles = (
+    imageWidth: number,
+    imageHeight: number,
+    crop: ImageEditorCrop | undefined,
+    hotspot: ImageEditorHotspot | undefined,
+    opts: { boxWidth: number; boxHeight: number; fit: "cover" | "contain" }
+): CroppedImageRenderStyles => {
+    const imageStyle = (rect: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    }): React.CSSProperties => {
+        const safeW = rect.width > 0 ? rect.width : 1;
+        const safeH = rect.height > 0 ? rect.height : 1;
+        return {
+            position: "absolute",
+            width: `${round(100 / safeW)}%`,
+            height: `${round(100 / safeH)}%`,
+            left: `${round(-(rect.x / safeW) * 100)}%`,
+            top: `${round(-(rect.y / safeH) * 100)}%`,
+            maxWidth: "none"
+        };
+    };
+
+    if (opts.fit === "cover") {
+        const targetAspect = opts.boxHeight > 0 ? opts.boxWidth / opts.boxHeight : 1;
+        const rect = getVisibleRect(imageWidth, imageHeight, crop, hotspot, targetAspect);
+        return {
+            wrapper: { position: "relative", width: "100%", height: "100%", overflow: "hidden" },
+            image: imageStyle(rect)
+        };
+    }
+
+    // contain: fit the whole crop region within the box, preserving its aspect.
+    const cropRect = getCropRect(crop);
+    const iw = imageWidth > 0 ? imageWidth : 1;
+    const ih = imageHeight > 0 ? imageHeight : 1;
+    const cropWpx = (cropRect.width > 0 ? cropRect.width : 1) * iw;
+    const cropHpx = (cropRect.height > 0 ? cropRect.height : 1) * ih;
+    const cropAspect = cropWpx / cropHpx;
+
+    let width = opts.boxWidth;
+    let height = opts.boxWidth / cropAspect;
+    if (height > opts.boxHeight) {
+        height = opts.boxHeight;
+        width = opts.boxHeight * cropAspect;
+    }
+
+    return {
+        wrapper: {
+            position: "relative",
+            width: `${round(width)}px`,
+            height: `${round(height)}px`,
+            overflow: "hidden"
+        },
+        image: imageStyle(cropRect)
+    };
+};

--- a/packages/admin-ui/src/ImageEditor/index.ts
+++ b/packages/admin-ui/src/ImageEditor/index.ts
@@ -1,0 +1,2 @@
+export * from "./ImageEditor.js";
+export * from "./types.js";

--- a/packages/admin-ui/src/ImageEditor/index.ts
+++ b/packages/admin-ui/src/ImageEditor/index.ts
@@ -1,2 +1,3 @@
 export * from "./ImageEditor.js";
 export * from "./types.js";
+export { getCroppedImageRenderStyles, type CroppedImageRenderStyles } from "./geometry.js";

--- a/packages/admin-ui/src/ImageEditor/types.ts
+++ b/packages/admin-ui/src/ImageEditor/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Generic, self-contained types for the reusable image editor dialog.
+ *
+ * These are intentionally NOT imported from `@webiny/website-builder-sdk`:
+ * `@webiny/admin-ui` is the low-level design-system layer and must not depend on
+ * higher-level SDKs. The shapes are structurally identical to the SDK's
+ * `WebinyImageEdit`/`WebinyImageValue`, so consumers (File Manager, Website
+ * Builder) can pass values across the boundary without any mapping.
+ */
+
+/** Minimal information the editor needs about the source image. */
+export interface ImageEditorImage {
+    src: string;
+    /** Intrinsic (original) pixel width. */
+    width: number;
+    /** Intrinsic (original) pixel height. */
+    height: number;
+}
+
+/** Crop stored as the fraction (0..1) cut off from each edge of the image. */
+export interface ImageEditorCrop {
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+}
+
+/** Focal region in normalized (0..1) coordinates of the original image. */
+export interface ImageEditorHotspot {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/** The complete non-destructive edit produced by the dialog. */
+export interface ImageEditorValue {
+    crop?: ImageEditorCrop;
+    hotspot?: ImageEditorHotspot;
+    alt?: string;
+    caption?: string;
+}
+
+/** A single aspect ratio used both for the crop selector and the preview strip. */
+export interface ImageEditorAspectRatio {
+    id: string;
+    label: string;
+    /** `width / height`. */
+    ratio: number;
+}
+
+/**
+ * The single source of truth for selectable aspect ratios, shared by the crop
+ * shape selector and the preview-shapes dropdown so their labels stay identical.
+ */
+export const DEFAULT_ASPECT_RATIOS: ImageEditorAspectRatio[] = [
+    { id: "1:1", label: "Square (1:1)", ratio: 1 },
+    { id: "4:3", label: "Landscape (4:3)", ratio: 4 / 3 },
+    { id: "16:9", label: "Widescreen (16:9)", ratio: 16 / 9 },
+    { id: "3:4", label: "Portrait (3:4)", ratio: 3 / 4 },
+    { id: "9:16", label: "Tall (9:16)", ratio: 9 / 16 }
+];
+
+/** Preview shapes selected by default (the originally specified square / 4:3 / 16:9). */
+export const DEFAULT_PREVIEW_RATIO_IDS = ["1:1", "4:3", "16:9"];

--- a/packages/admin-ui/src/index.ts
+++ b/packages/admin-ui/src/index.ts
@@ -31,6 +31,7 @@ export * from "./Heading/index.js";
 export * from "./Icon/index.js";
 export * from "./IconPicker/index.js";
 export * from "./Image/index.js";
+export * from "./ImageEditor/index.js";
 export * from "./Input/index.js";
 export * from "./Label/index.js";
 export * from "./Link/index.js";

--- a/packages/api-file-manager/src/domain/file/file.model.ts
+++ b/packages/api-file-manager/src/domain/file/file.model.ts
@@ -35,7 +35,11 @@ class FilePrivateModelImpl implements ModelFactory.Interface {
                     // Store complete raw EXIF as JSON
                     exif: fields.searchableJson().label("EXIF Data"),
                     // Store complete raw IPTC as JSON
-                    iptc: fields.searchableJson().label("IPTC Data")
+                    iptc: fields.searchableJson().label("IPTC Data"),
+                    // Non-destructive image edit (crop / hotspot / alt / caption).
+                    // Stored as free-form JSON so the shape can evolve without
+                    // schema changes; not indexed.
+                    imageEdit: fields.json().label("Image edit")
                 })),
             tags: fields
                 .text()

--- a/packages/app-file-manager/src/features/shared/FILE_FIELDS.ts
+++ b/packages/app-file-manager/src/features/shared/FILE_FIELDS.ts
@@ -25,5 +25,6 @@ export const FILE_FIELDS = [
     "metadata.image.format",
     "metadata.image.orientation",
     "metadata.exif",
-    "metadata.iptc"
+    "metadata.iptc",
+    "metadata.imageEdit"
 ];

--- a/packages/app-file-manager/src/presentation/FileActions/FileDetails/EditImage.tsx
+++ b/packages/app-file-manager/src/presentation/FileActions/FileDetails/EditImage.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { ReactComponent as CropIcon } from "@webiny/icons/crop.svg";
 import { ImageEditor } from "@webiny/admin-ui";
 import { FileManagerViewConfig, useFile } from "~/index.js";
+import { useFileManagerPresenter } from "~/presentation/FileList/FileManagerPresenterProvider.js";
 import { useEditImage } from "~/presentation/hooks/useEditImage.js";
+import type { FileItem } from "~/domain/types.js";
 
 const { FileDetails } = FileManagerViewConfig;
 
@@ -13,7 +15,19 @@ const { FileDetails } = FileManagerViewConfig;
  */
 export const EditImage = () => {
     const { file } = useFile();
-    const { open, openEditor, closeEditor, value, save } = useEditImage(file);
+    const { vm } = useFileManagerPresenter();
+    const fileDetails = vm.fileDetails;
+
+    // After saving, replace the file shown in the drawer so the preview updates
+    // in place (without needing to close and reopen the drawer).
+    const onSaved = useCallback(
+        (updated: FileItem) => {
+            fileDetails?.setFile(updated);
+        },
+        [fileDetails]
+    );
+
+    const { open, openEditor, closeEditor, value, save } = useEditImage(file, { onSaved });
 
     if (!file.type?.startsWith("image/") || file.type === "image/svg+xml") {
         return null;

--- a/packages/app-file-manager/src/presentation/FileActions/FileDetails/EditImage.tsx
+++ b/packages/app-file-manager/src/presentation/FileActions/FileDetails/EditImage.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { ReactComponent as CropIcon } from "@webiny/icons/crop.svg";
+import { ImageEditor } from "@webiny/admin-ui";
+import { FileManagerViewConfig, useFile } from "~/index.js";
+import { useEditImage } from "~/presentation/hooks/useEditImage.js";
+
+const { FileDetails } = FileManagerViewConfig;
+
+/**
+ * "Edit image" action in the File Details drawer. Shown for images only. Opens
+ * the reusable crop/hotspot/alt editor and saves to the file's asset-level
+ * metadata. The drawer stays mounted while open, so the dialog state is safe here.
+ */
+export const EditImage = () => {
+    const { file } = useFile();
+    const { open, openEditor, closeEditor, value, save } = useEditImage(file);
+
+    if (!file.type?.startsWith("image/") || file.type === "image/svg+xml") {
+        return null;
+    }
+
+    return (
+        <>
+            <FileDetails.Action.Button
+                label={"Edit image"}
+                icon={<CropIcon />}
+                onAction={openEditor}
+            />
+            <ImageEditor
+                open={open}
+                onClose={closeEditor}
+                image={{
+                    src: file.src,
+                    width: file.metadata?.image?.width ?? 0,
+                    height: file.metadata?.image?.height ?? 0
+                }}
+                value={value}
+                onSave={save}
+            />
+        </>
+    );
+};

--- a/packages/app-file-manager/src/presentation/FileActions/index.tsx
+++ b/packages/app-file-manager/src/presentation/FileActions/index.tsx
@@ -8,6 +8,7 @@ import { Download as FileDetailsDownload } from "./FileDetails/Download.js";
 import { MoveToFolder as FileDetailsMoveToFolder } from "./FileDetails/MoveToFolder.js";
 import { CopyUrl as FileDetailsCopyUrl } from "./FileDetails/CopyUrl.js";
 import { DeleteImage as FileDetailsDeleteImage } from "./FileDetails/DeleteImage.js";
+import { EditImage as FileDetailsEditImage } from "./FileDetails/EditImage.js";
 
 const { Browser, FileDetails } = FileManagerViewConfig;
 
@@ -20,6 +21,7 @@ export const FileActions = () => {
             <Browser.Grid.Item.Action name={"move"} element={<GridMoveToFolder />} />
             <Browser.Grid.Item.Action name={"delete"} element={<GridDelete />} />
             {/* File details actions. */}
+            <FileDetails.Action name={"editImage"} element={<FileDetailsEditImage />} />
             <FileDetails.Action name={"download"} element={<FileDetailsDownload />} />
             <FileDetails.Action name={"moveToFolder"} element={<FileDetailsMoveToFolder />} />
             <FileDetails.Action name={"copyUrl"} element={<FileDetailsCopyUrl />} />

--- a/packages/app-file-manager/src/presentation/FileDetails/FileDetailsPresenter.ts
+++ b/packages/app-file-manager/src/presentation/FileDetails/FileDetailsPresenter.ts
@@ -78,6 +78,12 @@ class FileDetailsPresenterImpl implements IFileDetailsPresenter {
         }
     }
 
+    setFile(file: FmFile): void {
+        runInAction(() => {
+            this.file = file;
+        });
+    }
+
     async saveFile(): Promise<boolean> {
         if (!this.file) {
             return false;

--- a/packages/app-file-manager/src/presentation/FileDetails/abstractions.ts
+++ b/packages/app-file-manager/src/presentation/FileDetails/abstractions.ts
@@ -25,6 +25,8 @@ export interface IFileDetailsPresenter {
     vm: IFileDetailsViewModel;
     loadFile(id: string): Promise<void>;
     saveFile(): Promise<boolean>;
+    /** Replace the currently displayed file (e.g. after an out-of-band update). */
+    setFile(file: FmFile): void;
 }
 
 export const FileDetailsPresenter =

--- a/packages/app-file-manager/src/presentation/FileList/FileListPresenter.test.ts
+++ b/packages/app-file-manager/src/presentation/FileList/FileListPresenter.test.ts
@@ -211,7 +211,8 @@ function createMockFileDetailsPresenter(): IFileDetailsPresenter {
             permissions: { canEdit: true, canDelete: true }
         },
         loadFile: vi.fn().mockResolvedValue(undefined),
-        saveFile: vi.fn().mockResolvedValue(undefined)
+        saveFile: vi.fn().mockResolvedValue(undefined),
+        setFile: vi.fn()
     };
 }
 

--- a/packages/app-file-manager/src/presentation/config/thumbnailRenderers/CroppedFileImage.tsx
+++ b/packages/app-file-manager/src/presentation/config/thumbnailRenderers/CroppedFileImage.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { Image } from "@webiny/app/components/index.js";
+import { cn, getCroppedImageRenderStyles } from "@webiny/admin-ui";
+import type { FileItem } from "~/domain/types.js";
+
+interface CroppedFileImageProps {
+    file: FileItem;
+    /** Width passed to the delivery transform (`?width=`). */
+    width: number;
+    /** How the (cropped) image fits its slot. */
+    fit: "cover" | "contain";
+    /** Class applied to the `<Image>` when there is no crop (original behavior). */
+    fallbackClassName?: string;
+}
+
+const isFullCrop = (crop: any): boolean => {
+    return !crop || (crop.top === 0 && crop.left === 0 && crop.bottom === 0 && crop.right === 0);
+};
+
+/**
+ * Renders a File Manager image thumbnail/preview honoring the saved crop (and, for
+ * `cover`, the hotspot). Falls back to the plain image when the file has no crop,
+ * so un-edited files render exactly as before.
+ */
+export const CroppedFileImage = ({
+    file,
+    width,
+    fit,
+    fallbackClassName
+}: CroppedFileImageProps) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [box, setBox] = useState({ w: 0, h: 0 });
+
+    useLayoutEffect(() => {
+        const el = ref.current;
+        if (!el) {
+            return;
+        }
+        const measure = () => {
+            const rect = el.getBoundingClientRect();
+            setBox({ w: rect.width, h: rect.height });
+        };
+        measure();
+        if (typeof ResizeObserver === "undefined") {
+            return;
+        }
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    const edit = file.metadata?.imageEdit;
+    const imageWidth = file.metadata?.image?.width ?? 0;
+    const imageHeight = file.metadata?.image?.height ?? 0;
+
+    if (isFullCrop(edit?.crop) || imageWidth <= 0 || imageHeight <= 0) {
+        return (
+            <Image
+                src={file.src}
+                alt={file.name}
+                transform={{ width }}
+                className={fallbackClassName}
+            />
+        );
+    }
+
+    const { wrapper, image } = getCroppedImageRenderStyles(
+        imageWidth,
+        imageHeight,
+        edit?.crop,
+        edit?.hotspot,
+        {
+            boxWidth: box.w,
+            boxHeight: box.h,
+            fit
+        }
+    );
+
+    return (
+        <div
+            ref={ref}
+            className={cn("flex h-full w-full items-center justify-center overflow-hidden")}
+        >
+            <div style={wrapper}>
+                <Image src={file.src} alt={file.name} transform={{ width }} style={image} />
+            </div>
+        </div>
+    );
+};

--- a/packages/app-file-manager/src/presentation/config/thumbnailRenderers/FilePreviewImageRenderer.tsx
+++ b/packages/app-file-manager/src/presentation/config/thumbnailRenderers/FilePreviewImageRenderer.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import { Image } from "@webiny/app/components/index.js";
 import { useFile } from "~/presentation/hooks/useFile.js";
-
-const width750 = { width: 750 };
+import { CroppedFileImage } from "./CroppedFileImage.js";
 
 export const FilePreviewImageRenderer = () => {
     const { file } = useFile();
     return (
-        <Image
-            src={file.src}
-            alt={file.name}
-            transform={width750}
-            className={"object-contain max-w-full max-h-full"}
+        <CroppedFileImage
+            file={file}
+            width={750}
+            fit={"contain"}
+            fallbackClassName={"object-contain max-w-full max-h-full"}
         />
     );
 };

--- a/packages/app-file-manager/src/presentation/config/thumbnailRenderers/GridItemImageRenderer.tsx
+++ b/packages/app-file-manager/src/presentation/config/thumbnailRenderers/GridItemImageRenderer.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import { Image } from "@webiny/app/components/index.js";
 import { useFile } from "~/presentation/hooks/useFile.js";
-
-const width300 = { width: 300 };
+import { CroppedFileImage } from "./CroppedFileImage.js";
 
 export const GridItemImageRenderer = () => {
     const { file } = useFile();
     return (
-        <Image
-            src={file.src}
-            alt={file.name}
-            transform={width300}
-            className={"object-contain max-w-full max-h-full"}
+        <CroppedFileImage
+            file={file}
+            width={300}
+            fit={"contain"}
+            fallbackClassName={"object-contain max-w-full max-h-full"}
         />
     );
 };

--- a/packages/app-file-manager/src/presentation/config/thumbnailRenderers/TableItemImageRenderer.tsx
+++ b/packages/app-file-manager/src/presentation/config/thumbnailRenderers/TableItemImageRenderer.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import { Image } from "@webiny/app/components/index.js";
 import { useFile } from "~/presentation/hooks/useFile.js";
-
-const width100 = { width: 100 };
+import { CroppedFileImage } from "./CroppedFileImage.js";
 
 export const TableItemImageRenderer = () => {
     const { file } = useFile();
     return (
-        <Image
-            src={file.src}
-            alt={file.name}
-            transform={width100}
-            className={"object-cover w-full h-full"}
+        <CroppedFileImage
+            file={file}
+            width={100}
+            fit={"cover"}
+            fallbackClassName={"object-cover w-full h-full"}
         />
     );
 };

--- a/packages/app-file-manager/src/presentation/fieldRenderers/CmsFilePickerRenderer.tsx
+++ b/packages/app-file-manager/src/presentation/fieldRenderers/CmsFilePickerRenderer.tsx
@@ -4,6 +4,8 @@ import { FileManager } from "@webiny/app-admin/base/ui/FileManager.js";
 import { FilePicker } from "@webiny/admin-ui";
 import type { FileManagerFileItem } from "@webiny/app-admin/base/ui/FileManager.js";
 import type { FileFieldSettings } from "@webiny/app-admin/features/formModel/fieldTypes/FileFieldType.js";
+import { isEditableImageUrl, useCmsImageEditor } from "~/presentation/hooks/useCmsImageEditor.js";
+import { CmsImageEditorDialog } from "./CmsImageEditorDialog.js";
 
 declare module "@webiny/app-admin/features/formModel/abstractions.js" {
     interface IFieldRendererRegistry {
@@ -13,6 +15,8 @@ declare module "@webiny/app-admin/features/formModel/abstractions.js" {
 
 export const CmsFilePickerRenderer = createFieldRenderer<"cmsFilePicker">(({ field }) => {
     const settings = field.rendererSettings as FileFieldSettings | undefined;
+    const value = field.value as string | undefined;
+    const editor = useCmsImageEditor();
 
     return (
         <FileManager
@@ -21,21 +25,30 @@ export const CmsFilePickerRenderer = createFieldRenderer<"cmsFilePicker">(({ fie
             own={settings?.own}
             scope={settings?.scope}
             render={({ showFileManager }) => (
-                <FilePicker
-                    label={field.label}
-                    description={field.description}
-                    note={field.note}
-                    hint={field.help}
-                    type="compact"
-                    value={field.value as string | undefined}
-                    validation={field.validation}
-                    onSelectItem={() =>
-                        showFileManager((file: FileManagerFileItem) => {
-                            field.onChange(file.src || "");
-                        })
-                    }
-                    onRemoveItem={() => field.onChange(null)}
-                />
+                <>
+                    <FilePicker
+                        label={field.label}
+                        description={field.description}
+                        note={field.note}
+                        hint={field.help}
+                        type="compact"
+                        value={value}
+                        validation={field.validation}
+                        onSelectItem={() =>
+                            showFileManager((file: FileManagerFileItem) => {
+                                field.onChange(file.src || "");
+                            })
+                        }
+                        onRemoveItem={() => field.onChange(null)}
+                        // The "Edit" (pencil) action opens the crop / focal point /
+                        // alt editor for image values (edits the file's asset-level
+                        // settings). Hidden for non-images.
+                        onEditItem={
+                            isEditableImageUrl(value) ? () => editor.openFor(value) : undefined
+                        }
+                    />
+                    <CmsImageEditorDialog editor={editor} />
+                </>
             )}
         />
     );

--- a/packages/app-file-manager/src/presentation/fieldRenderers/CmsImageEditorDialog.tsx
+++ b/packages/app-file-manager/src/presentation/fieldRenderers/CmsImageEditorDialog.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { ImageEditor, type ImageEditorValue } from "@webiny/admin-ui";
+import type { useCmsImageEditor } from "~/presentation/hooks/useCmsImageEditor.js";
+
+interface CmsImageEditorDialogProps {
+    editor: ReturnType<typeof useCmsImageEditor>;
+}
+
+/**
+ * Renders the shared image editor for a CMS file field once a file has been
+ * resolved (see `useCmsImageEditor`). Edits the File's asset-level crop/hotspot/alt.
+ */
+export const CmsImageEditorDialog = ({ editor }: CmsImageEditorDialogProps) => {
+    const { open, close, file, save } = editor;
+
+    if (!file) {
+        return null;
+    }
+
+    return (
+        <ImageEditor
+            open={open}
+            onClose={close}
+            image={{
+                src: file.src,
+                width: file.metadata?.image?.width ?? 0,
+                height: file.metadata?.image?.height ?? 0
+            }}
+            value={file.metadata?.imageEdit as ImageEditorValue | undefined}
+            onSave={save}
+        />
+    );
+};

--- a/packages/app-file-manager/src/presentation/fieldRenderers/CmsMultiFilePickerRenderer.tsx
+++ b/packages/app-file-manager/src/presentation/fieldRenderers/CmsMultiFilePickerRenderer.tsx
@@ -4,6 +4,8 @@ import { FileManager } from "@webiny/app-admin/base/ui/FileManager.js";
 import type { FileManagerFileItem } from "@webiny/app-admin/base/ui/FileManager.js";
 import { MultiFilePicker } from "@webiny/admin-ui";
 import type { FileFieldSettings } from "@webiny/app-admin/features/formModel/fieldTypes/FileFieldType.js";
+import { isEditableImageUrl, useCmsImageEditor } from "~/presentation/hooks/useCmsImageEditor.js";
+import { CmsImageEditorDialog } from "./CmsImageEditorDialog.js";
 
 declare module "@webiny/app-admin/features/formModel/abstractions.js" {
     interface IFieldRendererRegistry {
@@ -15,6 +17,7 @@ export const CmsMultiFilePickerRenderer = createFieldRenderer<"cmsMultiFilePicke
     const value = field.value as string[] | undefined;
     const settings = field.rendererSettings as FileFieldSettings | undefined;
     const currentValues = Array.isArray(value) ? value : [];
+    const editor = useCmsImageEditor();
 
     return (
         <FileManager
@@ -40,22 +43,31 @@ export const CmsMultiFilePickerRenderer = createFieldRenderer<"cmsMultiFilePicke
                 };
 
                 return (
-                    <MultiFilePicker
-                        label={field.label}
-                        description={field.description}
-                        note={field.note}
-                        hint={field.help}
-                        values={currentValues}
-                        type="compact"
-                        onSelectItem={() => selectFiles()}
-                        onReplaceItem={(_, index) => selectFiles(index)}
-                        onRemoveItem={(_, index) => {
-                            field.onChange([
-                                ...currentValues.slice(0, index),
-                                ...currentValues.slice(index + 1)
-                            ]);
-                        }}
-                    />
+                    <>
+                        <MultiFilePicker
+                            label={field.label}
+                            description={field.description}
+                            note={field.note}
+                            hint={field.help}
+                            values={currentValues}
+                            type="compact"
+                            onSelectItem={() => selectFiles()}
+                            onReplaceItem={(_, index) => selectFiles(index)}
+                            onEditItem={(_, index) => {
+                                const url = currentValues[index];
+                                if (isEditableImageUrl(url)) {
+                                    editor.openFor(url);
+                                }
+                            }}
+                            onRemoveItem={(_, index) => {
+                                field.onChange([
+                                    ...currentValues.slice(0, index),
+                                    ...currentValues.slice(index + 1)
+                                ]);
+                            }}
+                        />
+                        <CmsImageEditorDialog editor={editor} />
+                    </>
                 );
             }}
         />

--- a/packages/app-file-manager/src/presentation/hooks/useCmsImageEditor.ts
+++ b/packages/app-file-manager/src/presentation/hooks/useCmsImageEditor.ts
@@ -1,0 +1,85 @@
+import { useCallback, useState } from "react";
+import { useSnackbar } from "@webiny/app-admin";
+import { useContainer } from "@webiny/app";
+import type { ImageEditorValue } from "@webiny/admin-ui";
+import { GetFileUseCase } from "~/features/getFile/abstractions.js";
+import { UpdateFileUseCase } from "~/features/updateFile/abstractions.js";
+import type { FileItem } from "~/domain/types.js";
+
+const IMAGE_URL = /\.(jpe?g|png|webp|avif|gif)$/i;
+
+/** Whether a stored file URL points at a raster image we can crop (SVGs excluded). */
+export const isEditableImageUrl = (url: string | undefined): url is string => {
+    return !!url && IMAGE_URL.test(url.split("?")[0]);
+};
+
+/**
+ * Resolve a File's id from its public URL. File keys are `{id}/{filename}` and the
+ * URL is `{srcPrefix}{key}`, so the id is the second-to-last path segment (this is
+ * the same convention the asset-delivery ObjectKey relies on).
+ */
+const parseFileId = (url: string): string | undefined => {
+    const clean = url.split("?")[0].replace(/\/+$/, "");
+    const parts = clean.split("/").filter(Boolean);
+    return parts.length >= 2 ? parts[parts.length - 2] : undefined;
+};
+
+/**
+ * Drives the image editor for a Headless CMS file field, where the field value is
+ * only a URL. Resolves the underlying File (to get its dimensions + current edit),
+ * and saves the crop/hotspot/alt to the File's asset-level `metadata.imageEdit`.
+ */
+export function useCmsImageEditor() {
+    const { showSnackbar } = useSnackbar();
+    const container = useContainer();
+    const getFileUseCase = container.resolve(GetFileUseCase);
+    const updateFileUseCase = container.resolve(UpdateFileUseCase);
+
+    const [open, setOpen] = useState(false);
+    const [file, setFile] = useState<FileItem | null>(null);
+
+    const openFor = useCallback(
+        async (url: string) => {
+            const id = parseFileId(url);
+            if (!id) {
+                showSnackbar("Could not resolve the image to edit.");
+                return;
+            }
+            const result = await getFileUseCase.execute({ id });
+            if (result.success) {
+                setFile(result.file);
+                setOpen(true);
+            } else {
+                showSnackbar(result.error.message);
+            }
+        },
+        [getFileUseCase, showSnackbar]
+    );
+
+    const close = useCallback(() => setOpen(false), []);
+
+    const save = useCallback(
+        async (edit: ImageEditorValue) => {
+            if (!file) {
+                return;
+            }
+            const metadata: Record<string, any> = { ...file.metadata };
+            if (Object.keys(edit).length > 0) {
+                metadata.imageEdit = edit;
+            } else {
+                delete metadata.imageEdit;
+            }
+
+            const result = await updateFileUseCase.execute({ id: file.id, data: { metadata } });
+            if (result.success) {
+                showSnackbar("Image settings saved.");
+                setFile(result.file);
+            } else {
+                showSnackbar(result.error.message);
+            }
+        },
+        [file, updateFileUseCase, showSnackbar]
+    );
+
+    return { open, openFor, close, file, save };
+}

--- a/packages/app-file-manager/src/presentation/hooks/useEditImage.ts
+++ b/packages/app-file-manager/src/presentation/hooks/useEditImage.ts
@@ -5,14 +5,20 @@ import type { ImageEditorValue } from "@webiny/admin-ui";
 import { UpdateFileUseCase } from "~/features/updateFile/abstractions.js";
 import type { FileItem } from "~/domain/types.js";
 
+interface UseEditImageOptions {
+    /** Called with the updated file after a successful save (e.g. to refresh the UI). */
+    onSaved?: (file: FileItem) => void;
+}
+
 /**
  * Reads/writes the asset-level image edit (crop, hotspot, alt, caption) stored on
  * `file.metadata.imageEdit`, and manages the editor dialog's open state.
  */
-export function useEditImage(file: FileItem) {
+export function useEditImage(file: FileItem, options: UseEditImageOptions = {}) {
     const { showSnackbar } = useSnackbar();
     const container = useContainer();
     const updateFileUseCase = container.resolve(UpdateFileUseCase);
+    const { onSaved } = options;
 
     const [open, setOpen] = useState(false);
 
@@ -35,11 +41,13 @@ export function useEditImage(file: FileItem) {
 
             if (result.success) {
                 showSnackbar(`Image settings saved.`);
+                // Surface the updated file so the drawer/list previews refresh in place.
+                onSaved?.(result.file);
             } else {
                 showSnackbar(result.error.message);
             }
         },
-        [file.id, file.metadata, updateFileUseCase, showSnackbar]
+        [file.id, file.metadata, updateFileUseCase, showSnackbar, onSaved]
     );
 
     return { open, openEditor, closeEditor, value, save };

--- a/packages/app-file-manager/src/presentation/hooks/useEditImage.ts
+++ b/packages/app-file-manager/src/presentation/hooks/useEditImage.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from "react";
+import { useSnackbar } from "@webiny/app-admin";
+import { useContainer } from "@webiny/app";
+import type { ImageEditorValue } from "@webiny/admin-ui";
+import { UpdateFileUseCase } from "~/features/updateFile/abstractions.js";
+import type { FileItem } from "~/domain/types.js";
+
+/**
+ * Reads/writes the asset-level image edit (crop, hotspot, alt, caption) stored on
+ * `file.metadata.imageEdit`, and manages the editor dialog's open state.
+ */
+export function useEditImage(file: FileItem) {
+    const { showSnackbar } = useSnackbar();
+    const container = useContainer();
+    const updateFileUseCase = container.resolve(UpdateFileUseCase);
+
+    const [open, setOpen] = useState(false);
+
+    const value = (file.metadata?.imageEdit as ImageEditorValue | undefined) ?? undefined;
+
+    const openEditor = useCallback(() => setOpen(true), []);
+    const closeEditor = useCallback(() => setOpen(false), []);
+
+    const save = useCallback(
+        async (edit: ImageEditorValue) => {
+            // Preserve the rest of the metadata bag (image dimensions, exif, ...).
+            const metadata: Record<string, any> = { ...file.metadata };
+            if (Object.keys(edit).length > 0) {
+                metadata.imageEdit = edit;
+            } else {
+                delete metadata.imageEdit;
+            }
+
+            const result = await updateFileUseCase.execute({ id: file.id, data: { metadata } });
+
+            if (result.success) {
+                showSnackbar(`Image settings saved.`);
+            } else {
+                showSnackbar(result.error.message);
+            }
+        },
+        [file.id, file.metadata, updateFileUseCase, showSnackbar]
+    );
+
+    return { open, openEditor, closeEditor, value, save };
+}

--- a/packages/app-website-builder/src/inputRenderers/FileInput.tsx
+++ b/packages/app-website-builder/src/inputRenderers/FileInput.tsx
@@ -1,10 +1,19 @@
-import React from "react";
-import { FilePicker } from "@webiny/admin-ui";
+import React, { useState } from "react";
+import { FilePicker, ImageEditor, type ImageEditorValue } from "@webiny/admin-ui";
 import type { ElementInputRendererProps } from "~/BaseEditor/index.js";
 import { FileManager, type FileManagerFileItem } from "@webiny/app-admin";
 import { useBreakpoint } from "~/BaseEditor/hooks/useBreakpoint.js";
-import type { FileInput } from "@webiny/website-builder-sdk";
+import type { FileInput, WebinyImageEdit, WebinyImageValue } from "@webiny/website-builder-sdk";
 import { fileManagerItemToValue } from "~/shared/fileManagerItemToValue.js";
+
+const isEditableImage = (value: WebinyImageValue | undefined): value is WebinyImageValue => {
+    return (
+        !!value?.src &&
+        typeof value.mimeType === "string" &&
+        value.mimeType.startsWith("image/") &&
+        value.mimeType !== "image/svg+xml"
+    );
+};
 
 export const FileInputRenderer = ({
     value,
@@ -14,6 +23,10 @@ export const FileInputRenderer = ({
 }: ElementInputRendererProps) => {
     const input = props.input as FileInput;
     const { isBaseBreakpoint } = useBreakpoint();
+    const [editorOpen, setEditorOpen] = useState(false);
+
+    const fileValue = value as WebinyImageValue | undefined;
+    const editable = isEditableImage(fileValue);
 
     const onFileChange = (file: FileManagerFileItem) => {
         onChange(({ value }) => {
@@ -32,21 +45,51 @@ export const FileInputRenderer = ({
         });
     };
 
+    // Save the per-usage crop/hotspot/alt override back onto the element's value.
+    const onSaveEdit = (edit: ImageEditorValue) => {
+        onChange(({ value }) => {
+            const hasEdit = Object.keys(edit).length > 0;
+            value.set({
+                ...(fileValue as WebinyImageValue),
+                edit: hasEdit ? (edit as WebinyImageEdit) : undefined
+            });
+        });
+    };
+
     return (
         <FileManager
             accept={input.allowedFileTypes}
             onChange={onFileChange}
             render={({ showFileManager }) => (
-                <FilePicker
-                    variant={"secondary"}
-                    label={label}
-                    description={input.description}
-                    type="compact"
-                    value={value}
-                    onSelectItem={() => showFileManager()}
-                    onRemoveItem={onRemove}
-                    onEditItem={() => showFileManager()}
-                />
+                <>
+                    <FilePicker
+                        variant={"secondary"}
+                        label={label}
+                        description={input.description}
+                        type="compact"
+                        value={value}
+                        onSelectItem={() => showFileManager()}
+                        onRemoveItem={onRemove}
+                        // The "Edit" (pencil) action edits the image (crop / focal
+                        // point / alt). Replacing the file is done by clicking the
+                        // preview. For non-images there is nothing to edit, so the
+                        // pencil is hidden.
+                        onEditItem={editable ? () => setEditorOpen(true) : undefined}
+                    />
+                    {editable ? (
+                        <ImageEditor
+                            open={editorOpen}
+                            onClose={() => setEditorOpen(false)}
+                            image={{
+                                src: fileValue.src,
+                                width: fileValue.width ?? 0,
+                                height: fileValue.height ?? 0
+                            }}
+                            value={fileValue.edit as ImageEditorValue | undefined}
+                            onSave={onSaveEdit}
+                        />
+                    ) : null}
+                </>
             )}
         />
     );

--- a/packages/app-website-builder/src/shared/fileManagerItemToValue.ts
+++ b/packages/app-website-builder/src/shared/fileManagerItemToValue.ts
@@ -1,6 +1,11 @@
 import type { FileManagerFileItem } from "@webiny/app-admin";
 
 export const fileManagerItemToValue = (file: FileManagerFileItem) => {
+    // Seed the per-usage edit from the asset-level default (set in File Manager),
+    // if any. From here on the edit lives on the element's value and is editable
+    // per placement.
+    const assetEdit = file.metadata?.imageEdit;
+
     return {
         id: file.id,
         name: file.name,
@@ -8,6 +13,7 @@ export const fileManagerItemToValue = (file: FileManagerFileItem) => {
         mimeType: file.type,
         src: file.src || "",
         width: file.width,
-        height: file.height
+        height: file.height,
+        ...(assetEdit ? { edit: assetEdit } : {})
     };
 };

--- a/packages/website-builder-nextjs/src/editorComponents/Image.tsx
+++ b/packages/website-builder-nextjs/src/editorComponents/Image.tsx
@@ -1,55 +1,47 @@
 import React from "react";
-import Image from "next/image";
-import type { CssProperties } from "@webiny/website-builder-react";
-import type { ComponentProps } from "@webiny/website-builder-react";
+import type {
+    ComponentProps,
+    CssProperties,
+    WebinyImageValue
+} from "@webiny/website-builder-react";
+import { WebinyImage } from "@webiny/website-builder-react";
 
 type ImageProps = ComponentProps<{
     title: string;
     altText: string;
     highPriority: boolean;
-    image: {
-        id: string;
-        name: string;
-        size: number;
-        mimeType: string;
-        src: string;
-        width: number;
-        height: number;
-    };
+    image: WebinyImageValue;
 }>;
 
 export const ImageComponent = (props: ImageProps) => {
-    const image = useImage(props);
+    const { title = "", altText, image, highPriority } = props.inputs;
 
-    if (!image.src) {
+    if (!image?.src) {
         return <ImagePlaceholder style={props.styles} />;
     }
 
-    if (image.tag === "object") {
-        return <object style={image.styles} title={image.title} data={image.src} />;
+    // Explicit alt input wins; otherwise fall back to the alt stored with the image.
+    const alt = altText || image.edit?.alt || "";
+
+    // SVGs are vector — there's no raster crop/hotspot to apply.
+    if (image.src.endsWith(".svg")) {
+        return (
+            <object style={{ maxWidth: "100%", ...props.styles }} title={title} data={image.src} />
+        );
     }
 
+    // Renders honoring the crop + hotspot (pure CSS), at the crop's own aspect
+    // ratio. The Webiny CDN width parameter drives a responsive srcSet.
     return (
-        <div
-            style={{
-                position: "relative",
-                ...props.styles
-            }}
-        >
-            {/* <ImagePlaceholder style={image.styles} /> */}
-            <Image
-                alt={image.altText}
-                title={image.title}
-                src={image.src}
-                width={props.inputs.image.width}
-                height={props.inputs.image.height}
-                style={image.styles}
-                priority={props.inputs.highPriority}
-                loading={props.inputs.highPriority ? "eager" : "lazy"}
-                sizes={"100vw"}
-                loader={({ src, width }) => `${src}?width=${width}`}
-            />
-        </div>
+        <WebinyImage
+            image={image}
+            alt={alt}
+            title={title}
+            style={props.styles}
+            sizes={"100vw"}
+            loading={highPriority ? "eager" : "lazy"}
+            loader={({ src, width }) => `${src}?width=${width}`}
+        />
     );
 };
 
@@ -81,24 +73,4 @@ const ImagePlaceholder = ({ style }: { style: CssProperties }) => {
             </svg>
         </div>
     );
-};
-
-const useImage = ({ inputs, styles }: ImageProps) => {
-    const { title = "", altText, image } = inputs;
-    const src = image?.src;
-
-    const tag = src && src.endsWith(".svg") ? "object" : "img";
-
-    const imageStyles = {
-        maxWidth: "100%",
-        ...styles
-    };
-
-    return {
-        altText,
-        src: inputs.image?.src,
-        styles: imageStyles,
-        tag,
-        title
-    };
 };

--- a/packages/website-builder-react/src/image/WebinyImage.tsx
+++ b/packages/website-builder-react/src/image/WebinyImage.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import type { AspectRatioInput, WebinyImageValue } from "@webiny/website-builder-sdk";
+import { getWebinyImageProps } from "./getWebinyImageProps.js";
+
+export interface WebinyImageComponentProps extends Omit<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    "src" | "width" | "height" | "style" | "alt"
+> {
+    /** The image value from a Webiny file input (may carry a crop/hotspot/alt). */
+    image: WebinyImageValue;
+    /** Target aspect ratio (e.g. `16 / 9` or `{ width, height }`). Omit for the crop's own ratio. */
+    aspectRatio?: AspectRatioInput;
+    /** Explicit alt text; falls back to the image's stored alt. */
+    alt?: string;
+    /** Class applied to the wrapper element. */
+    className?: string;
+    /** Class applied to the `<img>` element. */
+    imgClassName?: string;
+    /** Extra styles merged into the wrapper (e.g. `maxWidth`). */
+    style?: React.CSSProperties;
+    /**
+     * Optional responsive URL builder — e.g. `({ src, width }) => \`${src}?width=${width}\``.
+     * When provided, a `srcSet` is generated from `widths`. This is also the seam for a
+     * future server/CDN transform (crop params can be appended here).
+     */
+    loader?: (params: { src: string; width: number }) => string;
+    /** Candidate widths for the generated `srcSet` (defaults to a common set). */
+    widths?: number[];
+    /** The `sizes` attribute for responsive selection. */
+    sizes?: string;
+}
+
+const DEFAULT_WIDTHS = [640, 750, 828, 1080, 1200, 1920, 2048];
+
+/**
+ * Renders a Webiny image honoring its non-destructive crop + hotspot, using pure
+ * CSS — no image backend required. The wrapper is an aspect-ratio box that clips
+ * to the cropped region (so it also prevents layout shift), and the `<img>` is
+ * scaled/positioned inside it.
+ *
+ * Compatible with SSR and static export. Pass a `loader` to emit a responsive
+ * `srcSet` (e.g. via the Webiny CDN's width parameter).
+ */
+export function WebinyImage({
+    image,
+    aspectRatio,
+    alt,
+    className,
+    imgClassName,
+    style,
+    loader,
+    widths = DEFAULT_WIDTHS,
+    sizes,
+    ...imgProps
+}: WebinyImageComponentProps) {
+    const {
+        style: containerStyle,
+        imgStyle,
+        src,
+        alt: resolvedAlt,
+        width
+    } = getWebinyImageProps(image, { aspectRatio, alt });
+
+    const srcSet = loader
+        ? widths
+              .filter(w => !width || w <= width)
+              .map(w => `${loader({ src, width: w })} ${w}w`)
+              .join(", ") || undefined
+        : undefined;
+
+    const resolvedSrc = loader ? loader({ src, width: width || widths[widths.length - 1] }) : src;
+
+    return (
+        <div className={className} style={{ ...containerStyle, ...style }}>
+            <img
+                {...imgProps}
+                className={imgClassName}
+                src={resolvedSrc}
+                srcSet={srcSet}
+                sizes={sizes}
+                alt={resolvedAlt}
+                style={imgStyle}
+            />
+        </div>
+    );
+}

--- a/packages/website-builder-react/src/image/getWebinyImageProps.test.ts
+++ b/packages/website-builder-react/src/image/getWebinyImageProps.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getWebinyImageProps } from "./getWebinyImageProps.js";
+import type { WebinyImageValue } from "@webiny/website-builder-sdk";
+
+const image = (overrides: Partial<WebinyImageValue> = {}): WebinyImageValue => ({
+    id: "1",
+    name: "photo.jpg",
+    size: 1234,
+    mimeType: "image/jpeg",
+    src: "https://cdn.test/photo.jpg",
+    width: 1600,
+    height: 900,
+    ...overrides
+});
+
+describe("getWebinyImageProps", () => {
+    it("returns wrapper + image styles and passes through src and dimensions", () => {
+        const props = getWebinyImageProps(image());
+        expect(props.src).toBe("https://cdn.test/photo.jpg");
+        expect(props.width).toBe(1600);
+        expect(props.height).toBe(900);
+        expect(props.style.overflow).toBe("hidden");
+        expect(props.style.position).toBe("relative");
+        expect(props.imgStyle.position).toBe("absolute");
+    });
+
+    it("resolves alt from the explicit option first", () => {
+        const props = getWebinyImageProps(image({ edit: { alt: "stored alt" } }), {
+            alt: "explicit alt"
+        });
+        expect(props.alt).toBe("explicit alt");
+    });
+
+    it("falls back to the image's stored alt", () => {
+        const props = getWebinyImageProps(image({ edit: { alt: "stored alt" } }));
+        expect(props.alt).toBe("stored alt");
+    });
+
+    it("defaults alt to an empty string", () => {
+        expect(getWebinyImageProps(image()).alt).toBe("");
+    });
+
+    it("produces a wrapper with the requested aspect ratio", () => {
+        const props = getWebinyImageProps(image(), { aspectRatio: 1 });
+        expect(props.style.aspectRatio).toBe("1");
+    });
+
+    it("offsets the image to reveal a hotspot-shifted crop region", () => {
+        // Square target on a 16:9 image, hotspot near the right edge — the visible
+        // window should shift right, i.e. a negative left offset.
+        const props = getWebinyImageProps(
+            image({ edit: { hotspot: { x: 0.9, y: 0.5, width: 0.2, height: 0.2 } } }),
+            { aspectRatio: 1 }
+        );
+        expect(parseFloat(props.imgStyle.left as string)).toBeLessThan(0);
+    });
+});

--- a/packages/website-builder-react/src/image/getWebinyImageProps.ts
+++ b/packages/website-builder-react/src/image/getWebinyImageProps.ts
@@ -1,0 +1,51 @@
+import type { CSSProperties } from "react";
+import {
+    getImageRenderData,
+    type AspectRatioInput,
+    type WebinyImageValue
+} from "@webiny/website-builder-sdk";
+
+export interface WebinyImageProps {
+    /** Wrapper style: an aspect-ratio box that clips overflow. Spread onto a container. */
+    style: CSSProperties;
+    /** Image style: absolutely positioned to reveal exactly the cropped/focused region. */
+    imgStyle: CSSProperties;
+    /** The image URL. */
+    src: string;
+    /** Resolved alt text (explicit override, else the image's stored alt, else ""). */
+    alt: string;
+    /** Intrinsic (original) pixel dimensions of the asset. */
+    width: number;
+    height: number;
+}
+
+export interface GetWebinyImagePropsOptions {
+    /** Target aspect ratio. Omit to render at the crop's own aspect ratio. */
+    aspectRatio?: AspectRatioInput;
+    /** Explicit alt text; falls back to the image's stored `edit.alt`. */
+    alt?: string;
+}
+
+/**
+ * Compute the props needed to render a Webiny image honoring its crop + hotspot,
+ * using pure CSS (no image backend). Works with a plain `<img>`, SSR, and static
+ * export. Spread `style` onto a wrapper element and `imgStyle` onto the `<img>`.
+ *
+ * This is the escape hatch for custom rendering; most consumers can use the
+ * `<WebinyImage>` component instead.
+ */
+export function getWebinyImageProps(
+    image: WebinyImageValue,
+    options: GetWebinyImagePropsOptions = {}
+): WebinyImageProps {
+    const data = getImageRenderData(image, options.aspectRatio);
+
+    return {
+        style: data.container,
+        imgStyle: data.image,
+        src: image.src,
+        alt: options.alt ?? image.edit?.alt ?? "",
+        width: data.intrinsicWidth,
+        height: data.intrinsicHeight
+    };
+}

--- a/packages/website-builder-react/src/image/index.ts
+++ b/packages/website-builder-react/src/image/index.ts
@@ -1,0 +1,2 @@
+export * from "./getWebinyImageProps.js";
+export * from "./WebinyImage.js";

--- a/packages/website-builder-react/src/index.ts
+++ b/packages/website-builder-react/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./components/index.js";
 export * from "./createComponent.js";
+export * from "./image/index.js";
 
 export {
     createTextInput,
@@ -30,6 +31,12 @@ export {
     forcedAssignment,
     registerAnalyticsProvider,
     getAnalyticsProvider,
+    // Image crop + hotspot geometry.
+    getImageRenderData,
+    getVisibleRect,
+    getCropRect,
+    resolveImageEdit,
+    ASPECT_RATIO_PRESETS,
     FORCED_VARIANT_PARAM,
     DEFAULT_VISITOR_COOKIE,
     CONTROL_VARIANT_ID,
@@ -56,6 +63,14 @@ export {
     type ComponentInput,
     type ComponentConstraint,
     type WebsiteBuilderThemeInput,
+    type WebinyImageValue,
+    type WebinyImageEdit,
+    type WebinyImageCrop,
+    type WebinyImageHotspot,
+    type AspectRatioInput,
+    type AspectRatioPreset,
+    type NormalizedRect,
+    type ImageRenderData,
     StyleSettings
 } from "@webiny/website-builder-sdk";
 

--- a/packages/website-builder-sdk/src/image/geometry.test.ts
+++ b/packages/website-builder-sdk/src/image/geometry.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { getCropRect, getImageRenderData, getVisibleRect, resolveImageEdit } from "./geometry.js";
+import type { WebinyImageEdit, WebinyImageValue } from "./types.js";
+
+const image = (edit?: WebinyImageEdit, width = 1000, height = 1000): WebinyImageValue => ({
+    id: "1",
+    name: "photo.jpg",
+    size: 1234,
+    mimeType: "image/jpeg",
+    src: "https://cdn.test/photo.jpg",
+    width,
+    height,
+    edit
+});
+
+describe("resolveImageEdit", () => {
+    it("prefers the override per property, falling back to the asset default", () => {
+        const assetDefault: WebinyImageEdit = {
+            crop: { top: 0.1, left: 0.1, bottom: 0.1, right: 0.1 },
+            hotspot: { x: 0.2, y: 0.2, width: 0.5, height: 0.5 },
+            alt: "default alt",
+            caption: "default caption"
+        };
+        const override: WebinyImageEdit = {
+            hotspot: { x: 0.8, y: 0.8, width: 0.3, height: 0.3 },
+            alt: "override alt"
+        };
+
+        const result = resolveImageEdit(override, assetDefault);
+
+        // crop + caption inherited, hotspot + alt overridden.
+        expect(result.crop).toEqual(assetDefault.crop);
+        expect(result.caption).toBe("default caption");
+        expect(result.hotspot).toEqual(override.hotspot);
+        expect(result.alt).toBe("override alt");
+    });
+
+    it("handles null/undefined inputs", () => {
+        expect(resolveImageEdit(null, null)).toEqual({
+            crop: undefined,
+            hotspot: undefined,
+            alt: undefined,
+            caption: undefined
+        });
+    });
+});
+
+describe("getCropRect", () => {
+    it("returns the full image when no crop is set", () => {
+        expect(getCropRect()).toEqual({ x: 0, y: 0, width: 1, height: 1 });
+    });
+
+    it("converts edge insets into a rectangle", () => {
+        const rect = getCropRect({ top: 0.1, left: 0.2, bottom: 0.3, right: 0.05 });
+        expect(rect.x).toBeCloseTo(0.2, 10);
+        expect(rect.y).toBeCloseTo(0.1, 10);
+        expect(rect.width).toBeCloseTo(0.75, 10);
+        expect(rect.height).toBeCloseTo(0.6, 10);
+    });
+
+    it("does not produce negative dimensions when insets overlap", () => {
+        const rect = getCropRect({ top: 0.7, left: 0.7, bottom: 0.7, right: 0.7 });
+        expect(rect.width).toBe(0);
+        expect(rect.height).toBe(0);
+    });
+
+    it("clamps out-of-range values", () => {
+        const rect = getCropRect({ top: -1, left: 2, bottom: 0, right: 0 });
+        expect(rect.x).toBe(1);
+        expect(rect.y).toBe(0);
+    });
+});
+
+describe("getVisibleRect", () => {
+    it("returns the crop rect when no aspect ratio is requested", () => {
+        const rect = getVisibleRect(
+            image({ crop: { top: 0.1, left: 0.1, bottom: 0.1, right: 0.1 } })
+        );
+        expect(rect).toEqual({ x: 0.1, y: 0.1, width: 0.8, height: 0.8 });
+    });
+
+    it("fits a 16:9 rect inside a square image, centered by default", () => {
+        // 1000x1000, target 16:9 -> width limited, height = 1000 * 9/16 = 562.5px = 0.5625.
+        const rect = getVisibleRect(image(), 16 / 9);
+        expect(rect.width).toBeCloseTo(1, 5);
+        expect(rect.height).toBeCloseTo(0.5625, 5);
+        // Centered vertically: y = (1 - 0.5625) / 2.
+        expect(rect.y).toBeCloseTo((1 - 0.5625) / 2, 5);
+        expect(rect.x).toBeCloseTo(0, 5);
+    });
+
+    it("shifts the visible rect toward the hotspot and clamps to bounds", () => {
+        // Hotspot near the top -> the 16:9 band should clamp to y = 0 (cannot go negative).
+        const rect = getVisibleRect(
+            image({ hotspot: { x: 0.5, y: 0.05, width: 0.2, height: 0.2 } }),
+            16 / 9
+        );
+        expect(rect.y).toBeCloseTo(0, 5);
+    });
+
+    it("keeps the visible rect within the crop rectangle", () => {
+        const rect = getVisibleRect(
+            image({
+                crop: { top: 0.25, left: 0, bottom: 0.25, right: 0 },
+                hotspot: { x: 0.5, y: 0.9, width: 0.2, height: 0.2 }
+            }),
+            1
+        );
+        // Crop is 1000x500; a square fit is 500x500 (0.5 tall). It must stay inside [0.25, 0.75].
+        expect(rect.y).toBeGreaterThanOrEqual(0.25 - 1e-9);
+        expect(rect.y + rect.height).toBeLessThanOrEqual(0.75 + 1e-9);
+    });
+
+    it("accepts an explicit width/height aspect ratio", () => {
+        const byObject = getVisibleRect(image(), { width: 16, height: 9 });
+        const byNumber = getVisibleRect(image(), 16 / 9);
+        expect(byObject).toEqual(byNumber);
+    });
+});
+
+describe("getImageRenderData", () => {
+    it("derives objectPosition from the hotspot", () => {
+        const data = getImageRenderData(
+            image({ hotspot: { x: 0.25, y: 0.75, width: 0.2, height: 0.2 } }),
+            1
+        );
+        expect(data.objectPosition).toBe("25% 75%");
+    });
+
+    it("produces an overflow-hidden container with the requested aspect ratio", () => {
+        const data = getImageRenderData(image(), 16 / 9);
+        expect(data.container.overflow).toBe("hidden");
+        expect(data.container.aspectRatio).toBe(`${Math.round((16 / 9) * 1000) / 1000}`);
+    });
+
+    it("scales and offsets the image so the visible rect fills the container", () => {
+        // Square image, 16:9 target: visible rect is full width, 0.5625 tall.
+        const data = getImageRenderData(image(), 16 / 9);
+        // width fills (100%), height scales up by 1/0.5625.
+        expect(data.image.width).toBe("100%");
+        expect(data.image.height).toBe(`${Math.round((100 / 0.5625) * 1000) / 1000}%`);
+        // left offset 0 (x=0), top offset negative (centered band).
+        expect(parseFloat(data.image.left)).toBe(0);
+        expect(parseFloat(data.image.top)).toBeLessThan(0);
+    });
+
+    it("stays finite for a degenerate (collapsed) crop", () => {
+        const data = getImageRenderData(
+            image({ crop: { top: 0.7, left: 0.7, bottom: 0.7, right: 0.7 } }),
+            1
+        );
+        expect(Number.isFinite(parseFloat(data.image.width))).toBe(true);
+        expect(Number.isFinite(parseFloat(data.image.height))).toBe(true);
+    });
+
+    it("passes through intrinsic dimensions", () => {
+        const data = getImageRenderData(image(undefined, 1920, 1080), 16 / 9);
+        expect(data.intrinsicWidth).toBe(1920);
+        expect(data.intrinsicHeight).toBe(1080);
+    });
+});

--- a/packages/website-builder-sdk/src/image/geometry.ts
+++ b/packages/website-builder-sdk/src/image/geometry.ts
@@ -1,0 +1,217 @@
+/**
+ * Pure geometry core for crop + hotspot rendering.
+ *
+ * This module is the single source of truth shared by:
+ *  - the Admin editor previews (square / 4:3 / 16:9),
+ *  - the Next.js render helper (`getWebinyImageProps` / `<WebinyImage>`),
+ *  - and any future URL-transform loader (`?rect=…`).
+ *
+ * Keeping the math here guarantees that what an editor previews is exactly what
+ * a visitor sees. Everything is framework-agnostic and side-effect free.
+ */
+import type {
+    AspectRatioInput,
+    WebinyImageCrop,
+    WebinyImageEdit,
+    WebinyImageHotspot,
+    WebinyImageValue
+} from "./types.js";
+
+/** A rectangle in normalized (0..1) coordinates of the original image. */
+export interface NormalizedRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * CSS needed to render an image cropped to a target aspect ratio while honoring
+ * both the crop rectangle and the hotspot — without any server-side processing.
+ *
+ * `objectPosition` is the simpler, hotspot-only path (apply to an `object-fit:
+ * cover` image). `container` + `image` is the accurate path that also honors the
+ * crop rectangle via an overflow-clipped wrapper.
+ */
+export interface ImageRenderData {
+    /** Final visible region in normalized original-image coordinates. */
+    rect: NormalizedRect;
+    /** `"50% 40%"` — focal point for the simple `object-fit: cover` path. */
+    objectPosition: string;
+    /** Wrapper style for the accurate crop path. */
+    container: {
+        position: "relative";
+        width: "100%";
+        aspectRatio: string;
+        overflow: "hidden";
+    };
+    /** `<img>` style for the accurate crop path (absolutely positioned inside `container`). */
+    image: {
+        position: "absolute";
+        width: string;
+        height: string;
+        left: string;
+        top: string;
+        maxWidth: "none";
+    };
+    /** Intrinsic pixel dimensions of the original asset (pass-through). */
+    intrinsicWidth: number;
+    intrinsicHeight: number;
+}
+
+const clamp = (value: number, min = 0, max = 1): number => {
+    if (Number.isNaN(value)) {
+        return min;
+    }
+    return Math.min(max, Math.max(min, value));
+};
+
+const round = (n: number): number => Math.round(n * 1000) / 1000;
+
+const DEFAULT_CROP: WebinyImageCrop = { top: 0, left: 0, bottom: 0, right: 0 };
+const DEFAULT_HOTSPOT: WebinyImageHotspot = { x: 0.5, y: 0.5, width: 1, height: 1 };
+
+/**
+ * Merge a per-usage override over an asset-level default, per property. Used by
+ * the Admin editor to seed a starting point; frontends render the already
+ * resolved `edit` and never need this.
+ */
+export function resolveImageEdit(
+    override?: WebinyImageEdit | null,
+    assetDefault?: WebinyImageEdit | null
+): WebinyImageEdit {
+    return {
+        crop: override?.crop ?? assetDefault?.crop,
+        hotspot: override?.hotspot ?? assetDefault?.hotspot,
+        alt: override?.alt ?? assetDefault?.alt,
+        caption: override?.caption ?? assetDefault?.caption
+    };
+}
+
+/**
+ * Convert a crop (edge insets) into a normalized rectangle. Defensive against
+ * missing/invalid values and against insets that would collapse the rectangle.
+ */
+export function getCropRect(crop?: WebinyImageCrop | null): NormalizedRect {
+    const top = clamp(crop?.top ?? DEFAULT_CROP.top);
+    const left = clamp(crop?.left ?? DEFAULT_CROP.left);
+    const bottom = clamp(crop?.bottom ?? DEFAULT_CROP.bottom);
+    const right = clamp(crop?.right ?? DEFAULT_CROP.right);
+
+    // Guard against overlapping insets collapsing width/height to <= 0.
+    const width = Math.max(0, 1 - left - right);
+    const height = Math.max(0, 1 - top - bottom);
+
+    return { x: left, y: top, width, height };
+}
+
+const resolveAspectRatio = (aspectRatio: AspectRatioInput): number => {
+    if (typeof aspectRatio === "number") {
+        return aspectRatio > 0 ? aspectRatio : 1;
+    }
+    const { width, height } = aspectRatio;
+    return width > 0 && height > 0 ? width / height : 1;
+};
+
+const getHotspotCenter = (hotspot?: WebinyImageHotspot | null): { x: number; y: number } => ({
+    x: clamp(hotspot?.x ?? DEFAULT_HOTSPOT.x),
+    y: clamp(hotspot?.y ?? DEFAULT_HOTSPOT.y)
+});
+
+/**
+ * Compute the final visible rectangle for a target aspect ratio.
+ *
+ * The largest rectangle of the requested aspect ratio that fits *inside the crop
+ * rectangle* is centered on the hotspot and clamped to the crop bounds. When no
+ * aspect ratio is requested, the crop rectangle itself is returned.
+ *
+ * @param value - Image value (needs intrinsic `width`/`height` and optional `edit`).
+ * @param aspectRatio - Optional target ratio (`w/h` or `{ width, height }`).
+ */
+export function getVisibleRect(
+    value: Pick<WebinyImageValue, "width" | "height" | "edit">,
+    aspectRatio?: AspectRatioInput
+): NormalizedRect {
+    const cropRect = getCropRect(value.edit?.crop);
+
+    if (aspectRatio === undefined || cropRect.width <= 0 || cropRect.height <= 0) {
+        return cropRect;
+    }
+
+    const iw = value.width > 0 ? value.width : 1;
+    const ih = value.height > 0 ? value.height : 1;
+    const targetAR = resolveAspectRatio(aspectRatio);
+
+    // Crop dimensions in pixels, and the crop's own aspect ratio.
+    const cropWpx = cropRect.width * iw;
+    const cropHpx = cropRect.height * ih;
+    const cropAR = cropWpx / cropHpx;
+
+    // Fit the target ratio inside the crop (the larger of the two fitting rects).
+    let finalWpx: number;
+    let finalHpx: number;
+    if (targetAR > cropAR) {
+        finalWpx = cropWpx;
+        finalHpx = cropWpx / targetAR;
+    } else {
+        finalHpx = cropHpx;
+        finalWpx = cropHpx * targetAR;
+    }
+
+    const finalW = finalWpx / iw;
+    const finalH = finalHpx / ih;
+
+    // Center on the hotspot, then clamp inside the crop rectangle.
+    const center = getHotspotCenter(value.edit?.hotspot);
+    const maxX = cropRect.x + cropRect.width - finalW;
+    const maxY = cropRect.y + cropRect.height - finalH;
+    const x = clamp(center.x - finalW / 2, cropRect.x, Math.max(cropRect.x, maxX));
+    const y = clamp(center.y - finalH / 2, cropRect.y, Math.max(cropRect.y, maxY));
+
+    return { x, y, width: finalW, height: finalH };
+}
+
+/**
+ * Produce everything a renderer needs to display an image at a target aspect
+ * ratio: a normalized rect (for URL transforms), a focal-point `objectPosition`
+ * (simple path), and container/image CSS (accurate path honoring the crop).
+ */
+export function getImageRenderData(
+    value: Pick<WebinyImageValue, "width" | "height" | "edit">,
+    aspectRatio?: AspectRatioInput
+): ImageRenderData {
+    const rect = getVisibleRect(value, aspectRatio);
+    const center = getHotspotCenter(value.edit?.hotspot);
+
+    // Guard against a zero-area rect (degenerate crop) so CSS stays finite.
+    const safeW = rect.width > 0 ? rect.width : 1;
+    const safeH = rect.height > 0 ? rect.height : 1;
+
+    // The display box aspect ratio: the requested ratio, or the visible rect's
+    // own pixel aspect ratio when no ratio was requested.
+    const boxAspectRatio =
+        aspectRatio !== undefined
+            ? resolveAspectRatio(aspectRatio)
+            : (rect.width * (value.width || 1)) / (rect.height * (value.height || 1));
+
+    return {
+        rect,
+        objectPosition: `${round(center.x * 100)}% ${round(center.y * 100)}%`,
+        container: {
+            position: "relative",
+            width: "100%",
+            aspectRatio: `${round(boxAspectRatio)}`,
+            overflow: "hidden"
+        },
+        image: {
+            position: "absolute",
+            width: `${round(100 / safeW)}%`,
+            height: `${round(100 / safeH)}%`,
+            left: `${round(-(rect.x / safeW) * 100)}%`,
+            top: `${round(-(rect.y / safeH) * 100)}%`,
+            maxWidth: "none"
+        },
+        intrinsicWidth: value.width,
+        intrinsicHeight: value.height
+    };
+}

--- a/packages/website-builder-sdk/src/image/index.ts
+++ b/packages/website-builder-sdk/src/image/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./presets.js";
+export * from "./geometry.js";

--- a/packages/website-builder-sdk/src/image/presets.ts
+++ b/packages/website-builder-sdk/src/image/presets.ts
@@ -1,0 +1,11 @@
+import type { AspectRatioPreset } from "./types.js";
+
+/**
+ * Default aspect ratios shown in the image editor's preview strip.
+ * A later phase will let a field lock to one of these (or a custom ratio).
+ */
+export const ASPECT_RATIO_PRESETS: AspectRatioPreset[] = [
+    { id: "square", label: "Square", ratio: 1 },
+    { id: "4:3", label: "4:3", ratio: 4 / 3 },
+    { id: "16:9", label: "16:9", ratio: 16 / 9 }
+];

--- a/packages/website-builder-sdk/src/image/types.ts
+++ b/packages/website-builder-sdk/src/image/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Non-destructive image editing types (crop + hotspot + alt/caption).
+ *
+ * All geometric values are normalized (0..1) and resolution-independent, so they
+ * survive resizing, re-encoding, and CDN transforms. Nothing here mutates the
+ * original asset — these describe *intent* that is applied at render time.
+ *
+ * The model mirrors the battle-tested Sanity/imgix approach:
+ *  - `crop`    = a hard rectangle. Nothing outside it is ever shown.
+ *  - `hotspot` = a focal region. When a target aspect ratio forces further
+ *                cutting inside the crop, the hotspot stays in frame.
+ */
+
+/**
+ * Crop stored as the fraction cut off from each edge of the original image.
+ * `{ top: 0, left: 0, bottom: 0, right: 0 }` means "no crop" (full image).
+ */
+export interface WebinyImageCrop {
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+}
+
+/**
+ * Focal region in normalized coordinates of the *original* image.
+ * `x`/`y` are the center of the region; `width`/`height` its size.
+ * The default (center, full image) is `{ x: 0.5, y: 0.5, width: 1, height: 1 }`.
+ */
+export interface WebinyImageHotspot {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * The complete, non-destructive edit applied to an image. Every property is
+ * optional so the type is fully backward-compatible with un-edited images.
+ */
+export interface WebinyImageEdit {
+    crop?: WebinyImageCrop;
+    hotspot?: WebinyImageHotspot;
+    /** Alternative text for accessibility / SEO. */
+    alt?: string;
+    /** Optional visible caption. */
+    caption?: string;
+}
+
+/**
+ * Runtime value produced by a `Webiny/FileManager` file input (and the shape a
+ * component receives via `props.inputs.<name>`). `width`/`height` are the
+ * intrinsic pixel dimensions of the original asset.
+ *
+ * `edit` is the *effective* edit to render (already resolved from the per-usage
+ * override + asset-level default at edit time), so frontends stay self-contained.
+ */
+export interface WebinyImageValue {
+    id: string;
+    name: string;
+    size: number;
+    mimeType: string;
+    src: string;
+    width: number;
+    height: number;
+    edit?: WebinyImageEdit;
+}
+
+/**
+ * A target aspect ratio, given either as a bare number (`width / height`) or as
+ * an explicit `{ width, height }` pair.
+ */
+export type AspectRatioInput = number | { width: number; height: number };
+
+/** A preset aspect ratio surfaced in the editor's preview strip. */
+export interface AspectRatioPreset {
+    id: string;
+    label: string;
+    /** `width / height`. */
+    ratio: number;
+}

--- a/packages/website-builder-sdk/src/index.ts
+++ b/packages/website-builder-sdk/src/index.ts
@@ -8,6 +8,7 @@ export * from "./DocumentStore.js";
 export * from "./Logger.js";
 export * from "./FunctionConverter.js";
 export * from "./createInput.js";
+export * from "./image/index.js";
 export * from "./MouseTracker.js";
 export * from "./ViewportManager.js";
 export * from "./messenger/Messenger.js";


### PR DESCRIPTION
## Summary

**Part 1/3** of the image crop & hotspot feature (umbrella: #TBD)

- Add `ImageEditor` component to `admin-ui` with crop rectangle, focal-point hotspot, aspect ratio preview, and alt/title meta fields
- Integrate image editing into File Manager (Edit Image action, preview refresh, thumbnail cropping)
- Add image crop/hotspot/alt editor to CMS file field renderers
- Persist image edit data as a JSON field on the File model
- Add geometry utilities and image presets to `website-builder-sdk`

## Packages touched

- `admin-ui` — new `ImageEditor/` component
- `api-file-manager` — file model update
- `app-file-manager` — edit actions, thumbnail renderers, CMS field renderers
- `app-website-builder` — FileInput, fileManagerItemToValue
- `website-builder-sdk` — image module (presets, types, geometry)
- `website-builder-nextjs`, `website-builder-react` — image component updates

## Test plan

- [ ] Open File Manager, select an image, verify "Edit Image" action opens the crop/hotspot editor
- [ ] Set a crop region and focal point, save, verify the data persists on reload
- [ ] Verify FM grid/table thumbnails reflect the saved crop
- [ ] In CMS, add a file field to a model, verify image editor dialog opens
- [ ] Check `website-builder-sdk` geometry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)