### PR TITLE
fix(ci): pin every job in an /alpha or /beta run to one commit

### DIFF
--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -55,6 +55,7 @@ jobs:
     name: Get PR branch
     outputs:
       pr-branch: ${{ steps.pr-branch.outputs.pr-branch }}
+      pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
       release-version: ${{ steps.release-version.outputs.release-version }}
     steps:
       - uses: actions/setup-node@v5
@@ -67,6 +68,14 @@ jobs:
         run: >-
           echo "pr-branch=$(gh pr view ${{ github.event.issue.number }} --repo
           ${{ github.repository }} --json headRefName -q .headRefName)" >>
+          $GITHUB_OUTPUT
+      - name: Get PR head SHA
+        id: pr-sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >-
+          echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{
+          github.repository }} --json headRefOid -q .headRefOid)" >>
           $GITHUB_OUTPUT
       - name: Parse release version from branch name
         id: release-version
@@ -98,7 +107,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
-          ref: ${{ needs.prBranch.outputs.pr-branch }}
+          ref: ${{ needs.prBranch.outputs.pr-sha }}
       - uses: actions/cache@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
@@ -147,7 +156,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
-          ref: ${{ needs.prBranch.outputs.pr-branch }}
+          ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -55,6 +55,7 @@ jobs:
     name: Get PR branch
     outputs:
       pr-branch: ${{ steps.pr-branch.outputs.pr-branch }}
+      pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
       release-version: ${{ steps.release-version.outputs.release-version }}
     steps:
       - uses: actions/setup-node@v5
@@ -67,6 +68,14 @@ jobs:
         run: >-
           echo "pr-branch=$(gh pr view ${{ github.event.issue.number }} --repo
           ${{ github.repository }} --json headRefName -q .headRefName)" >>
+          $GITHUB_OUTPUT
+      - name: Get PR head SHA
+        id: pr-sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >-
+          echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{
+          github.repository }} --json headRefOid -q .headRefOid)" >>
           $GITHUB_OUTPUT
       - name: Parse release version from branch name
         id: release-version
@@ -98,7 +107,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
-          ref: ${{ needs.prBranch.outputs.pr-branch }}
+          ref: ${{ needs.prBranch.outputs.pr-sha }}
       - uses: actions/cache@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
@@ -147,7 +156,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
-          ref: ${{ needs.prBranch.outputs.pr-branch }}
+          ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
       - uses: actions/cache@v5
         with:
@@ -234,7 +243,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
-          ref: ${{ needs.prBranch.outputs.pr-branch }}
+          ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
@@ -10,6 +10,10 @@ import {
 
 // The HEAD branch of the PR (e.g. "release/6.6.0") — used as checkout path and working dir.
 const PR_BRANCH = "${{ needs.prBranch.outputs.pr-branch }}";
+// The PR head commit, resolved once by the `prBranch` job. Used as the checkout ref so
+// every job in the run builds and publishes the exact same commit. `PR_BRANCH` stays the
+// checkout PATH (a stable, readable directory name) and the release-version source.
+const PR_SHA = "${{ needs.prBranch.outputs.pr-sha }}";
 const RELEASE_VERSION = "${{ needs.prBranch.outputs.release-version }}";
 
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: PR_BRANCH });
@@ -41,6 +45,7 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
             checkout: false,
             outputs: {
                 "pr-branch": "${{ steps.pr-branch.outputs.pr-branch }}",
+                "pr-sha": "${{ steps.pr-sha.outputs.pr-sha }}",
                 "release-version": "${{ steps.release-version.outputs.release-version }}"
             },
             steps: [
@@ -49,6 +54,15 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
                     id: "pr-branch",
                     env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
                     run: 'echo "pr-branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)" >> $GITHUB_OUTPUT'
+                },
+                {
+                    // Resolve the PR head ONCE so every job checks out the same commit. Checking
+                    // out by branch name re-resolves per job, and these jobs start minutes apart -
+                    // so a push mid-run could have us build one commit and publish another.
+                    name: "Get PR head SHA",
+                    id: "pr-sha",
+                    env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
+                    run: 'echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT'
                 },
                 {
                     name: "Parse release version from branch name",
@@ -65,7 +79,7 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
         build: createJob({
             name: "Build",
             needs: ["prBranch"],
-            checkout: { path: PR_BRANCH, ref: PR_BRANCH },
+            checkout: { path: PR_BRANCH, ref: PR_SHA },
             "runs-on": BUILD_PACKAGES_RUNNER,
             steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheUploadSteps]
         }),
@@ -77,7 +91,7 @@ export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
                 NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
                 SLACK_RELEASE_CHANNEL_WEBHOOK: "${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}"
             },
