### PR TITLE
refactor(api-scheduler-aws): resolve the scheduler service on demand

### DIFF
--- a/packages/api-scheduler-aws/src/context.ts
+++ b/packages/api-scheduler-aws/src/context.ts
@@ -1,49 +1,28 @@
 import type { Container } from "@webiny/di";
-import { RequestContextInitializer } from "@webiny/event-handler-core";
 import type {
     SchedulerClient,
     SchedulerClientConfig
 } from "@webiny/aws-sdk/client-scheduler/index.js";
-import { getManifest } from "~/manifest.js";
 import { SchedulerService } from "@webiny/api-scheduler/shared/abstractions.js";
-import { EventBridgeSchedulerService } from "~/features/SchedulerService/EventBridgeSchedulerService.js";
-import { VoidSchedulerService } from "@webiny/api-scheduler/features/SchedulerService/VoidSchedulerService.js";
-import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/index.js";
+import { createLazySchedulerService } from "~/features/SchedulerService/LazySchedulerService.js";
 
 export interface IRegisterSchedulerAwsExtensionParams {
     getClient(config?: SchedulerClientConfig): Pick<SchedulerClient, "send">;
 }
 
 /**
- * Registers the AWS (EventBridge Scheduler) transport for the scheduler. Binds `SchedulerService`
- * per-request via a RequestContextInitializer (post-tenant): resolves the deployed scheduler
- * manifest and picks the EventBridge service, or a no-op Void service when the manifest is missing.
+ * Registers the AWS (EventBridge Scheduler) transport for the scheduler.
+ *
+ * `SchedulerService` is bound at register time to a lazy implementation that reads the deployed
+ * scheduler manifest on first use and delegates to either the EventBridge service or the no-op Void
+ * service. Previously this was a per-request `RequestContextInitializer`, because the manifest read
+ * is async and DI resolution is not — along with a `getTenant()` guard, since a fixed-time hook can
+ * fire before the tenant is established. Neither is needed once the async work moves into the
+ * methods, which were already async.
  */
 export const registerSchedulerAwsExtension = (
     container: Container,
     params: IRegisterSchedulerAwsExtensionParams
 ) => {
-    container.registerInstance(RequestContextInitializer, {
-        async init(ctx: Record<string, any>) {
-            const requestContainer = ctx.container as Container;
-
-            if (!requestContainer.resolve(TenantContext).getTenant()) {
-                return;
-            }
-
-            const manifest = await getManifest();
-
-            if (manifest.error) {
-                requestContainer.registerInstance(SchedulerService, new VoidSchedulerService());
-            } else {
-                requestContainer.registerInstance(
-                    SchedulerService,
-                    new EventBridgeSchedulerService(params.getClient, {
-                        lambdaArn: manifest.data.lambdaArn,
-                        roleArn: manifest.data.roleArn
-                    })
-                );
-            }
-        }
-    });
+    container.registerInstance(SchedulerService, createLazySchedulerService(params.getClient));
 };

