### PR TITLE
docs(ai-context): add the provider rules learned from retiring RequestContextInitializer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,25 @@ Code-style rules live in `ai-context/code-style/`, one rule per file (ESLint-sty
 - When building a single package, use `yarn build -p <package-name> --safe-replace`, e.g., `yarn build -p @webiny/api-core --safe-replace`. We use "--safe-replace" in order to not have our active bundling watch process break.
 - To build all packages, simply run `yarn build`.
 - To build all packages without caching, use `yarn build --no-cache `.
+- `generate-webiny-package` emits unformatted output. Run `npx oxfmt packages/<new-package>` right
+  after it, or the commit carries hundreds of lines of unrelated reflow.
+- `yarn format` / `yarn lint` can silently no-op (`command not found: oxfmt`). Prefer `npx oxfmt` and
+  `npx oxlint`, and check with repo-wide `yarn format:check` — oxfmt formats markdown too, so a
+  packages-only run leaves `*.md` failing CI.
 
 ## Testing
 
 - To test a package, use `yarn test packages/<package-name>`, e.g., `yarn test packages/api-core`
+- Storage-backed suites need a storage flag or they **silently skip**. Without it the run reports
+  something like `(920 tests | 920 skipped)` and still exits 0, which reads as a pass. Use
+  `WEBINY_STORAGE=sql yarn test packages/<package-name>` (sqlite-backed).
+- CI selects test jobs by **changed package**, so a PR touching only `api-aco` never runs the
+  `api-headless-cms` suite. "CI will catch it" is false for cross-package behaviour changes —
+  comment `/vitest` on the PR to run the full matrix.
+- A unit test that registers its own subject can't prove the production wiring registers it. When
+  adding a transport, route, or event handler, assert it from the composition root as well; two
+  inbound transports have shipped unwired (WebSockets push, EventBridge Scheduler) with green
+  per-transport tests.
 
 ## Commits
 

--- a/ai-context/code-style/README.md
+++ b/ai-context/code-style/README.md
@@ -4,23 +4,26 @@ One rule per file. Each file states a single convention in `Do this / don't do t
 
 Read every rule in this folder before writing or editing code.
 
-| Rule                                                                                         | Summary                                                                     |
-| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [comments.md](./comments.md)                                                                 | `//` single-line, `/* */` multi-line, end with a period.                    |
-| [es-modules.md](./es-modules.md)                                                             | Use `import`/`export`, not CommonJS `require`.                              |
-| [one-import-per-line.md](./one-import-per-line.md)                                           | Only one named import per line.                                             |
-| [one-class-per-file.md](./one-class-per-file.md)                                             | One file MUST contain only one class.                                       |
-| [no-backwards-compat.md](./no-backwards-compat.md)                                           | Refactors ignore backwards compatibility unless the prompt says otherwise.  |
-| [no-console-in-backend.md](./no-console-in-backend.md)                                       | No `console.*` in `api-*` code; use the DI `Logger`.                        |
-| [no-inline-class-in-create-implementation.md](./no-inline-class-in-create-implementation.md) | Declare implementation classes separately with an `implements` clause.      |
-| [compose-css-class-names.md](./compose-css-class-names.md)                                   | Compose class names with a `cn` helper, never `+` or template literals.     |
-| [no-inline-conditional-spreads.md](./no-inline-conditional-spreads.md)                       | Build objects with `if` statements, not inline conditional spreads/casts.   |
-| [no-nested-call-arguments.md](./no-nested-call-arguments.md)                                 | Name each step; don't nest calls as arguments to other calls.               |
-| [one-public-function-per-file.md](./one-public-function-per-file.md)                         | One exported function per file; composition steps always get their own.     |
-| [prefer-type-annotation-over-cast.md](./prefer-type-annotation-over-cast.md)                 | Annotate the variable; never add parens just to cast an expression.         |
-| [no-container-as-service-locator.md](./no-container-as-service-locator.md)                   | Declare dependencies; don't inject a Container and resolve inside methods.  |
-| [no-stateless-private-methods.md](./no-stateless-private-methods.md)                         | A private method that never reads `this` becomes a module-level function.   |
-| [presenter-owns-component-state.md](./presenter-owns-component-state.md)                     | Non-trivial component state goes in a presenter, reached via `useFeature`.  |
-| [no-multiline-ternaries.md](./no-multiline-ternaries.md)                                     | Ternaries stay on one line; wrapping or nested ones become `if` statements. |
+| Rule                                                                                                   | Summary                                                                                |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [comments.md](./comments.md)                                                                           | `//` single-line, `/* */` multi-line, end with a period.                               |
+| [es-modules.md](./es-modules.md)                                                                       | Use `import`/`export`, not CommonJS `require`.                                         |
+| [one-import-per-line.md](./one-import-per-line.md)                                                     | Only one named import per line.                                                        |
+| [one-class-per-file.md](./one-class-per-file.md)                                                       | One file MUST contain only one class.                                                  |
+| [no-backwards-compat.md](./no-backwards-compat.md)                                                     | Refactors ignore backwards compatibility unless the prompt says otherwise.             |
+| [no-console-in-backend.md](./no-console-in-backend.md)                                                 | No `console.*` in `api-*` code; use the DI `Logger`.                                   |
+| [no-inline-class-in-create-implementation.md](./no-inline-class-in-create-implementation.md)           | Declare implementation classes separately with an `implements` clause.                 |
+| [compose-css-class-names.md](./compose-css-class-names.md)                                             | Compose class names with a `cn` helper, never `+` or template literals.                |
+| [no-inline-conditional-spreads.md](./no-inline-conditional-spreads.md)                                 | Build objects with `if` statements, not inline conditional spreads/casts.              |
+| [no-nested-call-arguments.md](./no-nested-call-arguments.md)                                           | Name each step; don't nest calls as arguments to other calls.                          |
+| [one-public-function-per-file.md](./one-public-function-per-file.md)                                   | One exported function per file; composition steps always get their own.                |
+| [prefer-type-annotation-over-cast.md](./prefer-type-annotation-over-cast.md)                           | Annotate the variable; never add parens just to cast an expression.                    |
+| [no-container-as-service-locator.md](./no-container-as-service-locator.md)                             | Declare dependencies; don't inject a Container and resolve inside methods.             |
+| [no-stateless-private-methods.md](./no-stateless-private-methods.md)                                   | A private method that never reads `this` becomes a module-level function.              |
+| [presenter-owns-component-state.md](./presenter-owns-component-state.md)                               | Non-trivial component state goes in a presenter, reached via `useFeature`.             |
+| [no-multiline-ternaries.md](./no-multiline-ternaries.md)                                               | Ternaries stay on one line; wrapping or nested ones become `if` statements.            |
+| [prefer-provider-over-resolved-value.md](./prefer-provider-over-resolved-value.md)                     | Inject a provider with `get()`; never an abstraction holding another's result.         |
+| [check-the-layer-below-before-caching.md](./check-the-layer-below-before-caching.md)                   | Check whether the layer below already caches; memoizing providers go per request.      |
+| [without-authorization-only-for-private-models.md](./without-authorization-only-for-private-models.md) | `withoutAuthorization` is a no-op on private models; keep it where reads are filtered. |
 
 When adding a new code-style rule, create a new `*.md` file here (one rule per file) and add it to the table above.

--- a/ai-context/code-style/check-the-layer-below-before-caching.md
+++ b/ai-context/code-style/check-the-layer-below-before-caching.md
@@ -1,0 +1,56 @@
+# Check The Layer Below Before Caching
+
+Before adding a cache to a provider or lazy service, look at what it calls. If that layer already
+caches, your cache is dead weight that adds a second thing to invalidate. If it doesn't, memoize.
+
+Answer it per class. The same refactor produced both answers several times over.
+
+```ts
+// Good — stateless, because the layer below caches.
+// GetModelUseCase goes through ModelsFetcher -> ModelCache, a per-request memory cache, so a
+// second get() is already cheap.
+class FileModelProviderImpl implements FileModelProvider.Interface {
+  constructor(private getModel: GetModelUseCase.Interface) {}
+
+  async get(): Promise<CmsModel> {
+    const result = await this.getModel.execute(FILE_MODEL_ID);
+    if (result.isFail()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+}
+```
+
+```ts
+// Good — memoized, because nothing below holds the imported module.
+class LazySharpTransformImpl implements AssetTransform.Interface {
+  private sharp: SharpModule | undefined;
+
+  private async getSharp(): Promise<SharpModule> {
+    if (!this.sharp) {
+      this.sharp = await import("sharp");
+    }
+    return this.sharp;
+  }
+}
+```
+
+Worked examples from the provider migration:
+
+| Provider                                  | Layer below                                    | Cache?    |
+| ----------------------------------------- | ---------------------------------------------- | --------- |
+| File / Folder / Workflow / Scheduler / WB | `ModelsFetcher` → per-request `ModelCache`     | stateless |
+| `LazySchedulerService`                    | `ServiceDiscovery.load()`, process-wide static | stateless |
+| `DeleteModelOperations`                   | nothing caches the key-value reads             | memoize   |
+| `LazySharpTransform`                      | nothing holds the imported module              | memoize   |
+
+## A memoizing provider must be registered per request
+
+Register it on the request container, never at root. A root singleton is shared by every child
+container, so a cached value leaks across tenants. This is not theoretical — it was caught by a
+failing test during the migration.
+
+Same trap in the other direction for anything that captures a container: a service registered at
+root captures the root container and sees none of the per-request registrations, so a
+container-capturing `EventPublisher` registered at root resolves zero per-request handlers.

--- a/ai-context/code-style/no-container-as-service-locator.md
+++ b/ai-context/code-style/no-container-as-service-locator.md
@@ -44,11 +44,12 @@ export const MyRoute = HttpRoute.createImplementation({
 `container.resolve(...)` IS correct in a `createFeature` `resolve()` hook — that hook exists to hand
 resolved instances to callers. This rule is about implementation classes.
 
-`HttpRouter` itself takes the container, and that is deliberate: it resolves routes inside `route()`
-so route construction happens AFTER the request-context initializers have run. Injecting the routes
-instead constructed every one of them before any initializer, so a route reaching a request-time
-token (`FileModel`, a per-request `CmsModel`) threw "No registration found" on every request. Routes
-can declare their dependencies precisely because the router does this.
+`HttpRouter` itself takes the container, and that is now only about cost: it resolves routes inside
+`route()` so it doesn't construct all of them to match one path. The original reason was stronger —
+construction used to happen before the request-context initializers ran, so a route reaching a
+request-time token (`FileModel`, a per-request `CmsModel`) threw "No registration found" on every
+request. Those tokens are providers with real implementations now and the initializers are gone, so
+that hazard no longer exists.
 
 Some routes (`AssetDeliveryRoute`, `WebsiteBuilderRedirectsRoute`) still resolve lazily inside
 `handle()` as a leftover of that old constraint. They no longer need to — don't copy them.

--- a/ai-context/code-style/prefer-provider-over-resolved-value.md
+++ b/ai-context/code-style/prefer-provider-over-resolved-value.md
@@ -1,0 +1,76 @@
+# Prefer A Provider Over A Resolved Value
+
+Inject the thing that produces a value, not the value itself. When a class needs data that another
+class has to fetch, depend on a provider with an async `get()` and await it inside the method that
+needs it.
+
+Don't create an abstraction whose only job is to hold the _result_ of some other abstraction. It has
+a recognisable signature: `createAbstraction<T>("SomethingModel")` with **no implementation**,
+populated from elsewhere with `registerInstance`. Resolving it builds nothing; it just reads what
+some earlier step deposited. That is a scheduling dependency wearing a DI costume, and it forces a
+per-request hook to exist purely to do the depositing.
+
+```ts
+// Bad — an abstraction that only holds a value someone else must put there first.
+export const FileModel = createAbstraction<CmsModel>("FileModel");
+
+// ...somewhere else, in a hook that MUST run before anything resolves FileModel:
+const model = await getModel.execute(FILE_MODEL_ID);
+container.registerInstance(FileModel, model.value);
+```
+
+```ts
+// Bad — the consumer now depends on that hook having already run.
+class GetFileUseCaseImpl {
+  constructor(
+    private fileModel: FileModel.Interface,
+    private getEntryById: GetEntryByIdUseCase.Interface
+  ) {}
+
+  async execute(id: string) {
+    return this.getEntryById.execute(this.fileModel, `${id}#0001`);
+  }
+}
+```
+
+```ts
+// Good — a real implementation that fetches on demand.
+class FileModelProviderImpl implements FileModelProvider.Interface {
+  constructor(private getModel: GetModelUseCase.Interface) {}
+
+  async get(): Promise<CmsModel> {
+    const result = await this.getModel.execute(FILE_MODEL_ID);
+    if (result.isFail()) {
+      throw result.error;
+    }
+    return result.value;
+  }
+}
+```
+
+```ts
+// Good — the consumer awaits it where it already had an async method.
+class GetFileUseCaseImpl {
+  constructor(
+    private fileModelProvider: FileModelProvider.Interface,
+    private getEntryById: GetEntryByIdUseCase.Interface
+  ) {}
+
+  async execute(id: string) {
+    const fileModel = await this.fileModelProvider.get();
+    return this.getEntryById.execute(fileModel, `${id}#0001`);
+  }
+}
+```
+
+The reason the bad shape keeps appearing is that constructors cannot await and DI resolution is
+synchronous (`resolve<T>(a): T`), so fetching a model up front looks impossible. Methods can await,
+and the consumer's methods are already async, so move the async work there.
+
+What you get: the dependency is visible in the constructor, resolution order stops mattering, and
+nothing needs a hook to fire at the right moment. Retiring `RequestContextInitializer` took no new
+DI machinery — every consumer switching to a provider was enough on its own.
+
+This also applies to picking an implementation based on async configuration. Rather than a hook that
+reads a manifest and then registers the right service, inject a lazy implementation that decides
+inside its own methods (see `LazySchedulerService`, `LazySharpTransform`).

--- a/ai-context/code-style/without-authorization-only-for-private-models.md
+++ b/ai-context/code-style/without-authorization-only-for-private-models.md
@@ -1,0 +1,36 @@
+# `withoutAuthorization` Only Where Authorization Actually Applies
+
+Don't wrap a private model's fetch in `IdentityContext.withoutAuthorization()`. It changes nothing
+and it reads as though something security-sensitive is happening.
+
+`PrivateModelBuilder` sets `authorization: false` on the model
+(`packages/api-headless-cms/src/features/modelBuilder/models/PrivateModelBuilder.ts`). `AccessControl`
+checks that flag in `modelAuthorizationDisabled()` and short-circuits access to `true` for every
+identity, so the wrapper cannot affect the outcome.
+
+```ts
+// Bad — the model is private, so this wrapper is a no-op.
+const result = await this.identityContext.withoutAuthorization(() => {
+  return this.getModel.execute(FILE_MODEL_ID);
+});
+```
+
+```ts
+// Good — private model, fetched directly.
+const result = await this.getModel.execute(FILE_MODEL_ID);
+```
+
+It IS load-bearing for anything permission-filtered. `ListModelsUseCase` returns a different set per
+identity, so dropping the wrapper there makes generated GraphQL schema vary by whoever triggered the
+build:
+
+```ts
+// Good — ListModels is permission-filtered, so this is required.
+const models = await this.identityContext.withoutAuthorization(() => {
+  return this.listModels.execute();
+});
+```
+
+Confirm the model is actually `.private()` before removing a wrapper. Removing one from a
+permission-filtered read is the one way this cleanup can silently weaken authorization, so treat
+"is this model private?" as a question to answer per call site, not per file.


### PR DESCRIPTION
The rules you asked me to write up once the provider work landed. #5654 is in, so these describe a finished state rather than a plan.

Each rule is a mistake this refactor actually made, not a general principle.

## New rules

**`prefer-provider-over-resolved-value.md`** — the headline. Never create an abstraction whose job is to hold the *result* of another abstraction. It has an exact signature: `createAbstraction<CmsModel>("XModel")` with no implementation, populated by `registerInstance` from somewhere else. Resolving it builds nothing, it just reads what an earlier step deposited, which is precisely what forces a per-request hook to exist.

Worth stating plainly because of how the design went: I spent a while designing a phase/lifecycle system to schedule those hooks correctly. The real problem was async values injected synchronously. Constructors can't await, methods can, and every consumer's methods were already async. Retiring `RequestContextInitializer` needed no new DI machinery at all.

**`check-the-layer-below-before-caching.md`** — applied five times during the migration, three different answers, so it's a per-class question rather than a habit. The worked examples are tabulated: the CMS model providers are stateless because `ModelsFetcher`/`ModelCache` already caches; `LazySchedulerService` is stateless because `ServiceDiscovery.load()` caches process-wide; `DeleteModelOperations` and `LazySharpTransform` memoize because nothing below them does. Includes the corollary that a memoizing provider must be registered per request, since a root singleton leaks across tenants — caught by a failing test, not theory.

**`without-authorization-only-for-private-models.md`** — `PrivateModelBuilder` sets `authorization: false`, and `AccessControl.modelAuthorizationDisabled()` short-circuits on that flag for every identity, so wrapping a private model's fetch achieves nothing. It IS load-bearing on permission-filtered reads like `ListModelsUseCase`, where dropping it would make generated schema vary by identity. This is the one place the cleanup could quietly weaken authorization, so the rule says to confirm `.private()` per call site.

## One correction

`no-container-as-service-locator.md` justified `HttpRouter` taking a container by the request-context initializers, which no longer exist. Those tokens are providers with real implementations now, so the correctness hazard is gone and what remains is cost — building all ~11 routes to match one path.

## AGENTS.md

Three things that cost real time this week:

- Storage-backed suites **skip silently** without `WEBINY_STORAGE` and still exit 0. `(920 tests | 920 skipped)` reads like a pass. This led me to wrongly claim a suite was unrunnable locally.
- CI picks test jobs by **changed package**, so "CI will catch it" is false for cross-package behaviour changes. `/vitest` runs the full matrix.
- A unit test that registers its own subject can't prove production wires it. Two inbound transports have now shipped unwired with green per-transport tests (WebSockets push, then EventBridge Scheduler in #5657).

Docs only, no code.
