### PR TITLE
fix(licensing): each licensable feature self-gates on its flag at register time

### DIFF
--- a/packages/api-audit-logs/src/AuditLogsFeature.ts
+++ b/packages/api-audit-logs/src/AuditLogsFeature.ts
@@ -20,6 +20,12 @@ const getDeleteLogsAfterDays = (days?: number): number => {
 export const AuditLogsFeature = createFeature({
     name: "AuditLogs",
     register(container: Container, config: AuditLogsFeatureConfig = {}) {
+        // Audit logs are license-gated — check at register time (license is fresh pre-register) so
+        // nothing wires up without the entitlement.
+        if (!container.resolve(FeatureFlags).get().isEnabled("auditLogs")) {
+            return;
+        }
+
         container.register(AuditLogsGraphQLSchema);
 
         let initialized = false;
@@ -35,11 +41,6 @@ export const AuditLogsFeature = createFeature({
                     return STUB_SCHEMA;
                 }
                 initialized = true;
-
-                const featureFlags = container.resolve(FeatureFlags);
-                if (!featureFlags.get().isEnabled("auditLogs")) {
-                    return STUB_SCHEMA;
-                }
 
                 const storage = container.resolve(AuditLogsStorage);
                 const eventPublisher = container.resolve(EventPublisher);

--- a/packages/api-headless-cms-workflows/src/CmsWorkflowsFeature.ts
+++ b/packages/api-headless-cms-workflows/src/CmsWorkflowsFeature.ts
@@ -1,5 +1,6 @@
 import { createFeature } from "@webiny/feature/api";
 import { CmsGraphQLSchemaFactory } from "@webiny/api-headless-cms";
+import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { EntryWorkflowsFeature } from "./features/EntryWorkflows/feature.js";
 import { WorkflowsFeature as CmsLocalWorkflowsFeature } from "./features/Workflows/index.js";
 import { WorkflowsFeature } from "@webiny/api-workflows";
@@ -8,7 +9,12 @@ import { createEntrySystemSchemaExtension } from "./graphql/entrySystemSchema.js
 export const CmsWorkflowsFeature = createFeature({
     name: "CmsWorkflows",
     register(container) {
-        // WCP guard is enforced inside WorkflowsContextEnhancer — register unconditionally.
+        // Advanced publishing workflow is license-gated — check at register time (license is fresh
+        // pre-register) so nothing wires up without the entitlement.
+        if (!container.resolve(FeatureFlags).get().isEnabled("advancedPublishingWorkflow")) {
+            return;
+        }
+
         EntryWorkflowsFeature.register(container);
         CmsLocalWorkflowsFeature.register(container);
         WorkflowsFeature.register(container);

--- a/packages/api-record-locking/src/RecordLockingAppFeature.ts
+++ b/packages/api-record-locking/src/RecordLockingAppFeature.ts
@@ -1,4 +1,5 @@
 import { type Container, createFeature } from "@webiny/feature/api";
+import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { RecordLockingModel } from "~/domain/RecordLockingModel.js";
 import { RecordLockingAppConfig } from "~/domain/RecordLockingAppConfig.js";
 import { getTimeout } from "~/utils/getTimeout.js";
@@ -14,6 +15,12 @@ export interface IRecordLockingAppFeatureParams {
 export const RecordLockingAppFeature = createFeature<IRecordLockingAppFeatureParams>({
     name: "RecordLockingApp",
     register(container: Container, params: IRecordLockingAppFeatureParams) {
+        // Record locking is license-gated — check at register time (license is fresh pre-register)
+        // so nothing wires up without the entitlement.
+        if (!container.resolve(FeatureFlags).get().isEnabled("recordLocking")) {
+            return;
+        }
+
         container.register(RecordLockingModel);
         container.registerInstance(RecordLockingAppConfig, {
             timeout: getTimeout(params?.timeout)

--- a/packages/api-record-locking/src/graphql/RecordLockingContextualSchema.ts
+++ b/packages/api-record-locking/src/graphql/RecordLockingContextualSchema.ts
@@ -4,7 +4,6 @@ import { makeExecutableSchema } from "@graphql-tools/schema";
 import { mergeResolvers } from "@graphql-tools/merge";
 import { GraphQLContextualSchema } from "@webiny/api-graphql";
 import type { IGraphQLContextualSchema } from "@webiny/api-graphql";
-import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel";
@@ -21,14 +20,15 @@ import { createGraphQLSchema } from "~/graphql/schema.js";
 
 class RecordLockingContextualSchemaImpl implements IGraphQLContextualSchema {
     constructor(
-        private featureFlags: FeatureFlags.Interface,
         private tenantCtx: TenantContext.Interface,
         private identityCtx: IdentityContext.Interface,
         private config: IRecordLockingAppConfig
     ) {}
 
     async build(ctx: Record<string, any>): Promise<GraphQLSchema> {
-        if (!this.featureFlags.get().isEnabled("recordLocking") || !this.tenantCtx.getTenant()) {
+        // Only registered when recordLocking is licensed (RecordLockingAppFeature gates on the flag),
+        // so here we only fall back to an empty schema until the tenant is known.
+        if (!this.tenantCtx.getTenant()) {
             return makeExecutableSchema({
                 typeDefs: "type Query\ntype Mutation",
                 assumeValidSDL: true
@@ -84,5 +84,5 @@ class RecordLockingContextualSchemaImpl implements IGraphQLContextualSchema {
 
 export const RecordLockingContextualSchema = GraphQLContextualSchema.createImplementation({
     implementation: RecordLockingContextualSchemaImpl,
-    dependencies: [FeatureFlags, TenantContext, IdentityContext, RecordLockingAppConfig]
+    dependencies: [TenantContext, IdentityContext, RecordLockingAppConfig]
 });

--- a/packages/api-website-builder-workflows/src/WebsiteBuilderPageSchemaFactory.ts
+++ b/packages/api-website-builder-workflows/src/WebsiteBuilderPageSchemaFactory.ts
@@ -3,19 +3,14 @@ import type {
     IGraphQLSchemaFactory,
     GraphQLSchemaFactory as GQLSchemaFactory
 } from "@webiny/api-graphql/graphql/abstractions.js";
-import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import type { WbPage } from "@webiny/api-website-builder/domain/page/abstractions.js";
 
+// Only registered when advancedPublishingWorkflow is licensed (WebsiteBuilderWorkflowsFeature gates
+// on the flag at register time), so no per-request license guard is needed here.
 class WebsiteBuilderPageSchemaFactoryImpl implements IGraphQLSchemaFactory {
-    constructor(private featureFlags: FeatureFlags.Interface) {}
-
     async execute(
         builder: GQLSchemaFactory.SchemaBuilder
     ): Promise<GQLSchemaFactory.SchemaBuilder> {
-        if (!this.featureFlags.get().isEnabled("advancedPublishingWorkflow")) {
-            return builder;
-        }
-
         builder.addTypeDefs(/* GraphQL */ `
             extend type WbPage {
                 system: CmsEntrySystem
@@ -33,5 +28,5 @@ class WebsiteBuilderPageSchemaFactoryImpl implements IGraphQLSchemaFactory {
 
 export const WebsiteBuilderPageSchemaFactory = GraphQLSchemaFactory.createImplementation({
     implementation: WebsiteBuilderPageSchemaFactoryImpl,
-    dependencies: [FeatureFlags]
+    dependencies: []
 });

--- a/packages/api-website-builder-workflows/src/WebsiteBuilderWorkflowsFeature.ts
+++ b/packages/api-website-builder-workflows/src/WebsiteBuilderWorkflowsFeature.ts
@@ -1,13 +1,17 @@
 import { type Container, createFeature } from "@webiny/feature/api";
+import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { PageWorkflowsFeature } from "./features/PageWorkflows/feature.js";
 import { WebsiteBuilderPageSchemaFactory } from "./WebsiteBuilderPageSchemaFactory.js";
 
 export const WebsiteBuilderWorkflowsFeature = createFeature({
     name: "WebsiteBuilderWorkflows",
     register(container: Container) {
-        // Page workflow handlers/decorators are register-time-safe and inert without workflow state
-        // (no license → no workflow states), so register unconditionally — matching CmsWorkflowsFeature.
-        // The WbPage.system schema extension is WCP-gated inside WebsiteBuilderPageSchemaFactory.
+        // Advanced publishing workflow is license-gated — check at register time (license is fresh
+        // pre-register) so nothing wires up without the entitlement.
+        if (!container.resolve(FeatureFlags).get().isEnabled("advancedPublishingWorkflow")) {
+            return;
+        }
+
         PageWorkflowsFeature.register(container);
         container.register(WebsiteBuilderPageSchemaFactory);
     }

--- a/packages/api-workflows/src/WorkflowsFeature.ts
+++ b/packages/api-workflows/src/WorkflowsFeature.ts
@@ -1,4 +1,5 @@
 import { type Container, createFeature } from "@webiny/feature/api";
+import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { WorkflowsInitializer } from "./WorkflowsInitializer.js";
 import { WorkflowsSchemaFactory } from "./WorkflowsSchemaFactory.js";
 import { WorkflowModel as WorkflowPrivateModel } from "./domain/workflow/workflowModel.js";
@@ -7,6 +8,12 @@ import { WorkflowStateModel as WorkflowStatePrivateModel } from "./domain/workfl
 export const WorkflowsFeature = createFeature({
     name: "Workflows",
     register(container: Container) {
+        // Advanced publishing workflow is license-gated. Check the effective flag at register time
+        // (the license is refreshed pre-register) so nothing is wired up without the entitlement.
+        if (!container.resolve(FeatureFlags).get().isEnabled("advancedPublishingWorkflow")) {
+            return;
+        }
+
         // Register private CMS model definitions early so HeadlessCmsInitializerImpl
         // picks them up when it builds the model list during the enhance phase.
         container.register(WorkflowPrivateModel);

--- a/packages/api-workflows/src/WorkflowsInitializer.ts
+++ b/packages/api-workflows/src/WorkflowsInitializer.ts
@@ -4,7 +4,6 @@ import type { IRequestContextInitializer } from "@webiny/event-handler-core";
 import { RequestContainer } from "@webiny/event-handler-core";
 import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
 import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
-import { FeatureFlags } from "@webiny/api-core/features/featureFlags/abstractions.js";
 import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import { WORKFLOW_MODEL_ID } from "./domain/workflow/workflowModel.js";
 import { WORKFLOW_STATE_MODEL_ID } from "./domain/workflowState/stateModel.js";
@@ -45,18 +44,16 @@ class WorkflowsInitializerImpl implements IRequestContextInitializer {
     constructor(
         private container: Container,
         private tenantCtx: TenantContext.Interface,
-        private identityCtx: IdentityContext.Interface,
-        private featureFlags: FeatureFlags.Interface
+        private identityCtx: IdentityContext.Interface
     ) {}
 
     async init(_ctx: Record<string, any>): Promise<void> {
         if (!this.initialized) {
             this.initialized = true;
 
-            if (
-                this.tenantCtx.getTenant() &&
-                this.featureFlags.get().isEnabled("advancedPublishingWorkflow")
-            ) {
+            // The feature is only registered when licensed (WorkflowsFeature gates on the flag), so
+            // here we only wait for the tenant to be known before the per-tenant model registration.
+            if (this.tenantCtx.getTenant()) {
                 await this.registerWorkflowFeatures();
             }
         }
@@ -115,5 +112,5 @@ class WorkflowsInitializerImpl implements IRequestContextInitializer {
 
 export const WorkflowsInitializer = RequestContextInitializer.createImplementation({
     implementation: WorkflowsInitializerImpl,
-    dependencies: [RequestContainer, TenantContext, IdentityContext, FeatureFlags]
+    dependencies: [RequestContainer, TenantContext, IdentityContext]
 });


### PR DESCRIPTION
## What

Fixes a **no-license boot failure** (reported by Pavel): cloning `next` without a WCP license broke at startup because licensable features were registered **unconditionally** and relied on *runtime* guards — which still half-wires a feature without an entitlement.

Each licensable feature now checks its effective `FeatureFlags` **at register time** (the license is refreshed pre-register) and registers nothing when off. The now-redundant **runtime guards are removed** in the same move; lifecycle gates (tenant-known) stay.

- `advancedPublishingWorkflow` → `WorkflowsFeature`, `CmsWorkflowsFeature`, `WebsiteBuilderWorkflowsFeature`
- `recordLocking` → `RecordLockingAppFeature`
- `auditLogs` → `AuditLogsFeature`

(Private files + folder-level permissions already register-time gated in #5537 / #5607.)

## Why feature self-gate (not gate in registerApiRequestStack)

These features **already import `FeatureFlags`** (for the runtime guards), so gating in the stack wouldn't make them flag-clean — it'd only couple the stack to per-feature licensing knowledge and add `if` clutter. Self-gating collocates the check with the feature, keeps `registerApiRequestStack` uniform, and lets the redundant runtime guard die in the same file.

## Behaviour

Neutral under a full license — every flag on → all features register as before (CI runs with a full test license). Differs only when a flag is off → the feature isn't wired up (the fix). `registerApiRequestStack` unchanged.

## Verification
Builds + lint clean. api-workflows + api-record-locking + api-audit-logs: 53 tests pass. Real acceptance = a no-license boot comes up clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rg3MRCToopzWSTPWqU9Lga