### PR TITLE
feat(build): add --preview flag to report what a build would do

### DIFF
--- a/scripts/buildPackages/src/buildPackages.ts
+++ b/scripts/buildPackages/src/buildPackages.ts
@@ -15,6 +15,8 @@ import { hideBin } from "yargs/helpers";
 import { PackageBuildError } from "./PackageBuildError";
 import { queueMetaWrite } from "./writeMetaQueue";
 import { createReporter } from "./reporter";
+import { previewBuild } from "./previewBuild";
+import { getPackagesWhitelist } from "./getPackagesWhitelist";
 
 const argv = yargs(hideBin(process.argv)).parse();
 
@@ -40,6 +42,12 @@ interface BuildOptions {
      * See `reporter.ts` for the event schema.
      */
     json?: boolean;
+    /**
+     * Report how many packages are already built and how many need to be (re)built,
+     * then exit without building anything. Combine with `--json` to poll it as a
+     * status indicator. See `previewBuild.ts`.
+     */
+    preview?: boolean;
 }
 
 interface BuildContext {
@@ -53,6 +61,13 @@ export const buildPackages = async () => {
     const options = argv as BuildOptions;
 
     const reporter = createReporter(options.json === true);
+
+    if (options.preview === true) {
+        // Nothing below this point runs: a preview reports the plan and stops. Notably,
+        // it also skips the `tsc --version` check, which nothing in a preview needs.
+        await previewBuild(options, reporter);
+        return;
+    }
 
     // Captured rather than inherited: in JSON mode stdout carries the event stream, and
     // in text mode the reporter needs to print this after the hardware report.
@@ -68,14 +83,7 @@ export const buildPackages = async () => {
         tscVersion: tscVersion.stdout?.trim() ?? ""
     });
 
-    let packagesWhitelist: string[] = [];
-    if (options.p) {
-        if (Array.isArray(options.p)) {
-            packagesWhitelist = options.p;
-        } else {
-            packagesWhitelist = [options.p];
-        }
-    }
+    const packagesWhitelist = getPackagesWhitelist(options.p);
 
     const {
         batches,

--- a/scripts/buildPackages/src/getBatches.ts
+++ b/scripts/buildPackages/src/getBatches.ts
@@ -13,6 +13,13 @@ import { getEffectiveHashes } from "./getEffectiveHashes";
 interface GetBatchesOptions {
     cache?: boolean;
     packagesWhitelist?: string[];
+    /**
+     * Leaves `dist` alone: no cache→dist restore, and no hashing of `dist` to decide
+     * whether a restore is needed. Used by `--preview`, which only reports what a build
+     * would do — nothing is written, and the expensive dist hashing is skipped, so it
+     * stays cheap enough to poll. `restoredFromCache` is then always empty.
+     */
+    skipCacheRestore?: boolean;
 }
 
 export async function getBatches(options: GetBatchesOptions = {}) {
@@ -75,7 +82,7 @@ export async function getBatches(options: GetBatchesOptions = {}) {
 
     // 2. Let's use cached built code where possible.
     const restoredFromCache: Package[] = [];
-    if (packagesUseCache.length) {
+    if (packagesUseCache.length && !options.skipCacheRestore) {
         // Skip the cache→dist copy for packages whose dist already matches the
         // cache byte-for-byte (content hash). Reads actual bytes in parallel, so
         // it can't go stale from out-of-band dist writes (`webiny watch`, manual

--- a/scripts/buildPackages/src/getPackagesWhitelist.ts
+++ b/scripts/buildPackages/src/getPackagesWhitelist.ts
@@ -1,0 +1,11 @@
+/**
+ * Packages named via `-p`. Yargs gives a string for a single occurrence and an
+ * array for repeated ones, so both shapes are normalized here.
+ */
+export const getPackagesWhitelist = (p?: string | string[]): string[] => {
+    if (!p) {
+        return [];
+    }
+
+    return Array.isArray(p) ? p : [p];
+};

--- a/scripts/buildPackages/src/previewBuild.ts
+++ b/scripts/buildPackages/src/previewBuild.ts
@@ -1,0 +1,38 @@
+import { getBatches } from "./getBatches";
+import { getPackagesWhitelist } from "./getPackagesWhitelist";
+import type { BuildReporter } from "./reporter";
+
+export interface PreviewBuildOptions {
+    p?: string | string[];
+    cache?: boolean;
+}
+
+/**
+ * Answers "what would a build do right now?" without building or writing anything:
+ * how many packages are already built, and how many need to be (re)built.
+ *
+ * Cheap enough to poll every few seconds — it computes the same dependency-aware build
+ * keys a real build uses, but skips the cache→dist restore and the dist hashing that
+ * decides whether a restore is needed. A package counted as already built may therefore
+ * still need its `dist` repopulated from the cache, which is a copy, not a build.
+ */
+export const previewBuild = async (options: PreviewBuildOptions, reporter: BuildReporter) => {
+    const start = Date.now();
+
+    const { batches, packagesNoCache, packagesUseCache, cacheEnabled, allPackages } =
+        await getBatches({
+            cache: options.cache ?? true,
+            packagesWhitelist: getPackagesWhitelist(options.p),
+            skipCacheRestore: true
+        });
+
+    reporter.preview({
+        totalPackages: allPackages.length,
+        cacheEnabled,
+        upToDate: packagesUseCache.length,
+        packagesToBuild: packagesNoCache.length,
+        packages: packagesNoCache.map(pkg => pkg.packageJson.name),
+        batches: batches.length,
+        duration: (Date.now() - start) / 1000
+    });
+};

--- a/scripts/buildPackages/src/reporter.ts
+++ b/scripts/buildPackages/src/reporter.ts
@@ -28,6 +28,23 @@ export interface BuildPlan {
     batches: number;
 }
 
+export interface BuildPreview {
+    /** Total number of buildable packages in the workspace (after `-p` filtering). */
+    totalPackages: number;
+    /** Whether the build cache was consulted at all (`--no-cache` turns it off). */
+    cacheEnabled: boolean;
+    /** Packages that are already built — their build key matches the one in the cache. */
+    upToDate: number;
+    /** How many packages a build would have to (re)build. */
+    packagesToBuild: number;
+    /** Names of the packages a build would have to (re)build. */
+    packages: string[];
+    /** Number of batches the build would be performed in. */
+    batches: number;
+    /** How long the preview itself took, in seconds. */
+    duration: number;
+}
+
 export interface BatchInfo {
     batch: number;
     totalBatches: number;
@@ -61,6 +78,8 @@ export interface BuildReporter {
 
     info(info: BuildInfo): void;
     plan(plan: BuildPlan): void;
+    /** The whole output of `--preview`: what a build would do, without doing it. */
+    preview(preview: BuildPreview): void;
     batchStart(batch: BatchInfo): void;
     batchEnd(batch: BatchInfo & { succeeded: number; failed: number; duration: number }): void;
     /** A batch was abandoned without running, because an earlier batch failed. */
@@ -70,6 +89,9 @@ export interface BuildReporter {
     end(result: BuildResult): void;
     log(message: string): void;
 }
+
+/** Beyond this, `--preview` prints a count instead of the whole list of package names. */
+const PREVIEW_PACKAGE_LIST_LIMIT = 20;
 
 const toMB = (bytes: number) => {
     const formatter = new Intl.NumberFormat("en", { style: "unit", unit: "megabyte" });
@@ -153,6 +175,40 @@ class TextReporter implements BuildReporter {
         }
     }
 
+    preview(preview: BuildPreview) {
+        console.log(`Total packages: ${green(preview.totalPackages)}`);
+        console.log(`Already built: ${green(preview.upToDate)}`);
+        console.log(
+            `Need to be built: ${preview.packagesToBuild ? red(preview.packagesToBuild) : green(0)}`
+        );
+
+        if (!preview.cacheEnabled) {
+            console.log(`\nCache is off (${green("--no-cache")}), so everything needs a build.`);
+        }
+
+        if (preview.packages.length) {
+            const shown = preview.packages.slice(0, PREVIEW_PACKAGE_LIST_LIMIT);
+
+            console.log("\nPackages that need to be built:");
+            for (const name of shown) {
+                console.log(`‣ ${red(name)}`);
+            }
+
+            const rest = preview.packages.length - shown.length;
+            if (rest > 0) {
+                console.log(`…and ${red(rest)} more.`);
+            }
+
+            console.log(
+                `\nThe build would be performed in ${green(preview.batches)} ${
+                    preview.batches === 1 ? "batch" : "batches"
+                }.`
+            );
+        }
+
+        console.log(`\nPreview took ${green(preview.duration)} seconds.`);
+    }
+
     batchStart() {
         // Rendered by Listr.
     }
@@ -222,6 +278,9 @@ class TextReporter implements BuildReporter {
  * `package:end` and `batch:skipped` both carry `completed`/`total`/`progress`, so a
  * progress bar can be driven without the consumer tracking counts itself, and still
  * reaches 1 when a failure abandons the remaining batches.
+ *
+ * `--preview` is the exception: it emits a single `build:preview` event and nothing
+ * else, so its stdout can be read with a plain `JSON.parse`.
  */
 class JsonReporter implements BuildReporter {
     readonly machineReadable = true;
@@ -246,6 +305,10 @@ class JsonReporter implements BuildReporter {
             packagesToBuild: plan.packages.length,
             packagesFromCache: plan.cachedPackages.length
         });
+    }
+
+    preview(preview: BuildPreview) {
+        this.emit("build:preview", { ...preview });
     }
 
     batchStart(batch: BatchInfo) {


### PR DESCRIPTION
### What changed

`yarn build` gets a `--preview` flag. It reports how many packages are already built and how many need to be rebuilt, then exits without building anything.

```
$ yarn build --preview
Total packages: 148
Already built: 146
Need to be built: 2

Packages that need to be built:
‣ @webiny/api-core
‣ @webiny/api-aco

The build would be performed in 2 batches.

Preview took 0.75 seconds.
```

Add `--json` and you get a single `build:preview` event instead, so the whole stdout can be read with one `JSON.parse` (no need to assemble the NDJSON stream that `--json` produces for a real build):

```json
{"type":"build:preview","ts":1788521712919,"totalPackages":148,"cacheEnabled":true,
 "upToDate":146,"packagesToBuild":2,"packages":["@webiny/api-core","@webiny/api-aco"],
 "batches":2,"duration":0.746}
```

That is what I wanted it for: an editor or dashboard can poll it and keep a build-status indicator on screen at all times.

The flag respects `-p` and `--no-cache`, and it computes the same dependency-aware build keys a real build uses, so dependents of a changed package are counted as needing a rebuild. Touching one file in `api-core` moves 74 packages into `packagesToBuild`.

Two limits worth knowing before you poll it:

- A run takes roughly 0.6 to 1.5 seconds of work, but about 2 seconds wall clock once `yarn` and `tsx` startup is counted. Polling every 2 seconds means running it back to back, so 5 seconds or slower is the saner cadence.
- "Already built" means the package's build key matches the cache, not that its `dist` is populated. Wipe a `dist` folder and preview still calls that package built, because the real build would restore it with a copy rather than a compile. Reporting that accurately would mean hashing every package's `dist` on every poll, which is the expensive part preview deliberately skips.

Preview writes nothing at all. It skips the cache to dist restore and the dist hashing that decides whether a restore is needed, which is what keeps it cheap.

### Changelog

**Title line:** Preview pending package builds without running a build

**Body:** There was no way to find out how much of the project still needed building without starting a build. The build command can now report how many packages are up to date and how many need to be rebuilt, and it can output that as raw data so an editor or dashboard can show it as a live status.

### Squash Merge Commit

```
feat(build): add --preview flag to report pending builds (#5640)
feat(build): preview how many packages need a rebuild (#5640)
```