-            checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
+            checkout: { path: PR_BRANCH, ref: PR_SHA, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
                 ...runBuildCacheDownloadSteps,

--- a/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
@@ -10,6 +10,10 @@ import {
 
 // The HEAD branch of the PR (e.g. "release/6.3.0") — used as checkout path and working dir.
 const PR_BRANCH = "${{ needs.prBranch.outputs.pr-branch }}";
+// The PR head commit, resolved once by the `prBranch` job. Used as the checkout ref so
+// every job in the run builds and publishes the exact same commit. `PR_BRANCH` stays the
+// checkout PATH (a stable, readable directory name) and the release-version source.
+const PR_SHA = "${{ needs.prBranch.outputs.pr-sha }}";
 const RELEASE_VERSION = "${{ needs.prBranch.outputs.release-version }}";
 
 const installBuildSteps = createInstallBuildSteps({ workingDirectory: PR_BRANCH });
@@ -39,6 +43,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
             checkout: false,
             outputs: {
                 "pr-branch": "${{ steps.pr-branch.outputs.pr-branch }}",
+                "pr-sha": "${{ steps.pr-sha.outputs.pr-sha }}",
                 "release-version": "${{ steps.release-version.outputs.release-version }}"
             },
             steps: [
@@ -47,6 +52,15 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                     id: "pr-branch",
                     env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
                     run: 'echo "pr-branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)" >> $GITHUB_OUTPUT'
+                },
+                {
+                    // Resolve the PR head ONCE so every job checks out the same commit. Checking
+                    // out by branch name re-resolves per job, and these jobs start minutes apart -
+                    // so a push mid-run could have us build one commit and publish another.
+                    name: "Get PR head SHA",
+                    id: "pr-sha",
+                    env: { GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}" },
+                    run: 'echo "pr-sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid -q .headRefOid)" >> $GITHUB_OUTPUT'
                 },
                 {
                     name: "Parse release version from branch name",
@@ -63,7 +77,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
         build: createJob({
             name: "Build",
             needs: ["prBranch"],
-            checkout: { path: PR_BRANCH, ref: PR_BRANCH },
+            checkout: { path: PR_BRANCH, ref: PR_SHA },
             "runs-on": BUILD_PACKAGES_RUNNER,
             steps: [...yarnCacheSteps, ...installBuildSteps, ...runBuildCacheUploadSteps]
         }),
@@ -75,7 +89,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                 NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
                 SLACK_RELEASE_CHANNEL_WEBHOOK: "${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}"
             },
-            checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
+            checkout: { path: PR_BRANCH, ref: PR_SHA, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
                 ...runBuildCacheDownloadSteps,
@@ -134,7 +148,7 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                 NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
                 SLACK_RELEASE_CHANNEL_WEBHOOK: "${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}"
             },
-            checkout: { path: PR_BRANCH, ref: PR_BRANCH, "fetch-depth": 0 },
+            checkout: { path: PR_BRANCH, ref: PR_SHA, "fetch-depth": 0 },
             steps: [
                 ...yarnCacheSteps,
                 ...runBuildCacheDownloadSteps,


### PR DESCRIPTION
### What changed

The `/alpha` and `/beta` jobs now all check out the same commit.

They checked out by branch name — `ref: ${{ needs.prBranch.outputs.pr-branch }}` — which re-resolves the branch tip in *each* job. Jobs in one run start minutes apart, so a push landing mid-run meant the `build` job could produce its artifact from one commit while the release job published a different one.

This is the same class of bug fixed for `/vitest` and `/e2e` in #5554, but the consequences are worse here: the output is **published to NPM and tagged**, so a mixed run ships packages built from code that was never the released commit.

`prBranch` now resolves the head SHA once and exposes it as `pr-sha`; every job checks that out. `pr-branch` is still used as the checkout **path** (a readable directory name) and as the source of the release version parsed from `release/x.y.z`.

| Workflow | Jobs pinned |
|---|---|
| `/alpha` | `build`, `npmReleaseAlpha` |
| `/beta` | `build`, `npmReleaseBeta`, `npmReleaseLatest` |

### Why detaching HEAD is safe here

Checking out a SHA detaches HEAD, which would break a job that pushes to the branch. These jobs don't:

- `scripts/release/src/Release.ts` creates a tag and pushes **only that tag** (`git tag v<version>` then `git push origin <tag>`). Tagging works fine detached.
- Grepped the release scripts for any `git commit` / `git add` against the branch — there are none. Version bumps are written to `package.json` files and published, not committed back.
- `fetch-depth: 0` is preserved on all three release jobs, which need full history for tag discovery and changelog generation.

### Verification

- All five pinned checkouts have `prBranch` as a direct need, so `pr-sha` actually resolves (checked against the generated YAML — `needs` only exposes direct dependencies, which is what bit us in #5554).
- Re-ran the repo-wide audit for jobs referencing a `needs.<job>` they don't declare: only the three jobs in the frozen `v5_PullRequestsCommandJest` workflow remain, which is intentionally untouched.
- `oxfmt --check` and `oxlint` clean; generated YAML rebuilt from source.

### Changelog

**More reliable release commands**

The `/alpha` and `/beta` release commands could build one version of the code and publish another if the branch was updated while the command was still running. Each run is now pinned to a single commit.

### Squash Merge Commit

```
fix(ci): pin /alpha and /beta runs to a single commit (#5579)
```
