### PR TITLE
ci: let the branch cleanup run on its own

### DIFF
--- a/.github/workflows/deleteMergedBranches.yml
+++ b/.github/workflows/deleteMergedBranches.yml
@@ -4,13 +4,15 @@
 # For more information, run "github-actions-wac --help".
 name: Delete Merged Branches
 'on':
+  schedule:
+    - cron: 30 3 * * *
   workflow_dispatch:
     inputs:
       dryRun:
         description: Only list the branches that would be deleted.
         type: boolean
         required: false
-        default: true
+        default: false
 concurrency:
   group: delete-merged-branches
   cancel-in-progress: false
@@ -50,6 +52,8 @@ jobs:
           CUTOFF=$(date -u -d "$MAX_AGE_DAYS days ago" +%s)
 
           DELETED=0
+
+          FAILED=0
 
 
           # name + head SHA in one listing, so the SHA below does not need
@@ -117,18 +121,39 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "$BRANCH: would be deleted (merged $MERGED_AT)."
-            else
-              gh api --method DELETE "repos/$REPO/git/refs/heads/$BRANCH"
-              echo "$BRANCH: deleted (merged $MERGED_AT)."
+              DELETED=$((DELETED + 1))
+              continue
             fi
-            DELETED=$((DELETED + 1))
+
+            # One branch failing to delete is not a reason to abandon the other 180, so
+            # swallow the error here and fail the job at the end instead.
+            if gh api --method DELETE "repos/$REPO/git/refs/heads/$BRANCH"; then
+              echo "$BRANCH: deleted (merged $MERGED_AT)."
+              DELETED=$((DELETED + 1))
+            else
+              echo "::warning::Could not delete $BRANCH."
+              FAILED=$((FAILED + 1))
+            fi
+
+            # Deleting a ref is a write, and GitHub's secondary rate limit on writes is
+            # around 80 a minute. The first live run has a backlog of ~185 branches to get
+            # through, so pace them rather than get throttled halfway.
+            sleep 1
           done <<< "$BRANCHES"
 
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "::notice::$DELETED branch(es) would be deleted."
-          else
-            echo "::notice::Deleted $DELETED branch(es)."
+            exit 0
+          fi
+
+
+          echo "::notice::Deleted $DELETED branch(es)."
+
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED branch(es) could not be deleted. See the warnings above."
+            exit 1
           fi
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/wac/deleteMergedBranches.wac.ts
+++ b/.github/workflows/wac/deleteMergedBranches.wac.ts
@@ -1,12 +1,10 @@
 import { createWorkflow } from "github-actions-wac";
 import { createJob } from "./jobs/index.js";
 
-// Deletes branches whose pull request was merged more than a week ago.
+// Deletes branches whose pull request was merged more than a week ago, once a day.
 //
-// Manual only, from the Actions tab. `dryRun` defaults to on, so a run lists what it would delete
-// and deletes nothing until somebody unchecks the box. There is no schedule yet: the backlog goes
-// back to May 2025, so the rule wants a few dry runs before it is allowed to delete on its own.
-// To make it automatic later, add `schedule: [{ cron: "30 3 * * *" }]` and flip the default.
+// It can also be run by hand from the Actions tab, where `dryRun` lists what a run would delete
+// without deleting anything. The scheduled run passes no inputs, so it always deletes.
 //
 // GitHub's built-in "automatically delete head branches" setting deletes the branch the second the
 // PR merges, which is too soon: right after a merge is exactly when someone still wants to check
