### PR TITLE
fix(website-builder-react): stack Grid columns via CSS media query

### DIFF
--- a/packages/website-builder-react/src/editorComponents/Grid.tsx
+++ b/packages/website-builder-react/src/editorComponents/Grid.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ComponentProps, ComponentPropsWithChildren } from "~/types.js";
+import { createGridClass, createGridStackingCss } from "./gridStyles.js";
 
 export const GridColumnComponent = ({
     inputs
@@ -23,7 +24,7 @@ type GridProps = ComponentProps<{
     reverseWhenStacked?: boolean;
 }>;
 
-export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
+export const GridComponent = ({ inputs, styles, element }: GridProps) => {
     const { gridLayout = "12", columns, columnGap, stackAtBreakpoint, reverseWhenStacked } = inputs;
     const rowConfig = gridLayout.split("-").map(size => parseInt(size));
     const rows: Column[][] = [];
@@ -36,22 +37,17 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
     // Number of pixels we need to subtract from each cell to ensure they fit in the grid with column gap
     const cellWidthReduction = columnGap ? columnGap - columnGap / rowConfig.length : 0;
 
-    const stackColumns = breakpoint === stackAtBreakpoint;
+    const gridClass = createGridClass(element.id);
 
-    if (stackColumns) {
-        styles.flexDirection = reverseWhenStacked ? "column-reverse" : "column";
-    }
+    // Columns stack via a CSS media query (see createGridStackingCss).
+    const stackCss = createGridStackingCss({ gridClass, stackAtBreakpoint, reverseWhenStacked });
 
     return (
-        <div style={styles}>
+        <div className={gridClass} style={styles}>
+            {stackCss ? <style dangerouslySetInnerHTML={{ __html: stackCss }} /> : null}
             {rows.map(columns => {
                 return columns.map((column, i) => (
-                    <Span
-                        key={i}
-                        stackColumns={stackColumns}
-                        size={rowConfig[i]}
-                        reductionInPx={cellWidthReduction}
-                    >
+                    <Span key={i} size={rowConfig[i]} reductionInPx={cellWidthReduction}>
                         <GridColumnComponent key={i} inputs={{ children: column.children }} />
                     </Span>
                 ));
@@ -63,15 +59,16 @@ export const GridComponent = ({ inputs, styles, breakpoint }: GridProps) => {
 interface SpanProps {
     size: number;
     reductionInPx: number;
-    stackColumns: boolean;
     children: React.ReactNode;
 }
 
-const Span = ({ size, children, reductionInPx, stackColumns }: SpanProps) => {
-    const width = stackColumns ? "100%" : `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
+const Span = ({ size, children, reductionInPx }: SpanProps) => {
+    // Base (row) width. The Grid's media query overrides this to 100% when stacked.
+    const width = `calc(${(size / 12) * 100}% - ${reductionInPx}px)`;
 
     return (
         <div
+            className="wb-grid-col"
             style={{
                 flex: `0 0 ${width}`,
                 maxWidth: width,

--- a/packages/website-builder-react/src/editorComponents/Grid.tsx
+++ b/packages/website-builder-react/src/editorComponents/Grid.tsx
@@ -44,6 +44,12 @@ export const GridComponent = ({ inputs, styles, element }: GridProps) => {
 
     return (
         <div className={gridClass} style={styles}>
+            {/*
+                A media query can't be expressed in an inline `style` attribute (that only
+                holds declarations, not at-rules), so the stacking CSS is emitted as a
+                scoped <style> tag. A <style> is `display:none` and valid inside <body>,
+                so it doesn't affect the grid's flex layout.
+            */}
             {stackCss ? <style dangerouslySetInnerHTML={{ __html: stackCss }} /> : null}
             {rows.map(columns => {
                 return columns.map((column, i) => (

--- a/packages/website-builder-react/src/editorComponents/gridStyles.ts
+++ b/packages/website-builder-react/src/editorComponents/gridStyles.ts
@@ -1,0 +1,58 @@
+import { viewportManager } from "@webiny/website-builder-sdk";
+
+/**
+ * Builds a stable, SSR-consistent class scoped to a single grid instance
+ * (e.g. `wb-grid-<id>`), sanitized to a valid CSS class name.
+ */
+export const createGridClass = (elementId: string): string => {
+    return `wb-grid-${String(elementId).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+};
+
+interface CreateGridStackingCssParams {
+    /** Scoped class applied to the grid container (from `createGridClass`). */
+    gridClass: string;
+    /** Breakpoint name at (and below) which columns stack, e.g. "mobile". */
+    stackAtBreakpoint?: string;
+    /** Reverse the visual order of columns when stacked. */
+    reverseWhenStacked?: boolean;
+}
+
+/**
+ * Builds the media query that stacks a grid's columns at (and below) the given
+ * breakpoint's width.
+ *
+ * Stacking is expressed as CSS rather than JS so the layout is correct straight
+ * from the SSR HTML — no hydration, no viewport JS, no flash — the browser
+ * applies it by the real viewport width. The width comes from the theme's
+ * breakpoint definition (populated on both server and client via ContentSdk.init).
+ *
+ * Returns an empty string when no stacking breakpoint is configured (or the
+ * named breakpoint is unknown), in which case the grid never stacks.
+ */
+export const createGridStackingCss = ({
+    gridClass,
+    stackAtBreakpoint,
+    reverseWhenStacked
+}: CreateGridStackingCssParams): string => {
+    if (!stackAtBreakpoint) {
+        return "";
+    }
+
+    const breakpoint = viewportManager
+        .getViewport()
+        .breakpoints.find(bp => bp.name === stackAtBreakpoint);
+
+    if (!breakpoint) {
+        return "";
+    }
+
+    const direction = reverseWhenStacked ? "column-reverse" : "column";
+
+    // `!important` overrides the inline base (row) styles set on the elements.
+    return [
+        `@media (max-width: ${breakpoint.maxWidth}px) {`,
+        `  .${gridClass} { flex-direction: ${direction} !important; }`,
+        `  .${gridClass} > .wb-grid-col { flex: 0 0 100% !important; max-width: 100% !important; }`,
+        `}`
+    ].join("\n");
+};

--- a/packages/website-builder-sdk/src/ContentSdk.ts
+++ b/packages/website-builder-sdk/src/ContentSdk.ts
@@ -95,9 +95,11 @@ export class ContentSdk implements IContentSdk, IRedirects {
 
         const theme = Theme.from(config.theme ?? {});
 
-        if (environment.isClient()) {
-            viewportManager.setBreakpoints(theme.breakpoints);
-        }
+        // Populate breakpoints on the server too, so SSR can generate
+        // breakpoint-aware CSS (e.g. Grid stacking media queries) from the
+        // real theme widths. The resize listener stays client-only (it's
+        // guarded in the ViewportManager constructor).
+        viewportManager.setBreakpoints(theme.breakpoints);
 
         let editingSdk;
         if (environment.isEditing()) {


### PR DESCRIPTION
## Problem

Grid column stacking is resolved in **JS** from the runtime viewport breakpoint (`breakpoint === stackAtBreakpoint`) and applied as **inline** styles.

On SSR the breakpoint is always `desktop`, so the served HTML renders columns side-by-side and only corrects once the client hydrates and re-resolves the breakpoint. That causes a layout **flash** — and stays broken entirely when the content subtree doesn't hydrate (e.g. content rendered via `next/dynamic({ssr:true})`), which is how this surfaced on an OpenNext/SSG frontend: a grid set to *stack at mobile* stayed 2-column at mobile width.

## Fix

Emit stacking as a **scoped CSS media query** in the rendered HTML, so the browser applies it by the real viewport width — no JS, no hydration dependency, no flash.

- Grid renders a scoped class `wb-grid-<element.id>` plus a `<style>` block:
  ```css
  @media (max-width: <breakpoint-width>px) {
    .wb-grid-<id> { flex-direction: column !important; }
    .wb-grid-<id> > .wb-grid-col { flex: 0 0 100% !important; max-width: 100% !important; }
  }
  ```
- The stack width is read from the **theme's** breakpoint definition (no hardcoded widths).
- `ContentSdk.init` now populates `viewportManager` breakpoints on the **server** too (the resize listener stays client-only), so SSR has the real widths to generate the media query.
- CSS/class string building lives in `gridStyles.ts` (`createGridClass`, `createGridStackingCss`), not inline in the component.

## Scope

**Grid stacking only.** Multiple grids and nested grids are safe (unique per-id class + direct-child combinator). Deliberately out of scope, as follow-ups:

- Per-breakpoint **styles** for all elements (e.g. responsive `rowGap`/`columnGap`, spacing, visibility) — same JS→`@media` treatment, generalized.
- Per-breakpoint **content** (text/RTE per breakpoint) and responsive images (`<picture>`/`srcset`).
- The content-hydration gap and SSG `draftMode` behavior (orthogonal bugs).

## Testing

- Verified the `@media` block is present in the SSR HTML and the browser stacks columns at the breakpoint width with **no client JS** (content subtree not hydrated).
- **Verified in the editor** — device preview stacking behaves correctly.
- Builds clean; changed files formatted (oxfmt) and linted (oxlint).

## Known follow-ups before merge

- No unit tests yet for `createGridClass` / `createGridStackingCss`.
- Changelog entry pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)