### PR TITLE
fix(ci): drop the run attempt from the build cache artifact name

### DIFF
--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -127,11 +127,12 @@ jobs:
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
           path: run-build-cache.tzst
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
+          overwrite: true
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -165,7 +166,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -127,11 +127,12 @@ jobs:
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
           path: run-build-cache.tzst
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
+          overwrite: true
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -165,7 +166,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -252,7 +253,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -158,11 +158,12 @@ jobs:
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
           path: run-build-cache.tzst
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
+          overwrite: true
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -254,7 +255,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -466,7 +467,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -164,11 +164,12 @@ jobs:
       - name: Upload build cache
         uses: actions/upload-artifact@v7
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
           path: run-build-cache.tzst
           retention-days: 1
           compression-level: 0
           if-no-files-found: error
+          overwrite: true
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -322,7 +323,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -489,7 +490,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -667,7 +668,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -835,7 +836,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
@@ -1004,7 +1005,7 @@ jobs:
       - name: Download build cache
         uses: actions/download-artifact@v8
         with:
-          name: run-build-cache-${{ github.run_attempt }}
+          name: run-build-cache
       - name: Extract build cache
         run: >-
           tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C

--- a/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
@@ -23,9 +23,13 @@ interface CreateRunBuildArtifactStepsParams {
 // both ways.
 const ARCHIVE = "run-build-cache.tzst";
 
-// Artifacts are already scoped to a single workflow run, so the attempt number is all that is
-// needed to keep re-runs from colliding with the previous attempt's upload.
-const ARTIFACT_NAME = "run-build-cache-${{ github.run_attempt }}";
+// Deliberately does NOT include `github.run_attempt`. Artifacts are scoped to a workflow run and
+// survive across its attempts, but "Re-run failed jobs" does NOT re-run the successful `build`
+// job - so an attempt-numbered name has the consumers looking for an artifact that was never
+// produced ("Artifact not found for name: run-build-cache-2"). A stable name lets a re-run of
+// failed jobs pick up the artifact the first attempt uploaded, and `overwrite: true` on the
+// upload lets a full re-run replace it instead of failing on the duplicate name.
+const ARTIFACT_NAME = "run-build-cache";
 
 const CACHED_PACKAGES = ".webiny/cached-packages";
 
@@ -53,7 +57,8 @@ export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifact
                 "retention-days": 1,
                 // The tarball is already zstd-compressed; re-deflating it only burns CPU.
                 "compression-level": 0,
-                "if-no-files-found": "error"
+                "if-no-files-found": "error",
+                overwrite: true
             }
         }
     ] as const;


### PR DESCRIPTION
### What changed

"Re-run failed jobs" was broken for every command workflow. Consumers failed immediately with:

```
##[error]Unable to download artifact(s): Artifact not found for name: run-build-cache-2
```

The artifact name included `github.run_attempt` (added in #5548) so a re-run could not collide with the previous attempt's upload. But **re-running only the failed jobs does not re-run the successful `build` job** — so nothing ever uploads `run-build-cache-<n>` for `n > 1`, and every consumer looks for an artifact that was never produced.

Confirmed on run `32242943220`, attempt 2, whose artifact list contains exactly one entry:

```
run-build-cache-1   expired=false   size=11553048
```

The artifact from attempt 1 was sitting right there, unexpired, under the name attempt 2 wasn't looking for.

### The fix

Artifacts are scoped to a workflow *run* and stay available across its attempts, so a stable name lets a re-run of failed jobs pick up what the first attempt uploaded.

`overwrite: true` covers the other direction: "Re-run all jobs" *does* re-run `build`, which would otherwise fail on the duplicate name. (Verified `overwrite` is a real input on `actions/upload-artifact@v7`.)

Applied through the shared `createRunBuildArtifactSteps` factory, so all four command workflows pick it up — 4 uploads and 10 downloads now agree on the name `run-build-cache`.

### Unrelated finding while verifying

The successful `/e2e` run `32239345423` shows the build cache is now working exactly as intended — **148/148 packages restored**, `Build packages` in 13s. The commit pinning from #5554 removed the source-drift that previously cost one package.

But the **yarn cache has never worked, in any workflow**:

```
Cache not found for input keys: yarn-Linux-d54f3ec1...
[warning] Path Validation Error: Path(s) specified in the action for caching do(es) not exist,
          hence no cache is being saved.
```

`createYarnCacheSteps` caches `<dir>/.yarn/cache`, but `.yarnrc.yml` sets `enableGlobalCache: true`, so yarn keeps its cache in the global folder and `<dir>/.yarn/cache` is never created. The step misses on restore and saves nothing on save, in every job — which is why `Install dependencies` costs ~88s every single run. I had previously attributed this warning to the empty-directory bug fixed in #5554; that was only part of the story, and this job resolves its directory correctly yet still fails. Worth its own PR.

### Changelog

**Fixed re-running failed CI jobs**

Re-running only the failed jobs of a test or release command failed immediately because the jobs could not find the build output from the original attempt. They now reuse it correctly.

### Squash Merge Commit

```
fix(ci): drop run attempt from build cache artifact name (#5580)
```
