### PR TITLE
fix(project-aws): let Infra.Vpc enabled={false} win over the production default

### DIFF
--- a/packages/project-aws/__tests__/isVpcEnabled.test.ts
+++ b/packages/project-aws/__tests__/isVpcEnabled.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
+import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { Vpc } from "~/pulumi/extensions/Vpc.js";
+import type { IProjectConfigModel } from "@webiny/project/abstractions/models/index.js";
+
+const PROD = true;
+const NOT_PROD = false;
+
+describe("isVpcEnabled", () => {
+    it("should use a VPC for production when no Infra.Vpc extension is registered", () => {
+        expect(isVpcEnabled(undefined, PROD)).toBe(true);
+    });
+
+    it("should not use a VPC outside production when no Infra.Vpc extension is registered", () => {
+        expect(isVpcEnabled(undefined, NOT_PROD)).toBe(false);
+    });
+
+    it("should honour an explicit enabled={false} even for production", () => {
+        // The regression this guards: production used to win over the explicit param, so
+        // `<Infra.Vpc enabled={false} />` silently did nothing on prod/production.
+        expect(isVpcEnabled(false, PROD)).toBe(false);
+        expect(isVpcEnabled(false, NOT_PROD)).toBe(false);
+    });
+
+    it("should honour an explicit enabled={true} outside production", () => {
+        expect(isVpcEnabled(true, NOT_PROD)).toBe(true);
+        expect(isVpcEnabled(true, PROD)).toBe(true);
+    });
+
+    it("should use a VPC whenever advanced params are given", () => {
+        expect(isVpcEnabled({ useVpcEndpoints: true }, NOT_PROD)).toBe(true);
+        expect(
+            isVpcEnabled(
+                {
+                    useExistingVpc: {
+                        lambdaFunctionsVpcConfig: {
+                            securityGroupIds: ["sg-1"],
+                            subnetIds: ["subnet-1"]
+                        }
+                    }
+                },
+                NOT_PROD
+            )
+        ).toBe(true);
+    });
+});
+
+/* Minimal project config exposing just the one method the getter calls. */
+const projectConfigWith = (params?: Record<string, unknown>): IProjectConfigModel =>
+    ({
+        extensionsByType: (type: unknown) =>
+            type === Vpc && params ? [{ params }] : ([] as unknown[])
+    }) as unknown as IProjectConfigModel;
+
+describe("getVpcConfigFromExtension", () => {
+    it("should return undefined when the extension is absent", () => {
+        expect(getVpcConfigFromExtension(projectConfigWith())).toBeUndefined();
+    });
+
+    it("should map enabled={false} to false", () => {
+        // isVpcEnabled relies on this exact value to distinguish "explicitly off" from "absent".
+        expect(getVpcConfigFromExtension(projectConfigWith({ enabled: false }))).toBe(false);
+    });
+
+    it("should map enabled={true} to true", () => {
+        expect(getVpcConfigFromExtension(projectConfigWith({ enabled: true }))).toBe(true);
+    });
+
+    it("should return the advanced params when any are given", () => {
+        expect(
+            getVpcConfigFromExtension(projectConfigWith({ enabled: true, useVpcEndpoints: true }))
+        ).toEqual({ useVpcEndpoints: true });
+    });
+
+    it("should prefer enabled={false} over advanced params", () => {
+        expect(
+            getVpcConfigFromExtension(projectConfigWith({ enabled: false, useVpcEndpoints: true }))
+        ).toBe(false);
+    });
+});

--- a/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/api/createApiPulumiApp.ts
@@ -22,6 +22,7 @@ import type { WithServiceManifest } from "~/pulumi/utils/withServiceManifest.js"
 import { ApiScheduler } from "~/pulumi/apps/api/ApiScheduler.js";
 import { getProjectSdk } from "@webiny/project";
 import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
 import { getOsConfigFromExtension } from "~/pulumi/apps/extensions/getOsConfigFromExtension.js";
 import { handleGuardDutyEvents } from "./handleGuardDutyEvents.js";
 import { ApiPulumi, SetApiCustomDomains } from "~/abstractions/features/pulumi/index.js";
