### PR TITLE
fix(api-website-builder): grant Website Builder API key read access to all WB entities

### DIFF
--- a/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
+++ b/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
@@ -19,12 +19,19 @@ class ApiKeyInstallerImpl implements AppInstaller.Interface {
             name: "Website Builder",
             description: "Integrate Next.js or custom frontend with Website Builder.",
             slug: "website-builder",
-            permissions: [
-                // Experiments and variants are governed by the Website Builder page permission,
-                // so read-only page access is all the frontend key needs to serve/preview them.
-                { name: "$wb.readonly" },
-                { name: "wb.page", rwd: "r" }
-            ]
+            // Mirrors exactly what Admin writes when you pick the "Read-only" access level for
+            // Website Builder (see `usePermissionForm`): a synthetic `$wb.readonly` marker plus
+            // `wb.*` with `rwd: "r"`.
+            //
+            // `$wb.readonly` carries no authorization weight — it exists so the Admin form can
+            // round-trip the chosen access level (`deserializePermissions` looks for it first).
+            // Drop it and the key still works, but Admin renders it as "Custom access". Keep it.
+            //
+            // `wb.*` + `rwd: "r"` grants read on every Website Builder entity (page, redirect, and
+            // anything added later) without granting writes — `hasFullSchemaAccess` deliberately
+            // does not treat a permission carrying `rwd` as full access. Enumerating entities
+            // individually is what previously left the frontend unable to read redirects.
+            permissions: [{ name: "$wb.readonly" }, { name: "wb.*", rwd: "r" }]
         });
 
         if (result.isOk()) {


### PR DESCRIPTION
Retargeted from #5494, which was opened against `next` and has been closed.

## Problem

Redirects never resolve on the website. The `Website Builder` API key created by `ApiKeyInstaller` was granted only:

```ts
permissions: [
    // Experiments and variants are governed by the Website Builder page permission,
    // so read-only page access is all the frontend key needs to serve/preview them.
    { name: "$wb.readonly" },
    { name: "wb.page", rwd: "r" }
]
```

That comment is the bug — read-only *page* access is not all the frontend key needs. `GetActiveRedirectsUseCase` gates on `permissions.canRead("redirect")`, which resolves to the `wb.redirect` entity permission (`domain/permissionsSchema.ts`). Neither `wb.redirect` nor a matching wildcard was granted, so `getEntityPermissions` returned `[]` and `canRead` was always `false` for the frontend identity.

Pages kept working, which is why this presented as a redirects-specific problem rather than a permissions one.

## Fix

```ts
permissions: [{ name: "$wb.readonly" }, { name: "wb.*", rwd: "r" }]
```

This is byte-for-byte what Admin writes when you select the **Read-only** access level for Website Builder — `usePermissionForm.ts` emits the `$wb.readonly` marker plus `resolveReadOnlyAccess(schema)`, which for `readOnlyAccess: true` (`app-website-builder/src/constants.ts`) is `[{ name: "wb.*", rwd: "r" }]`. Keeping the installer and the Admin UI in agreement is the point: an operator who inspects this key should see a normal "Read-only" selection, not a bespoke permission set.

Two properties worth stating explicitly, since both are easy to break:

- **`wb.*` + `rwd: "r"` grants read on every WB entity**, current and future, because `getEntityPermissions` falls back to wildcard matching (`minimatch("wb.redirect", "wb.*")`). It does **not** grant writes: `hasFullSchemaAccess` deliberately refuses to treat a permission carrying `rwd` as full access. Enumerating entities one by one is what caused this bug, and would cause it again the next time an entity is added.
- **`$wb.readonly` is a synthetic UI marker, not an authorization grant.** Nothing on the API side consumes it, but `deserializePermissions` checks for it *before* the full-access check, so removing it makes Admin render the key as "Custom access". It is intentionally retained. (An earlier revision of this PR removed it as "dead code" — it is not; it is constructed dynamically as `` `$${schema.prefix}.readonly` ``, so a literal grep does not find the producer.)

## Deploying to existing environments

`alwaysRun = true` re-runs `install()`, but `CreateApiKeyUseCase` will not update an existing key's permissions — it fails on the duplicate slug. **Existing environments need the `Website Builder` API key patched manually in Admin**: open it and set Website Builder → Read-only.

Verify with:

```
curl -H "Authorization: Bearer <token>" -H "X-Tenant: root" <apiHost>/wb/redirects
```

A `200` with a JSON array is correct. A `500` carrying `Tried to get value from a failed Result.` means the key authenticated but lacks the permission.

## Not included

`rest/getRedirects.ts:25` reads `result.value` with no `isFail()` check, so an authorization failure surfaces as a 500 rather than a 403 — `Result.value` throws `Tried to get value from a failed Result.` on a failed result. That masked this bug during diagnosis and is left for a follow-up, along with two other swallow points in the same flow: `website-builder-sdk` `ApiClient.fetch` ignores `res.ok`, and the Next.js starter kit's `middleware.ts` catches redirect-lookup failures with a bare `catch {}`.

Also noted while investigating, not fixed here: `RedirectAfterUpdateHandler` skips cache invalidation when only `redirectType` changes; `RedirectsProvider.redirectsCache` is write-only so every lookup refetches; redirect lookup is exact-match against `pathname` with no trailing-slash normalization on either write or read.

## Test plan

- [x] `yarn adio`, `yarn lint`, `yarn format`, `yarn webiny sync-dependencies`
- [x] Full `yarn build` green
- [x] Verified against a live environment: with `wb.*` read on the key, `GET /wb/redirects` returns `200 [{"id":"...","from":"/a","to":"/b","permanent":true}]`
- [ ] Fresh tenant install, then confirm the generated key resolves redirects without manual intervention
- [ ] Confirm Admin renders the generated key as "Read-only"

No automated coverage exists for `ApiKeyInstaller`'s permission list, so the remaining items are manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)