### PR TITLE
fix: reload scheduled actions when scheduler overlay closes

### DIFF
--- a/packages/app-headless-cms-scheduler/src/components/Browser/SchedulerMenuItem.tsx
+++ b/packages/app-headless-cms-scheduler/src/components/Browser/SchedulerMenuItem.tsx
@@ -3,11 +3,13 @@ import { useModel } from "@webiny/app-headless-cms/exports/admin/cms.js";
 import { usePermissions } from "~/hooks/usePermissions.js";
 import { Scheduler as BaseScheduler } from "@webiny/app-scheduler";
 import { SchedulerButton } from "./SchedulerButton.js";
+import { useScheduledActionsPresenter } from "~/hooks/useScheduledActionsPresenter.js";
 import { createNamespace } from "~/utils/index.js";
 
 export const SchedulerMenuItem = () => {
     const { model } = useModel();
     const { canPublish, canUnpublish } = usePermissions();
+    const scheduledActions = useScheduledActionsPresenter();
 
     const namespace = createNamespace(model);
 
@@ -20,6 +22,10 @@ export const SchedulerMenuItem = () => {
             namespace={namespace}
             canPublish={canPublish}
             canUnpublish={canUnpublish}
+            // The scheduler overlay opens on top of the entries list, so the list stays mounted and
+            // its cached scheduled actions go stale when one is cancelled here. Reload on close so the
+            // "Live" column reflects any cancellations before the user sees the list again.
+            onClose={() => scheduledActions.loadForModel(model.modelId)}
             render={({ showScheduler }) => {
                 return <SchedulerButton onClick={showScheduler} />;
             }}


### PR DESCRIPTION
## Problem

Cancelling a scheduled publish/unpublish from the **Scheduler overlay** left a stale **Scheduled** tag in the entries-list *Live* column. Reported by Sven ([screenshot](https://webiny.slack.com/archives/D03UVFX8TEU/p1784806447027699)): a Draft entry scheduled to publish, then cancelled via the Scheduler overlay, still showed *Scheduled* in the parent list.

## Root cause

The Scheduler overlay opens on top of the content-entries list, so `ListView` stays mounted and the singleton `ScheduledActionsPresenter` is never re-initialised. Its only refetch trigger is the list-presenter decorator's reaction keyed on each row's `status`/`live` version — and cancelling a scheduled publish on a Draft changes neither, so no refetch happens and the cached (now-deleted) scheduled action lingers.

## Fix

`SchedulerMenuItem` passes `onClose` to `Scheduler`, reloading the current model's scheduled actions when the overlay closes. The *Live* column then reconciles against fresh data before the user sees the list again.

## Testing

- `yarn check -p @webiny/app-headless-cms-scheduler` ✓
- `yarn lint` / `yarn format` / `yarn adio` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)