### PR TITLE
fix(file-manager): register WCP-gated features unconditionally, guard at request time

### DIFF
--- a/packages/api-file-manager-s3/src/FileManagerS3Feature.ts
+++ b/packages/api-file-manager-s3/src/FileManagerS3Feature.ts
@@ -1,6 +1,4 @@
 import { type Container, createFeature } from "@webiny/feature/api";
-import { RequestContextInitializer } from "@webiny/event-handler-core";
-import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { S3GraphQLSchema } from "./graphql/S3GraphQLSchema.js";
 import { DeleteFileFromBucketFeature } from "~/features/DeleteFileFromBucket/feature.js";
 import { WriteFileMetadataFeature } from "~/features/WriteFileMetadata/feature.js";
@@ -35,17 +33,9 @@ export const FileManagerS3Feature = createFeature({
         // CoreGraphQLSchemaFactory contributor (declares its resolver dependencies).
         container.register(S3GraphQLSchema);
 
-        // Threat scanning is WCP-gated. The gate MUST run after the per-request WCP license refresh
-        // (a RequestInitializer, pre-auth) — at register() time WcpContext still sees the NullLicense
-        // and the feature would silently never register. So gate + register it in a
-        // RequestContextInitializer (post-auth, post-license).
-        container.registerInstance(RequestContextInitializer, {
-            async init(ctx: Record<string, any>) {
-                const wcp = ctx.container.resolve(WcpContext);
-                if (wcp.canUseFileManagerThreatDetection()) {
-                    ApplyThreatScanningFeature.register(ctx.container);
-                }
-            }
-        });
+        // Threat scanning is WCP-gated, but the license is per-request (loaded post-register). Register
+        // unconditionally; CreateFileWithThreatScanDecorator + the GuardDuty event handler both guard
+        // on canUseFileManagerThreatDetection() at request time and no-op/pass-through when unlicensed.
+        ApplyThreatScanningFeature.register(container);
     }
 });

--- a/packages/api-file-manager-s3/src/enterprise/ApplyThreatScanning/CreateFileWithThreatScanDecorator.ts
+++ b/packages/api-file-manager-s3/src/enterprise/ApplyThreatScanning/CreateFileWithThreatScanDecorator.ts
@@ -1,13 +1,24 @@
 import { CreateFileUseCase } from "@webiny/api-file-manager/features/file/CreateFile/abstractions.js";
 import type { CreateFileInput } from "@webiny/api-file-manager/features/file/CreateFile/abstractions.js";
