### PR TITLE
fix(app-admin): skip schema validation for non-required empty fields

### DIFF
--- a/packages/app-admin/src/features/formModel/Field.ts
+++ b/packages/app-admin/src/features/formModel/Field.ts
@@ -277,6 +277,12 @@ export class Field implements IField {
         this._validation = validation;
     }
 
+    setValidationWithCache(validation: IFieldValidation, value: unknown, result: boolean): void {
+        this._validation = validation;
+        this._validationCacheKey = this._serializeValue(value);
+        this._validationCache = result;
+    }
+
     resetValidation(): void {
         this._validation = { isValid: null };
         this._validationCacheKey = undefined;
@@ -532,6 +538,19 @@ export class Field implements IField {
                     });
                     return false;
                 }
+            }
+
+            if (
+                !requiredState.required &&
+                (effectiveValue === null || effectiveValue === undefined)
+            ) {
+                const cacheKey = this._serializeValue(effectiveValue);
+                runInAction(() => {
+                    this._validation = { isValid: null };
+                    this._validationCacheKey = cacheKey;
+                    this._validationCache = true;
+                });
+                return true;
             }
 
             // Zod schema check

--- a/packages/app-admin/src/features/formModel/FormModel.test.ts
+++ b/packages/app-admin/src/features/formModel/FormModel.test.ts
@@ -212,6 +212,88 @@ describe("FormModel", () => {
             expect(form.errors[0].message).toBe("Email is required");
         });
 
