### PR TITLE
docs(gh-actions): add self-hosted (server) CI/CD workflow examples

### DIFF
--- a/docs/gh-actions-workflows/self-hosted/Dockerfile
+++ b/docs/gh-actions-workflows/self-hosted/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+#
+# Production build for a self-hosted (server) Webiny project. Multi-stage: build the self-contained
+# artifacts once, then ship a slim API runtime and a static Admin bundle. Build a single stage with
+# `--target api` or `--target admin`. Copy this file to your project root.
+
+# --- builder: produce the self-contained build/ folders -----------------------------------------
+FROM node:24-bookworm AS builder
+WORKDIR /project
+ENV WEBINY_HOSTING_TYPE=server NODE_ENV=production
+COPY . .
+RUN corepack enable && yarn install --immutable
+
+# The Admin bundle bakes its API origin at build time — override for a real host:
+#   docker build --target admin --build-arg WEBINY_API_URL=https://api.example.com ...
+ARG WEBINY_API_URL=http://localhost:3002
+ENV WEBINY_API_URL=$WEBINY_API_URL
+
+RUN yarn webiny build api && yarn webiny build admin
+
+# --- api: run the self-contained handler (node start.mjs) ---------------------------------------
+FROM node:24-bookworm-slim AS api
+WORKDIR /app
+COPY --from=builder /project/.webiny/workspace/apps/api/graphql/build ./
+# Database, storage and secrets are supplied at RUN time (never baked): WEBINY_SQL_FILENAME (SQLite)
+# or WEBINY_PG_* (Postgres), plus WEBINY_UPLOAD_SECRET, WEBINY_SELF_HOSTED_AUTH_SECRET, and
+# WEBINY_PROJECT_ID / WEBINY_PROJECT_API_KEY (WCP license).
+ENV PORT=3002
+EXPOSE 3002
+CMD ["node", "start.mjs"]
+
+# --- admin: static bundle served by nginx (with SPA fallback) -----------------------------------
+FROM nginx:alpine AS admin
+COPY --from=builder /project/.webiny/workspace/apps/admin/build /usr/share/nginx/html
+COPY nginx-spa.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/docs/gh-actions-workflows/self-hosted/README.md
+++ b/docs/gh-actions-workflows/self-hosted/README.md
@@ -1,0 +1,62 @@
+# Self-hosted (server) GitHub Actions workflows
+
+Example CI/CD for the **self-hosted (server) hosting type** — the counterpart to the AWS workflows in
+the parent folder. Instead of `webiny deploy` (which provisions AWS via Pulumi), these **build Docker
+images and push them to a registry**; your container platform then pulls and runs them.
+
+## What's here
+
+| File | Copy to | Purpose |
+|------|---------|---------|
+| `Dockerfile` | project root | Multi-stage build → `api` (Node, `node start.mjs`) and `admin` (nginx, static) images |
+| `nginx-spa.conf` | project root | nginx config for the Admin image — SPA fallback so deep-links/refresh don't 404 |
+| `pushDev.yml` / `pushStaging.yml` / `pushProd.yml` | `.github/workflows/` | On push to `dev` / `staging` / `prod`: build + push `api` and `admin` images tagged per environment |
+| `pullRequest.yml` | `.github/workflows/` | On PRs: static analysis + a build-only smoke check (self-hosted PRs create no infrastructure, so there is no per-PR environment to deploy or destroy — hence no "pull request closed" workflow) |
+
+## The model
+
+```
+git push  →  GitHub Actions  →  docker build (runs `webiny build` inside)  →  push image to GHCR  →  platform pulls + runs
+```
+
+The image is the whole deploy artifact — the server never runs `yarn install` or `webiny build`.
+
+## Registry
+
+These examples push to the **GitHub Container Registry** (`ghcr.io`) using the automatic
+`GITHUB_TOKEN` (note `permissions: packages: write`) — no extra secret needed. Images land at
+`ghcr.io/<owner>/<repo>/api:<env>` and `.../admin:<env>`. To pull them from your host, either make the
+package public or give the host a token with `read:packages`. Swap in Docker Hub / ECR / etc. by
+changing the `registry` + `tags`.
+
+## Configuration
+
+**GitHub secret (per environment):**
+
+- `PROD_WEBINY_API_URL` (and `STAGING_` / `DEV_`) — the Admin bundle bakes this at **build time** so the
+  browser knows where the API is. Set it to the public API URL for that environment.
+
+**Runtime env — set on your container platform, not in CI** (the same image runs everywhere; only these
+change per deployment):
+
+- Database — SQLite: `WEBINY_SQL_FILENAME` (on a persistent volume), **or** Postgres: `WEBINY_PG_HOST`,
+  `WEBINY_PG_PORT`, `WEBINY_PG_USER`, `WEBINY_PG_PASSWORD`, `WEBINY_PG_DATABASE`.
+- `WEBINY_UPLOAD_SECRET`, `WEBINY_SELF_HOSTED_AUTH_SECRET` — change from the dev defaults.
+- `WEBINY_PROJECT_ID`, `WEBINY_PROJECT_API_KEY` — WCP license.
+
+## Deploying (the last step)
+
+Each push workflow ends with a commented, platform-specific "tell the platform to pull the new image"
+step — ECS/Fargate, Cloud Run, Fly.io, Kubernetes. Uncomment and adapt the one for your platform, or
+let a platform that watches the registry (Render, Railway, …) pull automatically.
+
+## Notes from real deploys
+
+- **Memory**: the API is not tiny — give the container **≥ 512 MB (1 GB is comfortable)**. Under ~256 MB
+  it swaps and requests crawl.
+- **SQLite vs Postgres**: SQLite on a **persistent volume** is the simplest single-node setup (data +
+  uploads survive restarts, but a volume pins you to one machine). For multiple instances / HA, use
+  **Postgres** (shared) — no volume needed for the database.
+- **Admin is static + cross-origin**: it's served by nginx and calls the API on another origin, so the
+  API must allow the Admin's origin (CORS). The SPA fallback in `nginx-spa.conf` is what stops a hard
+  refresh on a client-side route from 404-ing.

