### PR TITLE
feat(ci): derive the release source from the version in Full Release

### DIFF
--- a/.github/workflows/fullRelease.yml
+++ b/.github/workflows/fullRelease.yml
@@ -7,49 +7,87 @@ name: 🚀 Full Release
   workflow_dispatch:
     inputs:
       version:
-        description: Release version (e.g. 6.3.0)
+        description: Release version (e.g. 6.3.0 for a minor, 6.3.1 for a patch)
         required: true
         type: string
-      sourceTag:
-        description: Git tag or branch to branch off from
-        required: false
-        default: next
-        type: string
 jobs:
-  validateInputs:
-    name: Validate inputs
+  resolveSource:
+    name: Resolve release source
+    outputs:
+      source-ref: ${{ steps.resolve.outputs.source-ref }}
+      base-branch: ${{ steps.resolve.outputs.base-branch }}
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       VERSION: ${{ github.event.inputs.version }}
-      SOURCE_TAG: ${{ github.event.inputs.sourceTag }}
     steps:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 24
-      - name: Validate workflow inputs
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          fetch-depth: 0
+      - name: Resolve source ref and base branch
+        id: resolve
         run: >-
-          set -e
+          set -euo pipefail
 
-          ok=1
 
           if ! printf "%s" "$VERSION" | grep -Eq "^6\.[0-9]+\.[0-9]+$"; then
             echo "::error::Invalid version [$VERSION]. Expected 6.x.y, e.g. 6.3.0 (three numbers, no alpha/beta)."
-            ok=0
-          fi
-
-          if [ -n "$SOURCE_TAG" ] && ! printf "%s" "$SOURCE_TAG" | grep -Eq
-          "^[A-Za-z0-9._/-]+$"; then
-            echo "::error::Invalid sourceTag [$SOURCE_TAG]. Use a valid branch or tag name (letters, digits, . _ / -)."
-            ok=0
-          fi
-
-          if [ "$ok" -ne 1 ]; then
-            echo "Input validation failed. Fix the inputs above and re-run the workflow."
             exit 1
           fi
 
