### PR TITLE
ci: pass build output between command jobs via artifacts, not cache

### DIFF
--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -86,34 +86,10 @@ jobs:
     permissions:
       contents: read
       actions: write
-  constants:
-    needs:
-      - checkComment
-      - prBranch
-    name: Create constants
-    outputs:
-      run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
-    steps:
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-      - name: Create workflow run cache key
-        id: run-cache-key
-        run: >-
-          echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{
-          vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT
-    runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: '--max_old_space_size=4096'
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-    permissions:
-      contents: read
-      actions: write
   build:
     name: Build
     needs:
       - prBranch
-      - constants
     runs-on: webiny-build-packages
     steps:
       - uses: actions/setup-node@v5
@@ -133,10 +109,18 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
-      - uses: actions/cache@v5
+      - name: Compress build cache
+        run: >-
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.prBranch.outputs.pr-branch }} .webiny/cached-packages
+      - name: Upload build cache
+        uses: actions/upload-artifact@v7
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+          path: run-build-cache.tzst
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -146,7 +130,6 @@ jobs:
   npmReleaseAlpha:
     needs:
       - prBranch
-      - constants
       - build
     name: NPM release ("alpha" tag)
     env:
@@ -168,10 +151,14 @@ jobs:
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -86,34 +86,10 @@ jobs:
     permissions:
       contents: read
       actions: write
-  constants:
-    needs:
-      - checkComment
-      - prBranch
-    name: Create constants
-    outputs:
-      run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
-    steps:
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-      - name: Create workflow run cache key
-        id: run-cache-key
-        run: >-
-          echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{
-          vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT
-    runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: '--max_old_space_size=4096'
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-    permissions:
-      contents: read
-      actions: write
   build:
     name: Build
     needs:
       - prBranch
-      - constants
     runs-on: webiny-build-packages
     steps:
       - uses: actions/setup-node@v5
@@ -133,10 +109,18 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
-      - uses: actions/cache@v5
+      - name: Compress build cache
+        run: >-
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.prBranch.outputs.pr-branch }} .webiny/cached-packages
+      - name: Upload build cache
+        uses: actions/upload-artifact@v7
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+          path: run-build-cache.tzst
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -146,7 +130,6 @@ jobs:
   npmReleaseBeta:
     needs:
       - prBranch
-      - constants
       - build
     name: NPM release ("beta" tag)
     env:
@@ -168,10 +151,14 @@ jobs:
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
@@ -227,7 +214,6 @@ jobs:
   npmReleaseLatest:
     needs:
       - prBranch
-      - constants
       - npmReleaseBeta
     name: NPM release ("latest" tag)
     environment: release
@@ -250,10 +236,14 @@ jobs:
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -90,7 +90,6 @@ jobs:
     name: Create constants
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
-      run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
       - uses: actions/setup-node@v5
         with:
@@ -101,11 +100,6 @@ jobs:
           echo "global-cache-key=${{ needs.baseBranch.outputs.base-branch }}-${{
           runner.os }}-$(/bin/date -u "+%m%d")-${{ vars.RANDOM_CACHE_KEY_SUFFIX
           }}" >> $GITHUB_OUTPUT
-      - name: Create workflow run cache key
-        id: run-cache-key
-        run: >-
-          echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{
-          vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -145,10 +139,18 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-      - uses: actions/cache@v5
+      - name: Compress build cache
+        run: >-
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }} .webiny/cached-packages
+      - name: Upload build cache
+        uses: actions/upload-artifact@v7
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+          path: run-build-cache.tzst
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
       - name: Upload build cache artifact
         uses: actions/upload-artifact@v6
         with:
@@ -240,10 +242,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -442,10 +448,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -96,7 +96,6 @@ jobs:
     name: Create constants
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
-      run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
       - uses: actions/setup-node@v5
         with:
