### PR TITLE
fix(app-headless-cms): export BindParentNameContext and provide it in Fields

### DIFF
--- a/packages/app-headless-cms-common/src/Fields/Fields.tsx
+++ b/packages/app-headless-cms-common/src/Fields/Fields.tsx
@@ -14,6 +14,7 @@ import { LayoutDescriptorCell } from "./LayoutDescriptorCell.js";
 import { useAuthentication } from "@webiny/app-admin";
 import { FieldRulesProvider, useParentRules } from "./FieldRulesProvider.js";
 import { evaluateAccessControlRules, useFieldEffectiveRules } from "./useFieldRules.js";
+import { BindParentNameContext } from "./useBind.js";
 
 interface FieldsProps {
     Bind: BindComponent;
@@ -183,19 +184,23 @@ export const Fields = ({ Bind, fields, layout, contentModel, gridClassName }: Fi
         return <LayoutNotDefined />;
     }
 
+    const parentName = Bind.parentName || "";
+
     return (
-        <Grid className={gridClassName}>
-            {layout.map((row, rowIndex) => (
-                <React.Fragment key={rowIndex}>
-                    <RowRenderer
-                        row={row}
-                        fields={fields}
-                        Bind={Bind}
-                        contentModel={contentModel}
-                        gridClassName={gridClassName}
-                    />
-                </React.Fragment>
-            ))}
-        </Grid>
+        <BindParentNameContext.Provider value={parentName}>
+            <Grid className={gridClassName}>
+                {layout.map((row, rowIndex) => (
+                    <React.Fragment key={rowIndex}>
+                        <RowRenderer
+                            row={row}
+                            fields={fields}
+                            Bind={Bind}
+                            contentModel={contentModel}
+                            gridClassName={gridClassName}
+                        />
+                    </React.Fragment>
+                ))}
+            </Grid>
+        </BindParentNameContext.Provider>
     );
 };

--- a/packages/app-headless-cms-common/src/Fields/useBind.tsx
+++ b/packages/app-headless-cms-common/src/Fields/useBind.tsx
@@ -9,6 +9,7 @@ import { createValidationContainer } from "~/createValidationContainer.js";
 const BindParentNameContext = createContext<string>("");
 
 export const useBindParentName = (): string => useContext(BindParentNameContext);
+export { BindParentNameContext };
 
 interface UseBindProps {
     Bind: BindComponent;


### PR DESCRIPTION
## Summary
- Export `BindParentNameContext` from `useBind.tsx` so external consumers can access it
- Wrap the `Fields` grid layout in a `BindParentNameContext.Provider` so nested field components receive the correct parent bind name through context

## Test plan
- [ ] Verify CMS fields render correctly with nested bind names
- [ ] Confirm `useBindParentName()` returns the expected parent name in nested field components

🤖 Generated with [Claude Code](https://claude.com/claude-code)