### PR TITLE
refactor(file-manager): load sharp lazily inside the handler, drop two initializers

### DIFF
--- a/packages/api-file-manager-s3/src/assetDelivery/feature.ts
+++ b/packages/api-file-manager-s3/src/assetDelivery/feature.ts
@@ -1,10 +1,10 @@
 import { createFeature } from "@webiny/feature/api";
 import { S3 } from "@webiny/aws-sdk/client-s3/index.js";
-import { RequestContextInitializer } from "@webiny/event-handler-core";
 import { S3Client, S3Bucket, S3AssetDeliveryConfig } from "./abstractions.js";
 import type { AssetDeliveryParams } from "./types.js";
 import { S3AssetResolverImpl } from "./s3/S3AssetResolver.js";
 import { S3OutputStrategyImpl } from "./s3/S3OutputStrategy.js";
+import { LazySharpTransformImpl } from "./s3/LazySharpTransform.js";
 
 export const createS3AssetDeliveryFeature = (params: AssetDeliveryParams = {}) => {
     return createFeature({
@@ -28,16 +28,8 @@ export const createS3AssetDeliveryFeature = (params: AssetDeliveryParams = {}) =
             container.register(S3OutputStrategyImpl);
 
             if (process.env.WEBINY_FUNCTION_TYPE === "asset-delivery") {
-                container.registerInstance(RequestContextInitializer, {
-                    async init(ctx) {
-                        const { SharpTransformImpl } = await import(
-                            /* webpackChunkName: "s3AssetDelivery" */ "./s3/SharpTransform.js"
-                        );
-                        (ctx.container as typeof container)
-                            .register(SharpTransformImpl)
-                            .inSingletonScope();
-                    }
-                });
+                // Registered eagerly; `sharp` is still loaded lazily, inside the handler.
+                container.register(LazySharpTransformImpl).inSingletonScope();
             }
         }
     });

--- a/packages/api-file-manager-s3/src/assetDelivery/s3/LazySharpTransform.ts
+++ b/packages/api-file-manager-s3/src/assetDelivery/s3/LazySharpTransform.ts
@@ -1,0 +1,59 @@
+import type { S3 } from "@webiny/aws-sdk/client-s3/index.js";
+import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
+import { GetFileUseCase } from "@webiny/api-file-manager/features/file/GetFile/index.js";
+import { ImageAssetTypeHandler } from "@webiny/api-file-manager/features/assetDelivery/assetTypes/image/index.js";
+import type { Asset } from "@webiny/api-file-manager/delivery/AssetDelivery/Asset.js";
+import type { AssetRequest } from "@webiny/api-file-manager/delivery/AssetDelivery/AssetRequest.js";
+import { S3AssetDeliveryConfig, S3Bucket, S3Client } from "~/assetDelivery/abstractions.js";
+import type { IS3AssetDeliveryConfig } from "~/assetDelivery/abstractions.js";
+
+/**
+ * Defers loading `sharp` until an image is actually transformed.
+ *
+ * The dynamic import is deliberate — it keeps `sharp` out of the main bundle (note the
+ * `webpackChunkName`). That import is async and DI resolution is not, which is why this used to be
+ * a per-request `RequestContextInitializer` that imported the module and then registered the real
+ * handler. `IAssetTypeHandler` has a single async method, so the import can be awaited there
+ * instead.
+ *
+ * The constructed handler IS memoized: the initializer registered it `.inSingletonScope()`, and
+ * nothing below caches the instance (Node caches the module, not the object built from it).
+ */
+class LazySharpTransform implements ImageAssetTypeHandler.Interface {
+    private handler: Promise<ImageAssetTypeHandler.Interface> | null = null;
+
+    constructor(
+        private readonly s3: S3,
+        private readonly bucket: string,
+        private readonly config: IS3AssetDeliveryConfig,
+        private readonly identityContext: IdentityContext.Interface,
+        private readonly getFile: GetFileUseCase.Interface
+    ) {}
+
+    private resolveHandler(): Promise<ImageAssetTypeHandler.Interface> {
+        if (!this.handler) {
+            this.handler = import(
+                /* webpackChunkName: "s3AssetDelivery" */ "./SharpTransform.js"
+            ).then(
+                ({ SharpTransform }) =>
+                    new SharpTransform(
+                        this.s3,
+                        this.bucket,
+                        this.config,
+                        this.identityContext,
+                        this.getFile
+                    )
+            );
+        }
+        return this.handler;
+    }
+
+    async handle(assetRequest: AssetRequest, asset: Asset): Promise<Asset> {
+        return (await this.resolveHandler()).handle(assetRequest, asset);
+    }
+}
+
+export const LazySharpTransformImpl = ImageAssetTypeHandler.createImplementation({
+    implementation: LazySharpTransform,
+    dependencies: [S3Client, S3Bucket, S3AssetDeliveryConfig, IdentityContext, GetFileUseCase]
+});