--- a/docs/gh-actions-workflows/self-hosted/nginx-spa.conf
+++ b/docs/gh-actions-workflows/self-hosted/nginx-spa.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Admin is a single-page app: serve the file if it exists, otherwise fall back to index.html so
+    # client-side routes (e.g. /cms/content-entries) resolve on hard refresh instead of a 404.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/gh-actions-workflows/self-hosted/pullRequest.yml
+++ b/docs/gh-actions-workflows/self-hosted/pullRequest.yml
@@ -1,0 +1,49 @@
+name: Pull Requests (self-hosted)
+
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  build-test-static:
+    name: Build and run static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: .yarn/cache
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Check code formatting
+        run: yarn format
+      - name: Lint
+        run: yarn lint
+
+  build-images:
+    name: Verify Docker images build
+    needs: build-test-static
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      # Build both images without pushing — a smoke check that the deploy artifacts still build.
+      # (Self-hosted PRs create no infrastructure, so there is no ephemeral environment to deploy or
+      # to tear down afterwards — hence no "pull request closed" workflow.)
+      - name: Build API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: api
+          push: false
+      - name: Build Admin image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: admin
+          push: false

--- a/docs/gh-actions-workflows/self-hosted/pushDev.yml
+++ b/docs/gh-actions-workflows/self-hosted/pushDev.yml
@@ -1,0 +1,75 @@
+name: Dev Branch - Push (self-hosted)
+
+on:
+  push:
+    branches: [dev]
+
+# Ensures only one build+push for the "dev" environment runs at a time.
+concurrency: dev
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push images to the GitHub Container Registry (ghcr.io)
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      # Install and cache dependencies (for the static analysis below).
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: .yarn/cache
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn --immutable
+
+      # Static code analysis.
+      - name: Check code formatting
+        run: yarn format
+      - name: Lint
+        run: yarn lint
+
+      # Build + push the self-contained images. The multi-stage Dockerfile runs `yarn webiny build`
+      # INSIDE the build, so there is no separate build step here.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build & push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: api
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/api:dev
+
+      - name: Build & push Admin image # Admin bakes the public API URL at build time.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: admin
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/admin:dev
+          build-args: |
+            WEBINY_API_URL=${{ secrets.DEV_WEBINY_API_URL }}
+
+      # Deploy: tell your container platform to pull the new images. This step is platform-specific;
+      # uncomment/adapt one of the following (or add your own):
+      #   - AWS ECS/Fargate: aws ecs update-service --cluster <c> --service <s> --force-new-deployment
+      #   - Google Cloud Run: gcloud run deploy webiny-api --image ghcr.io/${{ github.repository }}/api:dev
+      #   - Fly.io: flyctl deploy --image ghcr.io/${{ github.repository }}/api:dev
+      #   - Kubernetes: kubectl set image deployment/webiny-api api=ghcr.io/${{ github.repository }}/api:dev

