### PR TITLE
fix(app-website-builder): truncate long values in sidebar style rows

### DIFF
--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/Groups/Background/BackgroundImage.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/Groups/Background/BackgroundImage.tsx
@@ -95,6 +95,20 @@ export const BackgroundImage = observer(({ elementId }: { elementId: string }) =
 
     const fileInfo = metadata.get<FileInfo>("backgroundImage");
 
+    // The FilePicker expects a FileItemDto (`mimeType`, `src`), but our metadata stores the
+    // legacy shape (`type`, `url`). Map it across so the picker can detect an image and render
+    // the thumbnail (otherwise `mimeType` is undefined and it shows the generic file icon).
+    const pickerValue =
+        url && fileInfo
+            ? {
+                  id: fileInfo.id,
+                  name: fileInfo.name,
+                  size: fileInfo.size,
+                  mimeType: fileInfo.type,
+                  src: fileInfo.url
+              }
+            : undefined;
+
     return (
         <SidebarRow
             label={
@@ -113,7 +127,7 @@ export const BackgroundImage = observer(({ elementId }: { elementId: string }) =
                     <FilePicker
                         variant={"secondary"}
                         type="compact"
-                        value={url ? fileInfo : undefined}
+                        value={pickerValue}
                         onSelectItem={() => showFileManager()}
                         onRemoveItem={onRemove}
                         onEditItem={() => showFileManager()}

--- a/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/SidebarRow.tsx
+++ b/packages/app-website-builder/src/BaseEditor/defaultConfig/Sidebar/StyleSettings/SidebarRow.tsx
@@ -35,7 +35,10 @@ export const SidebarRow = ({ label, tooltip, children }: SidebarRowProps) => {
                     <div className={"w-xs shrink-0"} />
                 )}
             </div>
-            <div className={"flex-1"}>{children}</div>
+            {/* min-w-0 lets the cell shrink below its content's intrinsic width, so long
+                unbroken values (e.g. a hashed file name) truncate instead of widening the
+                row and pushing controls past the sidebar edge. */}
+            <div className={"flex-1 min-w-0"}>{children}</div>
         </div>
     );
 };


### PR DESCRIPTION
Two fixes for the page editor's Style panel, Background → Image (reported by German, Slack).

## 1. Long file names overflow the row and hide the actions

When the selected image has a long, unbroken file name (e.g. a hashed name like `clouds-128082585-e37ab6...-long-hash.jpeg`), the name isn't truncated: it widens the row past the sidebar and pushes the Edit / Remove buttons (`ItemActions` in `RichItemPreview`) off-screen, so the image can't be removed from the Style panel.

Root cause: `SidebarRow` — the shared wrapper for every style row — renders its content cell as `flex-1` with no `min-w-0`. Flex items default to `min-width: auto`, so the cell can't shrink below its content's intrinsic width. The admin-ui `RichItemPreview` / `ItemDescription` already truncate correctly; they just never received a bounded width.

Fix: `flex-1` → `flex-1 min-w-0` on the `SidebarRow` content cell. General fix — every style row now truncates instead of overflowing.

## 2. Background image shows a generic file icon instead of the thumbnail

The Background → Image picker rendered the generic FILE icon, while the Image page element (same `FilePicker`) shows the real thumbnail.

Root cause: our metadata stores the legacy shape (`type`, `url`), but `FilePicker` expects a `FileItemDto` (`mimeType`, `src`). `FileItem.create` reads `data.mimeType`, which was undefined, so it defaulted to `application/octet-stream` and `RichItemThumbnail` couldn't detect an image (`isImage` false) → generic icon.

Fix: map the stored metadata to the picker's expected shape (`type` → `mimeType`, `url` → `src`) before passing it as the value. Now the thumbnail renders, consistent with the Image element.

### Backwards compatibility

The thumbnail fix is display-only:
- No change to stored metadata (`onFileChange` still writes the same shape) — no migration needed.
- No change to the rendered background CSS (`backgroundImage: url(...)`) — existing pages render identically on the live site.
- Existing pages map cleanly and now show the thumbnail; any old entry with a missing/non-image `type` just falls back to the FILE icon (same as before — never a regression).

## Verification

- Full dependency-ordered build green.
- In the editor: pick an image with a long hashed name in Background → Image. Expected: thumbnail + truncated name with ellipsis + both Edit and Remove buttons visible within the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)