### PR TITLE
feat(create-webiny-project): add Postgres as a self-hosted database option

### DIFF
--- a/packages/create-webiny-project/_templates/server/postgres/webiny.config.tsx
+++ b/packages/create-webiny-project/_templates/server/postgres/webiny.config.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Admin } from "webiny/extensions";
+// Server-only namespaces come from the server hosting-type package. `webiny/extensions` exposes the
+// AWS namespaces, which don't include server-only extensions like `Infra.Postgres`.
+import { Infra } from "@webiny/project-server";
+import { SelfHostedAuth } from "@webiny/self-hosted-auth";
+
+/**
+ * Self-hosted (server) hosting-type project extensions. No AWS, no Pulumi, no `deploy` — a single
+ * long-running Node HTTP server backed by SQL storage. Run it with `yarn webiny watch`.
+ */
+export const Extensions = () => {
+    return (
+        <>
+            {/* SQL database — connect to a Postgres server. Connection params come from the WEBINY_PG_*
+                env vars (see `.env`); set `ssl` when connecting to a managed Postgres that requires it. */}
+            <Infra.Postgres
+                host={process.env.WEBINY_PG_HOST || "localhost"}
+                port={Number(process.env.WEBINY_PG_PORT) || 5432}
+                user={process.env.WEBINY_PG_USER || "postgres"}
+                password={process.env.WEBINY_PG_PASSWORD || "postgres"}
+                database={process.env.WEBINY_PG_DATABASE || "webiny"}
+            />
+
+            {/* Local file storage (uploaded files) + upload signing secret. Storage path resolves
+                against the project root, so uploads persist across rebuilds. */}
+            <Infra.FileStorage
+                path={process.env.WEBINY_LOCAL_STORAGE_PATH || "./.webiny/storage"}
+                uploadSecret={process.env.WEBINY_UPLOAD_SECRET || "dev-only-insecure-upload-secret"}
+            />
+
+            {/* The API's public origin. AWS derives this from stack output; the server has none, so it
+                is configured here. `Admin.ApiUrl` points the admin bundle at it; `Infra.ApiUrl` tells
+                the API its own origin (used for the file-upload URL + file srcPrefix). */}
+            <Admin.ApiUrl url={process.env.WEBINY_API_URL || "http://localhost:3002"} />
+            <Infra.ApiUrl url={process.env.WEBINY_API_URL || "http://localhost:3002"} />
+
+            {/* Auth: built-in self-hosted IdP (login screen + JWT). Back the secret with any env var. */}
+            <SelfHostedAuth
+                signingSecret={
+                    process.env.WEBINY_SELF_HOSTED_AUTH_SECRET || "dev-only-insecure-secret"
+                }
+            />
+        </>
+    );
+};

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
@@ -3,11 +3,25 @@ import path from "path";
 import { runInteractivePrompt } from "./runInteractivePrompt.js";
 import { CliParams } from "../../../../types.js";
 import { GetProjectRootPath } from "../../../../services/index.js";
-import { ServerProjectParams } from "./types.js";
+import { ServerProjectParams, StorageOps } from "./types.js";
 import { GetTemplatesFolderPath } from "../../../../services/GetTemplatesFolderPath.js";
 import { addProjectDependencies } from "../addProjectDependencies.js";
 
-const DOT_ENV = `# Self-hosted (server) hosting-type environment variables.
+// The database section of `.env` depends on the chosen storage.
+const DB_ENV: Record<StorageOps, string> = {
+    sqlite: `# SQLite database file (relative paths resolve against the project root).
+WEBINY_SQL_FILENAME=./.webiny/server.sqlite`,
+    postgres: `# Postgres connection.
+WEBINY_PG_HOST=localhost
+WEBINY_PG_PORT=5432
+WEBINY_PG_USER=postgres
+WEBINY_PG_PASSWORD=postgres
+WEBINY_PG_DATABASE=webiny`
+};
+
+const buildDotEnv = (
+    storageOps: StorageOps
+) => `# Self-hosted (server) hosting-type environment variables.
 # The values below are safe dev defaults. CHANGE the secrets before any real deployment.
 
 # Ports the API and Admin servers listen on during \`webiny watch\` / \`webiny serve\`.
@@ -17,8 +31,7 @@ WEBINY_ADMIN_PORT=3001
 # Public origin of the API (used by the Admin app + for file-upload URLs).
 WEBINY_API_URL=http://localhost:3002
 
-# SQLite database file (relative paths resolve against the project root).
-WEBINY_SQL_FILENAME=./.webiny/server.sqlite
+${DB_ENV[storageOps]}
 
 # Local file storage for uploaded files + upload signing secret.
 WEBINY_LOCAL_STORAGE_PATH=./.webiny/storage
@@ -53,8 +66,11 @@ export class SetupServerWebinyProject {
             "@webiny/self-hosted-auth": "latest"
         });
 
-        // Write the `.env` with the server hosting-type dev defaults.
-        fs.writeFileSync(path.join(projectRootFolderPath, ".env"), DOT_ENV);
+        // Write the `.env` with the server hosting-type dev defaults (DB section matches the choice).
+        fs.writeFileSync(
+            path.join(projectRootFolderPath, ".env"),
+            buildDotEnv(serverArgs.storageOps)
+        );
 
         return serverArgs;
     }

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/runInteractivePrompt.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/runInteractivePrompt.ts
@@ -6,6 +6,10 @@ const STORAGE_OPTIONS: Record<StorageOps, { value: StorageOps; name: string }> =
     sqlite: {
         value: "sqlite",
         name: "SQLite (single-file local database)"
+    },
+    postgres: {
+        value: "postgres",
+        name: "PostgreSQL (connect to a Postgres server)"
     }
 };
 

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/types.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/types.ts
@@ -1,4 +1,4 @@
-export type StorageOps = "sqlite";
+export type StorageOps = "sqlite" | "postgres";
 export type AiAgent = string | "other";
 
 export interface ServerProjectParams {


### PR DESCRIPTION
## Change

`create-webiny-project` for the self-hosted (server) hosting type only offered **SQLite**. This adds **PostgreSQL** as a database option:

- `StorageOps` is now `"sqlite" | "postgres"`, and the interactive database prompt lists both.
- New project template `_templates/server/postgres/webiny.config.tsx` — renders `<Infra.Postgres>` (connection from `WEBINY_PG_*` env), mirroring the SQLite template otherwise.
- The generated `.env` now carries the DB section that matches the choice — `WEBINY_PG_*` for Postgres, `WEBINY_SQL_FILENAME` for SQLite.

Relies on the config-driven SQL driver landed in #5510 (only the chosen driver ends up in the build).

## Test

- `create-webiny-project` builds; `dist/_templates/server/` contains both `sqlite` and `postgres`; the compiled prompt lists both options.
- The Postgres template uses the same `<Infra.Postgres>` + `WEBINY_PG_*` wiring already validated end-to-end (boots on Postgres, single-driver build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
