### PR TITLE
refactor(api-aco): DI-native ACO base + filter GraphQL schema contributors

### DIFF
--- a/packages/api-aco/src/AcoFeature.ts
+++ b/packages/api-aco/src/AcoFeature.ts
@@ -1,12 +1,12 @@
 import { createFeature } from "@webiny/feature/api";
 import { GraphQLSchemaFactory } from "@webiny/api-graphql/graphql/abstractions.js";
 import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
-import type { IGraphQLSchemaPlugin } from "@webiny/api-graphql/plugins/GraphQLSchemaPlugin.js";
 import type { Container } from "@webiny/di";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/abstractions.js";
 import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
 import { HeadlessCms } from "@webiny/api-headless-cms/features/shared/abstractions.js";
-import { createAcoGraphQL } from "./createAcoGraphQL.js";
+import { addAcoBaseSchema } from "./createAcoGraphQL.js";
+import { addFilterSchema } from "~/filter/filter.gql.js";
 import { AcoInitializer } from "./AcoInitializer.js";
 import { CreateFlpTask } from "~/flp/tasks/createFlp.task.js";
 import { UpdateFlpTask } from "~/flp/tasks/updateFlp.task.js";
@@ -52,22 +52,10 @@ import { EnsureFolderIsEmptyFeature } from "~/features/folder/EnsureFolderIsEmpt
 
 class AcoSchemaFactoryImpl implements GraphQLSchemaFactory.Interface {
     async execute(builder: IGraphQLSchemaBuilder): Promise<IGraphQLSchemaBuilder> {
-        // createAcoGraphQL() returns the static [baseSchema, filterSchema] GraphQLSchemaPlugins.
-        // The dynamic folder schema (needs the per-tenant folder model) is built by AcoInitializer.
-        const [baseSchema, filterSchema] = createAcoGraphQL() as unknown as IGraphQLSchemaPlugin[];
-
-        for (const plugin of [baseSchema, filterSchema]) {
-            const schema = (plugin as IGraphQLSchemaPlugin).schema;
-
-            if (schema.typeDefs) {
-                builder.addTypeDefs(schema.typeDefs);
-            }
-
-            if (schema.resolvers) {
-                builder.addLegacyResolvers(schema.resolvers as Record<string, any>);
-            }
-        }
-
+        // Static ACO base + filter schema (DI-native contributors declaring their deps). The dynamic
+        // folder schema (needs the per-tenant folder model) is still built by AcoInitializer.
+        addAcoBaseSchema(builder);
+        addFilterSchema(builder);
         return builder;
     }
 }

--- a/packages/api-aco/src/createAcoGraphQL.ts
+++ b/packages/api-aco/src/createAcoGraphQL.ts
@@ -1,76 +1,67 @@
-import { GraphQLSchemaPlugin } from "@webiny/api-graphql";
-import { filterSchema } from "~/filter/filter.gql.js";
+import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
 
