### PR TITLE
fix(api-headless-cms-bulk-actions): stop the list task looping when a round makes no progress

### DIFF
--- a/packages/api-headless-cms-bulk-actions/__tests__/tasks/createTasksByModel.test.ts
+++ b/packages/api-headless-cms-bulk-actions/__tests__/tasks/createTasksByModel.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Guards termination of the bulk-action list loop.
+ *
+ * The loop is CREATE_SUBTASKS → PROCESS_SUBTASKS → CHECK_MORE_SUBTASKS → CREATE_SUBTASKS, and every
+ * CHECK_MORE_SUBTASKS re-lists from the start. Progress is therefore whatever the action's
+ * `loadData` filter excludes, and nothing else. Two ways that stalls, both seen in production:
+ *
+ *  - `processData` fails permanently (a published entry is locked), so the filter keeps matching
+ *    and the same batch is dispatched every round until maxIterations (500) — hours of Lambda
+ *    invocations at one 120s wait per round, with the entry stuck and nothing reported.
+ *  - the subtasks can't be dispatched at all, which used to be logged and dropped, leaving the
+ *    parent waiting on children that were never created.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { CreateTasksByModel } from "~/features/EntriesBulkAction/internals/CreateTasksByModel.js";
+import { BulkActionOperationByModelAction } from "~/types.js";
+
+const model = { modelId: "product" } as any;
+
+const createDeps = (overrides: { triggerFails?: boolean } = {}) => {
+    const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), log: vi.fn(), debug: vi.fn() };
+
+    const triggerTask = {
+        execute: vi.fn(async () => {
+            if (overrides.triggerFails) {
+                throw new Error("Task dispatch rejected");
+            }
+            return { id: "child" } as any;
+        })
+    };
+
+    return {
+        logger,
+        triggerTask,
+        getModel: { execute: vi.fn(async () => ({ isFail: () => false, value: model })) }
+    };
+};
+
+/** Always returns the same two entries — a filter that never excludes what was processed. */
+const createStalledAction = () => ({
+    name: "applyDiscount",
+    loadData: vi.fn(async () => ({
+        entries: [{ id: "entry-1#0001" }, { id: "entry-2#0001" }],
+        meta: { totalCount: 2, hasMoreItems: false, cursor: null }
+    })),
+    processData: vi.fn()
+});
+
+const createController = () => ({
+    runtime: { isAborted: () => false, isCloseToTimeout: () => false },
+    state: { getTask: () => ({ id: "parent-task" }) },
+    response: {
+        error: vi.fn((message: string) => ({ status: "error", message })),
+        aborted: vi.fn(() => ({ status: "aborted" })),
+        continue: vi.fn((input: any) => ({ status: "continue", input }))
+    }
+});
+
+const baseInput = { actionName: "applyDiscount", modelId: "product" } as any;
+
+const run = (action: any, deps: ReturnType<typeof createDeps>, input: any) => {
+    const controller = createController();
+    const createTasks = new CreateTasksByModel(
+        deps.getModel as any,
+        deps.triggerTask as any,
+        action as any,
+        "hcmsBulkProcessEntries",
+        100,
+        deps.logger as any
+    );
+    return createTasks
+        .execute({ input, controller } as any)
+        .then(result => ({ result, controller }));
+};
+
+describe("CreateTasksByModel", () => {
+    it("dispatches subtasks and reports the batch it dispatched", async () => {
+        const deps = createDeps();
+        const { result } = await run(createStalledAction(), deps, baseInput);
+
+        expect(deps.triggerTask.execute).toHaveBeenCalledTimes(1);
+        expect(result).toMatchObject({
+            status: "continue",
+            input: { action: BulkActionOperationByModelAction.PROCESS_SUBTASKS }
+        });
+        // The fingerprint is what the next round compares against.
+        expect((result as any).input.dispatchedSignature).toBeTruthy();
+    });
+
+    it("ends the task when a round comes back with the same entries", async () => {
+        const deps = createDeps();
+
+        // Round one: dispatch, and keep the signature the engine would carry forward.
+        const first = await run(createStalledAction(), deps, baseInput);
+        const dispatchedSignature = (first.result as any).input.dispatchedSignature;
+
+        // Round two: same entries returned, because processData never excluded them.
+        const second = await run(createStalledAction(), deps, {
+            ...baseInput,
+            dispatchedSignature
+        });
+
+        expect(second.result).toMatchObject({ status: "error" });
+        expect((second.result as any).message).toMatch(/not converging/);
+        // Crucially, it did NOT dispatch the same batch a second time.
+        expect(deps.triggerTask.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("ends the task when no subtask could be dispatched", async () => {
+        const deps = createDeps({ triggerFails: true });
+        const { result } = await run(createStalledAction(), deps, baseInput);
+
+        expect(result).toMatchObject({ status: "error" });
+        expect((result as any).message).toMatch(/could not dispatch/);
+    });
+
+    it("logs each dispatch failure instead of dropping it", async () => {
+        const deps = createDeps({ triggerFails: true });
+        await run(createStalledAction(), deps, baseInput);
+
+        expect(deps.logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ actionName: "applyDiscount", modelId: "product" }),
+            expect.stringContaining("Failed to trigger")
+        );
+    });
+});

--- a/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/createBulkActionTasks.ts
@@ -9,6 +9,7 @@ import type {
 } from "~/types.js";
 import { BulkActionOperationByModelAction } from "~/types.js";
 import { EntriesBulkAction, EntriesBulkActionConfig } from "./abstractions.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import { BulkActionName } from "~/domain/BulkActionName.js";
 import { ChildTasksCleanup } from "./internals/ChildTasksCleanup.js";
 import { ProcessTask } from "./internals/ProcessTask.js";
@@ -45,7 +46,8 @@ class BulkActionListTask implements TaskDefinition.Interface<
         private readonly listTasks: ListTasksUseCase.Interface,
         private readonly triggerTask: TriggerTaskUseCase.Interface,
         private readonly tasksCrud: TasksCrud.Interface,
-        private readonly bulkActionsConfig: EntriesBulkActionConfig.Interface
+        private readonly bulkActionsConfig: EntriesBulkActionConfig.Interface,
+        private readonly logger: Logger.Interface
     ) {}
 
     async run({
@@ -82,7 +84,8 @@ class BulkActionListTask implements TaskDefinition.Interface<
                         this.triggerTask,
                         bulkAction,
                         BULK_ACTION_PROCESS_TASK_ID,
-                        batchSize
+                        batchSize,
+                        this.logger
                     );
                     return await createTasks.execute({ input, controller });
                 }
