### PR TITLE
chore(create-webiny-project): scope self-hosted ALPHA notice to local dev/testing

### DIFF
--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -232,10 +232,9 @@ export class CreateWebinyProject {
             console.log();
             console.log(
                 yellow(
-                    "⚠ The self-hosted (server) hosting type is in ALPHA. Develop locally with\n" +
-                        "  `webiny watch`. You can also build a self-contained, deployable artifact and\n" +
-                        "  run it anywhere with `node start.mjs` — no Webiny CLI or monorepo required on\n" +
-                        "  the server. It's still maturing, so expect some rough edges."
+                    "⚠ The self-hosted (server) hosting type is in ALPHA. It's for local\n" +
+                        "  development and testing with `webiny watch`. It's still maturing, so\n" +
+                        "  expect some rough edges."
                 )
             );
             console.log();


### PR DESCRIPTION
## Change

Trim the `create-webiny-project` post-create ALPHA notice for the self-hosted (server) hosting type. During ALPHA we're not offering standalone production deployment, so the "you can also build a self-contained, deployable artifact and run it with `node start.mjs`" line is removed. The notice now frames the hosting type as **local development + testing** with `webiny watch`.

Copy-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
