### PR TITLE
feat(cypress): authenticate against the self-hosted identity provider

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -825,6 +825,11 @@ jobs:
         run: >-
           yarn cy:run --browser chrome --spec
           "cypress/e2e/adminInstallation/**/*.cy.js"
+      - name: Cypress - run account test
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: >-
+          yarn cy:run --browser chrome --spec
+          "cypress/e2e/admin/account/**/*.cy.js"
       - name: Update PR comment - Server (SQLite) passed
         if: success()
         env:

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -221,12 +221,26 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
                     run: "cd cypress-tests && yarn cypress install"
                 },
                 {
-                    // Only the installation wizard for now. It is pure UI (no cy.login), so it does
-                    // not need the Cognito-based auth helper that the other specs use - porting that
-                    // to the self-hosted identity provider comes next.
+                    // Must run first: it completes the wizard, which is what creates the admin user
+                    // everything below authenticates as. Kept a separate step from the specs below
+                    // because Cypress orders specs alphabetically, and "admin/..." sorts before
+                    // "adminInstallation/..." - a single glob would run them in the wrong order.
                     name: "Cypress - run installation wizard test",
                     "working-directory": DIR_WEBINY_JS,
                     run: 'yarn cy:run --browser chrome --spec "cypress/e2e/adminInstallation/**/*.cy.js"'
+                },
+                {
+                    // Proves the self-hosted auth seam end to end: this spec authenticates through
+                    // `cy.login()` rather than the UI, so it exercises `authenticateWithSelfHosted`
+                    // and the token it seeds for the Admin app.
+                    //
+                    // Deliberately not the whole suite yet. The remaining specs cover features whose
+                    // behaviour on the server hosting type is simply unknown (file manager against
+                    // local storage, page builder, ...), and turning them all on at once would mix
+                    // real product gaps in with anything wrong here.
+                    name: "Cypress - run account test",
+                    "working-directory": DIR_WEBINY_JS,
+                    run: 'yarn cy:run --browser chrome --spec "cypress/e2e/admin/account/**/*.cy.js"'
                 },
                 ...createStatusRowUpdateSteps({ label }),
                 {

--- a/cypress-tests/cypress/support/login/authenticateWithSelfHosted.ts
+++ b/cypress-tests/cypress/support/login/authenticateWithSelfHosted.ts
@@ -1,0 +1,76 @@
+import type { User } from "./index";
+
+/**
+ * Authenticate against the self-hosted ("server" hosting type) identity provider.
+ *
+ * The counterpart to `authenticateWithCognito`. Self-hosted exposes a deliberately unauthenticated
+ * `selfHostedAuthLogin` mutation - it is how an identity is obtained in the first place - which
+ * exchanges an email/password pair for a signed JWT.
+ */
+const LOGIN_MUTATION = /* GraphQL */ `
+    mutation SelfHostedAuthLogin($email: String!, $password: String!) {
+        selfHostedAuthLogin(email: $email, password: $password) {
+            data {
+                token
+                expiresIn
+            }
+            error {
+                code
+                message
+            }
+        }
+    }
+`;
+
+// Where the Admin app reads its token from. Seeding it is what makes the BROWSER session
+// authenticated - unlike Cognito, whose SDK writes its own `CognitoIdentityServiceProvider.*` keys
+// as a side effect of authenticating, this provider expects the login screen to have stored it.
+export const SELF_HOSTED_AUTH_TOKEN_KEY = "webiny_self_hosted_auth_token";
+
+export default async ({
+    username,
+    password
+}: {
+    username: string;
+    password: string;
+}): Promise<User> => {
+    const response = await fetch(Cypress.env("GRAPHQL_API_URL"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            query: LOGIN_MUTATION,
+            variables: { email: username, password }
+        })
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            `Self-hosted login request failed with HTTP ${response.status} ${response.statusText}.`
+        );
+    }
+
+    const body = await response.json();
+
+    if (body.errors?.length) {
+        throw new Error(`Self-hosted login failed: ${body.errors[0].message}`);
+    }
+
+    const result = body.data?.selfHostedAuthLogin;
+
+    if (result?.error) {
+        throw new Error(
+            `Self-hosted login failed: ${result.error.message} (${result.error.code}).`
+        );
+    }
+
+    const token = result?.data?.token;
+
+    if (!token) {
+        throw new Error("Self-hosted login returned no token.");
+    }
+
+    window.localStorage.setItem(SELF_HOSTED_AUTH_TOKEN_KEY, token);
+
+    // Same shape the Cognito helper returns, so callers keep using `user.idToken.jwtToken`.
+    return { idToken: { jwtToken: token } };
+};

--- a/cypress-tests/cypress/support/login/index.ts
+++ b/cypress-tests/cypress/support/login/index.ts
@@ -1,4 +1,7 @@
 import authenticateWithCognito from "./authenticateWithCognito";
+import authenticateWithSelfHosted, {
+    SELF_HOSTED_AUTH_TOKEN_KEY
+} from "./authenticateWithSelfHosted";
 
 const DEFAULT_USERNAME = Cypress.env("DEFAULT_ADMIN_USER_USERNAME");
 const DEFAULT_PASSWORD = Cypress.env("DEFAULT_ADMIN_USER_PASSWORD");
@@ -7,8 +10,25 @@ const DEFAULT_LOGIN = { username: DEFAULT_USERNAME, password: DEFAULT_PASSWORD }
 
 const cache: Record<string, any> = {};
 
+// Which identity provider the project under test uses. Set by `setup-cypress` from the hosting type,
+// so the suite does not have to guess from whether the Cognito values happen to be blank.
+const isSelfHosted = () => Cypress.env("HOSTING_TYPE") === "server";
+
+const authenticate = ({ username, password }: LoginParams) =>
+    isSelfHosted()
+        ? authenticateWithSelfHosted({ username, password })
+        : authenticateWithCognito({ username, password });
+
 // A trivial approach. Upgrade if needed.