--- a/packages/api-scheduler-aws/src/features/SchedulerService/LazySchedulerService.ts
+++ b/packages/api-scheduler-aws/src/features/SchedulerService/LazySchedulerService.ts
@@ -1,0 +1,59 @@
+import type {
+    SchedulerClient,
+    SchedulerClientConfig
+} from "@webiny/aws-sdk/client-scheduler/index.js";
+import { SchedulerService } from "@webiny/api-scheduler/shared/abstractions.js";
+import { VoidSchedulerService } from "@webiny/api-scheduler/features/SchedulerService/VoidSchedulerService.js";
+import { getManifest } from "~/manifest.js";
+import { EventBridgeSchedulerService } from "./EventBridgeSchedulerService.js";
+
+export type GetSchedulerClient = (config?: SchedulerClientConfig) => Pick<SchedulerClient, "send">;
+
+/**
+ * Picks the real EventBridge service or the no-op Void service, deciding on first use rather than
+ * up front.
+ *
+ * The choice depends on the deployed scheduler manifest, and reading it is async — which is why
+ * this used to be a per-request `RequestContextInitializer` that resolved the manifest and then
+ * registered whichever service it implied. Every method here is already async, so the decision can
+ * simply be awaited at the point of use instead.
+ *
+ * No memoization: `ServiceDiscovery.load()` caches the manifest in a process-wide static, so
+ * `getManifest()` is cheap after the first call.
+ */
+class LazySchedulerServiceImpl implements SchedulerService.Interface {
+    constructor(private getClient: GetSchedulerClient) {}
+
+    private async service(): Promise<SchedulerService.Interface> {
+        const manifest = await getManifest();
+
+        if (manifest.error) {
+            return new VoidSchedulerService();
+        }
+
+        return new EventBridgeSchedulerService(this.getClient, {
+            lambdaArn: manifest.data.lambdaArn,
+            roleArn: manifest.data.roleArn
+        });
+    }
+
+    async create(params: SchedulerService.CreateParams): Promise<void> {
+        return (await this.service()).create(params);
+    }
+
+    async update(params: SchedulerService.UpdateParams): Promise<void> {
+        return (await this.service()).update(params);
+    }
+
+    async delete(params: SchedulerService.DeleteParams): Promise<void> {
+        return (await this.service()).delete(params);
+    }
+
+    async exists(params: SchedulerService.ExistsParams): Promise<boolean> {
+        return (await this.service()).exists(params);
+    }
+}
+
+export const createLazySchedulerService = (
+    getClient: GetSchedulerClient
+): SchedulerService.Interface => new LazySchedulerServiceImpl(getClient);


### PR DESCRIPTION
Slice **6** of retiring `RequestContextInitializer` — the first of the five **non-model** contributors. Independent of the Website Builder stack (#5643, #5645), so it can land in any order. Plan: `plans/retire-request-context-initializer.md`.

## Change

`registerSchedulerAwsExtension` used a per-request `RequestContextInitializer` to pick the scheduler transport: await the deployed manifest, then register either `EventBridgeSchedulerService` or the no-op `VoidSchedulerService`.

The hook existed for the **same reason the model abstractions needed one** — the manifest read is async, DI resolution is not.

```diff
-    container.registerInstance(RequestContextInitializer, {
-        async init(ctx) {
-            const requestContainer = ctx.container as Container;
-            if (!requestContainer.resolve(TenantContext).getTenant()) return;
-            const manifest = await getManifest();
-            if (manifest.error) {
-                requestContainer.registerInstance(SchedulerService, new VoidSchedulerService());
-            } else {
-                requestContainer.registerInstance(SchedulerService, new EventBridgeSchedulerService(...));
-            }
-        }
-    });
+    container.registerInstance(SchedulerService, createLazySchedulerService(params.getClient));
```

All four `ISchedulerService` methods (`create` / `update` / `delete` / `exists`) were already async, so the manifest read simply moves into them:

```ts
async create(params: SchedulerService.CreateParams): Promise<void> {
    return (await this.service()).create(params);
}
```

## Behaviour note

The `if (!getTenant()) return;` guard is gone — a fixed-time hook can fire before the tenant is established, so it had to check; a lazily resolved service cannot run too early.

That is a **small behaviour change worth naming**: previously, with no tenant, `SchedulerService` was left as whatever `SchedulerFeature` had registered. Now the AWS binding is always in place and resolves to Void when the manifest is missing. Same outcome, more directly.

## No memoization

Consistent with the earlier slices, and for the same reason: `ServiceDiscovery.load()` already caches the manifest in a **process-wide static**, so `getManifest()` is cheap after the first call. Adding a second cache would buy nothing.

## Verification

- **`api-scheduler-aws` 30 passed** (includes a full create → get → list → cancel flow and a non-root-tenant scheduled action)
- `api-scheduler` 1 passed · `api-event-handler-aws` builds
- `yarn adio` ✓ · oxlint clean · repo-wide `yarn format:check` ✓

One note for anyone re-running locally: **this package's tests want DDB, not the SQL preset.** With `WEBINY_STORAGE=sql` they fail on `ECONNREFUSED :8001` and a sqlite `NOT NULL` constraint on `webiny_core_tenants.createdOn`. Plain `yarn test` is correct here — I tripped over this myself and briefly mistook it for a regression.

## Remaining after this

4 `RequestContextInitializer` contributors: `HcmsTasks` deleteModel crud + gql, and `fm-s3` / `fm-server` assetDelivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)