@@ -107,11 +106,6 @@ jobs:
           echo "global-cache-key=${{ needs.baseBranch.outputs.base-branch }}-${{
           runner.os }}-$(/bin/date -u "+%m%d")-${{ vars.RANDOM_CACHE_KEY_SUFFIX
           }}" >> $GITHUB_OUTPUT
-      - name: Create workflow run cache key
-        id: run-cache-key
-        run: >-
-          echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{
-          vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -151,10 +145,18 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-      - uses: actions/cache@v5
+      - name: Compress build cache
+        run: >-
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }} .webiny/cached-packages
+      - name: Upload build cache
+        uses: actions/upload-artifact@v7
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+          path: run-build-cache.tzst
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -294,10 +296,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -444,10 +450,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -605,10 +615,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -756,10 +770,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -908,10 +926,14 @@ jobs:
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - name: Download build cache
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
-          key: ${{ needs.constants.outputs.run-cache-key }}
+          name: run-build-cache-${{ github.run_attempt }}
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
+          needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}

--- a/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
@@ -2,7 +2,8 @@ import { BUILD_PACKAGES_RUNNER } from "./utils/index.js";
 import { createJob, createSlashCommandWorkflow } from "./jobs/index.js";
 import {
     createInstallBuildSteps,
-    createRunBuildCacheSteps,
+    createRunBuildArtifactDownloadSteps,
+    createRunBuildArtifactUploadSteps,
     createYarnCacheSteps,
     withCommonParams
 } from "./steps/index.js";
@@ -13,7 +14,12 @@ const RELEASE_VERSION = "${{ needs.prBranch.outputs.release-version }}";
 
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: PR_BRANCH });
 const yarnCacheSteps = createYarnCacheSteps({ workingDirectory: PR_BRANCH });
-const runBuildCacheSteps = createRunBuildCacheSteps({ workingDirectory: PR_BRANCH });
+const runBuildCacheUploadSteps = createRunBuildArtifactUploadSteps({
+    workingDirectory: PR_BRANCH
+});
+const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
+    workingDirectory: PR_BRANCH
+});
 
 // Unlike /beta (which publishes a beta and can then immediately proceed to a "latest"
 // release), /alpha only ever publishes an alpha prerelease. There is no follow-up job.
@@ -56,30 +62,15 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
                 }
             ]
         }),
-        constants: createJob({
-            needs: ["checkComment", "prBranch"],
-            name: "Create constants",
-            checkout: false,
-            outputs: {
-                "run-cache-key": "${{ steps.run-cache-key.outputs.run-cache-key }}"
-            },
-            steps: [
-                {
-                    name: "Create workflow run cache key",
-                    id: "run-cache-key",
-                    run: 'echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT'
-                }
-            ]
-        }),
         build: createJob({
             name: "Build",
-            needs: ["prBranch", "constants"],
+            needs: ["prBranch"],
             checkout: { path: PR_BRANCH, ref: PR_BRANCH },
             "runs-on": BUILD_PACKAGES_RUNNER,
-            steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheSteps]
+            steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheUploadSteps]
         }),
         npmReleaseAlpha: createJob({
-            needs: ["prBranch", "constants", "build"],
+            needs: ["prBranch", "build"],
             name: 'NPM release ("alpha" tag)',
             env: {
                 GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -89,7 +80,7 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
             checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
-                ...runBuildCacheSteps,
+                ...runBuildCacheDownloadSteps,
                 ...installBuildSteps,
                 ...withCommonParams(
                     [

--- a/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
@@ -2,7 +2,8 @@ import { BUILD_PACKAGES_RUNNER } from "./utils/index.js";
 import { createJob, createSlashCommandWorkflow } from "./jobs/index.js";
 import {
     createInstallBuildSteps,
-    createRunBuildCacheSteps,
+    createRunBuildArtifactDownloadSteps,
+    createRunBuildArtifactUploadSteps,
     createYarnCacheSteps,
     withCommonParams
 } from "./steps/index.js";
@@ -13,7 +14,12 @@ const RELEASE_VERSION = "${{ needs.prBranch.outputs.release-version }}";
 
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: PR_BRANCH });
 const yarnCacheSteps = createYarnCacheSteps({ workingDirectory: PR_BRANCH });
-const runBuildCacheSteps = createRunBuildCacheSteps({ workingDirectory: PR_BRANCH });
+const runBuildCacheUploadSteps = createRunBuildArtifactUploadSteps({
+    workingDirectory: PR_BRANCH
+});
+const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
+    workingDirectory: PR_BRANCH
+});
 
 export const pullRequestsCommandBeta = createSlashCommandWorkflow({
     command: "beta",
@@ -54,30 +60,15 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                 }
             ]
         }),
