### PR TITLE
fix(ci): give the self-hosted E2E API the env it needs to boot

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -762,9 +762,6 @@ jobs:
         env:
           WEBINY_HOSTING_TYPE: server
           WEBINY_API_URL: http://localhost:3002
-          WEBINY_SQL_FILENAME: >-
-            ${{ github.workspace
-            }}/new-webiny-project-server/.webiny/server.sqlite
         run: yarn webiny build api && yarn webiny build admin
       - name: Start API
         env:

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -762,11 +762,20 @@ jobs:
         env:
           WEBINY_HOSTING_TYPE: server
           WEBINY_API_URL: http://localhost:3002
+          WEBINY_SQL_FILENAME: >-
+            ${{ github.workspace
+            }}/new-webiny-project-server/.webiny/server.sqlite
         run: yarn webiny build api && yarn webiny build admin
       - name: Start API
         env:
           PORT: '3002'
+          WEBINY_SQL_FILENAME: >-
+            ${{ github.workspace
+            }}/new-webiny-project-server/.webiny/server.sqlite
+          WEBINY_LOCAL_STORAGE_PATH: ${{ github.workspace }}/new-webiny-project-server/.webiny/storage
         run: |-
+          mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"
+          mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"
           cd new-webiny-project-server/.webiny/workspace/apps/api/graphql/build
           nohup node start.mjs > /tmp/webiny-api.log 2>&1 &
           echo "API starting on port 3002"

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -76,6 +76,17 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
         : undefined;
 
     // Supplied to every step that builds or runs the project, so the API talks to the right database.
+    //
+    // SQLite needs WEBINY_SQL_FILENAME even though the template's .env.example calls every variable
+    // optional: that promise holds for `yarn webiny watch`, which reads webiny.config.tsx, but the
+    // standalone handler we run here (`node start.mjs`) is configured purely from the environment
+    // and exits immediately without it:
+    //
+    //   Error: WEBINY_SQL_FILENAME is not set. Configure the database via
+    //   <Infra.Sqlite filename="..." /> in webiny.config.
+    //
+    // Absolute paths, because the API is started from inside its build folder rather than from the
+    // project root.
     const storageEnv: Record<string, string> = isPostgres
         ? {
               WEBINY_PG_HOST: PG.host,
@@ -84,7 +95,15 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
               WEBINY_PG_PASSWORD: PG.password,
               WEBINY_PG_DATABASE: PG.database
           }
