### PR TITLE
feat(wcp): consume new A/B testing and AI powerups license flags

### DIFF
--- a/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/Extension.tsx
+++ b/packages/ai-powerups/src/admin/presentation/CmsContentGeneration/Extension.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AdminConfig, RegisterFeature } from "@webiny/app-admin";
+import { AdminConfig, RegisterFeature, useWcp } from "@webiny/app-admin";
 import { InternalContentEntryEditorConfig } from "@webiny/app-headless-cms/admin/config/contentEntries/index.js";
 import { CmsGenerateContentButton } from "~/admin/presentation/CmsContentGeneration/CmsGenerateContentButton.js";
 import {
@@ -12,6 +12,12 @@ import { GenerateEntryContentFeature } from "~/admin/features/generateEntryConte
 const { Actions } = InternalContentEntryEditorConfig;
 
 export const CmsContentGeneration = () => {
+    const wcp = useWcp();
+
+    if (!wcp.canUseAiEntryGeneration()) {
+        return null;
+    }
+
     return (
         <>
             <RegisterFeature feature={CmsGenerateContentFeature} />

--- a/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
+++ b/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
@@ -2,6 +2,7 @@ import { CoreGraphQLSchemaFactory } from "@webiny/handler-graphql/graphql/abstra
 import { Response, ErrorResponse } from "@webiny/handler-graphql/responses.js";
 import { Ai } from "@webiny/api-core/features/ai/index.js";
 import { TaskService } from "@webiny/api-core/features/task/TaskService/index.js";
+import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
 import { UpdateSettingsUseCase } from "~/api/features/UpdateSettings/index.js";
 import { AiPowerUpsSettingsGraphQLMapper } from "./abstractions.js";
@@ -141,9 +142,18 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
 
         builder.addResolver<ICmsGenerateEntryContentTaskInput>({
             path: "AiPowerUpsMutation.generateEntryContent",
-            dependencies: [TaskService],
-            resolver: (taskService: TaskService.Interface) => {
+            dependencies: [TaskService, WcpContext],
+            resolver: (taskService: TaskService.Interface, wcp: WcpContext.Interface) => {
                 return async ({ args }) => {
+                    // Gated at resolver-time, NOT at feature-registration time: the WCP license is
+                    // loaded per request, so a register-time check reads the placeholder
+                    // NullLicense (canUse* → false).
+                    if (!wcp.canUseAiEntryGeneration()) {
+                        throw new Error(
+                            "AI entry generation cannot be used because your project license does not permit it."
+                        );
+                    }
+
                     const result = await taskService.trigger<ICmsGenerateEntryContentTaskInput>({
                         definition: CMS_GENERATE_ENTRY_CONTENT_TASK_ID,
                         input: {

--- a/packages/api-core/src/features/wcp/WcpContext/WcpContext.ts
+++ b/packages/api-core/src/features/wcp/WcpContext/WcpContext.ts
@@ -144,8 +144,28 @@ export class WcpContextImpl implements WcpContext.Interface {
         return this.license.canUseAiPageGeneration();
     }
 
+    canUseAiPageTranslation(): boolean {
+        return this.license.canUseAiPageTranslation();
+    }
+
     canUseAiLexicalGeneration(): boolean {
         return this.license.canUseAiLexicalGeneration();
+    }
+
+    canUseAiEntryGeneration(): boolean {
+        return this.license.canUseAiEntryGeneration();
+    }
+
+    canUseAiEntryComparison(): boolean {
+        return this.license.canUseAiEntryComparison();
+    }
+
+    canUseAiEntryTranslation(): boolean {
+        return this.license.canUseAiEntryTranslation();
+    }
+
+    canUseAbTesting(): boolean {
+        return this.license.canUseAbTesting();
     }
 
     ensureCanUseFeature(wcpFeatureId: keyof typeof WCP_FEATURE_LABEL): void {

--- a/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
+++ b/packages/api-core/src/features/wcp/WcpContext/decorators/WcpContextWithFeatureFlagsDecorator.ts
@@ -91,6 +91,10 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
                                 pageGeneration: flags.isAiPageGenerationEnabled()
                                     ? project.package.features.aiPowerups?.options?.websiteBuilder
                                           ?.pageGeneration
+                                    : false,
+                                pageTranslation: flags.isAiPageTranslationEnabled()
+                                    ? project.package.features.aiPowerups?.options?.websiteBuilder
+                                          ?.pageTranslation
                                     : false
                             },
                             fileManager: {
@@ -101,8 +105,28 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
                             },
                             lexicalGeneration: flags.isAiLexicalGenerationEnabled()
                                 ? project.package.features.aiPowerups?.options?.lexicalGeneration
-                                : false
+                                : false,
+                            cms: {
+                                entryGeneration: flags.isAiEntryGenerationEnabled()
+                                    ? project.package.features.aiPowerups?.options?.cms
+                                          ?.entryGeneration
+                                    : false,
+                                entryComparison: flags.isAiEntryComparisonEnabled()
+                                    ? project.package.features.aiPowerups?.options?.cms
+                                          ?.entryComparison
+                                    : false,
+                                entryTranslation: flags.isAiEntryTranslationEnabled()
+                                    ? project.package.features.aiPowerups?.options?.cms
+                                          ?.entryTranslation
+                                    : false
+                            }
                         }
+                    },
+                    abTesting: {
+                        ...project.package.features.abTesting,
+                        enabled: flags.isAbTestingEnabled()
+                            ? project.package.features.abTesting?.enabled
+                            : false
                     }
                 }
             }
@@ -184,11 +208,43 @@ class WcpContextWithFeatureFlagsDecoratorImpl implements WcpContext.Interface {
         );
     }
 
+    canUseAiPageTranslation() {
+        return (
+            this.decoratee.canUseAiPageTranslation() &&
+            this.featureFlags.get().isAiPageTranslationEnabled()
+        );
+    }
+
     canUseAiLexicalGeneration() {
         return (
             this.decoratee.canUseAiLexicalGeneration() &&
             this.featureFlags.get().isAiLexicalGenerationEnabled()
         );
+    }
+
+    canUseAiEntryGeneration() {
+        return (
+            this.decoratee.canUseAiEntryGeneration() &&
+            this.featureFlags.get().isAiEntryGenerationEnabled()
+        );
+    }
+
+    canUseAiEntryComparison() {
+        return (
+            this.decoratee.canUseAiEntryComparison() &&
+            this.featureFlags.get().isAiEntryComparisonEnabled()
+        );
+    }
+
+    canUseAiEntryTranslation() {
+        return (
+            this.decoratee.canUseAiEntryTranslation() &&
+            this.featureFlags.get().isAiEntryTranslationEnabled()
+        );
+    }
+
+    canUseAbTesting() {
+        return this.decoratee.canUseAbTesting() && this.featureFlags.get().isAbTestingEnabled();
     }
 
     ensureCanUseFeature(featureId: keyof typeof WCP_FEATURE_LABEL) {

--- a/packages/api-core/src/graphql/wcp/graphql.ts
+++ b/packages/api-core/src/graphql/wcp/graphql.ts
@@ -21,6 +21,7 @@ export const createWcpGraphQL = () => {
                 recordLocking: WcpProjectPackageFeaturesFeature
                 fileManager: WcpProjectPackageFeaturesFeature
                 aiPowerups: WcpProjectPackageFeaturesFeature
+                abTesting: WcpProjectPackageFeaturesFeature
             }
 
             type WcpProjectPackage {

--- a/packages/api-core/src/legacy/wcp/LegacyWcpContext.ts
+++ b/packages/api-core/src/legacy/wcp/LegacyWcpContext.ts
@@ -84,8 +84,28 @@ export class LegacyWcpContext implements WcpContextObject {
         return this.getWcpContext().canUseAiPageGeneration();
     }
 
+    canUseAiPageTranslation(): boolean {
+        return this.getWcpContext().canUseAiPageTranslation();
+    }
+
     canUseAiLexicalGeneration(): boolean {
         return this.getWcpContext().canUseAiLexicalGeneration();
+    }
+
+    canUseAiEntryGeneration(): boolean {
+        return this.getWcpContext().canUseAiEntryGeneration();
+    }
+
+    canUseAiEntryComparison(): boolean {
+        return this.getWcpContext().canUseAiEntryComparison();
+    }
+
+    canUseAiEntryTranslation(): boolean {
+        return this.getWcpContext().canUseAiEntryTranslation();
+    }
+
+    canUseAbTesting(): boolean {
+        return this.getWcpContext().canUseAbTesting();
     }
 
     ensureCanUseFeature(featureId: keyof typeof WCP_FEATURE_LABEL): void {

--- a/packages/api-file-manager/__tests__/features/assetDelivery/assetDelivery.di.test.ts
+++ b/packages/api-file-manager/__tests__/features/assetDelivery/assetDelivery.di.test.ts
@@ -46,7 +46,12 @@ const createMockWcpContext = (privateFiles = false): WcpContext.Interface => ({
     canUseHcmsFieldPermissions: () => false,
     canUseAiImageEnrichment: () => false,
     canUseAiPageGeneration: () => false,
-    canUseAiLexicalGeneration: () => false
+    canUseAiPageTranslation: () => false,
+    canUseAiLexicalGeneration: () => false,
+    canUseAiEntryGeneration: () => false,
+    canUseAiEntryComparison: () => false,
+    canUseAiEntryTranslation: () => false,
+    canUseAbTesting: () => false
 });
 
 describe("AssetDelivery DI integration", () => {

--- a/packages/api-website-builder/src/graphql/pages/pages.gql.ts
+++ b/packages/api-website-builder/src/graphql/pages/pages.gql.ts
@@ -25,6 +25,7 @@ import { DuplicatePageUseCase } from "~/features/pages/DuplicatePage/index.js";
 import { TranslatePageUseCase } from "~/features/pages/TranslatePage/index.js";
 import { CreatePageRevisionFromUseCase } from "~/features/pages/CreatePageRevisionFrom/index.js";
 import { KeyValueStore } from "@webiny/api-core/features/keyValueStore/index.js";
+import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { ListDeletedPagesUseCase } from "~/features/pages/ListDeletedPages/index.js";
 import { TrashPageUseCase } from "~/features/pages/TrashPage/index.js";
 import { RestorePageUseCase } from "~/features/pages/RestorePage/index.js";
@@ -229,6 +230,17 @@ export const createPagesSchema = () => {
                 translatePage: async (_, { pageId, languageCode, folderId }, context) => {
                     return resolve(async () => {
                         ensureAuthentication(context);
+
+                        // Gated at resolver-time, NOT at registration time: the WCP license is
+                        // loaded per request, so a register-time check reads the placeholder
+                        // NullLicense (canUse* → false).
+                        const wcp = context.container.resolve(WcpContext);
+                        if (!wcp.canUseAiPageTranslation()) {
+                            throw new Error(
+                                "Page translation cannot be used because your project license does not permit it."
+                            );
+                        }
+
                         const translatePage = context.container.resolve(TranslatePageUseCase);
                         const result = await translatePage.execute({
                             pageId,

--- a/packages/app-admin/src/components/Wcp.tsx
+++ b/packages/app-admin/src/components/Wcp.tsx
@@ -35,11 +35,17 @@ function CanUseHcmsFieldPermissions({ children }: ChildrenProps) {
     return wcp.canUseHcmsFieldPermissions() ? <>{children}</> : null;
 }
 
+function CanUseAbTesting({ children }: ChildrenProps) {
+    const wcp = useWcp();
+    return wcp.canUseAbTesting() ? <>{children}</> : null;
+}
+
 export const Wcp = {
     CanUseMultiTenancy,
     CanUseTeams,
     CanUsePrivateFiles,
     CanUseFileManagerThreatDetection,
     CanUseWorkflows,
-    CanUseHcmsFieldPermissions
+    CanUseHcmsFieldPermissions,
+    CanUseAbTesting
 };

--- a/packages/app-admin/src/features/wcp/ReactLicense.ts
+++ b/packages/app-admin/src/features/wcp/ReactLicense.ts
@@ -64,8 +64,28 @@ export class ReactLicense implements ILicense {
         return this.license.canUseAiPageGeneration();
     }
 
+    canUseAiPageTranslation(): boolean {
+        return this.license.canUseAiPageTranslation();
+    }
+
     canUseAiLexicalGeneration(): boolean {
         return this.license.canUseAiLexicalGeneration();
+    }
+
+    canUseAiEntryGeneration(): boolean {
+        return this.license.canUseAiEntryGeneration();
+    }
+
+    canUseAiEntryComparison(): boolean {
+        return this.license.canUseAiEntryComparison();
+    }
+
+    canUseAiEntryTranslation(): boolean {
+        return this.license.canUseAiEntryTranslation();
+    }
+
+    canUseAbTesting(): boolean {
+        return this.license.canUseAbTesting();
     }
 
     toDto(): DecryptedWcpProjectLicense | null {

--- a/packages/app-admin/src/features/wcp/WcpGateway.ts
+++ b/packages/app-admin/src/features/wcp/WcpGateway.ts
@@ -41,6 +41,9 @@ const GET_WCP_PROJECT = /* GraphQL */ `
                                 enabled
                                 options
                             }
+                            abTesting {
+                                enabled
+                            }
                         }
                     }
                 }

--- a/packages/app-website-builder/src/presentation/pages/TranslatePage/TranslatePageConfig.tsx
+++ b/packages/app-website-builder/src/presentation/pages/TranslatePage/TranslatePageConfig.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AdminConfig } from "@webiny/app-admin";
+import { AdminConfig, useWcp } from "@webiny/app-admin";
 import { HasPermission } from "~/presentation/security/HasPermission.js";
 import { TranslatePageAction } from "./TranslatePageAction.js";
 import { TranslatePageDialog, TRANSLATE_PAGE_DIALOG } from "./TranslatePageDialog.js";
@@ -8,6 +8,12 @@ import { PageListConfig } from "~/exports/admin/website-builder/page/list.js";
 const { Browser } = PageListConfig;
 
 export const TranslatePageConfig = () => {
+    const wcp = useWcp();
+
+    if (!wcp.canUseAiPageTranslation()) {
+        return null;
+    }
+
     return (
         <>
             <AdminConfig>

--- a/packages/feature-flags/src/FeatureFlags.ts
+++ b/packages/feature-flags/src/FeatureFlags.ts
@@ -87,7 +87,27 @@ export class FeatureFlags {
         return this.flags.aiPowerups?.options?.fileManager?.imageEnrichment !== false;
     }
 
+    isAiPageTranslationEnabled(): boolean {
+        return this.flags.aiPowerups?.options?.websiteBuilder?.pageTranslation !== false;
+    }
+
     isAiLexicalGenerationEnabled(): boolean {
         return this.flags.aiPowerups?.options?.lexicalGeneration !== false;
+    }
+
+    isAiEntryGenerationEnabled(): boolean {
+        return this.flags.aiPowerups?.options?.cms?.entryGeneration !== false;
+    }
+
+    isAiEntryComparisonEnabled(): boolean {
+        return this.flags.aiPowerups?.options?.cms?.entryComparison !== false;
+    }
+
+    isAiEntryTranslationEnabled(): boolean {
+        return this.flags.aiPowerups?.options?.cms?.entryTranslation !== false;
+    }
+
+    isAbTestingEnabled(): boolean {
+        return this.flags.abTesting !== false;
     }
 }

--- a/packages/feature-flags/src/types.ts
+++ b/packages/feature-flags/src/types.ts
@@ -11,16 +11,24 @@ export interface IFileManagerFeatureFlags {
 
 export interface IAiPowerupsWebsiteBuilderOptions {
     pageGeneration?: boolean;
+    pageTranslation?: boolean;
 }
 
 export interface IAiPowerupsFileManagerOptions {
     imageEnrichment?: boolean;
 }
 
+export interface IAiPowerupsCmsOptions {
+    entryGeneration?: boolean;
+    entryComparison?: boolean;
+    entryTranslation?: boolean;
+}
+
 export interface IAiPowerupsOptions {
     websiteBuilder?: IAiPowerupsWebsiteBuilderOptions;
     fileManager?: IAiPowerupsFileManagerOptions;
     lexicalGeneration?: boolean;
+    cms?: IAiPowerupsCmsOptions;
 }
 
 export interface IAiPowerupsFeatureFlags {
@@ -42,4 +50,5 @@ export interface IFeatureFlagsDto {
     recordLocking?: boolean;
     fileManager?: IFileManagerFeatureFlags;
     aiPowerups?: IAiPowerupsFeatureFlags;
+    abTesting?: boolean;
 }

--- a/packages/project/src/decorators/GetFeatureFlagsWithLicense.ts
+++ b/packages/project/src/decorators/GetFeatureFlagsWithLicense.ts
@@ -81,6 +81,10 @@ class GetFeatureFlagsWithLicenseDecorator implements GetFeatureFlags.Interface {
             featureFlagsDto.recordLocking,
             license.canUseRecordLocking()
         );
+        featureFlagsDto.abTesting = applyLicenseFlag(
+            featureFlagsDto.abTesting,
+            license.canUseAbTesting()
+        );
 
         // fileManager is always enabled; only restrict threatDetection via license.
         if (!featureFlagsDto.fileManager) {

--- a/packages/project/src/extensions/FeatureFlags.tsx
+++ b/packages/project/src/extensions/FeatureFlags.tsx
@@ -38,7 +38,8 @@ export const FeatureFlags = defineExtension({
                         .object({
                             websiteBuilder: z
                                 .object({
-                                    pageGeneration: z.boolean().optional()
+                                    pageGeneration: z.boolean().optional(),
+                                    pageTranslation: z.boolean().optional()
                                 })
                                 .optional(),
                             fileManager: z
@@ -46,11 +47,19 @@ export const FeatureFlags = defineExtension({
                                     imageEnrichment: z.boolean().optional()
                                 })
                                 .optional(),
-                            lexicalGeneration: z.boolean().optional()
+                            lexicalGeneration: z.boolean().optional(),
+                            cms: z
+                                .object({
+                                    entryGeneration: z.boolean().optional(),
+                                    entryComparison: z.boolean().optional(),
+                                    entryTranslation: z.boolean().optional()
+                                })
+                                .optional()
                         })
                         .optional()
                 })
-                .optional()
+                .optional(),
+            abTesting: z.boolean().optional()
         })
     }),
     render: ({ features = {} }) => {

--- a/packages/wcp/src/License.ts
+++ b/packages/wcp/src/License.ts
@@ -122,7 +122,30 @@ export class License implements ILicense {
         );
     }
 
+    canUseAiPageTranslation(): boolean {
+        return (
+            this.license.package.features.aiPowerups?.options?.websiteBuilder?.pageTranslation ===
+            true
+        );
+    }
+
     canUseAiLexicalGeneration(): boolean {
         return this.license.package.features.aiPowerups?.options?.lexicalGeneration === true;
+    }
+
+    canUseAiEntryGeneration(): boolean {
+        return this.license.package.features.aiPowerups?.options?.cms?.entryGeneration === true;
+    }
+
+    canUseAiEntryComparison(): boolean {
+        return this.license.package.features.aiPowerups?.options?.cms?.entryComparison === true;
+    }
+
+    canUseAiEntryTranslation(): boolean {
+        return this.license.package.features.aiPowerups?.options?.cms?.entryTranslation === true;
+    }
+
+    canUseAbTesting(): boolean {
+        return this.canUseFeature("abTesting");
     }
 }

--- a/packages/wcp/src/NullLicense.ts
+++ b/packages/wcp/src/NullLicense.ts
@@ -67,7 +67,27 @@ export class NullLicense implements ILicense {
         return false;
     }
 
+    canUseAiPageTranslation(): boolean {
+        return false;
+    }
+
     canUseAiLexicalGeneration(): boolean {
+        return false;
+    }
+
+    canUseAiEntryGeneration(): boolean {
+        return false;
+    }
+
+    canUseAiEntryComparison(): boolean {
+        return false;
+    }
+
+    canUseAiEntryTranslation(): boolean {
+        return false;
+    }
+
+    canUseAbTesting(): boolean {
         return false;
     }
 }

--- a/packages/wcp/src/index.ts
+++ b/packages/wcp/src/index.ts
@@ -12,5 +12,6 @@ export const WCP_FEATURE_LABEL = {
     advancedAccessControlLayer: "Advanced Access Control Layer (ACL)",
     auditLogs: "Audit Logs",
     recordLocking: "Record Locking",
-    fileManager: "File Manager"
+    fileManager: "File Manager",
+    abTesting: "A/B Testing"
 };

--- a/packages/wcp/src/testing/createTestWcpLicense.ts
+++ b/packages/wcp/src/testing/createTestWcpLicense.ts
@@ -54,6 +54,9 @@ export const createTestWcpLicense = (options?: LicenseOptions): DecryptedWcpProj
                 [PROJECT_PACKAGE_FEATURE_NAME.AI_POWERUPS]: {
                     enabled: false,
                     options: {}
+                },
+                [PROJECT_PACKAGE_FEATURE_NAME.AB_TESTING]: {
+                    enabled: false
                 }
             }
         }

--- a/packages/wcp/src/types.ts
+++ b/packages/wcp/src/types.ts
@@ -25,7 +25,12 @@ export interface ILicense {
     canUseHcmsFieldPermissions: () => boolean;
     canUseAiImageEnrichment: () => boolean;
     canUseAiPageGeneration: () => boolean;
+    canUseAiPageTranslation: () => boolean;
     canUseAiLexicalGeneration: () => boolean;
+    canUseAiEntryGeneration: () => boolean;
+    canUseAiEntryComparison: () => boolean;
+    canUseAiEntryTranslation: () => boolean;
+    canUseAbTesting: () => boolean;
 }
 
 export declare type WcpProjectEnvironment = {
@@ -55,7 +60,8 @@ export enum PROJECT_PACKAGE_FEATURE_NAME {
     AUDIT_LOGS = "auditLogs",
     RECORD_LOCKING = "recordLocking",
     FILE_MANAGER = "fileManager",
-    AI_POWERUPS = "aiPowerups"
+    AI_POWERUPS = "aiPowerups",
+    AB_TESTING = "abTesting"
 }
 
 export enum MT_OPTIONS_MAX_COUNT_TYPE {
@@ -106,10 +112,18 @@ export interface ProjectPackageFeatures {
     [PROJECT_PACKAGE_FEATURE_NAME.AI_POWERUPS]: {
         enabled: boolean;
         options: {
-            websiteBuilder?: { pageGeneration?: boolean };
+            websiteBuilder?: { pageGeneration?: boolean; pageTranslation?: boolean };
             fileManager?: { imageEnrichment?: boolean };
             lexicalGeneration?: boolean;
+            cms?: {
+                entryGeneration?: boolean;
+                entryComparison?: boolean;
+                entryTranslation?: boolean;
+            };
         };
+    };
+    [PROJECT_PACKAGE_FEATURE_NAME.AB_TESTING]: {
+        enabled: boolean;
     };
 }
 


### PR DESCRIPTION
## Summary

Consumer-side support in `webiny-js` for the new WCP license feature flags:

| Flag | Shape |
|---|---|
| `abTesting` | `{ enabled: boolean }` (top-level, enabled-only) |
| `aiPowerups.options.websiteBuilder.pageTranslation` | `boolean` |
| `aiPowerups.options.cms.entryGeneration` | `boolean` |
| `aiPowerups.options.cms.entryComparison` | `boolean` |
| `aiPowerups.options.cms.entryTranslation` | `boolean` |

Additive and backward compatible — a missing flag is treated as disabled, so licenses issued before this change behave as feature-off.

## Plumbing

- `@webiny/wcp`: `PROJECT_PACKAGE_FEATURE_NAME.AB_TESTING`, new `ProjectPackageFeatures` shape, `ILicense` methods `canUseAbTesting`, `canUseAiPageTranslation`, `canUseAiEntryGeneration`, `canUseAiEntryComparison`, `canUseAiEntryTranslation`, implemented in `License` / `NullLicense`; `WCP_FEATURE_LABEL.abTesting`; test license fixture updated.
- `@webiny/feature-flags`: new flag types and `is*Enabled()` checks (project-level opt-out, `!== false`).
- `@webiny/project`: `FeatureFlags` extension zod schema, and `abTesting` constrained by the license in `GetFeatureFlagsWithLicense`.
- `@webiny/api-core`: `WcpContext` + `LegacyWcpContext` delegations, `WcpContextWithFeatureFlagsDecorator` (license AND feature flag, plus the `getProjectWithFeatureFlags()` payload), and `abTesting` in the WCP GraphQL schema.
- `@webiny/app-admin`: `ReactLicense` delegations, `abTesting` in the `GetWcpProject` query, `Wcp.CanUseAbTesting` gate component.

## Feature gates

Applied where the feature exists today:

- **WB page translation** — `translatePage` GraphQL resolver + `TranslatePageConfig` admin action.
- **CMS AI entry generation** — `generateEntryContent` GraphQL resolver + `CmsContentGeneration` admin extension.

Gates are evaluated at resolver/render time, not at feature registration, because the license is loaded per request (a register-time check reads the placeholder `NullLicense`).

**No gates for `entryComparison`, `entryTranslation`, `abTesting`** — those features don't exist in this repo yet. The flags are plumbed end-to-end and ready for the features to check them.

Note: WB "Translate Page" is currently a non-AI page duplication into a target language, but it's the only page-translation surface, so it is gated by `aiPowerups.options.websiteBuilder.pageTranslation`.

## Test plan

- `yarn build` (all packages) — pass
- `yarn test packages/api-core` — 165 pass; `packages/api-file-manager` — 140 pass / 1 skipped; `packages/app-aco` — 93 pass
- `yarn adio`, `yarn lint`, `yarn format`, `yarn webiny sync-dependencies` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)