### PR TITLE
refactor(api-headless-cms-tasks): declare the delete-model dependencies

### DIFF
--- a/packages/api-headless-cms-tasks/package.json
+++ b/packages/api-headless-cms-tasks/package.json
@@ -22,7 +22,6 @@
     "@webiny/api-headless-cms": "0.0.0",
     "@webiny/api-headless-cms-bulk-actions": "0.0.0",
     "@webiny/background-tasks": "0.0.0",
-    "@webiny/di": "^1.0.2",
     "@webiny/error": "0.0.0",
     "@webiny/feature": "0.0.0",
     "@webiny/utils": "0.0.0",

--- a/packages/api-headless-cms-tasks/src/HcmsTasksFeature.ts
+++ b/packages/api-headless-cms-tasks/src/HcmsTasksFeature.ts
@@ -13,9 +13,6 @@ export const HcmsTasksFeature = createFeature({
 
         DeleteModelTaskFeature.register(container);
 
-        // DisableModelFeature resolves DeleteModelOperations eagerly (it binds
-        // `isModelBeingDeleted` into a decorator), so the operations must be registered first.
-        // That ordering is local and explicit here; it used to be spread across two initializers.
         container.register(DeleteModelOperationsImplementation);
         DisableModelFeature.register(container);
 

--- a/packages/api-headless-cms-tasks/src/features/DisableModel/BlockActionIfModelDisabled.ts
+++ b/packages/api-headless-cms-tasks/src/features/DisableModel/BlockActionIfModelDisabled.ts
@@ -1,15 +1,13 @@
 import { WebinyError } from "@webiny/error";
 import type { CmsModel } from "@webiny/api-headless-cms/types/index.js";
 import { BlockActionIfModelDisabled as Abstraction } from "./abstractions.js";
-import type { DeleteModelOperations } from "~/graphql/deleteModel/abstractions.js";
+import { DeleteModelOperations } from "~/graphql/deleteModel/abstractions.js";
 
-export class BlockActionIfModelDisabled implements Abstraction.Interface {
-    constructor(
-        private isModelBeingDeleted: DeleteModelOperations.Interface["isModelBeingDeleted"]
-    ) {}
+class BlockActionIfModelDisabledImpl implements Abstraction.Interface {
+    constructor(private readonly deleteModelOperations: DeleteModelOperations.Interface) {}
 
     async execute(model: CmsModel): Promise<void> {
-        const isBeingDeleted = await this.isModelBeingDeleted(model.modelId);
+        const isBeingDeleted = await this.deleteModelOperations.isModelBeingDeleted(model.modelId);
         if (!isBeingDeleted) {
             return;
         }
@@ -19,3 +17,17 @@ export class BlockActionIfModelDisabled implements Abstraction.Interface {
         );
     }
 }
+
+/**
+ * Takes `DeleteModelOperations` itself, not a pre-bound `isModelBeingDeleted`.
+ *
+ * Binding the method meant the feature had to `container.resolve(DeleteModelOperations)` while
+ * registering, which constructs it — and therefore everything it depends on — at register time.
+ * `HcmsTasksFeature` registers before `BackgroundTasksFeature`, so the moment the operations class
+ * declared its own task use cases that resolve threw "No registration found for
+ * Tasks/TriggerTaskUseCase". Depending on the abstraction defers construction to first use.
+ */
+export const BlockActionIfModelDisabledImplementation = Abstraction.createImplementation({
+    implementation: BlockActionIfModelDisabledImpl,
+    dependencies: [DeleteModelOperations]
+});

--- a/packages/api-headless-cms-tasks/src/features/DisableModel/feature.ts
+++ b/packages/api-headless-cms-tasks/src/features/DisableModel/feature.ts
@@ -1,7 +1,5 @@
 import { createFeature } from "@webiny/feature/api";
-import { BlockActionIfModelDisabled as Abstraction } from "./abstractions.js";
-import { BlockActionIfModelDisabled } from "./BlockActionIfModelDisabled.js";
-import { DeleteModelOperations } from "~/graphql/deleteModel/abstractions.js";
+import { BlockActionIfModelDisabledImplementation } from "./BlockActionIfModelDisabled.js";
 import { BlockModelActionOnEntryBeforeCreate } from "./handlers/BlockModelActionOnEntryBeforeCreate.js";
 import { BlockModelActionOnEntryRevisionBeforeCreate } from "./handlers/BlockModelActionOnEntryRevisionBeforeCreate.js";
 import { BlockModelActionOnEntryBeforeUpdate } from "./handlers/BlockModelActionOnEntryBeforeUpdate.js";
@@ -16,12 +14,7 @@ import { BlockModelActionOnModelBeforeCreateFrom } from "./handlers/BlockModelAc
 export const DisableModelFeature = createFeature({
     name: "DisableModel",
     register(container) {
-        const ops = container.resolve(DeleteModelOperations);
-
-        container.registerInstance(
-            Abstraction,
-            new BlockActionIfModelDisabled(ops.isModelBeingDeleted.bind(ops))
-        );
+        container.register(BlockActionIfModelDisabledImplementation);
 
         container.register(BlockModelActionOnEntryBeforeCreate);
         container.register(BlockModelActionOnEntryRevisionBeforeCreate);

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/DeleteModelOperationsImpl.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/DeleteModelOperationsImpl.ts
@@ -1,10 +1,11 @@
-import type { Container } from "@webiny/di";
-import { RequestContainer } from "@webiny/event-handler-core";
 import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/abstractions.js";
 import { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
+import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/abstractions.js";
 import { createCacheKey, createMemoryCache } from "@webiny/api-headless-cms/utils/index.js";
+import { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
+import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
+import { AbortTaskUseCase, GetTaskUseCase, TriggerTaskUseCase } from "@webiny/background-tasks/api";
 import type { IStoreValue } from "~/features/DeleteModelTask/types.js";
-import type { HcmsTasksContext } from "~/types.js";
 import { createDeleteModelStore } from "~/helpers/store.js";
 import { fullyDeleteModel } from "~/graphql/deleteModel/fullyDeleteModel.js";
 import { cancelDeleteModel } from "~/graphql/deleteModel/cancelDeleteModel.js";
@@ -22,21 +23,19 @@ import { DeleteModelOperations } from "~/graphql/deleteModel/abstractions.js";
  * The in-memory cache is KEPT. Unlike the CMS model providers — where `ModelsFetcher`/`ModelCache`
  * already cached a layer down — nothing caches these key-value reads, so without it every
  * `isModelBeingDeleted()` check would hit the store. It is cleared on mutation, as before.
- *
- * `RequestContainer` is injected only to hand a `{ container }` context to `fullyDeleteModel`,
- * `cancelDeleteModel` and `getDeleteModelProgress`, which service-locate their own dependencies
- * (`GetModelUseCase`, `AccessControl`, `TriggerTaskUseCase`, `GetTaskUseCase`, `AbortTaskUseCase`,
- * `IdentityContext`, `GlobalKeyValueStore`). Converting those three helpers to declare their
- * dependencies is a separate change — it touches ~271 lines across three files and is orthogonal to
- * retiring the initializer.
  */
 class DeleteModelOperationsImpl implements DeleteModelOperations.Interface {
     private readonly cache = createMemoryCache<Promise<IStoreValue[]>>();
 
     constructor(
-        private readonly container: Container,
         private readonly tenantContext: TenantContext.Interface,
-        private readonly keyValueStore: GlobalKeyValueStore.Interface
+        private readonly keyValueStore: GlobalKeyValueStore.Interface,
+        private readonly identityContext: IdentityContext.Interface,
+        private readonly getModel: GetModelUseCase.Interface,
+        private readonly accessControl: AccessControl.Interface,
+        private readonly triggerTask: TriggerTaskUseCase.Interface,
+        private readonly getTask: GetTaskUseCase.Interface,
+        private readonly abortTask: AbortTaskUseCase.Interface
     ) {}
 
     async listModelsBeingDeleted(): Promise<IStoreValue[]> {
@@ -50,19 +49,39 @@ class DeleteModelOperationsImpl implements DeleteModelOperations.Interface {
     }
 
     async fullyDeleteModel(modelId: string) {
-        const result = await fullyDeleteModel({ context: this.context(), modelId });
+        const result = await fullyDeleteModel({
+            getModel: this.getModel,
+            accessControl: this.accessControl,
+            keyValueStore: this.keyValueStore,
+            triggerTask: this.triggerTask,
+            identityContext: this.identityContext,
+            modelId
+        });
         this.cache.clear();
         return result;
     }
 
     async cancelFullyDeleteModel(modelId: string) {
-        const result = await cancelDeleteModel({ context: this.context(), modelId });
+        const result = await cancelDeleteModel({
+            getModel: this.getModel,
+            accessControl: this.accessControl,
+            keyValueStore: this.keyValueStore,
+            getTask: this.getTask,
+            abortTask: this.abortTask,
+            modelId
+        });
         this.cache.clear();
         return result;
     }
 
     async getDeleteModelProgress(modelId: string) {
-        return getDeleteModelProgress({ context: this.context(), modelId });
+        return getDeleteModelProgress({
+            getModel: this.getModel,
+            accessControl: this.accessControl,
+            keyValueStore: this.keyValueStore,
+            getTask: this.getTask,
+            modelId
+        });
     }
 
     private getTenant(): string {
@@ -72,13 +91,18 @@ class DeleteModelOperationsImpl implements DeleteModelOperations.Interface {
     private getStore() {
         return createDeleteModelStore(this.keyValueStore, this.getTenant());
     }
-
-    private context(): HcmsTasksContext {
-        return { container: this.container } as HcmsTasksContext;
-    }
 }
 
 export const DeleteModelOperationsImplementation = DeleteModelOperations.createImplementation({
     implementation: DeleteModelOperationsImpl,
-    dependencies: [RequestContainer, TenantContext, GlobalKeyValueStore]
+    dependencies: [
+        TenantContext,
+        GlobalKeyValueStore,
+        IdentityContext,
+        GetModelUseCase,
+        AccessControl,
+        TriggerTaskUseCase,
+        GetTaskUseCase,
+        AbortTaskUseCase
+    ]
 });

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/assertModelDeletable.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/assertModelDeletable.ts
@@ -1,0 +1,26 @@
+import type { CmsModel } from "@webiny/api-headless-cms/types/index.js";
+import { NotAuthorizedError } from "@webiny/api-headless-cms/utils/errors.js";
+import type { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
+
+export interface IAssertModelDeletableParams {
+    readonly accessControl: AccessControl.Interface;
+    readonly model: CmsModel;
+}
+
+/**
+ * The access checks every delete-model operation makes: delete on the model, write on its entries.
+ * All three operations ran this same pair inline.
+ */
+export const assertModelDeletable = async (params: IAssertModelDeletableParams): Promise<void> => {
+    const { accessControl, model } = params;
+
+    const canAccessModel = await accessControl.canAccessModel({ model, rwd: "d" });
+    if (!canAccessModel) {
+        throw new NotAuthorizedError(`Not allowed to access content model "${model.name}".`);
+    }
+
+    const canAccessEntry = await accessControl.canAccessEntry({ model, rwd: "w" });
+    if (!canAccessEntry) {
+        throw new NotAuthorizedError(`Not allowed to access "${model.modelId}" entries.`);
+    }
+};

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/cancelDeleteModel.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/cancelDeleteModel.ts
@@ -1,4 +1,3 @@
-import type { HcmsTasksContext } from "~/types.js";
 import { WebinyError } from "@webiny/error";
 import type {
     IDeleteCmsModelTask,
@@ -8,43 +7,35 @@ import type {
 import { createDeleteModelStore } from "~/helpers/store.js";
 import { DELETE_MODEL_TASK } from "~/constants.js";
 import { getStatus } from "~/graphql/deleteModel/status.js";
-import { NotAuthorizedError } from "@webiny/api-headless-cms/utils/errors.js";
-import { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
-import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
-import { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
-import { GetTaskUseCase, AbortTaskUseCase } from "@webiny/background-tasks/api";
+import { assertModelDeletable } from "~/graphql/deleteModel/assertModelDeletable.js";
+import type { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
+import type { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
+import type { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
+import type { GetTaskUseCase, AbortTaskUseCase } from "@webiny/background-tasks/api";
 
 export interface ICancelDeleteModelParams {
-    readonly context: Pick<HcmsTasksContext, "container">;
+    readonly getModel: GetModelUseCase.Interface;
+    readonly accessControl: AccessControl.Interface;
+    readonly keyValueStore: GlobalKeyValueStore.Interface;
+    readonly getTask: GetTaskUseCase.Interface;
+    readonly abortTask: AbortTaskUseCase.Interface;
     readonly modelId: string;
 }
 
 export const cancelDeleteModel = async (
     params: ICancelDeleteModelParams
 ): Promise<IDeleteCmsModelTask> => {
-    const { context, modelId } = params;
+    const { getModel, accessControl, keyValueStore, getTask, abortTask, modelId } = params;
 
-    const modelResult = await context.container.resolve(GetModelUseCase).execute(modelId);
+    const modelResult = await getModel.execute(modelId);
     if (modelResult.isFail()) {
         throw modelResult.error;
     }
     const model = modelResult.value;
-    const accessControl = context.container.resolve(AccessControl);
 
-    const canAccessModel = await accessControl.canAccessModel({ model, rwd: "d" });
-    if (!canAccessModel) {
-        throw new NotAuthorizedError(`Not allowed to access content model "${model.name}".`);
-    }
+    await assertModelDeletable({ accessControl, model });
 
-    const canAccessEntry = await accessControl.canAccessEntry({ model, rwd: "w" });
-    if (!canAccessEntry) {
-        throw new NotAuthorizedError(`Not allowed to access "${model.modelId}" entries.`);
-    }
-
-    const store = createDeleteModelStore(
-        context.container.resolve(GlobalKeyValueStore),
-        model.tenant
-    );
+    const store = createDeleteModelStore(keyValueStore, model.tenant);
     const existing = await store.get(model.modelId);
     const taskId = existing?.task;
 
@@ -56,9 +47,7 @@ export const cancelDeleteModel = async (
         });
     }
 
-    const task = await context.container
-        .resolve(GetTaskUseCase)
-        .execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>(taskId);
+    const task = await getTask.execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>(taskId);
     if (task?.definitionId !== DELETE_MODEL_TASK) {
         throw new WebinyError({
             message: `The task which is deleting a model cannot be found. Please check Step Functions for more info. Task id: ${taskId}`,
@@ -70,12 +59,10 @@ export const cancelDeleteModel = async (
         });
     }
 
-    const abortResult = await context.container
-        .resolve(AbortTaskUseCase)
-        .execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>({
-            id: task.id,
-            message: "User canceled the task."
-        });
+    const abortResult = await abortTask.execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>({
+        id: task.id,
+        message: "User canceled the task."
+    });
 
     const canceledTask = abortResult.value;
 

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/fullyDeleteModel.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/fullyDeleteModel.ts
@@ -1,5 +1,4 @@
-import type { HcmsTasksContext } from "~/types.js";
-import { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/abstractions.js";
+import type { IdentityContext } from "@webiny/api-core/features/security/IdentityContext/abstractions.js";
 import type {
     IDeleteCmsModelTask,
     IDeleteModelTaskInput
@@ -7,23 +6,28 @@ import type {
 import { createDeleteModelStore, createStoreValue } from "~/helpers/store.js";
 import { DELETE_MODEL_TASK } from "~/constants.js";
 import { getStatus } from "~/graphql/deleteModel/status.js";
-import { NotAuthorizedError } from "@webiny/api-headless-cms/utils/errors.js";
-import { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
-import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
-import { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
-import { TriggerTaskUseCase } from "@webiny/background-tasks/api";
+import { assertModelDeletable } from "~/graphql/deleteModel/assertModelDeletable.js";
+import type { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
+import type { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
+import type { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
+import type { TriggerTaskUseCase } from "@webiny/background-tasks/api";
 
 export interface IFullyDeleteModelParams {
-    readonly context: Pick<HcmsTasksContext, "container">;
+    readonly getModel: GetModelUseCase.Interface;
+    readonly accessControl: AccessControl.Interface;
+    readonly keyValueStore: GlobalKeyValueStore.Interface;
+    readonly triggerTask: TriggerTaskUseCase.Interface;
+    readonly identityContext: IdentityContext.Interface;
     readonly modelId: string;
 }
 
 export const fullyDeleteModel = async (
     params: IFullyDeleteModelParams
 ): Promise<IDeleteCmsModelTask> => {
-    const { context, modelId } = params;
+    const { getModel, accessControl, keyValueStore, triggerTask, identityContext, modelId } =
+        params;
 
-    const modelResult = await context.container.resolve(GetModelUseCase).execute(modelId);
+    const modelResult = await getModel.execute(modelId);
     if (modelResult.isFail()) {
         throw modelResult.error;
     }
@@ -33,24 +37,9 @@ export const fullyDeleteModel = async (
         throw new Error(`Cannot delete private model.`);
     }
 
-    const accessControl = context.container.resolve(AccessControl);
-    const canAccessModel = await accessControl.canAccessModel({ model, rwd: "d" });
-    if (!canAccessModel) {
-        throw new NotAuthorizedError(`Not allowed to access content model "${model.name}".`);
-    }
+    await assertModelDeletable({ accessControl, model });
 
-    const canAccessEntry = await accessControl.canAccessEntry({ model, rwd: "w" });
-    if (!canAccessEntry) {
-        throw new NotAuthorizedError(`Not allowed to access "${model.modelId}" entries.`);
-    }
-
-    if (!model) {
-        throw new Error(`Model "${modelId}" not found.`);
-    }
-    const store = createDeleteModelStore(
-        context.container.resolve(GlobalKeyValueStore),
-        model.tenant
-    );
+    const store = createDeleteModelStore(keyValueStore, model.tenant);
     const existing = await store.get(model.modelId);
     if (existing?.task) {
         throw new Error(
@@ -58,19 +47,17 @@ export const fullyDeleteModel = async (
         );
     }
 
-    const triggerResult = await context.container
-        .resolve(TriggerTaskUseCase)
-        .execute<IDeleteModelTaskInput>({
-            input: {
-                modelId
-            },
-            definition: DELETE_MODEL_TASK,
-            name: `Fully delete model: ${modelId}`
-        });
+    const triggerResult = await triggerTask.execute<IDeleteModelTaskInput>({
+        input: {
+            modelId
+        },
+        definition: DELETE_MODEL_TASK,
+        name: `Fully delete model: ${modelId}`
+    });
 
     const task = triggerResult.value;
 
-    const identity = context.container.resolve(IdentityContext).getIdentity();
+    const identity = identityContext.getIdentity();
 
     await store.set(
         createStoreValue({

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/getDeleteModelProgress.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/getDeleteModelProgress.ts
@@ -1,4 +1,3 @@
-import type { HcmsTasksContext } from "~/types.js";
 import { WebinyError } from "@webiny/error";
 import { NotFoundError } from "@webiny/api-graphql";
 import type { CmsModel } from "@webiny/api-headless-cms/types/index.js";
@@ -10,25 +9,28 @@ import type {
 import { createDeleteModelStore } from "~/helpers/store.js";
 import { DELETE_MODEL_TASK } from "~/constants.js";
 import { getStatus } from "~/graphql/deleteModel/status.js";
-import { NotAuthorizedError } from "@webiny/api-headless-cms/utils/errors.js";
-import { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
-import { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
-import { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
-import { GetTaskUseCase } from "@webiny/background-tasks/api";
+import { assertModelDeletable } from "~/graphql/deleteModel/assertModelDeletable.js";
+import type { AccessControl } from "@webiny/api-headless-cms/features/shared/abstractions.js";
+import type { GetModelUseCase } from "@webiny/api-headless-cms/features/contentModel/GetModel/index.js";
+import type { GlobalKeyValueStore } from "@webiny/api-core/features/keyValueStore/abstractions.js";
+import type { GetTaskUseCase } from "@webiny/background-tasks/api";
 
 export interface IGetDeleteModelProgress {
-    readonly context: Pick<HcmsTasksContext, "container">;
+    readonly getModel: GetModelUseCase.Interface;
+    readonly accessControl: AccessControl.Interface;
+    readonly keyValueStore: GlobalKeyValueStore.Interface;
+    readonly getTask: GetTaskUseCase.Interface;
     readonly modelId: string;
 }
 
 export const getDeleteModelProgress = async (
     params: IGetDeleteModelProgress
 ): Promise<IDeleteCmsModelTask> => {
-    const { context, modelId } = params;
+    const { getModel, accessControl, keyValueStore, getTask, modelId } = params;
 
     let model: CmsModel;
     try {
-        const modelResult = await context.container.resolve(GetModelUseCase).execute(modelId);
+        const modelResult = await getModel.execute(modelId);
         if (modelResult.isFail()) {
             throw modelResult.error;
         }
@@ -46,21 +48,9 @@ export const getDeleteModelProgress = async (
         });
     }
 
-    const accessControl = context.container.resolve(AccessControl);
-    const canAccessModel = await accessControl.canAccessModel({ model, rwd: "d" });
-    if (!canAccessModel) {
-        throw new NotAuthorizedError(`Not allowed to access content model "${model.name}".`);
-    }
+    await assertModelDeletable({ accessControl, model });
 
-    const canAccessEntry = await accessControl.canAccessEntry({ model, rwd: "w" });
-    if (!canAccessEntry) {
-        throw new NotAuthorizedError(`Not allowed to access "${model.modelId}" entries.`);
-    }
-
-    const store = createDeleteModelStore(
-        context.container.resolve(GlobalKeyValueStore),
-        model.tenant
-    );
+    const store = createDeleteModelStore(keyValueStore, model.tenant);
     const existing = await store.get(model.modelId);
 
     const taskId = existing?.task;
@@ -68,9 +58,7 @@ export const getDeleteModelProgress = async (
         throw new Error(`Model "${modelId}" is not being deleted.`);
     }
 
-    const task = await context.container
-        .resolve(GetTaskUseCase)
-        .execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>(taskId);
+    const task = await getTask.execute<IDeleteModelTaskInput, IDeleteModelTaskOutput>(taskId);
     if (task?.definitionId !== DELETE_MODEL_TASK) {
         throw new WebinyError({
             message: `The task which is deleting a model cannot be found.`,

--- a/packages/api-headless-cms-tasks/src/graphql/deleteModel/index.ts
+++ b/packages/api-headless-cms-tasks/src/graphql/deleteModel/index.ts
@@ -1,7 +1,6 @@
 import zod from "zod";
-import type { Container } from "@webiny/di";
-import { RequestContainer } from "@webiny/event-handler-core";
 import { TenantContext } from "@webiny/api-core/features/tenancy/TenantContext/abstractions.js";
+import { Logger } from "@webiny/api-core/features/logger/index.js";
 import { CmsGraphQLSchemaPlugin, CmsGraphQLSchemaFactory } from "@webiny/api-headless-cms";
 import { HeadlessCms } from "@webiny/api-headless-cms/features/shared/abstractions.js";
 import { DeleteModelOperations } from "~/graphql/deleteModel/abstractions.js";
@@ -53,8 +52,9 @@ const getValidation = zod
  */
 class DeleteModelGraphQLSchemaFactory implements CmsGraphQLSchemaFactory.Interface {
     constructor(
-        private readonly container: Container,
-        private readonly tenantContext: TenantContext.Interface
+        private readonly tenantContext: TenantContext.Interface,
+        private readonly headlessCms: HeadlessCms.Interface,
+        private readonly logger: Logger.Interface
     ) {}
 
     async execute() {
@@ -62,7 +62,7 @@ class DeleteModelGraphQLSchemaFactory implements CmsGraphQLSchemaFactory.Interfa
 
         // On a fresh project there is no tenant until installation completes; and the delete-model
         // schema only belongs on the MANAGE endpoint. (`isHeadlessCmsReady` only checks the tenant.)
-        if (!this.tenantContext.getTenant() || !this.container.resolve(HeadlessCms).MANAGE) {
+        if (!this.tenantContext.getTenant() || !this.headlessCms.MANAGE) {
             return [];
         }
 
@@ -123,7 +123,10 @@ class DeleteModelGraphQLSchemaFactory implements CmsGraphQLSchemaFactory.Interfa
                                 .resolve(DeleteModelOperations)
                                 .isModelBeingDeleted(model.modelId);
                         } catch (ex) {
-                            console.error(ex);
+                            this.logger.error(
+                                { error: ex, modelId: model.modelId },
+                                "Failed to read the delete-model status."
+                            );
                         }
                         return true;
                     }
@@ -216,5 +219,5 @@ class DeleteModelGraphQLSchemaFactory implements CmsGraphQLSchemaFactory.Interfa
 
 export const DeleteModelGraphQLSchemaFactoryImpl = CmsGraphQLSchemaFactory.createImplementation({
     implementation: DeleteModelGraphQLSchemaFactory,
-    dependencies: [RequestContainer, TenantContext]
+    dependencies: [TenantContext, HeadlessCms, Logger]
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11055,7 +11055,6 @@ __metadata:
     "@webiny/api-opensearch": "npm:0.0.0"
     "@webiny/background-tasks": "npm:0.0.0"
     "@webiny/build-tools": "npm:0.0.0"
-    "@webiny/di": "npm:^1.0.2"
     "@webiny/error": "npm:0.0.0"
     "@webiny/event-handler-core": "npm:0.0.0"
     "@webiny/feature": "npm:0.0.0"


### PR DESCRIPTION
The follow-up left out of #5651, and the finding slop cop raised there.

`DeleteModelOperationsImpl` injected `RequestContainer` for exactly one reason: to hand a `{ container }` context to `fullyDeleteModel`, `cancelDeleteModel` and `getDeleteModelProgress`, which then resolved seven abstractions out of it. Those three now take their dependencies as parameters, the container is gone, and the class declares what it uses. `no-container-as-service-locator` satisfied.

Two small cleanups on the way through:

- The three helpers each ran the same access-check pair inline (delete on the model, write on its entries). That moves into `assertModelDeletable`.
- `fullyDeleteModel` had an unreachable `if (!model)` guard sitting *after* `modelResult.value` had been read and after the access checks. Dropped.

## The interesting part

Resolving dependencies in a constructor rather than inside methods moves the work to **construction** time. `DisableModelFeature` was resolving `DeleteModelOperations` while registering, in order to bind `isModelBeingDeleted` into `BlockActionIfModelDisabled`. `HcmsTasksFeature` registers *before* `BackgroundTasksFeature`, so the moment the operations class declared its own task use cases, that register-time construction threw:

```
No registration found for Tasks/TriggerTaskUseCase
```

The package's own tests caught it, which is the good news.

Binding a method is the same anti-pattern the provider rule from #5660 describes — injecting a resolved value instead of the producer. So `BlockActionIfModelDisabled` becomes an ordinary implementation depending on `DeleteModelOperations`, which defers construction to first use. The registration-order comment in `HcmsTasksFeature` goes away with the constraint it documented.

This is worth noting generally: converting a service-locating class to declared dependencies changes *when* its dependencies are resolved. If anything resolves that class at register time, the conversion can break registration ordering that previously didn't matter.

## Also

`DeleteModelGraphQLSchemaFactory` drops `RequestContainer` as well — it resolved only `HeadlessCms` — and its bare `console.error` in the `isBeingDeleted` resolver becomes the DI `Logger` (`no-console-in-backend`). The `context.container.resolve(...)` calls inside the GraphQL resolvers stay; that's the resolver pattern, not an implementation class.

`@webiny/di` is no longer used by this package, so `adio` flagged it and it's removed.

## Verified

`api-headless-cms-tasks` 2/2, `api-headless-cms` 920 passed / 16 skipped, `api-headless-cms-bulk-actions` 3/3, `api-aco` 74 passed. Builds clean. `adio`, `format:check`, `oxlint`, `sync-dependencies` clean.

No new tests. The behaviour is unchanged and the existing suite already covers both delete-model paths — it's what caught the ordering break.
