### PR TITLE
fix(ci): always give `tar -C` a directory when extracting the build cache

### DIFF
--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -111,8 +111,10 @@ jobs:
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Compress build cache
         run: >-
-          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.prBranch.outputs.pr-branch }} .webiny/cached-packages
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}" .webiny/cached-packages
+        env:
+          WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
@@ -157,8 +159,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.prBranch.outputs.pr-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -111,8 +111,10 @@ jobs:
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Compress build cache
         run: >-
-          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.prBranch.outputs.pr-branch }} .webiny/cached-packages
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}" .webiny/cached-packages
+        env:
+          WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
@@ -157,8 +159,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.prBranch.outputs.pr-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
@@ -242,8 +246,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.prBranch.outputs.pr-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -141,8 +141,10 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Compress build cache
         run: >-
-          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }} .webiny/cached-packages
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}" .webiny/cached-packages
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
@@ -248,8 +250,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -454,8 +458,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -147,8 +147,10 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Compress build cache
         run: >-
-          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }} .webiny/cached-packages
+          tar -cf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}" .webiny/cached-packages
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
@@ -302,8 +304,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -456,8 +460,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -621,8 +627,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -776,8 +784,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -932,8 +942,10 @@ jobs:
           name: run-build-cache-${{ github.run_attempt }}
       - name: Extract build cache
         run: >-
-          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C ${{
-          needs.baseBranch.outputs.base-branch }}
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Install dependencies
         run: yarn --immutable
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}

--- a/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
@@ -29,11 +29,20 @@ const ARTIFACT_NAME = "run-build-cache-${{ github.run_attempt }}";
 
 const CACHED_PACKAGES = ".webiny/cached-packages";
 
+// The working directory is an expression like `${{ needs.baseBranch.outputs.base-branch }}`, and
+// `needs` only exposes a job's DIRECT dependencies. Some consumer jobs (the /vitest test jobs)
+// depend on that job only transitively, so the expression resolves to an empty string and those
+// jobs check the repository out at the workspace root instead of into a subdirectory. Passing the
+// directory through an env var lets the shell substitute `.` in that case, so `tar -C` always
+// receives an argument and extracts to wherever the checkout actually is.
+const TARGET_DIR = '"${WEBINY_JS_DIR:-.}"';
+
 export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifactStepsParams) => {
     return [
         {
             name: "Compress build cache",
-            run: `tar -cf ${ARCHIVE} --use-compress-program=zstdmt -C ${params.workingDirectory} ${CACHED_PACKAGES}`
+            run: `tar -cf ${ARCHIVE} --use-compress-program=zstdmt -C ${TARGET_DIR} ${CACHED_PACKAGES}`,
+            env: { WEBINY_JS_DIR: params.workingDirectory }
         },
         {
             name: "Upload build cache",
@@ -59,7 +68,8 @@ export const createRunBuildArtifactDownloadSteps = (params: CreateRunBuildArtifa
         },
         {
             name: "Extract build cache",
-            run: `tar -xf ${ARCHIVE} --use-compress-program=zstdmt -C ${params.workingDirectory}`
+            run: `tar -xf ${ARCHIVE} --use-compress-program=zstdmt -C ${TARGET_DIR}`,
+            env: { WEBINY_JS_DIR: params.workingDirectory }
         }
     ] as const;
 };


### PR DESCRIPTION
### What changed

Fixes the `/vitest` test jobs failing immediately after #5548 with:

```
tar: option requires an argument -- 'C'
Process completed with exit code 64
```

The working directory is the expression `${{ needs.baseBranch.outputs.base-branch }}`, and the `needs` context only exposes a job's **direct** dependencies. The vitest test jobs depend on `baseBranch` only transitively (through `constants` / `vitest-*-constants`), so the expression resolved to an empty string and `tar -C` was left with no argument at all.

The directory is now passed through a `WEBINY_JS_DIR` env var, letting the shell default it to `.`:

```
tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C "${WEBINY_JS_DIR:-.}"
```

So tar always receives an argument and extracts to wherever the checkout actually is. Verified locally that a tarball produced with the directory resolved (`next`) extracts correctly into that subdirectory when the value is set, and into the current directory when it is empty or unset.

The `build` job, the `/e2e` consumers and the `/alpha`/`/beta` consumers all have their directory job as a direct need, so they were already resolving correctly — but the env var is applied on both the compress and extract sides so the behaviour no longer depends on which jobs happen to be direct dependencies.

### A pre-existing bug this uncovered

This change deliberately only papers over a deeper issue, which is **not** introduced by #5548 and is left for a separate change.

Because `${{ needs.baseBranch.outputs.base-branch }}` is empty in the vitest test jobs, those jobs check the repository out at the workspace root instead of into a subdirectory, and *every* path in them silently loses its prefix. The most visible symptom is the yarn cache, which is configured with the absolute path:

```
path: /.yarn/cache
```

That is why it has long been warning `Path Validation Error: Path(s) specified in the action for caching do(es) not exist` and never populating — meaning those jobs also re-download all dependencies on every run.

The root-cause fix is to add `baseBranch` to those jobs' `needs` so the expression resolves. That changes the checkout location for every step in them, so it deserves its own PR rather than riding along with an incident fix.

### Changelog

**Fixed test commands failing to start**

The `/vitest` command was failing before running any tests. It now works again.

### Squash Merge Commit

```
fix(ci): give tar -C a directory when extracting build cache (#5550)
```
