### PR TITLE
fix(app-admin-ui): command palette no longer swallows Backspace in inputs

### DIFF
--- a/packages/app-admin-ui/src/CommandPalette/CommandPalette.tsx
+++ b/packages/app-admin-ui/src/CommandPalette/CommandPalette.tsx
@@ -53,7 +53,19 @@ const CommandPaletteBase = () => {
                 setQuery("");
             },
             backspace: (e: KeyboardEvent) => {
-                if (e.target instanceof HTMLInputElement) {
+                // This is a global (document-level) handler, so only act while the palette
+                // is actually open — otherwise it would swallow Backspace everywhere.
+                if (!presenter.vm.isOpen) {
+                    return;
+                }
+                // Never intercept Backspace while the user is editing text: <input>,
+                // <textarea>, or any contentEditable (e.g. rich-text/lexical) element.
+                const target = e.target;
+                if (
+                    target instanceof HTMLInputElement ||
+                    target instanceof HTMLTextAreaElement ||
+                    (target instanceof HTMLElement && target.isContentEditable)
+                ) {
                     return;
                 }
                 e.preventDefault();


### PR DESCRIPTION
## Problem

Typing in a **description** field (and any `<textarea>` / rich-text field), **Backspace does not delete** the character. Reported by Sven on a 6.5 deployment.

## Cause

`CommandPalette.tsx` registers a **global** (`document.body` keydown, via `useHotkeys`) `backspace` handler to "back out" of a command detail view. Two problems:

1. It's active **even when the palette is closed** — `useHotkeys(...)` runs before the `if (!vm.isOpen) return null` early-return, so the handler is always registered. When the palette's hotkey zIndex is the top layer (the common case on a normal form view), `triggerHotkeys` fires it on every Backspace, anywhere.
2. Its guard only exempted `<input>`:
   ```ts
   if (e.target instanceof HTMLInputElement) return;
   e.preventDefault();
   ```
   `<textarea>` and contentEditable (lexical/rich-text) targets fell through to `preventDefault()`, killing Backspace while editing text.

## Fix

- No-op unless the palette is actually open (`presenter.vm.isOpen`).
- Broaden the editable-target guard to skip `<input>`, `<textarea>`, and any `isContentEditable` element.

Backspace still backs out of a command detail while the palette is open; it no longer touches text editing anywhere else.

## Test

Manual: open a CMS entry with a description `<textarea>`, type, press Backspace → deletes (fixed). Open palette, enter a command detail, press Backspace → backs out (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)