### PR TITLE
feat(ci): run self-hosted E2E on push as well

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -889,3 +889,319 @@ jobs:
       contents: read
       actions: write
       id-token: write
+  e2eTests-server-sqlite:
+    needs:
+      - constants
+      - build
+    name: E2E (Server SQLite)
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: v6/.webiny/cached-packages
+          key: ${{ needs.constants.outputs.run-cache-key }}
+      - name: Install dependencies
+        run: yarn --immutable
+        working-directory: v6
+      - name: Build packages
+        run: yarn build --rebuild-dependents
+        working-directory: v6
+      - name: Start Verdaccio local server
+        working-directory: v6
+        run: >-
+          yarn add pm2 verdaccio && npx pm2 start verdaccio -- -c
+          .verdaccio.yaml
+      - name: Configure NPM to use local registry
+        run: npm config set registry http://localhost:4873
+      - name: Set git email
+        run: git config --global user.email "webiny-bot@webiny.com"
+      - name: Set git username
+        run: git config --global user.name "webiny-bot"
+      - name: Create ".npmrc" file in the project root, with a dummy auth token
+        working-directory: v6
+        run: echo '//localhost:4873/:_authToken="dummy-auth-token"' > .npmrc
+      - name: Version and publish to Verdaccio
+        working-directory: v6
+        run: yarn release --type=verdaccio
+      - name: Disable Webiny telemetry
+        run: >
+          mkdir ~/.webiny && echo '{ "id": "ci", "telemetry": false }' >
+          ~/.webiny/config
+      - name: Create a new self-hosted Webiny project
+        run: >-
+          npx create-webiny-project@local-npm new-webiny-project-server --tag
+          local-npm --no-interactive --hosting-type server --assign-to-yarnrc
+          '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}'
+          --template-options '{"storageOps":"sqlite"}'
+      - name: Print CLI version
+        working-directory: new-webiny-project-server
+        run: yarn webiny --version
+      - name: Build API and Admin
+        working-directory: new-webiny-project-server
+        env:
+          WEBINY_HOSTING_TYPE: server
+          WEBINY_API_URL: http://localhost:3002
+        run: yarn webiny build api && yarn webiny build admin
+      - name: Start API
+        env:
+          PORT: '3002'
+          WEBINY_SQL_FILENAME: >-
+            ${{ github.workspace
+            }}/new-webiny-project-server/.webiny/server.sqlite
+          WEBINY_LOCAL_STORAGE_PATH: ${{ github.workspace }}/new-webiny-project-server/.webiny/storage
+        run: |-
+          mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"
+          mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"
+          cd new-webiny-project-server/.webiny/workspace/apps/api/graphql/build
+          nohup node start.mjs > /tmp/webiny-api.log 2>&1 &
+          echo "API starting on port 3002"
+      - name: Serve Admin
+        run: >-
+          nohup npx --yes serve -s
+          new-webiny-project-server/.webiny/workspace/apps/admin/build -l 3001 >
+          /tmp/webiny-admin.log 2>&1 &
+
+          echo "Admin starting on port 3001"
+      - name: Wait for API and Admin
+        run: >-
+          set -euo pipefail
+
+
+          wait_for_port() {
+            for _ in $(seq 1 90); do
+              if (echo > /dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; then
+                echo "port $1 is accepting connections"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "::error::Timed out waiting for port $1."
+            return 1
+          }
+
+
+          wait_for_port 3002
+
+          wait_for_port 3001
+
+
+          # A listening socket is not the same as a working GraphQL endpoint.
+
+          curl -fsS -X POST http://localhost:3002/graphql -H 'content-type:
+          application/json' \
+            -d '{"query":"{__typename}"}' > /dev/null
+          echo "GraphQL API responded."
+      - name: Create Cypress config
+        working-directory: v6
+        run: >-
+          yarn setup-cypress:server --apiUrl http://localhost:3002 --adminUrl
+          http://localhost:3001
+      - name: Install Cypress binary
+        working-directory: v6
+        run: cd cypress-tests && yarn cypress install
+      - name: Cypress - run installation wizard test
+        working-directory: v6
+        run: >-
+          yarn cy:run --browser chrome --spec
+          "cypress/e2e/adminInstallation/**/*.cy.js"
+      - name: Print server logs
+        if: failure()
+        run: >-
+          echo "::group::API log"; cat /tmp/webiny-api.log || true; echo
+          "::endgroup::"
+
+          echo "::group::Admin log"; cat /tmp/webiny-admin.log || true; echo
+          "::endgroup::"
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: cypress-screenshots-server-sqlite
+          retention-days: 1
+          if-no-files-found: ignore
+          path: v6/cypress-tests/cypress/screenshots
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+    permissions:
+      contents: read
+      actions: write
+  e2eTests-server-postgres:
+    needs:
+      - constants
+      - build
+    name: E2E (Server Postgres)
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: webiny
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          path: v6
+      - name: Resolve Yarn cache folder
+        id: yarn-cache-folder
+        working-directory: v6
+        run: echo "path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: v6/.webiny/cached-packages
+          key: ${{ needs.constants.outputs.run-cache-key }}
+      - name: Install dependencies
+        run: yarn --immutable
+        working-directory: v6
+      - name: Build packages
+        run: yarn build --rebuild-dependents
+        working-directory: v6
+      - name: Start Verdaccio local server
+        working-directory: v6
+        run: >-
+          yarn add pm2 verdaccio && npx pm2 start verdaccio -- -c
+          .verdaccio.yaml
+      - name: Configure NPM to use local registry
+        run: npm config set registry http://localhost:4873
+      - name: Set git email
+        run: git config --global user.email "webiny-bot@webiny.com"
+      - name: Set git username
+        run: git config --global user.name "webiny-bot"
+      - name: Create ".npmrc" file in the project root, with a dummy auth token
+        working-directory: v6
+        run: echo '//localhost:4873/:_authToken="dummy-auth-token"' > .npmrc
+      - name: Version and publish to Verdaccio
+        working-directory: v6
+        run: yarn release --type=verdaccio
+      - name: Disable Webiny telemetry
+        run: >
+          mkdir ~/.webiny && echo '{ "id": "ci", "telemetry": false }' >
+          ~/.webiny/config
+      - name: Create a new self-hosted Webiny project
+        run: >-
+          npx create-webiny-project@local-npm new-webiny-project-server --tag
+          local-npm --no-interactive --hosting-type server --assign-to-yarnrc
+          '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}'
+          --template-options '{"storageOps":"postgres"}'
+      - name: Print CLI version
+        working-directory: new-webiny-project-server
+        run: yarn webiny --version
+      - name: Build API and Admin
+        working-directory: new-webiny-project-server
+        env:
+          WEBINY_HOSTING_TYPE: server
+          WEBINY_API_URL: http://localhost:3002
+        run: yarn webiny build api && yarn webiny build admin
+      - name: Start API
+        env:
+          PORT: '3002'
+          WEBINY_PG_HOST: localhost
+          WEBINY_PG_PORT: '5432'
+          WEBINY_PG_USER: postgres
+          WEBINY_PG_PASSWORD: postgres
+          WEBINY_PG_DATABASE: webiny
+          WEBINY_LOCAL_STORAGE_PATH: ${{ github.workspace }}/new-webiny-project-server/.webiny/storage
+        run: |-
+          mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"
+          mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"
+          cd new-webiny-project-server/.webiny/workspace/apps/api/graphql/build
+          nohup node start.mjs > /tmp/webiny-api.log 2>&1 &
+          echo "API starting on port 3002"
+      - name: Serve Admin
+        run: >-
+          nohup npx --yes serve -s
+          new-webiny-project-server/.webiny/workspace/apps/admin/build -l 3001 >
+          /tmp/webiny-admin.log 2>&1 &
+
+          echo "Admin starting on port 3001"
+      - name: Wait for API and Admin
+        run: >-
+          set -euo pipefail
+
+
+          wait_for_port() {
+            for _ in $(seq 1 90); do
+              if (echo > /dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; then
+                echo "port $1 is accepting connections"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "::error::Timed out waiting for port $1."
+            return 1
+          }
+
+
+          wait_for_port 3002
+
+          wait_for_port 3001
+
+
+          # A listening socket is not the same as a working GraphQL endpoint.
+
+          curl -fsS -X POST http://localhost:3002/graphql -H 'content-type:
+          application/json' \
+            -d '{"query":"{__typename}"}' > /dev/null
+          echo "GraphQL API responded."
+      - name: Create Cypress config
+        working-directory: v6
+        run: >-
+          yarn setup-cypress:server --apiUrl http://localhost:3002 --adminUrl
+          http://localhost:3001
+      - name: Install Cypress binary
+        working-directory: v6
+        run: cd cypress-tests && yarn cypress install
+      - name: Cypress - run installation wizard test
+        working-directory: v6
+        run: >-
+          yarn cy:run --browser chrome --spec
+          "cypress/e2e/adminInstallation/**/*.cy.js"
+      - name: Print server logs
+        if: failure()
+        run: >-
+          echo "::group::API log"; cat /tmp/webiny-api.log || true; echo
+          "::endgroup::"
+
+          echo "::group::Admin log"; cat /tmp/webiny-admin.log || true; echo
+          "::endgroup::"
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: cypress-screenshots-server-postgres
+          retention-days: 1
+          if-no-files-found: ignore
+          path: v6/cypress-tests/cypress/screenshots
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+    permissions:
+      contents: read
+      actions: write

--- a/.github/workflows/wac/e2e/createAwsJobs.ts
+++ b/.github/workflows/wac/e2e/createAwsJobs.ts
@@ -18,7 +18,10 @@ import {
 
 // AWS-deployed E2E: scaffold a project, deploy it with Pulumi, then run Cypress against the
 // deployed URLs. One variant per storage setup ("ddb", "ddb-os").
-export const createCypressJobs = (dbSetup: string) => {
+//
+// Named for the hosting type, not for Cypress - the self-hosted variants in createServerJobs run
+// Cypress too, so that would not distinguish them.
+export const createAwsJobs = (dbSetup: string) => {
     const jobNames = {
         constants: `e2e-wby-cms-${dbSetup}-constants`,
         projectSetup: `e2e-wby-cms-${dbSetup}-project-setup`,

--- a/.github/workflows/wac/e2e/createServerJobs.ts
+++ b/.github/workflows/wac/e2e/createServerJobs.ts
@@ -52,9 +52,27 @@ const PG = {
 //
 // Consequences: no `awsAuth`, no Pulumi backend, no `environment: next` secrets, and it runs on a
 // GitHub-hosted runner. That makes it far cheaper than the DDB / DDB+OS jobs.
-export const createServerJobs = (storageOps: ServerStorageOps) => {
+interface ServerProjectPartsParams {
+    // Where the webiny-js checkout lives: the PR's base branch expression for `/e2e`, a literal
+    // directory for `push`.
+    workingDirectory: string;
+    // When set, the variant reports its result into the PR status comment under this label. `push`
+    // has no PR to report into, so it omits this.
+    statusLabel?: string;
+}
+
+/**
+ * The self-hosted project lifecycle, shared by the `/e2e` and `push` workflows: publish to
+ * Verdaccio, scaffold, build, start, wait for readiness, run Cypress, dump logs on failure.
+ *
+ * The wrapping job supplies what differs between the two - how the repository is checked out, and
+ * how the build output arrives (an artifact on `issue_comment`, the run cache on `push`).
+ */
+export const createServerProjectParts = (
+    storageOps: ServerStorageOps,
+    { workingDirectory, statusLabel }: ServerProjectPartsParams
+) => {
     const isPostgres = storageOps === "postgres";
-    const label = serverVariantLabel(storageOps);
 
     // Postgres runs as a service container; SQLite needs nothing (the template writes a file).
     const services: NormalJob["services"] = isPostgres
@@ -107,147 +125,166 @@ export const createServerJobs = (storageOps: ServerStorageOps) => {
     };
 
     return {
+        services,
+        steps: [
+            ...createSetupVerdaccioSteps({ workingDirectory }),
+            {
+                name: 'Create ".npmrc" file in the project root, with a dummy auth token',
+                "working-directory": workingDirectory,
+                run: "echo '//localhost:4873/:_authToken=\"dummy-auth-token\"' > .npmrc"
+            },
+            {
+                name: "Version and publish to Verdaccio",
+                "working-directory": workingDirectory,
+                run: "yarn release --type=verdaccio"
+            },
+            {
+                name: "Disable Webiny telemetry",
+                run: 'mkdir ~/.webiny && echo \'{ "id": "ci", "telemetry": false }\' > ~/.webiny/config\n'
+            },
+            {
+                name: "Create a new self-hosted Webiny project",
+                run: `npx create-webiny-project@local-npm ${DIR_SERVER_PROJECT} --tag local-npm --no-interactive --hosting-type server --assign-to-yarnrc '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}' --template-options '{"storageOps":"${storageOps}"}'`
+            },
+            {
+                name: "Print CLI version",
+                "working-directory": DIR_SERVER_PROJECT,
+                run: "yarn webiny --version"
+            },
+            {
+                // The Admin bundle bakes its API origin at build time, so WEBINY_API_URL has to
+                // be set here and match where the API is actually started below.
+                name: "Build API and Admin",
+                "working-directory": DIR_SERVER_PROJECT,
+                // Only what the build actually bakes in: the hosting type, and the API origin,
+                // which the Admin bundle embeds. Database configuration is NOT needed here -
+                // `<Infra.Sqlite>` / `<Infra.Postgres>` in webiny.config.tsx already bake their
+                // own values, and the standalone handler we run below ignores those anyway (see
+                // the runtime env on "Start API").
+                env: {
+                    WEBINY_HOSTING_TYPE: "server",
+                    WEBINY_API_URL: SERVER_API_URL
+                },
+                run: "yarn webiny build api && yarn webiny build admin"
+            },
+            {
+                // Backgrounded so the job can continue; the process lives for the rest of the
+                // job. Logs go to a file so the failure handler below can surface them.
+                name: "Start API",
+                env: { PORT: `${SERVER_API_PORT}`, ...runtimeEnv },
+                run: [
+                    // SQLite will not create missing parent directories for its file, and the
+                    // local file storage folder does not exist until something writes to it.
+                    'mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"',
+                    'mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"',
+                    `cd ${SERVER_BUILD_DIR}/api/graphql/build`,
+                    "nohup node start.mjs > /tmp/webiny-api.log 2>&1 &",
+                    `echo "API starting on port ${SERVER_API_PORT}"`
+                ].join("\n")
+            },
+            {
+                // `serve -s` gives the SPA fallback the Admin app needs (a hard refresh on a
+                // client-side route must not 404) - the same thing nginx-spa.conf does for the
+                // documented Docker setup. `serve` itself is not published to Verdaccio, but
+                // .verdaccio.yaml proxies `**` to the npmjs uplink, so npx resolves it even
+                // though the registry is pointed at localhost:4873 at this point.
+                name: "Serve Admin",
+                run: [
+                    `nohup npx --yes serve -s ${SERVER_BUILD_DIR}/admin/build -l ${SERVER_ADMIN_PORT} > /tmp/webiny-admin.log 2>&1 &`,
+                    `echo "Admin starting on port ${SERVER_ADMIN_PORT}"`
+                ].join("\n")
+            },
+            {
+                name: "Wait for API and Admin",
+                run: [
+                    "set -euo pipefail",
+                    "",
+                    "wait_for_port() {",
+                    "  for _ in $(seq 1 90); do",
+                    '    if (echo > /dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; then',
+                    '      echo "port $1 is accepting connections"',
+                    "      return 0",
+                    "    fi",
+                    "    sleep 2",
+                    "  done",
+                    '  echo "::error::Timed out waiting for port $1."',
+                    "  return 1",
+                    "}",
+                    "",
+                    `wait_for_port ${SERVER_API_PORT}`,
+                    `wait_for_port ${SERVER_ADMIN_PORT}`,
+                    "",
+                    "# A listening socket is not the same as a working GraphQL endpoint.",
+                    `curl -fsS -X POST ${SERVER_API_URL}/graphql -H 'content-type: application/json' \\`,
+                    `  -d '{"query":"{__typename}"}' > /dev/null`,
+                    'echo "GraphQL API responded."'
+                ].join("\n")
+            },
+            {
+                name: "Create Cypress config",
+                "working-directory": workingDirectory,
+                run: `yarn setup-cypress:server --apiUrl ${SERVER_API_URL} --adminUrl ${SERVER_ADMIN_URL}`
+            },
+            {
+                name: "Install Cypress binary",
+                "working-directory": workingDirectory,
+                run: "cd cypress-tests && yarn cypress install"
+            },
+            {
+                // The same single spec the AWS variants run. /e2e is a smoke test - a freshly
+                // created project installs and the user lands in the dashboard - so every
+                // variant runs exactly this, and none tests more than its counterparts.
+                name: "Cypress - run installation wizard test",
+                "working-directory": workingDirectory,
+                run: 'yarn cy:run --browser chrome --spec "cypress/e2e/adminInstallation/**/*.cy.js"'
+            },
+            ...(statusLabel ? createStatusRowUpdateSteps({ label: statusLabel }) : []),
+            {
+                name: "Print server logs",
+                if: "failure()",
+                run: [
+                    'echo "::group::API log"; cat /tmp/webiny-api.log || true; echo "::endgroup::"',
+                    'echo "::group::Admin log"; cat /tmp/webiny-admin.log || true; echo "::endgroup::"'
+                ].join("\n")
+            },
+            {
+                name: "Upload Cypress screenshots",
+                if: "failure()",
+                uses: ACTION.uploadArtifactV6,
+                with: {
+                    name: `cypress-screenshots-server-${storageOps}`,
+                    "retention-days": 1,
+                    "if-no-files-found": "ignore",
+                    path: `${workingDirectory}/cypress-tests/cypress/screenshots`
+                }
+            }
+        ]
+    };
+};
+
+/**
+ * The `/e2e` command's server jobs: PR checkout, build output from the run artifact, and a row in
+ * the PR status comment.
+ */
+export const createServerJobs = (storageOps: ServerStorageOps) => {
+    const label = serverVariantLabel(storageOps);
+    const parts = createServerProjectParts(storageOps, {
+        workingDirectory: DIR_WEBINY_JS,
+        statusLabel: label
+    });
+
+    return {
         [`e2e-server-${storageOps}`]: createJob({
             needs: ["baseBranch", "constants", "build", "checkComment"],
             name: `E2E - ${label}`,
             checkout: { path: DIR_WEBINY_JS },
-            ...(services ? { services } : {}),
+            ...(parts.services ? { services: parts.services } : {}),
             steps: [
                 ...createCheckoutPrSteps({ workingDirectory: DIR_WEBINY_JS }),
                 ...yarnCacheSteps,
                 ...runBuildCacheDownloadSteps,
                 ...installBuildSteps,
-                ...createSetupVerdaccioSteps({ workingDirectory: DIR_WEBINY_JS }),
-                {
-                    name: 'Create ".npmrc" file in the project root, with a dummy auth token',
-                    "working-directory": DIR_WEBINY_JS,
-                    run: "echo '//localhost:4873/:_authToken=\"dummy-auth-token\"' > .npmrc"
-                },
-                {
-                    name: "Version and publish to Verdaccio",
-                    "working-directory": DIR_WEBINY_JS,
-                    run: "yarn release --type=verdaccio"
-                },
-                {
-                    name: "Disable Webiny telemetry",
-                    run: 'mkdir ~/.webiny && echo \'{ "id": "ci", "telemetry": false }\' > ~/.webiny/config\n'
-                },
-                {
-                    name: "Create a new self-hosted Webiny project",
-                    run: `npx create-webiny-project@local-npm ${DIR_SERVER_PROJECT} --tag local-npm --no-interactive --hosting-type server --assign-to-yarnrc '{"npmRegistryServer":"http://localhost:4873","unsafeHttpWhitelist":["localhost"]}' --template-options '{"storageOps":"${storageOps}"}'`
-                },
-                {
-                    name: "Print CLI version",
-                    "working-directory": DIR_SERVER_PROJECT,
-                    run: "yarn webiny --version"
-                },
-                {
-                    // The Admin bundle bakes its API origin at build time, so WEBINY_API_URL has to
-                    // be set here and match where the API is actually started below.
-                    name: "Build API and Admin",
-                    "working-directory": DIR_SERVER_PROJECT,
-                    // Only what the build actually bakes in: the hosting type, and the API origin,
-                    // which the Admin bundle embeds. Database configuration is NOT needed here -
-                    // `<Infra.Sqlite>` / `<Infra.Postgres>` in webiny.config.tsx already bake their
-                    // own values, and the standalone handler we run below ignores those anyway (see
-                    // the runtime env on "Start API").
-                    env: {
-                        WEBINY_HOSTING_TYPE: "server",
-                        WEBINY_API_URL: SERVER_API_URL
-                    },
-                    run: "yarn webiny build api && yarn webiny build admin"
-                },
-                {
-                    // Backgrounded so the job can continue; the process lives for the rest of the
-                    // job. Logs go to a file so the failure handler below can surface them.
-                    name: "Start API",
-                    env: { PORT: `${SERVER_API_PORT}`, ...runtimeEnv },
-                    run: [
-                        // SQLite will not create missing parent directories for its file, and the
-                        // local file storage folder does not exist until something writes to it.
-                        'mkdir -p "$(dirname "${WEBINY_SQL_FILENAME:-/tmp/unused}")"',
-                        'mkdir -p "${WEBINY_LOCAL_STORAGE_PATH:-/tmp/unused}"',
-                        `cd ${SERVER_BUILD_DIR}/api/graphql/build`,
-                        "nohup node start.mjs > /tmp/webiny-api.log 2>&1 &",
-                        `echo "API starting on port ${SERVER_API_PORT}"`
-                    ].join("\n")
-                },
-                {
-                    // `serve -s` gives the SPA fallback the Admin app needs (a hard refresh on a
-                    // client-side route must not 404) - the same thing nginx-spa.conf does for the
-                    // documented Docker setup. `serve` itself is not published to Verdaccio, but
-                    // .verdaccio.yaml proxies `**` to the npmjs uplink, so npx resolves it even
-                    // though the registry is pointed at localhost:4873 at this point.
-                    name: "Serve Admin",
-                    run: [
-                        `nohup npx --yes serve -s ${SERVER_BUILD_DIR}/admin/build -l ${SERVER_ADMIN_PORT} > /tmp/webiny-admin.log 2>&1 &`,
-                        `echo "Admin starting on port ${SERVER_ADMIN_PORT}"`
-                    ].join("\n")
-                },
-                {
-                    name: "Wait for API and Admin",
-                    run: [
-                        "set -euo pipefail",
-                        "",
-                        "wait_for_port() {",
-                        "  for _ in $(seq 1 90); do",
-                        '    if (echo > /dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; then',
-                        '      echo "port $1 is accepting connections"',
-                        "      return 0",
-                        "    fi",
-                        "    sleep 2",
-                        "  done",
-                        '  echo "::error::Timed out waiting for port $1."',
-                        "  return 1",
-                        "}",
-                        "",
-                        `wait_for_port ${SERVER_API_PORT}`,
-                        `wait_for_port ${SERVER_ADMIN_PORT}`,
-                        "",
-                        "# A listening socket is not the same as a working GraphQL endpoint.",
-                        `curl -fsS -X POST ${SERVER_API_URL}/graphql -H 'content-type: application/json' \\`,
-                        `  -d '{"query":"{__typename}"}' > /dev/null`,
-                        'echo "GraphQL API responded."'
-                    ].join("\n")
-                },
-                {
-                    name: "Create Cypress config",
-                    "working-directory": DIR_WEBINY_JS,
-                    run: `yarn setup-cypress:server --apiUrl ${SERVER_API_URL} --adminUrl ${SERVER_ADMIN_URL}`
-                },
-                {
-                    name: "Install Cypress binary",
-                    "working-directory": DIR_WEBINY_JS,
-                    run: "cd cypress-tests && yarn cypress install"
-                },
-                {
-                    // Only the installation wizard for now. It is pure UI (no cy.login), so it does
-                    // not need the Cognito-based auth helper that the other specs use - porting that
-                    // to the self-hosted identity provider comes next.
-                    name: "Cypress - run installation wizard test",
-                    "working-directory": DIR_WEBINY_JS,
-                    run: 'yarn cy:run --browser chrome --spec "cypress/e2e/adminInstallation/**/*.cy.js"'
-                },
-                ...createStatusRowUpdateSteps({ label }),
-                {
-                    name: "Print server logs",
-                    if: "failure()",
-                    run: [
-                        'echo "::group::API log"; cat /tmp/webiny-api.log || true; echo "::endgroup::"',
-                        'echo "::group::Admin log"; cat /tmp/webiny-admin.log || true; echo "::endgroup::"'
-                    ].join("\n")
-                },
-                {
-                    name: "Upload Cypress screenshots",
-                    if: "failure()",
-                    uses: ACTION.uploadArtifactV6,
-                    with: {
-                        name: `cypress-screenshots-server-${storageOps}`,
-                        "retention-days": 1,
-                        "if-no-files-found": "ignore",
-                        path: `${DIR_WEBINY_JS}/cypress-tests/cypress/screenshots`
-                    }
-                }
+                ...parts.steps
             ]
         })
     };

--- a/.github/workflows/wac/e2e/index.ts
+++ b/.github/workflows/wac/e2e/index.ts
@@ -1,5 +1,5 @@
 export * from "./constants.js";
 export * from "./statusComment.js";
 export * from "./sharedSteps.js";
-export * from "./createCypressJobs.js";
+export * from "./createAwsJobs.js";
 export * from "./createServerJobs.js";

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -3,7 +3,7 @@ import { createCheckoutPrSteps } from "./steps/index.js";
 import { AWS_REGION, BUILD_PACKAGES_RUNNER, NODE_OPTIONS } from "./utils/index.js";
 import type { ServerStorageOps } from "./e2e/index.js";
 import {
-    createCypressJobs,
+    createAwsJobs,
     createServerJobs,
     serverVariantCommentRow,
     DIR_WEBINY_JS,
@@ -92,8 +92,8 @@ export const pullRequestsCommandE2e = createSlashCommandWorkflow({
                 ...runBuildCacheUploadSteps
             ]
         }),
-        ...createCypressJobs("ddb"),
-        ...createCypressJobs("ddb-os"),
+        ...createAwsJobs("ddb"),
+        ...createAwsJobs("ddb-os"),
         ...SERVER_VARIANTS.reduce(
             (jobs, storageOps) => ({ ...jobs, ...createServerJobs(storageOps) }),
             {}

--- a/.github/workflows/wac/push.wac.ts
+++ b/.github/workflows/wac/push.wac.ts
@@ -16,6 +16,7 @@ import {
     createYarnCacheSteps,
     withCommonParams
 } from "./steps/index.js";
+import { createServerProjectParts, type ServerStorageOps } from "./e2e/index.js";
 import { AbstractStorageOps } from "./storageOps/AbstractStorageOps.js";
 import { DdbOsStorageOps, DdbStorageOps, SqlStorageOps } from "./storageOps/index.js";
 
@@ -39,6 +40,24 @@ const globalBuildCacheSteps = createGlobalBuildCacheSteps({
 const runBuildCacheSteps = createRunBuildCacheSteps({
     workingDirectory: DIR_WEBINY_JS
 });
+
+// Self-hosted ("server" hosting type) E2E, sharing its whole project lifecycle with the /e2e
+// command workflow. Only the wrapper differs: `push` checks out the pushed ref rather than a PR,
+// gets the build output from the run CACHE (a trusted trigger, so cache writes work) rather than
+// from an artifact, and has no PR comment to report into.
+const createServerE2EJobs = (storageOps: ServerStorageOps) => {
+    const parts = createServerProjectParts(storageOps, { workingDirectory: DIR_WEBINY_JS });
+
+    return {
+        [`e2eTests-server-${storageOps}`]: createJob({
+            needs: ["constants", "build"],
+            name: `E2E (Server ${storageOps === "postgres" ? "Postgres" : "SQLite"})`,
+            checkout: { path: DIR_WEBINY_JS },
+            ...(parts.services ? { services: parts.services } : {}),
+            steps: [...yarnCacheSteps, ...runBuildCacheSteps, ...installBuildSteps, ...parts.steps]
+        })
+    };
+};
 
 const createE2EJobs = (storageOps: AbstractStorageOps) => {
     const jobNames = {
@@ -434,6 +453,8 @@ export const push = createWorkflow({
         ...createVitestTestsJobs(ddbOsStorageOps),
         ...createVitestTestsJobs(sqlStorageOps),
         ...createE2EJobs(ddbStorageOps),
-        ...createE2EJobs(ddbOsStorageOps)
+        ...createE2EJobs(ddbOsStorageOps),
+        ...createServerE2EJobs("sqlite"),
+        ...createServerE2EJobs("postgres")
     }
 });

--- a/.github/workflows/wac/push.wac.ts
+++ b/.github/workflows/wac/push.wac.ts
@@ -59,7 +59,7 @@ const createServerE2EJobs = (storageOps: ServerStorageOps) => {
     };
 };
 
-const createE2EJobs = (storageOps: AbstractStorageOps) => {
+const createAwsE2EJobs = (storageOps: AbstractStorageOps) => {
     const jobNames = {
         constants: `e2eTests-${storageOps.shortId}-constants`,
         projectSetup: `e2eTests-${storageOps.shortId}-setup`,
@@ -452,8 +452,8 @@ export const push = createWorkflow({
         ...createVitestTestsJobs(ddbStorageOps),
         ...createVitestTestsJobs(ddbOsStorageOps),
         ...createVitestTestsJobs(sqlStorageOps),
-        ...createE2EJobs(ddbStorageOps),
-        ...createE2EJobs(ddbOsStorageOps),
+        ...createAwsE2EJobs(ddbStorageOps),
+        ...createAwsE2EJobs(ddbOsStorageOps),
         ...createServerE2EJobs("sqlite"),
         ...createServerE2EJobs("postgres")
     }


### PR DESCRIPTION
### What changed

Adds the SQLite and Postgres self-hosted variants to the **push** workflow, so `next` / `dev` / `release/*` get the same coverage the `/e2e` command already has. That completes backlog item 8.

### The extraction

`createServerJobs` was doing two jobs at once: describing how to scaffold, build, start and test a self-hosted project, *and* describing how the `/e2e` command wraps that. The first part is now `createServerProjectParts`, which both workflows call. The wrappers keep only what genuinely differs:

| | checkout | build output | status comment |
|---|---|---|---|
| `/e2e` | PR checkout, pinned to `pr-sha` | run **artifact** — `issue_comment` gets a read-only cache token | reports into the PR comment |
| `push` | the pushed ref | run **cache** — trusted trigger, so writes work and are cheaper | no PR to report into |

The status-comment steps became opt-in via a `statusLabel` param rather than unconditional, which is what lets `push` reuse everything else untouched.

### Verification

The extraction is the risky part, so it was checked directly rather than reasoned about:

- **`pullRequestsCommandE2e.yml` is byte-identical** before and after the refactor. The working `/e2e` jobs are provably unchanged.
- **No pre-existing push job changed** — the diff against `next` is exactly the two added jobs.
- The new push jobs carry **no PR-only constructs**: no `github.event.issue.number`, no `needs.checkComment` / `needs.baseBranch`, no `pr-sha`, no "Checkout Pull Request", no comment updates. Checked by scanning the generated job JSON for each.
- They restore the **run cache** (`needs.constants.outputs.run-cache-key`, which the push `build` job populates) rather than downloading an artifact.
- All 20 `run` steps in the new jobs checked with `bash -n`.
- `oxfmt --check` and `oxlint` clean.

### Also

Updated a stale comment in the `/e2e` job that still said porting Cypress auth to the self-hosted IdP "comes next". That work was deliberately dropped (#5599 closed) — every variant runs the installation wizard smoke test and nothing more, so no variant tests more than its counterparts.

### Cost

On `/e2e` these variants run in 4.8 min (SQLite) and 8 min (Postgres), against 12–13 min for the DDB ones — no Pulumi, no AWS, GitHub-hosted. They run in parallel with the existing jobs, so wall-clock on push should be unaffected.

### Not yet exercised

The push variants have never run. They share their entire lifecycle with the `/e2e` variants, which are both green in CI (runs `32948535831` and `32958520146`), so the untested surface is just the wrapper — checkout, cache restore, and `needs`. If something breaks, the log-dump and screenshot handlers come along with the shared steps.

### Changelog

**Self-hosted end-to-end coverage on every push**

Pushes to the main branches now also run the self-hosted end-to-end tests against both SQLite and Postgres, matching what the `/e2e` command already covered.

### Squash Merge Commit

```
feat(ci): run self-hosted E2E on push as well (#5601)
```