+        it("should skip zod validation for non-required field with null value", async () => {
+            const form = createForm({
+                fields: fields => ({
+                    description: fields.text().label("Description").schema(z.string())
+                })
+            });
+
+            const valid = await form.validate();
+
+            expect(valid).toBe(true);
+            expect(form.errors).toHaveLength(0);
+            expect(form.field("description").vm.validation.isValid).toBeNull();
+        });
+
+        it("should skip zod validation for non-required field with undefined value", async () => {
+            const form = createForm({
+                fields: fields => ({
+                    description: fields.text().label("Description").schema(z.string())
+                })
+            });
+
+            form.field("description").setValue(undefined as any);
+            const valid = await form.validate();
+
+            expect(valid).toBe(true);
+            expect(form.errors).toHaveLength(0);
+            expect(form.field("description").vm.validation.isValid).toBeNull();
+        });
+
+        it("should run zod validation for non-required field with empty string value", async () => {
+            const form = createForm({
+                fields: fields => ({
+                    description: fields
+                        .text()
+                        .label("Description")
+                        .schema(z.string().min(3, "Too short"))
+                })
+            });
+
+            form.field("description").setValue("");
+            const valid = await form.validate();
+
+            expect(valid).toBe(false);
+            expect(form.field("description").vm.validation.isValid).toBe(false);
+            expect(form.field("description").vm.validation.message).toBe("Too short");
+        });
+
+        it("should fail required validation for required field with null value even when schema is set", async () => {
+            const form = createForm({
+                fields: fields => ({
+                    description: fields
+                        .text()
+                        .label("Description")
+                        .required("Description is required")
+                        .schema(z.string().min(3, "Too short"))
+                })
+            });
+
+            const valid = await form.validate();
+
+            expect(valid).toBe(false);
+            expect(form.field("description").vm.validation.isValid).toBe(false);
+            expect(form.field("description").vm.validation.message).toBe("Description is required");
+        });
+
+        it("should run and pass zod validation for non-required field with valid value", async () => {
+            const form = createForm({
+                fields: fields => ({
+                    description: fields
+                        .text()
+                        .label("Description")
+                        .schema(z.string().min(3, "Too short"))
+                })
+            });
+
+            form.field("description").setValue("Hello world");
+            const valid = await form.validate();
+
+            expect(valid).toBe(true);
+            expect(form.field("description").vm.validation.isValid).toBe(true);
+        });
+
         it("should expose field-level validation in field.vm", async () => {
             const form = createBasicForm();
             await form.validate();
@@ -219,6 +301,26 @@ describe("FormModel", () => {
             const titleVm = form.field("title").vm;
             expect(titleVm.validation.isValid).toBe(false);
             expect(titleVm.validation.message).toBe("Title is required");
+        });
+
+        it("setValidationWithCache should populate the validation cache", async () => {
+            const schema = z.string().min(3, "Too short");
+            const spy = vi.spyOn(schema, "safeParseAsync");
+            const form = createForm({
+                fields: fields => ({
+                    description: fields.text().label("Description").schema(schema)
+                })
+            });
+
+            const valid1 = await form.validate();
+            expect(valid1).toBe(true);
+            expect(spy).not.toHaveBeenCalled();
+
+            const valid2 = await form.validate();
+            expect(valid2).toBe(true);
+            expect(spy).not.toHaveBeenCalled();
+            expect(form.field("description").vm.validation.isValid).toBeNull();
+            spy.mockRestore();
         });
 
         it("isValid should be null before first validation", () => {
@@ -1517,6 +1619,142 @@ describe("FormModel", () => {
                     }
                 });
             });
+
+            it("should skip schema validation for non-required object field with null underlying data", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street")
+                            }))
+                            .schema(z.object({ street: z.string().min(1) }))
+                    })
+                });
+
+                form.setData({ address: null as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
+
+            it("should skip schema validation for non-required object field with undefined underlying data", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street")
+                            }))
+                            .schema(z.object({ street: z.string().min(1) }))
+                    })
+                });
+
+                form.setData({ address: undefined as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
+
+            it("should run schema validation for non-required object field with populated values", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street")
+                            }))
+                            .schema(z.object({ street: z.string().min(5, "Street too short") }))
+                    })
+                });
+
+                form.field("address.street").setValue("Hi");
+                const valid = await form.validate();
+
+                expect(valid).toBe(false);
+                expect(form.errors).toHaveLength(1);
+                expect(form.errors[0].message).toBe("Street too short");
+            });
+
+            it("should run schema validation for required object field with populated but invalid values", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street")
+                            }))
+                            .required("Address is required")
+                            .schema(
+                                z.object({
+                                    street: z.string().min(5, "Street too short")
+                                })
+                            )
+                    })
+                });
+
+                form.field("address.street").setValue("Hi");
+                const valid = await form.validate();
+
+                expect(valid).toBe(false);
+                expect(form.errors).toHaveLength(1);
+                expect(form.errors[0].message).toBe("Street too short");
+            });
+
+            it("should fail required validation for required object field with null data even when schema is set", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street")
+                            }))
+                            .required("Address is required")
+                            .schema(z.object({ street: z.string().min(1) }))
+                    })
+                });
+
+                form.setData({ address: null as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(false);
+                expect(form.errors).toHaveLength(1);
+                expect(form.errors[0].message).toBe("Address is required");
+            });
+
+            it("should skip schema validation for non-required object field when all child values are empty", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        address: fields
+                            .object()
+                            .label("Address")
+                            .fields(f => ({
+                                street: f.text().label("Street"),
+                                city: f.text().label("City")
+                            }))
+                            .schema(
+                                z.object({
+                                    street: z.string().min(1),
+                                    city: z.string().min(1)
+                                })
+                            )
+                    })
+                });
+
+                form.field("address.street").setValue("");
+                form.field("address.city").setValue("");
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
         });
 
         describe("list object field", () => {
@@ -1671,6 +1909,110 @@ describe("FormModel", () => {
 
                 expect(valid).toBe(false);
                 expect(form.errors[0].message).toBe("At least 2 presets are required");
+            });
+
+            it("should skip listSchema validation for non-required list field with empty list", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        presets: fields
+                            .object()
+                            .label("Presets")
+                            .fields(f => ({
+                                name: f.text().label("Name")
+                            }))
+                            .list()
+                            .listSchema(z.array(z.any()).min(2, "At least 2 presets are required"))
+                    })
+                });
+
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
+
+            it("should skip listSchema validation for non-required list field with undefined value", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        presets: fields
+                            .object()
+                            .label("Presets")
+                            .fields(f => ({
+                                name: f.text().label("Name")
+                            }))
+                            .list()
+                            .listSchema(z.array(z.any()).min(2, "At least 2 presets are required"))
+                    })
+                });
+
+                form.setData({ presets: undefined as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
+
+            it("should skip listSchema validation for non-required list field with null value", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        presets: fields
+                            .object()
+                            .label("Presets")
+                            .fields(f => ({
+                                name: f.text().label("Name")
+                            }))
+                            .list()
+                            .listSchema(z.array(z.any()).min(2, "At least 2 presets are required"))
+                    })
+                });
+
+                form.setData({ presets: null as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(true);
+                expect(form.errors).toHaveLength(0);
+            });
+
+            it("should enforce listSchema validation for required list field with null value", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        presets: fields
+                            .object()
+                            .label("Presets")
+                            .fields(f => ({
+                                name: f.text().label("Name")
+                            }))
+                            .list()
+                            .required("Presets are required")
+                            .listSchema(z.array(z.any()).min(2, "At least 2 presets are required"))
+                    })
+                });
+
+                form.setData({ presets: null as any });
+                const valid = await form.validate();
+
+                expect(valid).toBe(false);
+                expect(form.errors[0].message).toBe("Presets are required");
+            });
+
+            it("should enforce listSchema validation for required list field with empty list", async () => {
+                const form = createForm({
+                    fields: fields => ({
+                        presets: fields
+                            .object()
+                            .label("Presets")
+                            .fields(f => ({
+                                name: f.text().label("Name")
+                            }))
+                            .list()
+                            .required("Presets are required")
+                            .listSchema(z.array(z.any()).min(2, "At least 2 presets are required"))
+                    })
+                });
+
+                const valid = await form.validate();
+
+                expect(valid).toBe(false);
             });
 
             it("should be dirty after adding an item", () => {

--- a/packages/app-admin/src/features/formModel/ObjectField.ts
+++ b/packages/app-admin/src/features/formModel/ObjectField.ts
@@ -230,6 +230,14 @@ export class ObjectField implements IObjectField {
         this._base.setValidation(validation);
     }
 
+    private setValidationWithCache(
+        validation: IFieldValidation,
+        value: unknown,
+        result: boolean
+    ): void {
+        this._base.setValidationWithCache(validation, value, result);
+    }
+
     addBeforeChange(cb: BeforeChangeCallback): void {
         this._base.addBeforeChange(cb);
     }
@@ -907,6 +915,15 @@ export class ObjectField implements IObjectField {
 
             if (this.config.isList && this.config.listSchema) {
                 const listData = this.getData();
+                if (
+                    !requiredState.required &&
+                    (listData === null ||
+                        listData === undefined ||
+                        (Array.isArray(listData) && listData.length === 0))
+                ) {
+                    this.setValidationWithCache({ isValid: null }, listData, true);
+                    return true;
+                }
                 const result = await this.config.listSchema.safeParseAsync(listData);
                 if (!result.success) {
                     const firstIssue = result.error.issues[0];
@@ -922,6 +939,19 @@ export class ObjectField implements IObjectField {
 
             if (this.config.schema) {
                 const data = this.getData();
+                if (!requiredState.required) {
+                    if (data == null) {
+                        this.setValidationWithCache({ isValid: null }, data, true);
+                        return true;
+                    }
+                    const hasAnyValue = Object.values(data).some(
+                        v => v !== null && v !== undefined && v !== ""
+                    );
+                    if (!hasAnyValue) {
+                        this.setValidationWithCache({ isValid: null }, data, true);
+                        return true;
+                    }
+                }
                 const result = await this.config.schema.safeParseAsync(data);
                 if (!result.success) {
                     const firstIssue = result.error.issues[0];


### PR DESCRIPTION
## Must

- Non-required fields with null/undefined values must not fail Zod schema validation
- Required fields must still fail required validation before schema runs
- Populated non-required fields must still run Zod schema validation
- Non-required object fields with all-empty children must skip schema validation
- Non-required list fields with empty/null/undefined data must skip listSchema validation

## What changed

**Field.ts** — Early return before the Zod schema check: when a field is not required and its effective value is null or undefined, set `isValid: null` in the cache and return `true` without invoking the schema. Added `setValidationWithCache` to populate the validation cache in a single call.

**ObjectField.ts** — Same early-return pattern in three places:
- `listSchema` validation: skip when not required and the list is null, undefined, or empty.
- `schema` validation: skip when not required and data is null/undefined, or when all child values are empty strings/null/undefined.
- Delegates to `Field.setValidationWithCache` through a private wrapper.

**FormModel.test.ts** — 17 new test cases covering the skip logic for scalar fields, object fields, and list object fields, plus a cache-population test for `setValidationWithCache`.

## What was deliberately not changed

- No changes to required-field validation paths — those still fail before schema runs.
- No changes to the `IField` interface — `setValidationWithCache` is internal to the class.
- No changes to non-Zod validators or custom validation callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)