### PR TITLE
refactor(api-aco): gate folder-level permissions on FeatureFlags, not WcpContext

### DIFF
--- a/packages/api-aco/src/AcoInitializer.ts
+++ b/packages/api-aco/src/AcoInitializer.ts
@@ -9,7 +9,7 @@ import { RequestContainer } from "@webiny/event-handler-core";
 import { isHeadlessCmsReady } from "@webiny/api-headless-cms";
 import { CmsModelFieldToGraphQLRegistry } from "@webiny/api-headless-cms/exports/api/cms/graphql.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/abstractions.js";
-import { WcpContext } from "@webiny/api-core/features/wcp/WcpContext/abstractions.js";
+import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { ListModelsUseCase } from "@webiny/api-headless-cms/features/contentModel/ListModels/index.js";
 import { createGraphQLSchemaPluginFromFieldPlugins } from "@webiny/api-headless-cms/utils/getSchemaFromFieldPlugins.js";
@@ -59,10 +59,15 @@ class AcoInitializerImpl implements IRequestContextInitializer {
             this.container.registerInstance(FolderModelAbstraction, folderModel.value);
         });
 
-        // CMS-entry folder-level-permission decorators (WCP-gated). Must be registered before any
-        // CMS-entry resolver runs, so this stays in the (pre-resolver) initializer rather than a
+        // CMS-entry folder-level-permission decorators (feature-flag gated). Must be registered before
+        // any CMS-entry resolver runs, so this stays in the (pre-resolver) initializer rather than a
         // lazy factory.
-        if (this.container.resolve(WcpContext).canUseFolderLevelPermissions()) {
+        if (
+            this.container
+                .resolve(FeatureFlags)
+                .get()
+                .isEnabled("advancedAccessControlLayer.folderLevelPermissions")
+        ) {
             CmsFlpFeature.register(this.container);
         }
 


### PR DESCRIPTION
## What (Phase 4)

`AcoInitializer` was the **last** `WcpContext.canUse*()` feature gate in `api-*`. Swap it for `FeatureFlags`:

```ts
// before
if (this.container.resolve(WcpContext).canUseFolderLevelPermissions()) { CmsFlpFeature.register(...) }
// after
if (this.container.resolve(FeatureFlags).get().isEnabled("advancedAccessControlLayer.folderLevelPermissions")) { CmsFlpFeature.register(...) }
```

The other former `canUse*` gates (private files, threat detection, audit logs, record locking, …) already read `FeatureFlags` (via #5559 / #5537).

## Not in scope (Phase 5)
The remaining `WcpContext` consumers are **not** feature gates, so they stay until the `WcpContext` deletion:
- seat/tenant increment-decrement decorators (billing — `incrementSeats`/`incrementTenants`)
- `WcpSchemaFactory` (the admin `wcp` gql query)
- an `AaclPermission` type import in `IdentityContext`

## Verification
api-aco: **74 tests pass**; build + lint clean. Behaviour equivalent (`isEnabled(flp) = userFlag && license.canUseFolderLevelPermissions()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rg3MRCToopzWSTPWqU9Lga