### PR TITLE
fix(api-core): resolve WCP license from runtime env for CLI-less deploys

### DIFF
--- a/packages/api-core/src/features/wcp/loadWcpLicense.ts
+++ b/packages/api-core/src/features/wcp/loadWcpLicense.ts
@@ -1,10 +1,46 @@
 import { getWcpProjectLicense, getWcpProjectEnvironment, NullLicense } from "@webiny/wcp";
-import type { DecryptedWcpProjectLicense, ILicense } from "@webiny/wcp/types.js";
+import type {
+    DecryptedWcpProjectLicense,
+    ILicense,
+    WcpProjectEnvironment
+} from "@webiny/wcp/types.js";
 import { License } from "@webiny/wcp";
 import type { CachedWcpProjectLicense } from "~/features/wcp/WcpContext/types.js";
 import { getWcpProjectLicenseCacheKey } from "~/features/wcp/WcpContext/utils.js";
 
-const wcpProjectEnvironment = getWcpProjectEnvironment();
+/**
+ * Resolve the WCP project environment used to fetch the license. Prefer the CLI-computed
+ * WCP_PROJECT_ENVIRONMENT blob (set by `applyWcpEnvVars` during `webiny serve` and the AWS deploy).
+ * When it's absent — a CLI-less self-hosted deploy that boots the built handler directly (e.g.
+ * `node start.mjs`) — derive the same org, project and api key straight from the runtime env, so a
+ * fresh license can still be fetched.
+ */
+function resolveWcpProjectEnvironment(): WcpProjectEnvironment | null {
+    const fromBlob = getWcpProjectEnvironment();
+    if (fromBlob) {
+        return fromBlob;
+    }
+
+    const projectId = process.env.WEBINY_PROJECT_ID || process.env.WCP_PROJECT_ID;
+    const apiKey =
+        process.env.WEBINY_PROJECT_API_KEY || process.env.WCP_PROJECT_ENVIRONMENT_API_KEY;
+    if (!projectId || !apiKey) {
+        return null;
+    }
+
+    // WEBINY_PROJECT_ID has an "orgId/projectId" shape.
+    const [orgId, project] = projectId.split("/");
+    if (!orgId || !project) {
+        return null;
+    }
+
+    // `id` is intentionally empty. The WCP backend identifies the specific project environment
+    // from the api key (sent as the request's authorization header); the license fetch only uses
+    // org/project (URL path) + apiKey (auth), never the environment id. So there's nothing to fill.
+    return { id: "", apiKey, org: { id: orgId }, project: { id: project } };
+}
+
+const wcpProjectEnvironment = resolveWcpProjectEnvironment();
 
 const cachedLicense: CachedWcpProjectLicense = {
     cacheKey: null,


### PR DESCRIPTION
## Change

`loadWcpLicense` only resolved the WCP project environment from the CLI-computed `WCP_PROJECT_ENVIRONMENT` blob (set by `applyWcpEnvVars` during `webiny serve` and the AWS deploy). A self-hosted **server** deploy boots the built handler directly (`node start.mjs`) with no CLI step, so the blob is absent — the license fell back to `NullLicense` and `getProject` returned `COULD_NOT_GET_PROJECT`.

This adds a fallback: when the blob is missing, derive `org` / `project` / `apiKey` straight from the runtime env (`WEBINY_PROJECT_ID` + `WEBINY_PROJECT_API_KEY`) so a fresh license is still fetched. No new WCP API call — the license endpoint already takes `{orgId, projectId, apiKey}`, and WCP resolves the specific environment from the api key server-side (so the environment `id` isn't needed).

Behavior unchanged when the blob is present (AWS + `webiny serve`).

## Test

Validated end-to-end on a self-hosted EC2 deploy: container env had only `WEBINY_PROJECT_ID` + `WEBINY_PROJECT_API_KEY` (no `WCP_PROJECT_ENVIRONMENT`), and `getProject` returned `error: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
