### PR TITLE
feat(build): add --json flag for machine-readable build progress

### DIFF
--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import yargs from "yargs";
 import { writeJsonFileSync } from "write-json-file";
 import { Listr, ListrTask } from "listr2";
@@ -15,10 +14,9 @@ import path from "path";
 import { hideBin } from "yargs/helpers";
 import { PackageBuildError } from "./PackageBuildError";
 import { queueMetaWrite } from "./writeMetaQueue";
+import { createReporter } from "./reporter";
 
 const argv = yargs(hideBin(process.argv)).parse();
-
-const { green, red } = chalk;
 
 const projectFolder = path.basename(process.cwd());
 
@@ -36,6 +34,12 @@ interface BuildOptions {
     cache?: boolean;
     buildOverrides?: string;
     safeReplace?: boolean;
+    /**
+     * Emit newline-delimited JSON progress events on stdout instead of the interactive
+     * Listr UI, so an external tool (IDE, CI dashboard) can render its own progress.
+     * See `reporter.ts` for the event schema.
+     */
+    json?: boolean;
 }
 
 interface BuildContext {
@@ -43,15 +47,26 @@ interface BuildContext {
 }
 
 const buildInParallel =
-    !process.env.CI || process.env.RUNNER_NAME?.startsWith("webiny-build-packages");
+    !process.env.CI || process.env.RUNNER_NAME?.startsWith("webiny-build-packages") === true;
 
 export const buildPackages = async () => {
     const options = argv as BuildOptions;
 
-    printHardwareReport();
+    const reporter = createReporter(options.json === true);
 
-    console.log("Check Typescript");
-    await execa("yarn", ["tsc", "--version"], { stdio: "inherit" });
+    // Captured rather than inherited: in JSON mode stdout carries the event stream, and
+    // in text mode the reporter needs to print this after the hardware report.
+    const tscVersion = await execa("yarn", ["tsc", "--version"]);
+
+    const hardware = getHardwareInfo();
+
+    reporter.info({
+        projectFolder,
+        runner: process.env.RUNNER_NAME || "N/A",
+        parallel: buildInParallel,
+        ...hardware,
+        tscVersion: tscVersion.stdout?.trim() ?? ""
+    });
 
     let packagesWhitelist: string[] = [];
     if (options.p) {
@@ -62,30 +77,48 @@ export const buildPackages = async () => {
         }
     }
 
-    const { batches, packagesNoCache, allPackages, buildKeys } = await getBatches({
+    const {
+        batches,
+        packagesNoCache,
+        packagesUseCache,
+        restoredFromCache,
+        cacheEnabled,
+        allPackages,
+        buildKeys
+    } = await getBatches({
         cache: options.cache ?? true,
         packagesWhitelist
     });
 
-    if (!packagesNoCache.length) {
-        console.log("There are no packages that need to be built.");
-        return;
-    }
+    const start = Date.now();
 
-    if (packagesNoCache.length > 10) {
-        console.log(`\nRunning build for ${green(packagesNoCache.length)} packages.`);
-    } else {
-        console.log("\nRunning build for the following package(s):");
-        for (let i = 0; i < packagesNoCache.length; i++) {
-            const item = packagesNoCache[i];
-            console.log(`‣ ${green(item.packageJson.name)}`);
-        }
+    reporter.plan({
+        totalPackages: allPackages.length,
+        cacheEnabled,
+        packages: packagesNoCache.map(pkg => pkg.packageJson.name),
+        cachedPackages: packagesUseCache.map(pkg => pkg.packageJson.name),
+        restoredPackages: restoredFromCache.map(pkg => pkg.packageJson.name),
+        // A single package is built directly, without batching.
+        batches: allPackages.length === 1 ? 0 : batches.length
+    });
+
+    if (!packagesNoCache.length) {
+        reporter.end({ success: true, duration: 0, built: 0, failed: 0, errors: [] });
+        return;
     }
 
     if (allPackages.length === 1) {
         const [pkg] = allPackages;
+
+        reporter.packageStart(pkg.packageJson.name, 0);
+
         try {
-            await buildPackage(pkg, options.buildOverrides, "inherit", options.safeReplace);
+            await buildPackage(
+                pkg,
+                options.buildOverrides,
+                reporter.machineReadable ? undefined : "inherit",
+                options.safeReplace
+            );
 
             // Record the dependency-aware build key so a later build treats this
             // package as a cache hit (the cache→dist copy is then skipped when
@@ -96,139 +129,237 @@ export const buildPackages = async () => {
             };
             writeJsonFileSync(META_FILE_PATH, meta);
 
+            const duration = Date.now() - start;
+            reporter.packageEnd({ name: pkg.packageJson.name, batch: 0, duration });
+
             sendNotification(`Webiny Build (${projectFolder})`, "Build completed successfully");
+
+            reporter.end({
+                success: true,
+                duration: duration / 1000,
+                built: 1,
+                failed: 0,
+                errors: []
+            });
         } catch (err) {
-            sendNotification(`Webiny Build (${projectFolder})`, "Build failed");
-            throw err;
-        }
-    } else {
-        const start = Date.now();
+            const error = err as Error;
+            const duration = Date.now() - start;
 
-        console.log(
-            `\nThe build process will be performed in ${green(batches.length)} ${
-                batches.length > 1 ? "batches" : "batch"
-            }.\n`
-        );
-        const metaJson = getBuildMeta();
-
-        const totalBatches = `${batches.length}`.padStart(2, "0");
-
-        const tasks = new Listr<BuildContext>(
-            batches.map<ListrTask>((packageNames, index) => {
-                const id = `${index + 1}`.padStart(2, "0");
-                const title = `[${id}/${totalBatches}] Batch #${id} (${packageNames.length} packages)`;
-
-                return {
-                    title,
-                    skip: ctx => ctx.skip,
-                    task: (ctx, task): Listr => {
-                        const packages = allPackages.filter(pkg => packageNames.includes(pkg.name));
-
-                        const subtasks = packages.map(pkg => {
-                            return {
-                                title: `${pkg.name}`,
-                                task: async () => {
-                                    try {
-                                        await buildPackage(
-                                            pkg,
-                                            options.buildOverrides,
-                                            undefined,
-                                            options.safeReplace
-                                        );
-
-                                        // Store the dependency-aware build key.
-                                        const key = buildKeys.get(pkg.name) ?? "";
-                                        await queueMetaWrite(async () => {
-                                            const currentMeta = getBuildMeta();
-                                            currentMeta.packages[pkg.packageJson.name] = {
-                                                sourceHash: key
-                                            };
-                                            return writeJsonFileSync(META_FILE_PATH, currentMeta);
-                                        });
-                                    } catch (err) {
-                                        ctx.skip = true;
-                                        throw new PackageBuildError(pkg, err as Error);
-                                    }
-                                }
-                            };
-                        });
-
-                        return task.newListr(subtasks, {
-                            concurrent: buildInParallel,
-                            exitOnError: false,
-                            collectErrors: true,
-                            rendererOptions: { showErrorMessage: false }
-                        });
-                    }
-                };
-            }),
-            {
-                concurrent: false,
-                collectErrors: true,
-                rendererOptions: {
-                    timer: {
-                        condition: true,
-                        field: duration => {
-                            return `${Math.round(duration / 1000)}s`;
-                        },
-                        format: () => {
-                            return time => {
-                                return time || "";
-                            };
-                        }
-                    },
-                    collapseSubtasks: true
-                }
-            }
-        );
-
-        await tasks.run();
-
-        const duration = (Date.now() - start) / 1000;
-
-        if (tasks.errors?.length) {
-            console.log();
-            console.log(
-                `Error building ${red(tasks.errors.length)} package(s). Check the logs below.`
-            );
-            console.log();
-
-            tasks.errors.forEach(listrError => {
-                const pkgBuildError = listrError.error as PackageBuildError;
-                console.log(red("✖ " + pkgBuildError.getPackage().name));
-                console.log(pkgBuildError.getBuildError().message);
-                console.log();
+            reporter.packageEnd({
+                name: pkg.packageJson.name,
+                batch: 0,
+                duration,
+                error: error.message
             });
 
-            sendNotification(
-                `Webiny Build (${projectFolder})`,
-                `Build failed after ${duration} seconds`
-            );
-            console.log(`Build failed in ${red(duration)} seconds.`);
-            process.exit(1);
+            sendNotification(`Webiny Build (${projectFolder})`, "Build failed");
+
+            reporter.end({
+                success: false,
+                duration: duration / 1000,
+                built: 0,
+                failed: 1,
+                errors: [{ name: pkg.packageJson.name, message: error.message }]
+            });
+
+            // In JSON mode the failure is already fully described by the event stream,
+            // so rethrowing would only add an unparseable stack trace to the output.
+            if (reporter.machineReadable) {
+                process.exit(1);
+            }
+
+            throw err;
         }
+
+        return;
+    }
+
+    const totalBatches = `${batches.length}`.padStart(2, "0");
+
+    // A failure in any batch skips every later batch, so the packages in them never
+    // report a result. Tracked here so the final report can account for all of them.
+    const succeededPackages = new Set<string>();
+    const failedPackages = new Set<string>();
+    const skipReported = new Set<number>();
+
+    const tasks = new Listr<BuildContext>(
+        batches.map<ListrTask>((packageNames, index) => {
+            const batchNumber = index + 1;
+            const id = `${batchNumber}`.padStart(2, "0");
+            const title = `[${id}/${totalBatches}] Batch #${id} (${packageNames.length} packages)`;
+
+            const packages = allPackages.filter(pkg => packageNames.includes(pkg.name));
+
+            const batchInfo = {
+                batch: batchNumber,
+                totalBatches: batches.length,
+                packages: packages.map(pkg => pkg.packageJson.name)
+            };
+
+            return {
+                title,
+                skip: ctx => {
+                    if (!ctx.skip) {
+                        return false;
+                    }
+
+                    // `skip` may be consulted more than once — report the batch only once.
+                    if (!skipReported.has(batchNumber)) {
+                        skipReported.add(batchNumber);
+                        reporter.batchSkipped(batchInfo);
+                    }
+
+                    return true;
+                },
+                task: async (ctx, task) => {
+                    const batchStart = Date.now();
+                    let succeeded = 0;
+                    let failed = 0;
+
+                    reporter.batchStart(batchInfo);
+
+                    const subtasks = packages.map(pkg => {
+                        return {
+                            title: `${pkg.name}`,
+                            task: async () => {
+                                const packageStart = Date.now();
+
+                                reporter.packageStart(pkg.packageJson.name, batchNumber);
+
+                                try {
+                                    await buildPackage(
+                                        pkg,
+                                        options.buildOverrides,
+                                        undefined,
+                                        options.safeReplace
+                                    );
+
+                                    // Store the dependency-aware build key.
+                                    const key = buildKeys.get(pkg.name) ?? "";
+                                    await queueMetaWrite(async () => {
+                                        const currentMeta = getBuildMeta();
+                                        currentMeta.packages[pkg.packageJson.name] = {
+                                            sourceHash: key
+                                        };
+                                        return writeJsonFileSync(META_FILE_PATH, currentMeta);
+                                    });
+
+                                    succeeded++;
+                                    succeededPackages.add(pkg.packageJson.name);
+                                    reporter.packageEnd({
+                                        name: pkg.packageJson.name,
+                                        batch: batchNumber,
+                                        duration: Date.now() - packageStart
+                                    });
+                                } catch (err) {
+                                    failed++;
+                                    failedPackages.add(pkg.packageJson.name);
+                                    reporter.packageEnd({
+                                        name: pkg.packageJson.name,
+                                        batch: batchNumber,
+                                        duration: Date.now() - packageStart,
+                                        error: (err as Error).message
+                                    });
+
+                                    ctx.skip = true;
+                                    throw new PackageBuildError(pkg, err as Error);
+                                }
+                            }
+                        };
+                    });
+
+                    const subtaskList = task.newListr(subtasks, {
+                        concurrent: buildInParallel,
+                        exitOnError: false,
+                        collectErrors: true,
+                        rendererOptions: { showErrorMessage: false }
+                    });
+
+                    // Run the subtasks here rather than returning the list, so the batch's
+                    // own totals are known by the time `batchEnd` is reported. `exitOnError`
+                    // is off, so this never throws — errors surface on `tasks.errors`.
+                    try {
+                        await subtaskList.run();
+                    } finally {
+                        reporter.batchEnd({
+                            ...batchInfo,
+                            succeeded,
+                            failed,
+                            duration: Date.now() - batchStart
+                        });
+                    }
+                }
+            };
+        }),
+        {
+            concurrent: false,
+            collectErrors: true,
+            // Suppresses the interactive UI for this list and all of its subtasks, leaving
+            // the JSON reporter as the only thing writing to stdout.
+            silentRendererCondition: reporter.machineReadable,
+            rendererOptions: {
+                timer: {
+                    condition: true,
+                    field: duration => {
+                        return `${Math.round(duration / 1000)}s`;
+                    },
+                    format: () => {
+                        return time => {
+                            return time || "";
+                        };
+                    }
+                },
+                collapseSubtasks: true
+            }
+        }
+    );
+
+    await tasks.run();
+
+    const duration = (Date.now() - start) / 1000;
+
+    if (tasks.errors?.length) {
+        const errors = tasks.errors.map(listrError => {
+            const pkgBuildError = listrError.error as PackageBuildError;
+            return {
+                name: pkgBuildError.getPackage().name,
+                message: pkgBuildError.getBuildError().message
+            };
+        });
 
         sendNotification(
             `Webiny Build (${projectFolder})`,
-            `Build finished in ${duration} seconds`
+            `Build failed after ${duration} seconds`
         );
-        console.log(`\nBuild finished in ${green(duration)} seconds.`);
+
+        // Packages in the batches that got skipped never ran, so they count as neither
+        // built nor failed.
+        const skippedPackages = packagesNoCache
+            .map(pkg => pkg.packageJson.name)
+            .filter(name => !succeededPackages.has(name) && !failedPackages.has(name));
+
+        reporter.end({
+            success: false,
+            duration,
+            built: succeededPackages.size,
+            failed: failedPackages.size,
+            skipped: skippedPackages.length,
+            skippedPackages,
+            errors
+        });
+
+        process.exit(1);
     }
-};
 
-const toMB = (bytes: number) => {
-    const formatter = new Intl.NumberFormat("en", { style: "unit", unit: "megabyte" });
+    sendNotification(`Webiny Build (${projectFolder})`, `Build finished in ${duration} seconds`);
 
-    return formatter.format(Math.round(bytes / 1024 / 1024));
-};
-
-const printHardwareReport = () => {
-    const { cpuCount, cpuName, freeMemory, totalMemory } = getHardwareInfo();
-    console.log(
-        `Runner: ${green(process.env.RUNNER_NAME || "N/A")}; Build packages: ${
-            buildInParallel ? green("in parallel") : green("in series")
-        }; Hardware: ${green(cpuCount)} CPUs (${cpuName}); Total Memory: ${green(
-            toMB(totalMemory)
-        )}; Free Memory: ${green(toMB(freeMemory))}.`
-    );
+    reporter.end({
+        success: true,
+        duration,
+        built: succeededPackages.size,
+        failed: 0,
+        skipped: 0,
+        skippedPackages: [],
+        errors: []
+    });
 };

--- a/scripts/buildPackages/src/getBatches.ts
+++ b/scripts/buildPackages/src/getBatches.ts
@@ -1,6 +1,5 @@
 import fs from "fs-extra";
 import path from "path";
-import chalk from "chalk";
 import { getPackages } from "../../utils/getPackages";
 import { WorkspaceGraph } from "../../utils/WorkspaceGraph.js";
 import { Package } from "./types";
@@ -10,8 +9,6 @@ import { getBuildMeta } from "./getBuildMeta";
 import { getPackageCacheFolderPath } from "./getPackageCacheFolderPath";
 import { distMatchesCache, recordCacheHash } from "./distContentHash";
 import { getEffectiveHashes } from "./getEffectiveHashes";
-
-const { green } = chalk;
 
 interface GetBatchesOptions {
     cache?: boolean;
@@ -36,8 +33,6 @@ export async function getBatches(options: GetBatchesOptions = {}) {
             return packagesWhitelist.includes(pkg.name);
         });
     }
-
-    console.log(`There is a total of ${green(workspacesPackages.length)} packages.`);
 
     const useCache = options.cache ?? false;
 
@@ -79,27 +74,14 @@ export async function getBatches(options: GetBatchesOptions = {}) {
     // changed package is already a cache miss above.
 
     // 2. Let's use cached built code where possible.
+    const restoredFromCache: Package[] = [];
     if (packagesUseCache.length) {
-        if (packagesUseCache.length > 10) {
-            console.log(`Using cache for ${green(packagesUseCache.length)} packages.`);
-            console.log(
-                `To build all packages regardless of cache, use the ${green("--no-cache")} flag.`
-            );
-        } else {
-            console.log("Using cache for following packages:");
-            for (let i = 0; i < packagesUseCache.length; i++) {
-                const item = packagesUseCache[i];
-                console.log(green(item.packageJson.name));
-            }
-        }
-
         // Skip the cache→dist copy for packages whose dist already matches the
         // cache byte-for-byte (content hash). Reads actual bytes in parallel, so
         // it can't go stale from out-of-band dist writes (`webiny watch`, manual
         // edits) — those change the hash and force a copy.
         const fresh = await Promise.all(packagesUseCache.map(pkg => distMatchesCache(pkg)));
 
-        const restored: Package[] = [];
         for (let i = 0; i < packagesUseCache.length; i++) {
             const workspacePackage = packagesUseCache[i];
 
@@ -109,26 +91,27 @@ export async function getBatches(options: GetBatchesOptions = {}) {
 
             const cacheFolderPath = path.join(CACHE_FOLDER_PATH, workspacePackage.packageJson.name);
             fs.copySync(cacheFolderPath, getBuildOutputFolder(workspacePackage));
-            restored.push(workspacePackage);
+            restoredFromCache.push(workspacePackage);
         }
 
-        if (restored.length) {
+        if (restoredFromCache.length) {
             // dist now equals the cache — record the hash so the next build can
             // verify freshness by hashing dist alone.
-            await Promise.all(restored.map(pkg => recordCacheHash(pkg)));
-            console.log(`Restored ${green(restored.length)} package(s) from cache into dist.`);
-        }
-    } else {
-        if (useCache) {
-            console.log("Cache is empty, all packages need to be built.");
-        } else {
-            console.log("Skipping cache.");
+            await Promise.all(restoredFromCache.map(pkg => recordCacheHash(pkg)));
         }
     }
 
     // 3. Where needed, let's build and update the cache.
     if (packagesNoCache.length === 0) {
-        return { batches: [], packagesNoCache, allPackages: workspacesPackages, buildKeys };
+        return {
+            batches: [],
+            packagesNoCache,
+            packagesUseCache,
+            restoredFromCache,
+            cacheEnabled: useCache,
+            allPackages: workspacesPackages,
+            buildKeys
+        };
     }
 
     const rawPackagesList = workspaceGraph.toposort();
@@ -164,6 +147,9 @@ export async function getBatches(options: GetBatchesOptions = {}) {
     return {
         batches,
         packagesNoCache,
+        packagesUseCache,
+        restoredFromCache,
+        cacheEnabled: useCache,
         allPackages: workspacesPackages,
         buildKeys
     };

--- a/scripts/buildPackages/src/reporter.ts
+++ b/scripts/buildPackages/src/reporter.ts
@@ -1,0 +1,299 @@
+import chalk from "chalk";
+
+const { green, red } = chalk;
+
+export interface BuildInfo {
+    projectFolder: string;
+    runner: string;
+    parallel: boolean;
+    cpuCount: number;
+    cpuName: string;
+    totalMemory: number;
+    freeMemory: number;
+    tscVersion: string;
+}
+
+export interface BuildPlan {
+    /** Total number of buildable packages in the workspace (after `-p` filtering). */
+    totalPackages: number;
+    /** Whether the build cache was consulted at all (`--no-cache` turns it off). */
+    cacheEnabled: boolean;
+    /** Packages that actually need to be built. */
+    packages: string[];
+    /** Packages served from the build cache. */
+    cachedPackages: string[];
+    /** Cached packages whose `dist` had to be repopulated from the cache folder. */
+    restoredPackages: string[];
+    /** Number of batches the build will be performed in. */
+    batches: number;
+}
+
+export interface BatchInfo {
+    batch: number;
+    totalBatches: number;
+    packages: string[];
+}
+
+export interface PackageResult {
+    name: string;
+    batch: number;
+    duration: number;
+    error?: string;
+}
+
+export interface BuildResult {
+    success: boolean;
+    duration: number;
+    built: number;
+    failed: number;
+    /** Packages that never ran, because an earlier batch failed. */
+    skipped: number;
+    skippedPackages: string[];
+    errors: { name: string; message: string }[];
+}
+
+export interface BuildReporter {
+    /**
+     * `true` when the reporter emits machine-readable output, meaning nothing else
+     * is allowed to write to stdout (child process output must be piped, not inherited).
+     */
+    readonly machineReadable: boolean;
+
+    info(info: BuildInfo): void;
+    plan(plan: BuildPlan): void;
+    batchStart(batch: BatchInfo): void;
+    batchEnd(batch: BatchInfo & { succeeded: number; failed: number; duration: number }): void;
+    /** A batch was abandoned without running, because an earlier batch failed. */
+    batchSkipped(batch: BatchInfo): void;
+    packageStart(name: string, batch: number): void;
+    packageEnd(result: PackageResult): void;
+    end(result: BuildResult): void;
+    log(message: string): void;
+}
+
+const toMB = (bytes: number) => {
+    const formatter = new Intl.NumberFormat("en", { style: "unit", unit: "megabyte" });
+
+    return formatter.format(Math.round(bytes / 1024 / 1024));
+};
+
+/**
+ * Human-readable reporter — reproduces the output the build has always printed.
+ * Per-package progress is rendered by Listr, so `batchStart`/`packageEnd` are no-ops here.
+ */
+class TextReporter implements BuildReporter {
+    readonly machineReadable = false;
+
+    private batched = false;
+
+    info(info: BuildInfo) {
+        console.log(
+            `Runner: ${green(info.runner)}; Build packages: ${
+                info.parallel ? green("in parallel") : green("in series")
+            }; Hardware: ${green(info.cpuCount)} CPUs (${info.cpuName}); Total Memory: ${green(
+                toMB(info.totalMemory)
+            )}; Free Memory: ${green(toMB(info.freeMemory))}.`
+        );
+
+        console.log("Check Typescript");
+        console.log(info.tscVersion);
+    }
+
+    plan(plan: BuildPlan) {
+        this.batched = plan.batches > 0;
+
+        console.log(`There is a total of ${green(plan.totalPackages)} packages.`);
+
+        if (plan.cachedPackages.length) {
+            if (plan.cachedPackages.length > 10) {
+                console.log(`Using cache for ${green(plan.cachedPackages.length)} packages.`);
+                console.log(
+                    `To build all packages regardless of cache, use the ${green(
+                        "--no-cache"
+                    )} flag.`
+                );
+            } else {
+                console.log("Using cache for following packages:");
+                for (const name of plan.cachedPackages) {
+                    console.log(green(name));
+                }
+            }
+
+            if (plan.restoredPackages.length) {
+                console.log(
+                    `Restored ${green(plan.restoredPackages.length)} package(s) from cache into dist.`
+                );
+            }
+        } else if (plan.cacheEnabled) {
+            console.log("Cache is empty, all packages need to be built.");
+        } else {
+            console.log("Skipping cache.");
+        }
+
+        if (!plan.packages.length) {
+            console.log("There are no packages that need to be built.");
+            return;
+        }
+
+        if (plan.packages.length > 10) {
+            console.log(`\nRunning build for ${green(plan.packages.length)} packages.`);
+        } else {
+            console.log("\nRunning build for the following package(s):");
+            for (const name of plan.packages) {
+                console.log(`‣ ${green(name)}`);
+            }
+        }
+
+        if (plan.batches > 0) {
+            console.log(
+                `\nThe build process will be performed in ${green(plan.batches)} ${
+                    plan.batches > 1 ? "batches" : "batch"
+                }.\n`
+            );
+        }
+    }
+
+    batchStart() {
+        // Rendered by Listr.
+    }
+
+    batchEnd() {
+        // Rendered by Listr.
+    }
+
+    batchSkipped() {
+        // Rendered by Listr.
+    }
+
+    packageStart() {
+        // Rendered by Listr.
+    }
+
+    packageEnd() {
+        // Rendered by Listr.
+    }
+
+    end(result: BuildResult) {
+        // Only the batched path prints a summary. A single package builds with inherited
+        // stdio, so the package's own build output is already the summary — and on failure
+        // the error is rethrown and printed by Node. Nothing-to-build says so in `plan`.
+        if (!this.batched) {
+            return;
+        }
+
+        if (!result.success) {
+            console.log();
+            console.log(`Error building ${red(result.failed)} package(s). Check the logs below.`);
+            console.log();
+
+            for (const error of result.errors) {
+                console.log(red("✖ " + error.name));
+                console.log(error.message);
+                console.log();
+            }
+
+            console.log(`Build failed in ${red(result.duration)} seconds.`);
+            return;
+        }
+
+        console.log(`\nBuild finished in ${green(result.duration)} seconds.`);
+    }
+
+    log(message: string) {
+        console.log(message);
+    }
+}
+
+/**
+ * Machine-readable reporter — writes newline-delimited JSON to stdout, one event per
+ * line, so an external tool (IDE, CI dashboard) can drive its own progress UI.
+ *
+ * Event types, in order of emission:
+ *   `build:info`     — hardware/runner/tsc details, once at startup
+ *   `build:plan`     — what will be built, what came from cache, how many batches
+ *   `batch:start`    — a batch begins
+ *   `package:start`  — a package build begins
+ *   `package:end`    — a package build finished (`error` set when it failed)
+ *   `batch:end`      — a batch finished
+ *   `batch:skipped`  — a batch was abandoned without running, an earlier batch having failed
+ *   `build:end`      — final result; always emitted, even when nothing was built
+ *   `log`            — free-form human message that has no structured equivalent
+ *
+ * `package:end` and `batch:skipped` both carry `completed`/`total`/`progress`, so a
+ * progress bar can be driven without the consumer tracking counts itself, and still
+ * reaches 1 when a failure abandons the remaining batches.
+ */
+class JsonReporter implements BuildReporter {
+    readonly machineReadable = true;
+
+    private total = 0;
+    private completed = 0;
+
+    private emit(type: string, payload: Record<string, unknown> = {}) {
+        process.stdout.write(JSON.stringify({ type, ts: Date.now(), ...payload }) + "\n");
+    }
+
+    info(info: BuildInfo) {
+        this.emit("build:info", { ...info });
+    }
+
+    plan(plan: BuildPlan) {
+        this.total = plan.packages.length;
+        this.completed = 0;
+
+        this.emit("build:plan", {
+            ...plan,
+            packagesToBuild: plan.packages.length,
+            packagesFromCache: plan.cachedPackages.length
+        });
+    }
+
+    batchStart(batch: BatchInfo) {
+        this.emit("batch:start", { ...batch });
+    }
+
+    batchEnd(batch: BatchInfo & { succeeded: number; failed: number; duration: number }) {
+        this.emit("batch:end", { ...batch });
+    }
+
+    batchSkipped(batch: BatchInfo) {
+        // Counts the batch's packages as completed, so `progress` still reaches 1 when a
+        // failure abandons the rest of the build and a progress bar can't stall mid-way.
+        this.completed += batch.packages.length;
+
+        this.emit("batch:skipped", {
+            ...batch,
+            completed: this.completed,
+            total: this.total,
+            progress: this.total > 0 ? this.completed / this.total : 1
+        });
+    }
+
+    packageStart(name: string, batch: number) {
+        this.emit("package:start", { name, batch });
+    }
+
+    packageEnd(result: PackageResult) {
+        this.completed++;
+
+        this.emit("package:end", {
+            ...result,
+            success: !result.error,
+            completed: this.completed,
+            total: this.total,
+            progress: this.total > 0 ? this.completed / this.total : 1
+        });
+    }
+
+    end(result: BuildResult) {
+        this.emit("build:end", { ...result });
+    }
+
+    log(message: string) {
+        this.emit("log", { message });
+    }
+}
+
+export const createReporter = (json: boolean): BuildReporter => {
+    return json ? new JsonReporter() : new TextReporter();
+};


### PR DESCRIPTION
## Problem

`yarn build` renders progress through Listr. That is good in a terminal and useless to anything else: an IDE button that shells out to the build gets a stream of ANSI redraws, not data. There is no way to drive an external progress bar.

## What changed

A `--json` flag. With it, the build writes newline-delimited JSON to stdout, one event per line, and nothing else touches stdout.

**`scripts/buildPackages/src/reporter.ts`** (new)

Reporter abstraction with two implementations. `TextReporter` reproduces the existing human output verbatim. `JsonReporter` emits the event stream.

**`scripts/buildPackages/src/buildPackages.ts`**

Adds the flag and routes all output through the reporter. JSON mode sets Listr's `silentRendererCondition` instead of running a second build loop, so both modes share one orchestration path and the batching, concurrency and error collection stay identical.

Child process stdio is piped rather than inherited in JSON mode, so `tsc` output can't corrupt the stream. The `yarn tsc --version` check is piped in both modes now, which is what keeps the text output in the original order.

**`scripts/buildPackages/src/getBatches.ts`**

Stops printing. It returns the cache details it used to log (`packagesUseCache`, `restoredFromCache`, `cacheEnabled`) and the reporter owns all output.

## Event schema

```
build:info     hardware, runner, parallel, tscVersion, projectFolder
build:plan     totalPackages, packagesToBuild, packagesFromCache, batches,
               packages[], cachedPackages[], restoredPackages[]
batch:start    batch, totalBatches, packages[]
package:start  name, batch
package:end    name, batch, duration, success, error?, completed, total, progress
batch:end      batch, totalBatches, succeeded, failed, duration
batch:skipped  batch, totalBatches, packages[], completed, total, progress
build:end      success, duration, built, failed, skipped, skippedPackages[], errors[]
```

Every event carries `ts`. `package:end` and `batch:skipped` carry `completed`/`total`/`progress`, so a consumer never counts packages itself.

Two things that matter for a progress bar. `build:end` always fires, including when there is nothing to build (`packagesToBuild: 0`), so a consumer never waits on a missing terminator. And when a failure abandons the remaining batches, `batch:skipped` accounts for those packages, so `progress` still reaches 1 instead of stalling part way.

Exit codes are unchanged. In JSON mode a single-package failure exits 1 rather than rethrowing, so a stack trace can't land in the middle of the stream. The error is in `package:end.error` and `build:end.errors[]`.

## Testing

**Text output is unchanged.** Captured output from the previous implementation via `git stash`, then diffed against this branch with only durations, memory and file sizes normalized:

| scenario | result |
| --- | --- |
| two packages, `--no-cache` | identical |
| two packages, cache hit | identical |
| single package | identical |
| multi-batch, 4 batches | identical¹ |
| two packages, failure | identical |
| single package, failure | identical |
| multi-batch, failure in an early batch | identical¹ |

¹ Only the line ordering among concurrently built packages differs. Order-insensitive diff is identical. Exit codes match on all seven.

**Full build, all 148 packages, 15 batches, `--no-cache`.** JSON mode: exit 0, 329 lines all valid JSON, progress monotonic to 1.0, `built + failed + skipped == packagesToBuild`, 148 `package:start` against 148 `package:end`, 15 `batch:start` against 15 `batch:end`, `build:info` first and `build:end` last, stderr empty. Text mode: exit 0, 15 batches, zero failures.

Checks: `yarn adio`, `yarn format`, `yarn lint`, `yarn webiny sync-dependencies`, `node scripts/generateTsConfigsInPackages.js` all clean with no resulting file changes.

## Known follow-ups

- No unit tests for `JsonReporter`. The event stream is verified end to end against a real 148-package build, not in isolation.
- `scripts/buildPackages/tsconfig.json` has a stale `include` pointing at `./buildMultiCore.ts`, which does not exist, and the root tsconfig excludes `scripts/**`. This folder is not typechecked in CI. I typechecked these files with a throwaway config and left the two pre-existing errors in `getBatches.ts` and `getEffectiveHashes.ts` alone. Worth fixing separately.
- CI behavior with `process.env.CI` set, which builds in series, is unchanged but not exercised here.
- `yarn webiny watch -p ...` still has no equivalent flag. Same problem, separate command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
