### PR TITLE
refactor(api-workflows): DI-native workflows GraphQL schema contributors

### DIFF
--- a/packages/api-workflows/src/WorkflowsSchemaFactory.ts
+++ b/packages/api-workflows/src/WorkflowsSchemaFactory.ts
@@ -3,72 +3,17 @@ import type {
     IGraphQLSchemaFactory,
     GraphQLSchemaFactory as GQLSchemaFactory
 } from "@webiny/api-graphql/graphql/abstractions.js";
-import { createNotificationsGraphQL } from "~/graphql/notifications.js";
-import { createWorkflowsSchema } from "~/graphql/workflows.js";
-import { createWorkflowStateSchema } from "~/graphql/workflowState.js";
-import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
-import type { IGraphQLSchemaPlugin } from "@webiny/api-graphql/plugins/GraphQLSchemaPlugin.js";
-
-function addPluginsToBuilder(
-    plugins: IGraphQLSchemaPlugin[],
-    builder: IGraphQLSchemaBuilder
-): void {
-    for (const plugin of plugins) {
-        const schema = plugin.schema;
-
-        if (schema.typeDefs) {
-            builder.addTypeDefs(schema.typeDefs);
-        }
-
-        if (schema.resolvers) {
-            addResolvers(builder, schema.resolvers as Record<string, any>, "");
-        }
-
-        if (schema.resolverDecorators) {
-            for (const [path, decorators] of Object.entries(schema.resolverDecorators)) {
-                for (const decorator of decorators as any[]) {
-                    builder.addResolverDecorator(path, decorator);
-                }
-            }
-        }
-    }
-}
-
-function addResolvers(
-    builder: IGraphQLSchemaBuilder,
-    resolvers: Record<string, any>,
-    prefix: string
-): void {
-    for (const [key, value] of Object.entries(resolvers)) {
-        const path = prefix ? `${prefix}.${key}` : key;
-
-        if (typeof value === "function") {
-            const oldResolver = value;
-            builder.addResolver({
-                path,
-                dependencies: [],
-                resolver:
-                    () =>
-                    ({ parent, args, context, info }: any) =>
-                        oldResolver(parent, args, context, info)
-            });
-        } else if (typeof value === "object" && value !== null) {
-            addResolvers(builder, value, path);
-        }
-    }
-}
+import { addNotificationsSchema } from "~/graphql/notifications.js";
+import { addWorkflowsSchema } from "~/graphql/workflows.js";
+import { addWorkflowStateSchema } from "~/graphql/workflowState.js";
 
 class WorkflowsSchemaFactoryImpl implements IGraphQLSchemaFactory {
     async execute(
         builder: GQLSchemaFactory.SchemaBuilder
     ): Promise<GQLSchemaFactory.SchemaBuilder> {
-        const plugins = [
-            createNotificationsGraphQL(),
-            createWorkflowsSchema(),
-            createWorkflowStateSchema()
-        ] as unknown as IGraphQLSchemaPlugin[];
-
-        addPluginsToBuilder(plugins, builder);
+        addWorkflowsSchema(builder);
+        addWorkflowStateSchema(builder);
+        addNotificationsSchema(builder);
 
         return builder;
     }

--- a/packages/api-workflows/src/graphql/notifications.ts
+++ b/packages/api-workflows/src/graphql/notifications.ts
@@ -1,52 +1,51 @@
-import { GraphQLSchemaPlugin, resolveList } from "@webiny/api-graphql";
+import { resolveList } from "@webiny/api-graphql";
+import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
 import { ListNotificationTypesUseCase } from "~/features/notifications/ListNotificationTypes/index.js";
 
-export const createNotificationsGraphQL = () => {
-    return new GraphQLSchemaPlugin({
-        typeDefs: `
-            type WorkflowNotificationTypeError {
-                message: String!
-                code: String
-                data: JSON
-                stack: String
-            }
-            
-            type WorkflowNotificationType {
-                id: String!
-                title: String!
-            }
-            
-            type ListWorkflowNotificationTypesResponse {
-                data: [WorkflowNotificationType!]
-                error: WorkflowNotificationTypeError
-            }
-            
-            extend type WorkflowsQuery {
-                listWorkflowNotificationTypes: ListWorkflowNotificationTypesResponse!
-            }
-        `,
-        resolvers: {
-            WorkflowsQuery: {
-                async listWorkflowNotificationTypes(_, __, context) {
-                    return resolveList(async () => {
-                        const useCase = context.container.resolve(ListNotificationTypesUseCase);
+export const addNotificationsSchema = (builder: IGraphQLSchemaBuilder): void => {
+    builder.addTypeDefs(`
+        type WorkflowNotificationTypeError {
+            message: String!
+            code: String
+            data: JSON
+            stack: String
+        }
 
-                        const results = await useCase.execute();
+        type WorkflowNotificationType {
+            id: String!
+            title: String!
+        }
 
-                        if (results.isFail()) {
-                            throw results.error;
+        type ListWorkflowNotificationTypesResponse {
+            data: [WorkflowNotificationType!]
+            error: WorkflowNotificationTypeError
+        }
+
+        extend type WorkflowsQuery {
+            listWorkflowNotificationTypes: ListWorkflowNotificationTypesResponse!
+        }
+    `);
+
+    builder.addResolver({
+        path: "WorkflowsQuery.listWorkflowNotificationTypes",
+        dependencies: [ListNotificationTypesUseCase],
+        resolver(listNotificationTypes) {
+            return () =>
+                resolveList(async () => {
+                    const results = await listNotificationTypes.execute();
+
+                    if (results.isFail()) {
+                        throw results.error;
+                    }
+                    return {
+                        items: results.value,
+                        meta: {
+                            totalCount: results.value.length,
+                            cursor: null,
+                            hasMoreItems: false
                         }
-                        return {
-                            items: results.value,
-                            meta: {
-                                totalCount: results.value.length,
-                                cursor: null,
-                                hasMoreItems: false
-                            }
-                        };
-                    });
-                }
-            }
+                    };
+                });
         }
     });
 };

--- a/packages/api-workflows/src/graphql/workflowState.ts
+++ b/packages/api-workflows/src/graphql/workflowState.ts
@@ -229,7 +229,10 @@ export const addWorkflowStateSchema = (builder: IGraphQLSchemaBuilder): void => 
     builder.addResolver<unknown, Partial<WorkflowState>>({
         path: "WorkflowState.isActive",
         dependencies: [],
-        resolver: () => ({ parent }) => parent.isActive || false
+        resolver:
+            () =>
+            ({ parent }) =>
+                parent.isActive || false
     });
 
     builder.addResolver({

--- a/packages/api-workflows/src/graphql/workflowState.ts
+++ b/packages/api-workflows/src/graphql/workflowState.ts
@@ -1,4 +1,5 @@
-import { GraphQLSchemaPlugin, resolve, resolveList } from "@webiny/api-graphql";
+import { resolve, resolveList } from "@webiny/api-graphql";
+import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
 import { createZodError } from "@webiny/utils";
 import { listWorkflowStatesValidation } from "./validation/listWorkflowStates.js";
 import { startWorkflowStateValidation } from "./validation/startWorkflowState.js";
@@ -23,466 +24,492 @@ import { TakeOverWorkflowStateStepUseCase } from "~/features/workflowState/TakeO
 import { WorkflowState } from "~/domain/workflowState/WorkflowState.js";
 import { WorkflowStateNotFoundError } from "~/domain/workflowState/errors.js";
 
-export const createWorkflowStateSchema = () => {
-    return new GraphQLSchemaPlugin({
-        typeDefs: /* GraphQL */ `
-            enum CmsEntryStateValue {
-                pending
-                inReview
-                approved
-                rejected
-            }
+export const addWorkflowStateSchema = (builder: IGraphQLSchemaBuilder): void => {
+    builder.addTypeDefs(/* GraphQL */ `
+        enum CmsEntryStateValue {
+            pending
+            inReview
+            approved
+            rejected
+        }
 
-            type CmsEntrySystemWorkflow {
-                workflowId: String
-                stepId: ID
-                stepName: String
-                state: CmsEntryStateValue
-            }
+        type CmsEntrySystemWorkflow {
+            workflowId: String
+            stepId: ID
+            stepName: String
+            state: CmsEntryStateValue
+        }
 
-            extend type CmsEntrySystem {
-                workflow: CmsEntrySystemWorkflow
-            }
+        extend type CmsEntrySystem {
+            workflow: CmsEntrySystemWorkflow
+        }
 
-            input ListWhereInputCmsEntrySystemWorkflowStateInput {
-                workflowId: String
-                stepId: ID
-                stepName: String
-                state: CmsEntryStateValue
-            }
+        input ListWhereInputCmsEntrySystemWorkflowStateInput {
+            workflowId: String
+            stepId: ID
+            stepName: String
+            state: CmsEntryStateValue
+        }
 
-            input ListWhereInputCmsEntrySystemWorkflowInput {
-                workflowId: String
-                stepId: ID
-                state: ListWhereInputCmsEntrySystemWorkflowStateInput
-                stepName: String
-            }
+        input ListWhereInputCmsEntrySystemWorkflowInput {
+            workflowId: String
+            stepId: ID
+            state: ListWhereInputCmsEntrySystemWorkflowStateInput
+            stepName: String
+        }
 
-            extend input ListWhereInputCmsEntrySystem {
-                workflow: ListWhereInputCmsEntrySystemWorkflowInput
-            }
+        extend input ListWhereInputCmsEntrySystem {
+            workflow: ListWhereInputCmsEntrySystemWorkflowInput
+        }
 
-            type WorkflowStateIdentity {
-                id: String!
-                displayName: String
-                type: String
-            }
+        type WorkflowStateIdentity {
+            id: String!
+            displayName: String
+            type: String
+        }
 
-            type WorkflowStateStepNotification {
-                id: String!
-            }
+        type WorkflowStateStepNotification {
+            id: String!
+        }
 
-            type WorkflowStateStepTeam {
-                id: String!
-            }
+        type WorkflowStateStepTeam {
+            id: String!
+        }
 
-            type WorkflowStateStep {
-                # workflow related
-                id: String!
-                title: String!
-                color: String!
-                description: String
-                teams: [WorkflowStateStepTeam!]!
-                notifications: [WorkflowStateStepNotification!]
-                # state related
-                state: CmsEntryStateValue!
-                comment: String
-                savedBy: WorkflowStateIdentity
-                # current user can take action on this step?
-                canReview: Boolean!
-                # is current user an owner of the step?
-                isOwner: Boolean!
-                # can current user take over this step?
-                canTakeOver: Boolean!
-            }
+        type WorkflowStateStep {
+            # workflow related
+            id: String!
+            title: String!
+            color: String!
+            description: String
+            teams: [WorkflowStateStepTeam!]!
+            notifications: [WorkflowStateStepNotification!]
+            # state related
+            state: CmsEntryStateValue!
+            comment: String
+            savedBy: WorkflowStateIdentity
+            # current user can take action on this step?
+            canReview: Boolean!
+            # is current user an owner of the step?
+            isOwner: Boolean!
+            # can current user take over this step?
+            canTakeOver: Boolean!
+        }
 
-            type WorkflowState {
-                id: String!
+        type WorkflowState {
+            id: String!
+            app: String!
+            title: String!
+            isActive: Boolean!
+            done: Boolean!
+            workflowId: String!
+            targetId: String!
+            targetRevisionId: String!
+            comment: String
+            state: CmsEntryStateValue!
+            steps: [WorkflowStateStep!]
+            createdOn: DateTime!
+            savedOn: DateTime!
+            createdBy: WorkflowStateIdentity!
+            savedBy: WorkflowStateIdentity!
+            currentStep: WorkflowStateStep!
+            nextStep: WorkflowStateStep
+            previousStep: WorkflowStateStep
+            targetContext: JSON
+        }
+
+        type ListWorkflowStatesResponse {
+            data: [WorkflowState!]
+            error: WorkflowError
+            meta: ListWorkflowsMeta
+        }
+
+        enum ListWorkflowStatesSort {
+            createdOn_ASC
+            createdOn_DESC
+            savedOn_ASC
+            savedOn_DESC
+        }
+
+        input ListWorkflowStatesWhereStepsInput {
+            id: String
+            id_in: [String!]
+            state: CmsEntryStateValue
+            state_in: [CmsEntryStateValue!]
+            savedBy: String
+            savedBy_in: [String!]
+        }
+
+        input ListWorkflowStatesWhereTeamsInput {
+            id: String
+            id_in: [String!]
+        }
+
+        input ListWorkflowStatesWhereNotificationsInput {
+            id: String
+            id_in: [String!]
+        }
+
+        input ListWorkflowStatesWhereInput {
+            app: String
+            app_in: [String!]
+            workflowId: String
+            workflowId_in: [String!]
+            targetId: String
+            targetId_in: [String!]
+            targetRevisionId: String
+            targetRevisionId_in: [String!]
+            state: CmsEntryStateValue
+            state_in: [CmsEntryStateValue!]
+            createdOn_gte: DateTime
+            createdOn_lte: DateTime
+            savedOn_gte: DateTime
+            savedOn_lte: DateTime
+            createdBy: String
+            savedBy: String
+            isActive: Boolean
+            steps: ListWorkflowStatesWhereStepsInput
+            teams: ListWorkflowStatesWhereTeamsInput
+            notifications: ListWorkflowStatesWhereNotificationsInput
+        }
+
+        type WorkflowStateResponse {
+            data: WorkflowState
+            error: WorkflowError
+        }
+
+        type CancelWorkflowStateResponse {
+            data: Boolean
+            error: WorkflowError
+        }
+
+        type TakeOverWorkflowStateStepResponse {
+            data: WorkflowState
+            error: WorkflowError
+        }
+
+        extend type WorkflowsQuery {
+            getWorkflowState(id: ID!): WorkflowStateResponse!
+            # always returns active workflow state for the given targetRevisionId - or null
+            getTargetWorkflowState(app: String!, targetRevisionId: ID!): WorkflowStateResponse!
+            listWorkflowStates(
+                where: ListWorkflowStatesWhereInput
+                sort: [ListWorkflowStatesSort!]
+                limit: Int
+                after: String
+            ): ListWorkflowStatesResponse!
+            listOwnWorkflowStates(
+                where: ListWorkflowStatesWhereInput
+                sort: [ListWorkflowStatesSort!]
+                limit: Int
+                after: String
+            ): ListWorkflowStatesResponse!
+            listRequestedWorkflowStates(
+                where: ListWorkflowStatesWhereInput
+                sort: [ListWorkflowStatesSort!]
+                limit: Int
+                after: String
+            ): ListWorkflowStatesResponse!
+        }
+
+        extend type WorkflowsMutation {
+            createWorkflowState(
                 app: String!
+                targetRevisionId: ID!
                 title: String!
-                isActive: Boolean!
-                done: Boolean!
-                workflowId: String!
-                targetId: String!
-                targetRevisionId: String!
-                comment: String
-                state: CmsEntryStateValue!
-                steps: [WorkflowStateStep!]
-                createdOn: DateTime!
-                savedOn: DateTime!
-                createdBy: WorkflowStateIdentity!
-                savedBy: WorkflowStateIdentity!
-                currentStep: WorkflowStateStep!
-                nextStep: WorkflowStateStep
-                previousStep: WorkflowStateStep
-                targetContext: JSON
-            }
+            ): WorkflowStateResponse!
+            startWorkflowStateStep(id: ID!): WorkflowStateResponse!
+            approveWorkflowStateStep(id: ID!, comment: String): WorkflowStateResponse!
+            rejectWorkflowStateStep(id: ID!, comment: String!): WorkflowStateResponse!
+            cancelWorkflowState(id: ID!): CancelWorkflowStateResponse!
+            takeOverWorkflowStateStep(id: ID!): TakeOverWorkflowStateStepResponse!
+        }
+    `);
 
-            type ListWorkflowStatesResponse {
-                data: [WorkflowState!]
-                error: WorkflowError
-                meta: ListWorkflowsMeta
-            }
+    builder.addResolver<unknown, Partial<WorkflowState>>({
+        path: "WorkflowState.isActive",
+        dependencies: [],
+        resolver: () => ({ parent }) => parent.isActive || false
+    });
 
-            enum ListWorkflowStatesSort {
-                createdOn_ASC
-                createdOn_DESC
-                savedOn_ASC
-                savedOn_DESC
-            }
+    builder.addResolver({
+        path: "WorkflowsQuery.getWorkflowState",
+        dependencies: [GetWorkflowStateUseCase],
+        resolver(getWorkflowState) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await getWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-            input ListWorkflowStatesWhereStepsInput {
-                id: String
-                id_in: [String!]
-                state: CmsEntryStateValue
-                state_in: [CmsEntryStateValue!]
-                savedBy: String
-                savedBy_in: [String!]
-            }
+                    const stateResult = await getWorkflowState.execute(result.data.id);
 
-            input ListWorkflowStatesWhereTeamsInput {
-                id: String
-                id_in: [String!]
-            }
+                    if (stateResult.isFail()) {
+                        throw stateResult.error;
+                    }
 
-            input ListWorkflowStatesWhereNotificationsInput {
-                id: String
-                id_in: [String!]
-            }
+                    return stateResult.value;
+                });
+        }
+    });
 
-            input ListWorkflowStatesWhereInput {
-                app: String
-                app_in: [String!]
-                workflowId: String
-                workflowId_in: [String!]
-                targetId: String
-                targetId_in: [String!]
-                targetRevisionId: String
-                targetRevisionId_in: [String!]
-                state: CmsEntryStateValue
-                state_in: [CmsEntryStateValue!]
-                createdOn_gte: DateTime
-                createdOn_lte: DateTime
-                savedOn_gte: DateTime
-                savedOn_lte: DateTime
-                createdBy: String
-                savedBy: String
-                isActive: Boolean
-                steps: ListWorkflowStatesWhereStepsInput
-                teams: ListWorkflowStatesWhereTeamsInput
-                notifications: ListWorkflowStatesWhereNotificationsInput
-            }
+    builder.addResolver({
+        path: "WorkflowsQuery.getTargetWorkflowState",
+        dependencies: [GetTargetWorkflowStateUseCase],
+        resolver(getTargetWorkflowState) {
+            return ({ args }) =>
+                resolve<WorkflowState | null>(async () => {
+                    const result = await getTargetWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-            type WorkflowStateResponse {
-                data: WorkflowState
-                error: WorkflowError
-            }
-
-            type CancelWorkflowStateResponse {
-                data: Boolean
-                error: WorkflowError
-            }
-
-            type TakeOverWorkflowStateStepResponse {
-                data: WorkflowState
-                error: WorkflowError
-            }
-
-            extend type WorkflowsQuery {
-                getWorkflowState(id: ID!): WorkflowStateResponse!
-                # always returns active workflow state for the given targetRevisionId - or null
-                getTargetWorkflowState(app: String!, targetRevisionId: ID!): WorkflowStateResponse!
-                listWorkflowStates(
-                    where: ListWorkflowStatesWhereInput
-                    sort: [ListWorkflowStatesSort!]
-                    limit: Int
-                    after: String
-                ): ListWorkflowStatesResponse!
-                listOwnWorkflowStates(
-                    where: ListWorkflowStatesWhereInput
-                    sort: [ListWorkflowStatesSort!]
-                    limit: Int
-                    after: String
-                ): ListWorkflowStatesResponse!
-                listRequestedWorkflowStates(
-                    where: ListWorkflowStatesWhereInput
-                    sort: [ListWorkflowStatesSort!]
-                    limit: Int
-                    after: String
-                ): ListWorkflowStatesResponse!
-            }
-
-            extend type WorkflowsMutation {
-                createWorkflowState(
-                    app: String!
-                    targetRevisionId: ID!
-                    title: String!
-                ): WorkflowStateResponse!
-                startWorkflowStateStep(id: ID!): WorkflowStateResponse!
-                approveWorkflowStateStep(id: ID!, comment: String): WorkflowStateResponse!
-                rejectWorkflowStateStep(id: ID!, comment: String!): WorkflowStateResponse!
-                cancelWorkflowState(id: ID!): CancelWorkflowStateResponse!
-                takeOverWorkflowStateStep(id: ID!): TakeOverWorkflowStateStepResponse!
-            }
-        `,
-        resolvers: {
-            WorkflowState: {
-                isActive: (parent: Partial<WorkflowState>) => {
-                    return parent.isActive || false;
-                }
-            },
-            WorkflowsQuery: {
-                getWorkflowState: async (_, args, context) => {
-                    return resolve<WorkflowState>(async () => {
-                        const result = await getWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
-
-                        const getWorkflowState = context.container.resolve(GetWorkflowStateUseCase);
-                        const stateResult = await getWorkflowState.execute(result.data.id);
-
-                        if (stateResult.isFail()) {
-                            throw stateResult.error;
-                        }
-
-                        return stateResult.value;
+                    const stateResult = await getTargetWorkflowState.execute({
+                        app: result.data.app,
+                        targetRevisionId: result.data.targetRevisionId
                     });
-                },
-                getTargetWorkflowState: async (_, args, context) => {
-                    return resolve<WorkflowState | null>(async () => {
-                        const result = await getTargetWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
+                    /**
+                     * TODO determine if we want to throw error or return null when not found.
+                     */
+                    if (stateResult.isFail()) {
+                        if (stateResult.error instanceof WorkflowStateNotFoundError) {
+                            return null;
                         }
+                        throw stateResult.error;
+                    }
 
-                        const getTargetWorkflowState = context.container.resolve(
-                            GetTargetWorkflowStateUseCase
-                        );
-                        const stateResult = await getTargetWorkflowState.execute({
-                            app: result.data.app,
-                            targetRevisionId: result.data.targetRevisionId
-                        });
-                        /**
-                         * TODO determine if we want to throw error or return null when not found.
-                         */
-                        if (stateResult.isFail()) {
-                            if (stateResult.error instanceof WorkflowStateNotFoundError) {
-                                return null;
+                    return stateResult.value;
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "WorkflowsQuery.listWorkflowStates",
+        dependencies: [ListWorkflowStatesUseCase],
+        resolver(listWorkflowStates) {
+            return ({ args }) =>
+                resolveList<WorkflowState>(async () => {
+                    const result = await listWorkflowStatesValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const listResult = await listWorkflowStates.execute({
+                        ...result.data,
+                        where: {
+                            values: {
+                                ...result.data?.where
                             }
-                            throw stateResult.error;
                         }
-
-                        return stateResult.value;
                     });
-                },
-                listWorkflowStates: async (_, args, context) => {
-                    return resolveList<WorkflowState>(async () => {
-                        const result = await listWorkflowStatesValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const listWorkflowStates =
-                            context.container.resolve(ListWorkflowStatesUseCase);
-                        const listResult = await listWorkflowStates.execute({
-                            ...result.data,
-                            where: {
-                                values: {
-                                    ...result.data?.where
-                                }
+                    if (listResult.isFail()) {
+                        throw listResult.error;
+                    }
+
+                    return listResult.value;
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "WorkflowsQuery.listOwnWorkflowStates",
+        dependencies: [ListOwnWorkflowStatesUseCase],
+        resolver(listOwnWorkflowStates) {
+            return ({ args }) =>
+                resolveList<WorkflowState>(async () => {
+                    const result = await listWorkflowStatesValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const listResult = await listOwnWorkflowStates.execute({
+                        ...result.data,
+                        where: {
+                            values: {
+                                ...result.data?.where
                             }
-                        });
-
-                        if (listResult.isFail()) {
-                            throw listResult.error;
                         }
-
-                        return listResult.value;
                     });
-                },
-                listOwnWorkflowStates: async (_, args, context) => {
-                    return resolveList<WorkflowState>(async () => {
-                        const result = await listWorkflowStatesValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const listOwnWorkflowStates = context.container.resolve(
-                            ListOwnWorkflowStatesUseCase
-                        );
-                        const listResult = await listOwnWorkflowStates.execute({
-                            ...result.data,
-                            where: {
-                                values: {
-                                    ...result.data?.where
-                                }
+                    if (listResult.isFail()) {
+                        throw listResult.error;
+                    }
+
+                    return listResult.value;
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "WorkflowsQuery.listRequestedWorkflowStates",
+        dependencies: [ListRequestedWorkflowStatesUseCase],
+        resolver(listRequestedWorkflowStates) {
+            return ({ args }) =>
+                resolveList<WorkflowState>(async () => {
+                    const result = await listWorkflowStatesValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const listResult = await listRequestedWorkflowStates.execute({
+                        ...result.data,
+                        where: {
+                            values: {
+                                ...result.data?.where
                             }
-                        });
-
-                        if (listResult.isFail()) {
-                            throw listResult.error;
                         }
-
-                        return listResult.value;
                     });
-                },
-                listRequestedWorkflowStates: async (_, args, context) => {
-                    return resolveList<WorkflowState>(async () => {
-                        const result = await listWorkflowStatesValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const listRequestedWorkflowStates = context.container.resolve(
-                            ListRequestedWorkflowStatesUseCase
-                        );
-                        const listResult = await listRequestedWorkflowStates.execute({
-                            ...result.data,
-                            where: {
-                                values: {
-                                    ...result.data?.where
-                                }
-                            }
-                        });
+                    if (listResult.isFail()) {
+                        throw listResult.error;
+                    }
 
-                        if (listResult.isFail()) {
-                            throw listResult.error;
-                        }
+                    return listResult.value;
+                });
+        }
+    });
 
-                        return listResult.value;
+    builder.addResolver({
+        path: "WorkflowsMutation.createWorkflowState",
+        dependencies: [CreateWorkflowStateUseCase],
+        resolver(createWorkflowState) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await createWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const createResult = await createWorkflowState.execute({
+                        app: result.data.app,
+                        targetRevisionId: result.data.targetRevisionId,
+                        title: result.data.title
                     });
-                }
-            },
-            WorkflowsMutation: {
-                createWorkflowState: async (_, args, context) => {
-                    return resolve<WorkflowState>(async () => {
-                        const result = await createWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const createWorkflowState = context.container.resolve(
-                            CreateWorkflowStateUseCase
-                        );
-                        const createResult = await createWorkflowState.execute({
-                            app: result.data.app,
-                            targetRevisionId: result.data.targetRevisionId,
-                            title: result.data.title
-                        });
+                    if (createResult.isFail()) {
+                        throw createResult.error;
+                    }
 
-                        if (createResult.isFail()) {
-                            throw createResult.error;
-                        }
+                    return createResult.value;
+                });
+        }
+    });
 
-                        return createResult.value;
-                    });
-                },
-                startWorkflowStateStep(_, args, context) {
-                    return resolve<WorkflowState>(async () => {
-                        const result = await startWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+    builder.addResolver({
+        path: "WorkflowsMutation.startWorkflowStateStep",
+        dependencies: [StartWorkflowStateStepUseCase],
+        resolver(startWorkflowStateStep) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await startWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-                        const startWorkflowStateStep = context.container.resolve(
-                            StartWorkflowStateStepUseCase
-                        );
-                        const startResult = await startWorkflowStateStep.execute(result.data.id);
+                    const startResult = await startWorkflowStateStep.execute(result.data.id);
 
-                        if (startResult.isFail()) {
-                            throw startResult.error;
-                        }
+                    if (startResult.isFail()) {
+                        throw startResult.error;
+                    }
 
-                        return startResult.value;
-                    });
-                },
-                approveWorkflowStateStep: (_, args, context) => {
-                    return resolve<WorkflowState>(async () => {
-                        const result = await approveWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+                    return startResult.value;
+                });
+        }
+    });
 
-                        const approveWorkflowStateStep = context.container.resolve(
-                            ApproveWorkflowStateStepUseCase
-                        );
-                        const approveResult = await approveWorkflowStateStep.execute(
-                            result.data.id,
-                            result.data.comment
-                        );
+    builder.addResolver({
+        path: "WorkflowsMutation.approveWorkflowStateStep",
+        dependencies: [ApproveWorkflowStateStepUseCase],
+        resolver(approveWorkflowStateStep) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await approveWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-                        if (approveResult.isFail()) {
-                            throw approveResult.error;
-                        }
+                    const approveResult = await approveWorkflowStateStep.execute(
+                        result.data.id,
+                        result.data.comment
+                    );
 
-                        return approveResult.value;
-                    });
-                },
-                rejectWorkflowStateStep: (_, args, context) => {
-                    return resolve<WorkflowState>(async () => {
-                        const result = await rejectWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+                    if (approveResult.isFail()) {
+                        throw approveResult.error;
+                    }
 
-                        const rejectWorkflowStateStep = context.container.resolve(
-                            RejectWorkflowStateStepUseCase
-                        );
-                        const rejectResult = await rejectWorkflowStateStep.execute(
-                            result.data.id,
-                            result.data.comment
-                        );
+                    return approveResult.value;
+                });
+        }
+    });
 
-                        if (rejectResult.isFail()) {
-                            throw rejectResult.error;
-                        }
+    builder.addResolver({
+        path: "WorkflowsMutation.rejectWorkflowStateStep",
+        dependencies: [RejectWorkflowStateStepUseCase],
+        resolver(rejectWorkflowStateStep) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await rejectWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-                        return rejectResult.value;
-                    });
-                },
-                cancelWorkflowState: (_, args, context) => {
-                    return resolve<boolean>(async () => {
-                        const result = await cancelWorkflowStateValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+                    const rejectResult = await rejectWorkflowStateStep.execute(
+                        result.data.id,
+                        result.data.comment
+                    );
 
-                        const cancelWorkflowState = context.container.resolve(
-                            CancelWorkflowStateUseCase
-                        );
-                        const cancelResult = await cancelWorkflowState.execute(result.data.id);
+                    if (rejectResult.isFail()) {
+                        throw rejectResult.error;
+                    }
 
-                        if (cancelResult.isFail()) {
-                            throw cancelResult.error;
-                        }
+                    return rejectResult.value;
+                });
+        }
+    });
 
-                        return true;
-                    });
-                },
-                takeOverWorkflowStateStep: (_, args, context) => {
-                    return resolve<WorkflowState>(async () => {
-                        const result =
-                            await takeOverWorkflowStateStepValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+    builder.addResolver({
+        path: "WorkflowsMutation.cancelWorkflowState",
+        dependencies: [CancelWorkflowStateUseCase],
+        resolver(cancelWorkflowState) {
+            return ({ args }) =>
+                resolve<boolean>(async () => {
+                    const result = await cancelWorkflowStateValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-                        const takeOverWorkflowStateStep = context.container.resolve(
-                            TakeOverWorkflowStateStepUseCase
-                        );
-                        const takeOverResult = await takeOverWorkflowStateStep.execute(
-                            result.data.id
-                        );
+                    const cancelResult = await cancelWorkflowState.execute(result.data.id);
 
-                        if (takeOverResult.isFail()) {
-                            throw takeOverResult.error;
-                        }
+                    if (cancelResult.isFail()) {
+                        throw cancelResult.error;
+                    }
 
-                        return takeOverResult.value;
-                    });
-                }
-            }
+                    return true;
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "WorkflowsMutation.takeOverWorkflowStateStep",
+        dependencies: [TakeOverWorkflowStateStepUseCase],
+        resolver(takeOverWorkflowStateStep) {
+            return ({ args }) =>
+                resolve<WorkflowState>(async () => {
+                    const result = await takeOverWorkflowStateStepValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const takeOverResult = await takeOverWorkflowStateStep.execute(result.data.id);
+
+                    if (takeOverResult.isFail()) {
+                        throw takeOverResult.error;
+                    }
+
+                    return takeOverResult.value;
+                });
         }
     });
 };

--- a/packages/api-workflows/src/graphql/workflows.ts
+++ b/packages/api-workflows/src/graphql/workflows.ts
@@ -1,4 +1,5 @@
-import { GraphQLSchemaPlugin, NotFoundError, resolve, resolveList } from "@webiny/api-graphql";
+import { NotFoundError, resolve, resolveList } from "@webiny/api-graphql";
+import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
 import { createZodError } from "@webiny/utils";
 import { listWorkflowsValidation } from "./validation/listWorkflows.js";
 import { getWorkflowValidation } from "./validation/getWorkflow.js";
@@ -9,221 +10,239 @@ import { ListWorkflowsUseCase } from "~/features/workflow/ListWorkflows/index.js
 import { StoreWorkflowUseCase } from "~/features/workflow/StoreWorkflow/index.js";
 import { DeleteWorkflowUseCase } from "~/features/workflow/DeleteWorkflow/index.js";
 
-export const createWorkflowsSchema = () => {
-    return new GraphQLSchemaPlugin({
-        typeDefs: /* GraphQL */ `
-            type WorkflowError {
-                code: String
-                message: String
-                data: JSON
-                stack: String
-            }
+export const addWorkflowsSchema = (builder: IGraphQLSchemaBuilder): void => {
+    builder.addTypeDefs(/* GraphQL */ `
+        type WorkflowError {
+            code: String
+            message: String
+            data: JSON
+            stack: String
+        }
 
-            input WorkflowStepNotificationInput {
-                id: String!
-            }
+        input WorkflowStepNotificationInput {
+            id: String!
+        }
 
-            input WorkflowStepTeamInput {
-                id: String!
-            }
+        input WorkflowStepTeamInput {
+            id: String!
+        }
 
-            input WorkflowStepInput {
-                id: String!
-                title: String!
-                color: String!
-                description: String
-                teams: [WorkflowStepTeamInput!]!
-                notifications: [WorkflowStepNotificationInput!]
-            }
+        input WorkflowStepInput {
+            id: String!
+            title: String!
+            color: String!
+            description: String
+            teams: [WorkflowStepTeamInput!]!
+            notifications: [WorkflowStepNotificationInput!]
+        }
 
-            input StoreWorkflowInput {
-                name: String!
-                steps: [WorkflowStepInput!]!
-            }
+        input StoreWorkflowInput {
+            name: String!
+            steps: [WorkflowStepInput!]!
+        }
 
-            type WorkflowStepNotification {
-                id: String!
-            }
+        type WorkflowStepNotification {
+            id: String!
+        }
 
-            type WorkflowStepTeam {
-                id: String!
-            }
+        type WorkflowStepTeam {
+            id: String!
+        }
 
-            type WorkflowStep {
-                id: String!
-                title: String!
-                color: String!
-                description: String
-                teams: [WorkflowStepTeam!]!
-                notifications: [WorkflowStepNotification!]
-            }
+        type WorkflowStep {
+            id: String!
+            title: String!
+            color: String!
+            description: String
+            teams: [WorkflowStepTeam!]!
+            notifications: [WorkflowStepNotification!]
+        }
 
-            type Workflow {
-                id: String!
+        type Workflow {
+            id: String!
+            app: String!
+            name: String!
+            steps: [WorkflowStep!]!
+        }
+
+        type ListWorkflowsMeta {
+            cursor: String
+            hasMoreItems: Boolean!
+            totalCount: Int!
+        }
+
+        type ListWorkflowsResponse {
+            data: [Workflow!]
+            meta: ListWorkflowsMeta
+            error: WorkflowError
+        }
+
+        type GetWorkflowResponse {
+            data: Workflow
+            error: WorkflowError
+        }
+
+        input ListWorkflowsWhereInput {
+            app: String
+            app_in: [String!]
+            id: String
+            id_in: [String!]
+        }
+
+        enum ListWorkflowsSort {
+            createdOn_ASC
+            createdOn_DESC
+        }
+
+        type WorkflowsQuery {
+            listWorkflows(
+                where: ListWorkflowsWhereInput
+                limit: Int
+                sort: [ListWorkflowsSort!]
+                after: String
+            ): ListWorkflowsResponse!
+            getWorkflow(app: String!, id: ID!): GetWorkflowResponse!
+        }
+
+        type CreateWorkflowResponse {
+            data: Workflow
+            error: WorkflowError
+        }
+
+        type StoreWorkflowResponse {
+            data: Workflow
+            error: WorkflowError
+        }
+
+        type DeleteWorkflowResponse {
+            data: Boolean
+            error: WorkflowError
+        }
+
+        type WorkflowsMutation {
+            storeWorkflow(
                 app: String!
-                name: String!
-                steps: [WorkflowStep!]!
-            }
+                id: ID!
+                data: StoreWorkflowInput!
+            ): StoreWorkflowResponse!
+            deleteWorkflow(app: String!, id: ID!): DeleteWorkflowResponse!
+        }
 
-            type ListWorkflowsMeta {
-                cursor: String
-                hasMoreItems: Boolean!
-                totalCount: Int!
-            }
+        extend type Query {
+            workflows: WorkflowsQuery
+        }
 
-            type ListWorkflowsResponse {
-                data: [Workflow!]
-                meta: ListWorkflowsMeta
-                error: WorkflowError
-            }
+        extend type Mutation {
+            workflows: WorkflowsMutation
+        }
+    `);
 
-            type GetWorkflowResponse {
-                data: Workflow
-                error: WorkflowError
-            }
+    builder.addResolver({
+        path: "Query.workflows",
+        dependencies: [],
+        resolver: () => () => ({})
+    });
 
-            input ListWorkflowsWhereInput {
-                app: String
-                app_in: [String!]
-                id: String
-                id_in: [String!]
-            }
+    builder.addResolver({
+        path: "Mutation.workflows",
+        dependencies: [],
+        resolver: () => () => ({})
+    });
 
-            enum ListWorkflowsSort {
-                createdOn_ASC
-                createdOn_DESC
-            }
+    builder.addResolver({
+        path: "WorkflowsQuery.getWorkflow",
+        dependencies: [GetWorkflowUseCase],
+        resolver(getWorkflow) {
+            return ({ args }) =>
+                resolve(async () => {
+                    const result = await getWorkflowValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-            type WorkflowsQuery {
-                listWorkflows(
-                    where: ListWorkflowsWhereInput
-                    limit: Int
-                    sort: [ListWorkflowsSort!]
-                    after: String
-                ): ListWorkflowsResponse!
-                getWorkflow(app: String!, id: ID!): GetWorkflowResponse!
-            }
+                    const workflowResult = await getWorkflow.execute(args);
 
-            type CreateWorkflowResponse {
-                data: Workflow
-                error: WorkflowError
-            }
+                    if (workflowResult.isFail()) {
+                        throw new NotFoundError(
+                            `Workflow in app "${args.app}" with id "${args.id}" was not found!`
+                        );
+                    }
 
-            type StoreWorkflowResponse {
-                data: Workflow
-                error: WorkflowError
-            }
+                    return workflowResult.value;
+                });
+        }
+    });
 
-            type DeleteWorkflowResponse {
-                data: Boolean
-                error: WorkflowError
-            }
+    builder.addResolver({
+        path: "WorkflowsQuery.listWorkflows",
+        dependencies: [ListWorkflowsUseCase],
+        resolver(listWorkflows) {
+            return ({ args }) =>
+                resolveList(async () => {
+                    const result = await listWorkflowsValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-            type WorkflowsMutation {
-                storeWorkflow(
-                    app: String!
-                    id: ID!
-                    data: StoreWorkflowInput!
-                ): StoreWorkflowResponse!
-                deleteWorkflow(app: String!, id: ID!): DeleteWorkflowResponse!
-            }
+                    const listResult = await listWorkflows.execute(result.data);
 
-            extend type Query {
-                workflows: WorkflowsQuery
-            }
+                    if (listResult.isFail()) {
+                        throw listResult.error;
+                    }
 
-            extend type Mutation {
-                workflows: WorkflowsMutation
-            }
-        `,
-        resolvers: {
-            Query: {
-                workflows: () => ({})
-            },
-            Mutation: {
-                workflows: () => ({})
-            },
-            WorkflowsQuery: {
-                getWorkflow: async (_, args, context) => {
-                    return resolve(async () => {
-                        const result = await getWorkflowValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
+                    return listResult.value;
+                });
+        }
+    });
 
-                        const getWorkflow = context.container.resolve(GetWorkflowUseCase);
-                        const workflowResult = await getWorkflow.execute(args);
+    builder.addResolver({
+        path: "WorkflowsMutation.storeWorkflow",
+        dependencies: [StoreWorkflowUseCase],
+        resolver(storeWorkflow) {
+            return ({ args }) =>
+                resolve(async () => {
+                    const result = await storeWorkflowValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
 
-                        if (workflowResult.isFail()) {
-                            throw new NotFoundError(
-                                `Workflow in app "${args.app}" with id "${args.id}" was not found!`
-                            );
-                        }
-
-                        return workflowResult.value;
+                    const storeResult = await storeWorkflow.execute({
+                        app: result.data.app,
+                        id: result.data.id,
+                        ...result.data.data
                     });
-                },
-                listWorkflows: async (_, args, context) => {
-                    return resolveList(async () => {
-                        const result = await listWorkflowsValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const listWorkflows = context.container.resolve(ListWorkflowsUseCase);
-                        const listResult = await listWorkflows.execute(result.data);
+                    if (storeResult.isFail()) {
+                        throw storeResult.error;
+                    }
 
-                        if (listResult.isFail()) {
-                            throw listResult.error;
-                        }
+                    return storeResult.value;
+                });
+        }
+    });
 
-                        return listResult.value;
+    builder.addResolver({
+        path: "WorkflowsMutation.deleteWorkflow",
+        dependencies: [DeleteWorkflowUseCase],
+        resolver(deleteWorkflow) {
+            return ({ args }) =>
+                resolve(async () => {
+                    const result = await deleteWorkflowValidation.safeParseAsync(args);
+                    if (!result.success) {
+                        throw createZodError(result.error);
+                    }
+
+                    const deleteResult = await deleteWorkflow.execute({
+                        app: result.data.app,
+                        id: result.data.id
                     });
-                }
-            },
-            WorkflowsMutation: {
-                storeWorkflow: async (_, args, context) => {
-                    return resolve(async () => {
-                        const result = await storeWorkflowValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
 
-                        const storeWorkflow = context.container.resolve(StoreWorkflowUseCase);
-                        const storeResult = await storeWorkflow.execute({
-                            app: result.data.app,
-                            id: result.data.id,
-                            ...result.data.data
-                        });
+                    if (deleteResult.isFail()) {
+                        throw deleteResult.error;
+                    }
 
-                        if (storeResult.isFail()) {
-                            throw storeResult.error;
-                        }
-
-                        return storeResult.value;
-                    });
-                },
-                deleteWorkflow: async (_, args, context) => {
-                    return resolve(async () => {
-                        const result = await deleteWorkflowValidation.safeParseAsync(args);
-                        if (!result.success) {
-                            throw createZodError(result.error);
-                        }
-
-                        const deleteWorkflow = context.container.resolve(DeleteWorkflowUseCase);
-                        const deleteResult = await deleteWorkflow.execute({
-                            app: result.data.app,
-                            id: result.data.id
-                        });
-
-                        if (deleteResult.isFail()) {
-                            throw deleteResult.error;
-                        }
-
-                        return true;
-                    });
-                }
-            }
+                    return true;
+                });
         }
     });
 };

--- a/packages/api-workflows/src/graphql/workflows.ts
+++ b/packages/api-workflows/src/graphql/workflows.ts
@@ -120,11 +120,7 @@ export const addWorkflowsSchema = (builder: IGraphQLSchemaBuilder): void => {
         }
 
         type WorkflowsMutation {
-            storeWorkflow(
-                app: String!
-                id: ID!
-                data: StoreWorkflowInput!
-            ): StoreWorkflowResponse!
+            storeWorkflow(app: String!, id: ID!, data: StoreWorkflowInput!): StoreWorkflowResponse!
             deleteWorkflow(app: String!, id: ID!): DeleteWorkflowResponse!
         }
 


### PR DESCRIPTION
Fourth slice of the **GraphQLSchemaPlugin → DI schema-contributor** migration (after #5483 fm-s3, #5484 fm-server, #5486 audit-logs).

## Change

`WorkflowsSchemaFactory` bridged three legacy `GraphQLSchemaPlugin`s (`notifications`/`workflows`/`workflowState`) via an `addPluginsToBuilder` + recursive `addResolvers` walker that wrapped every resolver as `fn(parent, args, context, info)` — still service-locating `context.container.resolve(UseCase)` at runtime.

Converted each `createXxxGraphQL()` into an `addXxxSchema(builder)` contributor (the api-core `addSystemSchema` precedent) using `builder.addTypeDefs` + `builder.addResolver({ dependencies:[UseCase], path, resolver })`. ~18 resolvers now **declare** their single use-case dependency; the recursive walker bridge is deleted. `WorkflowsSchemaFactory` just composes the three.

Validation (`safeParseAsync` schemas), `resolve`/`resolveList`, `NotFoundError`, the `WorkflowState.isActive` field resolver, and the `getTargetWorkflowState` null-on-not-found behavior are all preserved.

## Verification

api-workflows tests (53) green — broad real coverage of the migrated query/mutation resolvers. Build + adio + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)