--- a/packages/api-file-manager-server/src/assetDelivery/LazyLocalSharpTransform.ts
+++ b/packages/api-file-manager-server/src/assetDelivery/LazyLocalSharpTransform.ts
@@ -1,0 +1,58 @@
+import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/index.js";
+import { GetFileUseCase } from "@webiny/api-file-manager/features/file/GetFile/index.js";
+import { ImageAssetTypeHandler } from "@webiny/api-file-manager/features/assetDelivery/assetTypes/image/index.js";
+import type { IAssetTypeHandler } from "@webiny/api-file-manager/features/assetDelivery/abstractions/AssetType.js";
+import type { Asset } from "@webiny/api-file-manager/delivery/AssetDelivery/Asset.js";
+import type { AssetRequest } from "@webiny/api-file-manager/delivery/AssetDelivery/AssetRequest.js";
+import { LocalAssetDeliveryConfig, LocalStoragePath } from "~/assetDelivery/abstractions.js";
+import type { ILocalAssetDeliveryConfig } from "~/assetDelivery/abstractions.js";
+
+/**
+ * Defers loading `sharp` until an image is actually transformed. Server counterpart of
+ * `api-file-manager-s3`'s `LazySharpTransform`.
+ *
+ * The dynamic import is deliberate — it keeps `sharp` out of the main bundle (note the
+ * `webpackChunkName`). That import is async and DI resolution is not, which is why this used to be
+ * a per-request `RequestContextInitializer` that imported the module and then registered the real
+ * handler. `IAssetTypeHandler` has a single async method, so the import can be awaited there
+ * instead.
+ *
+ * The constructed handler IS memoized: the initializer registered it `.inSingletonScope()`, and
+ * nothing below caches the instance (Node caches the module, not the object built from it).
+ */
+class LazyLocalSharpTransform implements IAssetTypeHandler {
+    private handler: Promise<IAssetTypeHandler> | null = null;
+
+    constructor(
+        private readonly storagePath: string,
+        private readonly config: ILocalAssetDeliveryConfig,
+        private readonly identityContext: IdentityContext.Interface,
+        private readonly getFile: GetFileUseCase.Interface
+    ) {}
+
+    private resolveHandler(): Promise<IAssetTypeHandler> {
+        if (!this.handler) {
+            this.handler = import(
+                /* webpackChunkName: "localAssetDelivery" */ "./LocalSharpTransform.js"
+            ).then(
+                ({ LocalSharpTransform }) =>
+                    new LocalSharpTransform(
+                        this.storagePath,
+                        this.config,
+                        this.identityContext,
+                        this.getFile
+                    )
+            );
+        }
+        return this.handler;
+    }
+
+    async handle(assetRequest: AssetRequest, asset: Asset): Promise<Asset> {
+        return (await this.resolveHandler()).handle(assetRequest, asset);
+    }
+}
+
+export const LazyLocalSharpTransformImpl = ImageAssetTypeHandler.createImplementation({
+    implementation: LazyLocalSharpTransform,
+    dependencies: [LocalStoragePath, LocalAssetDeliveryConfig, IdentityContext, GetFileUseCase]
+});

--- a/packages/api-file-manager-server/src/assetDelivery/feature.ts
+++ b/packages/api-file-manager-server/src/assetDelivery/feature.ts
@@ -1,10 +1,10 @@
 import { createFeature } from "@webiny/feature/api";
-import { RequestContextInitializer } from "@webiny/event-handler-core";
 import { LocalStoragePath } from "./abstractions.js";
 import { LocalAssetDeliveryConfig } from "./abstractions.js";
 import type { AssetDeliveryParams } from "./types.js";
 import { LocalAssetResolver } from "./LocalAssetResolver.js";
 import { LocalOutputStrategy } from "./LocalOutputStrategy.js";
