### PR TITLE
fix(ci): pin /vitest and /e2e runs to a single commit, and fix the vitest yarn cache

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -66,6 +66,7 @@ jobs:
     name: Get base branch
     outputs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
+      pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
     steps:
       - uses: actions/setup-node@v5
         with:
@@ -78,6 +79,13 @@ jobs:
         run: >-
           echo "base-branch=$(gh pr view ${{ github.event.issue.number }} --json
           baseRefName -q .baseRefName)" >> $GITHUB_OUTPUT
+      - name: Get PR head SHA
+        id: pr-sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >-
+          echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --json
+          headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -122,7 +130,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -177,7 +187,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: List Cypress tests folders
@@ -230,7 +242,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -380,7 +394,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: List Cypress tests folders
@@ -438,7 +454,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -167,6 +167,7 @@ jobs:
       actions: write
   vitest-constants:
     needs:
+      - baseBranch
       - build
       - checkComment
     name: Vitest (No storage) - Constants
@@ -266,6 +267,7 @@ jobs:
       actions: write
   vitest-run:
     needs:
+      - baseBranch
       - constants
       - vitest-constants
     name: No storage / ${{ matrix.testCommand.title }}
@@ -322,6 +324,7 @@ jobs:
       actions: write
   vitest-ddb-constants:
     needs:
+      - baseBranch
       - build
       - checkComment
     name: Vitest (DDB) - Constants
@@ -419,6 +422,7 @@ jobs:
       actions: write
   vitest-ddb-run:
     needs:
+      - baseBranch
       - constants
       - vitest-ddb-constants
     name: DDB / ${{ matrix.testCommand.title }}
@@ -478,6 +482,7 @@ jobs:
       actions: write
   vitest-ddb-os-constants:
     needs:
+      - baseBranch
       - build
       - checkComment
     name: Vitest (DDB+OS) - Constants
@@ -575,6 +580,7 @@ jobs:
       actions: write
   vitest-ddb-os-run:
     needs:
+      - baseBranch
       - constants
       - vitest-ddb-os-constants
     name: DDB+OS / ${{ matrix.testCommand.title }}
@@ -646,6 +652,7 @@ jobs:
       id-token: write
   vitest-sql-constants:
     needs:
+      - baseBranch
       - build
       - checkComment
     name: Vitest (SQL) - Constants
@@ -743,6 +750,7 @@ jobs:
       actions: write
   vitest-sql-run:
     needs:
+      - baseBranch
       - constants
       - vitest-sql-constants
     name: SQL / ${{ matrix.testCommand.title }}
@@ -802,6 +810,7 @@ jobs:
       actions: write
   vitest-pglite-constants:
     needs:
+      - baseBranch
       - build
       - checkComment
     name: Vitest (PGlite) - Constants
@@ -899,6 +908,7 @@ jobs:
       actions: write
   vitest-pglite-run:
     needs:
+      - baseBranch
       - constants
       - vitest-pglite-constants
     name: PGlite / ${{ matrix.testCommand.title }}

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -72,6 +72,7 @@ jobs:
     name: Get base branch
     outputs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
+      pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
     steps:
       - uses: actions/setup-node@v5
         with:
@@ -84,6 +85,13 @@ jobs:
         run: >-
           echo "base-branch=$(gh pr view ${{ github.event.issue.number }} --json
           baseRefName -q .baseRefName)" >> $GITHUB_OUTPUT
+      - name: Get PR head SHA
+        id: pr-sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >-
+          echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --json
+          headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -128,7 +136,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -293,7 +303,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -451,7 +463,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -620,7 +634,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -779,7 +795,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5
@@ -939,7 +957,9 @@ jobs:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/cache@v5

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -31,7 +31,12 @@ const createCheckoutPrSteps = () =>
         {
             name: "Checkout Pull Request",
             "working-directory": DIR_WEBINY_JS,
-            run: "gh pr checkout ${{ github.event.issue.number }}",
+            // Detach onto the SHA `baseBranch` resolved, so every job in this run builds and
+            // tests the same commit even if the PR is pushed to mid-run.
+            run: [
+                "gh pr checkout ${{ github.event.issue.number }}",
+                "git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}"
+            ].join("\n"),
             env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" }
         }
     ] as NonNullable<NormalJob["steps"]>;