-          echo "Inputs OK: version=$VERSION sourceTag=${SOURCE_TAG:-next}"
+
+          MINOR="${VERSION%.*}"
+
+          PATCH="${VERSION##*.}"
+
+
+          if [ "$PATCH" = "0" ]; then
+            # A minor release opens the next line, so it branches off next.
+            SOURCE_REF="next"
+            BASE_BRANCH="next"
+          else
+            # A patch continues an existing line: it must build on the release before
+            # it. That predecessor is not optional - `yarn release` generates the
+            # changelog as `git log v<previous>..v<this>` using npm's latest dist-tag,
+            # so releasing out of order produces a changelog spanning two releases and
+            # publishes a version whose predecessor never existed.
+            PREVIOUS="${MINOR}.$((PATCH - 1))"
+            SOURCE_REF="v${PREVIOUS}"
+
+            if ! git rev-parse -q --verify "refs/tags/${SOURCE_REF}" > /dev/null; then
+              echo "::error::Cannot release ${VERSION}: tag ${SOURCE_REF} does not exist, so ${PREVIOUS} has not been released yet. Release it first."
+              exit 1
+            fi
+
+            # Source is a tag, so the release gets a base branch cut from it - that way
+            # the PR diff shows only release-specific work.
+            BASE_BRANCH="release/${VERSION}-base"
+          fi
+
+
+          echo "source-ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+
+          echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+
+          # Echoed before anything is created, so a wrong derivation is visible
+          up front
+
+          # rather than only in the resulting PR.
+
+          {
+            echo "### 🚀 Release plan"
+            echo ""
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Version | \`$VERSION\` |"
+            echo "| Branches off | \`$SOURCE_REF\` |"
+            echo "| Release branch | \`release/$VERSION\` |"
+            echo "| PR base | \`$BASE_BRANCH\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,7 +95,7 @@ jobs:
   createWebinyJsBranch:
     name: Create release branch (webiny-js)
     needs:
-      - validateInputs
+      - resolveSource
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -74,29 +112,29 @@ jobs:
       - name: Checkout source tag
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
-          ref: ${{ github.event.inputs.sourceTag }}
+          ref: ${{ needs.resolveSource.outputs.source-ref }}
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
       - name: Create and push release branch
         id: branch
         env:
           VERSION: ${{ github.event.inputs.version }}
-          SOURCE_TAG: ${{ github.event.inputs.sourceTag }}
+          SOURCE_REF: ${{ needs.resolveSource.outputs.source-ref }}
+          BASE_BRANCH: ${{ needs.resolveSource.outputs.base-branch }}
         run: >-
-          set -e
+          set -euo pipefail
 
-          # If the source is a tag, create a base branch off it so the PR diff
+          # For a patch the base branch is cut from the source tag, so the PR
+          diff
 
-          # shows only release-specific work. Otherwise (a branch, e.g. next),
+          # shows only release-specific work. For a minor it is `next` itself,
+          which
 
-          # the source branch itself is the PR base.
+          # already exists.
 
-          if git show-ref --verify --quiet "refs/tags/${SOURCE_TAG}"; then
-            BASE_BRANCH="release/${VERSION}-base"
+          if [ "$BASE_BRANCH" != "$SOURCE_REF" ]; then
             git checkout -b "$BASE_BRANCH"
             git push origin "$BASE_BRANCH"
-          else
-            BASE_BRANCH="${SOURCE_TAG}"
           fi
 
           git checkout -b "release/${VERSION}"
@@ -105,13 +143,11 @@ jobs:
           ci]" -m "Empty commit to allow PR creation."
 
           git push origin "release/${VERSION}"
-
-          echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
       - name: Open pull request
         id: pr
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          BASE_BRANCH: ${{ steps.branch.outputs.base-branch }}
+          BASE_BRANCH: ${{ needs.resolveSource.outputs.base-branch }}
         run: >-
           PR_URL=$(gh pr create --title "📦  Release ${{
           github.event.inputs.version }}" --body "Release ${{

--- a/.github/workflows/wac/fullRelease.wac.ts
+++ b/.github/workflows/wac/fullRelease.wac.ts
@@ -3,61 +3,101 @@ import { createWorkflow } from "github-actions-wac";
 import { createJob } from "./jobs/index.js";
 
 const VERSION = "${{ github.event.inputs.version }}";
-const SOURCE_TAG = "${{ github.event.inputs.sourceTag }}";
+
+// The ref the release branches off, worked out from the version alone (see the `resolveSource`
+// job). Consumed by every job after it.
+const SOURCE_REF = "${{ needs.resolveSource.outputs.source-ref }}";
+const BASE_BRANCH = "${{ needs.resolveSource.outputs.base-branch }}";
 
 export const fullRelease = createWorkflow({
     name: `🚀 Full Release`,
     on: {
         workflow_dispatch: {
+            // Version only. What a release branches off is not a free choice - it follows from
+            // the version - and asking for it separately only created ways to get the two out of
+            // step. Most damaging was the old `sourceTag` default of "next": a patch entered
+            // without changing it would branch off unreleased code.
             inputs: {
                 version: {
-                    description: "Release version (e.g. 6.3.0)",
+                    description: "Release version (e.g. 6.3.0 for a minor, 6.3.1 for a patch)",
                     required: true,
-                    type: "string"
-                },
-                sourceTag: {
-                    description: "Git tag or branch to branch off from",
-                    required: false,
-                    default: "next",
                     type: "string"
                 }
             }
         }
     },
     jobs: {
-        validateInputs: createJob({
-            name: "Validate inputs",
-            checkout: false,
-            env: {
-                VERSION,
-                SOURCE_TAG
+        // Validates the version and derives everything else from it. Runs before anything is
+        // pushed, so a bad input costs nothing.
+        resolveSource: createJob({
+            name: "Resolve release source",
+            // Needs the tags to check that a patch's predecessor actually exists.
+            checkout: { "fetch-depth": 0 },
+            outputs: {
+                "source-ref": "${{ steps.resolve.outputs.source-ref }}",
+                "base-branch": "${{ steps.resolve.outputs.base-branch }}"
             },
+            env: { VERSION },
             steps: [
                 {
-                    name: "Validate workflow inputs",
+                    name: "Resolve source ref and base branch",
+                    id: "resolve",
                     run: [
-                        "set -e",
-                        "ok=1",
+                        "set -euo pipefail",
+                        "",
                         'if ! printf "%s" "$VERSION" | grep -Eq "^6\\.[0-9]+\\.[0-9]+$"; then',
                         '  echo "::error::Invalid version [$VERSION]. Expected 6.x.y, e.g. 6.3.0 (three numbers, no alpha/beta)."',
-                        "  ok=0",
-                        "fi",
-                        'if [ -n "$SOURCE_TAG" ] && ! printf "%s" "$SOURCE_TAG" | grep -Eq "^[A-Za-z0-9._/-]+$"; then',
-                        '  echo "::error::Invalid sourceTag [$SOURCE_TAG]. Use a valid branch or tag name (letters, digits, . _ / -)."',
-                        "  ok=0",
-                        "fi",
-                        'if [ "$ok" -ne 1 ]; then',
-                        '  echo "Input validation failed. Fix the inputs above and re-run the workflow."',
                         "  exit 1",
                         "fi",
-                        'echo "Inputs OK: version=$VERSION sourceTag=${SOURCE_TAG:-next}"'
+                        "",
+                        'MINOR="${VERSION%.*}"',
+                        'PATCH="${VERSION##*.}"',
+                        "",
+                        'if [ "$PATCH" = "0" ]; then',
+                        "  # A minor release opens the next line, so it branches off next.",
+                        '  SOURCE_REF="next"',
+                        '  BASE_BRANCH="next"',
+                        "else",
+                        "  # A patch continues an existing line: it must build on the release before",
+                        "  # it. That predecessor is not optional - `yarn release` generates the",
+                        "  # changelog as `git log v<previous>..v<this>` using npm's latest dist-tag,",
+                        "  # so releasing out of order produces a changelog spanning two releases and",
+                        "  # publishes a version whose predecessor never existed.",
+                        '  PREVIOUS="${MINOR}.$((PATCH - 1))"',
+                        '  SOURCE_REF="v${PREVIOUS}"',
+                        "",
+                        '  if ! git rev-parse -q --verify "refs/tags/${SOURCE_REF}" > /dev/null; then',
+                        '    echo "::error::Cannot release ${VERSION}: tag ${SOURCE_REF} does not exist, so ${PREVIOUS} has not been released yet. Release it first."',
+                        "    exit 1",
+                        "  fi",
+                        "",
+                        "  # Source is a tag, so the release gets a base branch cut from it - that way",
+                        "  # the PR diff shows only release-specific work.",
+                        '  BASE_BRANCH="release/${VERSION}-base"',
+                        "fi",
+                        "",
+                        'echo "source-ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"',
+                        'echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"',
+                        "",
+                        "# Echoed before anything is created, so a wrong derivation is visible up front",
+                        "# rather than only in the resulting PR.",
+                        "{",
+                        '  echo "### 🚀 Release plan"',
+                        '  echo ""',
+                        '  echo "| | |"',
+                        '  echo "| --- | --- |"',
+                        '  echo "| Version | \\`$VERSION\\` |"',
+                        '  echo "| Branches off | \\`$SOURCE_REF\\` |"',
+                        '  echo "| Release branch | \\`release/$VERSION\\` |"',
+                        '  echo "| PR base | \\`$BASE_BRANCH\\` |"',
+                        '} >> "$GITHUB_STEP_SUMMARY"'
                     ].join("\n")
                 }
             ]
         }),
         createWebinyJsBranch: createJob({
             name: "Create release branch (webiny-js)",
-            needs: ["validateInputs"],
+            needs: ["resolveSource"],
             checkout: false,
             env: {
                 GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -76,7 +116,7 @@ export const fullRelease = createWorkflow({
                     name: "Checkout source tag",
                     uses: ACTION.checkout,
                     with: {
-                        ref: SOURCE_TAG,
+                        ref: SOURCE_REF,
                         "fetch-depth": 0,
                         token: "${{ secrets.GH_TOKEN }}"
                     }
@@ -86,24 +126,21 @@ export const fullRelease = createWorkflow({
                     id: "branch",
                     env: {
                         VERSION,
-                        SOURCE_TAG
+                        SOURCE_REF,
+                        BASE_BRANCH
                     },
                     run: [
-                        "set -e",
-                        "# If the source is a tag, create a base branch off it so the PR diff",
-                        "# shows only release-specific work. Otherwise (a branch, e.g. next),",
-                        "# the source branch itself is the PR base.",
-                        'if git show-ref --verify --quiet "refs/tags/${SOURCE_TAG}"; then',
-                        '  BASE_BRANCH="release/${VERSION}-base"',
+                        "set -euo pipefail",
+                        "# For a patch the base branch is cut from the source tag, so the PR diff",
+                        "# shows only release-specific work. For a minor it is `next` itself, which",
+                        "# already exists.",
+                        'if [ "$BASE_BRANCH" != "$SOURCE_REF" ]; then',
                         '  git checkout -b "$BASE_BRANCH"',
                         '  git push origin "$BASE_BRANCH"',
-                        "else",
-                        '  BASE_BRANCH="${SOURCE_TAG}"',
                         "fi",
                         'git checkout -b "release/${VERSION}"',
                         'git commit --allow-empty -m "chore: start release ${VERSION} [skip ci]" -m "Empty commit to allow PR creation."',
-                        'git push origin "release/${VERSION}"',
-                        'echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"'
+                        'git push origin "release/${VERSION}"'
                     ].join("\n")
                 },
                 {
@@ -111,7 +148,7 @@ export const fullRelease = createWorkflow({
                     id: "pr",
                     env: {
                         GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}",
-                        BASE_BRANCH: "${{ steps.branch.outputs.base-branch }}"
+                        BASE_BRANCH
                     },
                     run: `PR_URL=$(gh pr create --title "📦  Release ${VERSION}" --body "Release ${VERSION}\n\n**Docs PR:** https://github.com/webiny/docs.webiny.com/pulls?q=Release+${VERSION}" --base "$BASE_BRANCH" --head "release/${VERSION}") && echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT`
                 },


### PR DESCRIPTION
### What changed

Full Release asked for a release version **and** a `sourceTag` to branch off. What a release branches off is not a free choice — it follows from the version — so the second input only created ways to get the two out of step.

The damaging case was its default. `sourceTag` defaulted to `next`, so a patch entered without changing it would branch off **unreleased code**.

It now takes the version alone:

| Version | Branches off | PR base |
|---|---|---|
| `6.6.0` | `next` | `next` |
| `6.5.4` | tag `v6.5.3` | `release/6.5.4-base`, cut from it |

### Patches require their predecessor

Deliberately strict rather than lenient. `yarn release` builds the changelog as `git log v<previous>..v<this>` using npm's `latest` dist-tag, so releasing out of order produces a changelog spanning two releases *and* publishes a version whose predecessor never existed.

So a missing tag stops the run instead of quietly basing off an older one:

```
Cannot release 6.5.9: tag v6.5.8 does not exist, so 6.5.8 has not been released yet.
Release it first.
```

This is also why derivation is arithmetic (`6.5.4` → `v6.5.3`) rather than "latest tag in the `6.5.x` line". A lookup would survive a gap — but a gap is exactly the thing that must not be survived, and lookup would silently produce the broken release above.

### Resolve before acting

The new `resolveSource` job does validation and derivation together, **before anything is pushed**, and writes the resolved plan to the job summary:

```
### 🚀 Release plan

| Version | `6.5.4` |
| Branches off | `v6.5.3` |
| Release branch | `release/6.5.4` |
| PR base | `release/6.5.4-base` |
```

So a wrong derivation is visible up front rather than only in the resulting PR. The later jobs consume its outputs instead of re-deciding — the branch step no longer inspects whether the source is a tag, it is simply told what to create.

### Verification

Ran the generated resolve script against a scratch repo tagged `v6.4.9` and `v6.5.0`–`v6.5.3`:

| Input | Result |
|---|---|
| `6.6.0` | `source-ref=next base-branch=next` |
| `6.5.1` | `source-ref=v6.5.0 base-branch=release/6.5.1-base` |
| `6.5.4` | `source-ref=v6.5.3 base-branch=release/6.5.4-base` |
| `6.5.9` | fails — `v6.5.8` does not exist |
| `6.6.1` | fails — `v6.6.0` does not exist |
| `6.5.4-beta.1` | fails version check |
| `7.0.0` | fails version check |

The version check stays v6-only for now, as before. `bash -n` on the generated resolve and branch steps; `oxfmt --check` and `oxlint` clean; no other workflow touched.

### Note

Two patch releases cannot be in flight at once — `6.5.4` cannot start until `v6.5.3` exists. That was already true of the release process; this just enforces it at the point of entry instead of letting it produce a broken release later.

### Changelog

**Simpler, safer release workflow**

Starting a full release now only asks for the version number. Where the release branches from is worked out automatically, and the workflow refuses to start a patch release whose predecessor has not been released yet.

### Squash Merge Commit

```
feat(ci): derive release source from version in Full Release (#5605)
```