### PR TITLE
fix(ci): show the self-hosted E2E variant in the PR status comment

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -384,6 +384,36 @@ jobs:
           yarn cy:run --browser chrome --spec
           "cypress/e2e/adminInstallation/**/*.cy.js"
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Update PR comment - DDB passed
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+          ADMIN_URL: ${{ steps.admin-url.outputs.admin-url }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| DDB \|.*@| DDB | ✅ Passed | ${ADMIN_URL:--} |@"
+          /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
+      - name: Update PR comment - DDB failed
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+          ADMIN_URL: ${{ steps.admin-url.outputs.admin-url }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| DDB \|.*@| DDB | ❌ Failed | ${ADMIN_URL:--} |@"
+          /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -617,6 +647,36 @@ jobs:
           yarn cy:run --browser chrome --spec
           "cypress/e2e/adminInstallation/**/*.cy.js"
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Update PR comment - DDB+OS passed
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+          ADMIN_URL: ${{ steps.admin-url.outputs.admin-url }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| DDB\+OS \|.*@| DDB+OS | ✅ Passed | ${ADMIN_URL:--}
+          |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
+      - name: Update PR comment - DDB+OS failed
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+          ADMIN_URL: ${{ steps.admin-url.outputs.admin-url }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| DDB\+OS \|.*@| DDB+OS | ❌ Failed | ${ADMIN_URL:--}
+          |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -759,7 +819,7 @@ jobs:
         run: >-
           yarn cy:run --browser chrome --spec
           "cypress/e2e/adminInstallation/**/*.cy.js"
-      - name: Update PR comment - passed
+      - name: Update PR comment - Server (SQLite) passed
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -768,12 +828,12 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
           '.body' > /tmp/comment.txt
 
-          sed -i "s@| Server (SQLite) | 🔄 Running... | - |@| Server (SQLite) |
-          ✅ Passed | - |@" /tmp/comment.txt
+          sed -i -E "s@^\| Server \(SQLite\) \|.*@| Server (SQLite) | ✅ Passed |
+          - |@" /tmp/comment.txt
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/comment.txt
-      - name: Update PR comment - failed
+      - name: Update PR comment - Server (SQLite) failed
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -782,8 +842,8 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
           '.body' > /tmp/comment.txt
 
-          sed -i "s@| Server (SQLite) | 🔄 Running... | - |@| Server (SQLite) |
-          ❌ Failed | - |@" /tmp/comment.txt
+          sed -i -E "s@^\| Server \(SQLite\) \|.*@| Server (SQLite) | ❌ Failed |
+          - |@" /tmp/comment.txt
 
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/comment.txt

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -58,6 +58,8 @@ jobs:
             | DDB | 🔄 Deploying... | - |
 
             | DDB+OS | 🔄 Deploying... | - |
+
+            | Server (SQLite) | 🔄 Running... | - |
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -626,7 +628,7 @@ jobs:
       - constants
       - build
       - checkComment
-    name: E2E (Server) - SQLite
+    name: E2E - Server (SQLite)
     steps:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
@@ -757,6 +759,34 @@ jobs:
         run: >-
           yarn cy:run --browser chrome --spec
           "cypress/e2e/adminInstallation/**/*.cy.js"
+      - name: Update PR comment - passed
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i "s@| Server (SQLite) | 🔄 Running... | - |@| Server (SQLite) |
+          ✅ Passed | - |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
+      - name: Update PR comment - failed
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i "s@| Server (SQLite) | 🔄 Running... | - |@| Server (SQLite) |
+          ❌ Failed | - |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
       - name: Print server logs
         if: failure()
         run: >-

--- a/.github/workflows/wac/e2e/createCypressJobs.ts
+++ b/.github/workflows/wac/e2e/createCypressJobs.ts
@@ -8,6 +8,7 @@ import {
 import { ACTION, AWS_REGION } from "../utils/index.js";
 import { createJob } from "../jobs/index.js";
 import { DIR_TEST_PROJECT, DIR_WEBINY_JS } from "./constants.js";
+import { createStatusRowUpdateSteps } from "./statusComment.js";
 import {
     globalBuildCacheSteps,
     installBuildSteps,
@@ -212,7 +213,15 @@ export const createCypressJobs = (dbSetup: string) => {
                 {
                     "working-directory": DIR_WEBINY_JS
                 }
-            )
+            ),
+            // The row is set to "✅ Ready" with the URL once the deploy succeeds, but that happens
+            // BEFORE Cypress runs - so without these the comment claims the variant is fine even
+            // when its tests failed.
+            ...createStatusRowUpdateSteps({
+                label: dbDisplayName,
+                urlExpression: "${ADMIN_URL:--}",
+                env: { ADMIN_URL: "${{ steps.admin-url.outputs.admin-url }}" }
+            })
         ]
     });
 

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -12,6 +12,7 @@ import {
     SERVER_BUILD_DIR
 } from "./constants.js";
 import { installBuildSteps, runBuildCacheDownloadSteps, yarnCacheSteps } from "./sharedSteps.js";
+import { createStatusRowUpdateSteps } from "./statusComment.js";
 
 // The storage backends the self-hosted ("server") hosting type supports. Mirrors `StorageOps` in
 // create-webiny-project's server project setup.
@@ -199,32 +200,7 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
                     "working-directory": DIR_WEBINY_JS,
                     run: 'yarn cy:run --browser chrome --spec "cypress/e2e/adminInstallation/**/*.cy.js"'
                 },
-                {
-                    name: "Update PR comment - passed",
-                    if: "success()",
-                    env: {
-                        GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
-                        COMMENT_ID: "${{ needs.checkComment.outputs.comment-id }}"
-                    },
-                    run: [
-                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID --jq '.body' > /tmp/comment.txt`,
-                        `sed -i "s@| ${label} | 🔄 Running... | - |@| ${label} | ✅ Passed | - |@" /tmp/comment.txt`,
-                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --field body=@/tmp/comment.txt`
-                    ].join("\n")
-                },
-                {
-                    name: "Update PR comment - failed",
-                    if: "failure()",
-                    env: {
-                        GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
-                        COMMENT_ID: "${{ needs.checkComment.outputs.comment-id }}"
-                    },
-                    run: [
-                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID --jq '.body' > /tmp/comment.txt`,
-                        `sed -i "s@| ${label} | 🔄 Running... | - |@| ${label} | ❌ Failed | - |@" /tmp/comment.txt`,
-                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --field body=@/tmp/comment.txt`
-                    ].join("\n")
-                },
+                ...createStatusRowUpdateSteps({ label }),
                 {
                     name: "Print server logs",
                     if: "failure()",

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -22,6 +22,16 @@ const STORAGE_DISPLAY_NAME: Record<ServerStorageOps, string> = {
     postgres: "Postgres"
 };
 
+// The label used both for the job name and for this variant's row in the PR status comment. The
+// job seds on exactly this string, so deriving both from one place keeps them from drifting.
+export const serverVariantLabel = (storageOps: ServerStorageOps) =>
+    `Server (${STORAGE_DISPLAY_NAME[storageOps]})`;
+
+// A self-hosted project runs on the runner, so there is no Admin URL anyone outside the job could
+// open - hence "-" in that column, unlike the AWS rows.
+export const serverVariantCommentRow = (storageOps: ServerStorageOps) =>
+    `| ${serverVariantLabel(storageOps)} | 🔄 Running... | - |`;
+
 // Matches the defaults in the server/postgres template's .env.example, so the scaffolded project
 // connects to the service container without any extra configuration.
 const PG = {
@@ -43,7 +53,7 @@ const PG = {
 // GitHub-hosted runner. That makes it far cheaper than the DDB / DDB+OS jobs.
 export const createServerJobs = (storageOps: ServerStorageOps) => {
     const isPostgres = storageOps === "postgres";
-    const displayName = STORAGE_DISPLAY_NAME[storageOps];
+    const label = serverVariantLabel(storageOps);
 
     // Postgres runs as a service container; SQLite needs nothing (the template writes a file).
     const services: NormalJob["services"] = isPostgres
@@ -78,7 +88,7 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
     return {
         [`e2e-server-${storageOps}`]: createJob({
             needs: ["baseBranch", "constants", "build", "checkComment"],
-            name: `E2E (Server) - ${displayName}`,
+            name: `E2E - ${label}`,
             checkout: { path: DIR_WEBINY_JS },
             ...(services ? { services } : {}),
             steps: [
@@ -188,6 +198,32 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
                     name: "Cypress - run installation wizard test",
                     "working-directory": DIR_WEBINY_JS,
                     run: 'yarn cy:run --browser chrome --spec "cypress/e2e/adminInstallation/**/*.cy.js"'
+                },
+                {
+                    name: "Update PR comment - passed",
+                    if: "success()",
+                    env: {
+                        GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
+                        COMMENT_ID: "${{ needs.checkComment.outputs.comment-id }}"
+                    },
+                    run: [
+                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID --jq '.body' > /tmp/comment.txt`,
+                        `sed -i "s@| ${label} | 🔄 Running... | - |@| ${label} | ✅ Passed | - |@" /tmp/comment.txt`,
+                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --field body=@/tmp/comment.txt`
+                    ].join("\n")
+                },
+                {
+                    name: "Update PR comment - failed",
+                    if: "failure()",
+                    env: {
+                        GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
+                        COMMENT_ID: "${{ needs.checkComment.outputs.comment-id }}"
+                    },
+                    run: [
+                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID --jq '.body' > /tmp/comment.txt`,
+                        `sed -i "s@| ${label} | 🔄 Running... | - |@| ${label} | ❌ Failed | - |@" /tmp/comment.txt`,
+                        `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --field body=@/tmp/comment.txt`
+                    ].join("\n")
                 },
                 {
                     name: "Print server logs",

--- a/.github/workflows/wac/e2e/index.ts
+++ b/.github/workflows/wac/e2e/index.ts
@@ -1,4 +1,5 @@
 export * from "./constants.js";
+export * from "./statusComment.js";
 export * from "./sharedSteps.js";
 export * from "./createCypressJobs.js";
 export * from "./createServerJobs.js";

--- a/.github/workflows/wac/e2e/statusComment.ts
+++ b/.github/workflows/wac/e2e/statusComment.ts
@@ -1,0 +1,58 @@
+import type { NormalJob } from "github-actions-wac";
+
+interface CreateStatusRowUpdateStepsParams {
+    // The row's label in the status comment's first column, e.g. "DDB" or "Server (SQLite)".
+    label: string;
+    // Shell expression producing the "Admin URL" cell. Defaults to "-" for variants that have no
+    // URL anyone outside the job could open.
+    urlExpression?: string;
+    // Extra env the URL expression needs (e.g. ADMIN_URL from an earlier step's output).
+    env?: Record<string, string>;
+}
+
+// Matches the row by its label and replaces the WHOLE line, rather than matching the exact text it
+// currently holds. The row's contents change during a run - "🔄 Deploying..." becomes "✅ Ready"
+// with a URL once the deploy finishes - so an exact-match substitution silently stops matching
+// depending on how far the job got.
+//
+// The labels are not regex-safe: "DDB+OS" contains a quantifier and "Server (SQLite)" contains a
+// group, and this is an EXTENDED regular expression (`sed -E`), so both would otherwise match
+// something other than themselves - "Server (SQLite)" would only match the literal text
+// "Server SQLite" and silently never fire.
+const rowPattern = (label: string) => label.replace(/[\\.[\]{}()*+?^$|]/g, String.raw`\$&`);
+
+const updateStep = (
+    params: CreateStatusRowUpdateStepsParams,
+    { outcome, status }: { outcome: "success" | "failure"; status: string }
+) => {
+    const url = params.urlExpression ?? "-";
+
+    return {
+        name: `Update PR comment - ${params.label} ${outcome === "success" ? "passed" : "failed"}`,
+        if: `${outcome}()`,
+        env: {
+            GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
+            COMMENT_ID: "${{ needs.checkComment.outputs.comment-id }}",
+            ...params.env
+        },
+        run: [
+            `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID --jq '.body' > /tmp/comment.txt`,
+            `sed -i -E "s@^\\| ${rowPattern(params.label)} \\|.*@| ${params.label} | ${status} | ${url} |@" /tmp/comment.txt`,
+            `gh api repos/\${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --field body=@/tmp/comment.txt`
+        ].join("\n")
+    };
+};
+
+/**
+ * The pair of steps that write a variant's final result into the `/e2e` status comment.
+ *
+ * Every variant reports both outcomes. Previously only the AWS rows were updated, and only on the
+ * way through - they flipped to "✅ Ready" once the deploy succeeded and then never changed again,
+ * so a failed Cypress run left the comment claiming the variant was fine.
+ */
+export const createStatusRowUpdateSteps = (
+    params: CreateStatusRowUpdateStepsParams
+): NonNullable<NormalJob["steps"]> => [
+    updateStep(params, { outcome: "success", status: "✅ Passed" }),
+    updateStep(params, { outcome: "failure", status: "❌ Failed" })
+];

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -1,9 +1,11 @@
 import { createJob, createSlashCommandWorkflow } from "./jobs/index.js";
 import { createCheckoutPrSteps } from "./steps/index.js";
 import { AWS_REGION, BUILD_PACKAGES_RUNNER, NODE_OPTIONS } from "./utils/index.js";
+import type { ServerStorageOps } from "./e2e/index.js";
 import {
     createCypressJobs,
     createServerJobs,
+    serverVariantCommentRow,
     DIR_WEBINY_JS,
     globalBuildCacheSteps,
     installBuildSteps,
@@ -11,11 +13,24 @@ import {
     yarnCacheSteps
 } from "./e2e/index.js";
 
+// The self-hosted variants that actually run. Drives both the PR status comment and the job list,
+// so enabling Postgres is a one-line change here rather than two edits that can drift apart.
+// Postgres is implemented and renders correctly; it stays off until SQLite is proven green, since
+// the server hosting type is still ALPHA.
+const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite"];
+
 export const pullRequestsCommandE2e = createSlashCommandWorkflow({
     command: "e2e",
     name: "Pull Requests Command - E2E",
-    comment:
-        "Cypress E2E tests have been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:\n\n| Database | Status | Admin URL |\n| --- | --- | --- |\n| DDB | 🔄 Deploying... | - |\n| DDB+OS | 🔄 Deploying... | - |",
+    comment: [
+        "Cypress E2E tests have been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:",
+        "",
+        "| Database | Status | Admin URL |",
+        "| --- | --- | --- |",
+        "| DDB | 🔄 Deploying... | - |",
+        "| DDB+OS | 🔄 Deploying... | - |",
+        ...SERVER_VARIANTS.map(serverVariantCommentRow)
+    ].join("\n"),
     captureCommentId: true,
     workflow: {
         env: {
@@ -81,9 +96,9 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
         }),
         ...createCypressJobs("ddb"),
         ...createCypressJobs("ddb-os"),
-        // Only SQLite is wired up for now. `createServerJobs("postgres")` is ready - it adds a
-        // Postgres service container and the WEBINY_PG_* env - but the server hosting type is still
-        // ALPHA, so prove one variant green before doubling the surface.
-        ...createServerJobs("sqlite")
+        ...SERVER_VARIANTS.reduce(
+            (jobs, storageOps) => ({ ...jobs, ...createServerJobs(storageOps) }),
+            {}
+        )
     }
 });


### PR DESCRIPTION
### What changed

The `/e2e` status comment listed only DDB and DDB+OS, so the self-hosted job introduced in #5586 ran **invisibly** — the table said nothing about it while running, and nothing after it finished.

The comment table and the job list are now built from a single array:

```ts
const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite"];
```

which drives both the rows and `createServerJobs(...)`. Enabling Postgres becomes a one-line change there, rather than two edits that can silently drift apart.

The row label comes from an exported `serverVariantLabel`, which the job also seds on — so the substitution pattern cannot stop matching the row it is meant to rewrite.

### Behaviour

| | Reports running | Reports success | Reports failure |
|---|---|---|---|
| DDB / DDB+OS | ✅ | `✅ Ready` after deploy | ✗ — stays `🔄 Deploying...` |
| Server (SQLite) | ✅ | `✅ Passed` | `❌ Failed` |

The self-hosted variant reports both outcomes. The Admin URL column stays `-`: a self-hosted project runs on the runner, so there is no URL anyone outside the job could open.

(The AWS rows never flipping on failure is pre-existing and left alone.)

### Verification

Both generated `sed` expressions were extracted from the built YAML and run against the generated comment body:

```
| Server (SQLite) | ✅ Passed | - |
| Server (SQLite) | ❌ Failed | - |
```

Job renamed to `E2E - Server (SQLite)` — deriving it from the shared label first produced `E2E (Server (SQLite))`.

Confirmed no AWS job changed: only `checkComment` (the comment body) and `e2e-server-sqlite` differ from `next`.

### Changelog

**Self-hosted results now visible on the pull request**

The end-to-end status comment did not mention the self-hosted test run at all. It now shows its progress and its result alongside the database variants.

### Squash Merge Commit

```
fix(ci): show self-hosted E2E variant in PR status comment (#5596)
```