### PR TITLE
fix(create-webiny-project): clarify self-hosted watch instructions

### DIFF
--- a/packages/create-webiny-project/src/features/CreateWebinyProject.ts
+++ b/packages/create-webiny-project/src/features/CreateWebinyProject.ts
@@ -233,8 +233,8 @@ export class CreateWebinyProject {
             console.log(
                 yellow(
                     "⚠ The self-hosted (server) hosting type is in ALPHA. It's for local\n" +
-                        "  development and testing with `webiny watch`. It's still maturing, so\n" +
-                        "  expect some rough edges."
+                        "  development and testing with `webiny watch api` / `webiny watch admin`.\n" +
+                        "  It's still maturing, so expect some rough edges."
                 )
             );
             console.log();
@@ -246,9 +246,12 @@ export class CreateWebinyProject {
 
             console.log(
                 [
-                    `Start your project in development mode by running: ${green(
-                        `cd ${projectName} && yarn webiny watch`
-                    )}`,
+                    `First, enter the project directory: ${green(`cd ${projectName}`)}`,
+                    "",
+                    "Then start development mode. Watching all apps at once isn't supported yet,",
+                    `so run the API and Admin apps separately, each in its own terminal: ${green(
+                        "yarn webiny watch api"
+                    )} and ${green("yarn webiny watch admin")}.`,
                     "",
                     `To see all of the available CLI commands, run ${green(
                         "yarn webiny --help"


### PR DESCRIPTION
## Change

The self-hosted (server) hosting type doesn't yet support watching all apps at once, but the post-create message told users to run a single `yarn webiny watch` command.

Updated the create-webiny-project success output so it instructs users to run the API and Admin apps separately, each in its own terminal:
- `yarn webiny watch api`
- `yarn webiny watch admin`

Also updated the ALPHA warning line, which carried the same stale `webiny watch` hint.

## Notes

No behavior change — message text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)