### PR TITLE
fix(api-website-builder): restore wb.* read on the Website Builder API key

### DIFF
--- a/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
+++ b/packages/api-website-builder/src/features/installer/ApiKeyInstaller.ts
@@ -19,12 +19,18 @@ class ApiKeyInstallerImpl implements AppInstaller.Interface {
             name: "Website Builder",
             description: "Integrate Next.js or custom frontend with Website Builder.",
             slug: "website-builder",
-            permissions: [
-                // Experiments and variants are governed by the Website Builder page permission,
-                // so read-only page access is all the frontend key needs to serve/preview them.
-                { name: "$wb.readonly" },
-                { name: "wb.page", rwd: "r" }
-            ]
+            // Mirrors exactly what Admin writes when you pick the "Read-only" access level for
+            // Website Builder (see `usePermissionForm`).
+            //
+            // `$wb.readonly` carries no authorization weight — it exists so the Admin form can
+            // round-trip the chosen access level (`deserializePermissions` looks for it first).
+            // Drop it and the key still works, but Admin renders it as "Custom access". Keep it.
+            //
+            // `wb.*` + `rwd: "r"` grants read on every Website Builder entity (page, redirect, and
+            // anything added later) without granting writes — `hasFullSchemaAccess` deliberately
+            // does not treat a permission carrying `rwd` as full access. Enumerating entities
+            // individually is what left the frontend unable to read redirects.
+            permissions: [{ name: "$wb.readonly" }, { name: "wb.*", rwd: "r" }]
         });
 
         if (result.isOk()) {


### PR DESCRIPTION
Restores a fix that was merged and then silently reverted on `release/6.5.0`.

## What happened

#5502 granted the installer's API key `wb.*` with `rwd: "r"`, so the frontend could read redirects. It merged as `a3c0d0e6f3`.

`c087a467c2` — **"feat(admin): breadcrumbs" (#5496)** — then reverted it. That commit is `245 files changed, 1925 insertions(+), 3508 deletions(-)`, which is the signature of a branch that was cut before the changes it landed on top of. The merge overwrote them.

The confusing part, and the reason nobody noticed: **#5502 is still in `git log`**. It's a genuine ancestor of the current tip. Only the file content is gone. So the fix looks merged by every normal check while the installer once again creates a key limited to `wb.page` read — and `GET /wb/redirects` is rejected for the frontend identity, exactly as before.

This is live: it is the same bug currently being diagnosed with a customer whose redirects don't resolve.

## What this PR does

Restores the permission, nothing else:

```ts
permissions: [{ name: "$wb.readonly" }, { name: "wb.*", rwd: "r" }]
```

Plus the explanatory comment from #5502, since the stale one it replaced ("read-only page access is all the frontend key needs") is what led to the original bug.

## What this PR deliberately does not do

`c087a467c2` also reverted **#5507 "frontend SDK consolidation"**, which is *not* restored here:

- `packages/content-sdk` and `packages/content-sdk-nextjs` are back under their pre-#5507 names rather than `sdk-nextjs`
- The `Frontend Integration` / `frontend-integration` rename of this key is gone; `frontend-integration` has zero hits in the tree

I left the rename alone on purpose. `NextjsConfig` resolves the key with `getBySlug(...)`, and base is currently self-consistent on `website-builder` on both sides. Restoring only the installer's slug would break the Configure Next.js dialog — it would look for a key that no longer exists under that slug. #5507 needs re-landing as a unit, by whoever owns it.

## Worth a wider look

I confirmed three casualties (this file, `NextjsConfig`'s slug, `skills/user-skills/admin/ui-extensions/SKILL.md` at −176 lines) out of 245 files. **There are likely more that nobody has spotted**, for the same reason this one went unnoticed: the commits are all present in history. Reverting `c087a467c2` and re-landing #5496 rebased would address the whole class at once; this PR only fixes the one with a customer attached.

## Test plan

- [x] `yarn format:check`, `yarn lint`, `yarn adio`
- [x] `api-website-builder` builds
- [ ] Fresh tenant install, then confirm `GET /wb/redirects` returns 200 with the generated key
- [ ] Confirm Admin still renders the key as "Read-only"

Existing environments are unaffected either way — `CreateApiKeyUseCase` won't rewrite an existing key's permissions, so already-installed environments still need the key patched by hand in Admin (Website Builder → Read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)