### PR TITLE
ci: enable the self-hosted Postgres E2E variant

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -60,6 +60,8 @@ jobs:
             | DDB+OS | 🔄 Deploying... | - |
 
             | Server (SQLite) | 🔄 Running... | - |
+
+            | Server (Postgres) | 🔄 Running... | - |
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -866,6 +868,216 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: cypress-screenshots-server-sqlite
+          retention-days: 1
+          if-no-files-found: ignore
+          path: >-
+            ${{ needs.baseBranch.outputs.base-branch
+            }}/cypress-tests/cypress/screenshots
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+    permissions:
+      contents: read
+      actions: write
+  e2e-server-postgres:
+    needs:
+      - baseBranch
+      - constants
+      - build
+      - checkComment
+    name: E2E - Server (Postgres)
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: webiny
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          path: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Checkout Pull Request
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: |-
+          gh pr checkout ${{ github.event.issue.number }}
+          git checkout --detach ${{ needs.baseBranch.outputs.pr-sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Download build cache
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: run-build-cache
+      - name: Extract build cache
+        run: >-
+          tar -xf run-build-cache.tzst --use-compress-program=zstdmt -C
+          "${WEBINY_JS_DIR:-.}"
+        env:
+          WEBINY_JS_DIR: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Install dependencies
+        run: yarn --immutable
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Build packages
+        run: yarn build
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+      - name: Start Verdaccio local server
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: >-
+          yarn add pm2 verdaccio && npx pm2 start verdaccio -- -c
+          .verdaccio.yaml
+      - name: Configure NPM to use local registry
+        run: npm config set registry http://localhost:4873
+      - name: Set git email
+        run: git config --global user.email "webiny-bot@webiny.com"
+      - name: Set git username
+        run: git config --global user.name "webiny-bot"
+      - name: Create ".npmrc" file in the project root, with a dummy auth token
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: echo '//localhost:4873/:_authToken="dummy-auth-token"' > .npmrc
+      - name: Version and publish to Verdaccio
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: yarn release --type=verdaccio
+      - name: Disable Webiny telemetry
+        run: >
+          mkdir ~/.webiny && echo '{ "id": "ci", "telemetry": false }' >
+          ~/.webiny/config
+      - name: Create a new self-hosted Webiny project
+        run: >-
+          npx create-webiny-project@local-npm new-webiny-project-server --tag
+          local-npm --no-interactive --hosting-type server --assign-to-yarnrc
+          '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}'
+          --template-options '{"storageOps":"postgres"}'
+      - name: Print CLI version
+        working-directory: new-webiny-project-server
+        run: yarn webiny --version
+      - name: Build API and Admin
+        working-directory: new-webiny-project-server
+        env:
+          WEBINY_HOSTING_TYPE: server
+          WEBINY_API_URL: http://localhost:3002
+        run: yarn webiny build api && yarn webiny build admin
+      - name: Start API
+        env:
+          PORT: '3002'
+          WEBINY_PG_HOST: localhost
+          WEBINY_PG_PORT: '5432'
+          WEBINY_PG_USER: postgres
+          WEBINY_PG_PASSWORD: postgres
+          WEBINY_PG_DATABASE: webiny
+          WEBINY_LOCAL_STORAGE_PATH: ${{ github.workspace }}/new-webiny-project-server/.webiny/storage
+        run: |-
+          mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"
+          mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"
+          cd new-webiny-project-server/.webiny/workspace/apps/api/graphql/build
+          nohup node start.mjs > /tmp/webiny-api.log 2>&1 &
+          echo "API starting on port 3002"
+      - name: Serve Admin
+        run: >-
+          nohup npx --yes serve -s
+          new-webiny-project-server/.webiny/workspace/apps/admin/build -l 3001 >
+          /tmp/webiny-admin.log 2>&1 &
+
+          echo "Admin starting on port 3001"
+      - name: Wait for API and Admin
+        run: >-
+          set -euo pipefail
+
+
+          wait_for_port() {
+            for _ in $(seq 1 90); do
+              if (echo > /dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; then
+                echo "port $1 is accepting connections"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "::error::Timed out waiting for port $1."
+            return 1
+          }
+
+
+          wait_for_port 3002
+
+          wait_for_port 3001
+
+
+          # A listening socket is not the same as a working GraphQL endpoint.
+
+          curl -fsS -X POST http://localhost:3002/graphql -H 'content-type:
+          application/json' \
+            -d '{"query":"{__typename}"}' > /dev/null
+          echo "GraphQL API responded."
+      - name: Create Cypress config
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: >-
+          yarn setup-cypress:server --apiUrl http://localhost:3002 --adminUrl
+          http://localhost:3001
+      - name: Install Cypress binary
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: cd cypress-tests && yarn cypress install
+      - name: Cypress - run installation wizard test
+        working-directory: ${{ needs.baseBranch.outputs.base-branch }}
+        run: >-
+          yarn cy:run --browser chrome --spec
+          "cypress/e2e/adminInstallation/**/*.cy.js"
+      - name: Update PR comment - Server (Postgres) passed
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| Server \(Postgres\) \|.*@| Server (Postgres) | ✅
+          Passed | - |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
+      - name: Update PR comment - Server (Postgres) failed
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          COMMENT_ID: ${{ needs.checkComment.outputs.comment-id }}
+        run: >-
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID --jq
+          '.body' > /tmp/comment.txt
+
+          sed -i -E "s@^\| Server \(Postgres\) \|.*@| Server (Postgres) | ❌
+          Failed | - |@" /tmp/comment.txt
+
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
+          PATCH --field body=@/tmp/comment.txt
+      - name: Print server logs
+        if: failure()
+        run: >-
+          echo "::group::API log"; cat /tmp/webiny-api.log || true; echo
+          "::endgroup::"
+
+          echo "::group::Admin log"; cat /tmp/webiny-admin.log || true; echo
+          "::endgroup::"
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: cypress-screenshots-server-postgres
           retention-days: 1
           if-no-files-found: ignore
           path: >-

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -14,10 +14,8 @@ import {
 } from "./e2e/index.js";
 
 // The self-hosted variants that actually run. Drives both the PR status comment and the job list,
-// so enabling Postgres is a one-line change here rather than two edits that can drift apart.
-// Postgres is implemented and renders correctly; it stays off until SQLite is proven green, since
-// the server hosting type is still ALPHA.
-const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite"];
+// so the two cannot drift apart.
+const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite", "postgres"];
 
 export const pullRequestsCommandE2e = createSlashCommandWorkflow({
     command: "e2e",


### PR DESCRIPTION
### What changed

The SQLite variant is green in CI (run `32948535831`, `E2E - Server (SQLite) -> success`), so this switches on the Postgres variant that has been written and rendering correctly since #5586 but deliberately left unregistered.

It is one line:

```ts
const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite", "postgres"];
```

That array drives both the job list and the PR status comment rows, so the `Server (Postgres)` row and its pass/fail updates come along automatically — which is exactly why it was built that way in #5596.

### What the variant already had

| | |
|---|---|
| service container | `postgres:17` with a `pg_isready` health check — without it the job can reach `webiny build` before Postgres accepts connections |
| runtime env | `WEBINY_PG_HOST/PORT/USER/PASSWORD/DATABASE`, matching the postgres template's `.env.example` defaults, so the scaffolded project connects with no extra config |
| scaffolding | `--template-options '{"storageOps":"postgres"}'`, which selects the postgres template and therefore `<Infra.Postgres>` — which is what makes the build wire in `createPostgresConnection` rather than the SQLite one |

The two server jobs run on separate runners, so both using ports 3002/3001 is fine, and their Cypress screenshot artifacts are named per variant.

### Verification

- Diff against `next` is exactly the new job plus the extra comment row — **no existing job changed**
- All 24 `run` steps in the new job extracted from the generated YAML and checked with `bash -n`
- Confirmed the scaffold command passes `storageOps: postgres`, and that the build step carries no database env (driver selection comes from the config, not the environment)
- `oxfmt --check` and `oxlint` clean

### Cost

The SQLite variant runs in **4.8 min** against 12.2 (DDB) and 13.2 (DDB+OS) — no Pulumi, no AWS, GitHub-hosted. Postgres adds a second job of roughly that size, in parallel.

### Not yet exercised

Like every step of this series, the first real signal comes from an `/e2e` run after merge. The Postgres path shares everything with SQLite except the service container and the connection env, so if it fails I would expect it to be in one of those two places — and the failure handlers dump the API and Admin logs and upload screenshots.

### Changelog

**Self-hosted Postgres end-to-end coverage**

End-to-end tests now also cover the self-hosted hosting type running against Postgres, alongside the existing SQLite coverage.

### Squash Merge Commit

```
ci: enable the self-hosted Postgres E2E variant (#5600)
```