### PR TITLE
fix(cypress): construct the Cognito user pool lazily

### DIFF
--- a/cypress-tests/cypress/support/login/authenticateWithCognito.ts
+++ b/cypress-tests/cypress/support/login/authenticateWithCognito.ts
@@ -3,20 +3,28 @@ import * as AmazonCognitoIdentity from "amazon-cognito-identity-js";
 // @ts-expect-error
 global.fetch = fetch;
 
-const AWS_COGNITO = {
-    USER_POOL_ID: Cypress.env("AWS_COGNITO_USER_POOL_ID"),
-    CLIENT_ID: Cypress.env("AWS_COGNITO_CLIENT_ID")
-};
+// Constructed on first use, NOT at import time. `CognitoUserPool` throws "Both UserPoolId and
+// ClientId are required." when either is missing, and this module is pulled in by the support file
+// for EVERY spec - so building it eagerly made the whole suite fail to load on any setup without
+// Cognito, before a single test ran. The self-hosted (server) hosting type has its own identity
+// provider and leaves these blank.
+let userPool: AmazonCognitoIdentity.CognitoUserPool | undefined;
 
-const userPool = new AmazonCognitoIdentity.CognitoUserPool({
-    UserPoolId: AWS_COGNITO.USER_POOL_ID,
-    ClientId: AWS_COGNITO.CLIENT_ID
-});
+const getUserPool = () => {
+    if (!userPool) {
+        userPool = new AmazonCognitoIdentity.CognitoUserPool({
+            UserPoolId: Cypress.env("AWS_COGNITO_USER_POOL_ID"),
+            ClientId: Cypress.env("AWS_COGNITO_CLIENT_ID")
+        });
+    }
+
+    return userPool;
+};
 
 export default ({ username, password }: { username: string; password: string }) => {
     const userData = {
         Username: username,
-        Pool: userPool
+        Pool: getUserPool()
     };
 
     const authenticationDetails = new AmazonCognitoIdentity.AuthenticationDetails({


### PR DESCRIPTION
### What changed

The self-hosted `/e2e` run reached Cypress and then failed before a single test executed:

```
(Attempt 1 of 6) An uncaught error was detected outside of a test
...
1) An uncaught error was detected outside of a test:
   Error: The following error originated from your test code, not from Cypress.
   > Both UserPoolId and ClientId are required.

0 passing (898ms)
1 failing
```

`authenticateWithCognito` built its `CognitoUserPool` at **module level**:

```ts
const userPool = new AmazonCognitoIdentity.CognitoUserPool({
    UserPoolId: AWS_COGNITO.USER_POOL_ID,
    ClientId: AWS_COGNITO.CLIENT_ID
});
```

and the support file pulls that module in for **every** spec. `CognitoUserPool` throws when either value is missing, so on any setup without Cognito the whole suite failed to load — including the installation wizard spec, which never calls `cy.login` and logs in through the UI. Cypress retried five times and failed identically each time, because the error was in module evaluation rather than in a test.

The pool is now built on first use. Nothing changes for the AWS runs — same values, same pool, just constructed when `login` is first called. A setup with its own identity provider (the self-hosted hosting type leaves the Cognito values blank by design) can now load the support file and run specs that do not need Cognito auth.

### What this does not fix

Only specs that do not authenticate. The other 15 specs all go through `cy.login` → `authenticateWithCognito` and will still fail on self-hosted until that seam is ported to the self-hosted identity provider, which exposes an unauthenticated login mutation:

```graphql
selfHostedAuthLogin(email: String!, password: String!): SelfHostedAuthLoginResponse  # → { token, expiresIn }
```

That is the next piece of work.

### Verification

- `tsc --noEmit` on `cypress-tests` passes
- `oxfmt --check` and `oxlint` clean
- Checked the rest of the support chain for other import-time AWS construction — there is none; the only other Cognito reference is a `localStorage` key check inside `login()`, which is already lazy

### Changelog

**Internal test-harness fix**

The end-to-end test suite failed to start on setups that do not use AWS Cognito. No user-facing change.

### Squash Merge Commit

```
fix(cypress): construct the Cognito user pool lazily (#5598)
```