+import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 
 class CreateFileWithThreatScanDecoratorImpl implements CreateFileUseCase.Interface {
-    constructor(private decoratee: CreateFileUseCase.Interface) {}
+    constructor(
+        private wcp: WcpContext.Interface,
+        private decoratee: CreateFileUseCase.Interface
+    ) {}
 
     async execute(
         input: CreateFileInput,
         meta?: Record<string, any>
     ): ReturnType<CreateFileUseCase.Interface["execute"]> {
+        // WCP-gated at request time (the license is only known post-auth). When threat detection isn't
+        // licensed, pass through unchanged — behaviourally identical to this decorator not being
+        // registered (no threatScanInProgress tag added).
+        if (!this.wcp.canUseFileManagerThreatDetection()) {
+            return this.decoratee.execute(input, meta);
+        }
+
         const modifiedInput: CreateFileInput = {
             ...input,
             tags: [...(input.tags || []), "threatScanInProgress"]
@@ -19,5 +30,5 @@ class CreateFileWithThreatScanDecoratorImpl implements CreateFileUseCase.Interfa
 
 export const CreateFileWithThreatScanDecorator = CreateFileUseCase.createDecorator({
     decorator: CreateFileWithThreatScanDecoratorImpl,
-    dependencies: []
+    dependencies: [WcpContext]
 });

--- a/packages/api-file-manager/src/features/assetDelivery/feature.ts
+++ b/packages/api-file-manager/src/features/assetDelivery/feature.ts
@@ -1,5 +1,4 @@
 import { createFeature } from "@webiny/feature/api";
-import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { FilesAssetRequestResolverImpl } from "./FilesAssetRequestResolver.js";
 import { NullAssetResolverImpl } from "./NullAssetResolver.js";
 import { NullAssetOutputStrategyImpl } from "./NullAssetOutputStrategy.js";
@@ -27,10 +26,11 @@ export const AssetDeliveryFeature = createFeature({
 
         container.registerDecorator(PrivateFileAssetRequestResolverDecorator);
 
-        const wcp = container.resolve(WcpContext);
-        if (wcp.canUsePrivateFiles()) {
-            container.register(PrivateAuthenticatedAuthorizerImpl);
-            container.registerDecorator(PrivateFilesAssetProcessorDecorator);
-        }
+        // Private files are WCP-gated, but the license is per-request (loaded post-register, refreshed
+        // on a 5-min TTL), so a `canUsePrivateFiles()` check here would always read the NullLicense and
+        // never register. Register unconditionally; PrivateFilesAssetProcessor guards on the license at
+        // request time and passes through to its decoratee when unlicensed (== not registered).
+        container.register(PrivateAuthenticatedAuthorizerImpl);
+        container.registerDecorator(PrivateFilesAssetProcessorDecorator);
     }
 });

--- a/packages/api-file-manager/src/features/assetDelivery/privateFiles/PrivateFilesAssetProcessor.ts
+++ b/packages/api-file-manager/src/features/assetDelivery/privateFiles/PrivateFilesAssetProcessor.ts
@@ -2,6 +2,7 @@ import type { File } from "~/domain/file/types.js";
 import type { Asset } from "~/delivery/AssetDelivery/Asset.js";
 import type { AssetRequest } from "~/delivery/AssetDelivery/AssetRequest.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
+import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/index.js";
 import { GetFileUseCase } from "~/features/file/GetFile/index.js";
 import { NotAuthorizedOutputStrategy } from "./NotAuthorizedOutputStrategy.js";
 import { RedirectToPublicUrlOutputStrategy } from "./RedirectToPublicUrlOutputStrategy.js";
@@ -21,23 +22,33 @@ interface MaybePrivate {
 
 export class PrivateFilesAssetProcessor implements IAssetProcessor {
     private readonly identityContext: IdentityContext.Interface;
+    private readonly wcp: WcpContext.Interface;
     private readonly getFile: GetFileUseCase.Interface;
     private readonly assetAuthorizer: IAssetAuthorizer;
     private readonly assetProcessor: IAssetProcessor;
 
     constructor(
         identityContext: IdentityContext.Interface,
+        wcp: WcpContext.Interface,
         getFile: GetFileUseCase.Interface,
         assetAuthorizer: IAssetAuthorizer,
         assetProcessor: IAssetProcessor
     ) {
         this.identityContext = identityContext;
+        this.wcp = wcp;
         this.getFile = getFile;
         this.assetAuthorizer = assetAuthorizer;
         this.assetProcessor = assetProcessor;
     }
 
     async process(assetRequest: AssetRequest, asset: Asset): Promise<Asset> {
+        // WCP-gated at request time (the license is only known post-auth). When private files aren't
+        // licensed, pass through unchanged — behaviourally identical to this decorator not being
+        // registered (public delivery only).
+        if (!this.wcp.canUsePrivateFiles()) {
+            return this.assetProcessor.process(assetRequest, asset);
+        }
+
         const id = asset.getId();
 
         const file = await this.identityContext.withoutAuthorization(async () => {
@@ -94,5 +105,5 @@ export class PrivateFilesAssetProcessor implements IAssetProcessor {
 
 export const PrivateFilesAssetProcessorDecorator = AssetProcessor.createDecorator({
     decorator: PrivateFilesAssetProcessor,
-    dependencies: [IdentityContext, GetFileUseCase, AssetAuthorizer]
+    dependencies: [IdentityContext, WcpContext, GetFileUseCase, AssetAuthorizer]
 });


### PR DESCRIPTION
## The problem

`register()` runs **before** the per-request WCP license loads (the license is a pre-auth `RequestInitializer`, refreshed on a 5-min TTL). So any `wcp.canUse*()` call inside `register()` reads the **NullLicense** → always false. Two file-manager features gated that way:

- **assetDelivery private-files — real bug.** `assetDelivery/feature.ts` did `if (wcp.canUsePrivateFiles()) { register(PrivateAuthenticatedAuthorizer); registerDecorator(PrivateFilesAssetProcessor); }` at register time → always false → those two **never registered** → private files were dead regardless of license.
- **fm-s3 threat scanning — layering smell.** Gated by registering `ApplyThreatScanningFeature` inside a `RequestContextInitializer` — a domain/app feature reaching for a request-lifecycle (kernel) hook to work around the timing.

## The fix — register unconditionally, guard at run time

Registration is static composition wiring; the license is a per-request runtime rule, so it belongs at execute time (when the license is valid), inside the impl:

- `PrivateFilesAssetProcessor` (decorator) + `CreateFileWithThreatScanDecorator` now inject `WcpContext` and, when unlicensed, **pass through to their decoratee unchanged** — behaviourally identical to not being registered (public delivery / no threat-scan tag).
- `assetDelivery/feature.ts` + `FileManagerS3Feature` register both impls unconditionally; the RCI hack is gone from the FM domain layer.

**Rule:** never `canUse()` in `register()`; register the graph unconditionally, guard behaviour at run time (pass-through/fall-back when unlicensed).

## Verification

Build + `api-file-manager` (33) + `api-file-manager-s3` (9) green. Tests run unlicensed → guards pass through → identical to prior behaviour, so no regression. The **licensed** private-files path only becomes reachable with a real WCP license → **deploy-verify** (it was unreachable before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)