-const emptyResolver = () => ({});
-
-const baseSchema = new GraphQLSchemaPlugin({
-    typeDefs: /* GraphQL */ `
-        type AcoQuery {
-            _empty: String
-        }
-
-        type AcoMutation {
-            _empty: String
-        }
-
-        type AcoMeta {
-            hasMoreItems: Boolean
-            totalCount: Int
-            cursor: String
-        }
-
-        type AcoUser {
-            id: ID
-            displayName: String
-            type: String
-        }
-
-        type AcoError {
-            code: String
-            message: String
-            data: JSON
-            stack: String
-        }
-
-        type AcoBooleanResponse {
-            data: Boolean
-            error: AcoError
-        }
-
-        enum AcoSortDirection {
-            ASC
-            DESC
-        }
-
-        input AcoSort {
-            id: AcoSortDirection
-            createdOn: AcoSortDirection
-            modifiedOn: AcoSortDirection
-            savedOn: AcoSortDirection
-            title: AcoSortDirection
-        }
-
-        extend type Query {
-            aco: AcoQuery
-        }
-
-        extend type Mutation {
-            aco: AcoMutation
-        }
-    `,
-    resolvers: {
-        Query: {
-            aco: emptyResolver
-        },
-        Mutation: {
-            aco: emptyResolver
-        }
+const BASE_TYPE_DEFS = /* GraphQL */ `
+    type AcoQuery {
+        _empty: String
     }
-});
 
-// The dynamic folder schema (field plugins + folders schema) is built per-request by AcoInitializer,
-// which needs the resolved per-tenant folder model. Here we only provide the static base + filter
-// schema plugins.
-export const createAcoGraphQL = () => {
-    return [baseSchema, filterSchema];
+    type AcoMutation {
+        _empty: String
+    }
+
+    type AcoMeta {
+        hasMoreItems: Boolean
+        totalCount: Int
+        cursor: String
+    }
+
+    type AcoUser {
+        id: ID
+        displayName: String
+        type: String
+    }
+
+    type AcoError {
+        code: String
+        message: String
+        data: JSON
+        stack: String
+    }
+
+    type AcoBooleanResponse {
+        data: Boolean
+        error: AcoError
+    }
+
+    enum AcoSortDirection {
+        ASC
+        DESC
+    }
+
+    input AcoSort {
+        id: AcoSortDirection
+        createdOn: AcoSortDirection
+        modifiedOn: AcoSortDirection
+        savedOn: AcoSortDirection
+        title: AcoSortDirection
+    }
+
+    extend type Query {
+        aco: AcoQuery
+    }
+
+    extend type Mutation {
+        aco: AcoMutation
+    }
+`;
+
+/**
+ * The static ACO base schema (root Query.aco / Mutation.aco wrappers + shared types). The dynamic
+ * folder schema (field plugins + folders schema) is built per-request by AcoInitializer, which needs
+ * the resolved per-tenant folder model. The filter schema is contributed by addFilterSchema.
+ */
+export const addAcoBaseSchema = (builder: IGraphQLSchemaBuilder): void => {
+    builder.addTypeDefs(BASE_TYPE_DEFS);
+    builder.addResolver({ path: "Query.aco", dependencies: [], resolver: () => () => ({}) });
+    builder.addResolver({ path: "Mutation.aco", dependencies: [], resolver: () => () => ({}) });
 };

--- a/packages/api-aco/src/filter/filter.gql.ts
+++ b/packages/api-aco/src/filter/filter.gql.ts
@@ -1,14 +1,11 @@
 import { ErrorResponse, ListResponse } from "@webiny/api-graphql/responses.js";
-import { GraphQLSchemaPlugin } from "@webiny/api-graphql/plugins/GraphQLSchemaPlugin.js";
-
+import type { IGraphQLSchemaBuilder } from "@webiny/api-graphql/features/GraphQLSchemaBuilder/abstractions.js";
 import { ensureAuthentication } from "~/utils/ensureAuthentication.js";
 import { resolve } from "~/utils/resolve.js";
-
-import type { AcoContext } from "~/types.js";
 import { AcoFilterCrud } from "~/features/folder/shared/abstractions.js";
 
-export const filterSchema = new GraphQLSchemaPlugin<AcoContext>({
-    typeDefs: /* GraphQL */ `
+export const addFilterSchema = (builder: IGraphQLSchemaBuilder): void => {
+    builder.addTypeDefs(/* GraphQL */ `
         enum OperationEnum {
             AND
             OR
@@ -97,46 +94,69 @@ export const filterSchema = new GraphQLSchemaPlugin<AcoContext>({
             updateFilter(id: ID!, data: FilterUpdateInput!): FilterResponse
             deleteFilter(id: ID!): AcoBooleanResponse
         }
-    `,
-    resolvers: {
-        AcoQuery: {
-            getFilter: async (_, { id }, context) => {
-                return resolve(() => {
+    `);
+
+    builder.addResolver({
+        path: "AcoQuery.getFilter",
+        dependencies: [AcoFilterCrud],
+        resolver(filterCrud) {
+            return ({ args, context }) =>
+                resolve(() => {
                     ensureAuthentication(context);
-                    return context.container.resolve(AcoFilterCrud).get(id);
+                    return filterCrud.get(args.id);
                 });
-            },
-            listFilters: async (_, args: any, context) => {
+        }
+    });
+
+    builder.addResolver({
+        path: "AcoQuery.listFilters",
+        dependencies: [AcoFilterCrud],
+        resolver(filterCrud) {
+            return async ({ args, context }) => {
                 try {
                     ensureAuthentication(context);
-                    const [entries, meta] = await context.container
-                        .resolve(AcoFilterCrud)
-                        .list(args);
+                    const [entries, meta] = await filterCrud.list(args);
                     return new ListResponse(entries, meta);
                 } catch (e) {
                     return new ErrorResponse(e);
                 }
-            }
-        },
-        AcoMutation: {
-            createFilter: async (_, { data }, context) => {
-                return resolve(() => {
-                    ensureAuthentication(context);
-                    return context.container.resolve(AcoFilterCrud).create(data);
-                });
-            },
-            updateFilter: async (_, { id, data }, context) => {
-                return resolve(() => {
-                    ensureAuthentication(context);
-                    return context.container.resolve(AcoFilterCrud).update(id, data);
-                });
-            },
-            deleteFilter: async (_, { id }, context) => {
-                return resolve(() => {
-                    ensureAuthentication(context);
-                    return context.container.resolve(AcoFilterCrud).delete(id);
-                });
-            }
+            };
         }
-    }
-});
+    });
+
+    builder.addResolver({
+        path: "AcoMutation.createFilter",
+        dependencies: [AcoFilterCrud],
+        resolver(filterCrud) {
+            return ({ args, context }) =>
+                resolve(() => {
+                    ensureAuthentication(context);
+                    return filterCrud.create(args.data);
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "AcoMutation.updateFilter",
+        dependencies: [AcoFilterCrud],
+        resolver(filterCrud) {
+            return ({ args, context }) =>
+                resolve(() => {
+                    ensureAuthentication(context);
+                    return filterCrud.update(args.id, args.data);
+                });
+        }
+    });
+
+    builder.addResolver({
+        path: "AcoMutation.deleteFilter",
+        dependencies: [AcoFilterCrud],
+        resolver(filterCrud) {
+            return ({ args, context }) =>
+                resolve(() => {
+                    ensureAuthentication(context);
+                    return filterCrud.delete(args.id);
+                });
+        }
+    });
+};


### PR DESCRIPTION
Sixth slice of the **GraphQLSchemaPlugin → DI schema-contributor** migration (after fm-s3 #5483, fm-server #5484, audit-logs #5486, workflows #5492, website-builder #5493).

## Scope: the static ACO schema

`AcoSchemaFactory` bridged `createAcoGraphQL()` (base + filter `GraphQLSchemaPlugin`s) via `addLegacyResolvers`. Converted:
- `createAcoGraphQL.ts` → `addAcoBaseSchema(builder)` (base types + `Query.aco`/`Mutation.aco` wrappers).
- `filter/filter.gql.ts` → `addFilterSchema(builder)` — the 5 filter CRUD resolvers now declare the `AcoFilterCrud` dependency via `builder.addResolver` (was `context.container.resolve(AcoFilterCrud)`); `ensureAuthentication(context)` preserved.
- `AcoFeature`'s `AcoSchemaFactory` composes the two; bridge deleted.

## Deferred (not this PR)

The **dynamic folder schema** — `folder/folder.gql.ts` (`createFoldersSchema`) + `AcoInitializer` — is model-driven: built per-request from the resolved per-tenant folder model + `createGraphQLSchemaPluginFromFieldPlugins` (CMS field→schema generation). Same category as the CMS model schema; left for that cluster.

## Verification

api-aco tests (74) green — cover the filter CRUD resolvers. Build + adio + format:check + lint clean (`npx oxfmt`/`oxlint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)