### PR TITLE
ci: drop leftover debug artifact upload from the /e2e build job

### DIFF
--- a/.github/workflows/assignMilestone.yml
+++ b/.github/workflows/assignMilestone.yml
@@ -19,6 +19,8 @@ jobs:
     name: Assign milestone based on base branch
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
+      contents: read
+      actions: write
       issues: write
       pull-requests: write
     env:

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -153,13 +153,6 @@ jobs:
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
-      - name: Upload build cache artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: build-cache
-          retention-days: 1
-          include-hidden-files: true
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -294,17 +294,7 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
                 ...yarnCacheSteps,
                 ...globalBuildCacheSteps,
                 ...installBuildSteps,
-                ...runBuildCacheUploadSteps,
-                {
-                    name: "Upload build cache artifact",
-                    uses: "actions/upload-artifact@v6",
-                    with: {
-                        name: "build-cache",
-                        "retention-days": 1,
-                        "include-hidden-files": true,
-                        path: `${DIR_WEBINY_JS}/.webiny/cached-packages`
-                    }
-                }
+                ...runBuildCacheUploadSteps
             ]
         }),
         ...createCypressJobs("ddb"),


### PR DESCRIPTION
### What changed

The `/e2e` `build` job was uploading `.webiny/cached-packages` as a raw `build-cache` artifact — roughly **44k files / 168 MB** — on every run. Nothing consumes it.

Verified by enumerating every `download-artifact` step in the repository: all ten of them reference `run-build-cache-<attempt>`, the compressed tarball added in #5548. No job anywhere downloads `build-cache`.

It was introduced by `0fb9074409 ci: debug cache restoration [no ci]` in May and never cleaned up, so it has been costing a large upload on every `/e2e` run since. Removing it should shave a couple of minutes off each run.

After this change the `build` job has exactly one upload, matching `/vitest`, `/alpha` and `/beta`. The `verdaccio-files-*` and `project-files-*` uploads in the project-setup jobs are untouched — those are genuinely consumed by the Cypress jobs.

The equivalent raw uploads in `rebuildGlobalCache` (`build-cache`, `yarn-cache`, `packages`) are deliberately **left alone**: those came from a feature commit rather than a debug commit, so someone may be downloading them by hand for inspection.

### Also included

`assignMilestone.yml` is regenerated. It went stale when #5542 landed — the `createJob` permissions baseline now adds `contents: read` and `actions: write` to every job, and that workflow's committed YAML predates it. The extra scopes are harmless there (the job neither checks out nor caches), but without this regeneration the next `yarn ci-workflows:build` would produce an unrelated diff for whoever runs it.

### Changelog

**Internal CI cleanup**

Removed a leftover debugging step that was uploading a large file on every end-to-end test run. No user-facing change.

### Squash Merge Commit

```
ci: drop leftover debug artifact upload from /e2e build job (#5551)
```
