### PR TITLE
refactor(ai-powerups): return structured values from CmsGenerateEntryContentUseCase

### DIFF
--- a/extensions/bulkActions/aiContent/api/GenerateAiSummaryBulkAction.ts
+++ b/extensions/bulkActions/aiContent/api/GenerateAiSummaryBulkAction.ts
@@ -91,8 +91,8 @@ class GenerateAiSummaryBulkAction implements EntriesBulkAction.Interface<Generat
             throw result.error;
         }
 
-        // The use case returns the generated entry as a JSON string; take our field.
-        const generated = JSON.parse(result.value.output || "{}").aiSummary;
+        // The use case returns the generated entry as structured `values`; take our field.
+        const generated = result.value.values.aiSummary;
         const aiSummary = typeof generated === "string" ? generated : "";
 
         if (!aiSummary) {

--- a/extensions/bulkActions/aiContent/api/GenerateAiSummaryBulkAction.ts
+++ b/extensions/bulkActions/aiContent/api/GenerateAiSummaryBulkAction.ts
@@ -80,7 +80,7 @@ class GenerateAiSummaryBulkAction implements EntriesBulkAction.Interface<Generat
         // `runId` token is what lets this run converge (a new run uses a new token).
         const { projectId, writerPersonaId, readerPersonaId, runId = "" } = params.data ?? {};
 
-        const result = await this.generateContent.execute({
+        const result = await this.generateContent.execute<{ aiSummary?: string }>({
             modelId: model.modelId,
             prompt: `Write a concise, single-sentence marketing summary for the product "${entry.values.name}". Fill only the "aiSummary" field.`,
             writerPersonaId,
@@ -92,8 +92,7 @@ class GenerateAiSummaryBulkAction implements EntriesBulkAction.Interface<Generat
         }
 
         // The use case returns the generated entry as structured `values`; take our field.
-        const generated = result.value.values.aiSummary;
-        const aiSummary = typeof generated === "string" ? generated : "";
+        const aiSummary = result.value.values.aiSummary ?? "";
 
         if (!aiSummary) {
             this.logger.warn(

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentTask.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentTask.ts
@@ -1,6 +1,6 @@
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import { WebsocketsSendToIdentityUseCase } from "@webiny/api-websockets/features/SendToIdentity/abstractions.js";
-import { compress } from "@webiny/utils/features/compression/legacy/gzip.js";
+import { compressJson } from "@webiny/utils/features/compression/legacy/gzip.js";
 import { CmsGenerateEntryContentUseCase } from "~/api/features/CmsGenerateEntryContent/index.js";
 import type { GenerateEntryContentTelemetry } from "~/api/features/CmsGenerateEntryContent/abstractions.js";
 import { IdentityContext } from "@webiny/api-core/exports/api/security.js";
@@ -70,7 +70,7 @@ class CmsGenerateEntryContentTaskImpl implements TaskDefinition.Interface<ICmsGe
 
         // Serialize at the transport edge: the use case returns structured values; the
         // websocket stream carries a gzip+base64 JSON string that the Admin app decodes.
-        const compressed = await compress(JSON.stringify(result.value.values));
+        const compressed = await compressJson(result.value.values);
         const payload = compressed.toString("base64");
 
         await this.sendContentToUser(identity.id, payload, result.value.telemetry);

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentTask.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentTask.ts
@@ -68,7 +68,9 @@ class CmsGenerateEntryContentTaskImpl implements TaskDefinition.Interface<ICmsGe
             });
         }
 
-        const compressed = await compress(result.value.output);
+        // Serialize at the transport edge: the use case returns structured values; the
+        // websocket stream carries a gzip+base64 JSON string that the Admin app decodes.
+        const compressed = await compress(JSON.stringify(result.value.values));
         const payload = compressed.toString("base64");
 
         await this.sendContentToUser(identity.id, payload, result.value.telemetry);

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
@@ -133,8 +133,6 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
                 await injectDynamicZoneTypenames(resolved, modelAst, model.singularApiName);
             }
 
-            const output = JSON.stringify(resolved);
-
             const filesRead = new Set<string>();
             let toolCallsMade = 0;
             for (const step of aiResult.steps) {
@@ -158,7 +156,7 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
                 imageTagsInPrompt: imageTags
             };
 
-            return Result.ok({ output, telemetry });
+            return Result.ok({ values: resolved ?? {}, telemetry });
         } catch (error) {
             return Result.fail(
                 new Error(

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/CmsGenerateEntryContentUseCase.ts
@@ -37,9 +37,9 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
         private toolPipelineRunner: AiToolPipelineRunner.Interface
     ) {}
 
-    async execute(
+    async execute<TValues = Record<string, any>>(
         params: CmsGenerateEntryContentParams
-    ): Promise<Result<GenerateEntryContentResult, Error>> {
+    ): Promise<Result<GenerateEntryContentResult<TValues>, Error>> {
         const settingsResult = await this.getSettings.execute();
         if (settingsResult.isFail()) {
             return Result.fail(new Error("Failed to load AI PowerUps settings."));
@@ -156,7 +156,9 @@ class CmsGenerateEntryContentUseCaseImpl implements CmsGenerateEntryContentUseCa
                 imageTagsInPrompt: imageTags
             };
 
-            return Result.ok({ values: resolved ?? {}, telemetry });
+            // Boundary cast: the AI output is dynamic JSON, so this is the one honest point
+            // where we hand the resolved values to the caller's chosen `TValues` shape.
+            return Result.ok({ values: (resolved ?? {}) as TValues, telemetry });
         } catch (error) {
             return Result.fail(
                 new Error(

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/abstractions.ts
@@ -19,20 +19,21 @@ export interface GenerateEntryContentTelemetry {
     imageTagsInPrompt: string[];
 }
 
-export interface GenerateEntryContentResult {
+export interface GenerateEntryContentResult<TValues = Record<string, any>> {
     /**
      * The generated entry values, keyed by fieldId. Callers that consume the result
      * directly (e.g. a bulk action) can read fields straight off this object; transport
-     * edges (the background task / websocket stream) serialize it themselves.
+     * edges (the background task / websocket stream) serialize it themselves. Pass a type
+     * argument to `execute` to shape this (e.g. `execute<{ aiSummary?: string }>`).
      */
-    values: Record<string, any>;
+    values: TValues;
     telemetry: GenerateEntryContentTelemetry;
 }
 
 export interface ICmsGenerateEntryContentUseCase {
-    execute(
+    execute<TValues = Record<string, any>>(
         params: CmsGenerateEntryContentParams
-    ): Promise<Result<GenerateEntryContentResult, Error>>;
+    ): Promise<Result<GenerateEntryContentResult<TValues>, Error>>;
 }
 
 export const CmsGenerateEntryContentUseCase = createAbstraction<ICmsGenerateEntryContentUseCase>(

--- a/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/abstractions.ts
+++ b/packages/ai-powerups/src/api/features/CmsGenerateEntryContent/abstractions.ts
@@ -20,7 +20,12 @@ export interface GenerateEntryContentTelemetry {
 }
 
 export interface GenerateEntryContentResult {
-    output: string;
+    /**
+     * The generated entry values, keyed by fieldId. Callers that consume the result
+     * directly (e.g. a bulk action) can read fields straight off this object; transport
+     * edges (the background task / websocket stream) serialize it themselves.
+     */
+    values: Record<string, any>;
     telemetry: GenerateEntryContentTelemetry;
 }
 

--- a/packages/utils/src/features/compression/legacy/gzip.ts
+++ b/packages/utils/src/features/compression/legacy/gzip.ts
@@ -22,3 +22,23 @@ export const decompress = (input: zlib.InputType, options?: zlib.ZlibOptions): P
         });
     });
 };
+
+/**
+ * Compress a JS value: JSON-serializes it, then gzips the string. `zlib.gzip` only accepts
+ * strings/buffers, so plain objects must be stringified first — this wrapper does that.
+ */
+export const compressJson = (value: unknown, options?: zlib.ZlibOptions): Promise<Buffer> => {
+    return compress(JSON.stringify(value), options);
+};
+
+/**
+ * Inverse of `compressJson`: gunzips then `JSON.parse`s. Pass a type argument for the
+ * expected shape (unchecked at runtime).
+ */
+export const decompressJson = async <T = unknown>(
+    input: zlib.InputType,
+    options?: zlib.ZlibOptions
+): Promise<T> => {
+    const buffer = await decompress(input, options);
+    return JSON.parse(buffer.toString());
+};

--- a/skills/user-skills/api/ai-powerups-content/SKILL.md
+++ b/skills/user-skills/api/ai-powerups-content/SKILL.md
@@ -43,7 +43,7 @@ class MyThing {
     if (result.isFail()) {
       throw result.error; // e.g. "No AI provider configured. Add a provider in AI Power Ups settings."
     }
-    return result.value; // { output, telemetry }
+    return result.value; // { values, telemetry }
   }
 }
 ```
@@ -52,13 +52,13 @@ Register the dependency: `dependencies: [CmsGenerateEntryContentUseCase]`.
 
 ## Output shape — important
 
-`result.value.output` is `JSON.stringify(resolved)`, where `resolved` is an **entry-shaped
-object keyed by the model's field ids** (the use case is built to fill an entry from its
-schema). The AI decides which fields it fills, so:
+`result.value.values` is an **entry-shaped object keyed by the model's field ids** (the use
+case is built to fill an entry from its schema). The AI decides which fields it fills, so:
 
-- Parse it: `const resolved = JSON.parse(result.value.output || "{}")`.
-- Take **only** the field(s) you want (e.g. `resolved.aiSummary`) — do NOT blindly write
-  the whole object back, or the AI could overwrite `name`, `price`, etc.
+- Read **only** the field(s) you want (e.g. `result.value.values.aiSummary`) — do NOT blindly
+  write the whole object back, or the AI could overwrite `name`, `price`, etc.
+- Type the values at the call site if you like: `execute<{ aiSummary?: string }>(...)`, which
+  makes `result.value.values.aiSummary` typed (defaults to `Record<string, any>`).
 - Guard for the field being absent (the model may not have filled it): fall back to `""`
   and, if you're inside a converging background task, still mark the entry done so it
   doesn't loop.


### PR DESCRIPTION
## What

`CmsGenerateEntryContentUseCase` previously returned its result pre-serialized:

```ts
interface GenerateEntryContentResult {
  output: string; // JSON.stringify of the generated entry
  telemetry: GenerateEntryContentTelemetry;
}
```

Any direct caller had to `JSON.parse(result.value.output)` to get at the fields. This PR returns the structured object instead and moves serialization to the transport edge:

```ts
interface GenerateEntryContentResult {
  values: Record<string, any>; // the generated entry, keyed by fieldId
  telemetry: GenerateEntryContentTelemetry;
}
```

## Changes

- `abstractions.ts` — `output: string` → `values: Record<string, any>`.
- `CmsGenerateEntryContentUseCase.ts` — return `{ values: resolved ?? {}, telemetry }` (drop the internal `JSON.stringify`).
- `CmsGenerateEntryContentTask.ts` — serialize at the edge: `compress(JSON.stringify(result.value.values))`. The websocket stream still carries gzip+base64 JSON, so the Admin decode path is unchanged.

## Why

Direct consumers (e.g. a Headless CMS bulk action that generates content per entry) can now read `result.value.values.<field>` with no parse step. Transport concerns (compression, websocket framing) stay at the transport boundary.

## Consumers checked

- `CmsGenerateEntryContentTask` — the transport edge (updated here).
- The `WbGeneratePageContent` / `AiImageEnrichment` use cases have their own separate result types — not affected.

## Follow-ups (gated on this landing in a release)

- Update the `generateAiSummary` bulk-action demo to read `result.value.values.aiSummary` (drops its `JSON.parse`).
- Update the docs page (docs.webiny.com#806) AI snippet accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)