--- a/docs/gh-actions-workflows/self-hosted/pushProd.yml
+++ b/docs/gh-actions-workflows/self-hosted/pushProd.yml
@@ -1,0 +1,75 @@
+name: Prod Branch - Push (self-hosted)
+
+on:
+  push:
+    branches: [prod]
+
+# Ensures only one build+push for the "prod" environment runs at a time.
+concurrency: prod
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push images to the GitHub Container Registry (ghcr.io)
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      # Install and cache dependencies (for the static analysis below).
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: .yarn/cache
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn --immutable
+
+      # Static code analysis.
+      - name: Check code formatting
+        run: yarn format
+      - name: Lint
+        run: yarn lint
+
+      # Build + push the self-contained images. The multi-stage Dockerfile runs `yarn webiny build`
+      # INSIDE the build, so there is no separate build step here.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build & push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: api
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/api:prod
+
+      - name: Build & push Admin image # Admin bakes the public API URL at build time.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: admin
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/admin:prod
+          build-args: |
+            WEBINY_API_URL=${{ secrets.PROD_WEBINY_API_URL }}
+
+      # Deploy: tell your container platform to pull the new images. This step is platform-specific;
+      # uncomment/adapt one of the following (or add your own):
+      #   - AWS ECS/Fargate: aws ecs update-service --cluster <c> --service <s> --force-new-deployment
+      #   - Google Cloud Run: gcloud run deploy webiny-api --image ghcr.io/${{ github.repository }}/api:prod
+      #   - Fly.io: flyctl deploy --image ghcr.io/${{ github.repository }}/api:prod
+      #   - Kubernetes: kubectl set image deployment/webiny-api api=ghcr.io/${{ github.repository }}/api:prod

--- a/docs/gh-actions-workflows/self-hosted/pushStaging.yml
+++ b/docs/gh-actions-workflows/self-hosted/pushStaging.yml
@@ -1,0 +1,75 @@
+name: Staging Branch - Push (self-hosted)
+
+on:
+  push:
+    branches: [staging]
+
+# Ensures only one build+push for the "staging" environment runs at a time.
+concurrency: staging
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push images to the GitHub Container Registry (ghcr.io)
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      # Install and cache dependencies (for the static analysis below).
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: .yarn/cache
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn --immutable
+
+      # Static code analysis.
+      - name: Check code formatting
+        run: yarn format
+      - name: Lint
+        run: yarn lint
+
+      # Build + push the self-contained images. The multi-stage Dockerfile runs `yarn webiny build`
+      # INSIDE the build, so there is no separate build step here.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build & push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: api
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/api:staging
+
+      - name: Build & push Admin image # Admin bakes the public API URL at build time.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: admin
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/admin:staging
+          build-args: |
+            WEBINY_API_URL=${{ secrets.STAGING_WEBINY_API_URL }}
+
+      # Deploy: tell your container platform to pull the new images. This step is platform-specific;
+      # uncomment/adapt one of the following (or add your own):
+      #   - AWS ECS/Fargate: aws ecs update-service --cluster <c> --service <s> --force-new-deployment
+      #   - Google Cloud Run: gcloud run deploy webiny-api --image ghcr.io/${{ github.repository }}/api:staging
+      #   - Fly.io: flyctl deploy --image ghcr.io/${{ github.repository }}/api:staging
+      #   - Kubernetes: kubectl set image deployment/webiny-api api=ghcr.io/${{ github.repository }}/api:staging


### PR DESCRIPTION
## Change

Adds a `self-hosted/` set of GitHub Actions examples under `docs/gh-actions-workflows/`, mirroring the existing AWS examples but for the **self-hosted (server) hosting type**.

Where the AWS workflows run `yarn webiny deploy --env <env>` (Pulumi → AWS), the self-hosted flow is:

```
git push → GitHub Actions → docker build (runs `webiny build` inside) → push image to GHCR → platform pulls + runs
```

Included:
- **`Dockerfile`** — multi-stage: `api` (self-contained `build/`, `node start.mjs`) + `admin` (nginx static). **`nginx-spa.conf`** — SPA fallback so Admin deep-links/refresh don't 404.
- **`pushDev.yml` / `pushStaging.yml` / `pushProd.yml`** — on push to each branch: static analysis, then build + push `api`/`admin` images to GHCR tagged per environment. Ends with a commented, platform-specific "pull the new image" step (ECS/Cloud Run/Fly/k8s).
- **`pullRequest.yml`** — static analysis + a build-only smoke check. (Self-hosted PRs create no infrastructure, so there's no ephemeral environment to deploy or destroy — no "pull request closed" workflow.)
- **`README.md`** — the model, registry (GHCR via `GITHUB_TOKEN`), build-time vs runtime config, and notes from real deploys (memory sizing, SQLite-volume vs Postgres, CORS + SPA fallback).

Docs/examples only — no framework code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
