### PR TITLE
ci: validate inputs and support tag-based release branches in Full Release

### DIFF
--- a/.github/workflows/deleteReleaseBranch.yml
+++ b/.github/workflows/deleteReleaseBranch.yml
@@ -9,6 +9,7 @@ name: Delete Merged Release Branch
       - closed
     branches:
       - next
+      - release/*-base
 jobs:
   deleteBranch:
     name: Delete release branch
@@ -22,9 +23,25 @@ jobs:
       - name: Delete branch
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: >-
-          gh api --method DELETE /repos/${{ github.repository
-          }}/git/refs/heads/${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |-
+          set -e
+          # Delete the head release branch (Y) that was just merged.
+          gh api --method DELETE "/repos/$REPO/git/refs/heads/$HEAD_REF"
+          echo "Deleted head branch: $HEAD_REF"
+          # For tag-based (patch) releases the PR base is a throwaway
+          # "release/x.y.z-base" branch (X) - delete it too. Never delete next.
+          case "$BASE_REF" in
+            release/*-base)
+              gh api --method DELETE "/repos/$REPO/git/refs/heads/$BASE_REF"
+              echo "Deleted base branch: $BASE_REF"
+              ;;
+            *)
+              echo "Base branch $BASE_REF is not a release base branch; leaving it in place."
+              ;;
+          esac
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/fullRelease.yml
+++ b/.github/workflows/fullRelease.yml
@@ -33,9 +33,8 @@ jobs:
 
           ok=1
 
-          if ! printf "%s" "$VERSION" | grep -Eq
-          "^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$"; then
-            echo "::error::Invalid version [$VERSION]. Expected semver, e.g. 6.3.0 or 6.3.0-beta.1."
+          if ! printf "%s" "$VERSION" | grep -Eq "^6\.[0-9]+\.[0-9]+$"; then
+            echo "::error::Invalid version [$VERSION]. Expected 6.x.y, e.g. 6.3.0 (three numbers, no alpha/beta)."
             ok=0
           fi
 

--- a/.github/workflows/fullRelease.yml
+++ b/.github/workflows/fullRelease.yml
@@ -16,8 +16,46 @@ name: 🚀 Full Release
         default: next
         type: string
 jobs:
+  validateInputs:
+    name: Validate inputs
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      VERSION: ${{ github.event.inputs.version }}
+      SOURCE_TAG: ${{ github.event.inputs.sourceTag }}
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Validate workflow inputs
+        run: >-
+          set -e
+
+          ok=1
+
+          if ! printf "%s" "$VERSION" | grep -Eq
+          "^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$"; then
+            echo "::error::Invalid version [$VERSION]. Expected semver, e.g. 6.3.0 or 6.3.0-beta.1."
+            ok=0
+          fi
+
+          if [ -n "$SOURCE_TAG" ] && ! printf "%s" "$SOURCE_TAG" | grep -Eq
+          "^[A-Za-z0-9._/-]+$"; then
+            echo "::error::Invalid sourceTag [$SOURCE_TAG]. Use a valid branch or tag name (letters, digits, . _ / -)."
+            ok=0
+          fi
+
+          if [ "$ok" -ne 1 ]; then
+            echo "Input validation failed. Fix the inputs above and re-run the workflow."
+            exit 1
+          fi
+
+          echo "Inputs OK: version=$VERSION sourceTag=${SOURCE_TAG:-next}"
+    runs-on: ubuntu-latest
   createWebinyJsBranch:
     name: Create release branch (webiny-js)
+    needs:
+      - validateInputs
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -38,16 +76,40 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
       - name: Create and push release branch
+        id: branch
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          SOURCE_TAG: ${{ github.event.inputs.sourceTag }}
         run: >-
-          git checkout -b release/${{ github.event.inputs.version }} && git
-          commit --allow-empty -m "chore: start release ${{
-          github.event.inputs.version }}" -m "Empty commit to allow PR
-          creation." && git push origin release/${{ github.event.inputs.version
-          }}
+          set -e
+
+          # If the source is a tag, create a base branch off it so the PR diff
+
+          # shows only release-specific work. Otherwise (a branch, e.g. next),
+
+          # the source branch itself is the PR base.
+
+          if git show-ref --verify --quiet "refs/tags/${SOURCE_TAG}"; then
+            BASE_BRANCH="release/${VERSION}-base"
+            git checkout -b "$BASE_BRANCH"
+            git push origin "$BASE_BRANCH"
+          else
+            BASE_BRANCH="${SOURCE_TAG}"
+          fi
+
+          git checkout -b "release/${VERSION}"
+
+          git commit --allow-empty -m "chore: start release ${VERSION} [skip
+          ci]" -m "Empty commit to allow PR creation."
+
+          git push origin "release/${VERSION}"
+
+          echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
       - name: Open pull request
         id: pr
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          BASE_BRANCH: ${{ steps.branch.outputs.base-branch }}
         run: >-
           PR_URL=$(gh pr create --title "📦  Release ${{
           github.event.inputs.version }}" --body "Release ${{
@@ -56,9 +118,9 @@ jobs:
 
           **Docs PR:**
           https://github.com/webiny/docs.webiny.com/pulls?q=Release+${{
-          github.event.inputs.version }}" --base next --head release/${{
-          github.event.inputs.version }}) && echo "pr-url=$PR_URL" >>
-          $GITHUB_OUTPUT
+          github.event.inputs.version }}" --base "$BASE_BRANCH" --head
+          "release/${{ github.event.inputs.version }}") && echo "pr-url=$PR_URL"
+          >> $GITHUB_OUTPUT
       - name: Notify Slack - Release PR Created
         env:
           PR_URL: ${{ steps.pr.outputs.pr-url }}

--- a/.github/workflows/wac/deleteReleaseBranch.wac.ts
+++ b/.github/workflows/wac/deleteReleaseBranch.wac.ts
@@ -6,7 +6,7 @@ export const deleteReleaseBranch = createWorkflow({
     on: {
         pull_request: {
             types: ["closed"],
-            branches: ["next"]
+            branches: ["next", "release/*-base"]
         }
     },
     jobs: {
@@ -17,8 +17,29 @@ export const deleteReleaseBranch = createWorkflow({
             steps: [
                 {
                     name: "Delete branch",
-                    env: { GH_TOKEN: "${{ secrets.GH_TOKEN }}" },
-                    run: `gh api --method DELETE /repos/\${{ github.repository }}/git/refs/heads/\${{ github.event.pull_request.head.ref }}`
+                    env: {
+                        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+                        REPO: "${{ github.repository }}",
+                        HEAD_REF: "${{ github.event.pull_request.head.ref }}",
+                        BASE_REF: "${{ github.event.pull_request.base.ref }}"
+                    },
+                    run: [
+                        "set -e",
+                        "# Delete the head release branch (Y) that was just merged.",
+                        'gh api --method DELETE "/repos/$REPO/git/refs/heads/$HEAD_REF"',
+                        'echo "Deleted head branch: $HEAD_REF"',
+                        "# For tag-based (patch) releases the PR base is a throwaway",
+                        '# "release/x.y.z-base" branch (X) - delete it too. Never delete next.',
+                        'case "$BASE_REF" in',
+                        "  release/*-base)",
+                        '    gh api --method DELETE "/repos/$REPO/git/refs/heads/$BASE_REF"',
+                        '    echo "Deleted base branch: $BASE_REF"',
+                        "    ;;",
+                        "  *)",
+                        '    echo "Base branch $BASE_REF is not a release base branch; leaving it in place."',
+                        "    ;;",
+                        "esac"
+                    ].join("\n")
                 }
             ]
         })

--- a/.github/workflows/wac/fullRelease.wac.ts
+++ b/.github/workflows/wac/fullRelease.wac.ts
@@ -37,8 +37,8 @@ export const fullRelease = createWorkflow({
                     run: [
                         "set -e",
                         "ok=1",
-                        'if ! printf "%s" "$VERSION" | grep -Eq "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.]+)?$"; then',
-                        '  echo "::error::Invalid version [$VERSION]. Expected semver, e.g. 6.3.0 or 6.3.0-beta.1."',
+                        'if ! printf "%s" "$VERSION" | grep -Eq "^6\\.[0-9]+\\.[0-9]+$"; then',
+                        '  echo "::error::Invalid version [$VERSION]. Expected 6.x.y, e.g. 6.3.0 (three numbers, no alpha/beta)."',
                         "  ok=0",
                         "fi",
                         'if [ -n "$SOURCE_TAG" ] && ! printf "%s" "$SOURCE_TAG" | grep -Eq "^[A-Za-z0-9._/-]+$"; then',

--- a/.github/workflows/wac/fullRelease.wac.ts
+++ b/.github/workflows/wac/fullRelease.wac.ts
@@ -24,8 +24,39 @@ export const fullRelease = createWorkflow({
         }
     },
     jobs: {
+        validateInputs: createJob({
+            name: "Validate inputs",
+            checkout: false,
+            env: {
+                VERSION,
+                SOURCE_TAG
+            },
+            steps: [
+                {
+                    name: "Validate workflow inputs",
+                    run: [
+                        "set -e",
+                        "ok=1",
+                        'if ! printf "%s" "$VERSION" | grep -Eq "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.]+)?$"; then',
+                        '  echo "::error::Invalid version [$VERSION]. Expected semver, e.g. 6.3.0 or 6.3.0-beta.1."',
+                        "  ok=0",
+                        "fi",
+                        'if [ -n "$SOURCE_TAG" ] && ! printf "%s" "$SOURCE_TAG" | grep -Eq "^[A-Za-z0-9._/-]+$"; then',
+                        '  echo "::error::Invalid sourceTag [$SOURCE_TAG]. Use a valid branch or tag name (letters, digits, . _ / -)."',
+                        "  ok=0",
+                        "fi",
+                        'if [ "$ok" -ne 1 ]; then',
+                        '  echo "Input validation failed. Fix the inputs above and re-run the workflow."',
+                        "  exit 1",
+                        "fi",
+                        'echo "Inputs OK: version=$VERSION sourceTag=${SOURCE_TAG:-next}"'
+                    ].join("\n")
+                }
+            ]
+        }),
         createWebinyJsBranch: createJob({
             name: "Create release branch (webiny-js)",
+            needs: ["validateInputs"],
             checkout: false,
             env: {
                 GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -51,13 +82,37 @@ export const fullRelease = createWorkflow({
                 },
                 {
                     name: `Create and push release branch`,
-                    run: `git checkout -b release/${VERSION} && git commit --allow-empty -m "chore: start release ${VERSION}" -m "Empty commit to allow PR creation." && git push origin release/${VERSION}`
+                    id: "branch",
+                    env: {
+                        VERSION,
+                        SOURCE_TAG
+                    },
+                    run: [
+                        "set -e",
+                        "# If the source is a tag, create a base branch off it so the PR diff",
+                        "# shows only release-specific work. Otherwise (a branch, e.g. next),",
+                        "# the source branch itself is the PR base.",
+                        'if git show-ref --verify --quiet "refs/tags/${SOURCE_TAG}"; then',
+                        '  BASE_BRANCH="release/${VERSION}-base"',
+                        '  git checkout -b "$BASE_BRANCH"',
+                        '  git push origin "$BASE_BRANCH"',
+                        "else",
+                        '  BASE_BRANCH="${SOURCE_TAG}"',
+                        "fi",
+                        'git checkout -b "release/${VERSION}"',
+                        'git commit --allow-empty -m "chore: start release ${VERSION} [skip ci]" -m "Empty commit to allow PR creation."',
+                        'git push origin "release/${VERSION}"',
+                        'echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"'
+                    ].join("\n")
                 },
                 {
                     name: "Open pull request",
                     id: "pr",
-                    env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
-                    run: `PR_URL=$(gh pr create --title "📦  Release ${VERSION}" --body "Release ${VERSION}\n\n**Docs PR:** https://github.com/webiny/docs.webiny.com/pulls?q=Release+${VERSION}" --base next --head release/${VERSION}) && echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT`
+                    env: {
+                        GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
+                        BASE_BRANCH: "${{ steps.branch.outputs.base-branch }}"
+                    },
+                    run: `PR_URL=$(gh pr create --title "📦  Release ${VERSION}" --body "Release ${VERSION}\n\n**Docs PR:** https://github.com/webiny/docs.webiny.com/pulls?q=Release+${VERSION}" --base "$BASE_BRANCH" --head "release/${VERSION}") && echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT`
                 },
                 {
                     name: "Notify Slack - Release PR Created",


### PR DESCRIPTION
## Summary

Hardens the **Full Release** workflow and extends release-branch cleanup.

### `fullRelease`
- **New `validateInputs` gate job** — validates `version` is a `6.x.y` string (three numbers, no alpha/beta/pre-release tags; e.g. `6.3.0`) and `sourceTag` is a valid ref name. Fails fast with friendly `::error::` messages. All downstream jobs `needs` it.
- **Tag-based (patch) releases** — when `sourceTag` resolves to a git **tag** (e.g. `v6.4.3`), cut `release/x.y.z-base` off the tag, then `release/x.y.z` off that. PR targets the `-base` branch so the diff shows only release-specific work.
- **Branch source (e.g. `next`)** — single branch as before; PR targets that branch. PR base is now dynamic (no longer hardcoded `next`), fixing the case where choosing a tag still targeted `next`.
- **`[skip ci]`** added to the empty PR-bootstrap commit — no reason to run CI on an empty commit.

### `deleteReleaseBranch`
- Now also triggers on PRs into `release/*-base`.
- On merge: deletes the head `release/x.y.z` branch always; deletes the `release/*-base` base branch too when present. **`next` is never deleted.**

Generated `.yml` files regenerated via `yarn ci-workflows:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)