### PR TITLE
fix(ci): cache Yarn's global cache folder, not `<dir>/.yarn/cache`

### DIFF
--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -75,9 +75,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -115,9 +119,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -157,9 +165,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -205,9 +217,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -239,9 +255,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn --immutable
@@ -316,9 +336,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -405,9 +429,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -503,9 +531,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -593,9 +625,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: ${{ github.base_ref }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.base_ref }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.base_ref }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -108,9 +108,13 @@ jobs:
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.prBranch.outputs.pr-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn --immutable
@@ -159,9 +163,13 @@ jobs:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.prBranch.outputs.pr-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -108,9 +108,13 @@ jobs:
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.prBranch.outputs.pr-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn --immutable
@@ -159,9 +163,13 @@ jobs:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.prBranch.outputs.pr-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -246,9 +254,13 @@ jobs:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.prBranch.outputs.pr-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.prBranch.outputs.pr-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -135,9 +135,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -248,9 +252,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -460,9 +468,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -141,9 +141,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -316,9 +320,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -483,9 +491,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -661,9 +673,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -829,9 +845,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8
@@ -998,9 +1018,13 @@ jobs:
           git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
         uses: actions/download-artifact@v8

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,9 +49,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -85,9 +89,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -130,9 +138,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -164,9 +176,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn --immutable
@@ -232,9 +248,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -312,9 +332,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -399,9 +423,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -480,9 +508,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -561,9 +593,13 @@ jobs:
         with:
           fetch-depth: 0
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -727,9 +763,13 @@ jobs:
         with:
           fetch-depth: 0
           path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: v6/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/rebuildGlobalCacheDev.yml
+++ b/.github/workflows/rebuildGlobalCacheDev.yml
@@ -39,9 +39,13 @@ jobs:
         with:
           path: dev
           ref: dev
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: dev
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: dev/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/rebuildGlobalCacheNext.yml
+++ b/.github/workflows/rebuildGlobalCacheNext.yml
@@ -39,9 +39,13 @@ jobs:
         with:
           path: next
           ref: next
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: next
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: next/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,13 @@ jobs:
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.event.inputs.branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.event.inputs.branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -99,9 +103,13 @@ jobs:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.event.inputs.branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.event.inputs.branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -151,9 +159,13 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.event.inputs.branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.event.inputs.branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/unstableRelease.yml
+++ b/.github/workflows/unstableRelease.yml
@@ -52,9 +52,13 @@ jobs:
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.event.inputs.branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.event.inputs.branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:
@@ -96,9 +100,13 @@ jobs:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ github.event.inputs.branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
-          path: ${{ github.event.inputs.branch }}/.yarn/cache
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/wac/steps/createYarnCacheSteps.ts
+++ b/.github/workflows/wac/steps/createYarnCacheSteps.ts
@@ -2,12 +2,29 @@ interface CreateYarnCacheStepsParams {
     workingDirectory: string;
 }
 
+// Caches Yarn's download cache between runs.
+//
+// The folder is resolved at runtime rather than hardcoded, because where Yarn keeps its cache
+// depends on configuration. `.yarnrc.yml` sets `enableGlobalCache: true`, so the cache lives in
+// the global folder (`~/.yarn/berry/cache`) and NOT in the project's `.yarn/cache`. This used to
+// point at `<workingDirectory>/.yarn/cache`, which stopped existing when `enableGlobalCache` was
+// added in #5336 (2026-06-29) - from then on every job missed the cache on restore and warned
+// "Path Validation Error: Path(s) specified in the action for caching do(es) not exist" on save,
+// so `yarn --immutable` re-downloaded every dependency on every run.
+//
+// Asking Yarn where its cache is keeps this correct if that setting is ever flipped back.
 export const createYarnCacheSteps = (params: CreateYarnCacheStepsParams) => {
     return [
         {
+            name: "Resolve Yarn cache folder",
+            id: "yarn-cache-folder",
+            "working-directory": params.workingDirectory,
+            run: 'echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT'
+        },
+        {
             uses: "actions/cache@v5",
             with: {
-                path: [params.workingDirectory, ".yarn/cache"].filter(Boolean).join("/"),
+                path: "${{ steps.yarn-cache-folder.outputs.path }}",
                 key: "yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}"
             }
         }


### PR DESCRIPTION
### What changed

`createYarnCacheSteps` cached `<workingDirectory>/.yarn/cache`. `enableGlobalCache` controls whether Yarn keeps downloaded package archives in the project (`.yarn/cache`) or in a machine-wide folder (`~/.yarn/berry/cache`), and **Yarn 4 defaults it to `true`** — so with it on, the project path is never created.

The repo pinned it to `false` explicitly until **2026-05-04**, when #5154 (`fix: package exports in package.json`) dropped that line and left it to the default. #5336 later re-added it as `enableGlobalCache: true` on 2026-06-29, which was a no-op — it only made the existing default explicit.

Since then every job missed the cache on restore and warned on save:

```
Cache not found for input keys: yarn-Linux-d54f3ec1...
[warning] Path Validation Error: Path(s) specified in the action for caching do(es) not exist,
          hence no cache is being saved.
```

So `yarn --immutable` re-downloaded every dependency on every run — about **88s per job, in every job of every workflow**.

The warning appears in jobs that resolve their working directory correctly, so it is not a leftover of the empty-directory bug fixed in #5554 — I had initially attributed it there, which was wrong.

One data point does not fit the 2026-05-04 story and is worth flagging rather than glossing: a 400 MB `yarn-Linux-*` entry on `refs/heads/next` was created **2026-06-19**, well after the setting changed. Nothing in `.github/` or `scripts/` overrides `enableGlobalCache`, so the likeliest explanation is a stale `.yarn/cache` directory left in the persistent workspace of the self-hosted `webiny-build-packages` runner. Either way it does not change what this PR fixes: the configured path is wrong for the current setting.

### The fix

Ask Yarn where its cache is, rather than hardcoding it:

```yaml
- name: Resolve Yarn cache folder
  id: yarn-cache-folder
  working-directory: <dir>
  run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
- uses: actions/cache@v5
  with:
    path: ${{ steps.yarn-cache-folder.outputs.path }}
    key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
```

Resolving it at runtime means this keeps working whichever way `enableGlobalCache` is set, instead of breaking silently when someone changes it — which is exactly how it broke this time, as a side effect of an unrelated PR.

**Confirmed working:** this PR's own CI run saved a 465 MB `yarn-Linux-*` cache entry on `refs/pull/5581/merge` — the first new Yarn cache entry the repo has produced in months.

### Scope

This is the widest change of the CI series so far: `createYarnCacheSteps` is shared, so it touches all 10 workflows that use it. The step logic itself is identical everywhere, and the cache key is unchanged.

Verified against the generated YAML:

- 40 jobs use these steps; in every one the resolve step comes **before** the cache step
- every one of those jobs has an `actions/checkout` whose `path` matches the resolve step's `working-directory`, so `yarn config get` always runs against a real checkout with `.yarnrc.yml` present
- `oxfmt --check` and `oxlint` clean

### Left alone

The cache key still uses `hashFiles('**/yarn.lock')`, which will also match any nested lockfile (test fixtures, generated projects). Worth tightening to the root lockfile in a follow-up, but changing the key would invalidate every existing entry, so it does not belong in the same change as fixing the path.

### Changelog

**Faster CI runs**

Continuous integration jobs were re-downloading every dependency on every run because their dependency cache pointed at a folder that no longer existed. The cache works again.

### Squash Merge Commit

```
fix(ci): cache Yarn's global cache folder (#5581)
```