@@ -23,13 +21,14 @@ import { createJob } from "./jobs/index.js";
 export const deleteMergedBranches = createWorkflow({
     name: "Delete Merged Branches",
     on: {
+        schedule: [{ cron: "30 3 * * *" }],
         workflow_dispatch: {
             inputs: {
                 dryRun: {
                     description: "Only list the branches that would be deleted.",
                     type: "boolean",
                     required: false,
-                    default: true
+                    default: false
                 }
             }
         }
@@ -62,6 +61,7 @@ export const deleteMergedBranches = createWorkflow({
                         'OWNER="${REPO%%/*}"',
                         'CUTOFF=$(date -u -d "$MAX_AGE_DAYS days ago" +%s)',
                         "DELETED=0",
+                        "FAILED=0",
                         "",
                         "# name + head SHA in one listing, so the SHA below does not need another request.",
                         "# The `git/refs/heads/<name>` endpoint is no good for that: for a name that prefixes",
@@ -120,17 +120,36 @@ export const deleteMergedBranches = createWorkflow({
                         "",
                         '  if [ "$DRY_RUN" = "true" ]; then',
                         '    echo "$BRANCH: would be deleted (merged $MERGED_AT)."',
-                        "  else",
-                        '    gh api --method DELETE "repos/$REPO/git/refs/heads/$BRANCH"',
-                        '    echo "$BRANCH: deleted (merged $MERGED_AT)."',
+                        "    DELETED=$((DELETED + 1))",
+                        "    continue",
                         "  fi",
-                        "  DELETED=$((DELETED + 1))",
+                        "",
+                        "  # One branch failing to delete is not a reason to abandon the other 180, so",
+                        "  # swallow the error here and fail the job at the end instead.",
+                        '  if gh api --method DELETE "repos/$REPO/git/refs/heads/$BRANCH"; then',
+                        '    echo "$BRANCH: deleted (merged $MERGED_AT)."',
+                        "    DELETED=$((DELETED + 1))",
+                        "  else",
+                        '    echo "::warning::Could not delete $BRANCH."',
+                        "    FAILED=$((FAILED + 1))",
+                        "  fi",
+                        "",
+                        "  # Deleting a ref is a write, and GitHub's secondary rate limit on writes is",
+                        "  # around 80 a minute. The first live run has a backlog of ~185 branches to get",
+                        "  # through, so pace them rather than get throttled halfway.",
+                        "  sleep 1",
                         'done <<< "$BRANCHES"',
                         "",
                         'if [ "$DRY_RUN" = "true" ]; then',
                         '  echo "::notice::$DELETED branch(es) would be deleted."',
-                        "else",
-                        '  echo "::notice::Deleted $DELETED branch(es)."',
+                        "  exit 0",
+                        "fi",
+                        "",
+                        'echo "::notice::Deleted $DELETED branch(es)."',
+                        "",
+                        'if [ "$FAILED" -gt 0 ]; then',
+                        '  echo "::error::$FAILED branch(es) could not be deleted. See the warnings above."',
+                        "  exit 1",
                         "fi"
                     ].join("\n")
                 }


### PR DESCRIPTION
### What changed

Turns on the `Delete Merged Branches` workflow that #5653 added but deliberately left manual.

- The daily cron is back, at 03:30 UTC.
- `dryRun` now defaults to off, so pressing "Run workflow" deletes. Tick the box to get the old listing behavior.

The [dry run on 2026-09-05](https://github.com/webiny/webiny-js/actions/runs/33972396823) is what unblocks this. It walked all 323 branches and reported 185 deletable, with protected branches filtered out, `release/*` left to `deleteReleaseBranch`, open-PR branches skipped, branches pushed to after their merge skipped, and a branch merged 2 days earlier held back by the age check.

### Two changes for going live

Both only matter once the job actually deletes, and neither was worth adding while it was dry-run only.

**A failed delete no longer kills the run.** With `set -e`, one bad `gh api` call would abort partway through the backlog and leave the rest for tomorrow. Failures are now counted and logged as warnings naming the branch, and the job fails at the end if there were any.

**Deletes are paced one per second.** GitHub's secondary rate limit on writes is around 80 a minute. 185 deletes in a burst would trip it and fail somewhere in the middle. At one per second the first run takes about three minutes and stays well under. The dry-run path skips the sleep, so listing stays fast.

### First run

Expect roughly 185 deletions, since the backlog goes back to May 2025. After that it should be a handful a day at most.

Nothing here changes which branches qualify. That logic is unchanged from #5653 and is what the dry run exercised.

### Changelog

**Title line:** Automatic cleanup of old merged branches

**Body:** Branches whose pull request was merged over a week ago are now deleted automatically, once a day. This is a repository maintenance change with no effect on Webiny itself.

### Squash Merge Commit

```
ci: let the branch cleanup run on its own (#5658)
ci: enable the daily merged-branch cleanup schedule (#5658)
```
