### PR TITLE
ci(slop-cop): fail the job for opted-in authors when findings are reported

### DIFF
--- a/.github/workflows/slopCop.yml
+++ b/.github/workflows/slopCop.yml
@@ -58,6 +58,7 @@ jobs:
 
           gh pr diff "$PR_NUMBER" --repo "$REPO" > "$WORKDIR/diff.patch" || true
       - name: Run slop cop analysis
+        id: slop-cop
         if: ${{ env.ANTHROPIC_API_KEY != '' }}
         env:
           PR_JSON_FILE: ${{ runner.temp }}/slop-cop/pr.json
@@ -105,4 +106,17 @@ jobs:
               -F "body=@$REPORT"
             echo "::notice::Posted new slop cop comment."
           fi
+      - name: Fail if slop cop found something
+        if: >-
+          ${{ always() && contains(fromJSON('["adrians5j"]'),
+          github.event.pull_request.user.login) &&
+          steps.slop-cop.outputs.findings-count != '' &&
+          steps.slop-cop.outputs.findings-count != '0' }}
+        env:
+          FINDINGS_COUNT: ${{ steps.slop-cop.outputs.findings-count }}
+        run: >-
+          echo "::error::Slop cop reported $FINDINGS_COUNT finding(s). See the
+          slop cop comment on this PR."
+
+          exit 1
     runs-on: ubuntu-latest

--- a/.github/workflows/wac/slopCop.wac.ts
+++ b/.github/workflows/wac/slopCop.wac.ts
@@ -20,6 +20,14 @@ import { createJob } from "./jobs/index.js";
 // workflow with a writable token against untrusted head code) just to cover
 // forks, we skip fork PRs cleanly - the near-totality of PRs here come from
 // in-repo branches. The job is gated on `!head.repo.fork`.
+// Authors who have opted into slop cop BLOCKING their PRs. For everyone else the job stays
+// advisory - it comments and succeeds - which is the phase-1 behaviour described above.
+//
+// Opting in is per-author on purpose: the signal comes from an LLM and can be wrong, so making it a
+// hard gate is a choice each author makes for their own PRs rather than something imposed on
+// everyone at once.
+const BLOCKING_AUTHORS = ["adrians5j"];
+
 export const slopCop = createWorkflow({
     name: "Slop Cop",
     on: {
@@ -82,6 +90,7 @@ export const slopCop = createWorkflow({
                 },
                 {
                     name: "Run slop cop analysis",
+                    id: "slop-cop",
                     // Skip entirely when no key is configured (e.g. on forks of the repo
                     // that never set the secret) so the workflow stays green.
                     if: "${{ env.ANTHROPIC_API_KEY != '' }}",
@@ -125,6 +134,22 @@ export const slopCop = createWorkflow({
                         '    -F "body=@$REPORT"',
                         '  echo "::notice::Posted new slop cop comment."',
                         "fi"
+                    ].join("\n")
+                },
+                {
+                    // Runs AFTER the comment step so the findings are always visible on the PR,
+                    // whether or not the job then fails.
+                    //
+                    // An empty count means the analysis was skipped or errored (both deliberately
+                    // non-blocking), so only a real, non-zero count fails the job.
+                    name: "Fail if slop cop found something",
+                    if: `\${{ always() && contains(fromJSON('${JSON.stringify(BLOCKING_AUTHORS)}'), github.event.pull_request.user.login) && steps.slop-cop.outputs.findings-count != '' && steps.slop-cop.outputs.findings-count != '0' }}`,
+                    env: {
+                        FINDINGS_COUNT: "${{ steps.slop-cop.outputs.findings-count }}"
+                    },
+                    run: [
+                        'echo "::error::Slop cop reported $FINDINGS_COUNT finding(s). See the slop cop comment on this PR."',
+                        "exit 1"
                     ].join("\n")
                 }
             ]

--- a/.github/workflows/wac/utils/runNodeScripts/slopCop.js
+++ b/.github/workflows/wac/utils/runNodeScripts/slopCop.js
@@ -318,6 +318,18 @@ const main = async () => {
     const result = await callClaude(buildPrompt(loadPr()));
     fs.writeFileSync(outputPath, renderReport(result), "utf8");
     console.log(`Slop cop report written (verdict: ${result.verdict}).`);
+
+    // Machine-readable signal for the workflow, which uses it to decide whether to fail the job for
+    // authors who have opted into blocking. Mirrors what renderReport treats as "worth a look", so
+    // the comment and the exit status can never disagree.
+    const findingsCount =
+        result.verdict === "warnings" && Array.isArray(result.findings)
+            ? result.findings.length
+            : 0;
+
+    if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `findings-count=${findingsCount}\n`);
+    }
 };
 
 main().catch(err => {


### PR DESCRIPTION
### What changed

Slop cop has been advisory for everyone since it shipped — it comments and always succeeds. This makes it a **hard gate for authors who opt in**, starting with `adrians5j`. Everyone else keeps the current advisory behaviour.

```ts
const BLOCKING_AUTHORS = ["adrians5j"];
```

Opting in per-author is deliberate: the signal comes from an LLM and can be wrong, so turning it into something that blocks a merge is a choice each author makes for their own PRs rather than something imposed on the whole repo at once. Adding someone is one entry in that array.

### How it decides

The analysis script now writes `findings-count` to `$GITHUB_OUTPUT`, computed from **exactly** what the rendered comment treats as "worth a look":

```js
const findingsCount =
    result.verdict === "warnings" && Array.isArray(result.findings) ? result.findings.length : 0;
```

Deriving the gate and the comment from the same condition means the two cannot disagree — no failing a PR whose comment says there is nothing to flag, and no green run alongside a comment listing problems.

Verified across all four shapes the result can take:

| result | count | gate fires | comment says "nothing to flag" |
|---|---|---|---|
| `warnings` + 2 findings | 2 | yes | no |
| `warnings` + 0 findings | 0 | no | yes |
| `ok` verdict | 0 | no | yes |
| malformed `findings` | 0 | no | yes |

Consistent in every case. (The test pulls both expressions out of the real source, so it cannot drift from the implementation.)

### Ordering and safety

- The gate runs **after** the comment step, so the findings are always visible on the PR whether or not the job then fails — a red check with no explanation would be much worse than the current advisory comment.
- It is gated on `always()`, so a failure earlier in the job does not silently skip it.
- An **empty** count means the analysis was skipped (no `ANTHROPIC_API_KEY`, e.g. on forks) or errored — both deliberately non-blocking — so only a real, non-zero count fails the job.

### Changelog

**Stricter pull request checks for opted-in authors**

The automated pull request review can now block a merge for authors who opt in, instead of only leaving a comment.

### Squash Merge Commit

```
ci(slop-cop): fail for opted-in authors when findings reported (#5602)
```