### PR TITLE
chore(create-webiny-project): refresh self-hosted ALPHA notice

### DIFF
--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -232,9 +232,10 @@ export class CreateWebinyProject {
             console.log();
             console.log(
                 yellow(
-                    "⚠ The self-hosted (server) hosting type is in ALPHA. It is designed for local\n" +
-                        "  development via `webiny watch`. Standalone production packaging is still a\n" +
-                        "  work in progress (tracked in webiny-js#5429)."
+                    "⚠ The self-hosted (server) hosting type is in ALPHA. Develop locally with\n" +
+                        "  `webiny watch`. You can also build a self-contained, deployable artifact and\n" +
+                        "  run it anywhere with `node start.mjs` — no Webiny CLI or monorepo required on\n" +
+                        "  the server. It's still maturing, so expect some rough edges."
                 )
             );
             console.log();


### PR DESCRIPTION
## Change

The `create-webiny-project` success message for the self-hosted (server) hosting type said standalone production packaging was "still a work in progress". That's no longer true — the server build now emits a self-contained, runnable artifact (`node start.mjs`, no Webiny CLI or monorepo needed on the server).

Rewords the ALPHA notice to say packaging works, keeps the ALPHA/"expect rough edges" framing, and drops the stale tracking-issue reference.

Copy-only change (no logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