+//
+// The two providers store their session differently: the Cognito SDK writes its own
+// `CognitoIdentityServiceProvider.*` keys as a side effect of authenticating, while the self-hosted
+// Admin reads a single token key that our helper seeds.
 const hasLoginDataInLocalStorage = () => {
+    if (isSelfHosted()) {
+        return Boolean(localStorage.getItem(SELF_HOSTED_AUTH_TOKEN_KEY));
+    }
+
     for (const key in localStorage) {
         if (key.startsWith("CognitoIdentityServiceProvider")) {
             return true;
@@ -23,7 +43,7 @@ export const login = async ({ username, password } = DEFAULT_LOGIN) => {
         return cache[username + password];
     }
 
-    return authenticateWithCognito({ username, password }).then(response => {
+    return authenticate({ username, password }).then(response => {
         cache[username + password] = response;
         return cache[username + password];
     });

--- a/example.cypress.config.ts
+++ b/example.cypress.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
         openMode: 0
     },
     env: {
+        // Which identity provider the suite authenticates against: "aws" (Cognito) or "server"
+        // (the self-hosted hosting type's built-in IdP).
+        HOSTING_TYPE: "{HOSTING_TYPE}",
         ADMIN_URL: "{ADMIN_URL}",
         API_URL: "{API_URL}",
         GRAPHQL_API_URL: "{API_URL}/graphql",

--- a/scripts/setupCypress/setupCypressAws.js
+++ b/scripts/setupCypress/setupCypressAws.js
@@ -30,6 +30,7 @@ const adminUrl = args.localhost ? "http://localhost:3001" : readWebinyOutput("ad
 writeCypressConfig({
     force: args.force,
     values: {
+        HOSTING_TYPE: "aws",
         API_URL: api.apiUrl,
         ADMIN_URL: adminUrl,
         AWS_COGNITO_USER_POOL_ID: api.cognitoUserPoolId,

--- a/scripts/setupCypress/setupCypressServer.js
+++ b/scripts/setupCypress/setupCypressServer.js
@@ -33,6 +33,7 @@ if (!args.apiUrl || !args.adminUrl) {
 writeCypressConfig({
     force: args.force,
     values: {
+        HOSTING_TYPE: "server",
         API_URL: args.apiUrl,
         ADMIN_URL: args.adminUrl,
         AWS_COGNITO_USER_POOL_ID: "",


### PR DESCRIPTION
### What changed

The E2E suite could only authenticate through Cognito, so every spec calling `cy.login()` was unusable on the self-hosted ("server") hosting type — **15 of the 16 specs**.

Adds `authenticateWithSelfHosted`, the counterpart to `authenticateWithCognito`. Self-hosted exposes a deliberately unauthenticated login mutation:

```graphql
selfHostedAuthLogin(email: String!, password: String!)  # → { token, expiresIn }
```

It returns the same `{ idToken: { jwtToken } }` shape the Cognito helper does, so callers keep using `user.idToken.jwtToken` unchanged — `securityCreateApiKey`, `createGqlQuery` and friends needed no edits.

### The asymmetry worth knowing

The Cognito SDK writes its own `CognitoIdentityServiceProvider.*` keys as a side effect of authenticating, so the browser session becomes authenticated for free. This provider expects the **login screen** to have stored the token — so the helper seeds `webiny_self_hosted_auth_token` itself.

Without that, `cy.login()` would hand back a perfectly usable token for API calls while the Admin app still considered the session anonymous, and every spec that authenticates and then navigates would fail in a confusing way. `hasLoginDataInLocalStorage` now checks whichever key applies to the active provider.

### Choosing the provider

A new `HOSTING_TYPE` value in the Cypress config, written by `setup-cypress` (`"aws"` / `"server"`). Explicit rather than inferred from whether the Cognito values happen to be blank — the same reason the setup scripts were split in #5586.

### Spec coverage

The `/e2e` server job now runs the **account** spec in addition to the installation wizard. That spec does `beforeEach(() => cy.login())` and then navigates, so it exercises the new path end to end — programmatic auth *and* the seeded browser session.

It is a **separate step** from the wizard, not a widened glob: Cypress orders specs alphabetically and `admin/...` sorts before `adminInstallation/...`, so one glob would try to log in before the wizard had created the user.

**Deliberately not enabling the remaining specs yet.** They cover features whose behaviour on the server hosting type is simply unknown — file manager against local storage, page builder, and so on. Turning them all on at once would mix genuine product gaps in with anything wrong in this seam, which is exactly the debugging cost this series has been avoiding one step at a time.

Also note `admin/login/login.cy.js` will need work before it can run here: it drives the Cognito login UI (`/your e-mail/i`, `/sign in/i`), while the self-hosted screen uses `Email` / `Password` / `Submit`.

### Verification

- `tsc --noEmit` on `cypress-tests` passes
- `oxfmt --check` and `oxlint` clean
- Generated a server Cypress config and confirmed `HOSTING_TYPE: "server"` alongside blank Cognito values
- AWS path untouched: same helper, same config keys, `HOSTING_TYPE: "aws"` added

Not yet exercised in CI — like everything in this series, the first real signal comes from an `/e2e` run after merge.

### Changelog

**Self-hosted end-to-end authentication**

End-to-end tests can now sign in against the self-hosted identity provider, not just AWS Cognito, so self-hosted projects can be covered by the same test suite.

### Squash Merge Commit

```
feat(cypress): authenticate against the self-hosted IdP (#5599)
```