### PR TITLE
chore(create-webiny-project): ship .env.example instead of .env for self-hosted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .webiny
 .artifacts
 .env*
+# But do track the checked-in `.env.example` templates create-webiny-project scaffolds from
+# (safe example config — all vars commented, no secrets).
+!/packages/create-webiny-project/_templates/**/.env.example
 .npmrc
 .kiro
 .vscode

--- a/packages/create-webiny-project/_templates/server/postgres/.env.example
+++ b/packages/create-webiny-project/_templates/server/postgres/.env.example
@@ -1,0 +1,26 @@
+# Self-hosted (server) hosting-type environment variables.
+#
+# Everything here is OPTIONAL — the project runs with sensible defaults out of the box
+# (`yarn webiny watch`). To override a value, copy this file to `.env` and uncomment the line.
+
+# --- Dev server ports ---
+# WEBINY_API_PORT=3002
+# WEBINY_ADMIN_PORT=3001
+
+# --- Public API origin (used by the Admin app + file-upload URLs) ---
+# WEBINY_API_URL=http://localhost:3002
+
+# --- Database: Postgres connection ---
+# WEBINY_PG_HOST=localhost
+# WEBINY_PG_PORT=5432
+# WEBINY_PG_USER=postgres
+# WEBINY_PG_PASSWORD=postgres
+# WEBINY_PG_DATABASE=webiny
+
+# --- Local file storage for uploaded files ---
+# WEBINY_LOCAL_STORAGE_PATH=./.webiny/storage
+
+# --- Secrets: the defaults are INSECURE dev placeholders.
+#     Change these before any non-local use. ---
+# WEBINY_UPLOAD_SECRET=change-me
+# WEBINY_SELF_HOSTED_AUTH_SECRET=change-me

--- a/packages/create-webiny-project/_templates/server/sqlite/.env.example
+++ b/packages/create-webiny-project/_templates/server/sqlite/.env.example
@@ -1,0 +1,22 @@
+# Self-hosted (server) hosting-type environment variables.
+#
+# Everything here is OPTIONAL — the project runs with sensible defaults out of the box
+# (`yarn webiny watch`). To override a value, copy this file to `.env` and uncomment the line.
+
+# --- Dev server ports ---
+# WEBINY_API_PORT=3002
+# WEBINY_ADMIN_PORT=3001
+
+# --- Public API origin (used by the Admin app + file-upload URLs) ---
+# WEBINY_API_URL=http://localhost:3002
+
+# --- Database: SQLite file (path resolves against the project root) ---
+# WEBINY_SQL_FILENAME=./.webiny/server.sqlite
+
+# --- Local file storage for uploaded files ---
+# WEBINY_LOCAL_STORAGE_PATH=./.webiny/storage
+
+# --- Secrets: the defaults are INSECURE dev placeholders.
+#     Change these before any non-local use. ---
+# WEBINY_UPLOAD_SECRET=change-me
+# WEBINY_SELF_HOSTED_AUTH_SECRET=change-me

--- a/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject/projects/server/SetupServerWebinyProject.ts
@@ -3,43 +3,9 @@ import path from "path";
 import { runInteractivePrompt } from "./runInteractivePrompt.js";
 import { CliParams } from "../../../../types.js";
 import { GetProjectRootPath } from "../../../../services/index.js";
-import { ServerProjectParams, StorageOps } from "./types.js";
+import { ServerProjectParams } from "./types.js";
 import { GetTemplatesFolderPath } from "../../../../services/GetTemplatesFolderPath.js";
 import { addProjectDependencies } from "../addProjectDependencies.js";
-
-// The database section of `.env` depends on the chosen storage.
-const DB_ENV: Record<StorageOps, string> = {
-    sqlite: `# SQLite database file (relative paths resolve against the project root).
-WEBINY_SQL_FILENAME=./.webiny/server.sqlite`,
-    postgres: `# Postgres connection.
-WEBINY_PG_HOST=localhost
-WEBINY_PG_PORT=5432
-WEBINY_PG_USER=postgres
-WEBINY_PG_PASSWORD=postgres
-WEBINY_PG_DATABASE=webiny`
-};
-
-const buildDotEnv = (
-    storageOps: StorageOps
-) => `# Self-hosted (server) hosting-type environment variables.
-# The values below are safe dev defaults. CHANGE the secrets before any real deployment.
-
-# Ports the API and Admin servers listen on during \`webiny watch\` / \`webiny serve\`.
-WEBINY_API_PORT=3002
-WEBINY_ADMIN_PORT=3001
-
-# Public origin of the API (used by the Admin app + for file-upload URLs).
-WEBINY_API_URL=http://localhost:3002
-
-${DB_ENV[storageOps]}
-
-# Local file storage for uploaded files + upload signing secret.
-WEBINY_LOCAL_STORAGE_PATH=./.webiny/storage
-WEBINY_UPLOAD_SECRET=dev-only-insecure-upload-secret
-
-# JWT signing secret for the built-in self-hosted identity provider.
-WEBINY_SELF_HOSTED_AUTH_SECRET=dev-only-insecure-secret
-`;
 
 export class SetupServerWebinyProject {
     async execute(cliArgs: CliParams): Promise<ServerProjectParams> {
@@ -53,6 +19,8 @@ export class SetupServerWebinyProject {
         const getProjectRoot = new GetProjectRootPath();
         const projectRootFolderPath = getProjectRoot.execute(cliArgs);
 
+        // Copies the storage-specific template files into the project — `webiny.config.tsx` and a
+        // `.env.example` (all vars commented; the project runs on config defaults with no `.env`).
         fs.copySync(storageTemplatePath, projectRootFolderPath);
 
         // Server (self-hosted) hosting-type dependencies. The `webiny` CLI (server bin) sets
@@ -65,12 +33,6 @@ export class SetupServerWebinyProject {
             "@webiny/project-server-template": "latest",
             "@webiny/self-hosted-auth": "latest"
         });
-
-        // Write the `.env` with the server hosting-type dev defaults (DB section matches the choice).
-        fs.writeFileSync(
-            path.join(projectRootFolderPath, ".env"),
-            buildDotEnv(serverArgs.storageOps)
-        );
 
         return serverArgs;
     }


### PR DESCRIPTION
## Change

The self-hosted (server) scaffold generated a real `.env`. But every var in it just restated a default already present in `webiny.config.tsx` (`process.env.X || "…"`) or the serve runners (ports → 3002/3001) — so the project runs with **no `.env` at all**. Shipping a real `.env` with dummy secrets is also a smell (and can get committed).

Now it writes **`.env.example`**:
- every var **commented out** — pure documentation of the override knobs (the project works out of the box),
- DB section matches the chosen storage (SQLite / Postgres),
- the two secrets (`WEBINY_UPLOAD_SECRET`, `WEBINY_SELF_HOSTED_AUTH_SECRET`) surfaced with a "change before any non-local use" note.

## Test

`create-webiny-project` builds. Scaffolded projects now contain `.env.example` (not `.env`); `webiny watch` runs with no `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
