### PR TITLE
fix(api-core): extract AiModelRegistry to decouple model listing from Ai class

### DIFF
--- a/packages/ai-powerups/src/api/features/Providers/ProvidersHandler.ts
+++ b/packages/ai-powerups/src/api/features/Providers/ProvidersHandler.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Encryption } from "@webiny/api-core/features/encryption/index.js";
 import { Masker } from "@webiny/api-core/features/masker/index.js";
+import { AiModelRegistry } from "@webiny/api-core/features/ai/index.js";
 import { AiPowerUpsSettingsGroupHandler } from "~/api/features/shared/index.js";
 import type { PersistedProviderPreset, PersistedProviders, ProvidersSettings } from "./types.js";
 
@@ -22,7 +23,8 @@ class ProvidersHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
 
     constructor(
         private encryption: Encryption.Interface,
-        private masker: Masker.Interface
+        private masker: Masker.Interface,
+        private modelRegistry: AiModelRegistry.Interface
     ) {}
 
     mapFromStorage(persisted: unknown): ProvidersSettings {
@@ -47,6 +49,30 @@ class ProvidersHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
         const input = internal as ProvidersSettings;
         const existingData = existing as ProvidersSettings | null;
         const existingPresets = existingData?.presets ?? [];
+
+        // Validate that all preset models are in the registry.
+        const availableModels = await this.modelRegistry.listModels();
+        for (const preset of input.presets) {
+            if (!preset.model) {
+                continue;
+            }
+            const slashIndex = preset.model.indexOf("/");
+            if (slashIndex === -1) {
+                throw new Error(
+                    `Invalid model ID "${preset.model}" in preset "${preset.name}". Expected format: "<providerId>/<modelId>".`
+                );
+            }
+            const providerId = preset.model.slice(0, slashIndex);
+            const modelId = preset.model.slice(slashIndex + 1);
+            const found = availableModels.some(
+                m => m.providerId === providerId && m.modelId === modelId
+            );
+            if (!found) {
+                throw new Error(
+                    `Model "${preset.model}" in preset "${preset.name}" is not available. Use listModels() to see available models.`
+                );
+            }
+        }
 
         const presets: PersistedProviderPreset[] = await Promise.all(
             input.presets.map(async preset => {
@@ -82,5 +108,5 @@ class ProvidersHandlerImpl implements AiPowerUpsSettingsGroupHandler.Interface {
 
 export default AiPowerUpsSettingsGroupHandler.createImplementation({
     implementation: ProvidersHandlerImpl,
-    dependencies: [Encryption, Masker]
+    dependencies: [Encryption, Masker, AiModelRegistry]
 });

--- a/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
+++ b/packages/ai-powerups/src/api/graphql/BaseGraphQLSchema.ts
@@ -1,6 +1,6 @@
 import { CoreGraphQLSchemaFactory } from "@webiny/handler-graphql/graphql/abstractions.core.js";
 import { Response, ErrorResponse } from "@webiny/handler-graphql/responses.js";
-import { Ai } from "@webiny/api-core/features/ai/index.js";
+import { AiModelRegistry } from "@webiny/api-core/features/ai/index.js";
 import { TaskService } from "@webiny/api-core/features/task/TaskService/index.js";
 import { GetSettingsUseCase } from "~/api/features/GetSettings/index.js";
 import { UpdateSettingsUseCase } from "~/api/features/UpdateSettings/index.js";
@@ -73,9 +73,9 @@ class BaseGraphQLSchemaImpl implements CoreGraphQLSchemaFactory.Interface {
 
         builder.addResolver({
             path: "AiPowerUpsQuery.listModels",
-            dependencies: [Ai],
-            resolver: (ai: Ai.Interface) => {
-                return async () => ai.listModels();
+            dependencies: [AiModelRegistry],
+            resolver: (registry: AiModelRegistry.Interface) => {
+                return async () => registry.listModels();
             }
         });
 

--- a/packages/api-core/src/exports/api.ts
+++ b/packages/api-core/src/exports/api.ts
@@ -1,5 +1,10 @@
-export { AiSdk, AiSdkFactory, AiConnectionFactory, Ai } from "~/features/ai/index.js";
-export type { IAiConnection, IAiConnectionInline } from "~/features/ai/index.js";
+export {
+    AiSdk,
+    AiSdkFactory,
+    AiConnectionFactory,
+    Ai,
+    AiModelRegistry
+} from "~/features/ai/index.js";
 export { Logger } from "~/features/logger/index.js";
 export { Encryption } from "~/features/encryption/index.js";
 export { BuildParam, BuildParams } from "~/features/buildParams/index.js";

--- a/packages/api-core/src/features/ai/Ai.ts
+++ b/packages/api-core/src/features/ai/Ai.ts
@@ -4,21 +4,13 @@ import { streamText } from "ai";
 import { Ai as AiAbstraction } from "./abstractions.js";
 import { AiSdkFactory } from "./abstractions.js";
 import { AiConnectionFactory } from "./abstractions.js";
-import type { AiGenerateTextParams, AiModel, IAiSdkFactory } from "./abstractions.js";
+import { AiModelRegistry } from "./abstractions.js";
+import type { AiGenerateTextParams, AiModel } from "./abstractions.js";
 import type { AiStreamTextParams } from "./abstractions.js";
 import type { IAiSdk } from "./abstractions.js";
 import type { IAiConnection } from "./abstractions.js";
 import type { IAiConnectionInline } from "./abstractions.js";
 import type { LanguageModel } from "ai";
-
-function toAiModel(factory: IAiSdkFactory, modelId: string, modelName: string): AiModel {
-    return {
-        providerId: factory.id,
-        providerName: factory.name,
-        modelId,
-        modelName
-    };
-}
 
 class AiImpl implements AiAbstraction.Interface {
     private sdkCache = new Map<string, IAiSdk>();
@@ -26,7 +18,8 @@ class AiImpl implements AiAbstraction.Interface {
 
     constructor(
         private readonly sdkFactories: AiSdkFactory.Interface[],
-        private readonly connectionFactories: AiConnectionFactory.Interface[]
+        private readonly connectionFactories: AiConnectionFactory.Interface[],
+        private readonly modelRegistry: AiModelRegistry.Interface
     ) {}
 
     generateText(params: AiGenerateTextParams): ReturnType<typeof generateText> {
@@ -47,31 +40,24 @@ class AiImpl implements AiAbstraction.Interface {
     }
 
     listModels(): Promise<AiModel[]> {
-        return Promise.resolve(
-            this.sdkFactories.flatMap(factory =>
-                factory.models.map(m => toAiModel(factory, m.id, m.name))
-            )
-        );
+        return this.modelRegistry.listModels();
     }
 
     async listModelsByConnections(): Promise<AiModel[]> {
-        const connections = await this.getConnections();
-        return connections.flatMap(conn => {
-            const factory = this.sdkFactories.find(f => f.id === conn.sdkName);
-            if (!factory) {
-                return [];
-            }
-            return factory.models.map(m => toAiModel(factory, m.id, m.name));
-        });
+        const [connections, models] = await Promise.all([
+            this.getConnections(),
+            this.modelRegistry.listModels()
+        ]);
+        const connectedProviderIds = new Set(connections.map(c => c.sdkName));
+        return models.filter(m => connectedProviderIds.has(m.providerId));
     }
 
     async listModelsByConnection(connection: string | IAiConnectionInline): Promise<AiModel[]> {
-        const conn = await this.resolveConnection(undefined, connection);
-        const factory = this.sdkFactories.find(f => f.id === conn.sdkName);
-        if (!factory) {
-            return [];
-        }
-        return factory.models.map(m => toAiModel(factory, m.id, m.name));
+        const [conn, models] = await Promise.all([
+            this.resolveConnection(undefined, connection),
+            this.modelRegistry.listModels()
+        ]);
+        return models.filter(m => m.providerId === conn.sdkName);
     }
 
     private async resolveLanguageModel(
@@ -86,11 +72,20 @@ class AiImpl implements AiAbstraction.Interface {
         }
 
         const providerId = modelId.slice(0, slashIndex);
-        const modelName = modelId.slice(slashIndex + 1);
+        const rawModelId = modelId.slice(slashIndex + 1);
+
+        // Validate the model is in the registry.
+        const models = await this.modelRegistry.listModels();
+        const found = models.some(m => m.providerId === providerId && m.modelId === rawModelId);
+        if (!found) {
+            throw new Error(
+                `Model "${modelId}" is not available. Use listModels() to see available models.`
+            );
+        }
 
         const conn = await this.resolveConnection(providerId, connection);
         const sdk = await this.getSdk(conn);
-        return sdk.languageModel(modelName);
+        return sdk.languageModel(rawModelId);
     }
 
     private async getConnections(): Promise<IAiConnection[]> {
@@ -163,6 +158,7 @@ export const Ai = createImplementation({
     implementation: AiImpl,
     dependencies: [
         [AiSdkFactory, { multiple: true }],
-        [AiConnectionFactory, { multiple: true }]
+        [AiConnectionFactory, { multiple: true }],
+        AiModelRegistry
     ]
 });

--- a/packages/api-core/src/features/ai/AiModelRegistry.ts
+++ b/packages/api-core/src/features/ai/AiModelRegistry.ts
@@ -1,0 +1,23 @@
+import { AiModelRegistry as AiModelRegistryAbstraction } from "./abstractions.js";
+import { AiSdkFactory } from "./abstractions.js";
+import type { AiModel } from "./abstractions.js";
+
+class AiModelRegistryImpl implements AiModelRegistryAbstraction.Interface {
+    constructor(private readonly sdkFactories: AiSdkFactory.Interface[]) {}
+
+    async listModels(): Promise<AiModel[]> {
+        return this.sdkFactories.flatMap(factory =>
+            factory.models.map(m => ({
+                providerId: factory.id,
+                providerName: factory.name,
+                modelId: m.id,
+                modelName: m.name
+            }))
+        );
+    }
+}
+
+export const AiModelRegistry = AiModelRegistryAbstraction.createImplementation({
+    implementation: AiModelRegistryImpl,
+    dependencies: [[AiSdkFactory, { multiple: true }]]
+});

--- a/packages/api-core/src/features/ai/abstractions.ts
+++ b/packages/api-core/src/features/ai/abstractions.ts
@@ -100,6 +100,19 @@ export namespace Ai {
     export type StreamTextParams = AiStreamTextParams;
 }
 
+// AiModelRegistry
+
+export interface IAiModelRegistry {
+    listModels(): Promise<AiModel[]>;
+}
+
+/** Single source of truth for available AI models. Decoratable to restrict the model list. */
+export const AiModelRegistry = createAbstraction<IAiModelRegistry>("AiModelRegistry");
+
+export namespace AiModelRegistry {
+    export type Interface = IAiModelRegistry;
+}
+
 // AiSdkTool
 
 export interface IAiSdkTool<TInput = any> {

--- a/packages/api-core/src/features/ai/feature.ts
+++ b/packages/api-core/src/features/ai/feature.ts
@@ -2,6 +2,7 @@ import { createFeature } from "@webiny/feature/api";
 import { OpenAiSdkFactory } from "./OpenAiSdkFactory.js";
 import { AnthropicSdkFactory } from "./AnthropicSdkFactory.js";
 import { Ai } from "./Ai.js";
+import { AiModelRegistry } from "./AiModelRegistry.js";
 import { AiSdkTools } from "./AiSdkTools.js";
 
 export const AiFeature = createFeature({
@@ -9,6 +10,7 @@ export const AiFeature = createFeature({
     register(container) {
         container.register(OpenAiSdkFactory);
         container.register(AnthropicSdkFactory);
+        container.register(AiModelRegistry);
         container.register(Ai);
         container.register(AiSdkTools);
     }

--- a/packages/api-core/src/features/ai/index.ts
+++ b/packages/api-core/src/features/ai/index.ts
@@ -3,6 +3,7 @@ export {
     AiSdkFactory,
     AiConnectionFactory,
     Ai,
+    AiModelRegistry,
     AiSdkTool,
     AiSdkTools
 } from "./abstractions.js";
@@ -10,6 +11,7 @@ export type {
     IAiConnection,
     IAiConnectionInline,
     AiModel,
+    IAiModelRegistry,
     IAiSdkModel,
     IAiSdkTool,
     IAiSdkTools

--- a/packages/webiny/package.json
+++ b/packages/webiny/package.json
@@ -142,7 +142,7 @@
     "./extensions": "./extensions.js",
     "./api/tenant-manager": "./api/tenant-manager.js"
   },
-  "exportGenerationHash": "434a334ff04710c6f26c7f16ade8557424aba921faab88607f8104fbb4e2a4ed",
+  "exportGenerationHash": "a2170e982658aa5dbd6cd9bbae94752a99c871e83cac3c73d8e2a0e23838cae3",
   "webiny": {
     "publishFrom": "dist"
   }

--- a/packages/webiny/src/api.ts
+++ b/packages/webiny/src/api.ts
@@ -2,9 +2,9 @@ export {
     AiSdk,
     AiSdkFactory,
     AiConnectionFactory,
-    Ai
+    Ai,
+    AiModelRegistry
 } from "@webiny/api-core/features/ai/index.js";
-export type { IAiConnection, IAiConnectionInline } from "@webiny/api-core/features/ai/index.js";
 export { Logger } from "@webiny/api-core/features/logger/index.js";
 export { Encryption } from "@webiny/api-core/features/encryption/index.js";
 export { BuildParam, BuildParams } from "@webiny/api-core/features/buildParams/index.js";


### PR DESCRIPTION
## Summary

- Extract a standalone `AiModelRegistry` abstraction from the `Ai` class so model listing is a decoratable, independently injectable concern
- `Ai` now delegates `listModels()`, `listModelsByConnections()`, and `listModelsByConnection()` to the registry
- `ProvidersHandler` validates preset models against the registry before persisting
- The GraphQL `listModels` resolver now resolves from `AiModelRegistry` directly instead of `Ai`
- Export `AiModelRegistry` from `@webiny/api-core` and `webiny` packages

## Test plan

- [ ] Verify `listModels` GraphQL query returns the same results as before
- [ ] Verify saving provider presets with an invalid model ID is rejected
- [ ] Verify `Ai.generateText` / `Ai.streamText` still work with valid model IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)