### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/assignMilestone.yml
+++ b/.github/workflows/assignMilestone.yml
@@ -32,7 +32,7 @@ jobs:
       BASE_REF: ${{ github.event.pull_request.base.ref }}
       CURRENT_MILESTONE: ${{ github.event.pull_request.milestone.title }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Assign milestone

--- a/.github/workflows/chromaticStorybook.yml
+++ b/.github/workflows/chromaticStorybook.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Default Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
 
       # Checkout the PR's head branch if it's a pull request; otherwise, use the branch on which the action is triggered manually.
       - name: Checkout the PR's head branch if it's a pull request; otherwise, use the branch on which the action is triggered manually.
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           # Conditionally checkout based on event type and use hub fetched branch if needed.
@@ -44,7 +44,7 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && github.ref_name || env.head_branch }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 24
 
@@ -57,7 +57,7 @@ jobs:
       # Run Chromatic Action
       - name: Run Chromatic
         id: chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@c93e0bc3a63aa176e14a75b61a31847cbfdd341c # v1
         with:
           # Chromatic projectToken, see https://storybook.js.org/tutorials/design-systems-for-developers/react/en/review/ to obtain it
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
 
       # Create or update a comment on PR with the Storybook URL
       - name: Comment on PR with Storybook URL
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,14 +15,14 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJsAdminAccess
           aws-region: eu-central-1
           role-duration-seconds: 7200
 
       # We need this step because of the `aws-nuke.yml` config which is stored in our repo.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Login to GHCR
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
@@ -43,7 +43,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2

