### PR TITLE
fix(app-headless-cms): wire dropConfirmation to FolderTree and block visual update until confirmed

### DIFF
--- a/extensions/folderDropConfirmation/index.tsx
+++ b/extensions/folderDropConfirmation/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { ContentEntryListConfig } from "webiny/admin/cms/entry/list";
+
+const { Browser } = ContentEntryListConfig;
+
+const FolderDropConfirmationExtension = () => {
+    return (
+        <ContentEntryListConfig>
+            <Browser.Folder.DropConfirmation value={true} />
+        </ContentEntryListConfig>
+    );
+};
+
+export default FolderDropConfirmationExtension;

--- a/packages/admin-ui/src/Tree/useTree.ts
+++ b/packages/admin-ui/src/Tree/useTree.ts
@@ -56,8 +56,6 @@ export const useTree = <TData = Record<string, any>>(props: TreeProps<TData>) =>
             });
         });
 
-        await presenter.handleDrop(newNodeTree);
-
         if (props.onDrop) {
             const { dragSourceId, dropTargetId } = options;
 
@@ -70,8 +68,14 @@ export const useTree = <TData = Record<string, any>>(props: TreeProps<TData>) =>
                 dropTarget: newTreeDto.find(node => node.id === String(options.dropTargetId))
             };
 
-            await props.onDrop(newTreeDto, dropOptions);
+            try {
+                await props.onDrop(newTreeDto, dropOptions);
+            } catch {
+                return;
+            }
         }
+
+        await presenter.handleDrop(newNodeTree);
     };
 
     const changeOpen = (newOpenIds: NodeModel<TData>["id"][]) => {

--- a/packages/app-aco/src/components/FolderTree/List/List.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/List.tsx
@@ -98,13 +98,21 @@ export const List = ({
 
                 // Abort if either folder is not found
                 if (!folder || !targetFolder) {
-                    return;
+                    throw new Error("Folder not found");
                 }
 
-                showConfirmMoveFolderDialog({
-                    folder,
-                    targetFolder,
-                    onAccept: runDrop
+                await new Promise<void>((resolve, reject) => {
+                    showConfirmMoveFolderDialog({
+                        folder,
+                        targetFolder,
+                        onAccept: async () => {
+                            await runDrop();
+                            resolve();
+                        },
+                        onClose: () => {
+                            reject(new Error("cancelled"));
+                        }
+                    });
                 });
             } else {
                 // Otherwise, perform the drop immediately

--- a/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
+++ b/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
@@ -5,6 +5,7 @@ interface ShowDialogParams {
     folder: FolderDto;
     targetFolder: FolderDto;
     onAccept: (folder: FolderDto, targetFolder: FolderDto) => Promise<void>;
+    onClose?: () => void;
 }
 
 interface UseConfirmMoveFolderDialogResponse {
@@ -14,14 +15,15 @@ interface UseConfirmMoveFolderDialogResponse {
 export const useConfirmMoveFolderDialog = (): UseConfirmMoveFolderDialogResponse => {
     const dialogs = useDialogs();
 
-    const showDialog = ({ folder, targetFolder, onAccept }: ShowDialogParams) => {
+    const showDialog = ({ folder, targetFolder, onAccept, onClose }: ShowDialogParams) => {
         dialogs.showDialog({
             title: "Move folder",
             content: `You are about to move the folder "${folder.title}" into "${targetFolder.title}"! Are you sure you want to continue?`,
             acceptLabel: "Move folder",
             cancelLabel: "Cancel",
             loadingLabel: "Moving folder...",
-            onAccept: () => onAccept(folder, targetFolder)
+            onAccept: () => onAccept(folder, targetFolder),
+            onClose
         });
     };
 

--- a/packages/app-headless-cms/src/admin/components/ContentEntries/SidebarContent/SidebarContent.tsx
+++ b/packages/app-headless-cms/src/admin/components/ContentEntries/SidebarContent/SidebarContent.tsx
@@ -10,6 +10,7 @@ export const SidebarContent = () => {
         <div className={"flex-1 overflow-y-scroll"}>
             <FolderTree
                 folderActions={browser.folder.actions}
+                dropConfirmation={browser.folder.dropConfirmation}
                 focusedFolderId={currentFolderId}
                 onFolderClick={data => navigateToFolder(data.id)}
                 enableActions={true}

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -16,6 +16,7 @@ export const Extensions = () => {
             <Admin.Extension src={"@/extensions/customPageTypes/index.tsx"} />
             <Admin.Extension src={"@/extensions/customPageSettings/index.tsx"} />
             <Admin.Extension src={"@/extensions/customFormFieldType/index.tsx"} />
+            <Admin.Extension src={"@/extensions/folderDropConfirmation/index.tsx"} />
 
             {/*<Admin.Extension src={"@/extensions/AdminTitleLogo/AdminTitleLogo.tsx"} />*/}
             {/*<Admin.Extension src={"/extensions/AdminTheme/AdminTheme.tsx"} />*/}


### PR DESCRIPTION
## Summary
- Wire the `dropConfirmation` config prop from `ContentEntryListConfig` through to `FolderTree` in the HeadlessCMS sidebar — it was resolved but never passed
- Fix the `Tree` component (`admin-ui`) to run `onDrop` before the visual tree update, so consumers can block or cancel the reorder
- Wrap the folder move confirmation dialog in a promise so `onDrop` blocks until the user confirms or cancels, preventing the premature visual move
- Add a test extension (`extensions/folderDropConfirmation`) demonstrating `Browser.Folder.DropConfirmation`

## Changes
- `packages/app-headless-cms/.../SidebarContent.tsx` — pass `dropConfirmation` prop to `FolderTree`
- `packages/admin-ui/src/Tree/useTree.ts` — move `presenter.handleDrop` after `onDrop`; catch throws to skip the visual update on cancellation
- `packages/app-aco/.../List.tsx` — wrap confirmation dialog in a blocking promise
- `packages/app-aco/.../useConfirmMoveFolderDialog.tsx` — forward `onClose` callback to the dialog system
- `extensions/folderDropConfirmation/index.tsx` + `webiny.config.tsx` — test extension registration

## Test plan
- [ ] Enable the test extension, drag a folder in CMS content entry list
- [ ] Confirm dialog appears and folder does NOT move until "Move folder" is clicked
- [ ] Clicking "Cancel" leaves the folder in its original position
- [ ] Without the extension (dropConfirmation=false), folders drag-and-drop without a dialog as before
- [ ] Website Builder navigator drag-and-drop still works (other `Tree` consumer)