### PR TITLE
fix(app-headless-cms): fix dynamic zone template edit dialog and description overflow

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGridItem.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateGridItem.tsx
@@ -36,7 +36,7 @@ export const TemplateGridItem = makeDecoratable(
                         <Text size={"md"} className={"mb-xs text-neutral-primary font-semibold"}>
                             {template.name}
                         </Text>
-                        <Text size={"sm"} as={"div"} className={"text-neutral-muted"}>
+                        <Text size={"sm"} as={"div"} className={"text-neutral-muted line-clamp-2"}>
                             {template.description}
                         </Text>
                     </div>

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateListItem.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/dynamicZone/TemplateListItem.tsx
@@ -28,7 +28,7 @@ export const TemplateListItem = ({ template, onTemplate }: TemplateListItemProps
                         {template.name}
                     </Text>
                     {template.description && (
-                        <Text size={"sm"} as={"div"} className={"text-neutral-muted truncate"}>
+                        <Text size={"sm"} as={"div"} className={"text-neutral-muted"}>
                             {template.description}
                         </Text>
                     )}

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZone.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState, useCallback } from "react";
 import { Accordion } from "@webiny/admin-ui";
 import type { CmsDynamicZoneTemplate } from "~/types.js";
 import { AddTemplateIcon, AddTemplateButton } from "./AddTemplate.js";
 import { DynamicZoneTemplate } from "./DynamicZoneTemplate.js";
+import { TemplateDialog } from "./TemplateDialog.js";
 import { useModelField, useModelFieldEditor } from "~/admin/hooks/index.js";
 
 function updateOrCreateTemplate(
@@ -26,6 +27,9 @@ export const DynamicZone = () => {
     const { field } = useModelField();
     const { updateField } = useModelFieldEditor();
     const newTemplateId = useRef<string | undefined>(undefined);
+    const [templateToEdit, setTemplateToEdit] = useState<CmsDynamicZoneTemplate | undefined>(
+        undefined
+    );
 
     const templates: CmsDynamicZoneTemplate[] = field.settings?.templates || [];
 
@@ -43,13 +47,23 @@ export const DynamicZone = () => {
         });
     };
 
+    const onDialogClose = useCallback(() => {
+        setTemplateToEdit(undefined);
+    }, []);
+
     useEffect(() => {
-        // We only want to open the accordion item on first mount of a new template.
         newTemplateId.current = undefined;
     }, []);
 
     return (
         <>
+            {templateToEdit ? (
+                <TemplateDialog
+                    template={templateToEdit}
+                    onTemplate={onTemplate}
+                    onClose={onDialogClose}
+                />
+            ) : null}
             {templates.length ? (
                 <Accordion>
                     {templates.map((template, index) => (
@@ -60,6 +74,7 @@ export const DynamicZone = () => {
                             field={field}
                             template={template}
                             onChange={updateField}
+                            onEditTemplate={setTemplateToEdit}
                         />
                     ))}
                 </Accordion>

--- a/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fields/dynamicZone/DynamicZoneTemplate.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { set } from "dot-prop-immutable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ReactComponent as EditIcon } from "@webiny/icons/edit.svg";
@@ -13,7 +13,6 @@ import {
     removeValueAtIndex
 } from "~/admin/plugins/arrayUtils.js";
 import type { CmsDynamicZoneTemplate, CmsEditorFieldsLayout, CmsModelField } from "~/types.js";
-import { TemplateDialog } from "./TemplateDialog.js";
 import { FieldEditor } from "~/admin/components/FieldEditor/index.js";
 import { normalizeIcon } from "~/utils/normalizeIcon.js";
 
@@ -23,6 +22,7 @@ interface DynamicZoneTemplateProps {
     template: CmsDynamicZoneTemplate;
     onChange: (field: CmsModelField) => void;
     open: boolean;
+    onEditTemplate: (template: CmsDynamicZoneTemplate) => void;
 }
 
 interface UpdateTemplate {
@@ -40,7 +40,8 @@ export const DynamicZoneTemplate = ({
     field,
     template,
     onChange,
-    open
+    open,
+    onEditTemplate
 }: DynamicZoneTemplateProps) => {
     const { showConfirmation } = useConfirmationDialog({
         title: "Delete content template",
@@ -48,23 +49,15 @@ export const DynamicZoneTemplate = ({
         acceptLabel: "Yes, I'm sure!"
     });
 
-    const [templateToEdit, setTemplateToEdit] = useState<CmsDynamicZoneTemplate | undefined>(
-        undefined
-    );
-
     const templates = field.settings?.templates || [];
     const isFirst = index === 0;
     const isLast = index === templates.length - 1;
 
     const callbackDeps = [onChange, field, index, template.id];
 
-    const onDialogClose = useCallback(() => {
-        setTemplateToEdit(undefined);
-    }, []);
-
     const editTemplate = useCallback(() => {
-        setTemplateToEdit(template);
-    }, [template]);
+        onEditTemplate(template);
+    }, [template, onEditTemplate]);
 
     const updateTemplate = useCallback<UpdateTemplate>(params => {
         onChange(
@@ -102,7 +95,7 @@ export const DynamicZoneTemplate = ({
             title={template.name}
             description={template.description}
             icon={icon ? <FontAwesomeIcon icon={icon} /> : undefined}
-            open={open}
+            defaultOpen={open}
             actions={
                 <>
                     <Accordion.Item.Action
@@ -121,14 +114,6 @@ export const DynamicZoneTemplate = ({
                 </>
             }
         >
-            {templateToEdit ? (
-                <TemplateDialog
-                    template={templateToEdit}
-                    onTemplate={updateTemplate}
-                    onClose={onDialogClose}
-                />
-            ) : null}
-
             <FieldEditor
                 parent={field}
                 fields={template.fields}


### PR DESCRIPTION
## Summary
- Fix: clicking Edit on a collapsed Dynamic Zone template accordion item now opens the edit dialog (previously only worked when the accordion was expanded)
- Fix: long template descriptions in the "Insert a template" dialog no longer stretch the layout — list view wraps text, grid view clamps to 2 lines

## Changes
- `DynamicZone.tsx` — lift `templateToEdit` state here; render `TemplateDialog` outside the `Accordion` so it mounts regardless of accordion state
- `DynamicZoneTemplate.tsx` — replace internal dialog state with `onEditTemplate` callback to parent; use `defaultOpen` instead of `open` so the accordion stays uncontrolled after parent re-renders
- `TemplateListItem.tsx` — remove `truncate` from description to allow natural text wrapping in list view
- `TemplateGridItem.tsx` — add `line-clamp-2` to description to keep grid cards uniform

## Test plan
- [ ] Open content model editor with a Dynamic Zone field containing multiple templates
- [ ] Collapse all accordion items, click Edit on any template — dialog should open
- [ ] Accordion items expand/collapse normally by clicking the chevron
- [ ] Open "Insert a template" dialog in list view — long descriptions wrap to multiple lines
- [ ] Switch to grid view — long descriptions are clamped to 2 lines with ellipsis