@@ -258,7 +263,8 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
             needs: "checkComment",
             name: "Get base branch",
             outputs: {
-                "base-branch": "${{ steps.base-branch.outputs.base-branch }}"
+                "base-branch": "${{ steps.base-branch.outputs.base-branch }}",
+                "pr-sha": "${{ steps.pr-sha.outputs.pr-sha }}"
             },
             steps: [
                 {
@@ -266,6 +272,17 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
                     id: "base-branch",
                     env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
                     run: 'echo "base-branch=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q .baseRefName)" >> $GITHUB_OUTPUT'
+                },
+                {
+                    // Resolve the PR head ONCE, here, and have every job check out exactly this
+                    // commit. Jobs in a single run can start tens of minutes apart, and each
+                    // `gh pr checkout` would otherwise resolve the PR head at its own start time -
+                    // so a push mid-run makes the build job produce output from one commit while
+                    // the test jobs run against another.
+                    name: "Get PR head SHA",
+                    id: "pr-sha",
+                    env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
+                    run: 'echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT'
                 }
             ]
         }),

--- a/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
@@ -146,7 +146,7 @@ const createVitestTestsJobs = (storageOps?: AbstractStorageOps) => {
 
     return {
         [jobNames.constants]: createJob({
-            needs: ["build", "checkComment"],
+            needs: ["baseBranch", "build", "checkComment"],
             name: `Vitest (${rowLabel}) - Constants`,
             checkout: { path: DIR_WEBINY_JS },
             outputs: {
@@ -173,7 +173,7 @@ const createVitestTestsJobs = (storageOps?: AbstractStorageOps) => {
             steps: [createReportResultStep(rowLabel, jobNames.tests)]
         }),
         [jobNames.tests]: createJob({
-            needs: ["constants", jobNames.constants],
+            needs: ["baseBranch", "constants", jobNames.constants],
             // The group prefix lets `vitest-*-result` / `vitestStatusSummary`
             // filter this group's matrix legs out of the run's jobs API.
             name: `${rowLabel} / \${{ matrix.testCommand.title }}`,

--- a/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
@@ -46,7 +46,12 @@ const createCheckoutPrSteps = () =>
         {
             name: "Checkout Pull Request",
             "working-directory": DIR_WEBINY_JS,
-            run: "gh pr checkout ${{ github.event.issue.number }}",
+            // Detach onto the SHA `baseBranch` resolved, so every job in this run builds and
+            // tests the same commit even if the PR is pushed to mid-run.
+            run: [
+                "gh pr checkout ${{ github.event.issue.number }}",
+                "git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}"
+            ].join("\n"),
             env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" }
         }
     ] as NonNullable<NormalJob["steps"]>;
@@ -218,7 +223,8 @@ export const pullRequestsCommandVitest = createSlashCommandWorkflow({
             needs: "checkComment",
             name: "Get base branch",
             outputs: {
-                "base-branch": "${{ steps.base-branch.outputs.base-branch }}"
+                "base-branch": "${{ steps.base-branch.outputs.base-branch }}",
+                "pr-sha": "${{ steps.pr-sha.outputs.pr-sha }}"
             },
             steps: [
                 {
@@ -226,6 +232,17 @@ export const pullRequestsCommandVitest = createSlashCommandWorkflow({
                     id: "base-branch",
                     env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
                     run: 'echo "base-branch=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q .baseRefName)" >> $GITHUB_OUTPUT'
+                },
+                {
+                    // Resolve the PR head ONCE, here, and have every job check out exactly this
+                    // commit. Jobs in a single run can start tens of minutes apart, and each
+                    // `gh pr checkout` would otherwise resolve the PR head at its own start time -
+                    // so a push mid-run makes the build job produce output from one commit while
+                    // the test jobs run against another.
+                    name: "Get PR head SHA",
+                    id: "pr-sha",
+                    env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
+                    run: 'echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT'
                 }
             ]
         }),

--- a/.github/workflows/wac/utils/runNodeScripts/slopCop.js
+++ b/.github/workflows/wac/utils/runNodeScripts/slopCop.js
@@ -208,7 +208,10 @@ const callClaude = async prompt => {
 
 // The model is asked for bare JSON, but strip accidental ```json fences just in case.
 const parseResult = text => {
-    const cleaned = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+    const cleaned = text
+        .trim()
+        .replace(/^```(?:json)?\s*/i, "")
+        .replace(/\s*```$/, "");
     const start = cleaned.indexOf("{");
     const end = cleaned.lastIndexOf("}");
     if (start === -1 || end === -1) {
@@ -247,7 +250,9 @@ const renderReport = result => {
     const lines = [MARKER, "## 🚓 Slop Cop", ""];
 
     if (result.verdict !== "warnings" || findings.length === 0) {
-        lines.push("✅ Nothing worth flagging. The diff looks consistent with the PR's stated intent and the code-style rules.");
+        lines.push(
+            "✅ Nothing worth flagging. The diff looks consistent with the PR's stated intent and the code-style rules."
+        );
         if (result.summary) {
             lines.push("", `_${result.summary}_`);
         }

--- a/.github/workflows/wac/utils/runNodeScripts/slopCop.js
+++ b/.github/workflows/wac/utils/runNodeScripts/slopCop.js
@@ -208,10 +208,7 @@ const callClaude = async prompt => {
 
 // The model is asked for bare JSON, but strip accidental ```json fences just in case.
 const parseResult = text => {
-    const cleaned = text
-        .trim()
-        .replace(/^```(?:json)?\s*/i, "")
-        .replace(/\s*```$/, "");
+    const cleaned = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
     const start = cleaned.indexOf("{");
     const end = cleaned.lastIndexOf("}");
     if (start === -1 || end === -1) {
@@ -250,9 +247,7 @@ const renderReport = result => {
     const lines = [MARKER, "## 🚓 Slop Cop", ""];
 
     if (result.verdict !== "warnings" || findings.length === 0) {
-        lines.push(
-            "✅ Nothing worth flagging. The diff looks consistent with the PR's stated intent and the code-style rules."
-        );
+        lines.push("✅ Nothing worth flagging. The diff looks consistent with the PR's stated intent and the code-style rules.");
         if (result.summary) {
             lines.push("", `_${result.summary}_`);
         }


### PR DESCRIPTION
### What changed

Two related fixes to the `/vitest` and `/e2e` workflows, one commit each.

#### 1. Give the `/vitest` jobs a direct `baseBranch` dependency

The `vitest-*-constants` and `vitest-*-run` jobs use `${{ needs.baseBranch.outputs.base-branch }}` as their checkout path and working directory, but `needs` only exposes a job's **direct** dependencies and they reached `baseBranch` only transitively. The expression resolved to an empty string, so those jobs checked out at the workspace root and every path in them silently lost its prefix.

The most expensive symptom was the yarn cache, configured with the absolute path `/.yarn/cache`:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist,
hence no cache is being saved
```

That path never exists, so the cache never saved and those jobs re-downloaded every dependency on every run. It is also why `tar -C` needed a `.` fallback in #5550.

Adding `baseBranch` to their `needs` makes the expression resolve. Every step in those jobs is already scoped by that same expression — checkout path, yarn cache path, build-cache extraction, install/build, and the test command — so they all move together into the subdirectory that was always intended.

I audited **every** workflow for this class of bug by checking each job's `needs.<job>` references against its declared `needs`. Exactly ten jobs were affected here, plus three in the frozen `v5_PullRequestsCommandJest` workflow, which is left alone.

#### 2. Pin every job in a run to one commit

Each job ran `gh pr checkout <n>` independently, and that resolves the PR head at *that job's* start time. Jobs in one run start tens of minutes apart — on a recent `/e2e` run the `build` job checked out at 14:38:04 and a consumer at 15:10:35 — so a push landing mid-run makes the build job produce output from one commit while later jobs run against another.

This was observed for real, not hypothesised. On run `30919777205` (PR #5549):

| Time | Event |
|---|---|
| 14:33:51 | `9b71fa2e6` — PR head, no `cli-core` changes |
| **14:38:04** | `build` checks out → gets `9b71fa2e6` |
| **14:50:20** | `4306b831c` lands, changing `packages/cli-core/files/references.json` |
| **15:10:35** | consumer checks out → gets `280bdfa55`, including that change |

`getPackageSourceHash` hashes the whole package folder excluding only `dist`, `lib`, `node_modules` and `tsconfig.build.tsbuildinfo`, so `files/references.json` counts. The consumer computed a different hash for `@webiny/cli-core` than the build job had recorded and correctly rebuilt it.

The wasted 2.5s is irrelevant. Two jobs in one run disagreeing about what they are testing is not: a green run stops meaning "this commit passed" and a red one is hard to reproduce.

`baseBranch` now resolves the head SHA once, exposes it as `pr-sha`, and every checkout detaches onto it:

```
gh pr checkout ${{ github.event.issue.number }}
git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
```

Verified that all 11 pinned checkout sites across the two workflows have `baseBranch` as a direct need, so `pr-sha` actually resolves in each.

### Not included

- **`/alpha` and `/beta` have the same drift**, via `ref: ${{ needs.prBranch.outputs.pr-branch }}` on their checkout steps — a branch name, re-resolved per job. They use `actions/checkout` rather than `gh pr checkout`, so the fix is shaped differently and belongs in its own PR.
- **The `vitest-*-constants` jobs check out the base branch, not the PR.** They have no `Checkout Pull Request` step, so `listVitestTestCommands` discovers test commands from `next` rather than from the PR — meaning tests added by a PR may never be scheduled. Pre-existing and worth its own investigation.

### Changelog

**More reliable test and release commands**

Test runs triggered from a pull request could end up building one version of the code and testing another if the branch was updated while the run was in progress; each run is now pinned to a single commit. Test jobs also cache their dependencies correctly again instead of re-downloading them every time.

### Squash Merge Commit

```
fix(ci): pin /vitest and /e2e runs to one commit, fix yarn cache (#5554)
```
