### PR TITLE
feat(project-server): config-driven SQL database driver (sqlite/postgres)

### DIFF
--- a/packages/api-event-handler-server-sql/src/createPostgresConnection.ts
+++ b/packages/api-event-handler-server-sql/src/createPostgresConnection.ts
@@ -17,7 +17,11 @@ export interface CreatePostgresConnectionOptions {
 }
 
 const envBool = (name: string): boolean | undefined => {
-    return toBoolean(process.env[name]);
+    const value = process.env[name];
+    // Only convert when the var is actually set — an unset var must stay `undefined`, not become
+    // `false`. Callers rely on the `undefined` distinction (e.g. the SSL config is only applied when a
+    // WEBINY_PG_SSL* var is explicitly present); returning `false` for unset would always trigger it.
+    return value === undefined ? undefined : toBoolean(value);
 };
 
 const envInt = (name: string): number | undefined => {

--- a/packages/project-server-template/template/appTemplates/api/graphql/src/index.ts
+++ b/packages/project-server-template/template/appTemplates/api/graphql/src/index.ts
@@ -6,11 +6,16 @@
  * transport, with the self-hosted JWT identity provider. This file only supplies project-specific
  * extensions + the SQL (Knex) connection.
  *
- * The default connection is a local SQLite file (`createSqliteConnection`, driven by
- * `<Infra.Sqlite filename="..." />` → WEBINY_SQL_FILENAME). A real deployment can swap this for its
- * own Knex client (Postgres/MySQL) passed straight to `createSqlApiHandler`.
+ * The connection factory below is generated at build time from the DB infra extension
+ * (`<Infra.Sqlite>` / `<Infra.Postgres>`) in webiny.config.tsx — see GenerateApiDbConnection, which
+ * decorates the workspace build. It replaces the `__WEBINY_DB_FACTORY__` import with the chosen
+ * factory, rewriting the specifier to that factory's own module path so only the selected driver is
+ * traced into the bundle (the other database driver and its native binary stay out of the deploy
+ * artifact). The placeholder imports the real package here so the template parses, lints, and passes
+ * dependency checks before substitution.
  */
-import { createSqlApiHandler, createSqliteConnection } from "@webiny/api-event-handler-server-sql";
+import { createSqlApiHandler } from "@webiny/api-event-handler-server-sql";
+import { __WEBINY_DB_FACTORY__ } from "@webiny/api-event-handler-server-sql";
 import { extensions } from "./extensions";
 
-export const handler = createSqlApiHandler({ extensions, knex: createSqliteConnection() });
+export const handler = createSqlApiHandler({ extensions, knex: __WEBINY_DB_FACTORY__() });

--- a/packages/project-server/src/deploy/GenerateApiDbConnection.ts
+++ b/packages/project-server/src/deploy/GenerateApiDbConnection.ts
@@ -1,0 +1,80 @@
+import { replaceInPath } from "replace-in-path";
+import {
+    BuildAppWorkspaceService,
+    GetApp,
+    GetProjectConfigService,
+    GetProjectService,
+    LoggerService
+} from "@webiny/project/abstractions/index.js";
+import { getServerDbDriver } from "./getServerDbDriver.js";
+
+/**
+ * Generate the api composition root's database connection from the DB infra extension declared in
+ * webiny.config.tsx (`<Infra.Sqlite>` / `<Infra.Postgres>`). The api entry template ships with
+ * `{DB_FACTORY}` / `{DB_FACTORY_PATH}` placeholders; after the base workspace build copies it in, this
+ * decorator resolves the configured database and substitutes the matching connection factory (imported
+ * from its own module path).
+ *
+ * This decorates the workspace build (rather than an ApiBeforeBuild hook) so it runs right after the
+ * template is copied — the entry file must exist to substitute — and in both `build` and `watch`.
+ */
+const FACTORIES = {
+    sqlite: {
+        name: "createSqliteConnection",
+        modulePath: "@webiny/api-event-handler-server-sql/createSqliteConnection.js"
+    },
+    postgres: {
+        name: "createPostgresConnection",
+        modulePath: "@webiny/api-event-handler-server-sql/createPostgresConnection.js"
+    }
+} as const;
+
+class GenerateApiDbConnectionImpl implements BuildAppWorkspaceService.Interface {
+    constructor(
+        private getProjectConfigService: GetProjectConfigService.Interface,
+        private getProjectService: GetProjectService.Interface,
+        private logger: LoggerService.Interface,
+        private decoratee: BuildAppWorkspaceService.Interface
+    ) {}
+
+    async execute(appName: GetApp.AppName, options: BuildAppWorkspaceService.Options = {}) {
+        // Copy the app template into the workspace first — the entry file must exist to substitute.
+        await this.decoratee.execute(appName, options);
+
+        // The database connection lives in the api app only.
+        if (appName !== "api") {
+            return;
+        }
+
+        const driver = await getServerDbDriver(this.getProjectConfigService);
+        const factory = FACTORIES[driver];
+
+        const project = this.getProjectService.execute();
+        const entryFile = project.paths.workspaceFolder
+            .join("apps", "api", "graphql", "src", "index.ts")
+            .toString();
+
+        // The template imports the placeholder from the real package (so it parses, lints, and passes
+        // dependency checks). Rewrite that import to the chosen factory's own module path — so nft
+        // traces only the selected driver into the bundle — then swap the call site. replaceInPath
+        // treats `find` as a regex, so the literal patterns are escaped.
+        const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const placeholderImport =
+            'import { __WEBINY_DB_FACTORY__ } from "@webiny/api-event-handler-server-sql";';
+
+        replaceInPath(entryFile, [
+            {
+                find: escapeRegExp(placeholderImport),
+                replaceWith: `import { ${factory.name} } from "${factory.modulePath}";`
+            },
+            { find: escapeRegExp("__WEBINY_DB_FACTORY__("), replaceWith: `${factory.name}(` }
+        ]);
+
+        this.logger.debug("Generated api database connection (%s).", driver);
+    }
+}
+
+export const GenerateApiDbConnection = BuildAppWorkspaceService.createDecorator({
+    decorator: GenerateApiDbConnectionImpl,
+    dependencies: [GetProjectConfigService, GetProjectService, LoggerService]
+});

--- a/packages/project-server/src/deploy/PruneUnusedDbDriver.ts
+++ b/packages/project-server/src/deploy/PruneUnusedDbDriver.ts
@@ -1,0 +1,68 @@
+import path from "path";
+import fs from "fs";
+import {
+    ApiAfterBuild,
+    GetProjectConfigService,
+    GetProjectService,
+    LoggerService
+} from "@webiny/project/abstractions/index.js";
+import { getServerBuildPaths } from "./getServerBuildPaths.js";
+import { getServerDbDriver } from "./getServerDbDriver.js";
+
+/**
+ * Keep the deploy artifact single-driver. knex loads its SQL driver by client string at runtime, so
+ * @vercel/nft (which traces static requires) can't tell which one the app uses and copies BOTH drivers
+ * into build/node_modules. Only the configured factory is imported by the api entry, so the other
+ * driver is dead weight. Remove it — a Postgres build ships no `better-sqlite3`, a SQLite build no `pg`.
+ *
+ * Runs after CopyExternalDependencies (which does the nft copy). The package sets below are each
+ * driver's own dependency closure; the two never overlap, so removing the unused one is safe.
+ */
+const DRIVER_PACKAGES: Record<string, string[]> = {
+    sqlite: ["better-sqlite3", "bindings", "file-uri-to-path"],
+    postgres: [
+        "pg",
+        "pg-cloudflare",
+        "pg-connection-string",
+        "pg-int8",
+        "pg-pool",
+        "pg-protocol",
+        "pg-types",
+        "pgpass"
+    ]
+};
+
+class PruneUnusedDbDriverImpl implements ApiAfterBuild.Interface {
+    constructor(
+        private getProjectConfigService: GetProjectConfigService.Interface,
+        private getProjectService: GetProjectService.Interface,
+        private logger: LoggerService.Interface
+    ) {}
+
+    async execute() {
+        const { buildDir } = getServerBuildPaths(this.getProjectService);
+        const nodeModules = path.join(buildDir, "node_modules");
+        if (!fs.existsSync(nodeModules)) {
+            return;
+        }
+
+        const driver = await getServerDbDriver(this.getProjectConfigService);
+        const unused = driver === "postgres" ? "sqlite" : "postgres";
+
+        let removed = 0;
+        for (const pkg of DRIVER_PACKAGES[unused]) {
+            const dir = path.join(nodeModules, pkg);
+            if (fs.existsSync(dir)) {
+                fs.rmSync(dir, { recursive: true, force: true });
+                removed++;
+            }
+        }
+
+        this.logger.debug("Pruned the unused %s database driver (%s package(s)).", unused, removed);
+    }
+}
+
+export const PruneUnusedDbDriver = ApiAfterBuild.createImplementation({
+    implementation: PruneUnusedDbDriverImpl,
+    dependencies: [GetProjectConfigService, GetProjectService, LoggerService]
+});

--- a/packages/project-server/src/deploy/getServerDbDriver.ts
+++ b/packages/project-server/src/deploy/getServerDbDriver.ts
@@ -1,0 +1,29 @@
+import { GetProjectConfigService } from "@webiny/project/abstractions/index.js";
+
+export type ServerDbDriver = "sqlite" | "postgres";
+
+/**
+ * Resolve the self-hosted database driver from the DB infra extension declared in webiny.config.tsx
+ * (`<Infra.Sqlite>` / `<Infra.Postgres>`). Exactly one must be configured — fail loud otherwise.
+ *
+ * Queried without tags: the Infra.* extensions are project-level, not tagged to a specific app, so an
+ * app-scoped config query would filter them out.
+ */
+export const getServerDbDriver = async (
+    getProjectConfigService: GetProjectConfigService.Interface
+): Promise<ServerDbDriver> => {
+    const projectConfig = await getProjectConfigService.execute();
+
+    const hasSqlite = projectConfig.extensionsByType("Infra/Sqlite").length > 0;
+    const hasPostgres = projectConfig.extensionsByType("Infra/Postgres").length > 0;
+
+    if (hasSqlite === hasPostgres) {
+        throw new Error(
+            hasSqlite
+                ? "Both <Infra.Sqlite> and <Infra.Postgres> are configured in webiny.config. Configure exactly one."
+                : 'No database configured. Add <Infra.Sqlite filename="..." /> or <Infra.Postgres ... /> to webiny.config.'
+        );
+    }
+
+    return hasPostgres ? "postgres" : "sqlite";
+};

--- a/packages/project-server/src/registerServerProjectFeatures.ts
+++ b/packages/project-server/src/registerServerProjectFeatures.ts
@@ -4,13 +4,21 @@ import { BuildServerProjectWorkspace } from "./features/BuildServerProjectWorksp
 import { serverWatch } from "./features/Watch/ServerWatch.js";
 import { serverServe } from "./serve/ServerServe.js";
 import { serveWithBuildChecks } from "./serve/ServeWithBuildChecks.js";
+import { GenerateApiDbConnection } from "./deploy/GenerateApiDbConnection.js";
 import { CopyExternalDependencies } from "./deploy/CopyExternalDependencies.js";
+import { PruneUnusedDbDriver } from "./deploy/PruneUnusedDbDriver.js";
 import { EmitDeployEntry } from "./deploy/EmitDeployEntry.js";
 
 export const registerServerProjectFeatures = (container: Container): void => {
     // Replace the default (AWS) workspace builder with the server hosting-type one.
     // The server workspace has no Pulumi scaffolding — only app source templates.
     container.register(serverBuildAppWorkspaceService).inSingletonScope();
+    // Right after the api workspace is copied, generate its database connection from the DB infra
+    // extension (<Infra.Sqlite> / <Infra.Postgres>) in webiny.config.tsx: substitute the entry's
+    // {DB_FACTORY} placeholders with the chosen connection factory. Picking the driver here (build +
+    // watch) keeps only the chosen one in the bundle + deploy artifact — no sqlite driver in a
+    // postgres build, and vice versa.
+    container.registerDecorator(GenerateApiDbConnection);
     // Copy the server `webiny.config.base.tsx` (renders <Project />, not <ProjectAws />) into the
     // workspace, so none of the AWS deploy/Pulumi hooks are composed in the self-hosted hosting type.
     container.registerDecorator(BuildServerProjectWorkspace);
@@ -31,5 +39,9 @@ export const registerServerProjectFeatures = (container: Container): void => {
     // concerns: copy the external deps into build/node_modules, and emit the deploy entry (start.mjs +
     // package.json). Deploy-artifact packaging belongs with the server hosting type, not the bundler.
     container.register(CopyExternalDependencies);
+    // nft copies both SQL drivers (knex loads its driver by string, so the trace can't tell which is
+    // used). Prune the one the project didn't choose, right after the copy — keeps the artifact
+    // single-driver (no better-sqlite3 in a postgres build, and vice versa).
+    container.register(PruneUnusedDbDriver);
     container.register(EmitDeployEntry);
 };

--- a/packages/project-server/src/serve/runApiServer.ts
+++ b/packages/project-server/src/serve/runApiServer.ts
@@ -67,25 +67,19 @@ export async function runApiServer(
     // fetches a fresh license rather than reading the build-time plaintext value.
     const runtimeEnv = pickServerRuntimeEnvVariables();
 
-    // The database is mandatory and must be configured via `<Infra.Sqlite filename="..." />` in
-    // webiny.config (which bakes WEBINY_SQL_FILENAME). No implicit default: the child runs from the
-    // disposable app workspace, so a cwd-relative fallback would silently put the DB somewhere that's
-    // wiped on the next build and lose all data. Fail loudly instead.
-    const sqlFilename = process.env.WEBINY_SQL_FILENAME;
-    if (!sqlFilename) {
-        throw new Error(
-            `No database configured for the server hosting type. Add ${'`<Infra.Sqlite filename="./.webiny/server.sqlite" />`'} ` +
-                `to your webiny.config (or set WEBINY_SQL_FILENAME).`
-        );
-    }
-
+    // The database is driver-agnostic here: the DB infra extension in webiny.config (<Infra.Sqlite> /
+    // <Infra.Postgres>) emits its own connection env — an absolute WEBINY_SQL_FILENAME, or the
+    // WEBINY_PG_* set — which is forwarded via the runtime allowlist above. The connection factory the
+    // api build wired in (createSqliteConnection / createPostgresConnection) validates that env at boot
+    // and fails loud if the database is missing or misconfigured, so there's no driver-specific check
+    // in the runner.
     const args = watch ? ["--watch-path", buildDir.toString(), runnerPath] : [runnerPath];
 
     const child = spawn(process.execPath, args, {
         cwd: workspaceApi.toString(),
         // Piped so the caller can prefix/filter + render the output.
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...runtimeEnv, PORT: port, WEBINY_SQL_FILENAME: sqlFilename }
+        env: { ...runtimeEnv, PORT: port }
     });
 
     const cleanup = () => {

--- a/webiny.config.server.tsx
+++ b/webiny.config.server.tsx
@@ -14,7 +14,19 @@ export const ServerExtensions = () => {
         <>
             {/* SQL database. Relative paths resolve against the project root (not the disposable app
                 workspace), so data persists across builds/watch restarts. */}
-            <Infra.Sqlite filename={process.env.WEBINY_SQL_FILENAME || "./.webiny/server.sqlite"} />
+            {process.env.WEBINY_DB === "postgres" ? (
+                <Infra.Postgres
+                    host={process.env.WEBINY_PG_HOST || "localhost"}
+                    port={Number(process.env.WEBINY_PG_PORT) || 5432}
+                    user={process.env.WEBINY_PG_USER || "postgres"}
+                    password={process.env.WEBINY_PG_PASSWORD || "webiny"}
+                    database={process.env.WEBINY_PG_DATABASE || "webiny"}
+                />
+            ) : (
+                <Infra.Sqlite
+                    filename={process.env.WEBINY_SQL_FILENAME || "./.webiny/server.sqlite"}
+                />
+            )}
 
             {/* Local file storage (uploaded files) + upload signing secret. Storage path resolves like
                 the SQLite file — against the project root — so uploads persist across rebuilds. */}


### PR DESCRIPTION
## Change

The self-hosted (server) hosting type was hardcoded to SQLite end-to-end, even though Postgres support (`Infra.Postgres`, `createPostgresConnection`) already existed but was never wired. This makes the SQL **driver config-driven** from `webiny.config.tsx` (`<Infra.Sqlite>` / `<Infra.Postgres>`), and keeps the deploy artifact **single-driver**.

- **Tokenized api entry + `GenerateApiDbConnection`** (decorates the workspace build → runs in `build` *and* `watch`): resolves the driver from the DB infra extension (`getServerDbDriver`, fail-loud on none/both) and substitutes the chosen connection factory, imported from its own module path so only that driver's client string is in the bundle.
- **`PruneUnusedDbDriver`** (ApiAfterBuild): `@vercel/nft` copies *both* SQL drivers (knex loads its driver by string at runtime, so the trace can't tell which is used). This removes the unused driver's dependency closure — a Postgres build ships no `better-sqlite3`, a SQLite build no `pg`.
- **`runApiServer` driver-agnostic**: dropped the mandatory `WEBINY_SQL_FILENAME` check; the connection factory validates its own env at boot, so watch/serve work on either driver.
- **Postgres SSL fix** (`createPostgresConnection`): `envBool` returned `false` (not `undefined`) for unset vars, so the SSL-config branch always fired → every connection requested SSL → couldn't connect to a no-SSL Postgres.

The repo's own `webiny.config.server.tsx` now picks the driver from `WEBINY_DB` for local Postgres testing (defaults to SQLite — existing behavior unchanged). Happy to drop that dev-config bit if you'd rather keep it out.

## Test

- Both a Postgres build and a SQLite build verified single-driver (unused driver + its closure absent).
- Api boots on a local Postgres: schema created, GraphQL served, scheduler runs. Full browser run via `webiny-server watch api` + `watch admin` on Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