@@ -122,7 +125,7 @@ class BulkActionListTask implements TaskDefinition.Interface<
         try {
             await childTasksCleanup.execute({ tasksCrud: this.tasksCrud, task });
         } catch (ex) {
-            console.error(`Error while cleaning bulk action list child tasks.`, ex);
+            this.logger.error({ error: ex, task: task.id }, "Failed to clean up child tasks.");
         }
     }
 }
@@ -173,7 +176,8 @@ export const BulkActionListTaskDefinition = TaskDefinition.createImplementation(
         ListTasksUseCase,
         TriggerTaskUseCase,
         TasksCrud,
-        EntriesBulkActionConfig
+        EntriesBulkActionConfig,
+        Logger
     ]
 });
 

--- a/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/internals/CreateTasksByModel.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/internals/CreateTasksByModel.ts
@@ -5,6 +5,7 @@ import { BulkActionOperationByModelAction } from "~/types.js";
 import { EntriesBulkAction } from "~/features/EntriesBulkAction/abstractions.js";
 import type { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
 import type { TriggerTaskUseCase } from "@webiny/background-tasks/api";
+import type { Logger } from "@webiny/api-core/features/logger/index.js";
 
 const MAX_TASK_LIST_LENGTH = 10;
 
@@ -17,19 +18,24 @@ export class CreateTasksByModel {
     private readonly bulkAction: EntriesBulkAction.Interface;
     private readonly triggerTask: TriggerTaskUseCase.Interface;
     private readonly getModel: GetModelUseCase.Interface;
+    private readonly logger: Logger.Interface;
+    /** Every entry id dispatched during THIS run, used to detect a round that made no progress. */
+    private readonly dispatched: string[] = [];
 
     constructor(
         getModel: GetModelUseCase.Interface,
         triggerTask: TriggerTaskUseCase.Interface,
         bulkAction: EntriesBulkAction.Interface,
         taskDefinition: string,
-        batchSize: number
+        batchSize: number,
+        logger: Logger.Interface
     ) {
         this.getModel = getModel;
         this.taskCache = new TaskCache(taskDefinition);
         this.batchSize = batchSize;
         this.bulkAction = bulkAction;
         this.triggerTask = triggerTask;
+        this.logger = logger;
     }
 
     async execute(params: IBulkActionOperationByModelTaskParams) {
@@ -55,11 +61,7 @@ export class CreateTasksByModel {
                 if (controller.runtime.isAborted()) {
                     return controller.response.aborted();
                 } else if (controller.runtime.isCloseToTimeout()) {
-                    await this.taskCache.triggerTask(this.triggerTask, controller.state.getTask());
-                    return controller.response.continue({
-                        ...input,
-                        action: BulkActionOperationByModelAction.PROCESS_SUBTASKS
-                    });
+                    return await this.dispatchSubtasks(params);
                 }
 
                 // List entries from the HCMS based on the provided query
@@ -75,20 +77,12 @@ export class CreateTasksByModel {
 
                 // Continue processing if we are reached the task list length limit
                 if (this.taskCache.getTasksLength() === MAX_TASK_LIST_LENGTH) {
-                    await this.taskCache.triggerTask(this.triggerTask, controller.state.getTask());
-                    return controller.response.continue({
-                        ...input,
-                        action: BulkActionOperationByModelAction.PROCESS_SUBTASKS
-                    });
+                    return await this.dispatchSubtasks(params);
                 }
 
                 // Continue processing if no entries are returned in the current batch
                 if (entries.length === 0) {
-                    await this.taskCache.triggerTask(this.triggerTask, controller.state.getTask());
-                    return controller.response.continue({
-                        ...input,
-                        action: BulkActionOperationByModelAction.PROCESS_SUBTASKS
-                    });
+                    return await this.dispatchSubtasks(params);
                 }
 
                 // Extract entry IDs
@@ -98,6 +92,7 @@ export class CreateTasksByModel {
                 }
 
                 if (ids.length > 0) {
+                    this.dispatched.push(...ids);
                     this.taskCache.cacheTask({
                         actionName: input.actionName,
                         modelId: input.modelId,
@@ -109,12 +104,7 @@ export class CreateTasksByModel {
 
                 // Continue processing if there are no more entries or pagination is complete
                 if (!meta.hasMoreItems || !meta.cursor) {
-                    await this.taskCache.triggerTask(this.triggerTask, controller.state.getTask());
-
-                    return controller.response.continue({
-                        ...input,
-                        action: BulkActionOperationByModelAction.PROCESS_SUBTASKS
-                    });
+                    return await this.dispatchSubtasks(params);
                 }
 
                 listEntriesParams.after = meta.cursor;
@@ -122,5 +112,78 @@ export class CreateTasksByModel {
         } catch (ex) {
             return controller.response.error(ex.message ?? `Error while creating task.`);
         }
+    }
+
+    /**
+     * Triggers the cached subtasks and hands control to PROCESS_SUBTASKS.
+     *
+     * Two ways this loop fails to terminate, both guarded here:
+     *
+     * 1. Nothing could be dispatched. The parent advances to PROCESS_SUBTASKS regardless, finds no
+     *    running children, and comes straight back to CHECK_MORE_SUBTASKS with the same entries.
+     * 2. A round completed without changing the result set. The engine re-lists from the start on
+     *    every CHECK_MORE_SUBTASKS and relies on the action's `loadData` filter to exclude what it
+     *    has already handled. When `processData` fails permanently — a locked (published) entry is
+     *    the common case — the filter keeps matching and the same batch is dispatched forever, at
+     *    one 120s wait per round until maxIterations (500) is reached hours later.
+     *
+     * Both end the task with a message naming the cause, instead of spinning.
+     */
+    private async dispatchSubtasks(params: IBulkActionOperationByModelTaskParams) {
+        const { input, controller } = params;
+        const signature = this.dispatchedSignature();
+
+        if (signature && signature === input.dispatchedSignature) {
+            return controller.response.error(
+                `Bulk action "${input.actionName}" is not converging: the ${this.dispatched.length} ` +
+                    `entrie(s) dispatched in the previous round are still returned by loadData. ` +
+                    `Either its filter does not exclude processed entries, or processData fails for ` +
+                    `them (a published entry is locked and cannot be updated).`
+            );
+        }
+
+        const pending = this.taskCache.getTasksLength();
+        const { triggered, failures } = await this.taskCache.triggerTask(
+            this.triggerTask,
+            controller.state.getTask()
+        );
+
+        for (const failure of failures) {
+            this.logger.error(
+                { error: failure, actionName: input.actionName, modelId: input.modelId },
+                "Failed to trigger a bulk-action subtask."
+            );
+        }
+
+        if (pending > 0 && triggered === 0) {
+            return controller.response.error(
+                `Bulk action "${input.actionName}" could not dispatch any of its ${pending} ` +
+                    `subtask(s): ${failures[0]?.message ?? "unknown error"}`
+            );
+        }
+
+        return controller.response.continue({
+            ...input,
+            action: BulkActionOperationByModelAction.PROCESS_SUBTASKS,
+            dispatchedSignature: signature
+        });
+    }
+
+    /**
+     * A stable, compact fingerprint of everything dispatched so far. Compact because it travels in
+     * the task input across iterations, so the raw id list would grow without bound.
+     */
+    private dispatchedSignature(): string | undefined {
+        if (this.dispatched.length === 0) {
+            return undefined;
+        }
+
+        const joined = [...this.dispatched].sort().join(",");
+        let hash = 0;
+        for (let i = 0; i < joined.length; i++) {
+            hash = (Math.imul(31, hash) + joined.charCodeAt(i)) | 0;
+        }
+
+        return `${this.dispatched.length}:${(hash >>> 0).toString(36)}`;
     }
 }

--- a/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/internals/TaskCache.ts
+++ b/packages/api-headless-cms-bulk-actions/src/features/EntriesBulkAction/internals/TaskCache.ts
@@ -1,6 +1,11 @@
 import { TaskDefinition } from "@webiny/api-core/features/task/TaskDefinition/index.js";
 import type { TriggerTaskUseCase } from "@webiny/background-tasks/api";
 
+export interface ITriggerTasksResult {
+    triggered: number;
+    failures: Error[];
+}
+
 /**
  * TaskCache class for managing and triggering cached tasks.
  * @template TTask - Task input data.
@@ -22,15 +27,25 @@ export class TaskCache<TTask extends TaskDefinition.TaskInput = TaskDefinition.T
     }
 
     /**
-     * Triggers all cached tasks using the provided TriggerTaskUseCase and parent task.
+     * Triggers all cached tasks and REPORTS what happened, rather than deciding for the caller.
+     *
+     * A trigger failure used to be logged and dropped here, which left the parent waiting on
+     * subtasks that were never created — it advances to PROCESS_SUBTASKS either way, finds no
+     * running children, and loops. Returning the failures lets the caller end the task when
+     * nothing could be dispatched.
+     *
      * @param {TriggerTaskUseCase.Interface} triggerTask - The use case used to trigger the tasks.
      * @param {ITask} parent - The parent task to associate with the triggered tasks.
      */
-    async triggerTask(triggerTask: TriggerTaskUseCase.Interface, parent: TaskDefinition.Task) {
+    async triggerTask(
+        triggerTask: TriggerTaskUseCase.Interface,
+        parent: TaskDefinition.Task
+    ): Promise<ITriggerTasksResult> {
         const tasks = this.getTasks();
+        const result: ITriggerTasksResult = { triggered: 0, failures: [] };
 
         if (tasks.length === 0) {
-            return;
+            return result;
         }
 
         for (const task of tasks) {
@@ -40,13 +55,16 @@ export class TaskCache<TTask extends TaskDefinition.TaskInput = TaskDefinition.T
                     parent,
                     input: task
                 });
-            } catch (error) {
-                console.error(`Error triggering task.`, error);
+                result.triggered++;
+            } catch (ex) {
+                result.failures.push(ex instanceof Error ? ex : new Error(String(ex)));
             }
         }
 
         // Clear the cache after processing
         this.clearTasks();
+
+        return result;
     }
 
     /**

--- a/packages/api-headless-cms-bulk-actions/src/types.ts
+++ b/packages/api-headless-cms-bulk-actions/src/types.ts
@@ -49,6 +49,11 @@ export interface IBulkActionOperationByModelInput {
     after?: string | null;
     data?: Record<string, any>;
     action?: BulkActionOperationByModelAction;
+    /**
+     * Fingerprint of the entry ids dispatched in the previous round. Carried across iterations so
+     * CHECK_MORE_SUBTASKS can tell "there is more work" from "the same work came back untouched".
+     */
+    dispatchedSignature?: string;
 }
 
 export interface IBulkActionOperationByModelOutput {


### PR DESCRIPTION
The stuck bulk-action tasks from yesterday's testing. A bulk action whose entries can't be processed spins its Lambda indefinitely.

## Correcting what I told you

I said `TaskCache` swallowing trigger errors was what caused the infinite loop. That was wrong, and tracing the state machine properly gave a different answer. The subtasks were created fine — they ran and failed on locked entries. The loop is something else, and the swallowing is a real but separate bug.

## The actual cause

The list task cycles `CREATE_SUBTASKS → PROCESS_SUBTASKS → CHECK_MORE_SUBTASKS → CREATE_SUBTASKS`, and every `CHECK_MORE_SUBTASKS` re-lists **from the start** (the pagination cursor isn't carried across a `continue`). So the only thing that marks an entry as done is whatever the action's own `loadData` filter excludes.

When `processData` fails permanently, the filter keeps matching and the same batch is dispatched every round, forever. ApplyDiscount hits this on any published entry: a published revision is `locked` and `UpdateEntryUseCase` refuses it, so `onSale` never flips, so `values.onSale_not` keeps returning it.

Observed on the dev instance: iteration 4 → 9 → 12 → 18, one 120s wait per round, prices unchanged, nothing surfaced. `maxIterations = 500` is the only backstop, so it would have burned invocations for hours before failing with a message that explains nothing.

## The fix

Each round carries a compact fingerprint of the entry ids it dispatched. If a round completes and the next listing returns that same set, the task ends with a message naming both possible causes:

> Bulk action "applyDiscount" is not converging: the 2 entrie(s) dispatched in the previous round are still returned by loadData. Either its filter does not exclude processed entries, or processData fails for them (a published entry is locked and cannot be updated).

Fingerprint rather than the raw id list because it travels in the task input across iterations and would otherwise grow without bound.

## And the swallowing, separately

`TaskCache.triggerTask` caught every failure into `console.error` and cleared its cache anyway, so a dispatch failure left the parent waiting on children that were never created — the same stall by a different route. It now returns what it triggered and what failed. The caller ends the task when nothing could be dispatched, and logs each failure through the DI `Logger`. The `console.error` also broke our own `no-console-in-backend` rule, as did the one in `cleanup()`.

The four duplicated trigger-then-continue blocks collapse into one method, since all four needed both guards.

## Verified

Four new unit tests on `CreateTasksByModel`, which takes plain constructor args so it needs no DI harness. I disabled each guard in turn to confirm the tests actually fail without them.

`api-headless-cms-bulk-actions` 7/7 (3 pre-existing + 4 new), `api-aco` 74 passed. Three bulk-action packages build. `adio`, `format:check`, `oxlint`, `sync-dependencies` clean.

Not reproduced end to end on a deployed instance. The unit tests encode the exact sequence observed in the Step Functions execution history, but confirming it needs a deploy plus a deliberately failing action.

## Not in scope

The underlying design still makes per-entry progress the action author's responsibility via their filter, which is a sharp edge — `ApplyDiscountBulkAction` carries a long comment explaining it, and getting it wrong is what produced this. A framework-level "don't re-dispatch what already failed" would be the real fix. This PR makes the failure loud and cheap instead of silent and expensive.
