### PR TITLE
fix: add streaming API IAM permissions to the CF template

### DIFF
--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
@@ -73,6 +73,32 @@ Resources:
               - cloudfront:UpdateCloudFrontOriginAccessIdentity
               - cloudfront:DeleteCloudFrontOriginAccessIdentity
 
+          # Origin access control (OAC) is what lets CloudFront sign its requests to the streaming
+          # GraphQL Lambda Function URL, so that URL can stay on AWS_IAM authorization instead of
+          # being reachable from the internet. Note that this is a separate, newer concept from the
+          # origin access identity above, which is S3-only.
+          # Like origin access identities, OACs cannot be tagged, so there's no tag condition here.
+          - Effect: Allow
+            Resource: arn:*:cloudfront::*:origin-access-control/*
+            Action:
+              - cloudfront:CreateOriginAccessControl
+              - cloudfront:GetOriginAccessControl
+              - cloudfront:GetOriginAccessControlConfig
+              - cloudfront:UpdateOriginAccessControl
+              - cloudfront:DeleteOriginAccessControl
+
+          # The streaming cache behavior forwards headers and cookies via an origin request policy
+          # instead of the legacy (and deprecated) `forwardedValues` the other behaviors use.
+          # Origin request policies cannot be tagged either.
+          - Effect: Allow
+            Resource: arn:*:cloudfront::*:origin-request-policy/*
+            Action:
+              - cloudfront:CreateOriginRequestPolicy
+              - cloudfront:GetOriginRequestPolicy
+              - cloudfront:GetOriginRequestPolicyConfig
+              - cloudfront:UpdateOriginRequestPolicy
+              - cloudfront:DeleteOriginRequestPolicy
+
           # Amazon API Gateway
           - Effect: Allow
             Action:
@@ -317,6 +343,12 @@ Resources:
               - lambda:ListAliases
               # For deploying Lambda@Edge.
               - lambda:EnableReplication
+              # The streaming GraphQL function is reached through a Lambda Function URL, because
+              # Amazon API Gateway buffers the whole response and so cannot stream at all.
+              - lambda:CreateFunctionUrlConfig
+              - lambda:GetFunctionUrlConfig
+              - lambda:UpdateFunctionUrlConfig
+              - lambda:DeleteFunctionUrlConfig
             Resource:
               - arn:aws:lambda:*:*:function:wby-*
 


### PR DESCRIPTION
## What

Adds the IAM permissions the streaming API needs to `docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml`.

CloudFront, in `DeployWebinyPolicy1`, right after the existing origin-access-identity block. Two statements, each with create / get / get-config / update / delete:

- `arn:*:cloudfront::*:origin-access-control/*`
- `arn:*:cloudfront::*:origin-request-policy/*`

Lambda, in `DeployWebinyPolicy2`, added to the existing `arn:aws:lambda:*:*:function:wby-*` statement: `lambda:CreateFunctionUrlConfig`, `GetFunctionUrlConfig`, `UpdateFunctionUrlConfig`, `DeleteFunctionUrlConfig`.

## Why

The streaming GraphQL function runs behind a Lambda Function URL rather than API Gateway, because API Gateway buffers the whole Lambda response and so cannot stream at all. That URL stays on `AWS_IAM` authorization, and CloudFront signs each request to it using an origin access control. The streaming cache behavior also uses an origin request policy instead of the deprecated `forwardedValues` the other behaviors use, partly because it has to forward the two CORS preflight headers.

None of those resource types existed in a Webiny project before, so the deploy role never needed permissions for them. `api` stack deployments now fail with:

```
AccessDenied: not authorized to perform: cloudfront:CreateOriginRequestPolicy
  on resource: arn:aws:cloudfront::*:origin-request-policy/*
AccessDenied: not authorized to perform: cloudfront:CreateOriginAccessControl
  on resource: arn:aws:cloudfront::*:origin-access-control/*
```

The Function URL permissions weren't in that error only because the deployment died before reaching the function. They would have been the next failure.

I granted the full lifecycle for each resource type rather than only the two actions that failed, since the update and destroy paths would each hit a different missing action on a later run. Neither OACs nor origin request policies can be tagged, so neither statement carries a `WbyProjectName` tag condition. That matches how origin access identities are already handled directly above.

## Notes

Related source, for anyone checking the permissions against what actually gets deployed:

- `packages/project-aws/src/pulumi/apps/api/ApiCloudfront.ts:42` (OAC), `:64` (origin request policy)
- `packages/project-aws/src/pulumi/apps/api/ApiGraphqlStream.ts:68` (Function URL)

`lambda:AddPermission` / `RemovePermission` were already present and cover the two `aws.lambda.Permission` resources at the bottom of `ApiCloudfront.ts`.

Two things this PR does not do:

- The `GitHubActionsWebinyJs` role in our own deploy account is not created from this template, so CI stays broken until someone applies the same permissions there by hand.
- `docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE.yaml` (the pre-V6 template) is untouched.

## Testing

Docs-only YAML, no code changed. I parsed the template with the CFN short tags registered to confirm it's still valid and the statements landed in the right policies (18 / 12 / 8). Also checked the character counts against IAM's 6144-per-managed-policy limit: 4625, 3912, 1972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)