--- a/.github/workflows/deleteReleaseBranch.yml
+++ b/.github/workflows/deleteReleaseBranch.yml
@@ -17,7 +17,7 @@ jobs:
       ${{ github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/') }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Delete branch

--- a/.github/workflows/fullRelease.yml
+++ b/.github/workflows/fullRelease.yml
@@ -24,7 +24,7 @@ jobs:
       VERSION: ${{ github.event.inputs.version }}
       SOURCE_TAG: ${{ github.event.inputs.sourceTag }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Validate workflow inputs
@@ -64,7 +64,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Set git email
@@ -72,7 +72,7 @@ jobs:
       - name: Set git username
         run: git config --global user.name "webiny-bot"
       - name: Checkout source tag
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           ref: ${{ github.event.inputs.sourceTag }}
           fetch-depth: 0
@@ -147,7 +147,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Trigger generate-release-notes workflow

--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -17,10 +17,10 @@ jobs:
       changed-packages: ${{ steps.detect-changed-packages.outputs.changed-packages }}
       latest-webiny-version: ${{ steps.latest-webiny-version.outputs.latest-webiny-version }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Create global cache key
         id: global-cache-key
         run: >-
@@ -39,7 +39,7 @@ jobs:
           "$GITHUB_OUTPUT"
       - name: Detect changed files
         id: detect-changed-files
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
         with:
           filters: |
             changed:
@@ -69,21 +69,21 @@ jobs:
     needs: constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -93,7 +93,7 @@ jobs:
       - name: Build packages
         run: yarn build --rebuild-dependents
         working-directory: ${{ github.base_ref }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -113,21 +113,21 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       WEBINY_INFRA_API_MAX_BUNDLE_SIZE: ${{ vars.WEBINY_INFRA_API_MAX_BUNDLE_SIZE }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -159,21 +159,21 @@ jobs:
       - constants
     name: Static code analysis
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -211,21 +211,21 @@ jobs:
       - build
     name: Static code analysis (verify dependencies)
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -249,17 +249,17 @@ jobs:
     name: Static code analysis (TypeScript)
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -283,10 +283,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - id: list-vitest-test-commands
@@ -330,21 +330,21 @@ jobs:
       AWS_REGION: eu-central-1
     if: needs.vitest-constants.outputs.vitest-test-commands != '[]'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -368,10 +368,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - id: list-vitest-test-commands
@@ -418,26 +418,27 @@ jobs:
       WEBINY_STORAGE: ddb
     if: needs.vitest-ddb-constants.outputs.vitest-test-commands != '[]'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -462,10 +463,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - id: list-vitest-test-commands
@@ -520,26 +521,27 @@ jobs:
       needs.vitest-ddb-os-constants.outputs.vitest-test-commands != '[]' &&
       needs.constants.outputs.is-fork-pr != 'true'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -564,10 +566,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - id: list-vitest-test-commands
@@ -614,26 +616,27 @@ jobs:
       WEBINY_STORAGE: sql,ddb
     if: needs.vitest-sql-constants.outputs.vitest-test-commands != '[]'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.base_ref }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ github.base_ref }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.base_ref }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}

--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Check permission and react to comment
@@ -39,7 +39,8 @@ jobs:
           content=eyes
       - name: Create comment
         id: create-comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: >-
+          peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -58,7 +59,7 @@ jobs:
       pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
       release-version: ${{ steps.release-version.outputs.release-version }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Get PR branch
@@ -101,10 +102,10 @@ jobs:
       - prBranch
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
@@ -112,7 +113,7 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -129,7 +130,7 @@ jobs:
         env:
           WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Upload build cache
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: run-build-cache
           path: run-build-cache.tzst
@@ -155,10 +156,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
@@ -167,12 +168,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Check permission and react to comment
@@ -39,7 +39,8 @@ jobs:
           content=eyes
       - name: Create comment
         id: create-comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: >-
+          peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -58,7 +59,7 @@ jobs:
       pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
       release-version: ${{ steps.release-version.outputs.release-version }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Get PR branch
@@ -101,10 +102,10 @@ jobs:
       - prBranch
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
@@ -112,7 +113,7 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -129,7 +130,7 @@ jobs:
         env:
           WEBINY_JS_DIR: ${{ needs.prBranch.outputs.pr-branch }}
       - name: Upload build cache
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: run-build-cache
           path: run-build-cache.tzst
@@ -155,10 +156,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
@@ -167,12 +168,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -246,10 +247,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_RELEASE_CHANNEL_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
@@ -258,12 +259,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       comment-id: ${{ steps.create-comment.outputs.comment-id }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Check permission and react to comment
@@ -41,7 +41,8 @@ jobs:
           content=eyes
       - name: Create comment
         id: create-comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: >-
+          peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -68,10 +69,10 @@ jobs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
       pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Get base branch
         id: base-branch
         env:
@@ -99,7 +100,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Create global cache key
@@ -122,10 +123,10 @@ jobs:
       - constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -139,11 +140,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -160,7 +161,7 @@ jobs:
         env:
           WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Upload build cache
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: run-build-cache
           path: run-build-cache.tzst
@@ -184,10 +185,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -234,15 +235,16 @@ jobs:
       WEBINY_PULUMI_BACKEND: ${{ needs.e2e-wby-cms-ddb-constants.outputs.pulumi-backend-url }}
       WEBINY_INFRA_API_MAX_BUNDLE_SIZE: ${{ vars.WEBINY_INFRA_API_MAX_BUNDLE_SIZE }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -256,12 +258,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -294,7 +296,7 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: yarn release --type=verdaccio
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: verdaccio-files-ddb
           retention-days: 1
@@ -317,7 +319,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: project-files-ddb
           retention-days: 1
@@ -395,10 +397,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -450,15 +452,16 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ github.run_id }}_
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -472,12 +475,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -510,7 +513,7 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: yarn release --type=verdaccio
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: verdaccio-files-ddb-os
           retention-days: 1
@@ -542,7 +545,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: project-files-ddb-os
           retention-days: 1

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       comment-id: ${{ steps.create-comment.outputs.comment-id }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Check permission and react to comment
@@ -41,7 +41,8 @@ jobs:
           content=eyes
       - name: Create comment
         id: create-comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: >-
+          peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -74,10 +75,10 @@ jobs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
       pr-sha: ${{ steps.pr-sha.outputs.pr-sha }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Get base branch
         id: base-branch
         env:
@@ -105,7 +106,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Create global cache key
@@ -128,10 +129,10 @@ jobs:
       - constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -145,11 +146,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -166,7 +167,7 @@ jobs:
         env:
           WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Upload build cache
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: run-build-cache
           path: run-build-cache.tzst
@@ -189,10 +190,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Mark "No storage" as running
@@ -239,7 +240,7 @@ jobs:
     name: Vitest (No storage) - Report status
     if: always() && needs.checkComment.result == 'success'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Report "No storage" result
@@ -307,10 +308,10 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       AWS_REGION: eu-central-1
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -324,12 +325,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -359,10 +360,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Mark "DDB" as running
@@ -408,7 +409,7 @@ jobs:
     name: Vitest (DDB) - Report status
     if: always() && needs.checkComment.result == 'success'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Report "DDB" result
@@ -478,10 +479,10 @@ jobs:
       AWS_REGION: eu-central-1
       WEBINY_STORAGE: ddb
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -495,12 +496,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -530,10 +531,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Mark "DDB+OS" as running
@@ -579,7 +580,7 @@ jobs:
     name: Vitest (DDB+OS) - Report status
     if: always() && needs.checkComment.result == 'success'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Report "DDB+OS" result
@@ -655,15 +656,16 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ matrix.testCommand.id }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -677,12 +679,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -713,10 +715,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Mark "SQL" as running
@@ -762,7 +764,7 @@ jobs:
     name: Vitest (SQL) - Report status
     if: always() && needs.checkComment.result == 'success'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Report "SQL" result
@@ -832,10 +834,10 @@ jobs:
       AWS_REGION: eu-central-1
       WEBINY_STORAGE: sql,ddb
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -849,12 +851,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -884,10 +886,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Mark "PGlite" as running
@@ -933,7 +935,7 @@ jobs:
     name: Vitest (PGlite) - Report status
     if: always() && needs.checkComment.result == 'success'
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Report "PGlite" result
@@ -1005,10 +1007,10 @@ jobs:
       WEBINY_STORAGE: sql,ddb
       WEBINY_SQL_CLIENT: pglite
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -1022,12 +1024,12 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Download build cache
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: run-build-cache
       - name: Extract build cache
@@ -1074,7 +1076,7 @@ jobs:
       R_SQL: ${{ needs.vitest-sql-run.result }}
       R_PGLITE: ${{ needs.vitest-pglite-run.result }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Heal PR comment and update PR description

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,10 +16,10 @@ jobs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
       run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Create global cache key
         id: global-cache-key
         run: >-
@@ -43,21 +43,21 @@ jobs:
     needs: constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -67,7 +67,7 @@ jobs:
       - name: Build packages
         run: yarn build --rebuild-dependents
         working-directory: v6
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -83,21 +83,21 @@ jobs:
       - constants
       - build
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -132,21 +132,21 @@ jobs:
       - build
     name: Static code analysis (verify dependencies)
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -170,17 +170,17 @@ jobs:
     name: Static code analysis (TypeScript)
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -203,10 +203,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - id: list-vitest-test-commands
@@ -242,21 +242,21 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       AWS_REGION: eu-central-1
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -279,10 +279,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - id: list-vitest-test-commands
@@ -321,26 +321,27 @@ jobs:
       AWS_REGION: eu-central-1
       WEBINY_STORAGE: ddb
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -364,10 +365,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - id: list-vitest-test-commands
@@ -412,26 +413,27 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ matrix.testCommand.id }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -455,10 +457,10 @@ jobs:
     outputs:
       vitest-test-commands: ${{ steps.list-vitest-test-commands.outputs.vitest-test-commands }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - id: list-vitest-test-commands
@@ -497,26 +499,27 @@ jobs:
       AWS_REGION: eu-central-1
       WEBINY_STORAGE: sql,ddb
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: v6
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -541,10 +544,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: List Cypress tests folders
         id: list-cypress-folders
         run: >-
@@ -581,15 +584,16 @@ jobs:
       WEBINY_PULUMI_BACKEND: ${{ needs.e2eTests-ddb-constants.outputs.pulumi-backend-url }}
       WEBINY_INFRA_API_MAX_BUNDLE_SIZE: ${{ vars.WEBINY_INFRA_API_MAX_BUNDLE_SIZE }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
           path: v6
@@ -597,11 +601,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -629,7 +633,7 @@ jobs:
         run: yarn release --type=verdaccio
         working-directory: v6
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: verdaccio-files-ddb
           retention-days: 1
@@ -651,7 +655,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: project-files-ddb
           retention-days: 1
@@ -706,10 +710,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: List Cypress tests folders
         id: list-cypress-folders
         run: >-
@@ -751,15 +755,16 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ github.run_id }}_
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: >-
+          aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           fetch-depth: 0
           path: v6
@@ -767,11 +772,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: v6
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: v6/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -799,7 +804,7 @@ jobs:
         run: yarn release --type=verdaccio
         working-directory: v6
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: verdaccio-files-ddb-os
           retention-days: 1
@@ -830,7 +835,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: project-files-ddb-os
           retention-days: 1

--- a/.github/workflows/pushReleaseBranch.yml
+++ b/.github/workflows/pushReleaseBranch.yml
@@ -18,7 +18,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Check for open docs PR and trigger release notes regeneration

--- a/.github/workflows/rebuildGlobalCacheDev.yml
+++ b/.github/workflows/rebuildGlobalCacheDev.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Create global cache key
@@ -32,10 +32,10 @@ jobs:
     name: Cache dependencies and packages
     needs: constants
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: dev
           ref: dev
@@ -43,11 +43,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: dev
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: dev/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}

--- a/.github/workflows/rebuildGlobalCacheNext.yml
+++ b/.github/workflows/rebuildGlobalCacheNext.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
       - name: Create global cache key
@@ -32,10 +32,10 @@ jobs:
     name: Cache dependencies and packages
     needs: constants
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: next
           ref: next
@@ -43,11 +43,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: next
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: next/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -58,21 +58,21 @@ jobs:
         run: yarn build
         working-directory: next
       - name: Upload build cache artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: build-cache
           retention-days: 1
           include-hidden-files: true
           path: next/.webiny/cached-packages
       - name: Upload yarn cache artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: yarn-cache
           retention-days: 1
           include-hidden-files: true
           path: next/.yarn/cache
       - name: Upload packages artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: packages
           retention-days: 1

--- a/.github/workflows/rebuildGlobalCacheV5.yml
+++ b/.github/workflows/rebuildGlobalCacheV5.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Create global cache key
@@ -29,18 +29,18 @@ jobs:
     name: Cache dependencies and packages
     needs: constants
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: v5-dev
           ref: v5-dev
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5-dev/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5-dev/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
       run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Create global cache key
         id: global-cache-key
         run: >-
@@ -48,10 +48,10 @@ jobs:
     needs: constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
@@ -59,11 +59,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ github.event.inputs.branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -73,7 +73,7 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ github.event.inputs.branch }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -95,10 +95,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       BETA_VERSION: ${{ vars.BETA_VERSION }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
@@ -107,11 +107,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ github.event.inputs.branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -150,10 +150,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       LATEST_VERSION: ${{ vars.LATEST_VERSION }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
@@ -163,11 +163,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ github.event.inputs.branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}

--- a/.github/workflows/slopCop.yml
+++ b/.github/workflows/slopCop.yml
@@ -29,10 +29,10 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ANTHROPIC_MODEL: claude-sonnet-5
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Gather PR signals
         run: >-
           set -euo pipefail

--- a/.github/workflows/unstableRelease.yml
+++ b/.github/workflows/unstableRelease.yml
@@ -18,10 +18,10 @@ jobs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
       run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Create global cache key
         id: global-cache-key
         run: >-
@@ -45,10 +45,10 @@ jobs:
     needs: constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
@@ -56,11 +56,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ github.event.inputs.branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -70,7 +70,7 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ github.event.inputs.branch }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -92,10 +92,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       UNSTABLE_VERSION: ${{ vars.UNSTABLE_VERSION }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           path: ${{ github.event.inputs.branch }}
           ref: ${{ github.event.inputs.branch }}
@@ -104,11 +104,11 @@ jobs:
         id: yarn-cache-folder
         working-directory: ${{ github.event.inputs.branch }}
         run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ steps.yarn-cache-folder.outputs.path }}
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ${{ github.event.inputs.branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}

--- a/.github/workflows/v5_PullRequestsCommandCypress.yml
+++ b/.github/workflows/v5_PullRequestsCommandCypress.yml
@@ -12,12 +12,12 @@ jobs:
     name: Check comment for /v5_cypress
     if: ${{ github.event.issue.pull_request }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Check for Command
         id: command
-        uses: xt0rted/slash-command-action@v2
+        uses: xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           command: v5_cypress
@@ -26,7 +26,7 @@ jobs:
           allow-edits: 'false'
           permission-level: write
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -43,10 +43,10 @@ jobs:
     outputs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Get base branch
         id: base-branch
         env:
@@ -65,7 +65,7 @@ jobs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
       run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Create global cache key
@@ -90,10 +90,10 @@ jobs:
       - constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -101,11 +101,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -115,7 +115,7 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -132,10 +132,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -175,15 +175,15 @@ jobs:
       PULUMI_SECRETS_PROVIDER: ${{ secrets.PULUMI_SECRETS_PROVIDER }}
       WEBINY_PULUMI_BACKEND: ${{ needs.e2e-wby-cms-ddb-constants.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -191,11 +191,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -223,7 +223,7 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: yarn release --type=verdaccio
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: verdaccio-files-ddb
           retention-days: 1
@@ -246,7 +246,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: project-files-ddb
           retention-days: 1
@@ -316,10 +316,10 @@ jobs:
       PULUMI_SECRETS_PROVIDER: ${{ secrets.PULUMI_SECRETS_PROVIDER }}
       WEBINY_PULUMI_BACKEND: ${{ needs.e2e-wby-cms-ddb-constants.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -327,11 +327,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -364,10 +364,10 @@ jobs:
       cypress-folders: ${{ steps.list-cypress-folders.outputs.cypress-folders }}
       pulumi-backend-url: ${{ steps.pulumi-backend-url.outputs.pulumi-backend-url }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -412,15 +412,15 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.V5_OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ github.run_id }}_
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -428,11 +428,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -460,7 +460,7 @@ jobs:
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
         run: yarn release --type=verdaccio
       - name: Create verdaccio-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: verdaccio-files-ddb-os
           retention-days: 1
@@ -483,7 +483,7 @@ jobs:
         working-directory: new-webiny-project
         run: yarn webiny --version
       - name: Create project-files artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: project-files-ddb-os
           retention-days: 1
@@ -559,10 +559,10 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.V5_OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ github.run_id }}_
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -570,11 +570,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}

--- a/.github/workflows/v5_PullRequestsCommandJest.yml
+++ b/.github/workflows/v5_PullRequestsCommandJest.yml
@@ -12,12 +12,12 @@ jobs:
     name: Check comment for /v5_jest
     if: ${{ github.event.issue.pull_request }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Check for Command
         id: command
-        uses: xt0rted/slash-command-action@v2
+        uses: xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88 # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           command: v5_jest
@@ -26,7 +26,7 @@ jobs:
           allow-edits: 'false'
           permission-level: write
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
         with:
           issue-number: ${{ github.event.issue.number }}
           body: >-
@@ -43,10 +43,10 @@ jobs:
     outputs:
       base-branch: ${{ steps.base-branch.outputs.base-branch }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Get base branch
         id: base-branch
         env:
@@ -65,7 +65,7 @@ jobs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
       run-cache-key: ${{ steps.run-cache-key.outputs.run-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Create global cache key
@@ -90,10 +90,10 @@ jobs:
       - constants
     runs-on: webiny-build-packages
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -101,11 +101,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}
@@ -115,7 +115,7 @@ jobs:
       - name: Build packages
         run: yarn build
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -144,10 +144,10 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       AWS_REGION: eu-central-1
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -155,11 +155,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -212,10 +212,10 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       AWS_REGION: eu-central-1
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -223,11 +223,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}
@@ -289,15 +289,15 @@ jobs:
       OPENSEARCH_PASSWORD: ${{ secrets.V5_OPENSEARCH_PASSWORD }}
       OPENSEARCH_INDEX_PREFIX: ${{ matrix.package.id }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6.0.0
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: arn:aws:iam::726952677045:role/GitHubActionsWebinyJs
           aws-region: eu-central-1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Checkout Pull Request
@@ -305,11 +305,11 @@ jobs:
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ needs.baseBranch.outputs.base-branch }}/.webiny/cached-packages
           key: ${{ needs.constants.outputs.run-cache-key }}

--- a/.github/workflows/v5_customRelease.yml
+++ b/.github/workflows/v5_customRelease.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: webiny-build-packages
     environment: release
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.client_payload.branch }}
           fetch-depth: 0

--- a/.github/workflows/v5_rebuildGlobalCacheDev.yml
+++ b/.github/workflows/v5_rebuildGlobalCacheDev.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Create global cache key
@@ -29,18 +29,18 @@ jobs:
     name: Cache dependencies and packages
     needs: constants
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: v5_dev
           ref: v5_dev
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5_dev/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5_dev/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}

--- a/.github/workflows/v5_rebuildGlobalCacheNext.yml
+++ b/.github/workflows/v5_rebuildGlobalCacheNext.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       global-cache-key: ${{ steps.global-cache-key.outputs.global-cache-key }}
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
       - name: Create global cache key
@@ -29,18 +29,18 @@ jobs:
     name: Cache dependencies and packages
     needs: constants
     steps:
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: v5_next
           ref: v5_next
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5_next/.yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: v5_next/.webiny/cached-packages
           key: ${{ needs.constants.outputs.global-cache-key }}

--- a/.github/workflows/versionApproval.yml
+++ b/.github/workflows/versionApproval.yml
@@ -19,11 +19,11 @@ jobs:
       day: ${{ steps.get-day.outputs.day }}
       ts: ${{ steps.get-timestamp.outputs.ts }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Get day of the month
         id: get-day
@@ -39,19 +39,19 @@ jobs:
     outputs:
       version: ${{ steps.determine-release-version.outputs.version }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: yarn-cache
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: global-daily-packages-cache
         with:
           path: .webiny/cached-packages
@@ -63,7 +63,7 @@ jobs:
       - name: Build packages
         run: yarn build:quick
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .webiny/cached-packages
           key: packages-cache-${{ needs.init.outputs.ts }}
@@ -85,6 +85,6 @@ jobs:
     runs-on: webiny-build-packages
     environment: release
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24

--- a/.github/workflows/wac/fullRelease.wac.ts
+++ b/.github/workflows/wac/fullRelease.wac.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "./utils/index.js";
 import { createWorkflow } from "github-actions-wac";
 import { createJob } from "./jobs/index.js";
 
@@ -73,7 +74,7 @@ export const fullRelease = createWorkflow({
                 },
                 {
                     name: "Checkout source tag",
-                    uses: "actions/checkout@v5",
+                    uses: ACTION.checkout,
                     with: {
                         ref: SOURCE_TAG,
                         "fetch-depth": 0,

--- a/.github/workflows/wac/jobs/createJob.ts
+++ b/.github/workflows/wac/jobs/createJob.ts
@@ -1,5 +1,5 @@
 import { NormalJob } from "github-actions-wac";
-import { NODE_VERSION, AWS_REGION, NODE_OPTIONS } from "../utils/index.js";
+import { ACTION, AWS_REGION, NODE_OPTIONS, NODE_VERSION } from "../utils/index.js";
 
 interface CreateJobParams extends Partial<NormalJob> {
     awsAuth?: boolean;
@@ -11,7 +11,7 @@ export const createJob = (params: CreateJobParams): NormalJob => {
     const { awsAuth, checkout, setupNode, ...jobParams } = params;
 
     let setupNodeStep: Record<string, any> = {
-        uses: "actions/setup-node@v5",
+        uses: ACTION.setupNode,
         with: { "node-version": NODE_VERSION }
     };
 
@@ -60,7 +60,7 @@ export const createJob = (params: CreateJobParams): NormalJob => {
     if (awsAuth) {
         job.steps!.push({
             name: "Configure AWS Credentials",
-            uses: "aws-actions/configure-aws-credentials@v6.0.0",
+            uses: ACTION.configureAwsCredentials,
             with: {
                 "role-to-assume": "arn:aws:iam::726952677045:role/GitHubActionsWebinyJs",
                 "aws-region": AWS_REGION
@@ -70,9 +70,9 @@ export const createJob = (params: CreateJobParams): NormalJob => {
 
     if (checkout !== false) {
         if (typeof checkout === "object") {
-            job.steps!.push({ uses: "actions/checkout@v5", with: checkout });
+            job.steps!.push({ uses: ACTION.checkout, with: checkout });
         } else {
-            job.steps!.push({ uses: "actions/checkout@v5" });
+            job.steps!.push({ uses: ACTION.checkout });
         }
     }
 

--- a/.github/workflows/wac/jobs/createSlashCommandWorkflow.ts
+++ b/.github/workflows/wac/jobs/createSlashCommandWorkflow.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "../utils/index.js";
 import { createWorkflow } from "github-actions-wac";
 import { createJob } from "./createJob.js";
 import { checkCommandStep, commandTriggeredIf } from "./checkCommand.js";
@@ -46,7 +47,7 @@ export const createSlashCommandWorkflow = (params: CreateSlashCommandWorkflowPar
             {
                 name: "Create comment",
                 id: "create-comment",
-                uses: "peter-evans/create-or-update-comment@v5",
+                uses: ACTION.createOrUpdateComment,
                 with: {
                     "issue-number": "${{ github.event.issue.number }}",
                     body: comment

--- a/.github/workflows/wac/pullRequests.wac.ts
+++ b/.github/workflows/wac/pullRequests.wac.ts
@@ -1,11 +1,12 @@
 import { createWorkflow, NormalJob } from "github-actions-wac";
 import { createJob } from "./jobs/index.js";
 import {
-    NODE_VERSION,
-    BUILD_PACKAGES_RUNNER,
+    ACTION,
     AWS_REGION,
-    runNodeScript,
-    addToOutputs
+    BUILD_PACKAGES_RUNNER,
+    NODE_VERSION,
+    addToOutputs,
+    runNodeScript
 } from "./utils/index.js";
 import {
     createGlobalBuildCacheSteps,
@@ -168,7 +169,7 @@ export const pullRequests = createWorkflow({
                 {
                     name: "Detect changed files",
                     id: "detect-changed-files",
-                    uses: "dorny/paths-filter@v4",
+                    uses: ACTION.pathsFilter,
                     with: {
                         filters: "changed:\n  - 'packages/**/*'\n",
                         "list-files": "json"

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -9,7 +9,7 @@ import {
     createYarnCacheSteps,
     withCommonParams
 } from "./steps/index.js";
-import { AWS_REGION, BUILD_PACKAGES_RUNNER, NODE_OPTIONS } from "./utils/index.js";
+import { ACTION, AWS_REGION, BUILD_PACKAGES_RUNNER, NODE_OPTIONS } from "./utils/index.js";
 import { createJob, createSlashCommandWorkflow } from "./jobs/index.js";
 
 // Will print "next" or "dev". Important for caching (via actions/cache).
@@ -118,7 +118,7 @@ const createCypressJobs = (dbSetup: string) => {
             },
             {
                 name: "Create verdaccio-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: ACTION.uploadArtifactV6,
                 with: {
                     name: `verdaccio-files-${dbSetup}`,
                     "retention-days": 1,
@@ -153,7 +153,7 @@ const createCypressJobs = (dbSetup: string) => {
             },
             {
                 name: "Create project-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: ACTION.uploadArtifactV6,
                 with: {
                     name: `project-files-${dbSetup}`,
                     "retention-days": 1,

--- a/.github/workflows/wac/push.wac.ts
+++ b/.github/workflows/wac/push.wac.ts
@@ -1,5 +1,11 @@
 import { createWorkflow, NormalJob } from "github-actions-wac";
-import { AWS_REGION, BUILD_PACKAGES_RUNNER, NODE_VERSION, runNodeScript } from "./utils/index.js";
+import {
+    ACTION,
+    AWS_REGION,
+    BUILD_PACKAGES_RUNNER,
+    NODE_VERSION,
+    runNodeScript
+} from "./utils/index.js";
 import { createJob } from "./jobs/index.js";
 import {
     createDeployWebinySteps,
@@ -113,7 +119,7 @@ const createE2EJobs = (storageOps: AbstractStorageOps) => {
             ),
             {
                 name: "Create verdaccio-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: ACTION.uploadArtifactV6,
                 with: {
                     name: `verdaccio-files-${storageOps.shortId}`,
                     "retention-days": 1,
@@ -148,7 +154,7 @@ const createE2EJobs = (storageOps: AbstractStorageOps) => {
             },
             {
                 name: "Create project-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: ACTION.uploadArtifactV6,
                 with: {
                     name: `project-files-${storageOps.shortId}`,
                     "retention-days": 1,

--- a/.github/workflows/wac/rebuildGlobalCache.wac.ts
+++ b/.github/workflows/wac/rebuildGlobalCache.wac.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "./utils/index.js";
 import { createJob } from "./jobs/index.js";
 import {
     createGlobalBuildCacheSteps,
@@ -38,7 +39,7 @@ const createRebuildGlobalCacheWorkflow = (branchName: string) => ({
                     ? [
                           {
                               name: "Upload build cache artifact",
-                              uses: "actions/upload-artifact@v6",
+                              uses: ACTION.uploadArtifactV6,
                               with: {
                                   name: "build-cache",
                                   "retention-days": 1,
@@ -48,7 +49,7 @@ const createRebuildGlobalCacheWorkflow = (branchName: string) => ({
                           },
                           {
                               name: "Upload yarn cache artifact",
-                              uses: "actions/upload-artifact@v6",
+                              uses: ACTION.uploadArtifactV6,
                               with: {
                                   name: "yarn-cache",
                                   "retention-days": 1,
@@ -58,7 +59,7 @@ const createRebuildGlobalCacheWorkflow = (branchName: string) => ({
                           },
                           {
                               name: "Upload packages artifact",
-                              uses: "actions/upload-artifact@v6",
+                              uses: ACTION.uploadArtifactV6,
                               with: {
                                   name: "packages",
                                   "retention-days": 1,

--- a/.github/workflows/wac/steps/createGlobalBuildCacheSteps.ts
+++ b/.github/workflows/wac/steps/createGlobalBuildCacheSteps.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "../utils/index.js";
 interface CreateGlobalBuildCacheStepsParams {
     workingDirectory: string;
 }
@@ -5,7 +6,7 @@ interface CreateGlobalBuildCacheStepsParams {
 export const createGlobalBuildCacheSteps = (params: CreateGlobalBuildCacheStepsParams) => {
     return [
         {
-            uses: "actions/cache@v5",
+            uses: ACTION.cache,
             with: {
                 path: [params.workingDirectory, ".webiny/cached-packages"]
                     .filter(Boolean)

--- a/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildArtifactSteps.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "../utils/index.js";
 interface CreateRunBuildArtifactStepsParams {
     workingDirectory: string;
 }
@@ -50,7 +51,7 @@ export const createRunBuildArtifactUploadSteps = (params: CreateRunBuildArtifact
         },
         {
             name: "Upload build cache",
-            uses: "actions/upload-artifact@v7",
+            uses: ACTION.uploadArtifact,
             with: {
                 name: ARTIFACT_NAME,
                 path: ARCHIVE,
@@ -68,7 +69,7 @@ export const createRunBuildArtifactDownloadSteps = (params: CreateRunBuildArtifa
     return [
         {
             name: "Download build cache",
-            uses: "actions/download-artifact@v8",
+            uses: ACTION.downloadArtifact,
             with: { name: ARTIFACT_NAME }
         },
         {

--- a/.github/workflows/wac/steps/createRunBuildCacheSteps.ts
+++ b/.github/workflows/wac/steps/createRunBuildCacheSteps.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "../utils/index.js";
 interface CreateRunBuildCacheStepsParams {
     workingDirectory: string;
 }
@@ -5,7 +6,7 @@ interface CreateRunBuildCacheStepsParams {
 export const createRunBuildCacheSteps = (params: CreateRunBuildCacheStepsParams) => {
     return [
         {
-            uses: "actions/cache@v5",
+            uses: ACTION.cache,
             with: {
                 path: [params.workingDirectory, ".webiny/cached-packages"]
                     .filter(Boolean)

--- a/.github/workflows/wac/steps/createYarnCacheSteps.ts
+++ b/.github/workflows/wac/steps/createYarnCacheSteps.ts
@@ -1,3 +1,4 @@
+import { ACTION } from "../utils/index.js";
 interface CreateYarnCacheStepsParams {
     workingDirectory: string;
 }
@@ -22,7 +23,7 @@ export const createYarnCacheSteps = (params: CreateYarnCacheStepsParams) => {
             run: 'echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT'
         },
         {
-            uses: "actions/cache@v5",
+            uses: ACTION.cache,
             with: {
                 path: "${{ steps.yarn-cache-folder.outputs.path }}",
                 key: "yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}"

--- a/.github/workflows/wac/utils/actions.ts
+++ b/.github/workflows/wac/utils/actions.ts
@@ -1,0 +1,33 @@
+// Third-party GitHub Actions, pinned to commit SHAs rather than tags.
+//
+// A tag is mutable: whoever controls the action's repository can repoint `v5` at new code, and
+// every workflow in this repo would run it on the next push - with our secrets and a writable
+// token. Pinning to a SHA means an action's code can only change when someone changes it here,
+// in a reviewable diff.
+//
+// Keep the version in the trailing comment up to date when bumping. Generated YAML cannot carry
+// comments, so this file is the only place the human-readable version is recorded.
+//
+// To bump one: `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`
+export const ACTION = {
+    // actions/checkout v5
+    checkout: "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09",
+    // actions/setup-node v5
+    setupNode: "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444",
+    // actions/cache v5
+    cache: "actions/cache@caa296126883cff596d87d8935842f9db880ef25",
+    // actions/upload-artifact v6
+    uploadArtifactV6: "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+    // actions/upload-artifact v7
+    uploadArtifact: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    // actions/download-artifact v8
+    downloadArtifact: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    // aws-actions/configure-aws-credentials v6.0.0
+    configureAwsCredentials:
+        "aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7",
+    // peter-evans/create-or-update-comment v5
+    createOrUpdateComment:
+        "peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9",
+    // dorny/paths-filter v4
+    pathsFilter: "dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d"
+} as const;

--- a/.github/workflows/wac/utils/index.ts
+++ b/.github/workflows/wac/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./actions";
 export * from "./constants";
 export * from "./runNodeScript";
 export * from "./addToOutputs";

--- a/.github/workflows/wac/v5_pullRequestsCommandCypress.wac.frozen.ts
+++ b/.github/workflows/wac/v5_pullRequestsCommandCypress.wac.frozen.ts
@@ -128,7 +128,7 @@ const createCypressJobs = (dbSetup: string) => {
             },
             {
                 name: "Create verdaccio-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
                 with: {
                     name: `verdaccio-files-${dbSetup}`,
                     "retention-days": 1,
@@ -154,7 +154,7 @@ const createCypressJobs = (dbSetup: string) => {
             },
             {
                 name: "Create project-files artifact",
-                uses: "actions/upload-artifact@v6",
+                uses: "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
                 with: {
                     name: `project-files-${dbSetup}`,
                     "retention-days": 1,
@@ -256,7 +256,7 @@ export const v5_PullRequestsCommandCypress = createWorkflow({
                 {
                     name: "Check for Command",
                     id: "command",
-                    uses: "xt0rted/slash-command-action@v2",
+                    uses: "xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88",
                     with: {
                         "repo-token": "${{ secrets.GITHUB_TOKEN }}",
                         command: "v5_cypress",
@@ -268,7 +268,7 @@ export const v5_PullRequestsCommandCypress = createWorkflow({
                 },
                 {
                     name: "Create comment",
-                    uses: "peter-evans/create-or-update-comment@v2",
+                    uses: "peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d",
                     with: {
                         "issue-number": "${{ github.event.issue.number }}",
                         body: "Cypress E2E tests have been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:"

--- a/.github/workflows/wac/v5_pullRequestsCommandJest.wac.frozen.ts
+++ b/.github/workflows/wac/v5_pullRequestsCommandJest.wac.frozen.ts
@@ -94,7 +94,7 @@ export const v5_PullRequestsCommandJest = createWorkflow({
                 {
                     name: "Check for Command",
                     id: "command",
-                    uses: "xt0rted/slash-command-action@v2",
+                    uses: "xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88",
                     with: {
                         "repo-token": "${{ secrets.GITHUB_TOKEN }}",
                         command: "v5_jest",
@@ -106,7 +106,7 @@ export const v5_PullRequestsCommandJest = createWorkflow({
                 },
                 {
                     name: "Create comment",
-                    uses: "peter-evans/create-or-update-comment@v2",
+                    uses: "peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d",
                     with: {
                         "issue-number": "${{ github.event.issue.number }}",
                         body: "Jest tests have been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:"


### PR DESCRIPTION
### What changed

Every GitHub Action reference is now a commit SHA instead of a tag.

Tags are mutable. Whoever controls an action's repository can repoint `v5` at new code, and every workflow here would run it on the next push — with our secrets and, since we now grant them explicitly, a writable token. Pinning to a SHA means an action's code can only change when someone changes it *in this repo*, in a reviewable diff.

**359 `uses:` across all 25 workflows, 19 distinct actions, all pinned. No version changes** — every SHA is the commit its previous tag already pointed at.

### Three mechanisms

The workflows have three different provenances, so pinning them took three approaches:

| Provenance | Files | How |
|---|---|---|
| wac-managed | the active workflows | new `wac/utils/actions.ts` holds pinned refs as named constants; job/step factories reference them |
| hand-written | `chromaticStorybook`, `cleanup`, `codeql-analysis`, `v5_customRelease`, `versionApproval` | pinned in YAML directly, with a `# vX` comment |
| frozen v5 | no longer emitted by ghawac | pinned in the YAML **and** in the `.wac.frozen.ts` sources, so re-enabling one cannot silently unpin it |

Generated YAML cannot carry comments, so `wac/utils/actions.ts` is the only place the human-readable version is recorded. Keep its trailing comments current when bumping:

```ts
// actions/checkout v5
checkout: "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09",
```

To bump one: `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`

### Verification

- Parsed all 25 workflows with a YAML parser: every `uses:` matches `^[^@]+@[0-9a-f]{40}$`. 359 total, **0 unpinned**.
- Re-resolved all 17 `repo@tag` pairs against the GitHub API and confirmed each matches the SHA committed here.
- Four of them independently corroborated against `Download action repository ... (SHA:...)` lines in real run logs — `checkout@v5` `fbc6f399…`, `setup-node@v5` `a0853c24…`, `cache@v5` `caa29612…`, `download-artifact@v8` `3e5f45b2…`.
- Diff contains only action refs, the new constants file, and import reordering. Long SHA refs line-wrap in the generated YAML, which the parser check confirms is harmless.
- `oxfmt --check` and `oxlint` clean; generated YAML rebuilt from source.

### Deliberately not in this PR

Several actions are behind: `checkout` v4, `setup-node` v3/v4, `cache` v4, `upload-artifact` v6, `codeql-action` v2, `create-or-update-comment` v2, and the dead `xt0rted/slash-command-action` still referenced by the frozen v5 workflows. Bumping them changes behaviour; pinning does not. Mixing the two would make a 359-line mechanical diff impossible to review, so the bumps belong in their own PR.

### Changelog

**Supply-chain hardening for CI**

All third-party GitHub Actions used by the build pipeline are now pinned to exact commits, so an upstream change cannot alter what our workflows run without an explicit, reviewed update.

### Squash Merge Commit

```
ci: pin all GitHub Actions to commit SHAs (#5583)
```
