### PR TITLE
fix(admin-ui): port folder drop confirmation and sidebar truncation fixes to 6.5.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "webiny": {
+      "command": "npx",
+      "args": ["webiny-mcp", "serve", "--skills=./skills"]
+    },
+    "stdlib": {
+      "command": "npx",
+      "args": ["-y", "@webiny/stdlib", "serve"]
+    },
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}

--- a/extensions/folderDropConfirmation/index.tsx
+++ b/extensions/folderDropConfirmation/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { ContentEntryListConfig } from "webiny/admin/cms/entry/list";
+
+const { Browser } = ContentEntryListConfig;
+
+const FolderDropConfirmationExtension = () => {
+    return (
+        <ContentEntryListConfig>
+            <Browser.Folder.DropConfirmation value={true} />
+        </ContentEntryListConfig>
+    );
+};
+
+export default FolderDropConfirmationExtension;

--- a/packages/admin-ui/src/Sidebar/components/SidebarContent.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarContent.tsx
@@ -14,7 +14,7 @@ const SidebarContent = ({ className, children, ...props }: React.ComponentProps<
         return (
             <ScrollArea
                 data-sidebar="content"
-                className={cn("flex text-neutral-primary min-h-0 flex-1 flex-col gap-2", className)}
+                className={cn("flex text-neutral-primary min-h-0 flex-1 flex-col gap-2 [&_[data-radix-scroll-area-viewport]>div]:!block", className)}
                 {...restProps}
             >
                 {children}

--- a/packages/admin-ui/src/Sidebar/components/SidebarContent.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarContent.tsx
@@ -14,7 +14,10 @@ const SidebarContent = ({ className, children, ...props }: React.ComponentProps<
         return (
             <ScrollArea
                 data-sidebar="content"
-                className={cn("flex text-neutral-primary min-h-0 flex-1 flex-col gap-2 [&_[data-radix-scroll-area-viewport]>div]:!block", className)}
+                className={cn(
+                    "flex text-neutral-primary min-h-0 flex-1 flex-col gap-2 [&_[data-radix-scroll-area-viewport]>div]:!block",
+                    className
+                )}
                 {...restProps}
             >
                 {children}

--- a/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
@@ -85,7 +85,7 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
                 )}
                 {...props}
             >
-                <div data-sidebar="sidebar" className="flex h-full w-full py-xs flex-col">
+                <div data-sidebar="sidebar" className="flex h-full w-full py-xs flex-col overflow-hidden">
                     {children}
                 </div>
             </div>

--- a/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
+++ b/packages/admin-ui/src/Sidebar/components/SidebarRoot.tsx
@@ -85,7 +85,10 @@ const SidebarRoot = ({ side = "left", className, children, ...props }: SidebarRo
                 )}
                 {...props}
             >
-                <div data-sidebar="sidebar" className="flex h-full w-full py-xs flex-col overflow-hidden">
+                <div
+                    data-sidebar="sidebar"
+                    className="flex h-full w-full py-xs flex-col overflow-hidden"
+                >
                     {children}
                 </div>
             </div>

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubButton.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cva } from "~/utils.js";
+import { cn, cva } from "~/utils.js";
 import type { SidebarMenuItemProps } from "./SidebarMenuRootItem.js";
 import { DivButton } from "./DivButton.js";
 import { SidebarMenuItemBadge } from "./SidebarMenuItemBadge.js";
