### PR TITLE
fix(app-website-builder): make currentLanguage optional in translate page schema

### DIFF
--- a/packages/app-website-builder/src/presentation/pages/TranslatePage/translatePageSchema.ts
+++ b/packages/app-website-builder/src/presentation/pages/TranslatePage/translatePageSchema.ts
@@ -3,5 +3,5 @@ import { z } from "zod";
 export const translatePageParams = z.object({
     pageId: z.string(),
     folderId: z.string(),
-    currentLanguage: z.string()
+    currentLanguage: z.string().optional()
 });


### PR DESCRIPTION
Ports the applicable part of `4395d52e3c` (on `next`) to `release/6.4.6`.

## What ported

`translatePageParams.currentLanguage` is now `.optional()`.

Integration-created pages can lack a `language` property. `TranslatePageAction` derives `currentLanguage` from `page.properties.language`, so for those pages it's `undefined` and the Zod schema rejected the translate request with a `ZodError`. Making it optional prevents that. It's presentation-only (used to display the current language), so `undefined` is safe downstream.

## What did NOT port (and why)

The original commit also adds `GetDefaultLanguageUseCase` to `@webiny/languages` and updates `WbTranslatePageDecorator` to use it instead of hardcoding `"en"` as the translation source language. Those target the **AI page-translation** feature (`ai-powerups` `WbTranslatePage` decorator), which does not exist in `release/6.4.6` — its `TranslatePageUseCase` only duplicates the page and sets the target language; there's no AI content translation and no `"en"` fallback to fix. So there's nothing for those parts to attach to here.

If/when the AI page-translation feature is on 6.4.6, the `GetDefaultLanguage` + decorator changes should be ported too.

## Verification

- Translate an integration-created page (no `language` property) → no longer throws a ZodError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)