### PR TITLE
chore(ci): rename the slash-command workflows

### DIFF
--- a/.github/workflows/pullRequestsCommandAlpha.yml
+++ b/.github/workflows/pullRequestsCommandAlpha.yml
@@ -2,7 +2,7 @@
 # DO NOT MODIFY IT BY HAND. Instead, modify the source *.wac.ts file(s)
 # and run "github-actions-wac build" (or "ghawac build") to regenerate this file.
 # For more information, run "github-actions-wac --help".
-name: Pull Requests Command - Alpha Release
+name: 💬 PR Command - Alpha Release
 'on': issue_comment
 concurrency:
   group: alpha-release-${{ github.event.issue.number }}

--- a/.github/workflows/pullRequestsCommandBeta.yml
+++ b/.github/workflows/pullRequestsCommandBeta.yml
@@ -2,7 +2,7 @@
 # DO NOT MODIFY IT BY HAND. Instead, modify the source *.wac.ts file(s)
 # and run "github-actions-wac build" (or "ghawac build") to regenerate this file.
 # For more information, run "github-actions-wac --help".
-name: Pull Requests Command - Beta Release
+name: 💬 PR Command - Beta Release
 'on': issue_comment
 concurrency:
   group: beta-release-${{ github.event.issue.number }}

--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -2,7 +2,7 @@
 # DO NOT MODIFY IT BY HAND. Instead, modify the source *.wac.ts file(s)
 # and run "github-actions-wac build" (or "ghawac build") to regenerate this file.
 # For more information, run "github-actions-wac --help".
-name: Pull Requests Command - E2E
+name: 💬 PR Command - E2E
 'on': issue_comment
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/pullRequestsCommandVitest.yml
+++ b/.github/workflows/pullRequestsCommandVitest.yml
@@ -2,7 +2,7 @@
 # DO NOT MODIFY IT BY HAND. Instead, modify the source *.wac.ts file(s)
 # and run "github-actions-wac build" (or "ghawac build") to regenerate this file.
 # For more information, run "github-actions-wac --help".
-name: Pull Requests Command - Vitest
+name: 💬 PR Command - Vitest
 'on': issue_comment
 env:
   NODE_OPTIONS: '--max_old_space_size=4096'

--- a/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandAlpha.wac.ts
@@ -29,7 +29,7 @@ const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
 // release), /alpha only ever publishes an alpha prerelease. There is no follow-up job.
 export const pullRequestsCommandAlpha = createSlashCommandWorkflow({
     command: "alpha",
-    name: "Pull Requests Command - Alpha Release",
+    name: "💬 PR Command - Alpha Release",
     comment:
         "Alpha release has been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:",
     workflow: {

--- a/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandBeta.wac.ts
@@ -27,7 +27,7 @@ const runBuildCacheDownloadSteps = createRunBuildArtifactDownloadSteps({
 
 export const pullRequestsCommandBeta = createSlashCommandWorkflow({
     command: "beta",
-    name: "Pull Requests Command - Beta Release",
+    name: "💬 PR Command - Beta Release",
     comment:
         "Beta release has been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:",
     workflow: {

--- a/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandE2e.wac.ts
@@ -19,7 +19,7 @@ const SERVER_VARIANTS: ServerStorageOps[] = ["sqlite", "postgres"];
 
 export const pullRequestsCommandE2e = createSlashCommandWorkflow({
     command: "e2e",
-    name: "Pull Requests Command - E2E",
+    name: "💬 PR Command - E2E",
     comment: [
         "Cypress E2E tests have been initiated (for more information, click [here](https://github.com/webiny/webiny-js/actions/runs/${{ github.run_id }})). :sparkles:",
         "",

--- a/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
+++ b/.github/workflows/wac/pullRequestsCommandVitest.wac.ts
@@ -202,7 +202,7 @@ const createVitestTestsJobs = (storageOps?: AbstractStorageOps) => {
 
 export const pullRequestsCommandVitest = createSlashCommandWorkflow({
     command: "vitest",
-    name: "Pull Requests Command - Vitest",
+    name: "💬 PR Command - Vitest",
     comment: INITIAL_COMMENT_BODY,
     captureCommentId: true,
     workflow: {


### PR DESCRIPTION
Four workflows shared a 24-character prefix — `Pull Requests Command - ` — which pushed the part that actually distinguishes them off to the right in the Actions sidebar. Shortened to `PR Command`, with an emoji in front, matching what the release workflows already do (`🚀 Full Release`, `📦 Release`, `📦 Unstable Release`).

| Before | After |
| --- | --- |
| `Pull Requests Command - Alpha Release` | `💬 PR Command - Alpha Release` |
| `Pull Requests Command - Beta Release` | `💬 PR Command - Beta Release` |
| `Pull Requests Command - E2E` | `💬 PR Command - E2E` |
| `Pull Requests Command - Vitest` | `💬 PR Command - Vitest` |

One emoji across all four rather than one per command: `💬` marks the group, since what these four share is being triggered by a PR comment rather than by a push. The command name after the dash is what tells them apart.

## Safety

- `name` in `createSlashCommandWorkflow` is display-only.
- Grepped the repo: nothing outside the generated YAML and its `.wac.ts` source references these strings.
- Branch protection matches **job** names (`Build`, `NPM release ("beta" tag)`, …), which are untouched. No required check changes.
- The frozen v5 workflows keep their old names — `ghawac build` doesn't regenerate them.

## Test plan

`yarn ci-workflows:build` regenerates cleanly; the diff is one line per workflow plus its source. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)