@@ -58,14 +58,16 @@ const SidebarMenuSubButton = ({
     const sharedProps = {
         "data-sidebar": "menu-sub-button",
         "data-active": active,
-        className: variants({ variant, disabled, className }),
+        className: variants({ variant, disabled, className: cn(className, action && "pr-xl") }),
         onClick
     };
+
+    const textContent = <span className="truncate">{text}</span>;
 
     const content = to ? (
         <LinkComponent {...sharedProps} to={to} {...linkProps}>
             {icon}
-            {text}
+            {textContent}
             {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </LinkComponent>
     ) : (
@@ -77,13 +79,13 @@ const SidebarMenuSubButton = ({
             tabIndex={variant === "group-label" ? -1 : undefined}
         >
             {icon}
-            {text}
+            {textContent}
             {badge && (typeof badge === "string" ? <SidebarMenuItemBadge text={badge} /> : badge)}
         </DivButton>
     );
 
     return (
-        <div className={"flex items-center w-full relative group/menu-sub-button"}>
+        <div className={"flex items-center w-full min-w-0 relative group/menu-sub-button"}>
             {content}
 
             {action && (

--- a/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
+++ b/packages/admin-ui/src/Sidebar/components/items/SidebarMenuSubItem.tsx
@@ -161,7 +161,7 @@ const SidebarMenuSubItem = ({
 
         if (!collapsible) {
             return (
-                <div className={"flex items-center"}>
+                <div className={"flex items-center min-w-0"}>
                     <SidebarMenuSubItemIndentation
                         lvl={currentLevel}
                         variant={buttonProps.variant}
@@ -177,7 +177,7 @@ const SidebarMenuSubItem = ({
                 open={isSectionExpanded}
                 onOpenChange={toggleSectionExpanded}
             >
-                <div className={"flex items-center"}>
+                <div className={"flex items-center min-w-0"}>
                     <SidebarMenuSubItemIndentation
                         lvl={currentLevel}
                         variant={buttonProps.variant}
@@ -213,7 +213,7 @@ const SidebarMenuSubItem = ({
         <>
             <li
                 data-sidebar="menu-sub-item"
-                className={cn("group/menu-sub-item relative flex", className)}
+                className={cn("group/menu-sub-item relative flex min-w-0", className)}
             >
                 {sidebarMenuSubButton}
             </li>

--- a/packages/admin-ui/src/Tree/useTree.ts
+++ b/packages/admin-ui/src/Tree/useTree.ts
@@ -56,8 +56,6 @@ export const useTree = <TData = Record<string, any>>(props: TreeProps<TData>) =>
             });
         });
 
-        await presenter.handleDrop(newNodeTree);
-
         if (props.onDrop) {
             const { dragSourceId, dropTargetId } = options;
 
@@ -70,8 +68,14 @@ export const useTree = <TData = Record<string, any>>(props: TreeProps<TData>) =>
                 dropTarget: newTreeDto.find(node => node.id === String(options.dropTargetId))
             };
 
-            await props.onDrop(newTreeDto, dropOptions);
+            try {
+                await props.onDrop(newTreeDto, dropOptions);
+            } catch {
+                return;
+            }
         }
+
+        await presenter.handleDrop(newNodeTree);
     };
 
     const changeOpen = (newOpenIds: NodeModel<TData>["id"][]) => {

--- a/packages/app-aco/src/components/FolderTree/List/List.tsx
+++ b/packages/app-aco/src/components/FolderTree/List/List.tsx
@@ -98,13 +98,21 @@ export const List = ({
 
                 // Abort if either folder is not found
                 if (!folder || !targetFolder) {
-                    return;
+                    throw new Error("Folder not found");
                 }
 
-                showConfirmMoveFolderDialog({
-                    folder,
-                    targetFolder,
-                    onAccept: runDrop
+                await new Promise<void>((resolve, reject) => {
+                    showConfirmMoveFolderDialog({
+                        folder,
+                        targetFolder,
+                        onAccept: async () => {
+                            await runDrop();
+                            resolve();
+                        },
+                        onClose: () => {
+                            reject(new Error("cancelled"));
+                        }
+                    });
                 });
             } else {
                 // Otherwise, perform the drop immediately

--- a/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
+++ b/packages/app-aco/src/dialogs/useConfirmMoveFolderDialog.tsx
@@ -5,6 +5,7 @@ interface ShowDialogParams {
     folder: FolderDto;
     targetFolder: FolderDto;
     onAccept: (folder: FolderDto, targetFolder: FolderDto) => Promise<void>;
+    onClose?: () => void;
 }
 
 interface UseConfirmMoveFolderDialogResponse {
@@ -14,14 +15,15 @@ interface UseConfirmMoveFolderDialogResponse {
 export const useConfirmMoveFolderDialog = (): UseConfirmMoveFolderDialogResponse => {
     const dialogs = useDialogs();
 
-    const showDialog = ({ folder, targetFolder, onAccept }: ShowDialogParams) => {
+    const showDialog = ({ folder, targetFolder, onAccept, onClose }: ShowDialogParams) => {
         dialogs.showDialog({
             title: "Move folder",
             content: `You are about to move the folder "${folder.title}" into "${targetFolder.title}"! Are you sure you want to continue?`,
             acceptLabel: "Move folder",
             cancelLabel: "Cancel",
             loadingLabel: "Moving folder...",
-            onAccept: () => onAccept(folder, targetFolder)
+            onAccept: () => onAccept(folder, targetFolder),
+            onClose
         });
     };
 

--- a/packages/app-aco/src/presentation/folderTree/FolderTree.tsx
+++ b/packages/app-aco/src/presentation/folderTree/FolderTree.tsx
@@ -214,10 +214,18 @@ export const FolderTree = ({
                     return;
                 }
 
-                showConfirmMoveFolderDialog({
-                    folder,
-                    targetFolder,
-                    onAccept: runDrop
+                await new Promise<void>((resolve, reject) => {
+                    showConfirmMoveFolderDialog({
+                        folder,
+                        targetFolder,
+                        onAccept: async () => {
+                            await runDrop();
+                            resolve();
+                        },
+                        onClose: () => {
+                            reject(new Error("cancelled"));
+                        }
+                    });
                 });
             } else {
                 await runDrop();

--- a/packages/app-headless-cms/src/presentation/contentEntries/views/ContentEntriesListLayout.tsx
+++ b/packages/app-headless-cms/src/presentation/contentEntries/views/ContentEntriesListLayout.tsx
@@ -58,6 +58,7 @@ const DocumentList = observer(() => {
                             vm={presenter.folders.vm}
                             actions={presenter.folders}
                             folderActions={browser.folder.actions}
+                            dropConfirmation={browser.folder.dropConfirmation}
                             enableActions={true}
                             enableCreate={true}
                         />

--- a/webiny.config.tsx
+++ b/webiny.config.tsx
@@ -28,6 +28,7 @@ export const Extensions = () => {
             <ApplyDiscountExtension />
             {/* Bulk actions demo: "Generate AI summary" bulk action on Products (API + Admin) */}
             <AiContentExtension />
+            <Admin.Extension src={"@/extensions/folderDropConfirmation/index.tsx"} />
 
             {/*<Admin.Extension src={"@/extensions/AdminTitleLogo/AdminTitleLogo.tsx"} />*/}
             {/*<Admin.Extension src={"/extensions/AdminTheme/AdminTheme.tsx"} />*/}


### PR DESCRIPTION
## Summary
- Port two fixes from release/6.4.7 to release/6.5.0
- Wire `dropConfirmation` config prop to `FolderTree` in the 6.5.0 presentation-layer `ContentEntriesListLayout.tsx`
- Block the visual tree update until the drop confirmation dialog resolves (shared `useTree.ts`, `List.tsx`, `useConfirmMoveFolderDialog.tsx`)
- Truncate long sidebar menu item names to prevent layout overflow (shared `SidebarContent.tsx`, `SidebarRoot.tsx`, `SidebarMenuSubButton.tsx`, `SidebarMenuSubItem.tsx`)
- Fix drop confirmation blocking in the presentation-layer `FolderTree.tsx` (caught by no-mistakes review)

## Test plan
- [ ] CMS folder drop confirmation dialog appears when `Browser.Folder.DropConfirmation` is enabled
- [ ] Cancelling the dialog leaves the folder in its original position
- [ ] Long content model names in the sidebar truncate with ellipsis
- [ ] Sidebar expand/collapse chevrons remain visible with long names
- [ ] Pin icon does not overlap truncated text