+import { LazyLocalSharpTransformImpl } from "./LazyLocalSharpTransform.js";
 
 export const createLocalAssetDeliveryFeature = (params: AssetDeliveryParams = {}) => {
     return createFeature({
@@ -26,16 +26,8 @@ export const createLocalAssetDeliveryFeature = (params: AssetDeliveryParams = {}
             container.register(LocalOutputStrategy);
 
             if (process.env.WEBINY_FUNCTION_TYPE === "asset-delivery") {
-                container.registerInstance(RequestContextInitializer, {
-                    async init(ctx) {
-                        const { LocalSharpTransformImpl } = await import(
-                            /* webpackChunkName: "localAssetDelivery" */ "./LocalSharpTransform.js"
-                        );
-                        (ctx.container as typeof container)
-                            .register(LocalSharpTransformImpl)
-                            .inSingletonScope();
-                    }
-                });
+                // Registered eagerly; `sharp` is still loaded lazily, inside the handler.
+                container.register(LazyLocalSharpTransformImpl).inSingletonScope();
             }
         }
     });


### PR DESCRIPTION
Slice **7** of retiring `RequestContextInitializer` — the assetDelivery pair in `api-file-manager-s3` and `api-file-manager-server`. Base `next`, independent of the other open PRs. Plan: `plans/retire-request-context-initializer.md`.

## A different shape from the earlier slices

This hook wasn't hiding a model — it was hiding a `sharp` import. Both packages did:

```ts
container.registerInstance(RequestContextInitializer, {
    async init(ctx) {
        const { SharpTransformImpl } = await import(
            /* webpackChunkName: "s3AssetDelivery" */ "./s3/SharpTransform.js"
        );
        ctx.container.register(SharpTransformImpl).inSingletonScope();
    }
});
```

The dynamic import is **deliberate and stays** — it keeps `sharp` out of the main bundle. But it is async while DI resolution is not, which is the *same* reason every model abstraction needed a hook. And `IAssetTypeHandler` has a single async method, so the import can simply be awaited there:

```ts
async handle(assetRequest: AssetRequest, asset: Asset): Promise<Asset> {
    return (await this.resolveHandler()).handle(assetRequest, asset);
}
```

## Change

Adds `LazySharpTransform` (s3) and `LazyLocalSharpTransform` (server), each registered eagerly at register time behind the existing `WEBINY_FUNCTION_TYPE === "asset-delivery"` gate:

```diff
     if (process.env.WEBINY_FUNCTION_TYPE === "asset-delivery") {
-        container.registerInstance(RequestContextInitializer, { async init(ctx) { ...9 lines... } });
+        // Registered eagerly; `sharp` is still loaded lazily, inside the handler.
+        container.register(LazySharpTransformImpl).inSingletonScope();
     }
```

`sharp` still loads on first transform, not at boot. It also stops being re-imported per request — the old hook ran `await import()` on every request in an asset-delivery function.

## These DO memoize — unlike the model providers

Worth calling out because it's the opposite of the previous slices. The initializer registered the handler `.inSingletonScope()`, and **nothing below caches the instance** — Node caches the *module*, not the object built from it. So `resolveHandler()` memoizes the promise, preserving singleton semantics.

Same "check the layer below before adding a cache" test as the earlier slices, reaching the opposite answer. (For the model providers `ModelCache` already covered it; for `api-scheduler-aws` in #5648, `ServiceDiscovery.load()` already covered it.)

## Verification

- **`api-file-manager-s3` 9 passed** · **`api-file-manager-server` 22 passed** · **`api-file-manager` 69 passed / 1 skipped**
- both packages build
- `yarn adio` ✓ · oxlint clean · repo-wide `yarn format:check` ✓

The one thing tests don't cover: these paths only run when `WEBINY_FUNCTION_TYPE === "asset-delivery"`, so the lazy handler is exercised by an actual image transform in a deployed asset-delivery function rather than by unit tests. The delegation is a single method, and the constructor arguments are unchanged from `SharpTransform` / `LocalSharpTransform`, but that is worth a deployed sanity check on an image resize before relying on it.

## Remaining after this

`RequestContextInitializer` is gone from both packages. Repo-wide that leaves **the HcmsTasks deleteModel pair** (crud + gql) — plus `api-scheduler-aws`, already handled in #5648. Then the abstraction, its runner, the `HttpRouter` decorator and the 5 firing sites can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)