### PR TITLE
fix(ci): resolve the e2e test project by absolute path

### DIFF
--- a/.github/workflows/pullRequestsCommandE2e.yml
+++ b/.github/workflows/pullRequestsCommandE2e.yml
@@ -372,7 +372,9 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/comment.txt
       - name: Create Cypress config
-        run: yarn setup-cypress --projectFolder ../new-webiny-project
+        run: >-
+          yarn setup-cypress --projectFolder ${{ github.workspace
+          }}/new-webiny-project
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Save Cypress config
         id: save-cypress-config
@@ -636,7 +638,9 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X
           PATCH --field body=@/tmp/comment.txt
       - name: Create Cypress config
-        run: yarn setup-cypress --projectFolder ../new-webiny-project
+        run: >-
+          yarn setup-cypress --projectFolder ${{ github.workspace
+          }}/new-webiny-project
         working-directory: ${{ needs.baseBranch.outputs.base-branch }}
       - name: Save Cypress config
         id: save-cypress-config

--- a/.github/workflows/wac/e2e/constants.ts
+++ b/.github/workflows/wac/e2e/constants.ts
@@ -7,6 +7,11 @@ export const DIR_WEBINY_JS = "${{ needs.baseBranch.outputs.base-branch }}";
 // The AWS-deployed test project, scaffolded at the workspace root.
 export const DIR_TEST_PROJECT = "new-webiny-project";
 
+// Absolute path to the same project, for steps that run from DIR_WEBINY_JS and so cannot reach it
+// by name. Don't use "../" for this: DIR_WEBINY_JS is a branch name and branch names contain
+// slashes, so the checkout is often more than one directory deep.
+export const PATH_TEST_PROJECT = `\${{ github.workspace }}/${DIR_TEST_PROJECT}`;
+
 // The self-hosted ("server" hosting type) test project. Kept separate from the AWS one so both can
 // exist in the same run without colliding.
 export const DIR_SERVER_PROJECT = "new-webiny-project-server";

--- a/.github/workflows/wac/e2e/createAwsJobs.ts
+++ b/.github/workflows/wac/e2e/createAwsJobs.ts
@@ -7,7 +7,7 @@ import {
 } from "../steps/index.js";
 import { ACTION, AWS_REGION } from "../utils/index.js";
 import { createJob } from "../jobs/index.js";
-import { DIR_TEST_PROJECT, DIR_WEBINY_JS } from "./constants.js";
+import { DIR_TEST_PROJECT, DIR_WEBINY_JS, PATH_TEST_PROJECT } from "./constants.js";
 import { createStatusRowUpdateSteps } from "./statusComment.js";
 import {
     globalBuildCacheSteps,
@@ -192,12 +192,17 @@ export const createAwsJobs = (dbSetup: string) => {
                     //     name: "Deployment Summary",
                     //     run: `${runNodeScript(
                     //         "printDeploymentSummary",
-                    //         `../${DIR_TEST_PROJECT}`
+                    //         PATH_TEST_PROJECT
                     //     )} >> $GITHUB_STEP_SUMMARY`
                     // },
                     {
+                        // These steps run from DIR_WEBINY_JS, but the test project is scaffolded at
+                        // the workspace root, so the path has to climb out. `../` only works when
+                        // DIR_WEBINY_JS is one segment deep, and it isn't: it's the PR's base branch
+                        // name, which is usually something like "release/6.5.0". An absolute path
+                        // works whatever the branch is named.
                         name: "Create Cypress config",
-                        run: `yarn setup-cypress --projectFolder ../${DIR_TEST_PROJECT}`
+                        run: `yarn setup-cypress --projectFolder ${PATH_TEST_PROJECT}`
                     },
                     {
                         name: "Save Cypress config",


### PR DESCRIPTION
## Problem

`/e2e` fails at the "Create Cypress config" step:

```
Could not find specified project (received ../new-webiny-project,
full path /home/runner/work/webiny-js/webiny-js/adrian/new-webiny-project).
```

The checkout directory for the webiny-js repo is the PR's base branch name (`DIR_WEBINY_JS` in `wac/e2e/constants.ts`), and the test project is scaffolded at the workspace root. The step runs from the checkout and climbed out with `../`, which assumes the checkout is exactly one directory deep.

Base branches used to be `next` or `dev`, so it was. They aren't anymore:

| Base branch | Checkout | `../new-webiny-project` resolves to |
|---|---|---|
| `next` | `<workspace>/next` | `<workspace>/new-webiny-project` ✅ |
| `adrian/wb-experiment-model-provider` | `<workspace>/adrian/wb-experiment-model-provider` | `<workspace>/adrian/new-webiny-project` ❌ |
| `release/6.5.0` | `<workspace>/release/6.5.0` | `<workspace>/release/new-webiny-project` ❌ |

So `/e2e` is broken on every PR whose base branch contains a slash, which covers the `adrian/*` and `release/*` bases in use today. The deploy itself succeeds and then this step fails, which is why it reads as a Cypress problem.

## Fix

Reach the project by absolute path, `${{ github.workspace }}/new-webiny-project`, which is correct at any checkout depth. Added as `PATH_TEST_PROJECT` next to `DIR_TEST_PROJECT` so the reason is written down where the next person will look.

Every other step in the job reaches the project through `working-directory: new-webiny-project`, which is workspace-relative and was never affected. `push.yml` hardcodes its checkout directory to `v6`, one segment, so it was never affected either.

## Testing

Regenerated with `yarn ci-workflows:build` and parsed the result to confirm the folded YAML resolves to the intended command in both AWS jobs:

```
e2e-wby-cms-ddb-project-setup    -> yarn setup-cypress --projectFolder ${{ github.workspace }}/new-webiny-project
e2e-wby-cms-ddb-os-project-setup -> yarn setup-cypress --projectFolder ${{ github.workspace }}/new-webiny-project
```

The real test is running `/e2e` on a PR with a slashed base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)