-        : {};
+        : {
+              WEBINY_SQL_FILENAME: `\${{ github.workspace }}/${DIR_SERVER_PROJECT}/.webiny/server.sqlite`
+          };
+
+    // Uploaded files land on disk rather than in a bucket. Also absolute, for the same reason.
+    const runtimeEnv: Record<string, string> = {
+        ...storageEnv,
+        WEBINY_LOCAL_STORAGE_PATH: `\${{ github.workspace }}/${DIR_SERVER_PROJECT}/.webiny/storage`
+    };
 
     return {
         [`e2e-server-${storageOps}`]: createJob({
@@ -137,8 +156,12 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
                     // Backgrounded so the job can continue; the process lives for the rest of the
                     // job. Logs go to a file so the failure handler below can surface them.
                     name: "Start API",
-                    env: { PORT: `${SERVER_API_PORT}`, ...storageEnv },
+                    env: { PORT: `${SERVER_API_PORT}`, ...runtimeEnv },
                     run: [
+                        // SQLite will not create missing parent directories for its file, and the
+                        // local file storage folder does not exist until something writes to it.
+                        'mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"',
+                        'mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"',
                         `cd ${SERVER_BUILD_DIR}/api/graphql/build`,
                         "nohup node start.mjs > /tmp/webiny-api.log 2>&1 &",
                         `echo "API starting on port ${SERVER_API_PORT}"`

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -77,10 +77,11 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
 
     // Supplied to every step that builds or runs the project, so the API talks to the right database.
     //
-    // SQLite needs WEBINY_SQL_FILENAME even though the template's .env.example calls every variable
-    // optional: that promise holds for `yarn webiny watch`, which reads webiny.config.tsx, but the
-    // standalone handler we run here (`node start.mjs`) is configured purely from the environment
-    // and exits immediately without it:
+    // Why this is needed even though webiny.config.tsx already configures the database:
+    // `<Infra.Sqlite>` renders an `EnvVar` that is BAKED for the api runtime, and `runApiServer`
+    // (what `yarn webiny watch` uses) hands that baked env to the API process. Running the
+    // standalone handler directly - `node start.mjs`, which is what the documented Docker setup
+    // does too - bypasses that entirely, so the process sees none of it and exits immediately:
     //
     //   Error: WEBINY_SQL_FILENAME is not set. Configure the database via
     //   <Infra.Sqlite filename="..." /> in webiny.config.
@@ -145,10 +146,14 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
                     // be set here and match where the API is actually started below.
                     name: "Build API and Admin",
                     "working-directory": DIR_SERVER_PROJECT,
+                    // Only what the build actually bakes in: the hosting type, and the API origin,
+                    // which the Admin bundle embeds. Database configuration is NOT needed here -
+                    // `<Infra.Sqlite>` / `<Infra.Postgres>` in webiny.config.tsx already bake their
+                    // own values, and the standalone handler we run below ignores those anyway (see
+                    // the runtime env on "Start API").
                     env: {
                         WEBINY_HOSTING_TYPE: "server",
-                        WEBINY_API_URL: SERVER_API_URL,
-                        ...storageEnv
+                        WEBINY_API_URL: SERVER_API_URL
                     },
                     run: "yarn webiny build api && yarn webiny build admin"
                 },


### PR DESCRIPTION
### What changed

The first real `/e2e` run of the self-hosted job got much further than expected — scaffolded the project (118s) and completed `webiny build api && webiny build admin` (28s) — then the API exited immediately:

```
Error: WEBINY_SQL_FILENAME is not set. Configure the database via
<Infra.Sqlite filename="..." /> in webiny.config.
```

so `Wait for API and Admin` burned its full 180s and failed on port 3002.

### Why the template's "everything is optional" did not hold

`_templates/server/sqlite/.env.example` says:

> Everything here is OPTIONAL — the project runs with sensible defaults out of the box (`yarn webiny watch`).

That is true for `yarn webiny watch`, which reads `webiny.config.tsx`. But this job runs the **standalone handler** (`node start.mjs`), which is configured purely from the environment and has no config file to fall back on. The documented Dockerfile says the same thing from the other direction — it lists these as RUN-time variables, never baked into the image.

I took the `.env.example` at face value when writing the job. It was accurate for the workflow it names, and I was running a different one.

### The fix

`WEBINY_SQL_FILENAME` and `WEBINY_LOCAL_STORAGE_PATH` are now set for the API process, both **absolute** — the API is started from inside its build folder, not the project root, so a relative path would resolve to the wrong place.

Their parent directories are created first: SQLite does not create missing directories for its file, and the local storage folder does not exist until something writes to it.

Postgres already supplied its connection env, so only the SQLite variant was affected — but the storage path applies to both and is set for both.

### Status of the self-hosted job

Everything before the API start is now known-good on a real runner:

| Step | Result |
|---|---|
| scaffold `--hosting-type server` | ✅ 118s |
| `webiny build api && webiny build admin` | ✅ 28s |
| Start API | ❌ → fixed here |

The `❌ Failed` status-row update from #5596 also fired correctly, so the comment reported the failure rather than sitting on `🔄 Running...`.

Still unknown past this point: whether the Admin static server and the Cypress installation-wizard spec work. Those come after the API boots, so this run could not reach them.

### Changelog

**Internal CI fix**

The self-hosted end-to-end test could not start its API server because it was missing its database configuration. No user-facing change.

### Squash Merge Commit

```
fix(ci): give the self-hosted E2E API the env it needs to boot (#5597)
```