### PR TITLE
fix(api-website-builder): grant wb.redirect read to Website Builder API key

### DIFF
--- a/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
+++ b/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
@@ -19,7 +19,10 @@ class ApiKeyInstallerImpl implements AppInstaller.Interface {
             name: "Website Builder",
             description: "Integrate Next.js or custom frontend with Website Builder.",
             slug: "website-builder",
-            permissions: [{ name: "$wb.readonly" }, { name: "wb.page", rwd: "r" }]
+            permissions: [
+                { name: "wb.page", rwd: "r" },
+                { name: "wb.redirect", rwd: "r" }
+            ]
         });
 
         if (result.isOk()) {


### PR DESCRIPTION
## Problem

Redirects never resolve on the website. The `Website Builder` API key created by `ApiKeyInstaller` was granted only:

```ts
permissions: [{ name: "$wb.readonly" }, { name: "wb.page", rwd: "r" }]
```

`GetActiveRedirectsUseCase` gates on `permissions.canRead("redirect")`, which resolves to the `wb.redirect` entity permission (`domain/permissionsSchema.ts`). The key has no `wb.redirect` and no `wb.*` wildcard, so `getEntityPermissions` returns `[]` and `canRead` is always `false` for the frontend identity.

`$wb.readonly` is a dead string — it appears exactly once in the repo (that line) and nothing consumes `$`-prefixed permission names. Leftover from an earlier permission scheme.

Net effect: pages work, redirects never do.

## Fix

Grant `wb.redirect` read alongside `wb.page`, and drop the dead `$wb.readonly` entry.

## Deploying to existing environments

`alwaysRun = true` re-runs `install()`, but `CreateApiKeyUseCase` with slug `website-builder` will not update an existing key's permissions. **Existing environments need the `Website Builder` API key permissions patched manually in Admin** (add Website Builder → Redirects → read).

## Not included

Three failure-swallowing layers hide this class of bug and are left for a follow-up:

- `rest/WebsiteBuilderRedirectsRoute.ts:33-34` reads `result.value` with no `isFail()` check, so an authorization failure surfaces as a 500 (`Tried to get value from a failed Result.`) instead of a 403.
- `website-builder-sdk/src/dataProviders/ApiClient.ts:35` does `.then(res => res.json())` with no `res.ok` check, so an error body flows on as data and `RedirectsProvider.populateCache` throws `redirects is not iterable`.
- The consuming Next.js middleware catches with a bare `catch {}` and no logging, making 500s indistinguishable from "no redirect configured".

Also noted while investigating, not fixed here: `RedirectAfterUpdateHandler` skips cache invalidation when only `redirectType` changes; `RedirectsProvider.redirectsCache` is write-only so every lookup refetches; redirect path lookup is exact-match with no trailing-slash normalization on either write or read.

## Test plan

- [x] `yarn adio`, `yarn lint`, `yarn format`, `yarn webiny sync-dependencies`
- [x] `yarn build -p @webiny/api-website-builder`
- [ ] Fresh tenant install, then verify `GET /wb/redirects` returns 200 with the configured redirects using the generated `website-builder` API key
- [ ] Verify a redirect actually resolves end-to-end on the Next.js frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)