### PR TITLE
fix(ci): push the release tag with the PAT, not the default token

### DIFF
--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -255,6 +255,7 @@ jobs:
           path: ${{ needs.prBranch.outputs.pr-branch }}
           ref: ${{ needs.prBranch.outputs.pr-sha }}
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - name: Resolve Yarn cache folder
         id: yarn-cache-folder
         working-directory: ${{ needs.prBranch.outputs.pr-branch }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -917,7 +917,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Start Verdaccio local server
         working-directory: v6
@@ -1080,7 +1080,7 @@ jobs:
         run: yarn --immutable
         working-directory: v6
       - name: Build packages
-        run: yarn build --rebuild-dependents
+        run: yarn build
         working-directory: v6
       - name: Start Verdaccio local server
         working-directory: v6

--- a/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
@@ -148,7 +148,21 @@ export const pullRequestsCommandBeta = createSlashCommandWorkflow({
                 NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
                 SLACK_RELEASE_CHANNEL_WEBHOOK: "${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}"
             },
-            checkout: { path: PR_BRANCH, ref: PR_SHA, "fetch-depth": 0 },
+            // Checked out with the PAT, not the default token. `yarn release --type=latest
+            // --createGithubRelease` shells out to a raw `git tag` + `git push origin v<version>`,
+            // which uses whatever credentials actions/checkout persisted - so with the default
+            // token that push is made by github-actions[bot] and is refused:
+            //
+            //   remote: Permission to webiny/webiny-js.git denied to github-actions[bot].
+            //
+            // Packages are published BEFORE the tag is pushed, so the failure leaves a release on
+            // NPM with no matching tag. Matches what release.wac.ts already does for the same step.
+            checkout: {
+                path: PR_BRANCH,
+                ref: PR_SHA,
+                "fetch-depth": 0,
+                token: "${{ secrets.GH_TOKEN }}"
+            },
             steps: [
                 ...yarnCacheSteps,
                 ...runBuildCacheDownloadSteps,


### PR DESCRIPTION
### What broke

Releasing 6.4.9 published every package to NPM and then failed:

```
Error: Command failed with exit code 128: git push origin v6.4.9
remote: Permission to webiny/webiny-js.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/webiny/webiny-js/': The requested URL returned error: 403
```

So **6.4.9 is on NPM under the `latest` dist-tag with no matching git tag, no GitHub release and no changelog.**

### My regression, from #5542

That change set `contents: read` on every job created by `createJob`, justified at the time by *"all git/gh writes across workflows use the GH_TOKEN PAT, so contents: read on the default token is sufficient everywhere else."*

That is not true for this job. `yarn release --type=latest --createGithubRelease` shells out to a raw `git tag` + `git push origin v<version>`, which uses whatever credentials `actions/checkout` persisted — the default `GITHUB_TOKEN` — so the push is attempted by `github-actions[bot]` against a read-only contents scope.

### The fix

Check out with the PAT in that job:

```ts
checkout: { path: PR_BRANCH, ref: PR_SHA, "fetch-depth": 0, token: "${{ secrets.GH_TOKEN }}" }
```

This is what `release.wac.ts` already does for the identical step, and what `fullRelease.wac.ts` does for its branch pushes — the precedent existed, the `/beta` command just did not follow it.

Preferred over granting the bot `contents: write`, because the PAT also carries the ruleset bypass these pushes need — earlier pushes in this repo have logged `Bypassed rule violations for refs/heads/next` under the PAT.

### Scope

Audited every job that runs a raw `git push` or `--createGithubRelease`:

| Workflow / job | State |
|---|---|
| `pullRequestsCommandBeta` / `npmReleaseLatest` | **was broken** — fixed here |
| `release` / `npmReleaseLatest` | ok — already uses `GH_TOKEN` |
| `fullRelease` / `createWebinyJsBranch` | ok — already uses `GH_TOKEN` |
| `v5_customRelease`, `versionApproval` | ok — hand-written, no permissions block, so they inherit the repository default |

The alpha and beta publish steps do not tag: the tag push is gated on `createGithubRelease`, which only the `latest` step passes.

Re-ran the audit after the fix — nothing left on the bot token with `contents: read` that pushes refs.

### Worth noting

Packages are published **before** the tag is pushed, so a permissions failure at this point cannot roll back the NPM publish. That ordering is what turned a permissions bug into a half-completed release.

### Also included

Regenerates `push.yml`, which was stale on `next`: #5430 dropped `--rebuild-dependents` from `createInstallBuildSteps`, but two self-hosted jobs in the committed YAML still carried the flag. Exactly the drift a generated-YAML check would catch.

### Changelog

**Fixed release tagging**

The release workflow published packages to NPM but could not create the matching git tag, leaving releases untagged. It now tags correctly.

### Squash Merge Commit

```
fix(ci): push the release tag with the PAT, not the default token (#5610)
```