### PR TITLE
fix(app-headless-cms): prevent null predefined values from being stringified

### DIFF
--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/radioButtons.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/radioButtons.tsx
@@ -7,6 +7,9 @@ import { useFieldEffectiveRules, useModelField } from "@webiny/app-headless-cms-
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
+const isValidValue = (value: unknown): value is string | number =>
+    typeof value === "string" || typeof value === "number";
+
 const plugin: CmsModelFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-radio-buttons",
@@ -42,11 +45,16 @@ const plugin: CmsModelFieldRendererPlugin = {
                                 hint={field.help}
                                 items={options.map(option => ({
                                     label: option.label,
-                                    value: String(option.value),
+                                    value: isValidValue(option.value)
+                                        ? String(option.value)
+                                        : option.value,
                                     selected: option.selected
                                 }))}
-                                value={typeof value !== "undefined" ? String(value) : undefined}
+                                value={isValidValue(value) ? String(value) : undefined}
                                 onChange={value => {
+                                    if (!isValidValue(value)) {
+                                        return onChange(value);
+                                    }
                                     if (field.type === "number") {
                                         onChange(Number(value));
                                     } else {

--- a/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
+++ b/packages/app-headless-cms/src/admin/plugins/fieldRenderers/select.tsx
@@ -7,6 +7,9 @@ import { useFieldEffectiveRules, useModelField } from "@webiny/app-headless-cms-
 
 const t = i18n.ns("app-headless-cms/admin/fields/text");
 
+const isValidValue = (value: unknown): value is string | number =>
+    typeof value === "string" || typeof value === "number";
+
 const plugin: CmsModelFieldRendererPlugin = {
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-select-box",
@@ -40,8 +43,11 @@ const plugin: CmsModelFieldRendererPlugin = {
                                 options={options}
                                 placeholder={field.placeholder}
                                 data-testid={`fr.input.select.${field.label}`}
-                                value={typeof value !== "undefined" ? String(value) : undefined}
+                                value={isValidValue(value) ? String(value) : undefined}
                                 onChange={value => {
+                                    if (!isValidValue(value)) {
+                                        return onChange(value);
+                                    }
                                     if (field.type === "number") {
                                         onChange(Number(value));
                                     } else {


### PR DESCRIPTION
## Summary
- When a CMS field has predefined values but none are marked as "selected", the `defaultValue` is `null`
- The select and radio button field renderers were converting this `null` to the string `"null"` via `String(null)`, because the guard `typeof value !== "undefined"` passes for `null` (since `typeof null === "object"`)
- Added an `isValidValue` type guard that checks for `string` or `number` types before calling `String()`, falling through to `undefined` for null/undefined values

## Test plan
- [ ] Open a CMS model with a field that has predefined values but no default selected
- [ ] Verify the select/radio button renderer shows the placeholder instead of "null"
- [ ] Verify selecting a predefined value still works correctly
- [ ] Verify number-typed predefined values still convert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)