### PR TITLE
fix(deploy-template): add VPC endpoint permissions

### DIFF
--- a/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
+++ b/docs/DEPLOY_WEBINY_PROJECT_CF_TEMPLATE_V6.yaml
@@ -492,6 +492,11 @@ Resources:
               # arn:aws:ec2:*:*:route-table/*
               - ec2:CreateRouteTable
 
+              # arn:aws:ec2:*:*:vpc-endpoint/*
+              # Only used with the `useVpcEndpoints` VPC option, which keeps traffic to S3,
+              # DynamoDB, Amazon SQS, and Amazon EventBridge inside the VPC.
+              - ec2:CreateVpcEndpoint
+
           # Besides the above ec2 permissions, we also need this:
           - Effect: Allow
 
@@ -500,6 +505,7 @@ Resources:
             Resource: "*"
             Action:
               - ec2:DescribeAddressesAttribute
+              - ec2:DescribeVpcEndpoints
 
           - Effect: Allow
             # Resource ARNs must include at least 6 fields and include the following structure: arn:partition:service:region:account:resource.
@@ -515,6 +521,10 @@ Resources:
               - ec2:DeleteVpc
               - ec2:DescribeVpcAttribute
               - ec2:AttachInternetGateway
+
+              # Interface endpoints resolve via private DNS, which requires both DNS support and
+              # DNS hostnames on the VPC. Enabling them is a modify on the VPC itself.
+              - ec2:ModifyVpcAttribute
 
               # arn:aws:ec2:*:*:subnet/*
               - ec2:CreateNatGateway
@@ -537,6 +547,10 @@ Resources:
               # arn:aws:ec2:*:*:route-table/*
               - ec2:CreateRoute
               - ec2:DeleteRouteTable
+
+              # arn:aws:ec2:*:*:vpc-endpoint/*
+              - ec2:ModifyVpcEndpoint
+              - ec2:DeleteVpcEndpoints
 
           - Effect: Allow
             # Could not use tags.


### PR DESCRIPTION
## Problem

The `useVpcEndpoints` VPC option creates four VPC endpoints in the core app (`createCorePulumiApp.ts:166-217`): gateway endpoints for S3 and DynamoDB, interface endpoints for Amazon SQS and Amazon EventBridge. The same block turns on `enableDnsSupport` and `enableDnsHostnames` on the VPC, which interface endpoints need for private DNS resolution.

`DeployWebinyPolicy3` granted none of that. No VPC endpoint actions at all, and `ec2:DescribeVpcAttribute` without the matching `ec2:ModifyVpcAttribute`, so a deploy with that option on fails.

## Fix

Five actions added to the existing EC2 statements in `DeployWebinyPolicy3`:

| Action | Statement |
|---|---|
| `ec2:CreateVpcEndpoint` | request-tag scoped, with the other creates |
| `ec2:ModifyVpcEndpoint`, `ec2:DeleteVpcEndpoints`, `ec2:ModifyVpcAttribute` | resource-tag scoped, with the other modifies and deletes |
| `ec2:DescribeVpcEndpoints` | `Resource: "*"`, as describe actions don't support resource-level permissions |

This follows the split the surrounding EC2 statements already use. `DeployWebinyPolicy3` grows to 2,441 characters, well under the 6,144 managed policy limit.

## Testing

I found this by diffing the resource types the Pulumi apps construct against the template, not from a failed deploy, so the action list comes from the AWS service authorization reference rather than a real run. Worth confirming against a `useVpcEndpoints: true` deploy before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)