### PR TITLE
fix(website-builder-react): stack Grid columns via CSS media query

### DIFF
--- a/packages/api-aco/src/createAcoContext.ts
+++ b/packages/api-aco/src/createAcoContext.ts
@@ -50,10 +50,13 @@ const setupAcoContext = async (
 
     const getModel = context.container.resolve(GetModelUseCase);
 
-    await context.security.withoutAuthorization(async () => {
-        const folderModel = await getModel.execute(FOLDER_MODEL_ID);
-        context.container.registerInstance(FolderModelAbstraction, folderModel.value);
+    const folderModelResult = await context.security.withoutAuthorization(async () => {
+        return await getModel.execute(FOLDER_MODEL_ID);
     });
+    if (folderModelResult.isFail()) {
+        throw folderModelResult.error;
+    }
+    context.container.registerInstance(FolderModelAbstraction, folderModelResult.value);
 
     const getTenant = (): Tenant => {
         return tenancy.getCurrentTenant();

--- a/packages/api-aco/src/features/cms/decorators/ListDeletedEntriesWithFlpDecorator.ts
+++ b/packages/api-aco/src/features/cms/decorators/ListDeletedEntriesWithFlpDecorator.ts
@@ -25,6 +25,9 @@ class ListDeletedEntriesWithFlpDecoratorImpl implements ListDeletedEntriesUseCas
     ): ListDeletedEntriesUseCase.Return<T> {
         const loader = async (params?: CmsEntryListParams) => {
             const result = await this.decoratee.execute<T>(model, params);
+            if (result.isFail()) {
+                throw result.error;
+            }
             return result.value;
         };
 

--- a/packages/api-aco/src/features/cms/decorators/ListEntriesWithFlpDecorator.ts
+++ b/packages/api-aco/src/features/cms/decorators/ListEntriesWithFlpDecorator.ts
@@ -24,6 +24,9 @@ class ListEntriesWithFlpDecoratorImpl implements ListEntriesUseCase.Interface {
     ): ListEntriesUseCase.Return<T> {
         const loader = async (params?: CmsEntryListParams) => {
             const result = await this.decoratee.execute<T>(model, params);
+            if (result.isFail()) {
+                throw result.error;
+            }
             return result.value;
         };
 

--- a/packages/api-aco/src/features/cms/decorators/ListLatestEntriesWithFlpDecorator.ts
+++ b/packages/api-aco/src/features/cms/decorators/ListLatestEntriesWithFlpDecorator.ts
@@ -25,6 +25,9 @@ class ListLatestEntriesWithFlpDecoratorImpl implements ListLatestEntriesUseCase.
     ): ListLatestEntriesUseCase.Return<T> {
         const loader = async (params?: CmsEntryListParams) => {
             const result = await this.decoratee.execute<T>(model, params);
+            if (result.isFail()) {
+                throw result.error;
+            }
             return result.value;
         };
 

--- a/packages/api-aco/src/features/cms/decorators/ListPublishedEntriesWithFlpDecorator.ts
+++ b/packages/api-aco/src/features/cms/decorators/ListPublishedEntriesWithFlpDecorator.ts
@@ -25,6 +25,9 @@ class ListPublishedEntriesWithFlpDecoratorImpl implements ListPublishedEntriesUs
     ): ListPublishedEntriesUseCase.Return<T> {
         const loader = async (params?: CmsEntryListParams) => {
             const result = await this.decoratee.execute<T>(model, params);
+            if (result.isFail()) {
+                throw result.error;
+            }
             return result.value;
         };
 

--- a/packages/api-aco/src/features/folder/EnsureFolderIsEmpty/EnsureFolderIsEmpty.ts
+++ b/packages/api-aco/src/features/folder/EnsureFolderIsEmpty/EnsureFolderIsEmpty.ts
@@ -1,6 +1,7 @@
 import { FolderLevelPermissions } from "~/features/flp/FolderLevelPermissions/index.js";
 import { ListFoldersUseCase } from "~/features/folder/ListFolders/index.js";
 import { EnsureFolderIsEmpty as Abstraction } from "~/features/folder/EnsureFolderIsEmpty/abstractions.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
 import { FolderNotAuthorizedError, FolderNotEmptyError } from "~/domain/folder/errors.js";
 import { Result } from "@webiny/feature/api";
@@ -9,7 +10,8 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
     constructor(
         private identityContext: IdentityContext.Interface,
         private folderLevelPermissions: FolderLevelPermissions.Interface,
-        private listFoldersUseCase: ListFoldersUseCase.Interface
+        private listFoldersUseCase: ListFoldersUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async execute(
@@ -25,6 +27,10 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
                 },
                 limit: 1
             });
+            if (result.isFail()) {
+                this.logger.error(result.error);
+                return false;
+            }
 
             const { folders } = result.value;
 
@@ -68,5 +74,5 @@ class EnsureFolderIsEmptyImpl implements Abstraction.Interface {
 
 export const EnsureFolderIsEmpty = Abstraction.createImplementation({
     implementation: EnsureFolderIsEmptyImpl,
-    dependencies: [IdentityContext, FolderLevelPermissions, ListFoldersUseCase]
+    dependencies: [IdentityContext, FolderLevelPermissions, ListFoldersUseCase, Logger]
 });

--- a/packages/api-aco/src/features/folder/EnsureHcmsFolderIsEmptyOnDelete/ModelFolderBeforeDeleteHandler.ts
+++ b/packages/api-aco/src/features/folder/EnsureHcmsFolderIsEmptyOnDelete/ModelFolderBeforeDeleteHandler.ts
@@ -37,6 +37,9 @@ class ModelFolderBeforeDeleteHandlerImpl implements FolderBeforeDeleteEventHandl
                 },
                 limit: 1
             });
+            if (result.isFail()) {
+                throw result.error;
+            }
 
             const { entries } = result.value;
 

--- a/packages/api-aco/src/flp/tasks/syncFlp.task.ts
+++ b/packages/api-aco/src/flp/tasks/syncFlp.task.ts
@@ -34,6 +34,9 @@ class SyncFlpTaskImpl implements TaskDefinition.Interface<ISyncFlpTaskInput> {
              */
             if (input.folderId) {
                 const result = await this.getFolder.execute(input.folderId!);
+                if (result.isFail()) {
+                    return controller.response.error(result.error);
+                }
                 const folder = result.value;
 
                 await controller.task.trigger<IUpdateFlpTaskInput>({
@@ -75,6 +78,10 @@ class SyncFlpTaskImpl implements TaskDefinition.Interface<ISyncFlpTaskInput> {
                             parentId: null
                         }
                     });
+                    if (result.isFail()) {
+                        await controller.logger.error(result.error);
+                        continue;
+                    }
 
                     const { folders } = result.value;
 
@@ -113,6 +120,9 @@ class SyncFlpTaskImpl implements TaskDefinition.Interface<ISyncFlpTaskInput> {
                         parentId: null
                     }
                 });
+                if (result.isFail()) {
+                    return controller.response.error(result.error);
+                }
 
                 const { folders } = result.value;
 

--- a/packages/api-core/src/features/security/roles/Installer/RolesInstaller.ts
+++ b/packages/api-core/src/features/security/roles/Installer/RolesInstaller.ts
@@ -19,6 +19,9 @@ class RolesInstallerImpl implements AppInstaller.Interface {
 
     async install(): Promise<void> {
         const rolesResult = await this.listRolesUseCase.execute();
+        if (rolesResult.isFail()) {
+            throw rolesResult.error;
+        }
         const roles = rolesResult.value;
 
         if (!roles.find(g => g.slug === "full-access")) {

--- a/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
+++ b/packages/api-elasticsearch-tasks/src/tasks/createIndexes/CreateIndexesTaskRunner.ts
@@ -31,6 +31,9 @@ export class CreateIndexesTaskRunner {
         }
 
         const tenantsResult = await this.listTenantsUseCase.execute();
+        if (tenantsResult.isFail()) {
+            return this.taskController.response.error(tenantsResult.error);
+        }
         const tenants = tenantsResult.value;
 
         const indexes = await listIndexes(this.tenantContext, tenants, this.indexFactories);

--- a/packages/api-file-manager-aco/src/features/EnsureFolderIsEmptyBeforeDelete/EnsureFolderIsEmptyBeforeDelete.ts
+++ b/packages/api-file-manager-aco/src/features/EnsureFolderIsEmptyBeforeDelete/EnsureFolderIsEmptyBeforeDelete.ts
@@ -31,6 +31,10 @@ class EnsureFolderIsEmptyBeforeDeleteImpl implements FolderBeforeDeleteEventHand
                 limit: 1
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { items } = result.value;
 
             return items.length > 0;

--- a/packages/api-file-manager-s3/src/graphql/schema.ts
+++ b/packages/api-file-manager-s3/src/graphql/schema.ts
@@ -115,6 +115,9 @@ export const createS3GraphQLSchema = () => {
                         const data = args.data as PresignedPostPayloadData;
 
                         const settingsResult = await getSettings.execute();
+                        if (settingsResult.isFail()) {
+                            throw settingsResult.error;
+                        }
                         const settings = settingsResult.value;
 
                         const normalizer = createFileNormalizerFromContext(context);
@@ -142,6 +145,9 @@ export const createS3GraphQLSchema = () => {
 
                     try {
                         const settingsResult = await getSettings.execute();
+                        if (settingsResult.isFail()) {
+                            throw settingsResult.error;
+                        }
                         const settings = settingsResult.value;
 
                         const normalizer = createFileNormalizerFromContext(context);

--- a/packages/api-file-manager/src/features/settings/UpdateSettings/UpdateSettingsUseCase.ts
+++ b/packages/api-file-manager/src/features/settings/UpdateSettings/UpdateSettingsUseCase.ts
@@ -33,6 +33,9 @@ class UpdateSettingsUseCaseImpl implements UseCaseAbstraction.Interface {
 
         // Get existing settings to merge with new data
         const existingResult = await this.getSettings.execute();
+        if (existingResult.isFail()) {
+            return existingResult;
+        }
         const existing = existingResult.value;
 
         // Prepare merged settings

--- a/packages/api-file-manager/src/graphql/filesSchema.ts
+++ b/packages/api-file-manager/src/graphql/filesSchema.ts
@@ -34,6 +34,9 @@ export const createFilesSchema = (params: CreateFilesTypeDefsParams) => {
                     // TODO: create `FileUrlGenerator` service to use here
                     const getSettings = context.container.resolve(GetSettingsUseCase);
                     const result = await getSettings.execute();
+                    if (result.isFail()) {
+                        throw result.error;
+                    }
                     const settings = result.value;
                     return (settings?.srcPrefix || "") + file.key;
                 }

--- a/packages/api-file-manager/src/graphql/getFileByUrl.ts
+++ b/packages/api-file-manager/src/graphql/getFileByUrl.ts
@@ -5,6 +5,7 @@ import type { Security } from "@webiny/api-core/types/security.js";
 import { NotAuthorizedError } from "@webiny/api-core/features/security/shared/index.js";
 import type { ApiCoreContext } from "@webiny/api-core/types/core.js";
 import { ListFilesUseCase } from "~/features/file/ListFiles/index.js";
+import { Logger } from "@webiny/api-core/exports/api/logger";
 
 export const getFileByUrl = () => {
     const fileManagerGraphQL = new GraphQLSchemaPlugin<ApiCoreContext>({
@@ -19,7 +20,10 @@ export const getFileByUrl = () => {
                     const { url } = args as { url: string };
                     const useCase = new SecureGetFileByUrl(
                         context.security,
-                        new GetFileByUrlUseCase(context.container.resolve(ListFilesUseCase))
+                        new GetFileByUrlUseCase(
+                            context.container.resolve(ListFilesUseCase),
+                            context.container.resolve(Logger)
+                        )
                     );
                     try {
                         const file = await useCase.execute(url);
@@ -44,7 +48,10 @@ interface IGetFileByUrl {
 }
 
 class GetFileByUrlUseCase implements IGetFileByUrl {
-    constructor(private listFiles: ListFilesUseCase.Interface) {}
+    constructor(
+        private readonly listFiles: ListFilesUseCase.Interface,
+        private readonly logger: Logger.Interface
+    ) {}
 
     async execute(url: string): Promise<File | undefined> {
         const { pathname } = new URL(url);
@@ -56,6 +63,10 @@ class GetFileByUrlUseCase implements IGetFileByUrl {
             },
             limit: 1
         });
+        if (filesResult.isFail()) {
+            this.logger.error(filesResult.error);
+            return undefined;
+        }
 
         const files = filesResult.value.items;
 

--- a/packages/api-file-manager/src/graphql/index.ts
+++ b/packages/api-file-manager/src/graphql/index.ts
@@ -27,6 +27,9 @@ export const createGraphQLSchemaPlugin = () => {
 
             await context.security.withoutAuthorization(async () => {
                 const modelsResult = await listModels.execute();
+                if (modelsResult.isFail()) {
+                    throw modelsResult.error;
+                }
                 const models = modelsResult.value;
 
                 /**

--- a/packages/api-file-manager/src/index.ts
+++ b/packages/api-file-manager/src/index.ts
@@ -25,6 +25,9 @@ export const createFileManagerContext = () => {
 
         await context.security.withoutAuthorization(async () => {
             const fileModel = await getModel.execute(FILE_MODEL_ID);
+            if (fileModel.isFail()) {
+                throw fileModel.error;
+            }
             context.container.registerInstance(FileModelAbstraction, fileModel.value);
         });
 

--- a/packages/api-headless-cms-bulk-actions/src/features/DeleteEntriesBulkAction/DeleteEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/DeleteEntriesBulkAction/DeleteEntriesBulkAction.ts
@@ -16,6 +16,9 @@ class DeleteEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listDeletedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/MoveToFolderBulkAction/MoveToFolderBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/MoveToFolderBulkAction/MoveToFolderBulkAction.ts
@@ -15,6 +15,9 @@ class MoveToFolderBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listLatestEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/MoveToTrashBulkAction/MoveToTrashBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/MoveToTrashBulkAction/MoveToTrashBulkAction.ts
@@ -16,6 +16,9 @@ class MoveToTrashBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listLatestEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/PublishEntriesBulkAction/PublishEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/PublishEntriesBulkAction/PublishEntriesBulkAction.ts
@@ -24,6 +24,10 @@ class PublishEntriesBulkActionImpl implements EntriesBulkAction.Interface {
             }
         });
 
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
+
         return entriesResult.value;
     }
 

--- a/packages/api-headless-cms-bulk-actions/src/features/RestoreEntriesBulkAction/RestoreEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/RestoreEntriesBulkAction/RestoreEntriesBulkAction.ts
@@ -16,6 +16,9 @@ class RestoreEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listDeletedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/features/UnpublishEntriesBulkAction/UnpublishEntriesBulkAction.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/UnpublishEntriesBulkAction/UnpublishEntriesBulkAction.ts
@@ -15,6 +15,9 @@ class UnpublishEntriesBulkActionImpl implements EntriesBulkAction.Interface {
         params: EntriesBulkAction.LoadDataParams
     ): Promise<EntriesBulkAction.LoadDataResult> {
         const entriesResult = await this.listPublishedEntries.execute(model, params);
+        if (entriesResult.isFail()) {
+            throw entriesResult.error;
+        }
 
         return entriesResult.value;
     }

--- a/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
+++ b/packages/api-headless-cms-bulk-actions/src/tasks/EmptyTrashBinTaskDefinition.ts
@@ -57,6 +57,9 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
 
         // Fetch all tenants, excluding those already processed.
         const tenantsResult = await this.listTenants.execute();
+        if (tenantsResult.isFail()) {
+            return controller.response.error(tenantsResult.error);
+        }
         const baseTenants = tenantsResult.value;
         const executedTenantIds = input.executedTenantIds || [];
         const tenants = baseTenants.filter(tenant => !executedTenantIds.includes(tenant.id));
@@ -77,6 +80,10 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
 
             // List all non-private models.
             const modelsResult = await this.listModels.execute({ includePrivate: false });
+            if (modelsResult.isFail()) {
+                controller.logger.error(modelsResult.error);
+                return;
+            }
             const models = modelsResult.value;
 
             // Process each model to delete trashed entries.
@@ -95,6 +102,10 @@ class EmptyTrashBinTask implements TaskDefinition.Interface<
                         model,
                         listEntriesParams
                     );
+                    if (listResult.isFail()) {
+                        controller.logger.error(listResult.error);
+                        break;
+                    }
                     const { entries, meta } = listResult.value;
 
                     if (meta.totalCount === 0) {

--- a/packages/api-headless-cms-ddb-es/src/tasks/createIndexTaskPlugin.ts
+++ b/packages/api-headless-cms-ddb-es/src/tasks/createIndexTaskPlugin.ts
@@ -3,16 +3,22 @@ import type { Tenant } from "@webiny/api-core/types/tenancy.js";
 import { ListModelsUseCase } from "@webiny/api-headless-cms/features/contentModel/ListModels/index.js";
 import { CmsModelOpenSearchIndexProvider } from "~/features/CmsModelOpenSearchIndex/index.js";
 import { getOpenSearchIndexPrefix } from "@webiny/api-opensearch";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import type { CmsContext } from "~/types.js";
 
 class CreateElasticsearchIndexTask implements OpensearchTenantIndexFactory.Interface {
     constructor(
         private listModels: ListModelsUseCase.Interface,
-        private indexProvider: CmsModelOpenSearchIndexProvider.Interface
+        private indexProvider: CmsModelOpenSearchIndexProvider.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async getIndexList(_tenant: Tenant): Promise<OpensearchTenantIndexFactory.IndexConfig[]> {
         const result = await this.listModels.execute();
+        if (result.isFail()) {
+            this.logger.error(result.error);
+            return [];
+        }
         const models = result.value;
 
         if (models.length === 0) {
@@ -21,7 +27,7 @@ class CreateElasticsearchIndexTask implements OpensearchTenantIndexFactory.Inter
 
         const prefix = getOpenSearchIndexPrefix();
 
-        const indexes = await Promise.all(
+        return await Promise.all(
             models.map(async model => {
                 const { index, settings } = await this.indexProvider.execute({ model });
                 return {
@@ -30,8 +36,6 @@ class CreateElasticsearchIndexTask implements OpensearchTenantIndexFactory.Inter
                 };
             })
         );
-
-        return indexes;
     }
 }
 
@@ -39,6 +43,7 @@ export const createCreateIndexTask = (context: CmsContext) => {
     context.container.registerFactory(OpensearchTenantIndexFactory, () => {
         const listModels = context.container.resolve(ListModelsUseCase);
         const indexProvider = context.container.resolve(CmsModelOpenSearchIndexProvider);
-        return new CreateElasticsearchIndexTask(listModels, indexProvider);
+        const logger = context.container.resolve(Logger);
+        return new CreateElasticsearchIndexTask(listModels, indexProvider, logger);
     });
 };

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnEntryDeleteEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnEntryDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -17,7 +18,8 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterDeleteEventHandler.Event): Promise<void> {
@@ -47,6 +49,11 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return [];
+        }
+
         return actionsResult.value.items;
     }
 }
@@ -54,5 +61,5 @@ class CancelScheduledActionOnEntryDeleteHandlerImpl
 export const CancelScheduledActionOnEntryDeleteEventHandler =
     EntryAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnEntryDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnPublishEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnPublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypePublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -18,7 +19,8 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterPublishEventHandler.Event): Promise<void> {
@@ -37,6 +39,11 @@ class CancelScheduledActionOnPublishEventHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -52,5 +59,5 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 export const CancelScheduledActionOnPublishEventHandler =
     EntryAfterPublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPublishEventHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnRevisionDeleteEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnRevisionDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -15,7 +16,8 @@ import { createNamespace } from "~/utils/namespace.js";
 class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventHandler.Interface {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterDeleteEventHandler.Event): Promise<void> {
@@ -33,6 +35,11 @@ class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventH
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -48,5 +55,5 @@ class CancelScheduledActionOnDeleteHandlerImpl implements EntryAfterDeleteEventH
 export const CancelScheduledActionOnRevisionDeleteEventHandler =
     EntryAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnUnpublishEventHandler.ts
+++ b/packages/api-headless-cms-scheduler/src/features/CancelScheduledActionOnEntryChange/CancelScheduledActionOnUnpublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypeUnpublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 
 /**
@@ -18,7 +19,8 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: EntryAfterUnpublishEventHandler.Event): Promise<void> {
@@ -37,6 +39,11 @@ class CancelScheduledActionOnUnpublishHandlerImpl
             }
         });
 
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
+
         const actions = actionsResult.value.items;
 
         for (const action of actions) {
@@ -52,5 +59,5 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 export const CancelScheduledActionOnUnpublishEventHandler =
     EntryAfterUnpublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnUnpublishHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModel.ts
+++ b/packages/api-headless-cms-tasks/src/features/DeleteModelTask/DeleteModel.ts
@@ -107,6 +107,10 @@ export class DeleteModel implements IDeleteModel {
                 limit: 1000
             });
 
+            if (listResult.isFail()) {
+                return controller.response.error(listResult.error);
+            }
+
             const { folders, meta } = listResult.value;
 
             for (const item of folders) {

--- a/packages/api-headless-cms-workflows/src/features/EntryWorkflows/handlers/DeleteWorkflowsOnModelAfterDelete.ts
+++ b/packages/api-headless-cms-workflows/src/features/EntryWorkflows/handlers/DeleteWorkflowsOnModelAfterDelete.ts
@@ -25,6 +25,10 @@ class DeleteWorkflowsOnModelAfterDeleteImpl implements ModelAfterDeleteEventHand
             limit: 10000
         });
 
+        if (result.isFail()) {
+            return;
+        }
+
         const workflows = result.value.items;
 
         for (const workflow of workflows) {

--- a/packages/api-headless-cms/__tests__/converters/dynamicZone/dynamicZone.unknownTemplate.test.ts
+++ b/packages/api-headless-cms/__tests__/converters/dynamicZone/dynamicZone.unknownTemplate.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createModel } from "../mocks/model.js";
+import { createModelField } from "../mocks/field.js";
+import { getConverters, type IConvertersResponse } from "../__helpers/converters.js";
+
+const model = createModel({
+    fields: [
+        createModelField({
+            fieldId: "content",
+            type: "dynamicZone",
+            list: true,
+            settings: {
+                templates: [
+                    {
+                        id: "textTemplate",
+                        name: "Text Template",
+                        gqlTypeName: "TextTemplate",
+                        icon: undefined,
+                        description: "",
+                        fields: [
+                            createModelField({
+                                fieldId: "title",
+                                type: "text",
+                                list: false
+                            })
+                        ],
+                        layout: [],
+                        validation: []
+                    }
+                ]
+            }
+        })
+    ]
+});
+
+describe("dynamicZone storage converter - unknown template handling", () => {
+    let converters: IConvertersResponse;
+
+    beforeEach(async () => {
+        converters = await getConverters(model);
+    });
+
+    it("should not include undefined entries when a list item references an unknown template", () => {
+        const { convertFromStorage } = converters;
+
+        const storageValue = {
+            "dynamicZone@contentId": [
+                {
+                    _templateId: "textTemplate",
+                    "text@titleId": "Hello"
+                },
+                {
+                    _templateId: "deletedTemplate",
+                    "text@titleId": "This template no longer exists"
+                },
+                {
+                    _templateId: "textTemplate",
+                    "text@titleId": "World"
+                }
+            ]
+        };
+
+        const result = convertFromStorage({
+            fields: model.fields,
+            values: storageValue
+        });
+
+        const items = result.content;
+        expect(Array.isArray(items)).toBe(true);
+        // The unknown template entry should be filtered out, not left as undefined
+        expect(items).not.toContainEqual(undefined);
+        expect(items).toHaveLength(2);
+        expect(items[0]).toEqual({ _templateId: "textTemplate", title: "Hello" });
+        expect(items[1]).toEqual({ _templateId: "textTemplate", title: "World" });
+    });
+
+    it("should return undefined for a single-value field referencing an unknown template", () => {
+        const singleModel = createModel({
+            fields: [
+                createModelField({
+                    fieldId: "content",
+                    type: "dynamicZone",
+                    list: false,
+                    settings: {
+                        templates: [
+                            {
+                                id: "textTemplate",
+                                name: "Text Template",
+                                gqlTypeName: "TextTemplate",
+                                icon: undefined,
+                                description: "",
+                                fields: [
+                                    createModelField({
+                                        fieldId: "title",
+                                        type: "text",
+                                        list: false
+                                    })
+                                ],
+                                layout: [],
+                                validation: []
+                            }
+                        ]
+                    }
+                })
+            ]
+        });
+
+        const run = async () => {
+            const singleConverters = await getConverters(singleModel);
+            return singleConverters.convertFromStorage({
+                fields: singleModel.fields,
+                values: {
+                    "dynamicZone@contentId": {
+                        _templateId: "deletedTemplate",
+                        "text@titleId": "Gone"
+                    }
+                }
+            });
+        };
+
+        expect(run()).resolves.toEqual({ content: undefined });
+    });
+});

--- a/packages/api-headless-cms/src/features/graphql/fields/base/RefToGraphQL.ts
+++ b/packages/api-headless-cms/src/features/graphql/fields/base/RefToGraphQL.ts
@@ -15,6 +15,7 @@ import { createGraphQLInputField } from "./utils/createGraphQLInputField.js";
 import { GetModelUseCase } from "~/features/contentModel/GetModel/index.js";
 import { GetPublishedEntriesByIdsUseCase } from "~/features/contentEntry/GetPublishedEntriesByIds/index.js";
 import { GetLatestEntriesByIdsUseCase } from "~/features/contentEntry/GetLatestEntriesByIds/index.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 
 interface RefFieldValue {
     /**
@@ -150,6 +151,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
             const getModel = container.resolve(GetModelUseCase);
             const getPublishedByIds = container.resolve(GetPublishedEntriesByIdsUseCase);
             const getLatestByIds = container.resolve(GetLatestEntriesByIdsUseCase);
+            const logger = container.resolve(Logger);
 
             const initialValue = getValue(parent);
 
@@ -169,7 +171,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
                     return [];
                 }
 
-                const entriesByModel = referenceFieldValues.reduce(
+                const entriesByModel = referenceFieldValues.reduce<Record<string, string[]>>(
                     (collection, ref) => {
                         if (!collection[ref.modelId]) {
                             collection[ref.modelId] = [];
@@ -179,21 +181,29 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
                         collection[ref.modelId].push(ref.entryId);
                         return collection;
                     },
-                    {} as Record<string, string[]>
+                    {}
                 );
 
                 const getters = Object.keys(entriesByModel).map(async modelId => {
                     const idList = entriesByModel[modelId];
                     const modelResult = await getModel.execute(modelId);
+                    if (modelResult.isFail()) {
+                        logger.error(modelResult.error);
+                        return [];
+                    }
                     const model = modelResult.value;
 
-                    let entries: CmsEntry[];
+                    let entries: CmsEntry[] = [];
                     if (cms.READ) {
                         const getPublishedResult = await getPublishedByIds.execute(model, idList);
-                        entries = getPublishedResult.value;
+                        if (getPublishedResult.isOk()) {
+                            entries = getPublishedResult.value;
+                        }
                     } else {
-                        const latestByIsResult = await getLatestByIds.execute(model, idList);
-                        entries = latestByIsResult.value;
+                        const latestByIdsResult = await getLatestByIds.execute(model, idList);
+                        if (latestByIdsResult.isOk()) {
+                            entries = latestByIdsResult.value;
+                        }
                     }
                     return appendTypename(entries, modelIdToTypeName.get(modelId)!);
                 });
@@ -213,17 +223,25 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
 
             const value = initialValue as RefFieldValue;
             const modelResult = await getModel.execute(value.modelId);
+            if (modelResult.isFail()) {
+                logger.error(modelResult.error);
+                return null;
+            }
             const model = modelResult.value;
 
-            let revisions: CmsEntry[];
+            let revisions: CmsEntry[] = [];
             if (cms.READ) {
                 const publishedByIdsResult = await getPublishedByIds.execute(model, [
                     value.entryId
                 ]);
-                revisions = publishedByIdsResult.value;
+                if (publishedByIdsResult.isOk()) {
+                    revisions = publishedByIdsResult.value;
+                }
             } else {
                 const latestByIdsResult = await getLatestByIds.execute(model, [value.entryId]);
-                revisions = latestByIdsResult.value;
+                if (latestByIdsResult.isOk()) {
+                    revisions = latestByIdsResult.value;
+                }
             }
 
             if (!revisions || revisions.length === 0) {

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -119,13 +119,15 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
             const arrayValue = Array.isArray(value) ? value : [];
 
             return {
-                [field.fieldId]: arrayValue.map(item => {
-                    return this.processFromStorage({
-                        templates,
-                        converterCollection,
-                        value: item
-                    });
-                })
+                [field.fieldId]: arrayValue
+                    .map(item => {
+                        return this.processFromStorage({
+                            templates,
+                            converterCollection,
+                            value: item
+                        });
+                    })
+                    .filter(Boolean)
             };
         }
 
@@ -161,13 +163,15 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
 
         const template = templates.find(t => t.id === _templateId);
         if (!template) {
-            throw new WebinyError(
-                "Unknown template - converting from storage.",
-                "UNKNOWN_TEMPLATE",
-                {
+            // TODO Should we just return undefined?
+            console.warn({
+                message: "Unknown template - converting from storage.",
+                code: "UNKNOWN_TEMPLATE",
+                data: {
                     templateId: _templateId
                 }
-            );
+            });
+            return undefined;
         }
 
         return template.fields.reduce<GenericRecord<string>>(

--- a/packages/api-mailer/src/graphql/settings.ts
+++ b/packages/api-mailer/src/graphql/settings.ts
@@ -85,6 +85,10 @@ export const createSettingsGraphQL = () => {
                         const getSettings = context.container.resolve(GetSettingsUseCase);
                         const result = await getSettings.execute(SMTP_TRANSPORT_NAME);
 
+                        if (result.isFail()) {
+                            return new ErrorResponse(result.error);
+                        }
+
                         const { settings, source } = result.value;
 
                         return {

--- a/packages/api-scheduler/src/context.ts
+++ b/packages/api-scheduler/src/context.ts
@@ -57,10 +57,13 @@ export const createSchedulerContext = (params: ICreateHeadlessCmsSchedulerContex
         context.container.register(NamespaceHandlerExecutioner);
         context.container.register(SchedulerPermissionsResolver);
 
-        await context.security.withoutAuthorization(async () => {
-            const schedulerModel = await getModel.execute(SCHEDULE_MODEL_ID);
-            context.container.registerInstance(ScheduledActionModel, schedulerModel.value);
+        const schedulerModelResult = await context.security.withoutAuthorization(async () => {
+            return await getModel.execute(SCHEDULE_MODEL_ID);
         });
+        if (schedulerModelResult.isFail()) {
+            throw schedulerModelResult.error;
+        }
+        context.container.registerInstance(ScheduledActionModel, schedulerModelResult.value);
 
         // Register all features
         SchedulerFeature.register(context.container);

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageDeleteEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -17,7 +18,8 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterDeleteEventHandler.Event): Promise<void> {
@@ -30,6 +32,11 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -46,5 +53,5 @@ class CancelScheduledActionOnPageDeleteHandlerImpl
 export const CancelScheduledActionOnPageDeleteEventHandler =
     PageAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPageDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPagePublishEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPagePublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypePublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -19,7 +20,8 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterPublishEventHandler.Event): Promise<void> {
@@ -32,6 +34,11 @@ class CancelScheduledActionOnPublishEventHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -48,5 +55,5 @@ class CancelScheduledActionOnPublishEventHandlerImpl
 export const CancelScheduledActionOnPagePublishEventHandler =
     PageAfterPublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnPublishEventHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageUnpublishEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnPageUnpublishEventHandler.ts
@@ -4,6 +4,7 @@ import {
     ListScheduledActionsUseCase,
     ScheduledActionTypeUnpublish
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_PAGE } from "~/constants.js";
 
@@ -19,7 +20,8 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: PageAfterUnpublishEventHandler.Event): Promise<void> {
@@ -32,6 +34,11 @@ class CancelScheduledActionOnUnpublishHandlerImpl
                 targetId: page.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -48,5 +55,5 @@ class CancelScheduledActionOnUnpublishHandlerImpl
 export const CancelScheduledActionOnPageUnpublishEventHandler =
     PageAfterUnpublishEventHandler.createImplementation({
         implementation: CancelScheduledActionOnUnpublishHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnRedirectDeleteEventHandler.ts
+++ b/packages/api-website-builder-scheduler/src/features/CancelScheduledActionOnChange/CancelScheduledActionOnRedirectDeleteEventHandler.ts
@@ -3,6 +3,7 @@ import {
     CancelScheduledActionUseCase,
     ListScheduledActionsUseCase
 } from "@webiny/api-scheduler/exports/api/scheduler.js";
+import { Logger } from "@webiny/api-core/exports/api/logger.js";
 import { createNamespace } from "~/utils/namespace.js";
 import { SCHEDULED_ACTION_TYPE_REDIRECT } from "~/constants.js";
 
@@ -18,7 +19,8 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
 {
     constructor(
         private listScheduledActions: ListScheduledActionsUseCase.Interface,
-        private cancelScheduledAction: CancelScheduledActionUseCase.Interface
+        private cancelScheduledAction: CancelScheduledActionUseCase.Interface,
+        private logger: Logger.Interface
     ) {}
 
     async handle(event: RedirectAfterDeleteEventHandler.Event): Promise<void> {
@@ -30,6 +32,11 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
                 targetId: redirect.id
             }
         });
+
+        if (actionsResult.isFail()) {
+            this.logger.error(actionsResult.error);
+            return;
+        }
 
         const actions = actionsResult.value.items;
 
@@ -46,5 +53,5 @@ class CancelScheduledActionOnRedirectDeleteHandlerImpl
 export const CancelScheduledActionOnRedirectDeleteEventHandler =
     RedirectAfterDeleteEventHandler.createImplementation({
         implementation: CancelScheduledActionOnRedirectDeleteHandlerImpl,
-        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase]
+        dependencies: [ListScheduledActionsUseCase, CancelScheduledActionUseCase, Logger]
     });

--- a/packages/api-website-builder/src/features/folders/EnsureWbPageFolderIsEmptyOnDelete/EnsureWbPageFolderIsEmptyOnDelete.ts
+++ b/packages/api-website-builder/src/features/folders/EnsureWbPageFolderIsEmptyOnDelete/EnsureWbPageFolderIsEmptyOnDelete.ts
@@ -30,6 +30,10 @@ class EnsureWbPageFolderIsEmptyOnDeleteImpl implements FolderBeforeDeleteEventHa
                 after: null
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { pages } = result.value;
 
             return pages.length > 0;

--- a/packages/api-website-builder/src/features/folders/EnsureWbRedirectFolderIsEmptyOnDelete/EnsureWbRedirectFolderIsEmptyOnDelete.ts
+++ b/packages/api-website-builder/src/features/folders/EnsureWbRedirectFolderIsEmptyOnDelete/EnsureWbRedirectFolderIsEmptyOnDelete.ts
@@ -30,6 +30,10 @@ class EnsureWbRedirectFolderIsEmptyOnDeleteImpl
                 limit: 1
             });
 
+            if (result.isFail()) {
+                throw result.error;
+            }
+
             const { redirects } = result.value;
 
             return redirects.length > 0;

--- a/packages/api-website-builder/src/rest/getRedirects.ts
+++ b/packages/api-website-builder/src/rest/getRedirects.ts
@@ -21,6 +21,9 @@ export const createRedirectsRoute = () => {
             const getActiveRedirects = context.container.resolve(GetActiveRedirectsUseCase);
 
             const result = await getActiveRedirects.execute();
+            if (result.isFail()) {
+                return reply.code(500).send(result.error);
+            }
 
             const redirectsDto = result.value.map(entry => ActiveRedirectRestMapper.toDto(entry));
 

--- a/packages/api-workflows/src/features/workflowState/CreateWorkflowState/CreateWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/CreateWorkflowState/CreateWorkflowStateUseCase.ts
@@ -123,6 +123,9 @@ class CreateWorkflowStateUseCaseImpl implements UseCase.Interface {
         const createdRecord = createResult.value;
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const workflowState = new WorkflowState(createdRecord, teams, identity);
 

--- a/packages/api-workflows/src/features/workflowState/DeleteTargetWorkflowState/DeleteTargetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/DeleteTargetWorkflowState/DeleteTargetWorkflowStateUseCase.ts
@@ -49,6 +49,9 @@ class DeleteTargetWorkflowStateUseCaseImpl implements UseCase.Interface {
 
         const identity = this.identityContext.getIdentity();
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const state = new WorkflowState(record, teams, identity);
 

--- a/packages/api-workflows/src/features/workflowState/GetTargetWorkflowState/GetTargetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/GetTargetWorkflowState/GetTargetWorkflowStateUseCase.ts
@@ -37,6 +37,9 @@ class GetTargetWorkflowStateUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const workflowState = new WorkflowState(record, teams, identity);

--- a/packages/api-workflows/src/features/workflowState/GetWorkflowState/GetWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/GetWorkflowState/GetWorkflowStateUseCase.ts
@@ -23,6 +23,9 @@ class GetWorkflowStateUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const workflowState = new WorkflowState(record, teams, identity);

--- a/packages/api-workflows/src/features/workflowState/ListWorkflowStates/ListWorkflowStatesUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/ListWorkflowStates/ListWorkflowStatesUseCase.ts
@@ -18,6 +18,9 @@ class ListWorkflowStatesUseCaseImpl implements UseCase.Interface {
         const identity = this.identityContext.getIdentity();
 
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
 
         const recordsResult = await this.repository.execute(params);

--- a/packages/api-workflows/src/features/workflowState/UpdateWorkflowState/UpdateWorkflowStateUseCase.ts
+++ b/packages/api-workflows/src/features/workflowState/UpdateWorkflowState/UpdateWorkflowStateUseCase.ts
@@ -53,6 +53,9 @@ class UpdateWorkflowStateUseCaseImpl implements UseCase.Interface {
 
         const identity = this.identityContext.getIdentity();
         const teamsResult = await this.getUserTeams.execute(identity.id);
+        if (teamsResult.isFail()) {
+            return Result.fail(teamsResult.error);
+        }
         const teams = teamsResult.value;
         const updatedState = new WorkflowState(updatedRecord, teams, identity);
 

--- a/packages/background-tasks/src/api/graphql/index.ts
+++ b/packages/background-tasks/src/api/graphql/index.ts
@@ -42,11 +42,13 @@ const createGraphQL = () => {
         const listModels = ctx.container.resolve(ListModelsUseCase);
         const fieldRegistry = ctx.container.resolve(CmsModelFieldToGraphQLRegistry);
 
-        const models = await ctx.security.withoutAuthorization(async () => {
-            const modelsResult = await listModels.execute({ includePrivate: false });
-
-            return modelsResult.value.filter(model => model.fields.length > 0);
+        const modelsResult = await ctx.security.withoutAuthorization(async () => {
+            return await listModels.execute({ includePrivate: false });
         });
+        if (modelsResult.isFail()) {
+            throw modelsResult.error;
+        }
+        const models = modelsResult.value.filter(model => model.fields.length > 0);
         const taskFields = renderFields({
             models,
             model: taskModel,

--- a/packages/website-builder-react/src/editorComponents/Grid.tsx
+++ b/packages/website-builder-react/src/editorComponents/Grid.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ComponentProps, ComponentPropsWithChildren } from "~/types.js";
+import { createGridClass, createGridStackingCss } from "./gridStyles.js";
 
 export const GridColumnComponent = ({
     inputs
@@ -23,7 +24,7 @@ type GridProps = ComponentProps<{
     reverseWhenStacked?: boolean;
 }>;
 
-export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
+export const GridComponent = ({ inputs, styles, element }: GridProps) => {
     const { gridLayout = "12", columns, columnGap, stackAtBreakpoint, reverseWhenStacked } = inputs;
     const rowConfig = gridLayout.split("-").map(size => parseInt(size));
     const rows: Column[][] = [];
@@ -36,22 +37,17 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
     // Number of pixels we need to subtract from each cell to ensure they fit in the grid with column gap
     const cellWidthReduction = columnGap ? columnGap - columnGap / rowConfig.length : 0;
 
-    const stackColumns = breakpoint === stackAtBreakpoint;
+    const gridClass = createGridClass(element.id);
 
-    if (stackColumns) {
-        styles.flexDirection = reverseWhenStacked ? "column-reverse" : "column";
-    }
+    // Columns stack via a CSS media query (see createGridStackingCss).
+    const stackCss = createGridStackingCss({ gridClass, stackAtBreakpoint, reverseWhenStacked });
 
     return (
-        <div style={styles}>
+        <div className={gridClass} style={styles}>
+            {stackCss ? <style dangerouslySetInnerHTML={{ __html: stackCss }} /> : null}
             {rows.map(columns => {
                 return columns.map((column, i) => (
-                    <Span
-                        key={i}
-                        stackColumns={stackColumns}
-                        size={rowConfig[i]}
-                        reductionInPx={cellWidthReduction}
-                    >
+                    <Span key={i} size={rowConfig[i]} reductionInPx={cellWidthReduction}>
                         <GridColumnComponent key={i} inputs={{ children: column.children }} />
                     </Span>
                 ));
@@ -63,15 +59,16 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
 interface SpanProps {
     size: number;
     reductionInPx: number;
-    stackColumns: boolean;
     children: React.ReactNode;
 }
 
-const Span = ({ size, children, reductionInPx, stackColumns }: SpanProps) => {
-    const width = stackColumns ? "100%" : `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
+const Span = ({ size, children, reductionInPx }: SpanProps) => {
+    // Base (row) width. The Grid's media query overrides this to 100% when stacked.
+    const width = `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
 
     return (
         <div
+            className="wb-grid-col"
             style={{
                 flex: `0 0 ${width}`,
                 maxWidth: width,

--- a/packages/website-builder-react/src/editorComponents/gridStyles.ts
+++ b/packages/website-builder-react/src/editorComponents/gridStyles.ts
@@ -1,0 +1,58 @@
+import { viewportManager } from "@webiny/website-builder-sdk";
+
+/**
+ * Builds a stable, SSR-consistent class scoped to a single grid instance
+ * (e.g. `wb-grid-<id>`), sanitized to a valid CSS class name.
+ */
+export const createGridClass = (elementId: string): string => {
+    return `wb-grid-${String(elementId).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+};
+
+interface CreateGridStackingCssParams {
+    /** Scoped class applied to the grid container (from `createGridClass`). */
+    gridClass: string;
+    /** Breakpoint name at (and below) which columns stack, e.g. "mobile". */
+    stackAtBreakpoint?: string;
+    /** Reverse the visual order of columns when stacked. */
+    reverseWhenStacked?: boolean;
+}
+
+/**
+ * Builds the media query that stacks a grid's columns at (and below) the given
+ * breakpoint's width.
+ *
+ * Stacking is expressed as CSS rather than JS so the layout is correct straight
+ * from the SSR HTML — no hydration, no viewport JS, no flash — the browser
+ * applies it by the real viewport width. The width comes from the theme's
+ * breakpoint definition (populated on both server and client via ContentSdk.init).
+ *
+ * Returns an empty string when no stacking breakpoint is configured (or the
+ * named breakpoint is unknown), in which case the grid never stacks.
+ */
+export const createGridStackingCss = ({
+    gridClass,
+    stackAtBreakpoint,
+    reverseWhenStacked
+}: CreateGridStackingCssParams): string => {
+    if (!stackAtBreakpoint) {
+        return "";
+    }
+
+    const breakpoint = viewportManager
+        .getViewport()
+        .breakpoints.find(bp => bp.name === stackAtBreakpoint);
+
+    if (!breakpoint) {
+        return "";
+    }
+
+    const direction = reverseWhenStacked ? "column-reverse" : "column";
+
+    // `!important` overrides the inline base (row) styles set on the elements.
+    return [
+        `@media (max-width: ${breakpoint.maxWidth}px) {`,
+        `  .${gridClass} { flex-direction: ${direction} !important; }`,
+        `  .${gridClass} > .wb-grid-col { flex: 0 0 100% !important; max-width: 100% !important; }`,
+        `}`
+    ].join("\n");
+};

--- a/packages/website-builder-sdk/src/ContentSdk.ts
+++ b/packages/website-builder-sdk/src/ContentSdk.ts
@@ -95,9 +95,11 @@ export class ContentSdk implements IContentSdk, IRedirects {
 
         const theme = Theme.from(config.theme ?? {});
 
-        if (environment.isClient()) {
-            viewportManager.setBreakpoints(theme.breakpoints);
-        }
+        // Populate breakpoints on the server too, so SSR can generate
+        // breakpoint-aware CSS (e.g. Grid stacking media queries) from the
+        // real theme widths. The resize listener stays client-only (it's
+        // guarded in the ViewportManager constructor).
+        viewportManager.setBreakpoints(theme.breakpoints);
 
         let editingSdk;
         if (environment.isEditing()) {


### PR DESCRIPTION
## Problem

Grid column stacking is resolved in **JS** from the runtime viewport breakpoint (`breakpoint === stackAtBreakpoint`) and applied as **inline** styles.

On SSR the breakpoint is always `desktop`, so the served HTML renders columns side-by-side and only corrects once the client hydrates and re-resolves the breakpoint. That causes a layout **flash** — and stays broken entirely when the content subtree doesn't hydrate (e.g. content rendered via `next/dynamic({ssr:true})`), which is how this surfaced on an OpenNext/SSG frontend: a grid set to *stack at mobile* stayed 2-column at mobile width.

## Fix

Emit stacking as a **scoped CSS media query** in the rendered HTML, so the browser applies it by the real viewport width — no JS, no hydration dependency, no flash.

- Grid renders a scoped class `wb-grid-<element.id>` plus a `<style>` block:
  ```css
  @media (max-width: <breakpoint-width>px) {
    .wb-grid-<id> { flex-direction: column !important; }
    .wb-grid-<id> > .wb-grid-col { flex: 0 0 100% !important; max-width: 100% !important; }
  }
  ```
- The stack width is read from the **theme's** breakpoint definition (no hardcoded widths).
- `ContentSdk.init` now populates `viewportManager` breakpoints on the **server** too (the resize listener stays client-only), so SSR has the real widths to generate the media query.
- CSS/class string building lives in `gridStyles.ts` (`createGridClass`, `createGridStackingCss`), not inline in the component.

## Screenshot
<img width="2106" height="741" alt="image" src="https://github.com/user-attachments/assets/2447343a-61eb-486c-bf67-5591c7db7e8c" />

## Scope

**Grid stacking only.** Multiple grids and nested grids are safe (unique per-id class + direct-child combinator). Deliberately out of scope, as follow-ups:

- Per-breakpoint **styles** for all elements (e.g. responsive `rowGap`/`columnGap`, spacing, visibility) — same JS→`@media` treatment, generalized.
- Per-breakpoint **content** (text/RTE per breakpoint) and responsive images (`<picture>`/`srcset`).
- The content-hydration gap and SSG `draftMode` behavior (orthogonal bugs).

## Testing

- Verified the `@media` block is present in the SSR HTML and the browser stacks columns at the breakpoint width with no client JS.
- Builds clean; changed files formatted (oxfmt) and linted (oxlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)