### PR TITLE
feat(api-headless-cms): add stable _id to object and dynamic-zone values

### DIFF
--- a/packages/api-headless-cms-ddb-es/__tests__/converters/convertersEnabled.test.ts
+++ b/packages/api-headless-cms-ddb-es/__tests__/converters/convertersEnabled.test.ts
@@ -138,6 +138,7 @@ describe("storage field path converters enabled", () => {
             },
             "object@informationFieldIdWithSomeValue": {
                 ...expectedDynamoDbRecord["object@informationFieldIdWithSomeValue"],
+                _id: expect.any(String),
                 "long-text@subDescriptionFieldIdWithSomeValue": {
                     compression: "gzip",
                     value: expect.any(String)
@@ -146,6 +147,7 @@ describe("storage field path converters enabled", () => {
                     ...expectedDynamoDbRecord["object@informationFieldIdWithSomeValue"][
                         "object@subInformationFieldIdWithSomeValue"
                     ],
+                    _id: expect.any(String),
                     "long-text@subSecondSubDescriptionFieldIdWithSomeValue": {
                         compression: "gzip",
                         value: expect.any(String)

--- a/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/ObjectFieldIndex.ts
+++ b/packages/api-headless-cms-ddb-es/src/features/CmsEntryOpenSearchFieldIndex/fields/ObjectFieldIndex.ts
@@ -53,6 +53,11 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
                     fields
                 });
 
+                if (initialValue[key]?._id) {
+                    value._id = initialValue[key]._id;
+                    rawValue._id = initialValue[key]._id;
+                }
+
                 result.value.push(value);
                 result.rawValue.push(rawValue);
             }
@@ -88,15 +93,20 @@ class ObjectFieldIndexImpl implements CmsEntryOpenSearchFieldIndex.Interface {
         if (field.list) {
             const source = value || rawValue || [];
 
-            return source.map((_: any, index: number) =>
-                this.processFromIndex({
+            return source.map((_: any, index: number) => {
+                const processed = this.processFromIndex({
                     value: value ? value[index] || {} : {},
                     rawValue: rawValue ? rawValue[index] || {} : {},
                     getFieldIndex,
                     model,
                     fields
-                })
-            );
+                });
+                const sourceItem = value ? value[index] : rawValue ? rawValue[index] : null;
+                if (sourceItem?._id) {
+                    processed._id = sourceItem._id;
+                }
+                return processed;
+            });
         }
 
         return this.processFromIndex({

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -142,6 +142,10 @@ export default /* GraphQL */ `
         dateTimeWithoutTimezone_gte: DateTime
     }
 
+    extend type PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject {
+        _id: ID
+    }
+
     type PageModelApiName_Content_Objecting_NestedObject {
         objectTitle: String
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
@@ -169,6 +173,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Content_Objecting_DynamicZone_SuperNestedObject {
         _templateId: ID!
+        _id: ID
     }
 
     type PageModelApiName_Content_Objecting {
@@ -183,18 +188,22 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Content_Hero {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_SimpleText {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_Objecting {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_Author {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Header =
@@ -212,10 +221,12 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Header_TextHeader {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Header_ImageHeader {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Objective = PageModelApiName_Objective_Objecting
@@ -275,6 +286,10 @@ export default /* GraphQL */ `
         dateTimeWithoutTimezone_gte: DateTime
     }
 
+    extend type PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject {
+        _id: ID
+    }
+
     type PageModelApiName_Objective_Objecting_NestedObject {
         objectTitle: String
         objectBody: JSON
@@ -300,6 +315,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Objective_Objecting {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Reference = PageModelApiName_Reference_Author
@@ -310,6 +326,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Reference_Author {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_References1 = PageModelApiName_References1_Authors
@@ -320,6 +337,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_References1_Authors {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_References2 = PageModelApiName_References2_Author
@@ -330,6 +348,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_References2_Author {
         _templateId: ID!
+        _id: ID
     }
 
     type PageModelApiName_GhostObject {
@@ -360,6 +379,10 @@ export default /* GraphQL */ `
         dateTimeWithoutTimezone: DateTime
     }
 
+    extend input PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObjectInput {
+        _id: ID
+    }
+
     input PageModelApiName_Content_Objecting_NestedObjectInput {
         objectTitle: String
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObjectInput!]
@@ -371,6 +394,9 @@ export default /* GraphQL */ `
 
     input PageModelApiName_Content_Objecting_DynamicZoneInput {
         SuperNestedObject: PageModelApiName_Content_Objecting_DynamicZone_SuperNestedObjectInput
+    }
+    extend input PageModelApiName_Content_Objecting_DynamicZone_SuperNestedObjectInput {
+        _id: ID
     }
 
     input PageModelApiName_Content_ObjectingInput {
@@ -389,6 +415,21 @@ export default /* GraphQL */ `
         Objecting: PageModelApiName_Content_ObjectingInput
         Author: PageModelApiName_Content_AuthorInput
     }
+    extend input PageModelApiName_Content_HeroInput {
+        _id: ID
+    }
+
+    extend input PageModelApiName_Content_SimpleTextInput {
+        _id: ID
+    }
+
+    extend input PageModelApiName_Content_ObjectingInput {
+        _id: ID
+    }
+
+    extend input PageModelApiName_Content_AuthorInput {
+        _id: ID
+    }
 
     input PageModelApiName_Header_TextHeaderInput {
         title: String
@@ -403,6 +444,13 @@ export default /* GraphQL */ `
         TextHeader: PageModelApiName_Header_TextHeaderInput
         ImageHeader: PageModelApiName_Header_ImageHeaderInput
     }
+    extend input PageModelApiName_Header_TextHeaderInput {
+        _id: ID
+    }
+
+    extend input PageModelApiName_Header_ImageHeaderInput {
+        _id: ID
+    }
 
     input PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObjectInput {
         nestedObjectNestedTitle: String
@@ -410,6 +458,10 @@ export default /* GraphQL */ `
         time: Time
         dateTimeWithTimezone: DateTimeZ
         dateTimeWithoutTimezone: DateTime
+    }
+
+    extend input PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObjectInput {
+        _id: ID
     }
 
     input PageModelApiName_Objective_Objecting_NestedObjectInput {
@@ -425,6 +477,9 @@ export default /* GraphQL */ `
     input PageModelApiName_ObjectiveInput {
         Objecting: PageModelApiName_Objective_ObjectingInput
     }
+    extend input PageModelApiName_Objective_ObjectingInput {
+        _id: ID
+    }
 
     input PageModelApiName_Reference_AuthorInput {
         author: RefFieldInput
@@ -432,6 +487,9 @@ export default /* GraphQL */ `
 
     input PageModelApiName_ReferenceInput {
         Author: PageModelApiName_Reference_AuthorInput
+    }
+    extend input PageModelApiName_Reference_AuthorInput {
+        _id: ID
     }
 
     input PageModelApiName_References1_AuthorsInput {
@@ -441,6 +499,9 @@ export default /* GraphQL */ `
     input PageModelApiName_References1Input {
         Authors: PageModelApiName_References1_AuthorsInput
     }
+    extend input PageModelApiName_References1_AuthorsInput {
+        _id: ID
+    }
 
     input PageModelApiName_References2_AuthorInput {
         author: RefFieldInput
@@ -448,6 +509,9 @@ export default /* GraphQL */ `
 
     input PageModelApiName_References2Input {
         Author: PageModelApiName_References2_AuthorInput
+    }
+    extend input PageModelApiName_References2_AuthorInput {
+        _id: ID
     }
 
     input PageModelApiName_GhostObjectInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -151,10 +151,6 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
     }
 
-    extend type PageModelApiName_Content_Objecting_NestedObject {
-        _id: ID
-    }
-
     input PageModelApiName_Content_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -166,6 +162,10 @@ export default /* GraphQL */ `
         objectTitle_not_startsWith: String
 
         objectNestedObject: PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    extend type PageModelApiName_Content_Objecting_NestedObject {
+        _id: ID
     }
 
     union PageModelApiName_Content_Objecting_DynamicZone =
@@ -300,10 +300,6 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject!]
     }
 
-    extend type PageModelApiName_Objective_Objecting_NestedObject {
-        _id: ID
-    }
-
     input PageModelApiName_Objective_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -315,6 +311,10 @@ export default /* GraphQL */ `
         objectTitle_not_startsWith: String
 
         objectNestedObject: PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    extend type PageModelApiName_Objective_Objecting_NestedObject {
+        _id: ID
     }
 
     type PageModelApiName_Objective_Objecting {
@@ -365,6 +365,10 @@ export default /* GraphQL */ `
 
     input PageModelApiName_GhostObjectWhereInput {
         _empty: String
+    }
+
+    extend type PageModelApiName_GhostObject {
+        _id: ID
     }
 
     input PageModelApiName_Content_HeroInput {
@@ -532,6 +536,10 @@ export default /* GraphQL */ `
 
     input PageModelApiName_GhostObjectInput {
         _empty: String
+    }
+
+    extend input PageModelApiName_GhostObjectInput {
+        _id: ID
     }
 
     input PageModelApiNameInputValues {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.manage.ts
@@ -151,6 +151,10 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
     }
 
+    extend type PageModelApiName_Content_Objecting_NestedObject {
+        _id: ID
+    }
+
     input PageModelApiName_Content_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -296,6 +300,10 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject!]
     }
 
+    extend type PageModelApiName_Objective_Objecting_NestedObject {
+        _id: ID
+    }
+
     input PageModelApiName_Objective_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -388,6 +396,10 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObjectInput!]
     }
 
+    extend input PageModelApiName_Content_Objecting_NestedObjectInput {
+        _id: ID
+    }
+
     input PageModelApiName_Content_Objecting_DynamicZone_SuperNestedObjectInput {
         authors: [RefFieldInput]
     }
@@ -468,6 +480,10 @@ export default /* GraphQL */ `
         objectTitle: String
         objectBody: JSON
         objectNestedObject: [PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObjectInput!]
+    }
+
+    extend input PageModelApiName_Objective_Objecting_NestedObjectInput {
+        _id: ID
     }
 
     input PageModelApiName_Objective_ObjectingInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -130,10 +130,6 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
     }
 
-    extend type PageModelApiName_Content_Objecting_NestedObject {
-        _id: ID
-    }
-
     input PageModelApiName_Content_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -145,6 +141,10 @@ export default /* GraphQL */ `
         objectTitle_not_startsWith: String
 
         objectNestedObject: PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    extend type PageModelApiName_Content_Objecting_NestedObject {
+        _id: ID
     }
 
     union PageModelApiName_Content_Objecting_DynamicZone =
@@ -279,10 +279,6 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject!]
     }
 
-    extend type PageModelApiName_Objective_Objecting_NestedObject {
-        _id: ID
-    }
-
     input PageModelApiName_Objective_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -294,6 +290,10 @@ export default /* GraphQL */ `
         objectTitle_not_startsWith: String
 
         objectNestedObject: PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObjectWhereInput
+    }
+
+    extend type PageModelApiName_Objective_Objecting_NestedObject {
+        _id: ID
     }
 
     type PageModelApiName_Objective_Objecting {
@@ -344,6 +344,10 @@ export default /* GraphQL */ `
 
     input PageModelApiName_GhostObjectWhereInput {
         _empty: String
+    }
+
+    extend type PageModelApiName_GhostObject {
+        _id: ID
     }
 
     input PageModelApiNameGetWhereInputValues {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -130,6 +130,10 @@ export default /* GraphQL */ `
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
     }
 
+    extend type PageModelApiName_Content_Objecting_NestedObject {
+        _id: ID
+    }
+
     input PageModelApiName_Content_Objecting_NestedObjectWhereInput {
         objectTitle: String
         objectTitle_not: String
@@ -273,6 +277,10 @@ export default /* GraphQL */ `
         objectTitle: String
         objectBody(format: String): JSON
         objectNestedObject: [PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject!]
+    }
+
+    extend type PageModelApiName_Objective_Objecting_NestedObject {
+        _id: ID
     }
 
     input PageModelApiName_Objective_Objecting_NestedObjectWhereInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/page.read.ts
@@ -121,6 +121,10 @@ export default /* GraphQL */ `
         dateTimeWithoutTimezone_gte: DateTime
     }
 
+    extend type PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject {
+        _id: ID
+    }
+
     type PageModelApiName_Content_Objecting_NestedObject {
         objectTitle: String
         objectNestedObject: [PageModelApiName_Content_Objecting_NestedObject_ObjectNestedObject!]
@@ -148,6 +152,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Content_Objecting_DynamicZone_SuperNestedObject {
         _templateId: ID!
+        _id: ID
     }
 
     type PageModelApiName_Content_Objecting {
@@ -162,18 +167,22 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Content_Hero {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_SimpleText {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_Objecting {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Content_Author {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Header =
@@ -191,10 +200,12 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Header_TextHeader {
         _templateId: ID!
+        _id: ID
     }
 
     extend type PageModelApiName_Header_ImageHeader {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Objective = PageModelApiName_Objective_Objecting
@@ -254,6 +265,10 @@ export default /* GraphQL */ `
         dateTimeWithoutTimezone_gte: DateTime
     }
 
+    extend type PageModelApiName_Objective_Objecting_NestedObject_ObjectNestedObject {
+        _id: ID
+    }
+
     type PageModelApiName_Objective_Objecting_NestedObject {
         objectTitle: String
         objectBody(format: String): JSON
@@ -279,6 +294,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Objective_Objecting {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_Reference = PageModelApiName_Reference_Author
@@ -289,6 +305,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_Reference_Author {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_References1 = PageModelApiName_References1_Authors
@@ -299,6 +316,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_References1_Authors {
         _templateId: ID!
+        _id: ID
     }
 
     union PageModelApiName_References2 = PageModelApiName_References2_Author
@@ -309,6 +327,7 @@ export default /* GraphQL */ `
 
     extend type PageModelApiName_References2_Author {
         _templateId: ID!
+        _id: ID
     }
 
     type PageModelApiName_GhostObject {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -114,6 +114,10 @@ export default /* GraphQL */ `
         longText_not_contains: String
     }
 
+    extend type ProductApiSingular_Variant_Options {
+        _id: ID
+    }
+
     type ProductApiSingular_Variant {
         name: String
         price: Number
@@ -172,6 +176,10 @@ export default /* GraphQL */ `
         category: RefFieldInput
         categories: [RefFieldInput]
         longText: [String]
+    }
+
+    extend input ProductApiSingular_Variant_OptionsInput {
+        _id: ID
     }
 
     input ProductApiSingular_VariantInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -126,6 +126,10 @@ export default /* GraphQL */ `
         options: [ProductApiSingular_Variant_Options!]
     }
 
+    extend type ProductApiSingular_Variant {
+        _id: ID
+    }
+
     input ProductApiSingular_VariantWhereInput {
         name: String
         name_not: String
@@ -156,6 +160,10 @@ export default /* GraphQL */ `
 
     type ProductApiSingular_FieldsObject {
         text: String
+    }
+
+    extend type ProductApiSingular_FieldsObject {
+        _id: ID
     }
 
     input ProductApiSingular_FieldsObjectWhereInput {
@@ -190,8 +198,16 @@ export default /* GraphQL */ `
         options: [ProductApiSingular_Variant_OptionsInput!]
     }
 
+    extend input ProductApiSingular_VariantInput {
+        _id: ID
+    }
+
     input ProductApiSingular_FieldsObjectInput {
         text: String
+    }
+
+    extend input ProductApiSingular_FieldsObjectInput {
+        _id: ID
     }
 
     input ProductApiSingularInputValues {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.manage.ts
@@ -126,10 +126,6 @@ export default /* GraphQL */ `
         options: [ProductApiSingular_Variant_Options!]
     }
 
-    extend type ProductApiSingular_Variant {
-        _id: ID
-    }
-
     input ProductApiSingular_VariantWhereInput {
         name: String
         name_not: String
@@ -158,12 +154,12 @@ export default /* GraphQL */ `
         options: ProductApiSingular_Variant_OptionsWhereInput
     }
 
-    type ProductApiSingular_FieldsObject {
-        text: String
+    extend type ProductApiSingular_Variant {
+        _id: ID
     }
 
-    extend type ProductApiSingular_FieldsObject {
-        _id: ID
+    type ProductApiSingular_FieldsObject {
+        text: String
     }
 
     input ProductApiSingular_FieldsObjectWhereInput {
@@ -175,6 +171,10 @@ export default /* GraphQL */ `
         text_not_contains: String
         text_startsWith: String
         text_not_startsWith: String
+    }
+
+    extend type ProductApiSingular_FieldsObject {
+        _id: ID
     }
 
     input ProductApiSingular_Variant_OptionsInput {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -105,10 +105,6 @@ export default /* GraphQL */ `
         options: [ProductApiSingular_Variant_Options!]
     }
 
-    extend type ProductApiSingular_Variant {
-        _id: ID
-    }
-
     input ProductApiSingular_VariantWhereInput {
         name: String
         name_not: String
@@ -137,12 +133,12 @@ export default /* GraphQL */ `
         options: ProductApiSingular_Variant_OptionsWhereInput
     }
 
-    type ProductApiSingular_FieldsObject {
-        text: String
+    extend type ProductApiSingular_Variant {
+        _id: ID
     }
 
-    extend type ProductApiSingular_FieldsObject {
-        _id: ID
+    type ProductApiSingular_FieldsObject {
+        text: String
     }
 
     input ProductApiSingular_FieldsObjectWhereInput {
@@ -154,6 +150,10 @@ export default /* GraphQL */ `
         text_not_contains: String
         text_startsWith: String
         text_not_startsWith: String
+    }
+
+    extend type ProductApiSingular_FieldsObject {
+        _id: ID
     }
 
     input ProductApiSingularGetWhereInputValues {

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -93,6 +93,10 @@ export default /* GraphQL */ `
         longText_not_contains: String
     }
 
+    extend type ProductApiSingular_Variant_Options {
+        _id: ID
+    }
+
     type ProductApiSingular_Variant {
         name: String
         price: Number

--- a/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
+++ b/packages/api-headless-cms/__tests__/contentAPI/snapshots/product.read.ts
@@ -105,6 +105,10 @@ export default /* GraphQL */ `
         options: [ProductApiSingular_Variant_Options!]
     }
 
+    extend type ProductApiSingular_Variant {
+        _id: ID
+    }
+
     input ProductApiSingular_VariantWhereInput {
         name: String
         name_not: String
@@ -135,6 +139,10 @@ export default /* GraphQL */ `
 
     type ProductApiSingular_FieldsObject {
         text: String
+    }
+
+    extend type ProductApiSingular_FieldsObject {
+        _id: ID
     }
 
     input ProductApiSingular_FieldsObjectWhereInput {

--- a/packages/api-headless-cms/__tests__/contentTraverser/valuesSelection.test.ts
+++ b/packages/api-headless-cms/__tests__/contentTraverser/valuesSelection.test.ts
@@ -37,6 +37,7 @@ describe("ValuesSelectionGenerator", () => {
         // Hero template
         expect(selection).toContain("...on Article_Content_Hero {");
         expect(selection).toContain("_templateId");
+        expect(selection).toContain("_id");
         expect(selection).toContain("__typename");
 
         // SimpleText template

--- a/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
@@ -17,31 +17,35 @@ export async function ensureItemIds(modelAst: CmsModelAst, values: CmsEntryValue
     const traverser = new ContentEntryTraverser(modelAst);
 
     await traverser.traverse(values, async ({ field, value }) => {
-        if (!field.list) {
-            return;
-        }
-
         if (field.type !== "object" && field.type !== "dynamicZone") {
             return;
         }
 
-        if (!Array.isArray(value)) {
+        // List fields: assign _id to every array item.
+        if (field.list && Array.isArray(value)) {
+            const seen = new Set<string>();
+
+            for (const item of value) {
+                if (item == null || typeof item !== "object") {
+                    continue;
+                }
+
+                if (!item._id || seen.has(item._id)) {
+                    item._id = generateAlphaNumericLowerCaseId(12);
+                }
+
+                seen.add(item._id);
+            }
             return;
         }
 
-        const seen = new Set<string>();
-
-        for (const item of value) {
-            if (item == null || typeof item !== "object") {
-                continue;
+        // Single-value dynamic zone: assign _id to the value object.
+        if (!field.list && field.type === "dynamicZone") {
+            if (value != null && typeof value === "object" && !Array.isArray(value)) {
+                if (!value._id) {
+                    value._id = generateAlphaNumericLowerCaseId(12);
+                }
             }
-
-            // Assign _id if missing or if it's a duplicate within this array.
-            if (!item._id || seen.has(item._id)) {
-                item._id = generateAlphaNumericLowerCaseId(12);
-            }
-
-            seen.add(item._id);
         }
     });
 }

--- a/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
@@ -1,0 +1,47 @@
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils";
+import type { CmsModelAst, CmsEntryValues } from "~/types/index.js";
+import { ContentEntryTraverser } from "./ContentEntryTraverser/ContentEntryTraverser.js";
+
+/**
+ * Walk entry values using the model AST and assign a stable `_id` to every item
+ * in multi-value (list) object and dynamic-zone arrays.
+ *
+ * - Items that already carry an `_id` keep it.
+ * - Items without `_id` get a newly generated one.
+ * - Duplicate `_id` values within the same array are silently regenerated.
+ *
+ * Uses `ContentEntryTraverser` so nested objects / dynamic zones are handled
+ * automatically — no manual recursion needed.
+ */
+export async function ensureItemIds(modelAst: CmsModelAst, values: CmsEntryValues): Promise<void> {
+    const traverser = new ContentEntryTraverser(modelAst);
+
+    await traverser.traverse(values, async ({ field, value }) => {
+        if (!field.list) {
+            return;
+        }
+
+        if (field.type !== "object" && field.type !== "dynamicZone") {
+            return;
+        }
+
+        if (!Array.isArray(value)) {
+            return;
+        }
+
+        const seen = new Set<string>();
+
+        for (const item of value) {
+            if (item == null || typeof item !== "object") {
+                continue;
+            }
+
+            // Assign _id if missing or if it's a duplicate within this array.
+            if (!item._id || seen.has(item._id)) {
+                item._id = generateAlphaNumericLowerCaseId(12);
+            }
+
+            seen.add(item._id);
+        }
+    });
+}

--- a/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/ensureItemIds.ts
@@ -3,12 +3,12 @@ import type { CmsModelAst, CmsEntryValues } from "~/types/index.js";
 import { ContentEntryTraverser } from "./ContentEntryTraverser/ContentEntryTraverser.js";
 
 /**
- * Walk entry values using the model AST and assign a stable `_id` to every item
- * in multi-value (list) object and dynamic-zone arrays.
+ * Walk entry values using the model AST and assign a stable `_id` to every
+ * object and dynamic-zone value — both list items and single values.
  *
- * - Items that already carry an `_id` keep it.
- * - Items without `_id` get a newly generated one.
- * - Duplicate `_id` values within the same array are silently regenerated.
+ * - Values that already carry an `_id` keep it.
+ * - Values without `_id` get a newly generated one.
+ * - Duplicate `_id` values within a list array are silently regenerated.
  *
  * Uses `ContentEntryTraverser` so nested objects / dynamic zones are handled
  * automatically — no manual recursion needed.
@@ -39,12 +39,10 @@ export async function ensureItemIds(modelAst: CmsModelAst, values: CmsEntryValue
             return;
         }
 
-        // Single-value dynamic zone: assign _id to the value object.
-        if (!field.list && field.type === "dynamicZone") {
-            if (value != null && typeof value === "object" && !Array.isArray(value)) {
-                if (!value._id) {
-                    value._id = generateAlphaNumericLowerCaseId(12);
-                }
+        // Single-value: assign _id to the value object.
+        if (!field.list && value != null && typeof value === "object" && !Array.isArray(value)) {
+            if (!value._id) {
+                value._id = generateAlphaNumericLowerCaseId(12);
             }
         }
     });

--- a/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryDataFactory/CreateEntryDataFactory.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryDataFactory/CreateEntryDataFactory.ts
@@ -26,6 +26,8 @@ import { getIdentity } from "~/utils/identity.js";
 import { NotAuthorizedError } from "~/utils/errors.js";
 import { getSystem } from "../system.js";
 import { getExpiresAt } from "../expiresAt.js";
+import { ModelToAstConverter } from "~/features/contentModel/ModelToAstConverter/abstractions.js";
+import { ensureItemIds } from "../../ensureItemIds.js";
 
 type DefaultValue = boolean | number | string | null;
 
@@ -116,7 +118,8 @@ class CreateEntryDataFactoryImpl implements ICreateEntryDataFactory {
         private readonly cmsContext: CmsContext.Interface,
         private readonly identityContext: IdentityContext.Interface,
         private readonly tenantContext: TenantContext.Interface,
-        private readonly accessControl: AccessControl.Interface
+        private readonly accessControl: AccessControl.Interface,
+        private readonly modelToAstConverter: ModelToAstConverter.Interface
     ) {}
 
     public async create<TValues extends CmsEntryValues = CmsEntryValues>(
@@ -125,6 +128,9 @@ class CreateEntryDataFactoryImpl implements ICreateEntryDataFactory {
         options?: CreateCmsEntryOptionsInput
     ): Promise<ICreateEntryDataResponse<TValues>> {
         const initialValues = cleanInputValues<TValues>(model, rawInput.values || ({} as TValues));
+
+        const modelAst = this.modelToAstConverter.toAst(model);
+        await ensureItemIds(modelAst, initialValues);
 
         await validateModelEntryDataOrThrow({
             context: this.cmsContext,
@@ -297,5 +303,5 @@ class CreateEntryDataFactoryImpl implements ICreateEntryDataFactory {
 export const CreateEntryDataFactory = createImplementation({
     abstraction: FactoryAbstraction,
     implementation: CreateEntryDataFactoryImpl,
-    dependencies: [CmsContext, IdentityContext, TenantContext, AccessControl]
+    dependencies: [CmsContext, IdentityContext, TenantContext, AccessControl, ModelToAstConverter]
 });

--- a/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryRevisionFromDataFactory/CreateEntryRevisionFromDataFactory.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/CreateEntryRevisionFromDataFactory/CreateEntryRevisionFromDataFactory.ts
@@ -23,6 +23,8 @@ import WebinyError from "@webiny/error";
 import { STATUS_DRAFT, STATUS_PUBLISHED, STATUS_UNPUBLISHED } from "../statuses.js";
 import { NotAuthorizedError } from "~/utils/errors.js";
 import { getSystem } from "../system.js";
+import { ModelToAstConverter } from "~/features/contentModel/ModelToAstConverter/abstractions.js";
+import { ensureItemIds } from "../../ensureItemIds.js";
 
 const increaseEntryIdVersion = (id: string) => {
     const { id: entryId, version } = parseIdentifier(id);
@@ -49,7 +51,8 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
     public constructor(
         private readonly cmsContext: CmsContext.Interface,
         private readonly identityContext: IdentityContext.Interface,
-        private readonly accessControl: AccessControl.Interface
+        private readonly accessControl: AccessControl.Interface,
+        private readonly modelToAstConverter: ModelToAstConverter.Interface
     ) {}
 
     public async create<TValues extends CmsEntryValues = CmsEntryValues>(
@@ -64,6 +67,9 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
             ...originalEntry.values,
             ...mapAndCleanUpdatedInputData<TValues>(model, rawInput.values)
         };
+
+        const modelAst = this.modelToAstConverter.toAst(model);
+        await ensureItemIds(modelAst, initialValues);
 
         await validateModelEntryDataOrThrow({
             context: this.cmsContext,
@@ -213,5 +219,5 @@ class CreateEntryRevisionFromDataFactoryImpl implements ICreateEntryRevisionFrom
 export const CreateEntryRevisionFromDataFactory = createImplementation({
     abstraction: FactoryAbstraction,
     implementation: CreateEntryRevisionFromDataFactoryImpl,
-    dependencies: [CmsContext, IdentityContext, AccessControl]
+    dependencies: [CmsContext, IdentityContext, AccessControl, ModelToAstConverter]
 });

--- a/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/UpdateEntryDataFactory/UpdateEntryDataFactory.ts
+++ b/packages/api-headless-cms/src/features/contentEntry/entryDataFactories/UpdateEntryDataFactory/UpdateEntryDataFactory.ts
@@ -21,6 +21,8 @@ import { referenceFieldsMapping } from "~/crud/contentEntry/referenceFieldsMappi
 import { mapAndCleanUpdatedInputData } from "../mapAndCleanUpdatedInputData.js";
 import { getSystem } from "../system.js";
 import { getExpiresAt } from "../expiresAt.js";
+import { ModelToAstConverter } from "~/features/contentModel/ModelToAstConverter/abstractions.js";
+import { ensureItemIds } from "../../ensureItemIds.js";
 
 const allowedEntryStatus: string[] = ["draft", "published", "unpublished"];
 
@@ -31,7 +33,8 @@ const transformEntryStatus = (status: CmsEntryStatus | string): CmsEntryStatus =
 class UpdateEntryDataFactoryImpl implements IUpdateEntryDataFactory {
     public constructor(
         private readonly cmsContext: CmsContext.Interface,
-        private readonly identityContext: IdentityContext.Interface
+        private readonly identityContext: IdentityContext.Interface,
+        private readonly modelToAstConverter: ModelToAstConverter.Interface
     ) {}
 
     public async create<TValues extends CmsEntryValues = CmsEntryValues>(
@@ -57,6 +60,9 @@ class UpdateEntryDataFactoryImpl implements IUpdateEntryDataFactory {
             ...originalEntry.values,
             ...cleanedValues
         };
+
+        const modelAst = this.modelToAstConverter.toAst(model);
+        await ensureItemIds(modelAst, mergedValues);
 
         const values = await referenceFieldsMapping<TValues>({
             context: this.cmsContext,
@@ -146,5 +152,5 @@ class UpdateEntryDataFactoryImpl implements IUpdateEntryDataFactory {
 export const UpdateEntryDataFactory = createImplementation({
     abstraction: FactoryAbstraction,
     implementation: UpdateEntryDataFactoryImpl,
-    dependencies: [CmsContext, IdentityContext]
+    dependencies: [CmsContext, IdentityContext, ModelToAstConverter]
 });

--- a/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
+++ b/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
@@ -75,7 +75,7 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             return null;
         }
 
-        return `${field.fieldId} { ${childSelection} }`;
+        return `${field.fieldId} { _id ${childSelection} }`;
     }
 
     private walkCollectionNode(
@@ -95,7 +95,7 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             .filter(Boolean)
             .join("\n");
 
-        return `...on ${templateType} { ${childSelection} _templateId __typename }`;
+        return `...on ${templateType} { ${childSelection} _templateId _id __typename }`;
     }
 }
 

--- a/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
+++ b/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
@@ -75,8 +75,7 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             return null;
         }
 
-        const idSelection = field.list && field.type === "object" ? "_id " : "";
-        return `${field.fieldId} { ${idSelection}${childSelection} }`;
+        return `${field.fieldId} { _id ${childSelection} }`;
     }
 
     private walkCollectionNode(

--- a/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
+++ b/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
@@ -75,7 +75,8 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             return null;
         }
 
-        return `${field.fieldId} { _id ${childSelection} }`;
+        const idSelection = field.type === "object" ? "_id " : "";
+        return `${field.fieldId} { ${idSelection}${childSelection} }`;
     }
 
     private walkCollectionNode(

--- a/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
+++ b/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
@@ -75,7 +75,7 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             return null;
         }
 
-        const idSelection = field.list ? "_id " : "";
+        const idSelection = field.list && field.type === "object" ? "_id " : "";
         return `${field.fieldId} { ${idSelection}${childSelection} }`;
     }
 

--- a/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
+++ b/packages/api-headless-cms/src/features/contentModel/ValuesSelectionGenerator/ValuesSelectionGenerator.ts
@@ -75,7 +75,8 @@ class ValuesSelectionGeneratorImpl implements IValuesSelectionGenerator {
             return null;
         }
 
-        return `${field.fieldId} { _id ${childSelection} }`;
+        const idSelection = field.list ? "_id " : "";
+        return `${field.fieldId} { ${idSelection}${childSelection} }`;
     }
 
     private walkCollectionNode(

--- a/packages/api-headless-cms/src/features/graphql/fields/base/DynamicZoneToGraphQL.ts
+++ b/packages/api-headless-cms/src/features/graphql/fields/base/DynamicZoneToGraphQL.ts
@@ -132,6 +132,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
         const templateIds = templateTypes.map(type => {
             return `extend type ${type} {
                 _templateId: ID!
+                _id: ID
             }
             `;
         });
@@ -177,10 +178,11 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
             templates
         });
 
-        /* Add _templateId. */
+        /* Add _templateId and _id. */
         const templateIds = templateTypes.map(type => {
             return `extend type ${type} {
                 _templateId: ID!
+                _id: ID
             }
             `;
         });
@@ -239,9 +241,17 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
             )}
         }`);
 
+        /* Extend each template input type with _id. */
+        const templateInputIds = templateTypes.map(inputTypeName => {
+            return `extend input ${inputTypeName} {
+                _id: ID
+            }
+            `;
+        });
+
         return {
             fields: createGraphQLInputField(field, `${typeName}Input`),
-            typeDefs: typeDefs.join("\n")
+            typeDefs: typeDefs.concat(templateInputIds).join("\n")
         };
     }
 

--- a/packages/api-headless-cms/src/features/graphql/fields/base/ObjectToGraphQL.ts
+++ b/packages/api-headless-cms/src/features/graphql/fields/base/ObjectToGraphQL.ts
@@ -127,7 +127,7 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
             endpointType: "read"
         });
 
-        const itemIdTypeDef = field.list ? `\nextend type ${fieldType} {\n    _id: ID\n}\n` : "";
+        const itemIdTypeDef = `\nextend type ${fieldType} {\n    _id: ID\n}\n`;
 
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,
@@ -196,7 +196,7 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
             endpointType: "manage"
         });
 
-        const itemIdTypeDef = field.list ? `\nextend type ${fieldType} {\n    _id: ID\n}\n` : "";
+        const itemIdTypeDef = `\nextend type ${fieldType} {\n    _id: ID\n}\n`;
 
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,
@@ -228,7 +228,7 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
         }
         const { fieldType, typeDefs } = result;
 
-        const itemIdTypeDef = field.list ? `\nextend input ${fieldType} {\n    _id: ID\n}\n` : "";
+        const itemIdTypeDef = `\nextend input ${fieldType} {\n    _id: ID\n}\n`;
 
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,

--- a/packages/api-headless-cms/src/features/graphql/fields/base/ObjectToGraphQL.ts
+++ b/packages/api-headless-cms/src/features/graphql/fields/base/ObjectToGraphQL.ts
@@ -127,9 +127,11 @@ class ReadApi implements CmsModelFieldToGraphQL.ReadApi {
             endpointType: "read"
         });
 
+        const itemIdTypeDef = field.list ? `\nextend type ${fieldType} {\n    _id: ID\n}\n` : "";
+
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,
-            typeDefs: `${typeDefs}${childTypeDefs}`
+            typeDefs: `${typeDefs}${childTypeDefs}${itemIdTypeDef}`
         };
     }
 
@@ -194,9 +196,11 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
             endpointType: "manage"
         });
 
+        const itemIdTypeDef = field.list ? `\nextend type ${fieldType} {\n    _id: ID\n}\n` : "";
+
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,
-            typeDefs: `${typeDefs}\n${childTypeDefs}`
+            typeDefs: `${typeDefs}\n${childTypeDefs}${itemIdTypeDef}`
         };
     }
 
@@ -224,9 +228,11 @@ class ManageApi implements CmsModelFieldToGraphQL.ManageApi {
         }
         const { fieldType, typeDefs } = result;
 
+        const itemIdTypeDef = field.list ? `\nextend input ${fieldType} {\n    _id: ID\n}\n` : "";
+
         return {
             fields: `${field.fieldId}: ${field.list ? `[${fieldType}!]` : fieldType}`,
-            typeDefs
+            typeDefs: `${typeDefs}${itemIdTypeDef}`
         };
     }
 

--- a/packages/api-headless-cms/src/features/storage/fields/ObjectStorageTransform.ts
+++ b/packages/api-headless-cms/src/features/storage/fields/ObjectStorageTransform.ts
@@ -65,13 +65,14 @@ class StorageTransformImpl implements StorageTransform.Interface {
             });
         }
 
-        return await processValue({
+        const processed = await processValue({
             sourceValue: value,
             getStorageTransform,
             model,
             operation: "toStorage",
             fields
         });
+        return value._id ? { _id: value._id, ...processed } : processed;
     }
 
     public async fromStorage(
@@ -101,13 +102,14 @@ class StorageTransformImpl implements StorageTransform.Interface {
             );
         }
 
-        return await processValue({
+        const processed = await processValue({
             sourceValue: input,
             getStorageTransform,
             model,
             operation: "fromStorage",
             fields
         });
+        return input._id ? { _id: input._id, ...processed } : processed;
     }
 }
 

--- a/packages/api-headless-cms/src/features/storage/fields/ObjectStorageTransform.ts
+++ b/packages/api-headless-cms/src/features/storage/fields/ObjectStorageTransform.ts
@@ -53,15 +53,16 @@ class StorageTransformImpl implements StorageTransform.Interface {
         const fields = (field.settings?.fields || []) as CmsModelField[];
 
         if (field.list) {
-            return await pMap(value as GenericRecord[], value =>
-                processValue({
-                    sourceValue: value,
+            return await pMap(value as GenericRecord[], async itemValue => {
+                const processed = await processValue({
+                    sourceValue: itemValue,
                     getStorageTransform,
                     model,
                     operation: "toStorage",
                     fields
-                })
-            );
+                });
+                return itemValue._id ? { _id: itemValue._id, ...processed } : processed;
+            });
         }
 
         return await processValue({
@@ -88,13 +89,14 @@ class StorageTransformImpl implements StorageTransform.Interface {
 
             return await Promise.all(
                 values.map(async value => {
-                    return await processValue({
+                    const processed = await processValue({
                         sourceValue: value,
                         getStorageTransform,
                         model,
                         operation: "fromStorage",
                         fields
                     });
+                    return value._id ? { _id: value._id, ...processed } : processed;
                 })
             );
         }

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelDynamicZoneFieldConverterPlugin.ts
@@ -99,7 +99,8 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
                 return values;
             },
             {
-                _templateId: template.id
+                _templateId: template.id,
+                ...(value._id ? { _id: value._id } : {})
             }
         );
     }
@@ -181,7 +182,8 @@ export class CmsModelDynamicZoneFieldConverterPlugin extends CmsModelFieldConver
                 return values;
             },
             {
-                _templateId: template.id
+                _templateId: template.id,
+                ...(value._id ? { _id: value._id } : {})
             }
         );
     }

--- a/packages/api-headless-cms/src/fieldConverters/CmsModelObjectFieldConverterPlugin.ts
+++ b/packages/api-headless-cms/src/fieldConverters/CmsModelObjectFieldConverterPlugin.ts
@@ -85,6 +85,8 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
             return undefined;
         }
 
+        const initial: CmsEntryValues = value._id ? { _id: value._id } : {};
+
         return fields.reduce<CmsEntryValues>((output, field) => {
             if (value[field.fieldId] === undefined) {
                 return output;
@@ -101,7 +103,7 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
                 ...output,
                 ...newValue
             };
-        }, {});
+        }, initial);
     }
 
     public override convertFromStorage(params: ConvertParams): CmsEntryValues {
@@ -165,6 +167,8 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
             return undefined;
         }
 
+        const initial: CmsEntryValues = value._id ? { _id: value._id } : {};
+
         return fields.reduce<CmsEntryValues>((output, field) => {
             if (value[field.storageId] === undefined) {
                 return output;
@@ -185,6 +189,6 @@ export class CmsModelObjectFieldConverterPlugin extends CmsModelFieldConverterPl
                 ...output,
                 ...newValue
             };
-        }, {});
+        }, initial);
     }
 }

--- a/packages/app-headless-cms/src/features/contentEntry/valueTransformers/DynamicZoneValueTransformer.ts
+++ b/packages/app-headless-cms/src/features/contentEntry/valueTransformers/DynamicZoneValueTransformer.ts
@@ -4,6 +4,7 @@ import type { CmsModelField, CmsDynamicZoneTemplate } from "~/types.js";
 
 interface TemplateValue {
     _templateId: string;
+    _id?: string;
     [key: string]: unknown;
 }
 
@@ -32,14 +33,17 @@ class DynamicZoneValueTransformerImpl implements ICmsEntryValueTransformer {
         item: TemplateValue,
         templates: CmsDynamicZoneTemplate[]
     ): Record<string, unknown> | undefined {
-        const { _templateId, ...values } = item;
+        const { _templateId, _id, ...values } = item;
         const template = templates.find(tpl => tpl.id === _templateId);
         if (!template) {
             return undefined;
         }
 
         return {
-            [template.gqlTypeName]: this.preparer.prepare(values, template.fields || [])
+            [template.gqlTypeName]: {
+                ...this.preparer.prepare(values, template.fields || []),
+                ...(_id !== undefined ? { _id } : {})
+            }
         };
     }
 }

--- a/packages/app-headless-cms/src/features/contentEntry/valueTransformers/ObjectValueTransformer.ts
+++ b/packages/app-headless-cms/src/features/contentEntry/valueTransformers/ObjectValueTransformer.ts
@@ -17,7 +17,9 @@ class ObjectValueTransformerImpl implements ICmsEntryValueTransformer {
         if (field.list && Array.isArray(value)) {
             return value.map(item => {
                 if (item && typeof item === "object") {
-                    return this.preparer.prepare(item as Record<string, unknown>, childFields);
+                    const { _id, ...rest } = item as Record<string, unknown>;
+                    const prepared = this.preparer.prepare(rest, childFields);
+                    return _id !== undefined ? { _id, ...prepared } : prepared;
                 }
                 return item;
             });

--- a/packages/app-headless-cms/src/features/contentEntry/valueTransformers/ObjectValueTransformer.ts
+++ b/packages/app-headless-cms/src/features/contentEntry/valueTransformers/ObjectValueTransformer.ts
@@ -26,7 +26,9 @@ class ObjectValueTransformerImpl implements ICmsEntryValueTransformer {
         }
 
         if (typeof value === "object") {
-            return this.preparer.prepare(value as Record<string, unknown>, childFields);
+            const { _id, ...rest } = value as Record<string, unknown>;
+            const prepared = this.preparer.prepare(rest, childFields);
+            return _id !== undefined ? { _id, ...prepared } : prepared;
         }
 
         return value;

--- a/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
+++ b/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
@@ -34,12 +34,10 @@ export class DynamicZoneFieldMapper implements ICmsFieldTypeMapper {
                     }
                     t.fields(childRegistry => {
                         const result: Record<string, IFieldBuilder> = {};
-                        if (field.list) {
-                            result["_id"] = childRegistry
-                                .text()
-                                .hidden()
-                                .defaultValue(() => generateAlphaNumericLowerCaseId(12));
-                        }
+                        result["_id"] = childRegistry
+                            .text()
+                            .hidden()
+                            .defaultValue(() => generateAlphaNumericLowerCaseId(12));
                         if (template.fields && template.fields.length > 0) {
                             for (const child of template.fields) {
                                 result[child.fieldId] = context.mapField(child, childRegistry);

--- a/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
+++ b/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
@@ -37,7 +37,8 @@ export class DynamicZoneFieldMapper implements ICmsFieldTypeMapper {
                         result["_id"] = childRegistry
                             .text()
                             .hidden()
-                            .defaultValue(() => generateAlphaNumericLowerCaseId(12));
+                            .defaultValue(() => generateAlphaNumericLowerCaseId(12))
+                            .cloneValue(() => generateAlphaNumericLowerCaseId(12));
                         if (template.fields && template.fields.length > 0) {
                             for (const child of template.fields) {
                                 result[child.fieldId] = context.mapField(child, childRegistry);

--- a/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
+++ b/packages/app-headless-cms/src/features/formModel/mappers/DynamicZoneFieldMapper.ts
@@ -7,6 +7,7 @@ import type {
 import type { CmsModelField, CmsDynamicZoneTemplate } from "~/types.js";
 import { applyFieldProps } from "./applyFieldProps.js";
 import type { ITemplateIcon } from "@webiny/app-admin/features/formModel/index.js";
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils/generateId";
 
 export class DynamicZoneFieldMapper implements ICmsFieldTypeMapper {
     readonly type = "dynamicZone";
@@ -31,15 +32,21 @@ export class DynamicZoneFieldMapper implements ICmsFieldTypeMapper {
                             t.icon({ type: "icon", name: icon });
                         }
                     }
-                    if (template.fields && template.fields.length > 0) {
-                        t.fields(childRegistry => {
-                            const result: Record<string, IFieldBuilder> = {};
+                    t.fields(childRegistry => {
+                        const result: Record<string, IFieldBuilder> = {};
+                        if (field.list) {
+                            result["_id"] = childRegistry
+                                .text()
+                                .hidden()
+                                .defaultValue(() => generateAlphaNumericLowerCaseId(12));
+                        }
+                        if (template.fields && template.fields.length > 0) {
                             for (const child of template.fields) {
                                 result[child.fieldId] = context.mapField(child, childRegistry);
                             }
-                            return result;
-                        });
-                    }
+                        }
+                        return result;
+                    });
                 });
             }
         }

--- a/packages/app-headless-cms/src/features/formModel/mappers/ObjectFieldMapper.ts
+++ b/packages/app-headless-cms/src/features/formModel/mappers/ObjectFieldMapper.ts
@@ -6,6 +6,7 @@ import type {
 } from "@webiny/app-admin/features/formModel/abstractions.js";
 import type { CmsModelField } from "~/types.js";
 import { applyFieldProps } from "./applyFieldProps.js";
+import { generateAlphaNumericLowerCaseId } from "@webiny/utils/generateId";
 
 export class ObjectFieldMapper implements ICmsFieldTypeMapper {
     readonly type = "object";
@@ -21,6 +22,12 @@ export class ObjectFieldMapper implements ICmsFieldTypeMapper {
         if (childFields && childFields.length > 0) {
             builder.fields(childRegistry => {
                 const result: Record<string, IFieldBuilder> = {};
+                if (field.list) {
+                    result["_id"] = childRegistry
+                        .text()
+                        .hidden()
+                        .defaultValue(() => generateAlphaNumericLowerCaseId(12));
+                }
                 for (const child of childFields) {
                     result[child.fieldId] = context.mapField(child, childRegistry);
                 }

--- a/packages/app-headless-cms/src/features/formModel/mappers/ObjectFieldMapper.ts
+++ b/packages/app-headless-cms/src/features/formModel/mappers/ObjectFieldMapper.ts
@@ -22,12 +22,11 @@ export class ObjectFieldMapper implements ICmsFieldTypeMapper {
         if (childFields && childFields.length > 0) {
             builder.fields(childRegistry => {
                 const result: Record<string, IFieldBuilder> = {};
-                if (field.list) {
-                    result["_id"] = childRegistry
-                        .text()
-                        .hidden()
-                        .defaultValue(() => generateAlphaNumericLowerCaseId(12));
-                }
+                result["_id"] = childRegistry
+                    .text()
+                    .hidden()
+                    .defaultValue(() => generateAlphaNumericLowerCaseId(12))
+                    .cloneValue(() => generateAlphaNumericLowerCaseId(12));
                 for (const child of childFields) {
                     result[child.fieldId] = context.mapField(child, childRegistry);
                 }

--- a/packages/app-headless-cms/src/presentation/contentEntries/form/getFieldBuilders.test.ts
+++ b/packages/app-headless-cms/src/presentation/contentEntries/form/getFieldBuilders.test.ts
@@ -138,10 +138,10 @@ describe("getFieldBuilders with CMS model", () => {
             visited.push({ fieldType: builder.getType(), tags: builder.getTags() });
         });
         // top-level: textSingle, objectMultiple, dynamicZoneList = 3
-        // objectMultiple children: uuid, name = 2
-        // dynamicZoneList template "textBlock" children: uuid, title = 2
-        // Total = 7
-        expect(visited.length).toBe(7);
+        // objectMultiple children: _id, uuid, name = 3
+        // dynamicZoneList template "textBlock" children: _id, uuid, title = 3
+        // Total = 9
+        expect(visited.length).toBe(9);
     });
 
     it("traverse should find builders tagged 'uuid'", () => {
@@ -213,8 +213,8 @@ describe("getFieldBuilders with CMS model", () => {
                 textBuilders.push(builder.getName());
             }
         });
-        // textSingle + objectMultiple.uuid + objectMultiple.name + dz.textBlock.uuid + dz.textBlock.title = 5
-        expect(textBuilders.length).toBe(5);
+        // textSingle + objectMultiple._id + objectMultiple.uuid + objectMultiple.name + dz.textBlock._id + dz.textBlock.uuid + dz.textBlock.title = 7
+        expect(textBuilders.length).toBe(7);
     });
 
     it("should combine getName, getType, and getTags for precise filtering", () => {


### PR DESCRIPTION
## Summary

- Adds a server-generated `_id: ID` property to **every** object and dynamic-zone field value (both single-value and multi-value/list), giving external systems (comments, annotations, collaboration) a stable reference identifier
- Follows the existing `_templateId` pattern: synthetic property injected at GraphQL schema level, preserved through field converters, storage transforms, OpenSearch indexing, and frontend value transformers
- Auto-generates IDs on create/update using `generateAlphaNumericLowerCaseId(12)`, preserves client-sent values, silently regenerates duplicates within arrays

## Changes (22 files)

| Layer | Files | What |
|-------|-------|------|
| GraphQL Schema | `ObjectToGraphQL.ts`, `DynamicZoneToGraphQL.ts` | `extend type/input` with `_id: ID` for all object and DZ fields |
| ID Generation | `ensureItemIds.ts` (new) | Traverser-based utility to assign `_id` on save |
| Entry Factories | `CreateEntryDataFactory.ts`, `UpdateEntryDataFactory.ts`, `CreateEntryRevisionFromDataFactory.ts` | Call `ensureItemIds` before validation |
| Field Converters | `CmsModelObjectFieldConverterPlugin.ts`, `CmsModelDynamicZoneFieldConverterPlugin.ts` | Preserve `_id` through fieldId↔storageId conversion |
| Storage Transform | `ObjectStorageTransform.ts` | Preserve `_id` through storage value transforms |
| Query Selection | `ValuesSelectionGenerator.ts` | Include `_id` in generated GQL selections |
| Frontend | `ObjectValueTransformer.ts`, `DynamicZoneValueTransformer.ts` | Preserve `_id` through form submit round-trip |
| Frontend Form | `ObjectFieldMapper.ts`, `DynamicZoneFieldMapper.ts` | Add `_id` as hidden text field with auto-generated default |
| OpenSearch | `ObjectFieldIndex.ts` | Preserve `_id` in index value/rawValue arrays |
| Tests | 7 snapshot/test files | Updated SDL snapshots, field builder counts, and DDB converter expectations |

## Backward compatibility

- **Non-breaking GraphQL change** — optional `_id` field added to types and inputs
- **No data migration** — existing entries return `_id: null` until re-saved
- **On re-save** — all items missing `_id` get one auto-generated

## Test plan

- [x] `yarn test packages/api-headless-cms` — 296 files, 926 tests pass
- [x] `yarn test packages/app-headless-cms` — 2 files, 25 tests pass
- [x] `yarn test:os packages/api-headless-cms-ddb-es` — 31 files, 112 tests pass
- [ ] Create entry with object/DZ fields → verify `_id` returned on all values
- [ ] Update entry (add/remove/reorder items) → existing `_id` preserved, new items get new `_id`
- [ ] Read entry without `_id` in storage → `_id: null`, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)