### PR TITLE
fix(ci): discover vitest test commands from the PR, not the base branch

### DIFF
--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -206,6 +206,13 @@ jobs:
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/vitest-comment.txt
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - id: list-vitest-test-commands
         name: List Vitest Test Commands
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -364,6 +371,13 @@ jobs:
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/vitest-comment.txt
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - id: list-vitest-test-commands
         name: List Vitest Test Commands
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -524,6 +538,13 @@ jobs:
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/vitest-comment.txt
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - id: list-vitest-test-commands
         name: List Vitest Test Commands
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -696,6 +717,13 @@ jobs:
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/vitest-comment.txt
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - id: list-vitest-test-commands
         name: List Vitest Test Commands
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
@@ -856,6 +884,13 @@ jobs:
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/vitest-comment.txt
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - id: list-vitest-test-commands
         name: List Vitest Test Commands
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}

--- a/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
@@ -160,6 +160,13 @@ const createVitestTestsJobs = (storageOps?: AbstractStorageOps) => {
             },
             steps: [
                 createMarkRunningStep(rowLabel),
+                // Test discovery reads `packages/` off disk, so it has to run against the PR's
+                // code. Without this the job kept the default `issue_comment` checkout (the
+                // default branch), and a PR that added a package, added the first tests to an
+                // existing one, or changed a package's testing/sharding config would have those
+                // changes silently ignored - while a PR that deleted a package would still get a
+                // test job for it.
+                ...createCheckoutPrSteps(),
                 {
                     id: "list-vitest-test-commands",
                     name: "List Vitest Test Commands",


### PR DESCRIPTION
### What changed

The `vitest-*-constants` jobs now check out the pull request before discovering test commands.

They previously had no `Checkout Pull Request` step, so they kept the checkout that `issue_comment` gives a job by default — **the default branch**. `listVitestTestCommands` reads `packages/` off disk and filters each package on `testingEnabled()`, `hasTests()` and its storage-ops config, so the test matrix was built from `next` while the tests themselves ran against the PR.

That silently dropped or corrupted scheduling whenever a PR changed the shape of the test suite:

| PR does this | What happened |
|---|---|
| adds a package with tests, or the first tests to an existing package | never discovered, so **never tested** |
| deletes a package | still discovered, so a job ran `yarn test packages/<gone>` and failed |
| changes `testingEnabled` or a package's storage ops | the base branch's value won |
| changes `vitestCiConfig.sharding.shardsCount` | matrix sharded on the old count, tests ran the new code |

The first row is the one that matters: a PR could add tests, get a green `/vitest`, and never have run them.

### The fix

Reuses the same `createCheckoutPrSteps()` that the `build` and `vitest-*-run` jobs already use, so discovery runs against the same pinned commit as the rest of the run (the SHA pinning added in #5554). It is placed *after* the "mark running" step so the PR comment still updates immediately instead of waiting on a checkout:

```
0  actions/setup-node@v5
1  actions/checkout@v5
2  Mark "No storage" as running
3  Checkout Pull Request
4  List Vitest Test Commands
```

### Verification

- All five `vitest-*-constants` jobs now check out the PR, and all have `baseBranch` as a direct need so `pr-sha` resolves (checked against the generated YAML).
- Audited both command workflows for the same class of bug — every job that touches the source now checks out the PR. The `/e2e` constants jobs already did.
- `oxfmt --check` and `oxlint` clean; generated YAML rebuilt from source.

### Cost

Five extra `gh pr checkout` calls, one per storage group, all running in parallel — roughly 20–30s each, and they overlap with the `build` job rather than extending the critical path.

### Changelog

**Test discovery now reflects the pull request**

Test runs triggered on a pull request decided which tests to run by looking at the base branch instead of the pull request itself. Tests newly added in a pull request could be skipped entirely while the run still reported success. Discovery now uses the pull request's own code.

### Squash Merge Commit

```
fix(ci): discover vitest test commands from the PR, not base branch (#5578)
```