-        constants: createJob({
-            needs: ["checkComment", "prBranch"],
-            name: "Create constants",
-            checkout: false,
-            outputs: {
-                "run-cache-key": "${{ steps.run-cache-key.outputs.run-cache-key }}"
-            },
-            steps: [
-                {
-                    name: "Create workflow run cache key",
-                    id: "run-cache-key",
-                    run: 'echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT'
-                }
-            ]
-        }),
         build: createJob({
             name: "Build",
-            needs: ["prBranch", "constants"],
+            needs: ["prBranch"],
             checkout: { path: PR_BRANCH, ref: PR_BRANCH },
             "runs-on": BUILD_PACKAGES_RUNNER,
-            steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheSteps]
+            steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheUploadSteps]
         }),
         npmReleaseBeta: createJob({
-            needs: ["prBranch", "constants", "build"],
+            needs: ["prBranch", "build"],
             name: 'NPM release ("beta" tag)',
             env: {
                 GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -87,7 +78,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
             checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
-                ...runBuildCacheSteps,
+                ...runBuildCacheDownloadSteps,
                 ...installBuildSteps,
                 ...withCommonParams(
                     [
@@ -135,7 +126,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
             ]
         }),
         npmReleaseLatest: createJob({
-            needs: ["prBranch", "constants", "npmReleaseBeta"],
+            needs: ["prBranch", "npmReleaseBeta"],
             name: 'NPM release ("latest" tag)',
             environment: "release",
             env: {
@@ -146,7 +137,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
             checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
-                ...runBuildCacheSteps,
+                ...runBuildCacheDownloadSteps,
                 ...installBuildSteps,
                 ...withCommonParams(
                     [

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -3,7 +3,8 @@ import {
     createDeployWebinySteps,
     createGlobalBuildCacheSteps,
     createInstallBuildSteps,
-    createRunBuildCacheSteps,
+    createRunBuildArtifactDownloadSteps,
+    createRunBuildArtifactUploadSteps,
     createSetupVerdaccioSteps,
     createYarnCacheSteps,
     withCommonParams
@@ -18,7 +19,12 @@ const DIR_TEST_PROJECT = "new-webiny-project";
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: DIR_WEBINY_JS });
 const yarnCacheSteps = createYarnCacheSteps({ workingDirectory: DIR_WEBINY_JS });
 const globalBuildCacheSteps = createGlobalBuildCacheSteps({ workingDirectory: DIR_WEBINY_JS });
-const runBuildCacheSteps = createRunBuildCacheSteps({ workingDirectory: DIR_WEBINY_JS });
+const runBuildCacheUploadSteps = createRunBuildArtifactUploadSteps({
+    workingDirectory: DIR_WEBINY_JS
+});
+const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
+    workingDirectory: DIR_WEBINY_JS
+});
 
 const createCheckoutPrSteps = () =>
     [
@@ -92,7 +98,7 @@ const createCypressJobs = (dbSetup: string) => {
         steps: [
             ...createCheckoutPrSteps(),
             ...yarnCacheSteps,
-            ...runBuildCacheSteps,
+            ...runBuildCacheDownloadSteps,
             ...installBuildSteps,
             ...createSetupVerdaccioSteps({ workingDirectory: DIR_WEBINY_JS }),
             {
@@ -267,8 +273,7 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
             needs: "baseBranch",
             name: "Create constants",
             outputs: {
-                "global-cache-key": "${{ steps.global-cache-key.outputs.global-cache-key }}",
-                "run-cache-key": "${{ steps.run-cache-key.outputs.run-cache-key }}"
+                "global-cache-key": "${{ steps.global-cache-key.outputs.global-cache-key }}"
             },
             checkout: false,
             steps: [
@@ -276,11 +281,6 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
                     name: "Create global cache key",
                     id: "global-cache-key",
                     run: `echo "global-cache-key=\${{ needs.baseBranch.outputs.base-branch }}-\${{ runner.os }}-$(/bin/date -u "+%m%d")-\${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT`
-                },
-                {
-                    name: "Create workflow run cache key",
-                    id: "run-cache-key",
-                    run: 'echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT'
                 }
             ]
         }),
@@ -294,7 +294,7 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
                 ...yarnCacheSteps,
                 ...globalBuildCacheSteps,
                 ...installBuildSteps,
-                ...runBuildCacheSteps,
+                ...runBuildCacheUploadSteps,
                 {
                     name: "Upload build cache artifact",
                     uses: "actions/upload-artifact@v6",

--- a/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
@@ -2,7 +2,8 @@ import { NormalJob } from "github-actions-wac";
 import {
     createGlobalBuildCacheSteps,
     createInstallBuildSteps,
-    createRunBuildCacheSteps,
+    createRunBuildArtifactDownloadSteps,
+    createRunBuildArtifactUploadSteps,
     createYarnCacheSteps,
     withCommonParams
 } from "./steps/index.js";
@@ -33,7 +34,12 @@ const DIR_WEBINY_JS = "${{ needs.baseBranch.outputs.base-branch }}";
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: DIR_WEBINY_JS });
 const yarnCacheSteps = createYarnCacheSteps({ workingDirectory: DIR_WEBINY_JS });
 const globalBuildCacheSteps = createGlobalBuildCacheSteps({ workingDirectory: DIR_WEBINY_JS });
-const runBuildCacheSteps = createRunBuildCacheSteps({ workingDirectory: DIR_WEBINY_JS });
+const runBuildCacheUploadSteps = createRunBuildArtifactUploadSteps({
+    workingDirectory: DIR_WEBINY_JS
+});
+const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
+    workingDirectory: DIR_WEBINY_JS
+});
 
 const createCheckoutPrSteps = () =>
     [
@@ -186,7 +192,7 @@ const createVitestTestsJobs = (storageOps?: AbstractStorageOps) => {
             steps: [
                 ...createCheckoutPrSteps(),
                 ...yarnCacheSteps,
-                ...runBuildCacheSteps,
+                ...runBuildCacheDownloadSteps,
                 ...installBuildSteps,
                 ...withCommonParams([{ name: "Run tests", run: "${{ matrix.testCommand.cmd }}" }], {
                     "working-directory": DIR_WEBINY_JS
@@ -227,8 +233,7 @@ export const pullRequestsCommandVitest = createSlashCommandWorkflow({
             needs: "baseBranch",
             name: "Create constants",
             outputs: {
-                "global-cache-key": "${{ steps.global-cache-key.outputs.global-cache-key }}",
-                "run-cache-key": "${{ steps.run-cache-key.outputs.run-cache-key }}"
+                "global-cache-key": "${{ steps.global-cache-key.outputs.global-cache-key }}"
             },
             checkout: false,
             steps: [
@@ -236,11 +241,6 @@ export const pullRequestsCommandVitest = createSlashCommandWorkflow({
                     name: "Create global cache key",
                     id: "global-cache-key",
                     run: `echo "global-cache-key=\${{ needs.baseBranch.outputs.base-branch }}-\${{ runner.os }}-$(/bin/date -u "+%m%d")-\${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT`
-                },
-                {
-                    name: "Create workflow run cache key",
-                    id: "run-cache-key",
-                    run: 'echo "run-cache-key=${{ github.run_id }}-${{ github.run_attempt }}-${{ vars.RANDOM_CACHE_KEY_SUFFIX }}" >> $GITHUB_OUTPUT'
                 }
             ]
         }),
@@ -254,7 +254,7 @@ export const pullRequestsCommandVitest = createSlashCommandWorkflow({
                 ...yarnCacheSteps,
                 ...globalBuildCacheSteps,
                 ...installBuildSteps,
-                ...runBuildCacheSteps
+                ...runBuildCacheUploadSteps
             ]
         }),
         ...createVitestTestsJobs(),

--- a/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
@@ -1,0 +1,65 @@
+interface CreateRunBuildArtifactStepsParams {
+    workingDirectory: string;
+}
+
+// Passes the build output from the `build` job to the jobs that consume it, using artifacts
+// instead of `actions/cache` (see `createRunBuildCacheSteps`).
+//
+// Why: since GitHub's June 2026 "read-only cache for low-trust triggers" change, workflows
+// triggered by `issue_comment` (all of our /alpha, /beta, /e2e and /vitest commands) get a
+// read-only cache token. Cache SAVES fail with "cache write denied: token has no writable
+// scopes" no matter what `permissions` the job declares, so every consumer job missed the
+// cache and rebuilt from scratch. Artifacts are the documented way to pass data between jobs
+// and are not subject to that restriction.
+//
+// Cache-based steps are still correct (and cheaper) on trusted triggers - `push` and
+// `pull_request` - so those workflows keep using `createRunBuildCacheSteps`.
+//
+// The directory is tarred rather than handed to `upload-artifact` as-is: it is ~168 MB across
+// ~44k files, which compresses to ~12 MB as a single zstd tarball. Uploading and downloading
+// one small file beats zipping 44k files once and unzipping them in every consumer job.
+// `zstdmt` is what `actions/cache` itself shells out to, so it is present on both the hosted
+// and self-hosted runners. GNU tar appends `-d` when extracting, so the same program works
+// both ways.
+const ARCHIVE = "run-build-cache.tzst";
+
+// Artifacts are already scoped to a single workflow run, so the attempt number is all that is
+// needed to keep re-runs from colliding with the previous attempt's upload.
+const ARTIFACT_NAME = "run-build-cache-${{ github.run_attempt }}";
+
+const CACHED_PACKAGES = ".webiny/cached-packages";
+
+export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifactStepsParams) => {
+    return [
+        {
+            name: "Compress build cache",
+            run: `tar -cf ${ARCHIVE} --use-compress-program=zstdmt -C ${params.workingDirectory} ${CACHED_PACKAGES}`
+        },
+        {
+            name: "Upload build cache",
+            uses: "actions/upload-artifact@v7",
+            with: {
+                name: ARTIFACT_NAME,
+                path: ARCHIVE,
+                "retention-days": 1,
+                // The tarball is already zstd-compressed; re-deflating it only burns CPU.
+                "compression-level": 0,
+                "if-no-files-found": "error"
+            }
+        }
+    ] as const;
+};
+
+export const createRunBuildArtifactDownloadSteps = (params: CreateRunBuildArtifactStepsParams) => {
+    return [
+        {
+            name: "Download build cache",
+            uses: "actions/download-artifact@v8",
+            with: { name: ARTIFACT_NAME }
+        },
+        {
+            name: "Extract build cache",
+            run: `tar -xf ${ARCHIVE} --use-compress-program=zstdmt -C ${params.workingDirectory}`
+        }
+    ] as const;
+};

--- a/.github/workflows/wac/steps/index.ts
+++ b/.github/workflows/wac/steps/index.ts
@@ -2,6 +2,7 @@ export * from "./createDeployWebinySteps.js";
 export * from "./createSetupVerdaccioSteps.js";
 export * from "./createInstallBuildSteps.js";
 export * from "./createGlobalBuildCacheSteps.js";
+export * from "./createRunBuildArtifactSteps.js";
 export * from "./createRunBuildCacheSteps.js";
 export * from "./createYarnCacheSteps.js";
 export * from "./withCommonParams.js";


### PR DESCRIPTION
### What changed

The `/alpha`, `/beta`, `/e2e` and `/vitest` commands now pass the `build` job's output to the jobs that consume it as an **artifact** instead of through `actions/cache`.

Since GitHub's June 2026 *read-only Actions cache for low-trust triggers* change, workflows triggered by `issue_comment` — which is all four of these commands — receive a read-only cache token. Every cache save was failing with:

```
cache write denied: token has no writable scopes
```

This happens regardless of the job's `permissions`, so it was **not** fixed by #5542. The `build` job never published its output, every consumer job missed the cache, and each one rebuilt from scratch. Confirmed on runs from both Aug 3 and Aug 4, and confirmed absent on `push` and `pull_request` runs holding an identical `Actions: write` token.

**Measured on the same test job:**

| | Restore step | `Build packages` |
|---|---|---|
| `pull_request` (cache restored) | 3s | **13s** |
| `issue_comment` (cache denied) | 0s (miss) | **279s** |

Across ~60 matrix jobs that is roughly **four hours of wasted runner time per `/vitest` invocation**.

Artifacts are GitHub's documented mechanism for passing data between jobs and are not subject to the restriction. `push` and `pull_request` keep using `actions/cache`, which still works there and is cheaper — so `pullRequests.yml` and `push.yml` are untouched.

### Implementation notes

- New `createRunBuildArtifactSteps` exposes an upload half (used in `build`, after the build steps) and a download half (used in the consumers, before the install/build steps) — mirroring where the single cache step used to sit.
- **The directory is tarred rather than passed to `upload-artifact` as-is.** It is ~168 MB across ~44k files, but ~12 MB as one zstd tarball. Uploading and downloading a single small file beats zipping 44k files once and unzipping them in every consumer job. `compression-level: 0` avoids re-deflating an already-compressed tarball. `zstdmt` is what `actions/cache` itself shells out to, so it is present on both hosted and self-hosted runners, and GNU tar appends `-d` when extracting so the same program serves both directions.
- Artifact names are scoped per workflow run by GitHub, so `run-build-cache-${{ github.run_attempt }}` is enough to keep a re-run from colliding with the previous attempt.
- `retention-days: 1`, since this is strictly intra-run plumbing.
- Removed the now-orphaned `run-cache-key` output. That in turn left the `constants` job in `/alpha` and `/beta` with no outputs and no steps — it existed only to compute that key — so it is gone too; it would otherwise occupy a runner to do nothing. `RANDOM_CACHE_KEY_SUFFIX` still drives `global-cache-key`, so the manual cache-bust lever is unaffected. It was meaningless for artifacts, which are already per-run.

### Verification

- All four workflows: no dangling `needs`, and every downloading job transitively depends on the uploading `build` job (checked programmatically against the generated YAML).
- `yarn ci-workflows:build`, `yarn lint`, `yarn format:check` all clean.
- Confirmed no symlinks in `.webiny/cached-packages`, so tar/untar round-trips faithfully.

Worth flagging separately, both pre-existing and untouched here:

- `pullRequestsCommandE2e` and `rebuildGlobalCache` already upload a raw `build-cache` artifact (`upload-artifact@v6`, ~44k files) that **nothing ever downloads**. If that is genuinely unused it is costing minutes per run and could be dropped.
- The yarn cache save in these workflows warns `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`, so it may never be populating.

### Changelog

**Faster test and release commands on pull requests**

The `/vitest`, `/e2e`, `/alpha` and `/beta` commands were rebuilding the entire project separately in every job because a recent GitHub platform change stopped them from sharing their build output. They now share it again, cutting a large amount of redundant work from each run.

### Squash Merge Commit

```
ci: share command build output via artifacts, not cache (#5548)
fix(ci): restore build output sharing on issue_comment workflows (#5548)
```
