### PR TITLE
fix(api-file-manager): read image crop from correct metadata path

### DIFF
--- a/packages/api-file-manager-s3/src/assetDelivery/s3/SharpTransform.ts
+++ b/packages/api-file-manager-s3/src/assetDelivery/s3/SharpTransform.ts
@@ -91,7 +91,7 @@ export class SharpTransform implements ImageAssetTypeHandler.Interface {
             return undefined;
         }
 
-        const imageEdit = result.value.metadata?.imageEdit as AssetImageEdit | undefined;
+        const imageEdit = result.value.metadata?.image as AssetImageEdit | undefined;
         return imageEdit?.crop;
     }
 

--- a/packages/api-file-manager-server/src/assetDelivery/LocalSharpTransform.ts
+++ b/packages/api-file-manager-server/src/assetDelivery/LocalSharpTransform.ts
@@ -91,7 +91,7 @@ export class LocalSharpTransform implements IAssetTypeHandler {
             return undefined;
         }
 
-        const imageEdit = result.value.metadata?.imageEdit as AssetImageEdit | undefined;
+        const imageEdit = result.value.metadata?.image as AssetImageEdit | undefined;
         return imageEdit?.crop;
     }
 


### PR DESCRIPTION
## Summary

- **Fix:** `SharpTransform.loadAssetCrop` and `LocalSharpTransform.loadAssetCrop` were reading crop data from `metadata.imageEdit`, a key that is never written anywhere in the codebase. The File Manager's ImageEditor saves crop data to `metadata.image.crop`. Changed both methods to read from `metadata.image` so the asset-level crop set via the UI actually reaches the image delivery pipeline.
- **Files changed:** `packages/api-file-manager-s3/src/assetDelivery/s3/SharpTransform.ts`, `packages/api-file-manager-server/src/assetDelivery/LocalSharpTransform.ts`

## Test plan

- [ ] Upload an image via File Manager, apply a crop using the ImageEditor, save
- [ ] Request the image through the asset delivery URL and verify the crop is applied
- [ ] Verify uncropped images still render correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)