### PR TITLE
fix: DataTable columns menu multi-select + cog stays flush right

### DIFF
--- a/packages/admin-ui/src/DataTable/DataTable.tsx
+++ b/packages/admin-ui/src/DataTable/DataTable.tsx
@@ -427,14 +427,32 @@ const DecoratableDataTable = <T extends Record<string, any> & DataTableDefaultDa
 
     const getColumnWidth = useCallback(
         (column: Column<T>): number => {
+            // Non-resizable columns (e.g. row-selection, actions) keep their fixed size.
             if (!column.getCanResize()) {
                 return column.getSize();
             }
 
-            const tableSize = table.getTotalSize();
-            const columnSize = column.getSize();
+            /**
+             * Resizable columns share the space left after the fixed columns, proportionally to
+             * their own size. This makes the table always fill the full container width — even when
+             * columns are hidden — so trailing content (e.g. the columns-visibility cog) stays
+             * flush right instead of drifting left as columns are removed.
+             */
+            const visibleColumns = table.getVisibleLeafColumns();
+            const fixedTotal = visibleColumns
+                .filter(col => !col.getCanResize())
+                .reduce((total, col) => total + col.getSize(), 0);
+            const resizableTotal = visibleColumns
+                .filter(col => col.getCanResize())
+                .reduce((total, col) => total + col.getSize(), 0);
 
-            return Math.ceil((columnSize * tableWidth) / tableSize);
+            if (resizableTotal === 0) {
+                return column.getSize();
+            }
+
+            const available = Math.max(tableWidth - fixedTotal, 0);
+
+            return Math.ceil((column.getSize() * available) / resizableTotal);
         },
         [table, tableWidth]
     );

--- a/packages/admin-ui/src/DataTable/components/ColumnsVisibility.tsx
+++ b/packages/admin-ui/src/DataTable/components/ColumnsVisibility.tsx
@@ -63,6 +63,7 @@ export const ColumnsVisibility = <T,>(props: ColumnsVisibilityProps<T>) => {
                 return (
                     <DropdownMenu.Item
                         key={option.id}
+                        preventClose
                         text={
                             <Checkbox
                                 label={option.header}

--- a/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
+++ b/packages/admin-ui/src/DropdownMenu/components/DropdownMenuItem.tsx
@@ -14,6 +14,11 @@ interface DropdownMenuItemBaseProps {
     text?: React.ReactNode;
     disabled?: boolean;
     onClick?: React.MouseEventHandler;
+    /**
+     * Keep the menu open after selecting this item. Useful for items that toggle a value
+     * (e.g. a checkbox), where the user expects to make multiple selections in one session.
+     */
+    preventClose?: boolean;
 }
 
 type DropdownMenuItemButtonProps = (DropdownMenuItemBaseProps &
@@ -46,53 +51,69 @@ const variants = cva(
 const DropdownMenuItemBase = React.forwardRef<
     React.ElementRef<typeof DropdownMenuPrimitive.Item>,
     DropdownMenuItemProps
->(({ className, icon, text, readOnly, disabled, onClick, children, ...linkProps }, ref) => {
-    const { linkComponent: LinkComponent } = useAdminUi();
+>(
+    (
+        {
+            className,
+            icon,
+            text,
+            readOnly,
+            disabled,
+            onClick,
+            preventClose,
+            children,
+            ...linkProps
+        },
+        ref
+    ) => {
+        const { linkComponent: LinkComponent } = useAdminUi();
 
-    if (children) {
+        if (children) {
+            return (
+                <DropdownMenuSubRoot>
+                    <DropdownMenuSubTrigger>
+                        {icon}
+                        <span>{text}</span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuPortal>
+                        <DropdownMenuSubContent>{children}</DropdownMenuSubContent>
+                    </DropdownMenuPortal>
+                </DropdownMenuSubRoot>
+            );
+        }
+        const sharedProps = {
+            className: cn(
+                "flex px-sm py-xs-plus gap-sm-extra items-center text-md rounded-sm transition-colors group-focus:bg-neutral-dimmed",
+                {
+                    "[&_svg]:fill-neutral-disabled!": disabled
+                }
+            )
+        };
+
+        const content = linkProps.to ? (
+            <LinkComponent {...sharedProps} {...linkProps}>
+                {icon}
+                <span>{text}</span>
+            </LinkComponent>
+        ) : (
+            <div {...sharedProps} onClick={onClick}>
+                {icon}
+                <span>{text}</span>
+            </div>
+        );
+
         return (
-            <DropdownMenuSubRoot>
-                <DropdownMenuSubTrigger>
-                    {icon}
-                    <span>{text}</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                    <DropdownMenuSubContent>{children}</DropdownMenuSubContent>
-                </DropdownMenuPortal>
-            </DropdownMenuSubRoot>
+            <DropdownMenuPrimitive.Item
+                disabled={disabled}
+                ref={ref}
+                className={cn(variants({ readOnly }), className)}
+                onSelect={preventClose ? event => event.preventDefault() : undefined}
+            >
+                {content}
+            </DropdownMenuPrimitive.Item>
         );
     }
-    const sharedProps = {
-        className: cn(
-            "flex px-sm py-xs-plus gap-sm-extra items-center text-md rounded-sm transition-colors group-focus:bg-neutral-dimmed",
-            {
-                "[&_svg]:fill-neutral-disabled!": disabled
-            }
-        )
-    };
-
-    const content = linkProps.to ? (
-        <LinkComponent {...sharedProps} {...linkProps}>
-            {icon}
-            <span>{text}</span>
-        </LinkComponent>
-    ) : (
-        <div {...sharedProps} onClick={onClick}>
-            {icon}
-            <span>{text}</span>
-        </div>
-    );
-
-    return (
-        <DropdownMenuPrimitive.Item
-            disabled={disabled}
-            ref={ref}
-            className={cn(variants({ readOnly }), className)}
-        >
-            {content}
-        </DropdownMenuPrimitive.Item>
-    );
-});
+);
 
 DropdownMenuItemBase.displayName = DropdownMenuPrimitive.Item.displayName;
 


### PR DESCRIPTION
## Overview

Backport of two DataTable / DropdownMenu fixes to `release/6.4.6`.

## Changes

### 1. Columns menu — multi-select
- Radix `DropdownMenu.Item` closed the menu on select, so toggling one column checkbox closed the overlay and blocked multi-select. Added a `preventClose` prop on `DropdownMenu.Item` (forwards `onSelect` → `preventDefault`) and used it for the column-visibility checkboxes.

### 2. Columns cog — always flush right
- Resizable columns now absorb the space left by fixed columns, so the table always fills its container even when columns are hidden. Previously the width scaling ignored fixed columns, leaving a right-side gap that pulled the columns-visibility cog leftward as columns were removed.

## Test plan
- [ ] Columns menu: toggle multiple column checkboxes in one open session; menu stays open.
- [ ] Remove columns: settings cog stays pinned far right; table fills full width.

> Cherry-picked from the 6.5.0 work (PR #5498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