@@ -166,12 +167,9 @@ export const createApiPulumiApp = () => {
             const core = app.addModule(CoreOutput);
 
             // Register VPC config module to be available to other modules.
-            const vpcEnabled =
-                vpcExtensionsConfig === true ||
-                typeof vpcExtensionsConfig === "object" ||
-                isProduction;
-
-            app.addModule(VpcConfig, { enabled: vpcEnabled });
+            app.addModule(VpcConfig, {
+                enabled: isVpcEnabled(vpcExtensionsConfig, isProduction)
+            });
 
             const graphql = app.addModule(ApiGraphql, {
                 env: {

--- a/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
+++ b/packages/project-aws/src/pulumi/apps/core/createCorePulumiApp.ts
@@ -19,6 +19,7 @@ import { CorePulumi } from "~/abstractions/features/pulumi/index.js";
 import { corePulumi } from "~/pulumi/features/CorePulumi/index.js";
 import { getOsConfigFromExtension } from "~/pulumi/apps/extensions/getOsConfigFromExtension.js";
 import { getVpcConfigFromExtension } from "~/pulumi/apps/extensions/getVpcConfigFromExtension.js";
+import { isVpcEnabled } from "~/pulumi/apps/extensions/isVpcEnabled.js";
 import { applyAwsResourceTags, getAwsRegion } from "~/pulumi/apps/awsUtils.js";
 import { configureS3BucketMalwareProtection } from "./configureS3BucketMalwareProtection.js";
 import * as pulumi from "@pulumi/pulumi";
@@ -236,12 +237,9 @@ export function createCorePulumiApp() {
             const auditLogsDynamoDbTable = app.addModule(CoreAuditLogsDynamo, { protect });
 
             // Setup VPC
-            const vpcEnabled =
-                vpcExtensionsConfig === true ||
-                typeof vpcExtensionsConfig === "object" ||
-                isProduction;
-
-            const vpc = vpcEnabled ? app.addModule(CoreVpc) : null;
+            const vpc = isVpcEnabled(vpcExtensionsConfig, isProduction)
+                ? app.addModule(CoreVpc)
+                : null;
 
             // Setup Cognito
             const cognito = app.addModule(CoreCognito, {

--- a/packages/project-aws/src/pulumi/apps/extensions/isVpcEnabled.ts
+++ b/packages/project-aws/src/pulumi/apps/extensions/isVpcEnabled.ts
@@ -1,0 +1,29 @@
+import type { getVpcConfigFromExtension } from "./getVpcConfigFromExtension.js";
+
+export type VpcExtensionConfig = ReturnType<typeof getVpcConfigFromExtension>;
+
+/**
+ * Decides whether an app should use a VPC, from the `Infra.Vpc` extension config plus whether the
+ * target environment is a production one.
+ *
+ * Production environments get a VPC by default. An explicit `<Infra.Vpc enabled={false} />` beats
+ * that default: `enabled` is documented as a plain toggle, so ignoring it on production would
+ * silently do the opposite of what the project config asks for.
+ *
+ * Shared by the core and api apps so the two cannot disagree — a mismatch would leave the api app's
+ * Lambdas configured for subnets the core app never created.
+ */
+export function isVpcEnabled(config: VpcExtensionConfig, isProduction: boolean): boolean {
+    // Explicitly turned off via `<Infra.Vpc enabled={false} />`.
+    if (config === false) {
+        return false;
+    }
+
+    // Explicitly turned on, or given advanced params (useVpcEndpoints / useExistingVpc).
+    if (config === true || typeof config === "object") {
+        return true;
+    }
+
+    // No `Infra.Vpc` extension registered: a VPC is used for production environments only.
+    return isProduction;
+}


### PR DESCRIPTION
## The bug

Reported in the community Slack: a user added `<Infra.Vpc enabled={false} />` to `webiny.config.tsx` and nothing changed.

It wasn't their config. Production environments get a VPC by default, and that default was OR'd together with the extension's own params, in both the core and api apps:

```ts
const vpcEnabled =
    vpcExtensionsConfig === true ||
    typeof vpcExtensionsConfig === "object" ||
    isProduction;
```

`getVpcConfigFromExtension` maps `enabled={false}` to a literal `false`. That fails the first test, and `typeof false === "object"` fails the second, so the result fell through to `isProduction`. On `prod` or `production` (or anything registered via `Infra.ProductionEnvironments`), `<Infra.Vpc enabled={false} />` was a silent no-op. No error, no warning, VPC still created.

`enabled` is declared as `z.boolean().describe("Whether to enable VPC.")` with no hint that production overrides it, so the config did the opposite of what it said.

## The fix

An explicit `false` now wins over the production default. An absent extension still means "VPC for production environments only", so no existing deployment changes behavior unless it was explicitly asking for `enabled={false}` and being ignored.

The decision moved into a shared `isVpcEnabled()`:

```ts
export function isVpcEnabled(config: VpcExtensionConfig, isProduction: boolean): boolean {
    if (config === false) {
        return false;
    }
    if (config === true || typeof config === "object") {
        return true;
    }
    return isProduction;
}
```

Both apps had duplicated the original expression. Sharing it matters beyond tidiness: if core and api ever disagreed, the api app's Lambdas would point at subnets the core app never created.

`createSyncSystemPulumiApp` also reads the extension config, but only for the advanced-object branch, which `enabled={false}` already short-circuits in the getter. No change needed there.

## Tests

First tests for this area (both files previously had none). Full matrix of extension config against production/non-production, plus the `getVpcConfigFromExtension` mapping that `isVpcEnabled` depends on to tell "explicitly off" apart from "absent".

## One caveat for users

Turning a VPC off where it was previously on is a destructive change, not a config tweak. Pulumi tears the VPC down and moves the Lambdas out of it, and core has to deploy before api, since api reads the subnet and security group IDs from core's stack outputs. Might be worth a docs note.

## Verification

- `project-aws` tests: 40 passed, 10 of them new
- `tsc --noEmit` clean; `yarn check:test:types -p project-aws` reports 0 errors
- `yarn adio`, `oxfmt --check`, `oxlint --deny-warnings` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
