### PR TITLE
fix(app-website-builder): focus the title field when creating a page

### DIFF
--- a/packages/app-website-builder/src/presentation/pages/CreatePage/CreatePagePresenter.ts
+++ b/packages/app-website-builder/src/presentation/pages/CreatePage/CreatePagePresenter.ts
@@ -114,6 +114,7 @@ class CreatePagePresenterImpl implements PresenterAbstraction.Interface {
                     .text()
                     .label("Title")
                     .required("Title is required")
+                    .autoFocus()
                     .onBlur((value, { form }) => {
                         const currentPath = form.field("path").as("text").getValue() ?? "";
                         if (!PagePath.create(currentPath).isEmpty()) {


### PR DESCRIPTION
The create page form opened with nothing focused, so the first thing anyone does is reach for the mouse to click a single text input.

```diff
                     .text()
                     .label("Title")
                     .required("Title is required")
+                    .autoFocus()
```

Title is the only field a user fills in directly — `path` is derived from it on blur — so it's the obvious thing to focus.

## Note on provenance

This one-liner was sitting uncommitted in my working tree and predates the session it was found in, so I don't know who wrote it. It uses a real builder method (`FieldBuilder.autoFocus()`, `packages/app-admin/src/features/formModel/FieldBuilder.ts:75`) and a `git log -S` across all branches turns up nothing, so it had never been committed anywhere. Pulled out into its own PR rather than folded into an unrelated one.

## Not done here

If the intent is "first field focused on every create form", the sibling forms (Teams, Roles, API Keys, and the other create presenters) need the same treatment. That's a consistency decision rather than a bug fix, so it's not in this PR.

## Test plan

```
yarn build -p @webiny/app-website-builder    clean
yarn test packages/app-website-builder       12 files, 54 passed (1 file / 6 tests skipped)
yarn adio / lint / format                    clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)